### PR TITLE
Store Bitcoin txid in Processing and Signed withdrawal status

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -253,9 +253,17 @@ pub struct WithdrawalRequestQueue {
 pub enum WithdrawalStatus {
     Requested,
     Approved,
-    Processing { pending_withdrawal_id: Address },
-    Signed { pending_withdrawal_id: Address },
-    Confirmed { txid: BitcoinTxid },
+    Processing {
+        pending_withdrawal_id: Address,
+        txid: BitcoinTxid,
+    },
+    Signed {
+        pending_withdrawal_id: Address,
+        txid: BitcoinTxid,
+    },
+    Confirmed {
+        txid: BitcoinTxid,
+    },
 }
 
 impl WithdrawalStatus {

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -174,7 +174,7 @@ entry fun commit_withdrawal_tx(
     inputs.do_ref!(|utxo| btc.utxo_pool_mut().lock(utxo.id(), pending_id));
     let (request_infos, btc_to_burn) = btc
         .withdrawal_queue_mut()
-        .commit_requests(&request_ids, pending_id);
+        .commit_requests(&request_ids, pending_id, txid);
     // btc borrow released
 
     // Allocate presigs from core counter (must happen after btc borrow is released)
@@ -253,8 +253,9 @@ entry fun sign_withdrawal(
     let WithdrawalSignedMessage { withdrawal_id, signatures, .. } = approval;
 
     let queue = hashi.bitcoin_mut().withdrawal_queue_mut();
+    let txid = queue.borrow_pending_withdrawal(withdrawal_id).txid();
     queue.sign_pending_withdrawal(withdrawal_id, signatures);
-    queue.update_requests_signed(&request_ids, withdrawal_id);
+    queue.update_requests_signed(&request_ids, withdrawal_id, txid);
 }
 
 entry fun confirm_withdrawal(hashi: &mut Hashi, withdrawal_id: address, cert: CommitteeSignature) {

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -30,8 +30,8 @@ const EOutputCountMismatch: vector<u8> =
 public enum WithdrawalStatus has copy, drop, store {
     Requested,
     Approved,
-    Processing { pending_withdrawal_id: address },
-    Signed { pending_withdrawal_id: address },
+    Processing { pending_withdrawal_id: address, txid: address },
+    Signed { pending_withdrawal_id: address, txid: address },
     Confirmed { txid: address },
 }
 
@@ -169,6 +169,7 @@ public(package) fun commit_requests(
     self: &mut WithdrawalRequestQueue,
     request_ids: &vector<address>,
     pending_withdrawal_id: address,
+    txid: address,
 ): (vector<CommittedRequestInfo>, Balance<BTC>) {
     let mut infos = vector[];
     let mut total_btc = sui::balance::zero<BTC>();
@@ -187,7 +188,7 @@ public(package) fun commit_requests(
         });
 
         // Update status and move to processed
-        request.status = WithdrawalStatus::Processing { pending_withdrawal_id };
+        request.status = WithdrawalStatus::Processing { pending_withdrawal_id, txid };
         request.pending_withdrawal_id = option::some(pending_withdrawal_id);
         self.processed.add(*id, request);
     });
@@ -200,10 +201,11 @@ public(package) fun update_requests_signed(
     self: &mut WithdrawalRequestQueue,
     request_ids: &vector<address>,
     pending_withdrawal_id: address,
+    txid: address,
 ) {
     request_ids.do_ref!(|id| {
         let request: &mut WithdrawalRequest = self.processed.borrow_mut(*id);
-        request.status = WithdrawalStatus::Signed { pending_withdrawal_id };
+        request.status = WithdrawalStatus::Signed { pending_withdrawal_id, txid };
     });
 }
 
@@ -360,6 +362,13 @@ public(package) fun insert_pending_withdrawal(
     pending: PendingWithdrawal,
 ) {
     self.pending_withdrawals.add(pending.id, pending)
+}
+
+public(package) fun borrow_pending_withdrawal(
+    self: &WithdrawalRequestQueue,
+    withdrawal_id: address,
+): &PendingWithdrawal {
+    self.pending_withdrawals.borrow(withdrawal_id)
 }
 
 public(package) fun remove_pending_withdrawal(

--- a/packages/hashi/tests/withdraw_tests.move
+++ b/packages/hashi/tests/withdraw_tests.move
@@ -144,6 +144,7 @@ fun test_approve_request_with_certificate() {
         .commit_requests(
             &vector[id1, id2],
             pending_id,
+            @0xBEEF,
         );
     // Total: 10_000 + 20_000 = 30_000
     assert!(btc_balance.value() == 30_000);

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -71,7 +71,7 @@ fun approve_and_commit(
     let id = setup_request(queue, clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
     let info = infos[0];
     (id, info)
@@ -117,7 +117,7 @@ fun test_approve_request() {
 
     // Verify by committing — should not abort (only approved requests can be committed)
     let pending_id = ctx.fresh_object_address();
-    let (_, btc_balance) = queue.commit_requests(&vector[request_id], pending_id);
+    let (_, btc_balance) = queue.commit_requests(&vector[request_id], pending_id, @0xBEEF);
     let btc = &btc_balance;
     assert!(btc.value() == 10_000);
 
@@ -143,7 +143,7 @@ fun test_approve_multiple_requests() {
 
     // Commit all as approved
     let pending_id = ctx.fresh_object_address();
-    let (_, btc_balance) = queue.commit_requests(&vector[id1, id2, id3], pending_id);
+    let (_, btc_balance) = queue.commit_requests(&vector[id1, id2, id3], pending_id, @0xBEEF);
 
     // Total: 5_000 + 15_000 + 25_000 = 45_000
     assert!(btc_balance.value() == 45_000);
@@ -166,7 +166,7 @@ fun test_remove_approved_request_fails_when_not_approved() {
 
     // Try to commit without approving first — should abort
     let pending_id = ctx.fresh_object_address();
-    let (_, btc_balance) = queue.commit_requests(&vector[request_id], pending_id);
+    let (_, btc_balance) = queue.commit_requests(&vector[request_id], pending_id, @0xBEEF);
 
     // Cleanup (won't be reached)
     btc_balance.destroy_for_testing();
@@ -228,7 +228,11 @@ fun test_full_withdrawal_queue_lifecycle() {
 
     // Step 3: Commit — drain BTC and move to processed
     let pending_id_addr = ctx.fresh_object_address();
-    let (_infos, btc_balance) = queue.commit_requests(&vector[request_id], pending_id_addr);
+    let (_infos, btc_balance) = queue.commit_requests(
+        &vector[request_id],
+        pending_id_addr,
+        @0xBEEF,
+    );
     assert!(btc_balance.value() == 30_000);
     btc_balance.destroy_for_testing();
 
@@ -393,7 +397,7 @@ fun test_miner_fee_single_request() {
     let id = setup_request(&mut queue, &clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -433,7 +437,7 @@ fun test_miner_fee_single_request_large_fee() {
     let id = setup_request(&mut queue, &clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -476,7 +480,7 @@ fun test_miner_fee_batched_even_split() {
     queue.approve_withdrawal(id1);
     queue.approve_withdrawal(id2);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id1, id2], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id1, id2], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -527,7 +531,7 @@ fun test_miner_fee_batched_with_remainder() {
     queue.approve_withdrawal(id2);
     queue.approve_withdrawal(id3);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id1, id2, id3], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id1, id2, id3], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -577,7 +581,7 @@ fun test_miner_fee_batched_unequal_amounts() {
     queue.approve_withdrawal(id1);
     queue.approve_withdrawal(id2);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id1, id2], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id1, id2], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -620,7 +624,7 @@ fun test_miner_fee_zero() {
     let id = setup_request(&mut queue, &clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -661,7 +665,7 @@ fun test_miner_fee_output_at_dust_floor() {
     let id = setup_request(&mut queue, &clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -703,7 +707,7 @@ fun test_miner_fee_output_below_dust_aborts() {
     let id = setup_request(&mut queue, &clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -747,7 +751,7 @@ fun test_miner_fee_wrong_output_amount_aborts() {
     let id = setup_request(&mut queue, &clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(
@@ -788,7 +792,7 @@ fun test_miner_fee_wrong_address_aborts() {
     let id = setup_request(&mut queue, &clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     // Output uses a different address than the request (which uses all-zeros)
@@ -834,7 +838,7 @@ fun test_miner_fee_exceeds_max_aborts() {
     let id = setup_request(&mut queue, &clock, btc_amount, ctx);
     queue.approve_withdrawal(id);
     let pending_id = ctx.fresh_object_address();
-    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id);
+    let (infos, btc_balance) = queue.commit_requests(&vector[id], pending_id, @0xBEEF);
     btc_balance.destroy_for_testing();
 
     let pending = withdrawal_queue::new_pending_withdrawal(


### PR DESCRIPTION
## Summary
Adds `txid: address` to the `Processing` and `Signed` variants of `WithdrawalStatus`. The Bitcoin transaction ID is known from the moment `commit_withdrawal_tx` is called (it's passed in the `WithdrawalCommitmentMessage` and stored on the `PendingWithdrawal`) but was previously only written to the request status at the final `Confirmed` step.

## Why
The frontend needs the Bitcoin txid to show a clickable explorer link during the "signed and broadcasted" step. Previously it could only show the txid after confirmation. The `PendingWithdrawal` has the txid but it's stored in a plain `Bag` (not `ObjectBag`), making it hard to query directly from the frontend. Putting the txid on the request status makes it available via a single `getObject(request_id)` call.

## Changes
**Move:**
- `WithdrawalStatus::Processing` and `Signed` now carry `txid: address`
- `commit_requests` takes `txid` parameter and threads it into `Processing` status
- `update_requests_signed` takes `txid` parameter (reads it from `PendingWithdrawal` via new `borrow_pending_withdrawal` accessor)

**Rust:**
- `move_types::WithdrawalStatus` and `types::WithdrawalStatus` updated to match
- Status conversion updated