### PR TITLE
deposit: key requests by request id

### DIFF
--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -34,7 +34,7 @@ impl Hashi {
     ) -> anyhow::Result<()> {
         let state = self.onchain_state().state();
         let deposit_queue = &state.hashi().deposit_queue;
-        match deposit_queue.requests().get(&deposit_request.utxo.id) {
+        match deposit_queue.requests().get(&deposit_request.id) {
             None => {
                 bail!(
                     "Deposit request not found on Sui: {:?}",

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -672,7 +672,7 @@ async fn scrape_deposit_requests(
     client: Client,
     deposit_queue_id: Address,
 ) -> Result<types::DepositRequestQueue> {
-    let requests: BTreeMap<types::UtxoId, types::DepositRequest> = client
+    let requests: BTreeMap<Address, types::DepositRequest> = client
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(deposit_queue_id)
@@ -697,7 +697,7 @@ async fn scrape_deposit_requests(
              }| {
                 let utxo = convert_move_utxo(utxo);
                 (
-                    utxo.id,
+                    id,
                     types::DepositRequest {
                         id,
                         utxo,

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -315,7 +315,7 @@ pub struct Treasury {
 #[derive(Debug)]
 pub struct DepositRequestQueue {
     pub(super) id: Address,
-    pub(super) requests: BTreeMap<UtxoId, DepositRequest>,
+    pub(super) requests: BTreeMap<Address, DepositRequest>,
 }
 
 impl DepositRequestQueue {
@@ -323,7 +323,7 @@ impl DepositRequestQueue {
         &self.id
     }
 
-    pub fn requests(&self) -> &BTreeMap<UtxoId, DepositRequest> {
+    pub fn requests(&self) -> &BTreeMap<Address, DepositRequest> {
         &self.requests
     }
 }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -170,7 +170,7 @@ async fn handle_events(client: &Client, state: &OnchainState, events: &[HashiEve
                     .hashi
                     .deposit_queue
                     .requests
-                    .insert(deposit_request.utxo.id, deposit_request);
+                    .insert(deposit_request.id, deposit_request);
                 // TODO notify
             }
             HashiEvent::DepositConfirmedEvent(deposit_confirmed_event) => {
@@ -185,12 +185,21 @@ async fn handle_events(client: &Client, state: &OnchainState, events: &[HashiEve
                     derivation_path: deposit_confirmed_event.derivation_path,
                 };
 
-                state.hashi.deposit_queue.requests.remove(&utxo.id);
+                state
+                    .hashi
+                    .deposit_queue
+                    .requests
+                    .remove(&deposit_confirmed_event.request_id);
                 state.hashi.utxo_pool.utxos.insert(utxo.id, utxo);
                 // TODO notify
             }
-            HashiEvent::ExpiredDepositDeletedEvent(_) => {
-                // TODO: delete from the the deposit queue
+            HashiEvent::ExpiredDepositDeletedEvent(expired_deposit_deleted_event) => {
+                state
+                    .state_mut()
+                    .hashi
+                    .deposit_queue
+                    .requests
+                    .remove(&expired_deposit_deleted_event.request_id);
             }
             HashiEvent::StartReconfigEvent(start_reconfig_event) => {
                 let epoch = start_reconfig_event.epoch;


### PR DESCRIPTION
Rework how deposit requests are keyed in rust code to match how they are keyed in move code, by request id.