### PR TITLE
Update testnet_monitor to support deposit confirmation flow

### DIFF
--- a/crates/hashi-btc/examples/testnet_monitor.rs
+++ b/crates/hashi-btc/examples/testnet_monitor.rs
@@ -5,15 +5,19 @@
 //!
 //! Monitor testnet4:
 //! ```bash
-//! cargo run --example testnet_monitor
+//! cargo run --example testnet_monitor -- --bitcoind-url http://localhost:18332 --bitcoind-user myuser --bitcoind-password mypass
 //! ```
+use std::io::Write;
 use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
+use std::str::FromStr;
 
 use bitcoin::Network;
 use clap::Parser;
 use hashi_btc::config::MonitorConfig;
 use hashi_btc::monitor::Monitor;
 use kyoto::TrustedPeer;
+use tracing::error;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
@@ -34,18 +38,31 @@ struct Args {
     /// Enable verbose logging
     #[arg(short, long)]
     verbose: bool,
+
+    /// bitcoind JSON-RPC URL
+    #[arg(long, default_value = "http://localhost:18332")]
+    bitcoind_url: String,
+
+    /// bitcoind JSON-RPC username (optional)
+    #[arg(long)]
+    bitcoind_user: Option<String>,
+
+    /// bitcoind JSON-RPC password (optional)
+    #[arg(long)]
+    bitcoind_password: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    // Set up logging
-    let filter = if args.verbose {
-        EnvFilter::new("debug")
-    } else {
-        EnvFilter::new("info")
-    };
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        if args.verbose {
+            EnvFilter::new("debug")
+        } else {
+            EnvFilter::new("info")
+        }
+    });
 
     tracing_subscriber::registry()
         .with(fmt::layer())
@@ -53,24 +70,70 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     info!("Starting BTC testnet4 monitor");
+    let mut testnet_peers = Vec::new();
 
-    // Known working testnet4 peers (using socket addresses)
-    let testnet_peers = vec![
-        // seed.testnet4.bitcoin.sprovoost.nl:48333
-        TrustedPeer::from("37.27.3.75:48333".parse::<SocketAddr>()?),
-        // seed.testnet4.wiz.biz:48333
-        TrustedPeer::from("5.9.138.70:48333".parse::<SocketAddr>()?),
-        // Additional hardcoded testnet4 nodes (if available)
-        // These IPs are examples and may change
-        TrustedPeer::from("23.137.57.100:48333".parse::<SocketAddr>()?),
-        TrustedPeer::from("91.83.65.73:48333".parse::<SocketAddr>()?),
+    // Attempt to resolve DNS seeds
+    let dns_seeds = [
+        "seed.testnet4.bitcoin.sprovoost.nl",
+        "seed.testnet4.wiz.biz",
     ];
+    for seed in dns_seeds {
+        info!("Resolving seed: {}", seed);
+        match (seed, 48333).to_socket_addrs() {
+            Ok(addrs) => {
+                let mut count = 0;
+                for addr in addrs {
+                    testnet_peers.push(TrustedPeer::from(addr));
+                    count += 1;
+                }
+                info!("  Found {} peers from {}", count, seed);
+            }
+            Err(e) => {
+                error!("  Failed to resolve {}: {}", seed, e);
+            }
+        }
+    }
+
+    // Fallback to hardcoded peers if DNS resolution yields few results
+    if testnet_peers.is_empty() {
+        info!("No peers found via DNS. using fallback hardcoded peers.");
+        let fallback_peers = vec![
+            "178.63.87.163:48333",
+            "91.83.65.73:48333",
+            "54.74.158.50:48333",
+            "148.135.67.253:48333",
+            "80.253.94.252:48333",
+        ];
+
+        for peer_str in fallback_peers {
+            if let Ok(addr) = peer_str.parse::<SocketAddr>() {
+                testnet_peers.push(TrustedPeer::from(addr));
+            }
+        }
+    }
+
+    if testnet_peers.is_empty() {
+        error!("No peers found. The monitor cannot start.");
+        return Err("No peers available".into());
+    }
+
+    let bitcoind_auth = match (args.bitcoind_user, args.bitcoind_password) {
+        (Some(user), Some(pass)) => bitcoincore_rpc::Auth::UserPass(user, pass),
+        (None, None) => bitcoincore_rpc::Auth::None,
+        _ => {
+            eprintln!(
+                "Error: Both --bitcoind-user and --bitcoind-password must be provided together"
+            );
+            std::process::exit(1);
+        }
+    };
 
     let config = MonitorConfig::builder()
         .network(Network::Testnet4)
         .confirmation_threshold(args.confirmations)
         .trusted_peers(testnet_peers)
         .start_height(args.start_height)
+        .bitcoind_rpc_config(args.bitcoind_url.clone(), bitcoind_auth)
         .build();
 
     info!("Monitor configuration:");
@@ -80,6 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.confirmation_threshold
     );
     info!("  Starting height: {}", config.start_height);
