### PR TITLE
grpc: configure max decoding size

### DIFF
--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -568,7 +568,8 @@ mod tests {
         let sui_rpc_url = &test_networks.sui_network().rpc_url;
         let ids = test_networks.hashi_network().ids();
 
-        let (state, _service) = hashi::onchain::OnchainState::new(sui_rpc_url, ids, None).await?;
+        let (state, _service) =
+            hashi::onchain::OnchainState::new(sui_rpc_url, ids, None, None).await?;
 
         assert_eq!(state.state().hashi().committees.committees().len(), 1);
         assert_eq!(state.state().hashi().committees.members().len(), 1);

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -87,9 +87,10 @@ impl HashiClient {
         // Dropping the service immediately aborts the background watcher task, so the
         // OnchainState will have the initial scraped state but won't receive live updates.
         // This is fine for CLI commands for now.
-        let (onchain_state, _service) = OnchainState::new(&config.sui_rpc_url, hashi_ids, None)
-            .await
-            .context("Failed to initialize on-chain state")?;
+        let (onchain_state, _service) =
+            OnchainState::new(&config.sui_rpc_url, hashi_ids, None, None)
+                .await
+                .context("Failed to initialize on-chain state")?;
 
         // Try to create executor if keypair is available
         let executor = match config.load_keypair()? {

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -135,6 +135,13 @@ pub struct Config {
     /// When not set, AML screening is skipped.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub screener_endpoint: Option<String>,
+
+    /// Maximum gRPC decoding message size in bytes.
+    ///
+    /// Defaults to 16 MiB if not specified. Tonic's built-in default is 4 MiB,
+    /// which is too small for large MPC round messages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grpc_max_decoding_message_size: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, serde_derive::Deserialize, serde_derive::Serialize)]
@@ -305,6 +312,11 @@ impl Config {
 
     pub fn screener_endpoint(&self) -> Option<&str> {
         self.screener_endpoint.as_deref()
+    }
+
+    pub fn grpc_max_decoding_message_size(&self) -> usize {
+        self.grpc_max_decoding_message_size
+            .unwrap_or(16 * 1024 * 1024)
     }
 
     // Creates a new config suitable for testing. In particular this config will:

--- a/crates/hashi/src/grpc/client.rs
+++ b/crates/hashi/src/grpc/client.rs
@@ -25,10 +25,13 @@ use hashi_types::proto::mpc_service_client::MpcServiceClient;
 type Result<T, E = tonic::Status> = std::result::Result<T, E>;
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+
 #[derive(Clone, Debug)]
 pub struct Client {
     uri: http::Uri,
     channel: Channel,
+    max_decoding_message_size: usize,
 }
 
 impl Client {
@@ -54,7 +57,16 @@ impl Client {
             .http2_keep_alive_interval(Duration::from_secs(5))
             .connect_lazy();
 
-        Ok(Self { uri, channel })
+        Ok(Self {
+            uri,
+            channel,
+            max_decoding_message_size: DEFAULT_MAX_DECODING_MESSAGE_SIZE,
+        })
+    }
+
+    pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+        self.max_decoding_message_size = limit;
+        self
     }
 
     pub fn new_no_auth<T>(uri: T) -> Result<Self>
@@ -71,10 +83,12 @@ impl Client {
 
     pub fn bridge_service_client(&self) -> BridgeServiceClient<Channel> {
         BridgeServiceClient::new(self.channel.clone())
+            .max_decoding_message_size(self.max_decoding_message_size)
     }
 
     pub fn mpc_service_client(&self) -> MpcServiceClient<Channel> {
         MpcServiceClient::new(self.channel.clone())
+            .max_decoding_message_size(self.max_decoding_message_size)
     }
 
     pub async fn get_service_info(&self) -> Result<Response<GetServiceInfoResponse>> {

--- a/crates/hashi/src/grpc/mod.rs
+++ b/crates/hashi/src/grpc/mod.rs
@@ -38,10 +38,13 @@ impl HttpService {
 
     pub async fn start(self) -> (std::net::SocketAddr, Service) {
         let router = {
+            let max_decoding_message_size = self.inner.config.grpc_max_decoding_message_size();
             let bridge_service =
-                hashi_types::proto::bridge_service_server::BridgeServiceServer::new(self.clone());
+                hashi_types::proto::bridge_service_server::BridgeServiceServer::new(self.clone())
+                    .max_decoding_message_size(max_decoding_message_size);
             let mpc_service =
-                hashi_types::proto::mpc_service_server::MpcServiceServer::new(self.clone());
+                hashi_types::proto::mpc_service_server::MpcServiceServer::new(self.clone())
+                    .max_decoding_message_size(max_decoding_message_size);
 
             let (health_reporter, health_service) = tonic_health::server::health_reporter();
 

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -196,6 +196,7 @@ impl Hashi {
             self.config.sui_rpc.as_deref().unwrap(),
             self.config.hashi_ids(),
             self.config.tls_private_key().ok(),
+            Some(self.config.grpc_max_decoding_message_size()),
         )
         .await?;
         self.onchain_state

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -79,6 +79,10 @@ struct Inner {
     /// The checkpoint information that this state is recent to
     checkpoint: watch::Sender<CheckpointInfo>,
     state: RwLock<State>,
+    #[allow(unused)]
+    tls_private_key: Option<ed25519_dalek::SigningKey>,
+    #[allow(unused)]
+    grpc_max_decoding_message_size: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -99,12 +103,22 @@ impl OnchainState {
         sui_rpc_url: &str,
         ids: HashiIds,
         tls_private_key: Option<ed25519_dalek::SigningKey>,
+        grpc_max_decoding_message_size: Option<usize>,
     ) -> Result<(Self, Service)> {
         let client = Client::new(sui_rpc_url)?;
 
         let (mut state, checkpoint) = State::scrape(client.clone(), ids).await?;
-        if let Some(tls_private_key) = tls_private_key {
-            state.hashi.committees.set_tls_private_key(tls_private_key);
+        if let Some(tls_private_key) = &tls_private_key {
+            state
+                .hashi
+                .committees
+                .set_tls_private_key(tls_private_key.clone());
+        }
+        if let Some(limit) = grpc_max_decoding_message_size {
+            state
+                .hashi
+                .committees
+                .set_grpc_max_decoding_message_size(limit);
         }
 
         let (sender, _) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
@@ -115,6 +129,8 @@ impl OnchainState {
             sender,
             checkpoint,
             state: RwLock::new(state),
+            tls_private_key,
+            grpc_max_decoding_message_size,
         }
         .pipe(Arc::new)
         .pipe(Self);

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -47,6 +47,7 @@ pub struct CommitteeSet {
     committees: BTreeMap<u64, Committee>,
 
     tls_private_key: Option<ed25519_dalek::SigningKey>,
+    grpc_max_decoding_message_size: Option<usize>,
     clients: BTreeMap<Address, Client>,
 }
 
@@ -62,6 +63,7 @@ impl CommitteeSet {
             committees_id,
             committees: BTreeMap::new(),
             tls_private_key: None,
+            grpc_max_decoding_message_size: None,
             clients: BTreeMap::new(),
         }
     }
@@ -119,6 +121,12 @@ impl CommitteeSet {
         self
     }
 
+    pub fn set_grpc_max_decoding_message_size(&mut self, limit: usize) -> &mut Self {
+        self.grpc_max_decoding_message_size = Some(limit);
+        self.update_all_clients();
+        self
+    }
+
     pub fn set_members(&mut self, members: BTreeMap<Address, MemberInfo>) -> &mut Self {
         self.tls_public_key_to_address = members
             .values()
@@ -151,9 +159,12 @@ impl CommitteeSet {
                 } else {
                     crate::tls::make_client_config(tls_public_key)
                 };
-                let client = Client::new(endpoint_url, tls_config)
+                let mut client = Client::new(endpoint_url, tls_config)
                     .inspect_err(|e| tracing::debug!("unable to build client for {validator}: {e}"))
                     .ok()?;
+                if let Some(limit) = self.grpc_max_decoding_message_size {
+                    client = client.max_decoding_message_size(limit);
+                }
                 Some((validator, client))
             })
             .collect();
@@ -187,9 +198,12 @@ impl CommitteeSet {
             } else {
                 crate::tls::make_client_config(tls_public_key)
             };
-            if let Ok(client) = Client::new(endpoint_url, tls_config)
+            if let Ok(mut client) = Client::new(endpoint_url, tls_config)
                 .inspect_err(|e| tracing::debug!("unable to build client for {validator}: {e}"))
             {
+                if let Some(limit) = self.grpc_max_decoding_message_size {
+                    client = client.max_decoding_message_size(limit);
+                }
                 self.clients.insert(validator, client);
             }
         }


### PR DESCRIPTION
Allow for configuring the max decoding size, setting a default of 16MiB over the default 4MiB that is the default in tonic.