### PR TITLE
Add sweep-utxos CLI tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,6 +1729,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,17 +3221,24 @@ name = "internal-tools"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bitcoin",
  "clap",
+ "csv",
  "fastcrypto",
  "fastcrypto-tbls",
+ "futures",
  "hashi",
  "hashi-types",
  "hex",
  "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
  "sui-sdk-types",
  "tokio",
  "toml",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/crates/internal-tools/Cargo.toml
+++ b/crates/internal-tools/Cargo.toml
@@ -12,6 +12,8 @@ fastcrypto.workspace = true
 fastcrypto-tbls.workspace = true
 sui-sdk-types.workspace = true
 
+bitcoin.workspace = true
+
 clap.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
@@ -19,3 +21,9 @@ hex.workspace = true
 tracing-subscriber.workspace = true
 toml.workspace = true
 rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true
+futures.workspace = true
+csv = "1"
+url = "2"

--- a/crates/internal-tools/src/dump_utxos.rs
+++ b/crates/internal-tools/src/dump_utxos.rs
@@ -6,28 +6,19 @@ use hashi::onchain::OnchainState;
 pub fn run(onchain_state: &OnchainState) -> anyhow::Result<()> {
     let state = onchain_state.state();
     let utxo_pool = &state.hashi().utxo_pool;
-    let utxos: Vec<_> = utxo_pool.active_utxos().collect();
+    let utxos: Vec<_> = utxo_pool
+        .active_utxos()
+        .map(|(id, utxo)| (*id, utxo.clone()))
+        .collect();
 
-    println!("=== Active UTXOs ({} entries) ===\n", utxos.len());
+    eprintln!("{} active UTXOs", utxos.len());
 
-    let mut total_amount: u64 = 0;
-    for (id, utxo) in &utxos {
-        println!(
-            "  txid: {}  vout: {}  amount: {} sat  derivation_path: {}",
-            id.txid,
-            id.vout,
-            utxo.amount,
-            utxo.derivation_path
-                .map_or("none".to_string(), |p| p.to_string()),
-        );
-        total_amount += utxo.amount;
-    }
-
-    println!(
-        "\nTotal: {} sat ({:.8} BTC)",
+    let total_amount: u64 = utxos.iter().map(|(_, u)| u.amount).sum();
+    eprintln!(
+        "Total: {} sat ({:.8} BTC)",
         total_amount,
         total_amount as f64 / 1e8
     );
 
-    Ok(())
+    crate::utxo_csv::write_csv(&utxos, std::io::stdout().lock())
 }

--- a/crates/internal-tools/src/main.rs
+++ b/crates/internal-tools/src/main.rs
@@ -15,6 +15,7 @@ use hashi::onchain::OnchainState;
 mod dump_utxos;
 mod key_recovery;
 pub mod sweep_utxos;
+mod utxo_csv;
 
 #[derive(Parser)]
 #[command(name = "internal-tools", about = "Internal operator tools for Hashi")]

--- a/crates/internal-tools/src/main.rs
+++ b/crates/internal-tools/src/main.rs
@@ -14,13 +14,15 @@ use hashi::onchain::OnchainState;
 
 mod dump_utxos;
 mod key_recovery;
+pub mod sweep_utxos;
 
 #[derive(Parser)]
 #[command(name = "internal-tools", about = "Internal operator tools for Hashi")]
 struct Cli {
     /// Path to a node config TOML file (provides sui-rpc, chain-id, hashi-ids).
+    /// Required for key-recovery and dump-utxos; not needed for sweep-utxos.
     #[arg(long)]
-    config: PathBuf,
+    config: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Commands,
@@ -30,6 +32,7 @@ struct Cli {
 enum Commands {
     KeyRecovery(key_recovery::Args),
     DumpUtxos,
+    SweepUtxos(sweep_utxos::Args),
 }
 
 #[tokio::main]
@@ -37,8 +40,17 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let cli = Cli::parse();
 
-    let config_str = std::fs::read_to_string(&cli.config)
-        .with_context(|| format!("failed to read config: {}", cli.config.display()))?;
+    if let Commands::SweepUtxos(args) = cli.command {
+        return sweep_utxos::run(args).await;
+    }
+
+    let config_path = cli
+        .config
+        .as_ref()
+        .ok_or_else(|| anyhow!("--config is required for this command"))?;
+
+    let config_str = std::fs::read_to_string(config_path)
+        .with_context(|| format!("failed to read config: {}", config_path.display()))?;
     let config: Config =
         toml::from_str(&config_str).with_context(|| "failed to parse config TOML")?;
 
@@ -62,5 +74,6 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::KeyRecovery(args) => key_recovery::run(args, &onchain_state, chain_id).await,
         Commands::DumpUtxos => dump_utxos::run(&onchain_state),
+        Commands::SweepUtxos(_) => unreachable!(),
     }
 }

--- a/crates/internal-tools/src/main.rs
+++ b/crates/internal-tools/src/main.rs
@@ -14,25 +14,44 @@ use hashi::onchain::OnchainState;
 
 mod dump_utxos;
 mod key_recovery;
-pub mod sweep_utxos;
+mod sweep_utxos;
 mod utxo_csv;
 
 #[derive(Parser)]
 #[command(name = "internal-tools", about = "Internal operator tools for Hashi")]
 struct Cli {
-    /// Path to a node config TOML file (provides sui-rpc, chain-id, hashi-ids).
-    /// Required for key-recovery and dump-utxos; not needed for sweep-utxos.
-    #[arg(long)]
-    config: Option<PathBuf>,
-
     #[command(subcommand)]
     command: Commands,
 }
 
+/// Shared arguments for subcommands that connect to a Sui node.
+#[derive(Parser)]
+struct ConfigArgs {
+    /// Path to a node config TOML file (provides sui-rpc, chain-id, hashi-ids).
+    #[arg(long)]
+    config: PathBuf,
+}
+
+impl ConfigArgs {
+    fn load(&self) -> anyhow::Result<Config> {
+        let s = std::fs::read_to_string(&self.config)
+            .with_context(|| format!("failed to read config: {}", self.config.display()))?;
+        toml::from_str(&s).context("failed to parse config TOML")
+    }
+}
+
 #[derive(Subcommand)]
 enum Commands {
-    KeyRecovery(key_recovery::Args),
-    DumpUtxos,
+    KeyRecovery {
+        #[command(flatten)]
+        config: ConfigArgs,
+        #[command(flatten)]
+        args: key_recovery::Args,
+    },
+    DumpUtxos {
+        #[command(flatten)]
+        config: ConfigArgs,
+    },
     SweepUtxos(sweep_utxos::Args),
 }
 
@@ -41,40 +60,38 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let cli = Cli::parse();
 
-    if let Commands::SweepUtxos(args) = cli.command {
-        return sweep_utxos::run(args).await;
-    }
-
-    let config_path = cli
-        .config
-        .as_ref()
-        .ok_or_else(|| anyhow!("--config is required for this command"))?;
-
-    let config_str = std::fs::read_to_string(config_path)
-        .with_context(|| format!("failed to read config: {}", config_path.display()))?;
-    let config: Config =
-        toml::from_str(&config_str).with_context(|| "failed to parse config TOML")?;
-
-    let sui_rpc = config
-        .sui_rpc
-        .as_deref()
-        .ok_or_else(|| anyhow!("config missing sui-rpc"))?;
-    let chain_id = config
-        .sui_chain_id
-        .as_deref()
-        .ok_or_else(|| anyhow!("config missing sui-chain-id"))?;
-    let hashi_ids = config.hashi_ids();
-
-    println!("Connecting to Sui RPC: {sui_rpc}");
-    println!("Chain ID: {chain_id}");
-
-    let (onchain_state, _watcher) = OnchainState::new(sui_rpc, hashi_ids, None, None, None)
-        .await
-        .context("failed to connect to Sui RPC")?;
-
     match cli.command {
-        Commands::KeyRecovery(args) => key_recovery::run(args, &onchain_state, chain_id).await,
-        Commands::DumpUtxos => dump_utxos::run(&onchain_state),
-        Commands::SweepUtxos(_) => unreachable!(),
+        Commands::SweepUtxos(args) => sweep_utxos::run(args).await,
+        Commands::KeyRecovery { config, args } => {
+            let cfg = config.load()?;
+            let sui_rpc = cfg
+                .sui_rpc
+                .as_deref()
+                .ok_or_else(|| anyhow!("config missing sui-rpc"))?;
+            let chain_id = cfg
+                .sui_chain_id
+                .as_deref()
+                .ok_or_else(|| anyhow!("config missing sui-chain-id"))?;
+            println!("Connecting to Sui RPC: {sui_rpc}");
+            println!("Chain ID: {chain_id}");
+            let (onchain_state, _watcher) =
+                OnchainState::new(sui_rpc, cfg.hashi_ids(), None, None, None)
+                    .await
+                    .context("failed to connect to Sui RPC")?;
+            key_recovery::run(args, &onchain_state, chain_id).await
+        }
+        Commands::DumpUtxos { config } => {
+            let cfg = config.load()?;
+            let sui_rpc = cfg
+                .sui_rpc
+                .as_deref()
+                .ok_or_else(|| anyhow!("config missing sui-rpc"))?;
+            println!("Connecting to Sui RPC: {sui_rpc}");
+            let (onchain_state, _watcher) =
+                OnchainState::new(sui_rpc, cfg.hashi_ids(), None, None, None)
+                    .await
+                    .context("failed to connect to Sui RPC")?;
+            dump_utxos::run(&onchain_state)
+        }
     }
 }