+    info!("  bitcoind RPC URL: {}", config.bitcoind_rpc_url);
     info!("  Initial peers: {}", config.trusted_peers.len());
     info!("  Peer addresses:");
     for peer in &config.trusted_peers {
@@ -88,19 +152,66 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create and start the monitor
     info!("Starting monitor...");
-    let _monitor_client = Monitor::run(config)?;
+    let monitor_client = Monitor::run(config)?;
 
-    // The monitor is now running in background tasks
-    // In a real application, you would use monitor_client to interact with it
+    info!("Monitor is running.");
+    info!("Enter Bitcoin OutPoints in the format 'txid:vout' to confirm deposits.");
+    info!("Press Ctrl-C to exit.");
+    println!();
 
-    info!("Monitor is running. Press Ctrl-C to stop.");
+    // Interactive loop to accept OutPoint inputs
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
 
-    // Wait for ctrl-c
-    tokio::signal::ctrl_c().await?;
-    info!("Received shutdown signal");
+    loop {
+        print!("Enter OutPoint (txid:vout): ");
+        stdout.flush()?;
 
-    // In a real application, you would properly shutdown the monitor here
-    // For now, the tasks will be cancelled when the program exits
+        let mut input = String::new();
+        match stdin.read_line(&mut input) {
+            Ok(0) => {
+                // EOF reached
+                break;
+            }
+            Ok(_) => {
+                let input = input.trim();
+                if input.is_empty() {
+                    continue;
+                }
 
+                // Parse the OutPoint
+                match bitcoin::OutPoint::from_str(input) {
+                    Ok(outpoint) => {
+                        info!("Confirming deposit for OutPoint: {}", outpoint);
+
+                        // Spawn a task to confirm the deposit
+                        let client = monitor_client.clone();
+                        tokio::spawn(async move {
+                            match client.confirm_deposit(outpoint).await {
+                                Ok(txout) => {
+                                    info!("✓ Deposit confirmed for {}", outpoint);
+                                    info!("  Value: {} sats", txout.value.to_sat());
+                                    info!("  Script: {}", txout.script_pubkey);
+                                }
+                                Err(e) => {
+                                    error!("✗ Failed to confirm deposit for {}: {}", outpoint, e);
+                                }
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        eprintln!("Error: Invalid OutPoint format: {}", e);
+                        eprintln!("Expected format: txid:vout (e.g., abcd1234...:0)");
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to read input: {}", e);
+                break;
+            }
+        }
+    }
+
+    info!("Exiting...");
     Ok(())
 }

--- a/crates/hashi-btc/src/monitor.rs
+++ b/crates/hashi-btc/src/monitor.rs
@@ -154,14 +154,25 @@ impl Monitor {
     }
 
     fn confirm_deposit(&mut self, pending_deposit: PendingDeposit) {
+        debug!(
+            "Processing deposit confirmation for {}",
+            pending_deposit.outpoint.txid
+        );
+
         let Some(tip) = &self.tip else {
-            // Can't confirm a deposit if we don't yet know the tip of the chain.
+            debug!(
+                "Transaction {} confirmation on hold, pending chain tip update.",
+                pending_deposit.outpoint.txid
+            );
             self.pending_deposits.push(pending_deposit);
             return;
         };
 
         if pending_deposit.checked_at_height >= tip.height {
-            // Deposit not yet confirmed. Wait for more blocks.
+            debug!(
+                "Transaction {} already checked at height {}. Waiting for more blocks.",
+                pending_deposit.outpoint.txid, pending_deposit.checked_at_height
+            );
             self.pending_deposits.push(pending_deposit);
             return;
         }
@@ -202,6 +213,10 @@ impl Monitor {
             return;
         };
 
+        info!(
+            "Reprocessing {} pending deposits",
+            self.pending_deposits.len()
+        );
         for pending_deposit in std::mem::take(&mut self.pending_deposits) {
             tokio::spawn(Monitor::process_pending_deposit(
                 tip.to_owned(),
@@ -234,6 +249,10 @@ impl Monitor {
         let block_info = match pending_deposit.block_info {
             Some(block_info) => block_info,
             None => {
+                debug!(
+                    "Looking up block for transaction {}",
+                    pending_deposit.outpoint.txid
+                );
                 let tx_info = match bitcoind_rpc
                     .get_raw_transaction_info(&pending_deposit.outpoint.txid, None)
                 {
@@ -290,7 +309,11 @@ impl Monitor {
         };
 
         // Check if the deposit has enough confirmations yet.
-        if block_info.height < tip.height - confirmation_threshold {
+        if block_info.height > tip.height - confirmation_threshold - 1 {
+            debug!(
+                "Transaction {} is not yet confirmed. Block height is {}, tip is {}. Waiting for more blocks.",
+                pending_deposit.outpoint.txid, block_info.height, tip.height
+            );
             return;
         }
 
@@ -396,6 +419,7 @@ impl Drop for PendingDepositGuard {
     }
 }
 
+#[derive(Clone)]
 pub struct MonitorClient {
     tx: tokio::sync::mpsc::Sender<MonitorMessage>,
 }


### PR DESCRIPTION
- Adds integration with bitcoind
- Looks up peers from DNS (hard coded IPs become out of date)
- Adds feature to confirm deposits based on txid:vout entry

In `monitor.rs` also:
- Adds more logging
- Fixes a bug in calculation of deposit confirmations