### PR TITLE
Include encryption_public_key in CommitteeMember

### DIFF
--- a/crates/hashi/src/committee.rs
+++ b/crates/hashi/src/committee.rs
@@ -10,6 +10,11 @@ use std::collections::HashMap;
 use sui_crypto::SignatureError;
 use sui_sdk_types::Address;
 
+pub type EncryptionPrivateKey =
+    fastcrypto_tbls::ecies_v1::PrivateKey<crate::dkg::EncryptionGroupElement>;
+pub type EncryptionPublicKey =
+    fastcrypto_tbls::ecies_v1::PublicKey<crate::dkg::EncryptionGroupElement>;
+
 /// A thin wrapper around min_pk::BLS12381PrivateKey needed to implement Clone.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Bls12381PrivateKey(min_pk::BLS12381PrivateKey);
@@ -54,17 +59,18 @@ impl Bls12381PrivateKey {
 }
 
 #[derive(Debug, Clone)]
-pub struct BlsCommittee {
+pub struct Committee {
     epoch: u64,
-    members: Vec<BlsCommitteeMember>,
+    members: Vec<CommitteeMember>,
     address_to_index: HashMap<Address, usize>,
     total_weight: u64,
 }
 
 #[derive(Debug, Clone)]
-pub struct BlsCommitteeMember {
+pub struct CommitteeMember {
     address: Address,
     public_key: BLS12381PublicKey,
+    encryption_public_key: EncryptionPublicKey,
     weight: u64,
 }
 
@@ -97,8 +103,8 @@ impl MemberSignature {
     }
 }
 
-impl BlsCommittee {
-    pub fn new(members: Vec<BlsCommitteeMember>, epoch: u64) -> Self {
+impl Committee {
+    pub fn new(members: Vec<CommitteeMember>, epoch: u64) -> Self {
         let total_weight = members.iter().map(|member| member.weight).sum();
         let address_to_index = members
             .iter()
@@ -113,7 +119,7 @@ impl BlsCommittee {
         }
     }
 
-    pub fn members(&self) -> &[BlsCommitteeMember] {
+    pub fn members(&self) -> &[CommitteeMember] {
         &self.members
     }
 
@@ -122,7 +128,7 @@ impl BlsCommittee {
         self.total_weight
     }
 
-    fn member(&self, address: &Address) -> Result<&BlsCommitteeMember, SignatureError> {
+    fn member(&self, address: &Address) -> Result<&CommitteeMember, SignatureError> {
         let index = self
             .address_to_index
             .get(address)
@@ -139,7 +145,7 @@ impl BlsCommittee {
         self.address_to_index.get(address).copied()
     }
 
-    /// Verify a single signature provided by a [BlsCommitteeMember].
+    /// Verify a single signature provided by a [CommitteeMember].
     fn verify<T: Serialize>(
         &self,
         message: &T,
@@ -201,11 +207,17 @@ impl BlsCommittee {
     }
 }
 
-impl BlsCommitteeMember {
-    pub fn new(address: Address, public_key: BLS12381PublicKey, weight: u64) -> Self {
+impl CommitteeMember {
+    pub fn new(
+        address: Address,
+        public_key: BLS12381PublicKey,
+        encryption_public_key: EncryptionPublicKey,
+        weight: u64,
+    ) -> Self {
         Self {
             address,
             public_key,
+            encryption_public_key,
             weight,
         }
     }
@@ -216,6 +228,10 @@ impl BlsCommitteeMember {
 
     pub fn public_key(&self) -> &BLS12381PublicKey {
         &self.public_key
+    }
+
+    pub fn encryption_public_key(&self) -> &EncryptionPublicKey {
+        &self.encryption_public_key
     }
 
     pub fn weight(&self) -> u64 {
@@ -234,7 +250,7 @@ pub struct CommitteeSignature<T> {
 impl<T> CommitteeSignature<T> {
     /// Verify that the committee could be used to verify this certificate, e.g., that the epoch and
     /// the number of signers match.
-    fn verify_committee(&self, committee: &BlsCommittee) -> Result<(), SignatureError> {
+    fn verify_committee(&self, committee: &Committee) -> Result<(), SignatureError> {
         if committee.epoch != self.epoch || self.signers_bitmap.size != committee.members.len() {
             return Err(SignatureError::from_source(
                 "committee signature does not match committee",
@@ -244,7 +260,7 @@ impl<T> CommitteeSignature<T> {
     }
 
     /// The committee members included in this signature.
-    pub fn signers(&self, committee: &BlsCommittee) -> Result<Vec<Address>, SignatureError> {
+    pub fn signers(&self, committee: &Committee) -> Result<Vec<Address>, SignatureError> {
         self.verify_committee(committee)?;
         Ok(self
             .signers_bitmap
@@ -254,7 +270,7 @@ impl<T> CommitteeSignature<T> {
     }
 
     /// The total weight of the signers of this signature.
-    pub fn weight(&self, committee: &BlsCommittee) -> Result<u64, SignatureError> {
+    pub fn weight(&self, committee: &Committee) -> Result<u64, SignatureError> {
         self.verify_committee(committee)?;
         Ok(self
             .signers_bitmap
@@ -267,7 +283,7 @@ impl<T> CommitteeSignature<T> {
     pub fn is_signer(
         &self,
         address: &Address,
-        committee: &BlsCommittee,
+        committee: &Committee,
     ) -> Result<bool, SignatureError> {
         self.verify_committee(committee)?;
         let index = committee
@@ -280,7 +296,7 @@ impl<T> CommitteeSignature<T> {
 
 #[derive(Debug)]
 pub struct BlsSignatureAggregator<'a, T> {
-    committee: &'a BlsCommittee,
+    committee: &'a Committee,
     aggregate_signature: Option<BLS12381AggregateSignature>,
     bitmap: BitMap,
     signed_weight: u64,
@@ -288,7 +304,7 @@ pub struct BlsSignatureAggregator<'a, T> {
 }
 
 impl<'a, T: Serialize + Clone> BlsSignatureAggregator<'a, T> {
-    pub fn new(committee: &'a BlsCommittee, message: T) -> Self {
+    pub fn new(committee: &'a Committee, message: T) -> Self {
         Self {
             bitmap: BitMap::new(committee.size()),
             committee,
@@ -485,16 +501,24 @@ mod test {
             .map(|(i, _)| Address::new([i as u8; 32]))
             .collect::<Vec<_>>();
 
+        let mut rng = rand::thread_rng();
+        let encryption_public_keys: Vec<EncryptionPublicKey> = private_keys
+            .iter()
+            .enumerate()
+            .map(|_| EncryptionPublicKey::from_private_key(&EncryptionPrivateKey::new(&mut rng)))
+            .collect();
+
         let members = private_keys
             .iter()
             .enumerate()
-            .map(|(i, key)| BlsCommitteeMember {
+            .map(|(i, key)| CommitteeMember {
                 address: addresses[i],
                 public_key: key.public_key(),
+                encryption_public_key: encryption_public_keys[i].clone(),
                 weight: 1,
             })
             .collect();
-        let committee = BlsCommittee::new(members, epoch);
+        let committee = Committee::new(members, epoch);
 
         let mut aggregator = BlsSignatureAggregator::new(&committee, message.clone());
 
@@ -574,16 +598,24 @@ mod test {
             .map(|(i, _)| Address::new([i as u8; 32]))
             .collect::<Vec<_>>();
 
+        let mut rng = rand::thread_rng();
+        let encryption_public_keys: Vec<EncryptionPublicKey> = private_keys
+            .iter()
+            .enumerate()
+            .map(|_| EncryptionPublicKey::from_private_key(&EncryptionPrivateKey::new(&mut rng)))
+            .collect();
+
         let members = private_keys
             .iter()
             .enumerate()
-            .map(|(i, key)| BlsCommitteeMember {
+            .map(|(i, key)| CommitteeMember {
                 address: addresses[i],
                 public_key: key.public_key(),
+                encryption_public_key: encryption_public_keys[i].clone(),
                 weight: 1,
             })
             .collect();
-        let committee = BlsCommittee::new(members, epoch);
+        let committee = Committee::new(members, epoch);
 
         let mut aggregator = BlsSignatureAggregator::new(&committee, message.clone());
 
@@ -613,13 +645,14 @@ mod test {
         assert!(certificate.is_signer(&unknown_address, &committee).is_err());
 
         // Test is_signer returns error for wrong committee (different epoch)
-        let wrong_committee = BlsCommittee::new(
+        let wrong_committee = Committee::new(
             private_keys
                 .iter()
                 .enumerate()
-                .map(|(i, key)| BlsCommitteeMember {
+                .map(|(i, key)| CommitteeMember {
                     address: addresses[i],
                     public_key: key.public_key(),
+                    encryption_public_key: encryption_public_keys[i].clone(),
                     weight: 1,
                 })
                 .collect(),

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -1,10 +1,8 @@
 use std::net::SocketAddr;
-
-use crate::dkg::EncryptionGroupElement;
 use sui_crypto::ed25519::Ed25519PrivateKey;
 use sui_sdk_types::Address;
 
-use crate::bls::Bls12381PrivateKey;
+use crate::committee::{Bls12381PrivateKey, EncryptionPrivateKey, EncryptionPublicKey};
 
 #[derive(Clone, Debug, Default, serde_derive::Deserialize, serde_derive::Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -13,8 +11,7 @@ pub struct Config {
     pub protocol_private_key: Option<Bls12381PrivateKey>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub encryption_private_key:
-        Option<fastcrypto_tbls::ecies_v1::PrivateKey<EncryptionGroupElement>>,
+    pub encryption_private_key: Option<EncryptionPrivateKey>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls_private_key: Option<String>,
@@ -100,20 +97,16 @@ impl Config {
         Ok(ed25519_dalek::VerifyingKey::from(&tls_private_key))
     }
 
-    pub fn encryption_private_key(
-        &self,
-    ) -> Result<fastcrypto_tbls::ecies_v1::PrivateKey<EncryptionGroupElement>, anyhow::Error> {
+    pub fn encryption_private_key(&self) -> Result<EncryptionPrivateKey, anyhow::Error> {
         self.encryption_private_key
             .clone()
             .ok_or_else(|| anyhow::anyhow!("no encryption_private_key configured"))
     }
 
-    pub fn encryption_public_key(
-        &self,
-    ) -> Result<fastcrypto_tbls::ecies_v1::PublicKey<EncryptionGroupElement>, anyhow::Error> {
+    pub fn encryption_public_key(&self) -> Result<EncryptionPublicKey, anyhow::Error> {
         let encryption_private_key = self.encryption_private_key()?;
 
-        Ok(fastcrypto_tbls::ecies_v1::PublicKey::from_private_key(
+        Ok(EncryptionPublicKey::from_private_key(
             &encryption_private_key,
         ))
     }
@@ -206,9 +199,7 @@ impl Config {
         );
 
         config.protocol_private_key = Some(Bls12381PrivateKey::generate(&mut rand::thread_rng()));
-        config.encryption_private_key = Some(fastcrypto_tbls::ecies_v1::PrivateKey::new(
-            &mut rand::thread_rng(),
-        ));
+        config.encryption_private_key = Some(EncryptionPrivateKey::new(&mut rand::thread_rng()));
 
         config.https_address = Some(SocketAddr::from(([127, 0, 0, 1], get_available_port())));
         config.http_address = Some(SocketAddr::from(([127, 0, 0, 1], get_available_port())));

--- a/crates/hashi/src/dkg/mod.rs
+++ b/crates/hashi/src/dkg/mod.rs
@@ -3,7 +3,7 @@
 pub mod rpc;
 pub mod types;
 
-use crate::bls::{BlsCommittee, BlsSignatureAggregator};
+use crate::committee::{BlsSignatureAggregator, Committee};
 use crate::communication::{ChannelResult, P2PChannel, with_timeout_and_retry};
 use crate::dkg::types::MpcMessageV1::Dkg;
 use crate::dkg::types::{Certificate, DkgDealerMessageHash};
@@ -39,8 +39,8 @@ pub struct DkgManager {
     pub dkg_config: DkgConfig,
     pub session_id: SessionId,
     pub encryption_key: PrivateKey<EncryptionGroupElement>,
-    pub bls_signing_key: crate::bls::Bls12381PrivateKey,
-    pub bls_committee: BlsCommittee,
+    pub bls_signing_key: crate::committee::Bls12381PrivateKey,
+    pub committee: Committee,
 
     // Mutable during the epoch
     pub dealer_outputs: HashMap<Address, avss::PartialOutput>,
@@ -57,31 +57,20 @@ impl DkgManager {
         committee_set: &CommitteeSet,
         session_id: SessionId,
         encryption_key: PrivateKey<EncryptionGroupElement>,
-        bls_signing_key: crate::bls::Bls12381PrivateKey,
+        bls_signing_key: crate::committee::Bls12381PrivateKey,
         public_message_store: Box<dyn PublicMessagesStore>,
     ) -> DkgResult<Self> {
-        let bls_committee = committee_set
+        let committee = committee_set
             .current_committee()
             .ok_or_else(|| DkgError::InvalidConfig("no committee for current epoch".into()))?
             .clone();
-        let mut nodes_vec = Vec::with_capacity(bls_committee.members().len());
-        for (index, member) in bls_committee.members().iter().enumerate() {
-            let addr = member.validator_address();
-            let member_info = committee_set
-                .members()
-                .get(&addr)
-                .expect("committee member missing - on-chain invariant violation");
-            // Use fallback key for nodes without valid encryption key.
-            // These nodes cannot decrypt shares but still count toward thresholds.
-            let encryption_pk = member_info
-                .next_epoch_encryption_public_key
-                .clone()
-                .unwrap_or_else(fallback_encryption_public_key);
+        let mut nodes_vec = Vec::with_capacity(committee.members().len());
+        for (index, member) in committee.members().iter().enumerate() {
             let party_id = index as u16;
             debug_assert_eq!(party_id as usize, nodes_vec.len());
             nodes_vec.push(Node {
                 id: party_id,
-                pk: encryption_pk,
+                pk: member.encryption_public_key().to_owned(),
                 weight: member.weight() as u16,
             });
         }
@@ -92,7 +81,7 @@ impl DkgManager {
         let max_faulty = (total_weight - 1) / 3;
         let threshold = max_faulty + 1;
         let dkg_config = DkgConfig::new(committee_set.epoch(), nodes, threshold, max_faulty)?;
-        let party_id = bls_committee
+        let party_id = committee
             .index_of(&address)
             .expect("address not in committee") as u16;
         Ok(Self {
@@ -102,7 +91,7 @@ impl DkgManager {
             session_id,
             encryption_key,
             bls_signing_key,
-            bls_committee,
+            committee,
             dealer_outputs: HashMap::new(),
             dealer_messages: HashMap::new(),
             message_responses: HashMap::new(),
@@ -222,7 +211,7 @@ impl DkgManager {
             .expect("own message should always be valid");
         let message_hash = compute_message_hash(&dealer_message);
         let mut aggregator = BlsSignatureAggregator::new(
-            &self.bls_committee,
+            &self.committee,
             Dkg(DkgDealerMessageHash {
                 dealer_address: self.address,
                 message_hash,
@@ -232,7 +221,7 @@ impl DkgManager {
             .add_signature_from(self.address, my_signature.clone())
             .expect("first signature should always be valid");
         let recipients: Vec<_> = self
-            .bls_committee
+            .committee
             .members()
             .iter()
             .map(|m| m.validator_address())
@@ -289,7 +278,7 @@ impl DkgManager {
                     if certified_dealers.contains_key(&dealer) {
                         continue;
                     }
-                    if let Err(e) = self.bls_committee.verify_signature(&cert) {
+                    if let Err(e) = self.committee.verify_signature(&cert) {
                         tracing::info!("Invalid certificate signature from {:?}: {}", &dealer, e);
                         continue;
                     }
@@ -323,13 +312,13 @@ impl DkgManager {
                     if self.complaints_to_process.contains_key(&dealer) {
                         self.recover_shares_via_complaint(
                             &dealer,
-                            cert.signers(&self.bls_committee)
+                            cert.signers(&self.committee)
                                 .expect("certificate verified above"),
                             p2p_channel,
                         )
                         .await?;
                     }
-                    let dealer_weight = self.bls_committee.weight_of(&dealer).map_err(|_| {
+                    let dealer_weight = self.committee.weight_of(&dealer).map_err(|_| {
                         DkgError::ProtocolFailed("Missing dealer weight".parse().unwrap())
                     })?;
                     dealer_weight_sum += dealer_weight as u32;
@@ -433,7 +422,7 @@ impl DkgManager {
             .keys()
             .map(|dealer| {
                 let dealer_party_id = self
-                    .bls_committee
+                    .committee
                     .index_of(dealer)
                     .expect("certified dealer must be committee member")
                     as u16;
@@ -474,7 +463,7 @@ impl DkgManager {
         // - Round 2: Call 2-3 more signers, wait ~2s
         // - and so on
         if certificate
-            .is_signer(&self.address, &self.bls_committee)
+            .is_signer(&self.address, &self.committee)
             .map_err(|e| DkgError::CryptoError(e.to_string()))?
         {
             tracing::error!(
@@ -485,7 +474,7 @@ impl DkgManager {
                 "Self in certificate signers but message not available".to_string(),
             ));
         }
-        let signers = certificate.signers(&self.bls_committee).map_err(|_| {
+        let signers = certificate.signers(&self.committee).map_err(|_| {
             DkgError::ProtocolFailed(
                 "Certificate does not match the current epoch or committee".to_string(),
             )
@@ -591,7 +580,7 @@ impl DkgManager {
 }
 
 /// TODO: Replace generator with a nothing-up-my-sleeve point with unknown discrete log.
-fn fallback_encryption_public_key() -> PublicKey<EncryptionGroupElement> {
+pub fn fallback_encryption_public_key() -> PublicKey<EncryptionGroupElement> {
     PublicKey::from(EncryptionGroupElement::generator())
 }
 
@@ -621,14 +610,13 @@ async fn send_dkg_message_to_many(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bls::{BlsCommittee, BlsCommitteeMember, MemberSignature};
+    use crate::committee::{Committee, CommitteeMember, EncryptionPublicKey, MemberSignature};
     use crate::dkg::types::ProtocolType;
     use crate::onchain::types::MemberInfo;
     use fastcrypto::encoding::Encoding;
     use fastcrypto::encoding::Hex;
     use fastcrypto::groups::Scalar;
     use fastcrypto_tbls::ecies_v1::MultiRecipientEncryption;
-    use fastcrypto_tbls::ecies_v1::PublicKey;
     use fastcrypto_tbls::polynomial::Poly;
     use fastcrypto_tbls::random_oracle::RandomOracle;
     use fastcrypto_tbls::threshold_schnorr::avss;
@@ -671,7 +659,7 @@ mod tests {
     struct TestSetup {
         pub committee_set: CommitteeSet,
         pub encryption_keys: Vec<PrivateKey<EncryptionGroupElement>>,
-        pub bls_keys: Vec<crate::bls::Bls12381PrivateKey>,
+        pub bls_keys: Vec<crate::committee::Bls12381PrivateKey>,
     }
 
     impl TestSetup {
@@ -683,13 +671,13 @@ mod tests {
                 .collect();
 
             let bls_keys: Vec<_> = (0..num_validators)
-                .map(|_| crate::bls::Bls12381PrivateKey::generate(&mut rng))
+                .map(|_| crate::committee::Bls12381PrivateKey::generate(&mut rng))
                 .collect();
 
             let epoch = 100u64;
 
             // Build MemberInfo for each validator
-            let members: BTreeMap<Address, MemberInfo> = (0..num_validators)
+            let member_infos: BTreeMap<Address, MemberInfo> = (0..num_validators)
                 .map(|i| {
                     let addr = Address::new([i as u8; 32]);
                     let next_epoch_encryption_public_key =
@@ -706,22 +694,27 @@ mod tests {
                 })
                 .collect();
 
-            // Build BlsCommittee
-            let bls_members: Vec<_> = (0..num_validators)
+            // Build Committee
+            let members: Vec<_> = (0..num_validators)
                 .map(|i| {
                     let addr = Address::new([i as u8; 32]);
-                    BlsCommitteeMember::new(addr, bls_keys[i].public_key(), 1)
+                    CommitteeMember::new(
+                        addr,
+                        bls_keys[i].public_key(),
+                        EncryptionPublicKey::from_private_key(&encryption_keys[i]),
+                        1,
+                    )
                 })
                 .collect();
-            let bls_committee = BlsCommittee::new(bls_members, epoch);
+            let committee = Committee::new(members, epoch);
 
             let mut committees = BTreeMap::new();
-            committees.insert(epoch, bls_committee);
+            committees.insert(epoch, committee);
 
             let mut committee_set = CommitteeSet::new(Address::ZERO, Address::ZERO);
             committee_set
                 .set_epoch(epoch)
-                .set_members(members)
+                .set_members(member_infos)
                 .set_committees(committees);
 
             Self {
@@ -740,13 +733,13 @@ mod tests {
                 .collect();
 
             let bls_keys: Vec<_> = (0..num_validators)
-                .map(|_| crate::bls::Bls12381PrivateKey::generate(&mut rng))
+                .map(|_| crate::committee::Bls12381PrivateKey::generate(&mut rng))
                 .collect();
 
             let epoch = 100u64;
 
             // Build MemberInfo for each validator
-            let members: BTreeMap<Address, MemberInfo> = (0..num_validators)
+            let member_infos: BTreeMap<Address, MemberInfo> = (0..num_validators)
                 .map(|i| {
                     let addr = Address::new([i as u8; 32]);
                     let next_epoch_encryption_public_key =
@@ -763,22 +756,28 @@ mod tests {
                 })
                 .collect();
 
-            // Build BlsCommittee with custom weights
-            let bls_members: Vec<_> = (0..num_validators)
+            // Build Committee with custom weights
+            let members: Vec<_> = (0..num_validators)
                 .map(|i| {
                     let addr = Address::new([i as u8; 32]);
-                    BlsCommitteeMember::new(addr, bls_keys[i].public_key(), weights[i].into())
+                    let encryption_public_key = PublicKey::from_private_key(&encryption_keys[i]);
+                    CommitteeMember::new(
+                        addr,
+                        bls_keys[i].public_key(),
+                        encryption_public_key,
+                        weights[i].into(),
+                    )
                 })
                 .collect();
-            let bls_committee = BlsCommittee::new(bls_members, epoch);
+            let committee = Committee::new(members, epoch);
 
             let mut committees = BTreeMap::new();
-            committees.insert(epoch, bls_committee);
+            committees.insert(epoch, committee);
 
             let mut committee_set = CommitteeSet::new(Address::ZERO, Address::ZERO);
             committee_set
                 .set_epoch(epoch)
-                .set_members(members)
+                .set_members(member_infos)
                 .set_committees(committees);
 
             Self {
@@ -826,7 +825,7 @@ mod tests {
             )
         }
 
-        fn bls_committee(&self) -> &BlsCommittee {
+        fn committee(&self) -> &Committee {
             self.committee_set.current_committee().unwrap()
         }
 
@@ -856,7 +855,7 @@ mod tests {
     }
 
     fn create_test_certificate(
-        bls_committee: &BlsCommittee,
+        committee: &Committee,
         dealer_message: &avss::Message,
         dealer_address: Address,
         signatures: Vec<MemberSignature>,
@@ -866,7 +865,7 @@ mod tests {
             dealer_address,
             message_hash,
         });
-        let mut aggregator = BlsSignatureAggregator::new(bls_committee, dkg_message);
+        let mut aggregator = BlsSignatureAggregator::new(committee, dkg_message);
         for signature in signatures {
             aggregator
                 .add_signature(signature)
@@ -1331,103 +1330,7 @@ mod tests {
         // Verify DkgConfig was built correctly
         assert_eq!(manager.dkg_config.epoch, setup.epoch());
         assert_eq!(manager.dkg_config.nodes.num_nodes(), 5);
-        assert_eq!(manager.bls_committee.members().len(), 5);
-    }
-
-    #[test]
-    fn test_dkg_manager_uses_fallback_key_for_members_without_encryption_key() {
-        let mut rng = rand::thread_rng();
-
-        // Create a custom CommitteeSet where one member lacks encryption key
-        let num_validators = 5;
-        let encryption_keys: Vec<_> = (0..num_validators)
-            .map(|_| PrivateKey::<EncryptionGroupElement>::new(&mut rng))
-            .collect();
-        let bls_keys: Vec<_> = (0..num_validators)
-            .map(|_| crate::bls::Bls12381PrivateKey::generate(&mut rng))
-            .collect();
-
-        let epoch = 100u64;
-
-        // Build MemberInfo - validator 2 has NO encryption key
-        let members: BTreeMap<Address, MemberInfo> = (0..num_validators)
-            .map(|i| {
-                let addr = Address::new([i as u8; 32]);
-                let next_epoch_encryption_public_key = if i == 2 {
-                    None // No encryption key for validator 2
-                } else {
-                    Some(PublicKey::from_private_key(&encryption_keys[i]))
-                };
-                let member_info = MemberInfo {
-                    validator_address: addr,
-                    operator_address: addr,
-                    next_epoch_public_key: bls_keys[i].public_key(),
-                    https_address: None,
-                    tls_public_key: None,
-                    next_epoch_encryption_public_key,
-                };
-                (addr, member_info)
-            })
-            .collect();
-
-        // Build BlsCommittee (all validators included)
-        let bls_members: Vec<_> = (0..num_validators)
-            .map(|i| {
-                let addr = Address::new([i as u8; 32]);
-                BlsCommitteeMember::new(addr, bls_keys[i].public_key(), 1)
-            })
-            .collect();
-        let bls_committee = BlsCommittee::new(bls_members, epoch);
-
-        let mut committees = BTreeMap::new();
-        committees.insert(epoch, bls_committee);
-
-        let mut committee_set = CommitteeSet::new(Address::ZERO, Address::ZERO);
-        committee_set
-            .set_epoch(epoch)
-            .set_members(members)
-            .set_committees(committees);
-
-        // Create manager for validator 0
-        let session_id = SessionId::new("test", epoch, &ProtocolType::DkgKeyGeneration);
-        let manager = DkgManager::new(
-            Address::new([0; 32]),
-            &committee_set,
-            session_id,
-            encryption_keys[0].clone(),
-            bls_keys[0].clone(),
-            Box::new(MockPublicMessagesStore),
-        )
-        .expect("Should create manager");
-
-        // All 5 validators should be in DKG (validator 2 gets fallback key)
-        assert_eq!(
-            manager.dkg_config.nodes.num_nodes(),
-            5,
-            "All members should be included (missing keys get fallback)"
-        );
-
-        // Validator 2 should have the fallback encryption key
-        let node2 = manager.dkg_config.nodes.node_id_to_node(2).unwrap();
-        assert_eq!(
-            node2.pk,
-            fallback_encryption_public_key(),
-            "Validator without encryption key should have fallback key"
-        );
-
-        // Party IDs should match committee indices
-        assert_eq!(
-            manager.bls_committee.index_of(&Address::new([0; 32])),
-            Some(0)
-        );
-        assert_eq!(
-            manager.bls_committee.index_of(&Address::new([2; 32])),
-            Some(2)
-        );
-
-        // Threshold should be based on all 5 validators: (5-1)/3 + 1 = 2
-        assert_eq!(manager.dkg_config.threshold, 2);
-        assert_eq!(manager.dkg_config.max_faulty, 1);
+        assert_eq!(manager.committee.members().len(), 5);
     }
 
     #[test]
@@ -1438,7 +1341,7 @@ mod tests {
             .map(|_| PrivateKey::<EncryptionGroupElement>::new(&mut rng))
             .collect();
         let bls_keys: Vec<_> = (0..5)
-            .map(|_| crate::bls::Bls12381PrivateKey::generate(&mut rng))
+            .map(|_| crate::committee::Bls12381PrivateKey::generate(&mut rng))
             .collect();
 
         let epoch = 100u64;
@@ -1512,12 +1415,12 @@ mod tests {
                 i
             );
 
-            // Verify the address maps to this party_id via bls_committee
-            let expected_party_id = manager.bls_committee.index_of(&setup.address(i));
+            // Verify the address maps to this party_id via committee
+            let expected_party_id = manager.committee.index_of(&setup.address(i));
             assert_eq!(
                 expected_party_id,
                 Some(i),
-                "bls_committee.index_of should map correctly for validator {}",
+                "committee.index_of should map correctly for validator {}",
                 i
             );
         }
@@ -1695,7 +1598,7 @@ mod tests {
 
             // Create certificate using helper
             let cert = create_test_certificate(
-                setup.bls_committee(),
+                setup.committee(),
                 message,
                 dealer_address,
                 validator_signatures,
@@ -1738,14 +1641,12 @@ mod tests {
 
         // Create certificates (using actual BLS signatures from validator)
         let sig0 = receive_dealer_message(&mut validator, &message0, dealer_addr0).unwrap();
-        let cert0 =
-            create_test_certificate(setup.bls_committee(), &message0, dealer_addr0, vec![sig0])
-                .unwrap();
+        let cert0 = create_test_certificate(setup.committee(), &message0, dealer_addr0, vec![sig0])
+            .unwrap();
 
         let sig1 = receive_dealer_message(&mut validator, &message1, dealer_addr1).unwrap();
-        let cert1 =
-            create_test_certificate(setup.bls_committee(), &message1, dealer_addr1, vec![sig1])
-                .unwrap();
+        let cert1 = create_test_certificate(setup.committee(), &message1, dealer_addr1, vec![sig1])
+            .unwrap();
 
         let mut certificates = HashMap::new();
         certificates.insert(dealer_addr0, cert0);
@@ -1793,9 +1694,8 @@ mod tests {
             }
 
             // Create certificate using helper
-            let cert =
-                create_test_certificate(setup.bls_committee(), message, dealer_addr, signatures)
-                    .unwrap();
+            let cert = create_test_certificate(setup.committee(), message, dealer_addr, signatures)
+                .unwrap();
             certificates.push(cert);
         }
 
@@ -1907,9 +1807,8 @@ mod tests {
                 signatures.push(sig);
             }
 
-            let cert =
-                create_test_certificate(setup.bls_committee(), message, dealer_addr, signatures)
-                    .unwrap();
+            let cert = create_test_certificate(setup.committee(), message, dealer_addr, signatures)
+                .unwrap();
             certificates.push(cert);
         }
 
@@ -2084,9 +1983,8 @@ mod tests {
             }
 
             // Create certificate using helper
-            let cert =
-                create_test_certificate(setup.bls_committee(), message, dealer_addr, signatures)
-                    .unwrap();
+            let cert = create_test_certificate(setup.committee(), message, dealer_addr, signatures)
+                .unwrap();
             certificates.push(cert);
         }
 
@@ -2176,7 +2074,7 @@ mod tests {
         let epoch = setup.epoch();
         // Create certificates with signers (excluding party 2 who has complaint)
         let cert_0 = create_certificate_with_signers(
-            setup.bls_committee(),
+            setup.committee(),
             &dealer_0_addr,
             &dealer_0_message,
             [
@@ -2191,7 +2089,7 @@ mod tests {
         .unwrap();
 
         let cert_1 = create_certificate_with_signers(
-            setup.bls_committee(),
+            setup.committee(),
             &dealer_1_addr,
             &dealer_1_message,
             [
@@ -2272,9 +2170,8 @@ mod tests {
             }
 
             // Create certificate using helper
-            let cert =
-                create_test_certificate(setup.bls_committee(), message, dealer_addr, signatures)
-                    .unwrap();
+            let cert = create_test_certificate(setup.committee(), message, dealer_addr, signatures)
+                .unwrap();
             valid_certificates.push(cert);
         }
 
@@ -2306,7 +2203,7 @@ mod tests {
             .collect();
 
         let invalid_cert = create_test_certificate(
-            setup.bls_committee(),
+            setup.committee(),
             &invalid_dealer_msg,
             dealer_addr_3,
             invalid_signatures,
@@ -2387,9 +2284,8 @@ mod tests {
             }
 
             // Create certificate using helper
-            let cert =
-                create_test_certificate(setup.bls_committee(), message, dealer_addr, signatures)
-                    .unwrap();
+            let cert = create_test_certificate(setup.committee(), message, dealer_addr, signatures)
+                .unwrap();
             certificates.push(cert);
         }
 
@@ -2586,7 +2482,7 @@ mod tests {
 
         // Get the list of signers from the certificate
         let signers = cert
-            .signers(setup.bls_committee())
+            .signers(setup.committee())
             .expect("Failed to get signers from certificate");
 
         // Verify the dealer's own signature is included
@@ -2680,9 +2576,9 @@ mod tests {
         });
 
         let config = setup.dkg_config();
-        let bls_committee = setup.bls_committee();
+        let committee = setup.committee();
         let mut aggregator =
-            crate::bls::BlsSignatureAggregator::new(bls_committee, dkg_message.clone());
+            crate::committee::BlsSignatureAggregator::new(committee, dkg_message.clone());
 
         // Add signatures from validators until we meet the required weight
         let dkg_required = config.threshold;
@@ -2909,11 +2805,9 @@ mod tests {
 
         // Create certificates using the test helper
         let cert1 =
-            create_test_certificate(setup.bls_committee(), &msg1, dealer1_addr, signatures_1)
-                .unwrap();
+            create_test_certificate(setup.committee(), &msg1, dealer1_addr, signatures_1).unwrap();
         let cert2 =
-            create_test_certificate(setup.bls_committee(), &msg2, dealer2_addr, signatures_2)
-                .unwrap();
+            create_test_certificate(setup.committee(), &msg2, dealer2_addr, signatures_2).unwrap();
 
         // Create mock P2P channel with dealers that have messages
         let mut dealers = HashMap::new();
@@ -2991,21 +2885,21 @@ mod tests {
 
         // Create certificates for all three dealers
         let cert1 = create_test_certificate(
-            setup.bls_committee(),
+            setup.committee(),
             &msg1,
             dealer1_addr,
             create_sigs(dealer1_addr, &msg1),
         )
         .unwrap();
         let cert2 = create_test_certificate(
-            setup.bls_committee(),
+            setup.committee(),
             &msg2,
             dealer2_addr,
             create_sigs(dealer2_addr, &msg2),
         )
         .unwrap();
         let cert3 = create_test_certificate(
-            setup.bls_committee(),
+            setup.committee(),
             &msg3,
             dealer3_addr,
             create_sigs(dealer3_addr, &msg3),
@@ -3087,7 +2981,7 @@ mod tests {
         let epoch = setup.epoch();
         // Create certificates with signers (excluding party 2 who has complaint)
         let cert0 = create_certificate_with_signers(
-            setup.bls_committee(),
+            setup.committee(),
             &dealer0_addr,
             &dealer0_message,
             [
@@ -3101,7 +2995,7 @@ mod tests {
         )
         .unwrap();
         let cert1 = create_certificate_with_signers(
-            setup.bls_committee(),
+            setup.committee(),
             &dealer1_addr,
             &dealer1_message,
             [
@@ -3496,9 +3390,9 @@ mod tests {
         });
 
         // Create a minimal certificate
-        let bls_committee = setup.bls_committee();
+        let committee = setup.committee();
         let cert = create_certificate_with_signers(
-            bls_committee,
+            committee,
             &dealer_addr,
             dealer_message,
             [(1usize, party_addr)]
@@ -3515,7 +3409,7 @@ mod tests {
         let result = party_manager
             .recover_shares_via_complaint(
                 &dealer_addr,
-                cert.signers(&party_manager.bls_committee).unwrap(),
+                cert.signers(&party_manager.committee).unwrap(),
                 &mock_p2p,
             )
             .await;
@@ -3777,9 +3671,9 @@ mod tests {
         let dealer_signature = setup.bls_keys[0].sign(setup.epoch(), dealer_address, &dkg_message);
 
         // Create certificate with dealer's signature
-        let bls_committee = setup.bls_committee();
+        let committee = setup.committee();
         let cert = create_certificate_with_signers(
-            bls_committee,
+            committee,
             &dealer_address,
             dealer_message,
             vec![dealer_signature],
@@ -3839,9 +3733,9 @@ mod tests {
             setup.bls_keys[1].sign(setup.epoch(), validator_1_addr, &dkg_message);
         let dealer_signature = setup.bls_keys[0].sign(setup.epoch(), dealer_addr, &dkg_message);
 
-        let bls_committee = setup.bls_committee();
+        let committee = setup.committee();
         let cert = create_certificate_with_signers(
-            bls_committee,
+            committee,
             &dealer_addr,
             dealer_message,
             vec![validator_1_signature, dealer_signature],
@@ -3892,9 +3786,9 @@ mod tests {
         let party_signature = setup.bls_keys[1].sign(setup.epoch(), party_addr, &dkg_message);
         let dealer_signature = setup.bls_keys[0].sign(setup.epoch(), dealer_addr, &dkg_message);
 
-        let bls_committee = setup.bls_committee();
+        let committee = setup.committee();
         let cert = create_certificate_with_signers(
-            bls_committee,
+            committee,
             &dealer_addr,
             dealer_message,
             vec![party_signature, dealer_signature],
@@ -3950,9 +3844,9 @@ mod tests {
         let signer_2_signature = setup.bls_keys[2].sign(setup.epoch(), signer_2_addr, &dkg_message);
         let signer_3_signature = setup.bls_keys[3].sign(setup.epoch(), signer_3_addr, &dkg_message);
 
-        let bls_committee = setup.bls_committee();
+        let committee = setup.committee();
         let cert = create_certificate_with_signers(
-            bls_committee,
+            committee,
             &dealer_addr,
             dealer_message,
             vec![signer_2_signature, signer_3_signature],
@@ -4024,9 +3918,9 @@ mod tests {
             setup.bls_keys[3].sign(setup.epoch(), byzantine_signer_addr, &dkg_message);
         let dealer_a_signature = setup.bls_keys[0].sign(setup.epoch(), dealer_a_addr, &dkg_message);
 
-        let bls_committee = setup.bls_committee();
+        let committee = setup.committee();
         let cert = create_certificate_with_signers(
-            bls_committee,
+            committee,
             &dealer_a_addr,
             &message_a,
             vec![byzantine_signature, dealer_a_signature],
@@ -4052,7 +3946,7 @@ mod tests {
         assert!(party_mgr.dealer_messages.contains_key(&dealer_a_addr));
     }
     fn create_certificate_with_signers(
-        bls_committee: &BlsCommittee,
+        committee: &Committee,
         dealer_address: &Address,
         message: &avss::Message,
         signatures: Vec<MemberSignature>,
@@ -4063,7 +3957,7 @@ mod tests {
             message_hash,
         });
 
-        let mut aggregator = BlsSignatureAggregator::new(bls_committee, dkg_message);
+        let mut aggregator = BlsSignatureAggregator::new(committee, dkg_message);
 
         for signature in signatures {
             aggregator
@@ -4392,7 +4286,7 @@ mod tests {
             dealer_address: dealer_addr,
             message_hash,
         });
-        let committee = setup.bls_committee();
+        let committee = setup.committee();
         let mut aggregator = BlsSignatureAggregator::new(committee, dkg_message);
         for (_, _, sig) in &signers {
             aggregator.add_signature(sig.clone()).unwrap();

--- a/crates/hashi/src/dkg/rpc/proto_conversions.rs
+++ b/crates/hashi/src/dkg/rpc/proto_conversions.rs
@@ -1,4 +1,4 @@
-use crate::bls::BLS12381Signature;
+use crate::committee::BLS12381Signature;
 use crate::dkg::types;
 use crate::proto;
 use fastcrypto::traits::ToFromBytes;

--- a/crates/hashi/src/dkg/types.rs
+++ b/crates/hashi/src/dkg/types.rs
@@ -1,6 +1,6 @@
 //! Core types for the DKG protocol
 
-use crate::bls::{BLS12381Signature, CommitteeSignature};
+use crate::committee::{BLS12381Signature, CommitteeSignature};
 use fastcrypto::error::FastCryptoError;
 use fastcrypto_tbls::nodes::Nodes;
 use fastcrypto_tbls::{
@@ -195,8 +195,7 @@ impl From<crate::communication::ChannelError> for DkgError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fastcrypto::groups::ristretto255::RistrettoPoint;
-    use fastcrypto_tbls::ecies_v1::{PrivateKey, PublicKey};
+    use crate::committee::{EncryptionPrivateKey, EncryptionPublicKey};
     use fastcrypto_tbls::nodes::Node;
 
     impl MpcMessageV1 {
@@ -217,8 +216,8 @@ mod tests {
         party_id: u16,
         weight: u16,
     ) -> (Address, Node<EncryptionGroupElement>) {
-        let private_key = PrivateKey::<RistrettoPoint>::new(&mut rand::thread_rng());
-        let public_key = PublicKey::from_private_key(&private_key);
+        let private_key = EncryptionPrivateKey::new(&mut rand::thread_rng());
+        let public_key = EncryptionPublicKey::from_private_key(&private_key);
         let address = Address::new([party_id as u8; 32]);
         let node = Node {
             id: party_id,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-pub mod bls;
+pub mod committee;
 pub mod communication;
 pub mod config;
 pub mod dkg;

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -21,9 +21,10 @@ use sui_sdk_types::TypeTag;
 use tap::Pipe;
 use tokio::sync::broadcast;
 
-use crate::bls::BlsCommittee;
-use crate::bls::BlsCommitteeMember;
+use crate::committee::Committee;
+use crate::committee::CommitteeMember;
 use crate::config::HashiIds;
+use crate::dkg::fallback_encryption_public_key;
 
 const BROADCAST_CHANNEL_CAPACITY: usize = 100;
 
@@ -331,8 +332,8 @@ async fn scrape_member_info(
 async fn scrape_committees(
     client: Client,
     committees_id: Address,
-) -> Result<BTreeMap<u64, BlsCommittee>> {
-    let committees: BTreeMap<u64, BlsCommittee> = client
+) -> Result<BTreeMap<u64, Committee>> {
+    let committees: BTreeMap<u64, Committee> = client
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(committees_id)
@@ -356,7 +357,7 @@ async fn scrape_committees(
                 .into_iter()
                 .map(convert_move_committee_member)
                 .collect();
-            let committee = BlsCommittee::new(members, move_committee.epoch);
+            let committee = Committee::new(members, move_committee.epoch);
             (move_committee.epoch, committee)
         })
         .try_collect()
@@ -369,13 +370,18 @@ fn convert_move_committee_member(
     move_types::CommitteeMember {
         validator_address,
         public_key,
-        encryption_key: _,
+        encryption_public_key,
         weight,
     }: move_types::CommitteeMember,
-) -> BlsCommitteeMember {
-    BlsCommitteeMember::new(
+) -> CommitteeMember {
+    CommitteeMember::new(
         validator_address,
         convert_move_uncompressed_g1_pubkey(&public_key),
+        // Use fallback key for nodes without valid encryption key.
+        // These nodes cannot decrypt shares but still count toward thresholds.
+        crate::dkg::EncryptionGroupElement::try_from(encryption_public_key.as_slice())
+            .map(Into::into)
+            .unwrap_or_else(|_| fallback_encryption_public_key()),
         weight.into(),
     )
 }
@@ -468,4 +474,67 @@ async fn scrape_utxo_pool(client: Client, utxo_pool_id: Address) -> Result<types
     };
 
     Ok(pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use fastcrypto::{
+        serde_helpers::ToFromByteArray,
+        traits::{KeyPair, ToFromBytes},
+    };
+
+    use crate::dkg::EncryptionGroupElement;
+
+    use super::*;
+
+    #[test]
+    fn test_convert_move_committee_member() {
+        let mut rng = rand::thread_rng();
+        let validator_address =
+            Address::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let bls_keypair = fastcrypto::bls12381::min_pk::BLS12381KeyPair::generate(&mut rng);
+        let encryption_private_key =
+            fastcrypto_tbls::ecies_v1::PrivateKey::<EncryptionGroupElement>::new(&mut rng);
+        let encryption_public_key =
+            fastcrypto_tbls::ecies_v1::PublicKey::from_private_key(&encryption_private_key);
+
+        let move_committee_member = move_types::CommitteeMember {
+            validator_address,
+            public_key: bls_keypair.public().as_bytes().to_owned(),
+            encryption_public_key: encryption_public_key.as_element().to_byte_array().into(),
+            weight: 1,
+        };
+        let committee_member = convert_move_committee_member(move_committee_member);
+
+        assert_eq!(committee_member.validator_address(), validator_address);
+        assert_eq!(committee_member.public_key(), bls_keypair.public());
+        assert_eq!(
+            committee_member.encryption_public_key().as_element(),
+            encryption_public_key.as_element()
+        );
+        assert_eq!(committee_member.weight(), 1);
+    }
+
+    #[test]
+    fn test_convert_move_committee_member_uses_fallback_key() {
+        let mut rng = rand::thread_rng();
+        let validator_address =
+            Address::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let bls_keypair = fastcrypto::bls12381::min_pk::BLS12381KeyPair::generate(&mut rng);
+        let mut encryption_key_vec = vec![0u8; 32];
+        encryption_key_vec[0] = 1;
+
+        let move_committee_member = move_types::CommitteeMember {
+            validator_address,
+            public_key: bls_keypair.public().as_bytes().to_owned(),
+            encryption_public_key: encryption_key_vec,
+            weight: 1,
+        };
+        let committee_member = convert_move_committee_member(move_committee_member);
+
+        assert_eq!(
+            *committee_member.encryption_public_key(),
+            fallback_encryption_public_key()
+        )
+    }
 }

--- a/crates/hashi/src/onchain/move_types.rs
+++ b/crates/hashi/src/onchain/move_types.rs
@@ -54,7 +54,7 @@ pub struct MemberInfo {
     /// bls12381 public key to be used in the next epoch.
     ///
     /// The public key for this node which is active in the current epoch can
-    /// be found in the `BlsCommittee` struct.
+    /// be found in the `Committee` struct.
     ///
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
@@ -86,7 +86,7 @@ pub struct MemberInfo {
 pub struct CommitteeMember {
     pub validator_address: Address,
     pub public_key: Vec<u8>, //Element<UncompressedG1>,
-    pub encryption_key: Vec<u8>,
+    pub encryption_public_key: Vec<u8>,
     pub weight: u16,
 }
 

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -8,7 +8,10 @@ use axum::http;
 use fastcrypto::bls12381::min_pk::BLS12381PublicKey;
 use sui_sdk_types::{Address, TypeTag};
 
-use crate::{bls::BlsCommittee, grpc::Client};
+use crate::{
+    committee::{Committee, EncryptionPublicKey},
+    grpc::Client,
+};
 
 #[derive(Debug)]
 pub struct Hashi {
@@ -31,7 +34,7 @@ pub struct CommitteeSet {
     epoch: u64,
     /// Id of the `Bag` containing the committee's per epoch
     committees_id: Address,
-    committees: BTreeMap<u64, BlsCommittee>,
+    committees: BTreeMap<u64, Committee>,
 
     tls_private_key: Option<ed25519_dalek::SigningKey>,
     clients: BTreeMap<Address, Client>,
@@ -55,11 +58,11 @@ impl CommitteeSet {
         &self.members
     }
 
-    pub fn committees(&self) -> &BTreeMap<u64, BlsCommittee> {
+    pub fn committees(&self) -> &BTreeMap<u64, Committee> {
         &self.committees
     }
 
-    pub fn current_committee(&self) -> Option<&BlsCommittee> {
+    pub fn current_committee(&self) -> Option<&Committee> {
         self.committees().get(&self.epoch())
     }
 
@@ -124,7 +127,7 @@ impl CommitteeSet {
         self
     }
 
-    pub fn set_committees(&mut self, committees: BTreeMap<u64, BlsCommittee>) -> &mut Self {
+    pub fn set_committees(&mut self, committees: BTreeMap<u64, Committee>) -> &mut Self {
         self.committees = committees;
         self
     }
@@ -150,7 +153,7 @@ pub struct MemberInfo {
     /// bls12381 public key to be used in the next epoch.
     ///
     /// The public key for this node which is active in the current epoch can
-    /// be found in the `BlsCommittee` struct.
+    /// be found in the `Committee` struct.
     ///
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
@@ -174,8 +177,7 @@ pub struct MemberInfo {
     ///
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
-    pub next_epoch_encryption_public_key:
-        Option<fastcrypto_tbls::ecies_v1::PublicKey<crate::dkg::EncryptionGroupElement>>,
+    pub next_epoch_encryption_public_key: Option<EncryptionPublicKey>,
 }
 
 impl MemberInfo {
@@ -199,9 +201,7 @@ impl MemberInfo {
         self.https_address.as_ref()
     }
 
-    pub fn next_epoch_encryption_public_key(
-        &self,
-    ) -> Option<&fastcrypto_tbls::ecies_v1::PublicKey<crate::dkg::EncryptionGroupElement>> {
+    pub fn next_epoch_encryption_public_key(&self) -> Option<&EncryptionPublicKey> {
         self.next_epoch_encryption_public_key.as_ref()
     }
 }

--- a/crates/hashi/src/storage.rs
+++ b/crates/hashi/src/storage.rs
@@ -1,6 +1,5 @@
-use crate::dkg::EncryptionGroupElement;
+use crate::committee::EncryptionPrivateKey;
 use anyhow::Result;
-use fastcrypto_tbls::ecies_v1::PrivateKey;
 use fastcrypto_tbls::threshold_schnorr::avss;
 use sui_sdk_types::Address;
 
@@ -24,10 +23,10 @@ pub trait SecretsStore: Send + Sync {
     ///
     /// Fails if called more than once.
     // TODO: Apply at node initialization
-    fn store_encryption_key(&mut self, key: &PrivateKey<EncryptionGroupElement>) -> Result<()>;
+    fn store_encryption_key(&mut self, key: &EncryptionPrivateKey) -> Result<()>;
 
     /// Retrieve encryption private key
-    fn get_encryption_key(&self) -> Result<Option<PrivateKey<EncryptionGroupElement>>>;
+    fn get_encryption_key(&self) -> Result<Option<EncryptionPrivateKey>>;
 
     /// Clear all secrets (called at epoch transitions)
     fn clear(&mut self) -> Result<()>;

--- a/packages/hashi/sources/committee/committee.move
+++ b/packages/hashi/sources/committee/committee.move
@@ -21,7 +21,7 @@ const EIncorrectCommittee: u64 = 3;
 public struct CommitteeMember has copy, drop, store {
     validator_address: address,
     public_key: Element<UncompressedG1>,
-    encryption_key: vector<u8>,
+    encryption_public_key: vector<u8>,
     weight: u16,
 }
 
@@ -62,14 +62,14 @@ public(package) fun new_committee(epoch: u64, members: vector<CommitteeMember>):
 public(package) fun new_committee_member(
     validator_address: address,
     public_key: Element<UncompressedG1>,
-    encryption_key: vector<u8>,
+    encryption_public_key: vector<u8>,
     weight: u16,
 ): CommitteeMember {
     assert!(weight > 0, EIncorrectCommittee);
     CommitteeMember {
         validator_address,
         public_key,
-        encryption_key,
+        encryption_public_key,
         weight,
     }
 }

--- a/packages/hashi/sources/committee/committee_set.move
+++ b/packages/hashi/sources/committee/committee_set.move
@@ -73,7 +73,7 @@ public struct MemberInfo has store {
     /// bls12381 public key to be used in the next epoch.
     ///
     /// The public key for this node which is active in the current epoch can
-    /// be found in the `BlsCommittee` struct.
+    /// be found in the `Committee` struct.
     ///
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.


### PR DESCRIPTION
Change terminology:
- `BlsCommitee` -> `Committee`
- `BlsCommiteeMember` -> `CommitteeMember`
- `bls.rs` -> `committee.rs`

And add `encryption_public_key` to `CommitteeMember` for future use when changing epochs.