### PR TITLE
config: set default bitcoin confirmation threshold to 6

### DIFF
--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -730,6 +730,10 @@ impl Monitor {
         .await;
         match gettxout_result {
             Ok(Some(_)) => {
+                info!(
+                    "Deposit {}:{} confirmed with {confirmations}/{confirmation_threshold} confirmations",
+                    pending_deposit.outpoint.txid, pending_deposit.outpoint.vout,
+                );
                 let pending_deposit = pending_deposit.take();
                 let _ = pending_deposit.result_tx.send(Ok(txout));
             }

--- a/crates/hashi/src/grpc/bridge_service.rs
+++ b/crates/hashi/src/grpc/bridge_service.rs
@@ -57,6 +57,13 @@ impl BridgeService for HttpService {
             .validate_and_sign_deposit_confirmation(&deposit_request)
             .await
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        tracing::info!(
+            deposit_request_id = %deposit_request.id,
+            utxo_txid = %deposit_request.utxo.id.txid,
+            utxo_vout = deposit_request.utxo.id.vout,
+            amount = deposit_request.utxo.amount,
+            "Signed deposit confirmation",
+        );
         Ok(Response::new(SignDepositConfirmationResponse {
             member_signature: Some(member_signature),
         }))
@@ -75,6 +82,10 @@ impl BridgeService for HttpService {
             .validate_and_sign_withdrawal_request_approval(&approval)
             .await
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        tracing::info!(
+            request_id = %approval.request_id,
+            "Signed withdrawal request approval",
+        );
         Ok(Response::new(SignWithdrawalRequestApprovalResponse {
             member_signature: Some(member_signature),
         }))
@@ -93,6 +104,11 @@ impl BridgeService for HttpService {
             .validate_and_sign_withdrawal_tx_commitment(&approval)
             .await
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        tracing::info!(
+            txid = %approval.txid,
+            requests = approval.request_ids.len(),
+            "Signed withdrawal tx construction",
+        );
         Ok(Response::new(SignWithdrawalTxConstructionResponse {
             member_signature: Some(member_signature),
         }))
@@ -137,6 +153,10 @@ impl BridgeService for HttpService {
             .inner
             .validate_and_sign_withdrawal_tx_signing(&message)
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        tracing::info!(
+            withdrawal_id = %message.withdrawal_id,
+            "Signed withdrawal tx signing",
+        );
         Ok(Response::new(SignWithdrawalTxSigningResponse {
             member_signature: Some(member_signature),
         }))
@@ -155,6 +175,10 @@ impl BridgeService for HttpService {
             .inner
             .sign_withdrawal_confirmation(&pending_withdrawal_id)
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        tracing::info!(
+            pending_withdrawal_id = %pending_withdrawal_id,
+            "Signed withdrawal confirmation",
+        );
         Ok(Response::new(SignWithdrawalConfirmationResponse {
             member_signature: Some(member_signature),
         }))

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -449,7 +449,8 @@ impl LeaderService {
                 inner.metrics.deposits_confirmed_total.inc();
                 info!(deposit_request_id = %deposit_request.id, "Successfully submitted deposit confirmation");
             })
-            .inspect_err(|_| {
+            .inspect_err(|e| {
+                error!(deposit_request_id = %deposit_request.id, "Failed to submit deposit confirmation: {e}");
                 inner
                     .metrics
                     .sui_tx_submissions_total

--- a/design/src/config.md
+++ b/design/src/config.md
@@ -43,7 +43,7 @@ fee deduction. The floor ensures the worst-case network fee is always at least
 | | |
 |---|---|
 | **Type** | `u64` |
-| **Default** | `1` (will be set to `6` before mainnet) |
+| **Default** | `6` |
 | **Unit** | blocks |
 
 The number of Bitcoin block confirmations required before a deposit is

--- a/design/src/move-model-lifecycle.md
+++ b/design/src/move-model-lifecycle.md
@@ -144,7 +144,7 @@ flowchart TD
     style PW_SIGNED fill:#00d4aa,color:#000
 ```
 
-> **Note:** The Bitcoin confirmation threshold is stored on-chain in config key `bitcoin_confirmation_threshold` (default `1`, will be set to `6` before mainnet). Witness signatures are stored on-chain so that any leader can reconstruct and re-broadcast the signed Bitcoin transaction without MPC re-signing (e.g., after leader rotation or mempool eviction).
+> **Note:** The Bitcoin confirmation threshold is stored on-chain in config key `bitcoin_confirmation_threshold` (default `6`). Witness signatures are stored on-chain so that any leader can reconstruct and re-broadcast the signed Bitcoin transaction without MPC re-signing (e.g., after leader rotation or mempool eviction).
 
 ### Withdrawal Flow Summary
 

--- a/packages/hashi/sources/btc/btc_config.move
+++ b/packages/hashi/sources/btc/btc_config.move
@@ -106,6 +106,6 @@ public(package) fun set_withdrawal_cancellation_cooldown_ms(self: &mut Config, c
 public(package) fun init_defaults(config: &mut Config) {
     config.upsert(b"bitcoin_deposit_minimum", config_value::new_u64(30_000));
     config.upsert(b"bitcoin_withdrawal_minimum", config_value::new_u64(30_000));
-    config.upsert(b"bitcoin_confirmation_threshold", config_value::new_u64(1)); // TODO: set to 6 before mainnet
+    config.upsert(b"bitcoin_confirmation_threshold", config_value::new_u64(6));
     config.upsert(b"withdrawal_cancellation_cooldown_ms", config_value::new_u64(1000 * 60 * 60)); // 1 hour
 }


### PR DESCRIPTION
The industry-standard 6-block confirmation threshold guards against chain reorganizations. Previously the on-chain default was 1 with a TODO to raise it before mainnet. The Rust-side fallback was already 6.