### PR TITLE
test-harness: publish and initialize hashi package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,6 +3179,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,12 +3509,18 @@ name = "test-networks"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base64ct",
  "bitcoin",
  "bitcoincore-rpc",
  "futures",
  "hashi",
  "prometheus",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sui-crypto",
  "sui-rpc",
+ "sui-sdk-types",
  "tempfile",
  "tokio",
  "tracing",
@@ -4012,6 +4031,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
-use sui_crypto::simple::SimpleKeypair;
+use sui_crypto::ed25519::Ed25519PrivateKey;
+use sui_sdk_types::Address;
 
 use crate::bls::Bls12381PrivateKey;
 
@@ -15,6 +16,9 @@ pub struct Config {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operator_private_key: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validator_address: Option<Address>,
 
     /// Configure the address to listen on for https
     ///
@@ -39,6 +43,15 @@ pub struct Config {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bitcoin_chain_id: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hashi_ids: Option<HashiIds>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sui_rpc: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bitcoin_rpc: Option<String>,
 }
 
 impl Config {
@@ -82,31 +95,37 @@ impl Config {
         Ok(ed25519_dalek::VerifyingKey::from(&tls_private_key))
     }
 
-    pub fn operator_private_key(&self) -> Result<SimpleKeypair, anyhow::Error> {
+    //TODO support more than just Ed25519
+    pub fn operator_private_key(&self) -> Result<Ed25519PrivateKey, anyhow::Error> {
         let raw = self
             .operator_private_key
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("no operator_private_key configured"))?;
 
         if let Ok(private_key) = std::fs::read(raw) {
-            if let Ok(pk) = SimpleKeypair::from_der(&private_key) {
+            if let Ok(pk) = Ed25519PrivateKey::from_der(&private_key) {
                 return Ok(pk);
             }
 
             if let Some(pk) = std::str::from_utf8(&private_key)
                 .ok()
-                .and_then(|pk| SimpleKeypair::from_pem(pk).ok())
+                .and_then(|pk| Ed25519PrivateKey::from_pem(pk).ok())
             {
                 return Ok(pk);
             }
         }
 
-        if let Ok(private_key) = SimpleKeypair::from_pem(raw) {
+        if let Ok(private_key) = Ed25519PrivateKey::from_pem(raw) {
             return Ok(private_key);
         }
 
         // maybe some other format?
         Err(anyhow::anyhow!("unable to load operator_private_key"))
+    }
+
+    pub fn validator_address(&self) -> Result<Address, anyhow::Error> {
+        self.validator_address
+            .ok_or_else(|| anyhow::anyhow!("no validator address configured"))
     }
 
     pub fn https_address(&self) -> SocketAddr {
@@ -136,6 +155,14 @@ impl Config {
             .unwrap_or("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")
     }
 
+    pub fn hashi_ids(&self) -> HashiIds {
+        // TODO fill in mainnet values once published
+        self.hashi_ids.unwrap_or(HashiIds {
+            package_id: Address::ZERO,
+            hashi_object_id: Address::ZERO,
+        })
+    }
+
     // Creates a new config suitable for testing. In particular this config will:
     // - have randomly generated private key material
     // - localhost only listen addresses using available ports
@@ -155,6 +182,8 @@ impl Config {
                 .to_owned(),
         );
 
+        config.protocol_private_key = Some(Bls12381PrivateKey::generate(&mut rand::thread_rng()));
+
         config.https_address = Some(SocketAddr::from(([127, 0, 0, 1], get_available_port())));
         config.http_address = Some(SocketAddr::from(([127, 0, 0, 1], get_available_port())));
         config.metrics_http_address =
@@ -162,6 +191,15 @@ impl Config {
 
         config
     }
+}
+
+/// Relevant Onchain Ids for the hashi protocol.
+#[derive(Debug, Clone, Copy, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct HashiIds {
+    /// The original package id of the `hashi` package.
+    pub package_id: Address,
+    /// Id of the main `Hashi` shared object.
+    pub hashi_object_id: Address,
 }
 
 /// Return an ephemeral, available port. On unix systems, the port returned will be in the

--- a/crates/test-networks/Cargo.toml
+++ b/crates/test-networks/Cargo.toml
@@ -13,6 +13,12 @@ bitcoin = "0.32"
 bitcoincore-rpc = "0.19"
 tempfile = "3.0"
 sui-rpc = "0.1"
+sui-crypto = { version = "0.1", features = ["ed25519"] }
+sui-sdk-types = "0.1"
+base64ct = { version = "1.8.0", features = ["std"] }
+serde_yaml = "0.9.34"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 
 [dev-dependencies]
 futures = "0.3"

--- a/crates/test-networks/src/bitcoin_node.rs
+++ b/crates/test-networks/src/bitcoin_node.rs
@@ -1,11 +1,20 @@
-use anyhow::{Result, anyhow};
-use bitcoin::{Address, Amount, BlockHash, Txid};
-use bitcoincore_rpc::{Auth, Client, RpcApi};
+use anyhow::Result;
+use anyhow::anyhow;
+use bitcoin::Address;
+use bitcoin::Amount;
+use bitcoin::BlockHash;
+use bitcoin::Txid;
+use bitcoincore_rpc::Auth;
+use bitcoincore_rpc::Client;
+use bitcoincore_rpc::RpcApi;
 use hashi::config::get_available_port;
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Child;
+use std::process::Command;
 use std::time::Duration;
-use tracing::{info, warn};
+use tracing::info;
+use tracing::warn;
 
 const DEFAULT_INITIAL_BLOCKS: u64 = 101;
 const BITCOIN_CORE_STARTUP_TIMEOUT_SECS: u64 = 60;

--- a/crates/test-networks/src/hashi_network.rs
+++ b/crates/test-networks/src/hashi_network.rs
@@ -1,7 +1,14 @@
 use anyhow::Result;
-use hashi::{Hashi, ServerVersion, config::Config as HashiConfig};
-use std::{net::SocketAddr, sync::Arc};
+use hashi::Hashi;
+use hashi::ServerVersion;
+use hashi::config::Config as HashiConfig;
+use hashi::config::HashiIds;
+use std::net::SocketAddr;
+use std::sync::Arc;
 use tracing::info;
+
+use crate::BitcoinNodeHandle;
+use crate::SuiNetworkHandle;
 
 const HTTPS_SCHEME: &str = "https://";
 const HTTP_SCHEME: &str = "http://";
@@ -67,21 +74,51 @@ impl HashiNetworkBuilder {
         self
     }
 
-    pub async fn build(self) -> Result<HashiNetwork> {
-        let mut nodes = Vec::with_capacity(self.num_nodes);
-        for i in 0..self.num_nodes {
-            let config = HashiConfig::new_for_testing();
+    pub async fn build(
+        self,
+        sui: &SuiNetworkHandle,
+        bitcoin: &BitcoinNodeHandle,
+        hashi_ids: HashiIds,
+    ) -> Result<HashiNetwork> {
+        let bitcoin_rpc = bitcoin.rpc_url().to_owned();
+        let sui_rpc = sui.rpc_url.clone();
+
+        let mut configs = Vec::with_capacity(self.num_nodes);
+        for (validator_address, private_key) in sui.validator_keys.iter().take(self.num_nodes) {
+            let mut config = HashiConfig::new_for_testing();
+            config.hashi_ids = Some(hashi_ids);
+            config.validator_address = Some(*validator_address);
+            config.operator_private_key = Some(private_key.to_pem()?);
+            config.sui_rpc = Some(sui_rpc.clone());
+            config.bitcoin_rpc = Some(bitcoin_rpc.clone());
+
+            //TODO fill in chain ids
+            config.sui_chain_id = None;
+            config.bitcoin_chain_id = None;
+
+            configs.push(config);
+        }
+
+        for config in &configs {
+            let client = sui.client.clone();
+            register_onchain(client, config).await?;
+        }
+
+        let mut nodes = Vec::with_capacity(configs.len());
+        for config in configs {
+            let validator_address = config.validator_address()?;
             let node_handle = HashiNodeHandle::new(config)?;
             node_handle.start();
             info!(
                 "Created Hashi node {} at HTTPS: {}, HTTP: {}, Metrics: {}",
-                i,
+                validator_address,
                 node_handle.https_address(),
                 node_handle.http_address(),
                 node_handle.metrics_address()
             );
             nodes.push(node_handle);
         }
+
         Ok(HashiNetwork(nodes))
     }
 }
@@ -92,88 +129,7 @@ impl Default for HashiNetworkBuilder {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_hashi_network_multiple_nodes() -> Result<()> {
-        let hashi_network = HashiNetworkBuilder::new().with_num_nodes(3).build().await?;
-        assert_eq!(hashi_network.nodes().len(), 3);
-        for node in hashi_network.nodes().iter() {
-            assert!(!node.https_url().is_empty());
-            assert!(!node.http_url().is_empty());
-            assert!(!node.metrics_url().is_empty());
-
-            // Verify each node has unique ports
-            let https_port = node.https_address().port();
-            let http_port = node.http_address().port();
-            let metrics_port = node.metrics_address().port();
-            assert_ne!(https_port, http_port);
-            assert_ne!(https_port, metrics_port);
-            assert_ne!(http_port, metrics_port);
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_default_configuration() -> Result<()> {
-        let builder = HashiNetworkBuilder::new();
-        assert_eq!(builder.num_nodes, 1);
-        Ok(())
-    }
-
-    #[test]
-    fn test_builder_fluent_api() {
-        const NUM_NODES: usize = 3;
-
-        let builder = HashiNetworkBuilder::new().with_num_nodes(NUM_NODES);
-
-        assert_eq!(builder.num_nodes, NUM_NODES);
-    }
-
-    #[test]
-    fn test_builder_default_trait() {
-        let builder1 = HashiNetworkBuilder::new();
-        let builder2 = HashiNetworkBuilder::default();
-
-        assert_eq!(builder1.num_nodes, builder2.num_nodes);
-    }
-
-    #[tokio::test]
-    async fn test_node_handle_url_formatting() -> Result<()> {
-        let config = HashiConfig::new_for_testing();
-        let https_port = config.https_address().port();
-        let http_port = config.http_address().port();
-        let metrics_port = config.metrics_http_address().port();
-        let node_handle = HashiNodeHandle::new(config)?;
-
-        const HTTPS_URL_PREFIX: &str = "https://127.0.0.1:";
-        const HTTP_URL_PREFIX: &str = "http://127.0.0.1:";
-
-        assert_eq!(
-            node_handle.https_url(),
-            format!("{}{}", HTTPS_URL_PREFIX, https_port)
-        );
-        assert_eq!(
-            node_handle.http_url(),
-            format!("{}{}", HTTP_URL_PREFIX, http_port)
-        );
-        assert_eq!(
-            node_handle.metrics_url(),
-            format!("{}{}", HTTP_URL_PREFIX, metrics_port)
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_zero_nodes_build() -> Result<()> {
-        let network = HashiNetworkBuilder::new().with_num_nodes(0).build().await?;
-
-        assert_eq!(network.nodes().len(), 0);
-        assert!(network.nodes().is_empty());
-
-        Ok(())
-    }
+async fn register_onchain(_client: sui_rpc::Client, _config: &HashiConfig) -> Result<()> {
+    // TODO flesh out onchain register flow
+    Ok(())
 }

--- a/crates/test-networks/src/lib.rs
+++ b/crates/test-networks/src/lib.rs
@@ -1,16 +1,23 @@
-use std::{path::Path, process::Command};
+use std::path::Path;
+use std::process::Command;
 
 use anyhow::Result;
 
 pub mod bitcoin_node;
 pub mod hashi_network;
+mod publish;
 pub mod sui_network;
 
-pub use bitcoin_node::{BitcoinNodeBuilder, BitcoinNodeHandle};
-pub use hashi_network::{HashiNetwork, HashiNetworkBuilder, HashiNodeHandle};
-pub use sui_network::{SuiNetworkBuilder, SuiNetworkHandle};
+pub use bitcoin_node::BitcoinNodeBuilder;
+pub use bitcoin_node::BitcoinNodeHandle;
+pub use hashi_network::HashiNetwork;
+pub use hashi_network::HashiNetworkBuilder;
+pub use hashi_network::HashiNodeHandle;
+pub use sui_network::SuiNetworkBuilder;
+pub use sui_network::SuiNetworkHandle;
 use tempfile::TempDir;
 
+use crate::publish::publish;
 use crate::sui_network::sui_binary;
 
 pub struct TestNetworks {
@@ -91,20 +98,36 @@ impl TestNetworksBuilder {
             .prefix("hashi-test-env-")
             .tempdir()?;
 
-        let sui_network = self
+        println!("test env: {}", dir.path().display());
+
+        let mut sui_network = self
             .sui_builder
             .dir(&dir.path().join("sui"))
             .build()
             .await?;
         let bitcoin_node = self.bitcoin_builder.dir(dir.as_ref()).build().await?;
-        let hashi_network = self.hashi_builder.build().await?;
         Self::cp_packages(dir.as_ref())?;
+
+        let hashi_ids = publish(
+            dir.as_ref(),
+            &mut sui_network.client,
+            sui_network.user_keys.first().unwrap(),
+        )
+        .await?;
+
+        let hashi_network = self
+            .hashi_builder
+            .build(&sui_network, &bitcoin_node, hashi_ids)
+            .await?;
+
         let test_networks = TestNetworks {
             dir,
             sui_network,
             hashi_network,
             bitcoin_node,
         };
+
+        println!("rpc url: {}", test_networks.sui_network().rpc_url);
 
         Ok(test_networks)
     }
@@ -148,6 +171,10 @@ mod tests {
         assert_eq!(test_networks.hashi_network().nodes().len(), TEST_NUM_NODES);
         assert_eq!(test_networks.sui_network().num_validators, TEST_NUM_NODES);
         assert!(!test_networks.bitcoin_node().rpc_url().is_empty());
+
+        // loop {
+        //     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        // }
 
         Ok(())
     }

--- a/crates/test-networks/src/publish.rs
+++ b/crates/test-networks/src/publish.rs
@@ -1,0 +1,255 @@
+use anyhow::Result;
+use hashi::config::HashiIds;
+use std::path::Path;
+use std::process::Command;
+use std::str::FromStr;
+use sui_crypto::SuiSigner;
+use sui_crypto::ed25519::Ed25519PrivateKey;
+use sui_rpc::Client;
+use sui_rpc::field::FieldMask;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2::ExecuteTransactionRequest;
+use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
+use sui_sdk_types::Address;
+use sui_sdk_types::Digest;
+
+use crate::sui_network::sui_binary;
+
+#[derive(serde::Deserialize)]
+struct MoveBuildOutput {
+    modules: Vec<String>,
+    dependencies: Vec<Address>,
+    digest: Vec<u8>,
+}
+
+pub async fn publish(
+    dir: &Path,
+    client: &mut Client,
+    private_key: &Ed25519PrivateKey,
+) -> Result<HashiIds> {
+    let publish_command = build_package(dir)?;
+    let ids = publish_transaction(client, private_key, publish_command).await?;
+
+    Ok(ids)
+}
+
+fn build_package(dir: &Path) -> Result<sui_sdk_types::Publish> {
+    let client_config = dir.join("sui/client.yaml");
+    let hashi_package = dir.join("packages/hashi");
+
+    let mut cmd = Command::new(sui_binary());
+    cmd.arg("move")
+        .arg("--client.config")
+        .arg(client_config)
+        .arg("-p")
+        .arg(hashi_package)
+        .arg("build")
+        .arg("--ignore-chain") // TODO remove once 1.62 is released
+        .arg("--dump-bytecode-as-base64");
+    let output = cmd.output()?;
+
+    let move_build_output: MoveBuildOutput = serde_json::from_slice(&output.stdout)?;
+    let modules = move_build_output
+        .modules
+        .into_iter()
+        .map(|b64| <base64ct::Base64 as base64ct::Encoding>::decode_vec(&b64))
+        .collect::<Result<Vec<_>, _>>()?;
+    let _digest = Digest::from_bytes(move_build_output.digest)?;
+
+    Ok(sui_sdk_types::Publish {
+        modules,
+        dependencies: move_build_output.dependencies,
+    })
+}
+
+async fn publish_transaction(
+    client: &mut Client,
+    private_key: &Ed25519PrivateKey,
+    publish: sui_sdk_types::Publish,
+) -> Result<HashiIds> {
+    use sui_sdk_types::bcs::ToBcs;
+    use sui_sdk_types::*;
+
+    let sender = private_key.public_key().derive_address();
+    let price = client.get_reference_gas_price().await?;
+    let gas_objects = client
+        .select_coins(&sender, &StructTag::sui().into(), 1_000_000_000, &[])
+        .await?;
+    let gas_object = (&gas_objects[0].object_reference()).try_into()?;
+
+    let pt = ProgrammableTransaction {
+        inputs: vec![Input::Pure {
+            value: sender.to_bcs()?,
+        }],
+        commands: vec![
+            Command::Publish(publish),
+            Command::TransferObjects(TransferObjects {
+                objects: vec![Argument::Result(0)],
+                address: Argument::Input(0),
+            }),
+        ],
+    };
+
+    let publish_transaction = Transaction {
+        kind: TransactionKind::ProgrammableTransaction(pt),
+        sender,
+        gas_payment: GasPayment {
+            objects: vec![gas_object],
+            owner: sender,
+            price,
+            budget: 1_000_000_000,
+        },
+        expiration: TransactionExpiration::None,
+    };
+
+    let signature = private_key.sign_transaction(&publish_transaction)?;
+
+    let response = client
+        .execute_transaction_and_wait_for_checkpoint(
+            ExecuteTransactionRequest::new(publish_transaction.into())
+                .with_signatures(vec![signature.into()])
+                .with_read_mask(FieldMask::from_str("*")),
+            std::time::Duration::from_secs(10),
+        )
+        .await?
+        .into_inner();
+
+    assert!(
+        response.transaction().effects().status().success(),
+        "publish failed"
+    );
+
+    let upgrade_cap = {
+        let upgrade_cap_type = StructTag::from_str("0x2::package::UpgradeCap")?.to_string();
+        let upgrade_cap = response
+            .transaction()
+            .effects()
+            .changed_objects()
+            .iter()
+            .find(|o| o.object_type() == upgrade_cap_type)
+            .unwrap();
+        ObjectReference::new(
+            upgrade_cap.object_id().parse()?,
+            upgrade_cap.output_version(),
+            upgrade_cap.output_digest().parse()?,
+        )
+    };
+
+    let package_id = response
+        .transaction()
+        .effects()
+        .changed_objects()
+        .iter()
+        .find(|o| o.object_type() == "package")
+        .unwrap()
+        .object_id()
+        .parse::<Address>()?;
+
+    let hashi = {
+        let hashi_type = StructTag::new(
+            package_id,
+            Identifier::from_static("hashi"),
+            Identifier::from_static("Hashi"),
+            vec![],
+        )
+        .to_string();
+        let hashi = response
+            .transaction()
+            .effects()
+            .changed_objects()
+            .iter()
+            .find(|o| o.object_type() == hashi_type)
+            .unwrap();
+        ObjectReference::new(
+            hashi.object_id().parse()?,
+            hashi.output_version(),
+            hashi.output_digest().parse()?,
+        )
+    };
+
+    println!("package: {package_id}");
+
+    let coin_registry = {
+        let resp = client
+            .ledger_client()
+            .get_object(
+                GetObjectRequest::new(&Address::from_static("0xc"))
+                    .with_read_mask(FieldMask::from_paths(["object_id", "owner"])),
+            )
+            .await?
+            .into_inner();
+
+        Input::Shared {
+            object_id: Address::from_static("0xc"),
+            initial_shared_version: resp.object().owner().version(),
+            mutable: true,
+        }
+    };
+
+    let gas_objects = client
+        .select_coins(&sender, &StructTag::sui().into(), 1_000_000_000, &[])
+        .await?;
+    let gas_object = (&gas_objects[0].object_reference()).try_into()?;
+
+    let pt = ProgrammableTransaction {
+        inputs: vec![
+            Input::Shared {
+                object_id: *hashi.object_id(),
+                initial_shared_version: hashi.version(),
+                mutable: true,
+            },
+            coin_registry,
+            Input::ImmutableOrOwned(upgrade_cap),
+        ],
+        commands: vec![
+            Command::MoveCall(MoveCall {
+                package: package_id,
+                module: Identifier::from_static("hashi"),
+                function: Identifier::from_static("register_btc"),
+                type_arguments: vec![],
+                arguments: vec![Argument::Input(0), Argument::Input(1)],
+            }),
+            Command::MoveCall(MoveCall {
+                package: package_id,
+                module: Identifier::from_static("hashi"),
+                function: Identifier::from_static("register_upgrade_cap"),
+                type_arguments: vec![],
+                arguments: vec![Argument::Input(0), Argument::Input(2)],
+            }),
+        ],
+    };
+
+    let init_transaction = Transaction {
+        kind: TransactionKind::ProgrammableTransaction(pt),
+        sender,
+        gas_payment: GasPayment {
+            objects: vec![gas_object],
+            owner: sender,
+            price,
+            budget: 1_000_000_000,
+        },
+        expiration: TransactionExpiration::None,
+    };
+
+    let signature = private_key.sign_transaction(&init_transaction)?;
+
+    let response = client
+        .execute_transaction_and_wait_for_checkpoint(
+            ExecuteTransactionRequest::new(init_transaction.into())
+                .with_signatures(vec![signature.into()])
+                .with_read_mask(FieldMask::from_str("*")),
+            std::time::Duration::from_secs(10),
+        )
+        .await?
+        .into_inner();
+
+    assert!(
+        response.transaction().effects().status().success(),
+        "registering upgrade cap and Coin<BTC> failed"
+    );
+
+    Ok(HashiIds {
+        package_id,
+        hashi_object_id: *hashi.object_id(),
+    })
+}

--- a/crates/test-networks/src/sui_network.rs
+++ b/crates/test-networks/src/sui_network.rs
@@ -1,9 +1,18 @@
 use anyhow::Result;
 use anyhow::anyhow;
+use anyhow::bail;
 use hashi::config::get_available_port;
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
-use tokio::time::{Duration, sleep};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Child;
+use std::process::Command;
+use sui_crypto::ed25519::Ed25519PrivateKey;
+use sui_rpc::Client;
+use sui_sdk_types::Address;
+use sui_sdk_types::SignatureScheme;
+use tokio::time::Duration;
+use tokio::time::sleep;
 
 const DEFAULT_NUM_VALIDATORS: usize = 4;
 const DEFAULT_EPOCH_DURATION_MS: u64 = 60_000;
@@ -31,10 +40,7 @@ pub fn sui_binary() -> &'static Path {
         .as_path()
 }
 
-async fn wait_for_ready(port: u16) -> Result<()> {
-    let http_url = format!("http://127.0.0.1:{port}");
-    let mut client = sui_rpc::Client::new(http_url)?;
-
+async fn wait_for_ready(client: &mut Client) -> Result<()> {
     // Wait till the network has started up and at least one checkpoint has been produced
     for _ in 0..NETWORK_STARTUP_TIMEOUT_SECS {
         if let Ok(resp) = client
@@ -48,9 +54,8 @@ async fn wait_for_ready(port: u16) -> Result<()> {
         sleep(Duration::from_secs(NETWORK_STARTUP_POLL_INTERVAL_SECS)).await;
     }
     anyhow::bail!(
-        "Network failed to start within {}s timeout on port {}",
+        "Network failed to start within {}s timeout",
         NETWORK_STARTUP_TIMEOUT_SECS,
-        port
     )
 }
 
@@ -64,11 +69,14 @@ pub struct SuiNetworkHandle {
 
     /// Network endpoints
     pub rpc_url: String,
-    pub faucet_url: String,
+    pub client: Client,
 
     /// Network configuration
     pub num_validators: usize,
     pub epoch_duration_ms: u64,
+
+    pub validator_keys: BTreeMap<Address, Ed25519PrivateKey>,
+    pub user_keys: Vec<Ed25519PrivateKey>,
 }
 
 impl Drop for SuiNetworkHandle {
@@ -122,19 +130,25 @@ impl SuiNetworkBuilder {
             .clone()
             .ok_or_else(|| anyhow!("no directory configured"))?;
         self.generate_genesis(&dir)?;
+        let (validator_keys, user_keys) = load_keys(&dir)?;
+
         let rpc_port = get_available_port();
-        let faucet_port = get_available_port();
-        let process = self.start_network(&dir, rpc_port, faucet_port)?;
+        let process = self.start_network(&dir, rpc_port)?;
+
         let rpc_url = format!("http://127.0.0.1:{rpc_port}");
-        let faucet_url = format!("http://127.0.0.1:{faucet_port}");
-        wait_for_ready(rpc_port).await?;
+
+        let mut client = sui_rpc::Client::new(&rpc_url)?;
+        wait_for_ready(&mut client).await?;
+
         Ok(SuiNetworkHandle {
             process,
             dir,
             rpc_url,
-            faucet_url,
+            client,
             num_validators: self.num_validators,
             epoch_duration_ms: self.epoch_duration_ms,
+            validator_keys,
+            user_keys,
         })
     }
 
@@ -156,7 +170,7 @@ impl SuiNetworkBuilder {
         Ok(())
     }
 
-    fn start_network(&self, dir: &Path, rpc_port: u16, _faucet_port: u16) -> Result<Child> {
+    fn start_network(&self, dir: &Path, rpc_port: u16) -> Result<Child> {
         let stdout_name = dir.join("out.stdout");
         let stdout = std::fs::File::create(stdout_name)?;
         let stderr_name = dir.join("out.stderr");
@@ -169,13 +183,75 @@ impl SuiNetworkBuilder {
             .arg(dir)
             .arg("--fullnode-rpc-port")
             .arg(rpc_port.to_string())
-            //XXX uncomment once 1.62 release is cut
-            // .arg(format!("--with-faucet=127.0.0.1:{faucet_port}"))
             .stdout(stdout)
             .stderr(stderr)
             .spawn()
             .map_err(|e| anyhow!("Failed to run `sui start`: {e}"))
     }
+}
+
+fn keypair_from_base64(b64: &str) -> Result<Ed25519PrivateKey> {
+    let bytes = <base64ct::Base64 as base64ct::Encoding>::decode_vec(b64)?;
+
+    let keypair =
+        match SignatureScheme::from_byte(*bytes.first().ok_or_else(|| anyhow!("Invalid key"))?)
+            .map_err(|e| anyhow!("{e}"))?
+        {
+            SignatureScheme::Ed25519 => Ed25519PrivateKey::new(
+                bytes
+                    .get(1..)
+                    .ok_or_else(|| anyhow!("Invalid key"))?
+                    .try_into()?,
+            ),
+            SignatureScheme::Secp256k1 => bail!("invalid key"),
+            SignatureScheme::Secp256r1 => bail!("invalid key"),
+            _ => bail!("invalid key"),
+        };
+
+    Ok(keypair)
+}
+
+fn ed25519_private_key_from_base64(b64: &str) -> Result<Ed25519PrivateKey> {
+    let bytes = <base64ct::Base64 as base64ct::Encoding>::decode_vec(b64)?;
+    Ok(Ed25519PrivateKey::new((&bytes[..]).try_into()?))
+}
+
+fn load_keys(dir: &Path) -> Result<(BTreeMap<Address, Ed25519PrivateKey>, Vec<Ed25519PrivateKey>)> {
+    #[derive(serde::Deserialize)]
+    struct Config {
+        validator_configs: Vec<NodeConfig>,
+        account_keys: Vec<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    struct NodeConfig {
+        account_key_pair: RawKey,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct RawKey {
+        value: String,
+    }
+
+    let raw = std::fs::read(dir.join("network.yaml"))?;
+    let network_config: Config = serde_yaml::from_slice(&raw)?;
+
+    let mut validator_keys = BTreeMap::new();
+
+    for validator in network_config.validator_configs {
+        let keypair = keypair_from_base64(&validator.account_key_pair.value)?;
+        let address = keypair.public_key().derive_address();
+        validator_keys.insert(address, keypair);
+    }
+
+    let mut user_keys = vec![];
+
+    for raw_key in network_config.account_keys {
+        user_keys.push(ed25519_private_key_from_base64(&raw_key)?);
+    }
+
+    Ok((validator_keys, user_keys))
 }
 
 #[cfg(test)]
@@ -216,7 +292,6 @@ mod tests {
         // Verify all networks started successfully with unique ports
         let mut networks = Vec::new();
         let mut rpc_ports = HashSet::new();
-        let mut faucet_ports = HashSet::new();
 
         for (i, result) in results {
             match result {
@@ -227,12 +302,6 @@ mod tests {
                         .next_back()
                         .and_then(|p| p.parse().ok())
                         .expect("Failed to parse RPC port");
-                    let faucet_port: u16 = network
-                        .faucet_url
-                        .split(':')
-                        .next_back()
-                        .and_then(|p| p.parse().ok())
-                        .expect("Failed to parse faucet port");
 
                     // Verify ports are unique
                     assert!(
@@ -240,12 +309,6 @@ mod tests {
                         "Network {} has duplicate RPC port {}",
                         i,
                         rpc_port
-                    );
-                    assert!(
-                        faucet_ports.insert(faucet_port),
-                        "Network {} has duplicate faucet port {}",
-                        i,
-                        faucet_port
                     );
 
                     // Verify network configuration


### PR DESCRIPTION
When spinning up a test harness, compile and publish the hashi move package as well as initialize `Coin<BTC>` by registering with the CoinRegistry and storing the package's UpgradeCap inside of the `Hashi` shared object.