--- a/crates/internal-tools/src/sweep_utxos.rs
+++ b/crates/internal-tools/src/sweep_utxos.rs
@@ -52,6 +52,13 @@ use hashi_types::guardian::bitcoin_utils;
 const VERIFY_CONCURRENCY: usize = 64;
 const BROADCAST_CONCURRENCY: usize = 8;
 
+/// Fixed transaction overhead in weight units (version, locktime, segwit marker, varint counts).
+const TX_FIXED_WEIGHT: u64 = 44;
+/// Per-input weight for a taproot script-path spend (outpoint + sequence + witness).
+const TX_PER_INPUT_WEIGHT: u64 = 299;
+/// Per-output weight for a P2TR output (value + scriptPubKey).
+const TX_PER_OUTPUT_WEIGHT: u64 = 172;
+
 #[derive(Parser)]
 pub struct Args {
     #[arg(long)]
@@ -72,19 +79,19 @@ pub struct Args {
     #[arg(long, default_value = "")]
     rpc_password: String,
 
-    #[arg(long, default_value = "signet")]
-    network: String,
+    #[arg(long, default_value = "signet", value_parser = parse_network)]
+    network: Network,
 
-    #[arg(long, default_value_t = 1.0)]
-    fee_rate: f64,
+    #[arg(long, default_value_t = 1)]
+    fee_rate: u64,
 
     #[arg(long, default_value_t = 250)]
     batch_size: usize,
 
-    #[arg(long, default_value_t = false)]
+    #[arg(long)]
     verify: bool,
 
-    #[arg(long, default_value_t = false)]
+    #[arg(long)]
     broadcast: bool,
 }
 
@@ -156,21 +163,21 @@ impl BitcoinRpc {
         }
         let addr = result["scriptPubKey"]["address"]
             .as_str()
-            .unwrap_or("")
-            .to_string();
-        Ok(Some(addr))
+            .map(|s| s.to_string());
+        Ok(addr)
     }
 
     async fn send_raw_transaction(&self, tx_hex: &str) -> anyhow::Result<String> {
         let result = self
             .call("sendrawtransaction", serde_json::json!([tx_hex]))
             .await?;
-        Ok(result.as_str().unwrap_or("").to_string())
+        result
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow!("sendrawtransaction returned non-string result: {result}"))
     }
 }
 
