### PR TITLE
Use kebab-case serde for HashiIds to match Config convention

### DIFF
--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -342,6 +342,7 @@ impl Config {
 
 /// Relevant Onchain Ids for the hashi protocol.
 #[derive(Debug, Clone, Copy, serde_derive::Deserialize, serde_derive::Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct HashiIds {
     /// The original package id of the `hashi` package.
     pub package_id: Address,


### PR DESCRIPTION
The parent `Config` struct uses `#[serde(rename_all = "kebab-case")]` but `HashiIds` was missing it, causing an inconsistency where config fields used `hashi-ids` (kebab) but the nested keys expected `package_id` and `hashi_object_id` (snake_case). This adds the same attribute so TOML configs consistently use kebab-case throughout.