### PR TITLE
Fix locking issue in e2e test

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -518,14 +518,16 @@ mod tests {
         create_deposit_and_wait(&mut networks, deposit_amount_sats).await?;
 
         // First withdrawal
-        let hashi = networks.hashi_network.nodes()[0].hashi().clone();
-        withdraw_and_confirm(
-            &mut networks,
-            &hashi,
-            user_key.clone(),
-            withdrawal_amount_sats,
-        )
-        .await?;
+        {
+            let hashi = networks.hashi_network.nodes()[0].hashi().clone();
+            withdraw_and_confirm(
+                &mut networks,
+                &hashi,
+                user_key.clone(),
+                withdrawal_amount_sats,
+            )
+            .await?;
+        }
 
         // Second deposit
         create_deposit_and_wait(&mut networks, deposit_amount_sats).await?;

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -102,7 +102,7 @@ impl HashiNodeHandle {
     }
 
     async fn shutdown(&mut self) {
-        let Some((service, hashi)) = self.service.take() else {
+        let Some((service, _hashi)) = self.service.take() else {
             tracing::warn!("Hashi node not running, cannot shutdown");
             return;
         };
@@ -110,10 +110,6 @@ impl HashiNodeHandle {
         if let Err(e) = result {
             tracing::warn!("Hashi shutdown error: {e}");
         }
-        // Explicitly close the database to release the file lock.
-        // After shutdown, orphaned background tasks may still hold Arc<Hashi>,
-        // preventing the fjall database from being dropped naturally.
-        hashi.db.close();
     }
 
     pub async fn restart(&mut self) -> Result<()> {

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -6,6 +6,7 @@ use kyoto::FeeRate;
 use kyoto::HeaderCheckpoint;
 use sui_futures::service::Service;
 use tokio::sync::oneshot;
+use tokio::task::JoinSet;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -27,6 +28,7 @@ pub struct Monitor {
     requester: kyoto::Requester,
     tip: Option<HeaderCheckpoint>,
     pending_deposits: Vec<PendingDeposit>,
+    pending_deposit_workers: JoinSet<()>,
 }
 
 impl Monitor {
@@ -64,6 +66,7 @@ impl Monitor {
             client_tx: client_tx.clone(),
             tip: None,
             pending_deposits: vec![],
+            pending_deposit_workers: JoinSet::new(),
         };
 
         // Spawn tasks with graceful shutdown support.
@@ -94,6 +97,11 @@ impl Monitor {
                         }
                         Some(msg) = kyoto_client.warn_rx.recv() => {
                             warn!("Kyoto: {msg}");
+                        }
+                        Some(join_result) = monitor.pending_deposit_workers.join_next(), if !monitor.pending_deposit_workers.is_empty() => {
+                            if let Err(e) = join_result {
+                                error!("Pending deposit worker task failed: {e}");
+                            }
                         }
                         else => {
                             break;
@@ -189,14 +197,15 @@ impl Monitor {
             return;
         }
 
-        tokio::spawn(Monitor::process_pending_deposit(
-            tip.to_owned(),
-            self.config.confirmation_threshold,
-            self.bitcoind_rpc.clone(),
-            self.requester.clone(),
-            self.client_tx.clone(),
-            pending_deposit,
-        ));
+        self.pending_deposit_workers
+            .spawn(Monitor::process_pending_deposit(
+                tip.to_owned(),
+                self.config.confirmation_threshold,
+                self.bitcoind_rpc.clone(),
+                self.requester.clone(),
+                self.client_tx.clone(),
+                pending_deposit,
+            ));
     }
 
     fn get_recent_fee_rate(
@@ -277,14 +286,15 @@ impl Monitor {
             self.pending_deposits.len()
         );
         for pending_deposit in std::mem::take(&mut self.pending_deposits) {
-            tokio::spawn(Monitor::process_pending_deposit(
-                tip.to_owned(),
-                self.config.confirmation_threshold,
-                self.bitcoind_rpc.clone(),
-                self.requester.clone(),
-                self.client_tx.clone(),
-                pending_deposit,
-            ));
+            self.pending_deposit_workers
+                .spawn(Monitor::process_pending_deposit(
+                    tip.to_owned(),
+                    self.config.confirmation_threshold,
+                    self.bitcoind_rpc.clone(),
+                    self.requester.clone(),
+                    self.client_tx.clone(),
+                    pending_deposit,
+                ));
         }
     }
 
@@ -466,14 +476,12 @@ impl AsRef<PendingDeposit> for PendingDepositGuard {
 
 impl Drop for PendingDepositGuard {
     fn drop(&mut self) {
-        if let Some(deposit) = self.deposit.take() {
-            let client_tx = self.client_tx.clone();
-            tokio::spawn(async move {
-                client_tx
-                    .send(MonitorMessage::ConfirmDeposit(deposit))
-                    .await
-                    .expect("re-enqueue PendingDeposit must succeed");
-            });
+        if let Some(deposit) = self.deposit.take()
+            && let Err(e) = self
+                .client_tx
+                .try_send(MonitorMessage::ConfirmDeposit(deposit))
+        {
+            warn!("Failed to re-enqueue PendingDeposit on drop: {e}");
         }
     }
 }

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -77,15 +77,6 @@ impl Database {
         })
     }
 
-    /// Close the database, releasing the file lock.
-    ///
-    /// This drops all internal fjall handles, which releases the OS file lock
-    /// even if other `Arc<Database>` references exist.
-    /// Any subsequent operations on this database will return an error.
-    pub fn close(&self) {
-        let _ = self.inner.lock().unwrap().take();
-    }
-
     fn with_inner<T>(&self, f: impl FnOnce(&DatabaseInner) -> Result<T>) -> Result<T> {
         let guard = self
             .inner


### PR DESCRIPTION
Fixes a DB-lock failure in test_presigning_recovery_within_batch by narrowing the lifetime of a cloned Arc<Hashi> used for the first withdrawal. This ensures the old node’s DB handle is dropped before node restart, preventing FjallError: Locked when reopening the same database path.