-/// Reimplemented from `fastcrypto_tbls::threshold_schnorr::key_derivation::compute_tweak`
-/// (pub(crate), so not directly accessible).
 fn compute_tweak(vk: &G, address: &[u8; 32]) -> S {
     let mut ikm: Vec<u8> = vk.x_as_be_bytes().expect("non-identity point").to_vec();
     ikm.extend_from_slice(address);
@@ -196,16 +203,15 @@ fn parse_network(s: &str) -> anyhow::Result<Network> {
 }
 
 fn estimate_tx_weight(n_inputs: usize) -> Weight {
-    let fixed_wu: u64 = 44;
-    let per_input_wu: u64 = 299;
-    let per_output_wu: u64 = 172;
-    Weight::from_wu(fixed_wu + (n_inputs as u64) * per_input_wu + per_output_wu)
+    Weight::from_wu(
+        TX_FIXED_WEIGHT + (n_inputs as u64) * TX_PER_INPUT_WEIGHT + TX_PER_OUTPUT_WEIGHT,
+    )
 }
 
-fn estimate_fee(n_inputs: usize, fee_rate: FeeRate) -> Amount {
+fn estimate_fee(n_inputs: usize, fee_rate: FeeRate) -> anyhow::Result<Amount> {
     fee_rate
         .fee_wu(estimate_tx_weight(n_inputs))
-        .unwrap_or(Amount::from_sat(0))
+        .ok_or_else(|| anyhow!("fee calculation overflow for {n_inputs} inputs"))
 }
 
 fn prepare_inputs(
@@ -275,7 +281,7 @@ fn build_and_sign_sweep_tx(
     let secp = Secp256k1::new();
 
     let total_input: Amount = inputs.iter().map(|inp| inp.amount).sum();
-    let fee = estimate_fee(inputs.len(), fee_rate);
+    let fee = estimate_fee(inputs.len(), fee_rate)?;
     if fee >= total_input {
         bail!(
             "fee ({} sat) exceeds total input ({} sat) for {} inputs",
@@ -349,7 +355,6 @@ async fn verify_utxos_against_node(
 ) -> anyhow::Result<Vec<PreparedInput>> {
     let total = inputs.len();
     let checked = Arc::new(AtomicUsize::new(0));
-    let skipped = Arc::new(AtomicUsize::new(0));
 
     println!("  Checking {total} UTXOs with {VERIFY_CONCURRENCY} concurrent requests...");
 
@@ -357,7 +362,6 @@ async fn verify_utxos_against_node(
         .map(|(i, inp)| {
             let rpc = rpc.clone();
             let checked = checked.clone();
-            let skipped = skipped.clone();
             let txid_str = inp.outpoint.txid.to_string();
             let vout = inp.outpoint.vout;
             let expected_addr = inp.address.to_string();
@@ -370,11 +374,11 @@ async fn verify_utxos_against_node(
 
                 match rpc.get_tx_out(&txid_str, vout).await {
                     Ok(Some(addr)) if addr == expected_addr => (i, true),
-                    Ok(Some(_)) | Ok(None) => {
-                        skipped.fetch_add(1, Ordering::Relaxed);
+                    Ok(Some(_)) | Ok(None) => (i, false),
+                    Err(e) => {
+                        eprintln!("  WARN: RPC error verifying UTXO {i} ({txid_str}:{vout}): {e}");
                         (i, false)
                     }
-                    Err(_) => (i, true),
                 }
             }
         })
@@ -382,22 +386,21 @@ async fn verify_utxos_against_node(
         .collect()
         .await;
 
-    let keep_set: std::collections::HashSet<usize> = results
-        .into_iter()
-        .filter(|(_, keep)| *keep)
-        .map(|(i, _)| i)
-        .collect();
+    let mut keep = vec![false; total];
+    for (i, should_keep) in results {
+        keep[i] = should_keep;
+    }
 
     let filtered: Vec<PreparedInput> = inputs
         .into_iter()
-        .enumerate()
-        .filter(|(i, _)| keep_set.contains(i))
-        .map(|(_, inp)| inp)
+        .zip(keep)
+        .filter(|(_, k)| *k)
+        .map(|(inp, _)| inp)
         .collect();
 
-    let skipped_count = skipped.load(Ordering::Relaxed);
+    let skipped = total - filtered.len();
     println!(
-        "Verified: {total} UTXOs checked, {skipped_count} skipped, {} remaining",
+        "Verified: {total} UTXOs checked, {skipped} skipped, {} remaining",
         filtered.len()
     );
     Ok(filtered)
@@ -407,59 +410,45 @@ async fn broadcast_transactions(
     signed_txs: &[(Transaction, Amount, Amount)],
     rpc: &Arc<BitcoinRpc>,
 ) -> (usize, usize) {
-    let success = Arc::new(AtomicUsize::new(0));
-    let failed = Arc::new(AtomicUsize::new(0));
-
-    let results: Vec<(usize, Result<String, anyhow::Error>)> =
+    let mut results: Vec<(usize, Result<String, anyhow::Error>)> =
         stream::iter(signed_txs.iter().enumerate())
             .map(|(i, (tx, _fee, _out))| {
                 let rpc = rpc.clone();
                 let raw_hex = consensus::encode::serialize_hex(tx);
-                let success = success.clone();
-                let failed = failed.clone();
-
-                async move {
-                    match rpc.send_raw_transaction(&raw_hex).await {
-                        Ok(txid) => {
-                            success.fetch_add(1, Ordering::Relaxed);
-                            (i, Ok(txid))
-                        }
-                        Err(e) => {
-                            failed.fetch_add(1, Ordering::Relaxed);
-                            (i, Err(e))
-                        }
-                    }
-                }
+                async move { (i, rpc.send_raw_transaction(&raw_hex).await) }
             })
             .buffer_unordered(BROADCAST_CONCURRENCY)
             .collect()
             .await;
 
-    let mut sorted_results = results;
-    sorted_results.sort_by_key(|(i, _)| *i);
-    for (i, result) in &sorted_results {
+    results.sort_by_key(|(i, _)| *i);
+
+    let mut ok = 0;
+    let mut fail = 0;
+    for (i, result) in &results {
         match result {
-            Ok(txid) => println!("  Tx {} broadcast OK: {txid}", i + 1),
-            Err(e) => eprintln!("  Tx {} broadcast FAILED: {e}", i + 1),
+            Ok(txid) => {
+                ok += 1;
+                println!("  Tx {} broadcast OK: {txid}", i + 1);
+            }
+            Err(e) => {
+                fail += 1;
+                eprintln!("  Tx {} broadcast FAILED: {e}", i + 1);
+            }
         }
     }
 
-    (
-        success.load(Ordering::Relaxed),
-        failed.load(Ordering::Relaxed),
-    )
+    (ok, fail)
 }
 
 pub async fn run(args: Args) -> anyhow::Result<()> {
-    let network = parse_network(&args.network)?;
-
     let destination = Address::from_str(&args.destination)
         .with_context(|| format!("invalid destination address: {}", args.destination))?
-        .require_network(network)
+        .require_network(args.network)
         .with_context(|| {
             format!(
                 "destination address {} is not valid for network {:?}",
-                args.destination, network
+                args.destination, args.network
             )
         })?;
 
@@ -477,10 +466,10 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
 
     let master_xonly = XOnlyPublicKey::from_slice(&master_x).context("invalid master xonly key")?;
     let master_address =
-        bitcoin_utils::single_key_taproot_script_path_address(&master_xonly, network);
+        bitcoin_utils::single_key_taproot_script_path_address(&master_xonly, args.network);
     println!("Master deposit address: {}", master_address);
 
-    println!("\nParsing CSV: {}", args.csv.display());
+    println!("Parsing CSV: {}", args.csv.display());
     let utxos = crate::utxo_csv::parse_csv(&args.csv)?;
     let total_amount: u64 = utxos.iter().map(|u| u.amount).sum();
     println!(
@@ -490,8 +479,8 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         total_amount as f64 / 1e8
     );
 
-    println!("\nDeriving keys and computing addresses...");
-    let mut inputs = prepare_inputs(&utxos, &parent_sk, &parent_pk, network)?;
+    println!("Deriving keys and computing addresses...");
+    let mut inputs = prepare_inputs(&utxos, &parent_sk, &parent_pk, args.network)?;
     println!("Prepared {} inputs successfully", inputs.len());
 
     let rpc = Arc::new(BitcoinRpc::new(
@@ -509,18 +498,18 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     }
 
     if inputs.is_empty() {
-        println!("\nNo spendable UTXOs found. Nothing to do.");
+        println!("No spendable UTXOs found. Nothing to do.");
         return Ok(());
     }
 
-    let fee_rate = FeeRate::from_sat_per_vb(args.fee_rate as u64)
-        .ok_or_else(|| anyhow!("invalid fee rate"))?;
-    println!("\nFee rate: {} sat/vB", args.fee_rate);
+    let fee_rate =
+        FeeRate::from_sat_per_vb(args.fee_rate).ok_or_else(|| anyhow!("invalid fee rate"))?;
+    println!("Fee rate: {} sat/vB", args.fee_rate);
     println!("Destination: {destination}");
     println!("Batch size: {} inputs per tx", args.batch_size);
 
     let batches: Vec<&[PreparedInput]> = inputs.chunks(args.batch_size).collect();
-    println!("\nBuilding {} transactions...", batches.len());
+    println!("Building {} transactions...", batches.len());
 
     let mut total_fees = Amount::from_sat(0);
     let mut total_output = Amount::from_sat(0);
@@ -548,7 +537,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     }
 
     let spendable_amount: Amount = inputs.iter().map(|inp| inp.amount).sum();
-    println!("\n=== Summary ===");
+    println!("=== Summary ===");
     println!("Total UTXOs: {}", inputs.len());
     println!(
         "Total input: {} sat ({:.8} BTC)",
@@ -569,14 +558,14 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     println!("Destination: {destination}");
 
     if args.broadcast {
-        println!("\n=== Broadcasting transactions ({BROADCAST_CONCURRENCY} concurrent) ===");
+        println!("=== Broadcasting transactions ({BROADCAST_CONCURRENCY} concurrent) ===");
         let (ok, fail) = broadcast_transactions(&signed_txs, &rpc).await;
-        println!("\nBroadcast complete: {ok} succeeded, {fail} failed");
+        println!("Broadcast complete: {ok} succeeded, {fail} failed");
     } else {
-        println!("\n=== Signed transaction hex (dry run) ===");
+        println!("=== Signed transaction hex (dry run) ===");
         for (i, (tx, _fee, _out)) in signed_txs.iter().enumerate() {
             let raw_hex = consensus::encode::serialize_hex(tx);
-            println!("\n--- Tx {} (txid: {}) ---", i + 1, tx.compute_txid());
+            println!("--- Tx {} (txid: {}) ---", i + 1, tx.compute_txid());
             if i == 0 || i == signed_txs.len() - 1 || signed_txs.len() <= 5 {
                 println!("{raw_hex}");
             } else if i == 1 {
@@ -586,7 +575,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
                 );
             }
         }
-        println!("\nDry run complete. Use --broadcast to send transactions to the network.");
+        println!("Dry run complete. Use --broadcast to send transactions to the network.");
     }
 
     Ok(())

--- a/crates/internal-tools/src/sweep_utxos.rs
+++ b/crates/internal-tools/src/sweep_utxos.rs
@@ -1,0 +1,667 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use anyhow::Context;
+use anyhow::anyhow;
+use anyhow::bail;
+use bitcoin::Address;
+use bitcoin::Amount;
+use bitcoin::FeeRate;
+use bitcoin::Network;
+use bitcoin::OutPoint;
+use bitcoin::ScriptBuf;
+use bitcoin::Sequence;
+use bitcoin::TapSighashType;
+use bitcoin::Transaction;
+use bitcoin::TxIn;
+use bitcoin::TxOut;
+use bitcoin::Txid;
+use bitcoin::Weight;
+use bitcoin::Witness;
+use bitcoin::absolute::LockTime;
+use bitcoin::consensus;
+use bitcoin::hashes::Hash;
+use bitcoin::secp256k1::Message;
+use bitcoin::secp256k1::Secp256k1;
+use bitcoin::secp256k1::XOnlyPublicKey;
+use bitcoin::secp256k1::{self};
+use bitcoin::sighash::Prevouts;
+use bitcoin::sighash::SighashCache;
+use bitcoin::taproot::Signature;
+use bitcoin::taproot::TapLeafHash;
+use bitcoin::transaction::Version;
+use clap::Parser;
+use fastcrypto::groups::GroupElement;
+use fastcrypto::hmac::HkdfIkm;
+use fastcrypto::hmac::hkdf_sha3_256;
+use fastcrypto::serde_helpers::ToFromByteArray;
+use fastcrypto::traits::ToFromBytes;
+use fastcrypto_tbls::threshold_schnorr::G;
+use fastcrypto_tbls::threshold_schnorr::S;
+use futures::stream::StreamExt;
+use futures::stream::{self};
+use hashi_types::guardian::bitcoin_utils;
+
+const VERIFY_CONCURRENCY: usize = 64;
+const BROADCAST_CONCURRENCY: usize = 8;
+
+#[derive(Parser)]
+pub struct Args {
+    #[arg(long)]
+    csv: PathBuf,
+
+    #[arg(long)]
+    private_key: String,
+
+    #[arg(long)]
+    destination: String,
+
+    #[arg(long, default_value = "http://127.0.0.1:38332")]
+    bitcoin_rpc: String,
+
+    #[arg(long, default_value = "")]
+    rpc_user: String,
+
+    #[arg(long, default_value = "")]
+    rpc_password: String,
+
+    #[arg(long, default_value = "signet")]
+    network: String,
+
+    #[arg(long, default_value_t = 1.0)]
+    fee_rate: f64,
+
+    #[arg(long, default_value_t = 250)]
+    batch_size: usize,
+
+    #[arg(long, default_value_t = false)]
+    verify: bool,
+
+    #[arg(long, default_value_t = false)]
+    broadcast: bool,
+}
+
+#[derive(Debug, Clone)]
+struct UtxoRecord {
+    txid: [u8; 32],
+    vout: u32,
+    derivation_path: Option<[u8; 32]>,
+    amount: u64,
+}
+
+struct PreparedInput {
+    outpoint: OutPoint,
+    amount: Amount,
+    secret_key: secp256k1::SecretKey,
+    tapscript: ScriptBuf,
+    control_block: bitcoin::taproot::ControlBlock,
+    leaf_hash: TapLeafHash,
+    address: Address,
+}
+
+struct BitcoinRpc {
+    client: reqwest::Client,
+    url: String,
+    auth: Option<(String, String)>,
+    next_id: AtomicUsize,
+}
+
+impl BitcoinRpc {
+    fn new(url: &str, user: &str, password: &str) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            url: url.to_string(),
+            auth: if user.is_empty() {
+                None
+            } else {
+                Some((user.to_string(), password.to_string()))
+            },
+            next_id: AtomicUsize::new(1),
+        }
+    }
+
+    async fn call(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let body = serde_json::json!({
+            "jsonrpc": "1.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+
+        let mut req = self.client.post(&self.url).json(&body);
+        if let Some((user, pass)) = &self.auth {
+            req = req.basic_auth(user, Some(pass));
+        }
+
+        let resp = req.send().await.context("RPC request failed")?;
+        let json: serde_json::Value = resp.json().await.context("RPC response parse failed")?;
+
+        if let Some(error) = json.get("error").filter(|e| !e.is_null()) {
+            bail!("RPC error: {error}");
+        }
+
+        Ok(json["result"].clone())
+    }
+
+    async fn get_tx_out(&self, txid: &str, vout: u32) -> anyhow::Result<Option<String>> {
+        let result = self
+            .call("gettxout", serde_json::json!([txid, vout]))
+            .await?;
+        if result.is_null() {
+            return Ok(None);
+        }
+        let addr = result["scriptPubKey"]["address"]
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        Ok(Some(addr))
+    }
+
+    async fn send_raw_transaction(&self, tx_hex: &str) -> anyhow::Result<String> {
+        let result = self
+            .call("sendrawtransaction", serde_json::json!([tx_hex]))
+            .await?;
+        Ok(result.as_str().unwrap_or("").to_string())
+    }
+}
+
+/// Reimplemented from `fastcrypto_tbls::threshold_schnorr::key_derivation::compute_tweak`
+/// (pub(crate), so not directly accessible).
+fn compute_tweak(vk: &G, address: &[u8; 32]) -> S {
+    let mut ikm: Vec<u8> = vk.x_as_be_bytes().expect("non-identity point").to_vec();
+    ikm.extend_from_slice(address);
+
+    let bytes = hkdf_sha3_256(&HkdfIkm::from_bytes(&ikm).expect("valid ikm"), &[], &[], 64)
+        .expect("hkdf should not fail for 64 bytes");
+    S::from_bytes_mod_order(&bytes)
+}
+
+fn derive_child_secret_key(parent_sk: &S, parent_pk: &G, derivation_path: &[u8; 32]) -> S {
+    let tweak = compute_tweak(parent_pk, derivation_path);
+    *parent_sk + tweak
+}
+
+fn parse_hex_bytes_32(hex_str: &str) -> anyhow::Result<[u8; 32]> {
+    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes = hex::decode(hex_str).context("invalid hex")?;
+    bytes
+        .try_into()
+        .map_err(|v: Vec<u8>| anyhow!("expected 32 bytes, got {}", v.len()))
+}
+
+fn parse_csv(path: &std::path::Path) -> anyhow::Result<Vec<UtxoRecord>> {
+    let mut reader = csv::Reader::from_path(path).context("failed to open CSV")?;
+    let mut records = Vec::new();
+
+    for (i, result) in reader.records().enumerate() {
+        let record = result.with_context(|| format!("failed to read CSV row {}", i + 1))?;
+
+        let txid_str = record
+            .get(0)
+            .ok_or_else(|| anyhow!("row {}: missing txid", i + 1))?;
+        let vout_str = record
+            .get(1)
+            .ok_or_else(|| anyhow!("row {}: missing vout", i + 1))?;
+        let deriv_str = record
+            .get(2)
+            .ok_or_else(|| anyhow!("row {}: missing derivation_path", i + 1))?;
+        let amount_str = record
+            .get(3)
+            .ok_or_else(|| anyhow!("row {}: missing amount", i + 1))?;
+
+        let txid =
+            parse_hex_bytes_32(txid_str).with_context(|| format!("row {}: bad txid", i + 1))?;
+        let vout: u32 = vout_str
+            .parse()
+            .with_context(|| format!("row {}: bad vout", i + 1))?;
+        let derivation_path = if deriv_str.is_empty() {
+            None
+        } else {
+            Some(
+                parse_hex_bytes_32(deriv_str)
+                    .with_context(|| format!("row {}: bad derivation_path", i + 1))?,
+            )
+        };
+        let amount: u64 = amount_str
+            .parse()
+            .with_context(|| format!("row {}: bad amount", i + 1))?;
+
+        records.push(UtxoRecord {
+            txid,
+            vout,
+            derivation_path,
+            amount,
+        });
+    }
+
+    Ok(records)
+}
+
+fn parse_network(s: &str) -> anyhow::Result<Network> {
+    match s {
+        "mainnet" | "bitcoin" => Ok(Network::Bitcoin),
+        "testnet4" => Ok(Network::Testnet4),
+        "signet" => Ok(Network::Signet),
+        "regtest" => Ok(Network::Regtest),
+        _ => bail!("unknown network: {s}"),
+    }
+}
+
+fn estimate_tx_weight(n_inputs: usize) -> Weight {
+    let fixed_wu: u64 = 44;
+    let per_input_wu: u64 = 299;
+    let per_output_wu: u64 = 172;
+    Weight::from_wu(fixed_wu + (n_inputs as u64) * per_input_wu + per_output_wu)
+}
+
+fn estimate_fee(n_inputs: usize, fee_rate: FeeRate) -> Amount {
+    let weight = estimate_tx_weight(n_inputs);
+    fee_rate.fee_wu(weight).unwrap_or(Amount::from_sat(0))
+}
+
+fn prepare_inputs(
+    records: &[UtxoRecord],
+    parent_sk: &S,
+    parent_pk: &G,
+    network: Network,
+) -> anyhow::Result<Vec<PreparedInput>> {
+    let secp = Secp256k1::new();
+    let mut inputs = Vec::with_capacity(records.len());
+
+    for (i, rec) in records.iter().enumerate() {
+        let child_sk_scalar = match &rec.derivation_path {
+            Some(path) => derive_child_secret_key(parent_sk, parent_pk, path),
+            None => *parent_sk,
+        };
+
+        let sk_bytes = child_sk_scalar.to_byte_array();
+        let child_pk_point = G::generator() * child_sk_scalar;
+
+        let xonly_bytes = child_pk_point
+            .x_as_be_bytes()
+            .map_err(|e| anyhow!("utxo {i}: x_as_be_bytes: {e}"))?;
+
+        let xonly_pk = XOnlyPublicKey::from_slice(&xonly_bytes)
+            .with_context(|| format!("utxo {i}: invalid x-only key"))?;
+
+        let (tapscript, control_block, leaf_hash) =
+            bitcoin_utils::single_key_taproot_script_path_spend_artifacts(&xonly_pk);
+        let address = bitcoin_utils::single_key_taproot_script_path_address(&xonly_pk, network);
+
+        let secret_key = secp256k1::SecretKey::from_slice(&sk_bytes)
+            .with_context(|| format!("utxo {i}: invalid secret key"))?;
+
+        let keypair = secp256k1::Keypair::from_secret_key(&secp, &secret_key);
+        let (derived_xonly, _parity) = keypair.x_only_public_key();
+        if derived_xonly != xonly_pk {
+            bail!(
+                "utxo {i}: derived pubkey mismatch: expected {}, got {}",
+                xonly_pk,
+                derived_xonly
+            );
+        }
+
+        let outpoint = OutPoint {
+            txid: Txid::from_byte_array(rec.txid),
+            vout: rec.vout,
+        };
+
+        inputs.push(PreparedInput {
+            outpoint,
+            amount: Amount::from_sat(rec.amount),
+            secret_key,
+            tapscript,
+            control_block,
+            leaf_hash,
+            address,
+        });
+    }
+
+    Ok(inputs)
+}
+
+fn build_and_sign_sweep_tx(
+    inputs: &[PreparedInput],
+    destination: &Address,
+    fee_rate: FeeRate,
+) -> anyhow::Result<(Transaction, Amount)> {
+    let secp = Secp256k1::new();
+
+    let total_input: Amount = inputs.iter().map(|inp| inp.amount).sum();
+    let fee = estimate_fee(inputs.len(), fee_rate);
+    if fee >= total_input {
+        bail!(
+            "fee ({} sat) exceeds total input ({} sat) for {} inputs",
+            fee.to_sat(),
+            total_input.to_sat(),
+            inputs.len()
+        );
+    }
+    let output_amount = total_input - fee;
+
+    let tx_inputs: Vec<TxIn> = inputs
+        .iter()
+        .map(|inp| TxIn {
+            previous_output: inp.outpoint,
+            script_sig: ScriptBuf::default(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::default(),
+        })
+        .collect();
+
+    let tx_outputs = vec![TxOut {
+        value: output_amount,
+        script_pubkey: destination.script_pubkey(),
+    }];
+
+    let mut tx = Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: tx_inputs,
+        output: tx_outputs,
+    };
+
+    let prevouts: Vec<TxOut> = inputs
+        .iter()
+        .map(|inp| TxOut {
+            value: inp.amount,
+            script_pubkey: inp.address.script_pubkey(),
+        })
+        .collect();
+
+    for (idx, inp) in inputs.iter().enumerate() {
+        let mut sighasher = SighashCache::new(&tx);
+        let sighash = sighasher
+            .taproot_script_spend_signature_hash(
+                idx,
+                &Prevouts::All(&prevouts),
+                inp.leaf_hash,
+                TapSighashType::Default,
+            )
+            .with_context(|| format!("sighash computation failed for input {idx}"))?;
+
+        let message = Message::from_digest(*sighash.as_byte_array());
+        let keypair = secp256k1::Keypair::from_secret_key(&secp, &inp.secret_key);
+        let schnorr_sig = secp.sign_schnorr_no_aux_rand(&message, &keypair);
+
+        let signature = Signature {
+            signature: schnorr_sig,
+            sighash_type: TapSighashType::Default,
+        };
+
+        let witness = Witness::from_slice(&[
+            signature.to_vec(),
+            inp.tapscript.to_bytes(),
+            inp.control_block.serialize(),
+        ]);
+
+        tx.input[idx].witness = witness;
+    }
+
+    Ok((tx, fee))
+}
+
+async fn verify_utxos_against_node(
+    inputs: Vec<PreparedInput>,
+    rpc: &Arc<BitcoinRpc>,
+) -> anyhow::Result<Vec<PreparedInput>> {
+    let total = inputs.len();
+    let checked = Arc::new(AtomicUsize::new(0));
+    let skipped = Arc::new(AtomicUsize::new(0));
+
+    println!("  Checking {total} UTXOs with {VERIFY_CONCURRENCY} concurrent requests...");
+
+    let results: Vec<(usize, bool)> = stream::iter(inputs.iter().enumerate())
+        .map(|(i, inp)| {
+            let rpc = rpc.clone();
+            let checked = checked.clone();
+            let skipped = skipped.clone();
+            let txid_str = inp.outpoint.txid.to_string();
+            let vout = inp.outpoint.vout;
+            let expected_addr = inp.address.to_string();
+
+            async move {
+                let cnt = checked.fetch_add(1, Ordering::Relaxed) + 1;
+                if cnt.is_multiple_of(2000) {
+                    eprintln!("  ... verified {cnt}/{total}");
+                }
+
+                match rpc.get_tx_out(&txid_str, vout).await {
+                    Ok(Some(addr)) => {
+                        if addr == expected_addr {
+                            (i, true)
+                        } else {
+                            skipped.fetch_add(1, Ordering::Relaxed);
+                            (i, false)
+                        }
+                    }
+                    Ok(None) => {
+                        skipped.fetch_add(1, Ordering::Relaxed);
+                        (i, false)
+                    }
+                    Err(_) => (i, true),
+                }
+            }
+        })
+        .buffer_unordered(VERIFY_CONCURRENCY)
+        .collect()
+        .await;
+
+    let keep_set: std::collections::HashSet<usize> = results
+        .into_iter()
+        .filter(|(_, keep)| *keep)
+        .map(|(i, _)| i)
+        .collect();
+
+    let filtered: Vec<PreparedInput> = inputs
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| keep_set.contains(i))
+        .map(|(_, inp)| inp)
+        .collect();
+
+    let skipped_count = skipped.load(Ordering::Relaxed);
+    println!(
+        "Verified: {total} UTXOs checked, {skipped_count} skipped, {} remaining",
+        filtered.len()
+    );
+    Ok(filtered)
+}
+
+async fn broadcast_transactions(
+    signed_txs: &[(Transaction, Amount, Amount)],
+    rpc: &Arc<BitcoinRpc>,
+) -> (usize, usize) {
+    let success = Arc::new(AtomicUsize::new(0));
+    let failed = Arc::new(AtomicUsize::new(0));
+
+    let results: Vec<(usize, Result<String, anyhow::Error>)> =
+        stream::iter(signed_txs.iter().enumerate())
+            .map(|(i, (tx, _fee, _out))| {
+                let rpc = rpc.clone();
+                let raw_hex = consensus::encode::serialize_hex(tx);
+                let success = success.clone();
+                let failed = failed.clone();
+
+                async move {
+                    match rpc.send_raw_transaction(&raw_hex).await {
+                        Ok(txid) => {
+                            success.fetch_add(1, Ordering::Relaxed);
+                            (i, Ok(txid))
+                        }
+                        Err(e) => {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            (i, Err(e))
+                        }
+                    }
+                }
+            })
+            .buffer_unordered(BROADCAST_CONCURRENCY)
+            .collect()
+            .await;
+
+    let mut sorted_results = results;
+    sorted_results.sort_by_key(|(i, _)| *i);
+    for (i, result) in &sorted_results {
+        match result {
+            Ok(txid) => println!("  Tx {} broadcast OK: {txid}", i + 1),
+            Err(e) => eprintln!("  Tx {} broadcast FAILED: {e}", i + 1),
+        }
+    }
+
+    (
+        success.load(Ordering::Relaxed),
+        failed.load(Ordering::Relaxed),
+    )
+}
+
+pub async fn run(args: Args) -> anyhow::Result<()> {
+    let network = parse_network(&args.network)?;
+
+    let destination = Address::from_str(&args.destination)
+        .with_context(|| format!("invalid destination address: {}", args.destination))?
+        .require_network(network)
+        .with_context(|| {
+            format!(
+                "destination address {} is not valid for network {:?}",
+                args.destination, network
+            )
+        })?;
+
+    let sk_bytes = parse_hex_bytes_32(&args.private_key).context("invalid private key hex")?;
+    let parent_sk = S::from_byte_array(&sk_bytes).map_err(|e| anyhow!("invalid scalar: {e}"))?;
+
+    let parent_pk = G::generator() * parent_sk;
+    let master_x = parent_pk
+        .x_as_be_bytes()
+        .map_err(|e| anyhow!("invalid master key: {e}"))?;
+    println!("Master public key (x-only): {}", hex::encode(master_x));
+
+    let master_xonly = XOnlyPublicKey::from_slice(&master_x).context("invalid master xonly key")?;
+    let master_address =
+        bitcoin_utils::single_key_taproot_script_path_address(&master_xonly, network);
+    println!("Master deposit address: {}", master_address);
+
+    println!("\nParsing CSV: {}", args.csv.display());
+    let records = parse_csv(&args.csv)?;
+    let total_utxos = records.len();
+    let total_amount: u64 = records.iter().map(|r| r.amount).sum();
+    println!(
+        "Parsed {} UTXOs, total: {} sat ({:.8} BTC)",
+        total_utxos,
+        total_amount,
+        total_amount as f64 / 1e8
+    );
+
+    println!("\nDeriving keys and computing addresses...");
+    let mut inputs = prepare_inputs(&records, &parent_sk, &parent_pk, network)?;
+    println!("Prepared {} inputs successfully", inputs.len());
+
+    let rpc = Arc::new(BitcoinRpc::new(
+        &args.bitcoin_rpc,
+        &args.rpc_user,
+        &args.rpc_password,
+    ));
+
+    if args.verify {
+        println!(
+            "\nVerifying UTXOs against Bitcoin node at {}...",
+            args.bitcoin_rpc
+        );
+        inputs = verify_utxos_against_node(inputs, &rpc).await?;
+    }
+
+    if inputs.is_empty() {
+        println!("\nNo spendable UTXOs found. Nothing to do.");
+        return Ok(());
+    }
+
+    let fee_rate = FeeRate::from_sat_per_vb(args.fee_rate as u64)
+        .ok_or_else(|| anyhow!("invalid fee rate"))?;
+    println!("\nFee rate: {} sat/vB", args.fee_rate);
+    println!("Destination: {destination}");
+    println!("Batch size: {} inputs per tx", args.batch_size);
+
+    let batches: Vec<&[PreparedInput]> = inputs.chunks(args.batch_size).collect();
+    println!("\nBuilding {} transactions...", batches.len());
+
+    let mut total_fees = Amount::from_sat(0);
+    let mut total_output = Amount::from_sat(0);
+    let mut signed_txs: Vec<(Transaction, Amount, Amount)> = Vec::new();
+
+    for (batch_idx, batch) in batches.iter().enumerate() {
+        let batch_input_total: Amount = batch.iter().map(|inp| inp.amount).sum();
+        let (tx, fee) = build_and_sign_sweep_tx(batch, &destination, fee_rate)?;
+        let output_amount = batch_input_total - fee;
+
+        total_fees += fee;
+        total_output += output_amount;
+
+        println!(
+            "  Tx {}: {} inputs, {} sat in, {} sat out, {} sat fee, txid: {}",
+            batch_idx + 1,
+            batch.len(),
+            batch_input_total.to_sat(),
+            output_amount.to_sat(),
+            fee.to_sat(),
+            tx.compute_txid(),
+        );
+
+        signed_txs.push((tx, fee, output_amount));
+    }
+
+    let spendable_amount: Amount = inputs.iter().map(|inp| inp.amount).sum();
+    println!("\n=== Summary ===");
+    println!("Total UTXOs: {}", inputs.len());
+    println!(
+        "Total input: {} sat ({:.8} BTC)",
+        spendable_amount.to_sat(),
+        spendable_amount.to_sat() as f64 / 1e8
+    );
+    println!(
+        "Total output: {} sat ({:.8} BTC)",
+        total_output.to_sat(),
+        total_output.to_sat() as f64 / 1e8
+    );
+    println!(
+        "Total fees: {} sat ({:.8} BTC)",
+        total_fees.to_sat(),
+        total_fees.to_sat() as f64 / 1e8
+    );
+    println!("Transactions: {}", signed_txs.len());
+    println!("Destination: {destination}");
+
+    if args.broadcast {
+        println!("\n=== Broadcasting transactions ({BROADCAST_CONCURRENCY} concurrent) ===");
+        let (ok, fail) = broadcast_transactions(&signed_txs, &rpc).await;
+        println!("\nBroadcast complete: {ok} succeeded, {fail} failed");
+    } else {
+        println!("\n=== Signed transaction hex (dry run) ===");
+        for (i, (tx, _fee, _out)) in signed_txs.iter().enumerate() {
+            let raw_hex = consensus::encode::serialize_hex(tx);
+            println!("\n--- Tx {} (txid: {}) ---", i + 1, tx.compute_txid());
+            if i == 0 || i == signed_txs.len() - 1 || signed_txs.len() <= 5 {
+                println!("{raw_hex}");
+            } else if i == 1 {
+                println!(
+                    "  ... ({} more transactions omitted) ...",
+                    signed_txs.len() - 2
+                );
+            }
+        }
+        println!("\nDry run complete. Use --broadcast to send transactions to the network.");
+    }
+
+    Ok(())
+}

--- a/crates/internal-tools/src/sweep_utxos.rs
+++ b/crates/internal-tools/src/sweep_utxos.rs
@@ -46,6 +46,7 @@ use fastcrypto_tbls::threshold_schnorr::G;
 use fastcrypto_tbls::threshold_schnorr::S;
 use futures::stream::StreamExt;
 use futures::stream::{self};
+use hashi::onchain::types::Utxo;
 use hashi_types::guardian::bitcoin_utils;
 
 const VERIFY_CONCURRENCY: usize = 64;
@@ -85,14 +86,6 @@ pub struct Args {
 
     #[arg(long, default_value_t = false)]
     broadcast: bool,
-}
-
-#[derive(Debug, Clone)]
-struct UtxoRecord {
-    txid: [u8; 32],
-    vout: u32,
-    derivation_path: Option<[u8; 32]>,
-    amount: u64,
 }
 
 struct PreparedInput {
@@ -192,62 +185,6 @@ fn derive_child_secret_key(parent_sk: &S, parent_pk: &G, derivation_path: &[u8; 
     *parent_sk + tweak
 }
 
-fn parse_hex_bytes_32(hex_str: &str) -> anyhow::Result<[u8; 32]> {
-    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
-    let bytes = hex::decode(hex_str).context("invalid hex")?;
-    bytes
-        .try_into()
-        .map_err(|v: Vec<u8>| anyhow!("expected 32 bytes, got {}", v.len()))
-}
-
-fn parse_csv(path: &std::path::Path) -> anyhow::Result<Vec<UtxoRecord>> {
-    let mut reader = csv::Reader::from_path(path).context("failed to open CSV")?;
-    let mut records = Vec::new();
-
-    for (i, result) in reader.records().enumerate() {
-        let record = result.with_context(|| format!("failed to read CSV row {}", i + 1))?;
-
-        let txid_str = record
-            .get(0)
-            .ok_or_else(|| anyhow!("row {}: missing txid", i + 1))?;
-        let vout_str = record
-            .get(1)
-            .ok_or_else(|| anyhow!("row {}: missing vout", i + 1))?;
-        let deriv_str = record
-            .get(2)
-            .ok_or_else(|| anyhow!("row {}: missing derivation_path", i + 1))?;
-        let amount_str = record
-            .get(3)
-            .ok_or_else(|| anyhow!("row {}: missing amount", i + 1))?;
-
-        let txid =
-            parse_hex_bytes_32(txid_str).with_context(|| format!("row {}: bad txid", i + 1))?;
-        let vout: u32 = vout_str
-            .parse()
-            .with_context(|| format!("row {}: bad vout", i + 1))?;
-        let derivation_path = if deriv_str.is_empty() {
-            None
-        } else {
-            Some(
-                parse_hex_bytes_32(deriv_str)
-                    .with_context(|| format!("row {}: bad derivation_path", i + 1))?,
-            )
-        };
-        let amount: u64 = amount_str
-            .parse()
-            .with_context(|| format!("row {}: bad amount", i + 1))?;
-
-        records.push(UtxoRecord {
-            txid,
-            vout,
-            derivation_path,
-            amount,
-        });
-    }
-
-    Ok(records)
-}
-
 fn parse_network(s: &str) -> anyhow::Result<Network> {
     match s {
         "mainnet" | "bitcoin" => Ok(Network::Bitcoin),
@@ -266,22 +203,23 @@ fn estimate_tx_weight(n_inputs: usize) -> Weight {
 }
 
 fn estimate_fee(n_inputs: usize, fee_rate: FeeRate) -> Amount {
-    let weight = estimate_tx_weight(n_inputs);
-    fee_rate.fee_wu(weight).unwrap_or(Amount::from_sat(0))
+    fee_rate
+        .fee_wu(estimate_tx_weight(n_inputs))
+        .unwrap_or(Amount::from_sat(0))
 }
 
 fn prepare_inputs(
-    records: &[UtxoRecord],
+    utxos: &[Utxo],
     parent_sk: &S,
     parent_pk: &G,
     network: Network,
 ) -> anyhow::Result<Vec<PreparedInput>> {
     let secp = Secp256k1::new();
-    let mut inputs = Vec::with_capacity(records.len());
+    let mut inputs = Vec::with_capacity(utxos.len());
 
-    for (i, rec) in records.iter().enumerate() {
-        let child_sk_scalar = match &rec.derivation_path {
-            Some(path) => derive_child_secret_key(parent_sk, parent_pk, path),
+    for (i, utxo) in utxos.iter().enumerate() {
+        let child_sk_scalar = match &utxo.derivation_path {
+            Some(path) => derive_child_secret_key(parent_sk, parent_pk, &path.into_inner()),
             None => *parent_sk,
         };
 
@@ -312,14 +250,12 @@ fn prepare_inputs(
             );
         }
 
-        let outpoint = OutPoint {
-            txid: Txid::from_byte_array(rec.txid),
-            vout: rec.vout,
-        };
-
         inputs.push(PreparedInput {
-            outpoint,
-            amount: Amount::from_sat(rec.amount),
+            outpoint: OutPoint {
+                txid: Txid::from_byte_array(utxo.id.txid.into_inner()),
+                vout: utxo.id.vout,
+            },
+            amount: Amount::from_sat(utxo.amount),
             secret_key,
             tapscript,
             control_block,
@@ -360,16 +296,14 @@ fn build_and_sign_sweep_tx(
         })
         .collect();
 
-    let tx_outputs = vec![TxOut {
-        value: output_amount,
-        script_pubkey: destination.script_pubkey(),
-    }];
-
     let mut tx = Transaction {
         version: Version::TWO,
         lock_time: LockTime::ZERO,
         input: tx_inputs,
-        output: tx_outputs,
+        output: vec![TxOut {
+            value: output_amount,
+            script_pubkey: destination.script_pubkey(),
+        }],
     };
 
     let prevouts: Vec<TxOut> = inputs
@@ -395,18 +329,15 @@ fn build_and_sign_sweep_tx(
         let keypair = secp256k1::Keypair::from_secret_key(&secp, &inp.secret_key);
         let schnorr_sig = secp.sign_schnorr_no_aux_rand(&message, &keypair);
 
-        let signature = Signature {
-            signature: schnorr_sig,
-            sighash_type: TapSighashType::Default,
-        };
-
-        let witness = Witness::from_slice(&[
-            signature.to_vec(),
+        tx.input[idx].witness = Witness::from_slice(&[
+            Signature {
+                signature: schnorr_sig,
+                sighash_type: TapSighashType::Default,
+            }
+            .to_vec(),
             inp.tapscript.to_bytes(),
             inp.control_block.serialize(),
         ]);
-
-        tx.input[idx].witness = witness;
     }
 
     Ok((tx, fee))
@@ -438,15 +369,8 @@ async fn verify_utxos_against_node(
                 }
 
                 match rpc.get_tx_out(&txid_str, vout).await {
-                    Ok(Some(addr)) => {
-                        if addr == expected_addr {
-                            (i, true)
-                        } else {
-                            skipped.fetch_add(1, Ordering::Relaxed);
-                            (i, false)
-                        }
-                    }
-                    Ok(None) => {
+                    Ok(Some(addr)) if addr == expected_addr => (i, true),
+                    Ok(Some(_)) | Ok(None) => {
                         skipped.fetch_add(1, Ordering::Relaxed);
                         (i, false)
                     }
@@ -539,7 +463,10 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
             )
         })?;
 
-    let sk_bytes = parse_hex_bytes_32(&args.private_key).context("invalid private key hex")?;
+    let sk_bytes: [u8; 32] = hex::decode(&args.private_key)
+        .context("invalid private key hex")?
+        .try_into()
+        .map_err(|v: Vec<u8>| anyhow!("expected 32 bytes, got {}", v.len()))?;
     let parent_sk = S::from_byte_array(&sk_bytes).map_err(|e| anyhow!("invalid scalar: {e}"))?;
 
     let parent_pk = G::generator() * parent_sk;
@@ -554,18 +481,17 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
     println!("Master deposit address: {}", master_address);
 
     println!("\nParsing CSV: {}", args.csv.display());
-    let records = parse_csv(&args.csv)?;
-    let total_utxos = records.len();
-    let total_amount: u64 = records.iter().map(|r| r.amount).sum();
+    let utxos = crate::utxo_csv::parse_csv(&args.csv)?;
+    let total_amount: u64 = utxos.iter().map(|u| u.amount).sum();
     println!(
         "Parsed {} UTXOs, total: {} sat ({:.8} BTC)",
-        total_utxos,
+        utxos.len(),
         total_amount,
         total_amount as f64 / 1e8
     );
 
     println!("\nDeriving keys and computing addresses...");
-    let mut inputs = prepare_inputs(&records, &parent_sk, &parent_pk, network)?;
+    let mut inputs = prepare_inputs(&utxos, &parent_sk, &parent_pk, network)?;
     println!("Prepared {} inputs successfully", inputs.len());
 
     let rpc = Arc::new(BitcoinRpc::new(

--- a/crates/internal-tools/src/utxo_csv.rs
+++ b/crates/internal-tools/src/utxo_csv.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use anyhow::anyhow;
 use hashi::onchain::types::Utxo;
 use hashi::onchain::types::UtxoId;
+use hashi_types::bitcoin_txid::BitcoinTxid;
 use sui_sdk_types::Address;
 
 pub fn write_csv(utxos: &[(UtxoId, Utxo)], mut w: impl Write) -> anyhow::Result<()> {
@@ -42,7 +43,7 @@ pub fn parse_csv(path: &Path) -> anyhow::Result<Vec<Utxo>> {
             .get(3)
             .ok_or_else(|| anyhow!("row {row}: missing amount"))?;
 
-        let txid: Address = txid_str
+        let txid: BitcoinTxid = txid_str
             .parse()
             .with_context(|| format!("row {row}: bad txid"))?;
         let vout: u32 = vout_str

--- a/crates/internal-tools/src/utxo_csv.rs
+++ b/crates/internal-tools/src/utxo_csv.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::Context;
+use anyhow::anyhow;
+use hashi::onchain::types::Utxo;
+use hashi::onchain::types::UtxoId;
+use sui_sdk_types::Address;
+
+pub fn write_csv(utxos: &[(UtxoId, Utxo)], mut w: impl Write) -> anyhow::Result<()> {
+    writeln!(w, "txid,vout,derivation_path,amount")?;
+    for (id, utxo) in utxos {
+        let deriv = utxo
+            .derivation_path
+            .map_or(String::new(), |p| p.to_string());
+        writeln!(w, "{},{},{},{}", id.txid, id.vout, deriv, utxo.amount)?;
+    }
+    Ok(())
+}
+
+pub fn parse_csv(path: &Path) -> anyhow::Result<Vec<Utxo>> {
+    let mut reader = csv::Reader::from_path(path).context("failed to open CSV")?;
+    let mut utxos = Vec::new();
+
+    for (i, result) in reader.records().enumerate() {
+        let row = i + 1;
+        let record = result.with_context(|| format!("failed to read CSV row {row}"))?;
+
+        let txid_str = record
+            .get(0)
+            .ok_or_else(|| anyhow!("row {row}: missing txid"))?;
+        let vout_str = record
+            .get(1)
+            .ok_or_else(|| anyhow!("row {row}: missing vout"))?;
+        let deriv_str = record
+            .get(2)
+            .ok_or_else(|| anyhow!("row {row}: missing derivation_path"))?;
+        let amount_str = record
+            .get(3)
+            .ok_or_else(|| anyhow!("row {row}: missing amount"))?;
+
+        let txid: Address = txid_str
+            .parse()
+            .with_context(|| format!("row {row}: bad txid"))?;
+        let vout: u32 = vout_str
+            .parse()
+            .with_context(|| format!("row {row}: bad vout"))?;
+        let derivation_path: Option<Address> = if deriv_str.is_empty() {
+            None
+        } else {
+            Some(
+                deriv_str
+                    .parse()
+                    .with_context(|| format!("row {row}: bad derivation_path"))?,
+            )
+        };
+        let amount: u64 = amount_str
+            .parse()
+            .with_context(|| format!("row {row}: bad amount"))?;
+
+        utxos.push(Utxo {
+            id: UtxoId { txid, vout },
+            amount,
+            derivation_path,
+        });
+    }
+
+    Ok(utxos)
+}


### PR DESCRIPTION
- Adds `sweep-utxos` subcommand to `internal-tools` for consolidating bridge UTXOs after MPC key recovery
- Derives child keys, builds batched taproot script-path spend txs, verifies against node, and broadcasts
- Async RPC with concurrent verification and broadcast

Test run:
https://mempool.space/signet/address/tb1pzqu0ks0qd8508ffg4yn50heajaz9ysrz0jcfgzu42adrjgrgu55smw26y2