### PR TITLE
Resolve a TODO on "expect"

### DIFF
--- a/crates/hashi/src/dkg/mod.rs
+++ b/crates/hashi/src/dkg/mod.rs
@@ -431,7 +431,6 @@ impl DkgManager {
         certified_dealers: &HashMap<Address, Certificate>,
     ) -> DkgResult<DkgOutput> {
         let threshold = self.dkg_config.threshold;
-        // TODO: Handle missing messages and invalid shares
         let outputs: HashMap<PartyId, avss::PartialOutput> = certified_dealers
             .keys()
             .map(|dealer| {


### PR DESCRIPTION
@benr-ml The second lookup can legitimately fail. We might receive a certificate from TOB for a dealer whose message we never received via P2P. No?

#14