### PR TITLE
Fix 5-step withdrawal pipeline: gRPC fan-out, renames, and complete step wiring

### DIFF
--- a/crates/hashi-types/proto/sui/hashi/v1alpha/bridge_service.proto
+++ b/crates/hashi-types/proto/sui/hashi/v1alpha/bridge_service.proto
@@ -11,13 +11,16 @@ service BridgeService {
   rpc GetServiceInfo(GetServiceInfoRequest) returns (GetServiceInfoResponse);
   // Sign a deposit confirmation, confirming that bitcoin has been deposited into hashi
   rpc SignDepositConfirmation(SignDepositConfirmationRequest) returns (SignDepositConfirmationResponse);
-  // Sign approval for a proposed withdrawal transaction, confirming that the
-  // validator agrees the bitcoin transaction is valid and should be processed.
-  rpc SignWithdrawalApproval(SignWithdrawalApprovalRequest) returns (SignWithdrawalApprovalResponse);
-  // Sign a bitcoin withdrawal transaction. The validator checks that a matching
-  // PendingWithdrawal exists on-chain, then produces a partial signature.
+  // Step 1: Sign approval for a batch of unapproved withdrawal requests.
+  rpc SignRequestApproval(SignRequestApprovalRequest) returns (SignRequestApprovalResponse);
+  // Step 2: Sign approval for a proposed withdrawal transaction construction,
+  // confirming that the validator agrees the bitcoin transaction is valid.
+  rpc SignWithdrawalTxConstruction(SignWithdrawalTxConstructionRequest) returns (SignWithdrawalTxConstructionResponse);
+  // Step 2b: Sign a bitcoin withdrawal transaction (MPC Schnorr).
   rpc SignWithdrawalTransaction(SignWithdrawalTransactionRequest) returns (SignWithdrawalTransactionResponse);
-  // Sign committee approval to confirm a processed withdrawal on-chain.
+  // Step 3: Sign the BLS certificate over the witness signatures for on-chain storage.
+  rpc SignWithdrawalTxSigning(SignWithdrawalTxSigningRequest) returns (SignWithdrawalTxSigningResponse);
+  // Step 4: Sign committee approval to confirm a processed withdrawal on-chain.
   rpc SignWithdrawalConfirmation(SignWithdrawalConfirmationRequest) returns (SignWithdrawalConfirmationResponse);
 }
 
@@ -79,8 +82,18 @@ message SignDepositConfirmationResponse {
   MemberSignature member_signature = 1;
 }
 
