### PR TITLE
Increase `NETWORK_STARTUP_TIMEOUT_SECS`

### DIFF
--- a/crates/test-networks/src/sui_network.rs
+++ b/crates/test-networks/src/sui_network.rs
@@ -7,7 +7,7 @@ use tokio::time::{Duration, sleep};
 
 const DEFAULT_NUM_VALIDATORS: usize = 4;
 const DEFAULT_EPOCH_DURATION_MS: u64 = 60_000;
-const NETWORK_STARTUP_TIMEOUT_SECS: u64 = 10;
+const NETWORK_STARTUP_TIMEOUT_SECS: u64 = 30;
 const NETWORK_STARTUP_POLL_INTERVAL_SECS: u64 = 1;
 
 pub fn sui_binary() -> &'static Path {


### PR DESCRIPTION
[The recent change to wait for checkpoint production for Sui test network](https://github.com/MystenLabs/hashi/blob/92abce43f2c69166987a57e6111a4cfb23523dcd/crates/test-networks/src/sui_network.rs#L38-L44) leads to some CI timeout failures in `sui_network::tests` in #51 , e.g.
```
   thread 'sui_network::tests::test_parallel_sui_networks' (9274) panicked at crates/test-networks/src/sui_network.rs:257:21:
    Network 0 failed to start: Network failed to start within 10s timeout on port 38517
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

#3 #16 