-// Maps to crate::withdrawals::WithdrawalApproval
-message SignWithdrawalApprovalRequest {
+// Maps to crate::withdrawals::RequestApproval
+message SignRequestApprovalRequest {
+  // Withdrawal request ids to approve (each 32 bytes).
+  repeated bytes request_ids = 1;
+}
+
+message SignRequestApprovalResponse {
+  MemberSignature member_signature = 1;
+}
+
+// Maps to crate::withdrawals::WithdrawalTxConstruction
+message SignWithdrawalTxConstructionRequest {
   // Withdrawal request ids (each 32 bytes).
   repeated bytes request_ids = 1;
 
@@ -102,7 +115,7 @@ message WithdrawalOutput {
   bytes bitcoin_address = 2;
 }
 
-message SignWithdrawalApprovalResponse {
+message SignWithdrawalTxConstructionResponse {
   MemberSignature member_signature = 1;
 }
 
@@ -114,6 +127,22 @@ message SignWithdrawalTransactionRequest {
 message SignWithdrawalTransactionResponse {
   // One aggregated MPC Schnorr signature per transaction input.
   repeated bytes signatures_by_input = 1;
+}
+
+// Maps to crate::withdrawals::WithdrawalTxSigning
+message SignWithdrawalTxSigningRequest {
+  // Pending withdrawal id on Sui (32 bytes).
+  bytes withdrawal_id = 1;
+
+  // Withdrawal request ids (each 32 bytes).
+  repeated bytes request_ids = 2;
+
+  // One Schnorr signature per transaction input.
+  repeated bytes signatures = 3;
+}
+
+message SignWithdrawalTxSigningResponse {
+  MemberSignature member_signature = 1;
 }
 
 message SignWithdrawalConfirmationRequest {

--- a/crates/hashi-types/src/proto/generated/sui.hashi.v1alpha.rs
+++ b/crates/hashi-types/src/proto/generated/sui.hashi.v1alpha.rs
@@ -60,9 +60,21 @@ pub struct SignDepositConfirmationResponse {
     #[prost(message, optional, tag = "1")]
     pub member_signature: ::core::option::Option<MemberSignature>,
 }
-/// Maps to crate::withdrawals::WithdrawalApproval
+/// Maps to crate::withdrawals::RequestApproval
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SignRequestApprovalRequest {
+    /// Withdrawal request ids to approve (each 32 bytes).
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    pub request_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SignRequestApprovalResponse {
+    #[prost(message, optional, tag = "1")]
+    pub member_signature: ::core::option::Option<MemberSignature>,
+}
+/// Maps to crate::withdrawals::WithdrawalTxConstruction
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SignWithdrawalApprovalRequest {
+pub struct SignWithdrawalTxConstructionRequest {
     /// Withdrawal request ids (each 32 bytes).
     #[prost(bytes = "bytes", repeated, tag = "1")]
     pub request_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
@@ -86,7 +98,7 @@ pub struct WithdrawalOutput {
     pub bitcoin_address: ::prost::bytes::Bytes,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct SignWithdrawalApprovalResponse {
+pub struct SignWithdrawalTxConstructionResponse {
     #[prost(message, optional, tag = "1")]
     pub member_signature: ::core::option::Option<MemberSignature>,
 }
@@ -101,6 +113,24 @@ pub struct SignWithdrawalTransactionResponse {
     /// One aggregated MPC Schnorr signature per transaction input.
     #[prost(bytes = "bytes", repeated, tag = "1")]
     pub signatures_by_input: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+/// Maps to crate::withdrawals::WithdrawalTxSigning
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SignWithdrawalTxSigningRequest {
+    /// Pending withdrawal id on Sui (32 bytes).
+    #[prost(bytes = "bytes", tag = "1")]
+    pub withdrawal_id: ::prost::bytes::Bytes,
+    /// Withdrawal request ids (each 32 bytes).
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub request_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    /// One Schnorr signature per transaction input.
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    pub signatures: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SignWithdrawalTxSigningResponse {
+    #[prost(message, optional, tag = "1")]
+    pub member_signature: ::core::option::Option<MemberSignature>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SignWithdrawalConfirmationRequest {
@@ -261,13 +291,12 @@ pub mod bridge_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
-        /// Sign approval for a proposed withdrawal transaction, confirming that the
-        /// validator agrees the bitcoin transaction is valid and should be processed.
-        pub async fn sign_withdrawal_approval(
+        /// Sign approval for a batch of unapproved withdrawal requests.
+        pub async fn sign_request_approval(
             &mut self,
-            request: impl tonic::IntoRequest<super::SignWithdrawalApprovalRequest>,
+            request: impl tonic::IntoRequest<super::SignRequestApprovalRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::SignWithdrawalApprovalResponse>,
+            tonic::Response<super::SignRequestApprovalResponse>,
             tonic::Status,
         > {
             self.inner
@@ -280,14 +309,45 @@ pub mod bridge_service_client {
                 })?;
             let codec = tonic_prost::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/sui.hashi.v1alpha.BridgeService/SignWithdrawalApproval",
+                "/sui.hashi.v1alpha.BridgeService/SignRequestApproval",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "sui.hashi.v1alpha.BridgeService",
-                        "SignWithdrawalApproval",
+                        "SignRequestApproval",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Sign approval for a proposed withdrawal transaction construction, confirming that the
+        /// validator agrees the bitcoin transaction is valid.
+        pub async fn sign_withdrawal_tx_construction(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SignWithdrawalTxConstructionRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::SignWithdrawalTxConstructionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/sui.hashi.v1alpha.BridgeService/SignWithdrawalTxConstruction",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "sui.hashi.v1alpha.BridgeService",
+                        "SignWithdrawalTxConstruction",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -319,6 +379,36 @@ pub mod bridge_service_client {
                     GrpcMethod::new(
                         "sui.hashi.v1alpha.BridgeService",
                         "SignWithdrawalTransaction",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// Sign the BLS certificate over the witness signatures for on-chain storage.
+        pub async fn sign_withdrawal_tx_signing(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SignWithdrawalTxSigningRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::SignWithdrawalTxSigningResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/sui.hashi.v1alpha.BridgeService/SignWithdrawalTxSigning",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "sui.hashi.v1alpha.BridgeService",
+                        "SignWithdrawalTxSigning",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -384,13 +474,20 @@ pub mod bridge_service_server {
             tonic::Response<super::SignDepositConfirmationResponse>,
             tonic::Status,
         >;
-        /// Sign approval for a proposed withdrawal transaction, confirming that the
-        /// validator agrees the bitcoin transaction is valid and should be processed.
-        async fn sign_withdrawal_approval(
+        /// Sign approval for a batch of unapproved withdrawal requests.
+        async fn sign_request_approval(
             &self,
-            request: tonic::Request<super::SignWithdrawalApprovalRequest>,
+            request: tonic::Request<super::SignRequestApprovalRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::SignWithdrawalApprovalResponse>,
+            tonic::Response<super::SignRequestApprovalResponse>,
+            tonic::Status,
+        >;
+        /// Sign approval for a proposed withdrawal transaction construction.
+        async fn sign_withdrawal_tx_construction(
+            &self,
+            request: tonic::Request<super::SignWithdrawalTxConstructionRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::SignWithdrawalTxConstructionResponse>,
             tonic::Status,
         >;
         /// Sign a bitcoin withdrawal transaction. The validator checks that a matching
@@ -400,6 +497,14 @@ pub mod bridge_service_server {
             request: tonic::Request<super::SignWithdrawalTransactionRequest>,
         ) -> std::result::Result<
             tonic::Response<super::SignWithdrawalTransactionResponse>,
+            tonic::Status,
+        >;
+        /// Sign the BLS certificate over the witness signatures for on-chain storage.
+        async fn sign_withdrawal_tx_signing(
+            &self,
+            request: tonic::Request<super::SignWithdrawalTxSigningRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::SignWithdrawalTxSigningResponse>,
             tonic::Status,
         >;
         /// Sign committee approval to confirm a processed withdrawal on-chain.
@@ -584,25 +689,25 @@ pub mod bridge_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/sui.hashi.v1alpha.BridgeService/SignWithdrawalApproval" => {
+                "/sui.hashi.v1alpha.BridgeService/SignRequestApproval" => {
                     #[allow(non_camel_case_types)]
-                    struct SignWithdrawalApprovalSvc<T: BridgeService>(pub Arc<T>);
+                    struct SignRequestApprovalSvc<T: BridgeService>(pub Arc<T>);
                     impl<
                         T: BridgeService,
-                    > tonic::server::UnaryService<super::SignWithdrawalApprovalRequest>
-                    for SignWithdrawalApprovalSvc<T> {
-                        type Response = super::SignWithdrawalApprovalResponse;
+                    > tonic::server::UnaryService<super::SignRequestApprovalRequest>
+                    for SignRequestApprovalSvc<T> {
+                        type Response = super::SignRequestApprovalResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::SignWithdrawalApprovalRequest>,
+                            request: tonic::Request<super::SignRequestApprovalRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BridgeService>::sign_withdrawal_approval(
+                                <T as BridgeService>::sign_request_approval(
                                         &inner,
                                         request,
                                     )
@@ -617,7 +722,56 @@ pub mod bridge_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = SignWithdrawalApprovalSvc(inner);
+                        let method = SignRequestApprovalSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/sui.hashi.v1alpha.BridgeService/SignWithdrawalTxConstruction" => {
+                    #[allow(non_camel_case_types)]
+                    struct SignWithdrawalTxConstructionSvc<T: BridgeService>(pub Arc<T>);
+                    impl<
+                        T: BridgeService,
+                    > tonic::server::UnaryService<super::SignWithdrawalTxConstructionRequest>
+                    for SignWithdrawalTxConstructionSvc<T> {
+                        type Response = super::SignWithdrawalTxConstructionResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SignWithdrawalTxConstructionRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as BridgeService>::sign_withdrawal_tx_construction(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SignWithdrawalTxConstructionSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -670,6 +824,57 @@ pub mod bridge_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SignWithdrawalTransactionSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/sui.hashi.v1alpha.BridgeService/SignWithdrawalTxSigning" => {
+                    #[allow(non_camel_case_types)]
+                    struct SignWithdrawalTxSigningSvc<T: BridgeService>(pub Arc<T>);
+                    impl<
+                        T: BridgeService,
+                    > tonic::server::UnaryService<super::SignWithdrawalTxSigningRequest>
+                    for SignWithdrawalTxSigningSvc<T> {
+                        type Response = super::SignWithdrawalTxSigningResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::SignWithdrawalTxSigningRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as BridgeService>::sign_withdrawal_tx_signing(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SignWithdrawalTxSigningSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/hashi/src/grpc/bridge_service.rs
+++ b/crates/hashi/src/grpc/bridge_service.rs
@@ -8,17 +8,23 @@ use crate::onchain::types::DepositRequest;
 use crate::onchain::types::OutputUtxo;
 use crate::onchain::types::Utxo;
 use crate::onchain::types::UtxoId;
-use crate::withdrawals::WithdrawalApproval;
+use crate::withdrawals::RequestApproval;
+use crate::withdrawals::WithdrawalTxConstruction;
+use crate::withdrawals::WithdrawalTxSigning;
 use hashi_types::proto::GetServiceInfoRequest;
 use hashi_types::proto::GetServiceInfoResponse;
 use hashi_types::proto::SignDepositConfirmationRequest;
 use hashi_types::proto::SignDepositConfirmationResponse;
-use hashi_types::proto::SignWithdrawalApprovalRequest;
-use hashi_types::proto::SignWithdrawalApprovalResponse;
+use hashi_types::proto::SignRequestApprovalRequest;
+use hashi_types::proto::SignRequestApprovalResponse;
 use hashi_types::proto::SignWithdrawalConfirmationRequest;
 use hashi_types::proto::SignWithdrawalConfirmationResponse;
 use hashi_types::proto::SignWithdrawalTransactionRequest;
 use hashi_types::proto::SignWithdrawalTransactionResponse;
+use hashi_types::proto::SignWithdrawalTxConstructionRequest;
+use hashi_types::proto::SignWithdrawalTxConstructionResponse;
+use hashi_types::proto::SignWithdrawalTxSigningRequest;
+use hashi_types::proto::SignWithdrawalTxSigningResponse;
 use hashi_types::proto::bridge_service_server::BridgeService;
 use sui_sdk_types::Address;
 
@@ -52,19 +58,37 @@ impl BridgeService for HttpService {
         }))
     }
 
-    async fn sign_withdrawal_approval(
+    /// Step 1: Validate and sign approval for a batch of unapproved withdrawal requests.
+    async fn sign_request_approval(
         &self,
-        request: Request<SignWithdrawalApprovalRequest>,
-    ) -> Result<Response<SignWithdrawalApprovalResponse>, Status> {
+        request: Request<SignRequestApprovalRequest>,
+    ) -> Result<Response<SignRequestApprovalResponse>, Status> {
         authenticate_caller(&request)?;
-        let approval = parse_withdrawal_approval(request.get_ref())
+        let approval = parse_request_approval(request.get_ref())
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
         let member_signature = self
             .inner
-            .validate_and_sign_withdrawal_approval(&approval)
+            .validate_and_sign_request_approval(&approval)
+            .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        Ok(Response::new(SignRequestApprovalResponse {
+            member_signature: Some(member_signature),
+        }))
+    }
+
+    /// Step 2: Validate and sign a proposed withdrawal transaction construction.
+    async fn sign_withdrawal_tx_construction(
+        &self,
+        request: Request<SignWithdrawalTxConstructionRequest>,
+    ) -> Result<Response<SignWithdrawalTxConstructionResponse>, Status> {
+        authenticate_caller(&request)?;
+        let approval = parse_withdrawal_tx_construction(request.get_ref())
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        let member_signature = self
+            .inner
+            .validate_and_sign_withdrawal_tx_construction(&approval)
             .await
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
-        Ok(Response::new(SignWithdrawalApprovalResponse {
+        Ok(Response::new(SignWithdrawalTxConstructionResponse {
             member_signature: Some(member_signature),
         }))
     }
@@ -93,6 +117,23 @@ impl BridgeService for HttpService {
                 .iter()
                 .map(|sig| sig.to_byte_array().to_vec().into())
                 .collect(),
+        }))
+    }
+
+    /// Step 3: Validate and sign the BLS certificate over witness signatures.
+    async fn sign_withdrawal_tx_signing(
+        &self,
+        request: Request<SignWithdrawalTxSigningRequest>,
+    ) -> Result<Response<SignWithdrawalTxSigningResponse>, Status> {
+        authenticate_caller(&request)?;
+        let message = parse_withdrawal_tx_signing(request.get_ref())
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        let member_signature = self
+            .inner
+            .validate_and_sign_withdrawal_tx_signing(&message)
+            .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        Ok(Response::new(SignWithdrawalTxSigningResponse {
+            member_signature: Some(member_signature),
         }))
     }
 
@@ -148,9 +189,20 @@ fn parse_deposit_request(
     })
 }
 
-fn parse_withdrawal_approval(
-    request: &SignWithdrawalApprovalRequest,
-) -> anyhow::Result<WithdrawalApproval> {
+fn parse_request_approval(
+    request: &SignRequestApprovalRequest,
+) -> anyhow::Result<RequestApproval> {
+    let request_ids: Vec<Address> = request
+        .request_ids
+        .iter()
+        .map(|bytes| parse_address(bytes))
+        .collect::<anyhow::Result<_>>()?;
+    Ok(RequestApproval { request_ids })
+}
+
+fn parse_withdrawal_tx_construction(
+    request: &SignWithdrawalTxConstructionRequest,
+) -> anyhow::Result<WithdrawalTxConstruction> {
     let request_ids: Vec<Address> = request
         .request_ids
         .iter()
@@ -179,11 +231,32 @@ fn parse_withdrawal_approval(
         .collect();
     let txid = parse_address(&request.txid)?;
 
-    Ok(WithdrawalApproval {
+    Ok(WithdrawalTxConstruction {
         request_ids,
         selected_utxos,
         outputs,
         txid,
+    })
+}
+
+fn parse_withdrawal_tx_signing(
+    request: &SignWithdrawalTxSigningRequest,
+) -> anyhow::Result<WithdrawalTxSigning> {
+    let withdrawal_id = parse_address(&request.withdrawal_id)?;
+    let request_ids: Vec<Address> = request
+        .request_ids
+        .iter()
+        .map(|bytes| parse_address(bytes))
+        .collect::<anyhow::Result<_>>()?;
+    let signatures: Vec<Vec<u8>> = request
+        .signatures
+        .iter()
+        .map(|bytes| bytes.to_vec())
+        .collect();
+    Ok(WithdrawalTxSigning {
+        withdrawal_id,
+        request_ids,
+        signatures,
     })
 }
 

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -7,10 +7,8 @@ use crate::onchain::types::PendingWithdrawal;
 use crate::onchain::types::WithdrawalRequest;
 use crate::sui_tx_executor::SuiTxExecutor;
 use crate::withdrawals::RequestApproval;
-use crate::withdrawals::WithdrawalApproval;
-use crate::withdrawals::WithdrawalInputSignature;
-use crate::withdrawals::WithdrawalSignedMessage;
-use bitcoin::hashes::Hash;
+use crate::withdrawals::WithdrawalTxConstruction;
+use crate::withdrawals::WithdrawalTxSigning;
 pub use fastcrypto::bls12381::min_pk::BLS12381Signature;
 use fastcrypto::groups::secp256k1::schnorr::SchnorrSignature;
 use fastcrypto::serde_helpers::ToFromByteArray;
@@ -22,9 +20,11 @@ use hashi_types::committee::MemberSignature;
 use hashi_types::committee::certificate_threshold;
 use hashi_types::guardian::bitcoin_utils;
 use hashi_types::proto::SignDepositConfirmationRequest;
-use hashi_types::proto::SignWithdrawalApprovalRequest;
+use hashi_types::proto::SignRequestApprovalRequest;
 use hashi_types::proto::SignWithdrawalConfirmationRequest;
 use hashi_types::proto::SignWithdrawalTransactionRequest;
+use hashi_types::proto::SignWithdrawalTxConstructionRequest;
+use hashi_types::proto::SignWithdrawalTxSigningRequest;
 use std::sync::Arc;
 use sui_futures::service::Service;
 use sui_sdk_types::Address;
@@ -307,14 +307,21 @@ impl LeaderService {
             request_ids: request_ids.clone(),
         };
 
-        // TODO: Fan out to committee via a new gRPC endpoint for request approval.
-        // For now, the leader validates and signs locally.
+        // Fan out to committee for BLS signatures
+        let members = self
+            .inner
+            .onchain_state()
+            .current_committee_members()
+            .expect("No current committee members");
+
+        let proto_request = approval.to_proto();
         let mut signatures: Vec<MemberSignature> = Vec::new();
-        match self.inner.validate_and_sign_request_approval(&approval) {
-            Ok(sig) => signatures.push(sig),
-            Err(e) => {
-                error!("Failed to sign request approval: {e}");
-                return;
+        for member in &members {
+            if let Some(signature) = self
+                .request_request_approval_signature(proto_request.clone(), member)
+                .await
+            {
+                signatures.push(signature);
             }
         }
 
@@ -387,7 +394,7 @@ impl LeaderService {
         }
 
         // 2. Build the withdrawal approval (craft unsigned BTC tx, select UTXOs, etc.)
-        let approval = match self.inner.build_withdrawal_approval(request).await {
+        let approval = match self.inner.build_withdrawal_tx_construction(request).await {
             Ok(approval) => approval,
             Err(e) => {
                 error!(
@@ -409,7 +416,7 @@ impl LeaderService {
         let mut signatures: Vec<MemberSignature> = Vec::new();
         for member in &members {
             if let Some(signature) = self
-                .request_withdrawal_approval_signature(proto_request.clone(), member)
+                .request_withdrawal_tx_construction_signature(proto_request.clone(), member)
                 .await
             {
                 signatures.push(signature);
@@ -486,63 +493,45 @@ impl LeaderService {
             .current_committee_members()
             .expect("No current committee members");
 
-        // 1. Request MPC-signed withdrawal tx witnesses from committee members.
-        let mut signatures_by_input = None;
-        for member in &members {
-            match self
-                .request_withdrawal_tx_signature(&pending.id, member)
-                .await
-            {
-                Ok(signatures) => {
-                    signatures_by_input = Some(signatures);
-                    break;
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to get withdrawal tx signature from {}: {e}",
-                        member.validator_address()
-                    );
-                }
-            }
-        }
-
-        let Some(signatures_by_input) = signatures_by_input else {
-            error!(
-                "No withdrawal tx signatures collected for {:?}; skipping",
-                pending.id
-            );
+        // 1. Request signed withdrawal tx witnesses from committee members.
+        // MPC signing requires all threshold members to participate simultaneously
+        // via P2P, so we must fan out requests in parallel.
+        let Some(signatures_by_input) = self
+            .collect_withdrawal_tx_signatures(&pending.id, &members)
+            .await
+        else {
             return;
         };
 
         // 2. Extract raw signature bytes for on-chain storage
         let witness_signatures: Vec<Vec<u8>> = signatures_by_input
             .iter()
-            .map(|s| s.hashi_signature.clone())
+            .map(|s| s.to_byte_array().to_vec())
             .collect();
 
-        // 3. Build the WithdrawalSignedMessage and get BLS certificate
-        let signed_message = WithdrawalSignedMessage {
+        // 3. Build the WithdrawalTxSigning and get BLS certificate via fan-out
+        let signed_message = WithdrawalTxSigning {
             withdrawal_id: pending.id,
             request_ids: pending.request_ids.clone(),
             signatures: witness_signatures.clone(),
         };
+
+        let proto_request = signed_message.to_proto();
+        let mut bls_signatures: Vec<MemberSignature> = Vec::new();
+        for member in &members {
+            if let Some(signature) = self
+                .request_withdrawal_tx_signing_signature(proto_request.clone(), member)
+                .await
+            {
+                bls_signatures.push(signature);
+            }
+        }
 
         let committee = self
             .inner
             .onchain_state()
             .current_committee()
             .expect("No current committee");
-
-        // TODO: Fan out to committee via a new gRPC endpoint for sign message.
-        // For now, the leader validates and signs locally.
-        let mut bls_signatures: Vec<MemberSignature> = Vec::new();
-        match self.inner.sign_withdrawal_signed_message(&signed_message) {
-            Ok(sig) => bls_signatures.push(sig),
-            Err(e) => {
-                error!("Failed to sign withdrawal signed message: {e}");
-                return;
-            }
-        }
 
         let mut aggregator = BlsSignatureAggregator::new(&committee, signed_message.clone());
         for sig in bls_signatures {
@@ -584,6 +573,60 @@ impl LeaderService {
         {
             error!(
                 "Failed to submit sign_withdrawal for {:?}: {e}",
+                pending.id
+            );
+            return;
+        }
+
+        // 5. Build and broadcast the signed BTC transaction
+        let broadcastable_tx = match self
+            .build_broadcastable_withdrawal_tx(pending, &signatures_by_input)
+        {
+            Ok(tx) => tx,
+            Err(e) => {
+                error!(
+                    "Failed to build broadcastable withdrawal tx for {:?}: {e}",
+                    pending.id
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = self
+            .inner
+            .btc_monitor()
+            .broadcast_transaction(broadcastable_tx)
+            .await
+        {
+            error!(
+                "Failed to broadcast withdrawal tx for {:?}: {e}",
+                pending.id
+            );
+            return;
+        }
+        info!("Broadcast withdrawal tx for {:?}", pending.id);
+
+        // 6. Collect BLS signatures for withdrawal confirmation and submit on-chain
+        let confirmation_cert = match self
+            .collect_withdrawal_confirmation_signature(pending.id, &members)
+            .await
+        {
+            Ok(cert) => cert,
+            Err(e) => {
+                error!(
+                    "Failed to collect withdrawal confirmation signatures for {:?}: {e}",
+                    pending.id
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = self
+            .submit_confirm_withdrawal(&pending.id, &confirmation_cert)
+            .await
+        {
+            error!(
+                "Failed to submit confirm_withdrawal for {:?}: {e}",
                 pending.id
             );
         }
@@ -697,9 +740,9 @@ impl LeaderService {
         Ok(tx)
     }
 
-    async fn request_withdrawal_approval_signature(
+    async fn request_withdrawal_tx_construction_signature(
         &self,
-        proto_request: SignWithdrawalApprovalRequest,
+        proto_request: SignWithdrawalTxConstructionRequest,
         member: &CommitteeMember,
     ) -> Option<MemberSignature> {
         let validator_address = member.validator_address();
@@ -721,7 +764,7 @@ impl LeaderService {
             })?;
 
         let response = rpc_client
-            .sign_withdrawal_approval(proto_request.clone())
+            .sign_withdrawal_tx_construction(proto_request.clone())
             .await
             .inspect_err(|e| {
                 error!(
@@ -744,6 +787,112 @@ impl LeaderService {
             .inspect_err(|e| {
                 error!(
                     "Failed to parse member signature from withdrawal approval response from {}: {e}",
+                    validator_address
+                );
+            })
+            .ok()
+    }
+
+    async fn request_request_approval_signature(
+        &self,
+        proto_request: SignRequestApprovalRequest,
+        member: &CommitteeMember,
+    ) -> Option<MemberSignature> {
+        let validator_address = member.validator_address();
+        trace!(
+            "Requesting request approval signature from {}",
+            validator_address
+        );
+
+        let mut rpc_client = self
+            .inner
+            .onchain_state()
+            .bridge_service_client(&validator_address)
+            .or_else(|| {
+                error!(
+                    "Cannot find client for validator address: {:?}",
+                    validator_address
+                );
+                None
+            })?;
+
+        let response = rpc_client
+            .sign_request_approval(proto_request.clone())
+            .await
+            .inspect_err(|e| {
+                error!(
+                    "Failed to get request approval signature from {}: {e}",
+                    validator_address
+                );
+            })
+            .ok()?;
+
+        trace!(
+            "Retrieved request approval signature from {}",
+            validator_address
+        );
+
+        response
+            .into_inner()
+            .member_signature
+            .ok_or_else(|| anyhow::anyhow!("No member_signature in response"))
+            .and_then(parse_member_signature)
+            .inspect_err(|e| {
+                error!(
+                    "Failed to parse member signature from request approval response from {}: {e}",
+                    validator_address
+                );
+            })
+            .ok()
+    }
+
+    async fn request_withdrawal_tx_signing_signature(
+        &self,
+        proto_request: SignWithdrawalTxSigningRequest,
+        member: &CommitteeMember,
+    ) -> Option<MemberSignature> {
+        let validator_address = member.validator_address();
+        trace!(
+            "Requesting withdrawal tx signing signature from {}",
+            validator_address
+        );
+
+        let mut rpc_client = self
+            .inner
+            .onchain_state()
+            .bridge_service_client(&validator_address)
+            .or_else(|| {
+                error!(
+                    "Cannot find client for validator address: {:?}",
+                    validator_address
+                );
+                None
+            })?;
+
+        let response = rpc_client
+            .sign_withdrawal_tx_signing(proto_request.clone())
+            .await
+            .inspect_err(|e| {
+                error!(
+                    "Failed to get withdrawal tx signing signature from {}: {e}",
+                    validator_address
+                );
+            })
+            .ok()?;
+
+        trace!(
+            "Retrieved withdrawal tx signing signature from {}",
+            validator_address
+        );
+
+        response
+            .into_inner()
+            .member_signature
+            .ok_or_else(|| anyhow::anyhow!("No member_signature in response"))
+            .and_then(parse_member_signature)
+            .inspect_err(|e| {
+                error!(
+                    "Failed to parse member signature from withdrawal tx signing response from {}: {e}",
                     validator_address
                 );
             })
@@ -902,7 +1051,7 @@ impl LeaderService {
 
     async fn submit_construct_withdrawal(
         &self,
-        approval: &WithdrawalApproval,
+        approval: &WithdrawalTxConstruction,
         cert: &CommitteeSignature,
     ) -> anyhow::Result<()> {
         info!(
@@ -986,9 +1135,21 @@ fn parse_member_signature(
     Ok(MemberSignature::new(epoch, address, signature))
 }
 
-impl WithdrawalApproval {
-    fn to_proto(&self) -> SignWithdrawalApprovalRequest {
-        SignWithdrawalApprovalRequest {
+impl RequestApproval {
+    fn to_proto(&self) -> SignRequestApprovalRequest {
+        SignRequestApprovalRequest {
+            request_ids: self
+                .request_ids
+                .iter()
+                .map(|id| id.as_bytes().to_vec().into())
+                .collect(),
+        }
+    }
+}
+
+impl WithdrawalTxConstruction {
+    fn to_proto(&self) -> SignWithdrawalTxConstructionRequest {
+        SignWithdrawalTxConstructionRequest {
             request_ids: self
                 .request_ids
                 .iter()
@@ -1011,6 +1172,24 @@ impl WithdrawalApproval {
                 })
                 .collect(),
             txid: self.txid.as_bytes().to_vec().into(),
+        }
+    }
+}
+
+impl WithdrawalTxSigning {
+    fn to_proto(&self) -> SignWithdrawalTxSigningRequest {
+        SignWithdrawalTxSigningRequest {
+            withdrawal_id: self.withdrawal_id.as_bytes().to_vec().into(),
+            request_ids: self
+                .request_ids
+                .iter()
+                .map(|id| id.as_bytes().to_vec().into())
+                .collect(),
+            signatures: self
+                .signatures
+                .iter()
+                .map(|sig| sig.clone().into())
+                .collect(),
         }
     }
 }

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -64,7 +64,7 @@ use crate::config::HashiIds;
 use crate::mpc::types::CertificateV1;
 use crate::onchain::OnchainState;
 use crate::onchain::types::DepositRequest;
-use crate::withdrawals::WithdrawalApproval;
+use crate::withdrawals::WithdrawalTxConstruction;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 10;
 
@@ -731,7 +731,7 @@ impl SuiTxExecutor {
     /// - `r: &Random`
     pub async fn execute_construct_withdrawal(
         &mut self,
-        approval: &WithdrawalApproval,
+        approval: &WithdrawalTxConstruction,
         cert: &CommitteeSignature,
     ) -> anyhow::Result<()> {
         let mut builder = TransactionBuilder::new();

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -67,7 +67,7 @@ pub struct RequestApproval {
 /// The data that validators BLS-sign over to commit to a withdrawal transaction.
 /// This is the step 2 certificate with UTXO selection and tx construction.
 #[derive(Clone, Debug, serde_derive::Serialize)]
-pub struct WithdrawalApproval {
+pub struct WithdrawalTxConstruction {
     pub request_ids: Vec<Address>,
     pub selected_utxos: Vec<UtxoId>,
     pub outputs: Vec<OutputUtxo>,
@@ -77,7 +77,7 @@ pub struct WithdrawalApproval {
 /// The data that validators BLS-sign over to store witness signatures on-chain.
 /// This is the step 3 certificate.
 #[derive(Clone, Debug, serde_derive::Serialize)]
-pub struct WithdrawalSignedMessage {
+pub struct WithdrawalTxSigning {
     pub withdrawal_id: Address,
     pub request_ids: Vec<Address>,
     pub signatures: Vec<Vec<u8>>,
@@ -94,7 +94,7 @@ impl Hashi {
     pub fn validate_and_sign_request_approval(
         &self,
         approval: &RequestApproval,
-    ) -> anyhow::Result<MemberSignature> {
+    ) -> anyhow::Result<hashi_types::proto::MemberSignature> {
         anyhow::ensure!(!approval.request_ids.is_empty(), "No request IDs");
 
         // Verify each request_id exists and is not yet approved
@@ -109,22 +109,22 @@ impl Hashi {
             );
         }
 
-        self.sign_message(&approval)
+        self.sign_message_proto(&approval)
     }
 
     // --- Step 2: Construction approval (with UTXO selection) ---
 
-    pub async fn validate_and_sign_withdrawal_approval(
+    pub async fn validate_and_sign_withdrawal_tx_construction(
         &self,
-        approval: &WithdrawalApproval,
+        approval: &WithdrawalTxConstruction,
     ) -> anyhow::Result<hashi_types::proto::MemberSignature> {
-        self.validate_withdrawal_approval(approval).await?;
-        self.sign_withdrawal_approval(approval)
+        self.validate_withdrawal_tx_construction(approval).await?;
+        self.sign_withdrawal_tx_construction(approval)
     }
 
-    pub async fn validate_withdrawal_approval(
+    pub async fn validate_withdrawal_tx_construction(
         &self,
-        approval: &WithdrawalApproval,
+        approval: &WithdrawalTxConstruction,
     ) -> anyhow::Result<()> {
         anyhow::ensure!(!approval.request_ids.is_empty(), "No request IDs");
         anyhow::ensure!(!approval.selected_utxos.is_empty(), "No selected UTXOs");
@@ -288,9 +288,9 @@ impl Hashi {
         Ok(())
     }
 
-    fn sign_withdrawal_approval(
+    fn sign_withdrawal_tx_construction(
         &self,
-        approval: &WithdrawalApproval,
+        approval: &WithdrawalTxConstruction,
     ) -> anyhow::Result<hashi_types::proto::MemberSignature> {
         self.sign_message_proto(approval)
     }
@@ -314,10 +314,10 @@ impl Hashi {
 
     // --- Step 3: Sign withdrawal (store witness signatures on-chain) ---
 
-    pub fn sign_withdrawal_signed_message(
+    pub fn validate_and_sign_withdrawal_tx_signing(
         &self,
-        message: &WithdrawalSignedMessage,
-    ) -> anyhow::Result<MemberSignature> {
+        message: &WithdrawalTxSigning,
+    ) -> anyhow::Result<hashi_types::proto::MemberSignature> {
         // Verify the pending withdrawal exists
         let _pending = self
             .onchain_state()
@@ -329,7 +329,7 @@ impl Hashi {
                 )
             })?;
 
-        self.sign_message(message)
+        self.sign_message_proto(message)
     }
 
     // --- Generic BLS signing helper ---
@@ -588,7 +588,7 @@ impl Hashi {
 
     /// Build an unsigned Bitcoin transaction for a withdrawal. This is used both
     /// by the leader when initially crafting the tx, and by validators when
-    /// verifying that a proposed `WithdrawalApproval` produces the expected txid.
+    /// verifying that a proposed `WithdrawalTxConstruction` produces the expected txid.
     pub fn build_unsigned_withdrawal_tx(
         &self,
         selected_utxos: &[Utxo],
@@ -624,11 +624,11 @@ impl Hashi {
 
     /// Build a withdrawal approval: select UTXOs with fee awareness, compute
     /// outputs (withdrawal destination + optional change), build the unsigned
-    /// BTC tx, and return a `WithdrawalApproval` containing the txid.
-    pub async fn build_withdrawal_approval(
+    /// BTC tx, and return a `WithdrawalTxConstruction` containing the txid.
+    pub async fn build_withdrawal_tx_construction(
         &self,
         request: &WithdrawalRequest,
-    ) -> anyhow::Result<WithdrawalApproval> {
+    ) -> anyhow::Result<WithdrawalTxConstruction> {
         // Fetch current fee rate from the Bitcoin node
         let kyoto_fee_rate = self
             .btc_monitor()
@@ -665,7 +665,7 @@ impl Hashi {
         let txid_bytes: [u8; 32] = tx.compute_txid().to_byte_array();
         let txid = Address::new(txid_bytes);
 
-        Ok(WithdrawalApproval {
+        Ok(WithdrawalTxConstruction {
             request_ids,
             selected_utxos: utxo_ids,
             outputs,


### PR DESCRIPTION
## Summary

- **Rename Step 2**: `WithdrawalApproval` → `WithdrawalTxConstruction` (struct, RPC, proto messages, all methods)
- **Rename Step 3**: `WithdrawalSignedMessage` → `WithdrawalTxSigning` (struct, validation method, proto messages)
- **Add gRPC fan-out for Steps 1 & 3**: Previously these steps only signed BLS certificates locally (leader-only, weight 2500), which couldn't reach quorum (≥6666). Now the leader fans out signing requests to all committee members via gRPC, matching the pattern used by Step 2.
- **Wire up Steps 4-5**: After MPC signing completes, the leader now broadcasts the signed BTC transaction and collects BLS signatures for withdrawal confirmation, completing the full pipeline.

## Changes

| File | What changed |
|------|-------------|
| `bridge_service.proto` | Renamed RPCs/messages, added `SignWithdrawalTxSigning` |
| `sui.hashi.v1alpha.rs` | Hand-edited generated code to match proto |
| `withdrawals.rs` | Renamed structs + methods, changed return types to proto `MemberSignature` |
| `bridge_service.rs` | Added `sign_request_approval` and `sign_withdrawal_tx_signing` handlers |
| `leader/mod.rs` | Fan-out for Steps 1 & 3, wired broadcast + confirm after MPC signing |
| `sui_tx_executor.rs` | Renamed `WithdrawalApproval` → `WithdrawalTxConstruction` |

## Test plan

- [x] `cargo check --all-features -p hashi` passes
- [x] `test_bitcoin_withdrawal_e2e_flow` e2e test passes