### PR TITLE
Unify user_requests index on BitcoinState

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -61,6 +61,7 @@ pub struct BitcoinState {
     pub deposit_queue: DepositRequestQueue,
     pub withdrawal_queue: WithdrawalRequestQueue,
     pub utxo_pool: UtxoPool,
+    pub user_requests: Table,
 }
 
 /// Rust version of the Move hashi::committee_set::CommitteeSet type.
@@ -224,8 +225,6 @@ pub struct DepositRequestQueue {
     pub requests: Bag,
     /// Completed deposits (confirmed or expired)
     pub processed: Bag,
-    /// Per-sender index: sender address -> Bag of request IDs
-    pub user_requests: Table,
 }
 
 /// Rust version of the Move sui::table::Table type (header only).
@@ -246,8 +245,6 @@ pub struct WithdrawalRequestQueue {
     pub withdrawal_txns: Bag,
     /// Confirmed withdrawal transactions (historical record)
     pub confirmed_txns: Bag,
-    /// Per-sender index: sender address -> Bag of request IDs
-    pub user_requests: Table,
 }
 
 /// Rust version of the Move hashi::withdrawal_queue::WithdrawalStatus enum.

--- a/packages/hashi/sources/btc/bitcoin_state.move
+++ b/packages/hashi/sources/btc/bitcoin_state.move
@@ -8,6 +8,7 @@ use hashi::{
     utxo_pool::UtxoPool,
     withdrawal_queue::WithdrawalRequestQueue
 };
+use sui::{bag::Bag, table::Table};
 
 public struct BitcoinStateKey has copy, drop, store {}
 
@@ -15,6 +16,9 @@ public struct BitcoinState has store {
     deposit_queue: DepositRequestQueue,
     withdrawal_queue: WithdrawalRequestQueue,
     utxo_pool: UtxoPool,
+    /// Per-user index: user address -> Bag of request IDs (deposits and withdrawals).
+    /// Allows clients to discover all requests for a given address.
+    user_requests: Table<address, Bag>,
 }
 
 public(package) fun key(): BitcoinStateKey { BitcoinStateKey {} }
@@ -24,6 +28,7 @@ public(package) fun new(ctx: &mut TxContext): BitcoinState {
         deposit_queue: hashi::deposit_queue::create(ctx),
         withdrawal_queue: hashi::withdrawal_queue::create(ctx),
         utxo_pool: hashi::utxo_pool::create(ctx),
+        user_requests: sui::table::new(ctx),
     }
 }
 
@@ -49,4 +54,52 @@ public(package) fun utxo_pool(self: &BitcoinState): &UtxoPool {
 
 public(package) fun utxo_pool_mut(self: &mut BitcoinState): &mut UtxoPool {
     &mut self.utxo_pool
+}
+
+// ======== User Request Index ========
+
+/// Index a request ID under a user address.
+public(package) fun index_user_request(
+    self: &mut BitcoinState,
+    user: address,
+    request_id: address,
+    ctx: &mut TxContext,
+) {
+    if (!self.user_requests.contains(user)) {
+        self.user_requests.add(user, sui::bag::new(ctx));
+    };
+    self.user_requests[user].add(request_id, true);
+}
+
+/// Remove a request ID from a user's index.
+public(package) fun unindex_user_request(
+    self: &mut BitcoinState,
+    user: address,
+    request_id: address,
+) {
+    if (self.user_requests.contains(user)) {
+        let user_bag: &mut Bag = &mut self.user_requests[user];
+        if (user_bag.contains(request_id)) {
+            let _: bool = user_bag.remove(request_id);
+        };
+        // Clean up the empty bag so we don't leak storage on the table.
+        if (user_bag.is_empty()) {
+            let empty_bag: Bag = self.user_requests.remove(user);
+            empty_bag.destroy_empty();
+        };
+    };
+}
+
+/// Check if a user has any indexed requests.
+public(package) fun has_user_requests(self: &BitcoinState, user: address): bool {
+    self.user_requests.contains(user)
+}
+
+/// Check if a specific request ID is in a user's index.
+public(package) fun user_has_request(
+    self: &BitcoinState,
+    user: address,
+    request_id: address,
+): bool {
+    self.user_requests.contains(user) && self.user_requests[user].contains(request_id)
 }

--- a/packages/hashi/sources/btc/deposit.move
+++ b/packages/hashi/sources/btc/deposit.move
@@ -108,8 +108,15 @@ public fun confirm_deposit(
     // Insert UTXO into active pool
     hashi.bitcoin_mut().utxo_pool_mut().insert_active(utxo);
 
-    // Move request to processed bag and index by recipient
-    hashi.bitcoin_mut().deposit_queue_mut().insert_processed(request, ctx);
+    // Move request to processed bag.
+    let (req_id, recipient_opt) = hashi.bitcoin_mut().deposit_queue_mut().insert_processed(request);
+
+    // Index by recipient for client discovery.
+    if (recipient_opt.is_some()) {
+        hashi.bitcoin_mut().index_user_request(recipient_opt.destroy_some(), req_id, ctx);
+    } else {
+        recipient_opt.destroy_none();
+    };
 }
 
 public fun delete_expired_deposit(

--- a/packages/hashi/sources/btc/deposit_queue.move
+++ b/packages/hashi/sources/btc/deposit_queue.move
@@ -4,7 +4,7 @@
 module hashi::deposit_queue;
 
 use hashi::utxo::Utxo;
-use sui::{bag::Bag, clock::Clock, object_bag::ObjectBag, table::Table};
+use sui::{clock::Clock, object_bag::ObjectBag};
 
 // const MAX_DEPOSIT_REQUEST_AGE_MS: u64 = 1000 * 60 * 60 * 24 * 3; // 3 days
 const MAX_DEPOSIT_REQUEST_AGE_MS: u64 = 1000 * 60 * 60 * 24; // 1 days
@@ -31,10 +31,6 @@ public struct DepositRequestQueue has store {
     requests: ObjectBag,
     /// Completed deposits (confirmed or expired).
     processed: ObjectBag,
-    /// Per-sender index: sender address -> Bag of request IDs.
-    /// Allows clients to discover all deposit requests for a given address.
-    /// TODO: consider unifying this with the user_requests index in the withdrawal_queue
-    user_requests: Table<address, Bag>,
 }
 
 // ======== Constructors ========
@@ -43,7 +39,6 @@ public(package) fun create(ctx: &mut TxContext): DepositRequestQueue {
     DepositRequestQueue {
         requests: sui::object_bag::new(ctx),
         processed: sui::object_bag::new(ctx),
-        user_requests: sui::table::new(ctx),
     }
 }
 
@@ -84,35 +79,16 @@ public(package) fun utxo(request: &DepositRequest): Utxo {
     request.utxo
 }
 
-/// Index a deposit request by a user address.
-/// Called at confirmation time to index by the recipient (derivation_path).
-public(package) fun index_by_user(
-    self: &mut DepositRequestQueue,
-    request_id: address,
-    user: address,
-    ctx: &mut TxContext,
-) {
-    if (!self.user_requests.contains(user)) {
-        self.user_requests.add(user, sui::bag::new(ctx));
-    };
-    self.user_requests[user].add(request_id, true);
-}
-
-/// Insert a completed deposit into the processed bag and index by recipient.
+/// Insert a completed deposit into the processed bag.
+/// Returns (request_id, recipient) so the caller can index by user.
 public(package) fun insert_processed(
     self: &mut DepositRequestQueue,
     request: DepositRequest,
-    ctx: &mut TxContext,
-) {
+): (address, Option<address>) {
     let request_id = request.id.to_address();
-
-    // Index by recipient so they can discover their deposits.
-    let recipient_opt = request.utxo.derivation_path();
-    if (recipient_opt.is_some()) {
-        self.index_by_user(request_id, *recipient_opt.borrow(), ctx);
-    };
-
+    let recipient = request.utxo.derivation_path();
     self.processed.add(request_id, request);
+    (request_id, recipient)
 }
 
 /// Delete an expired deposit request.
@@ -159,20 +135,6 @@ public(package) fun request_sui_tx_digest(self: &DepositRequest): vector<u8> {
 
 public(package) fun request_utxo(self: &DepositRequest): &Utxo {
     &self.utxo
-}
-
-/// Check if a user has any requests indexed.
-public(package) fun has_user_requests(self: &DepositRequestQueue, sender: address): bool {
-    self.user_requests.contains(sender)
-}
-
-/// Check if a specific request ID is in a user's index.
-public(package) fun user_has_request(
-    self: &DepositRequestQueue,
-    sender: address,
-    request_id: address,
-): bool {
-    self.user_requests.contains(sender) && self.user_requests[sender].contains(request_id)
 }
 
 // ======== Internal ========

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -115,10 +115,14 @@ public fun request_withdrawal(
         clock,
         ctx,
     );
+    let request_id = request.request_id().to_address();
     hashi::withdrawal_queue::emit_withdrawal_requested(&request);
 
-    // Insert into the active requests bag and index by sender.
-    hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal(request, ctx);
+    // Insert into the active requests bag.
+    hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal(request);
+
+    // Index by sender for client discovery.
+    hashi.bitcoin_mut().index_user_request(ctx.sender(), request_id, ctx);
 }
 
 entry fun approve_request(hashi: &mut Hashi, request_id: address, cert: CommitteeSignature) {
@@ -323,5 +327,10 @@ public fun cancel_withdrawal(
     hashi::withdrawal_queue::emit_withdrawal_cancelled(request);
 
     // Return BTC to the requester.
-    hashi.bitcoin_mut().withdrawal_queue_mut().cancel_withdrawal(request_id)
+    let btc = hashi.bitcoin_mut().withdrawal_queue_mut().cancel_withdrawal(request_id);
+
+    // Clean up the user index.
+    hashi.bitcoin_mut().unindex_user_request(ctx.sender(), request_id);
+
+    btc
 }

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -4,7 +4,7 @@
 module hashi::withdrawal_queue;
 
 use hashi::{btc::BTC, btc_config, config::Config, utxo::{Utxo, UtxoId}};
-use sui::{bag::Bag, balance::Balance, clock::Clock, object_bag::ObjectBag, table::Table};
+use sui::{balance::Balance, clock::Clock, object_bag::ObjectBag};
 
 use fun btc_config::worst_case_network_fee as Config.worst_case_network_fee;
 
@@ -69,10 +69,6 @@ public struct WithdrawalRequestQueue has store {
     withdrawal_txns: ObjectBag,
     /// Confirmed withdrawal transactions (historical record).
     confirmed_txns: ObjectBag,
-    /// Per-sender index: sender address -> Bag of request IDs.
-    /// Allows clients to discover all withdrawal requests for a given address.
-    /// TODO: consider unifying this with the user_requests index in the deposit_queue
-    user_requests: Table<address, Bag>,
 }
 
 /// A Bitcoin transaction constructed for one or more withdrawal requests.
@@ -117,7 +113,6 @@ public(package) fun create(ctx: &mut TxContext): WithdrawalRequestQueue {
         processed: sui::object_bag::new(ctx),
         withdrawal_txns: sui::object_bag::new(ctx),
         confirmed_txns: sui::object_bag::new(ctx),
-        user_requests: sui::table::new(ctx),
     }
 }
 
@@ -151,16 +146,8 @@ public(package) fun create_withdrawal(
 public(package) fun insert_withdrawal(
     self: &mut WithdrawalRequestQueue,
     request: WithdrawalRequest,
-    ctx: &mut TxContext,
 ) {
     let request_id = request.id.to_address();
-    // Index by sender for client discovery
-    let sender = request.sender;
-    if (!self.user_requests.contains(sender)) {
-        self.user_requests.add(sender, sui::bag::new(ctx));
-    };
-    self.user_requests[sender].add(request_id, true);
-
     self.requests.add(request_id, request);
 }
 
@@ -242,15 +229,6 @@ public(package) fun cancel_withdrawal(
     request_id: address,
 ): Balance<BTC> {
     let request: WithdrawalRequest = self.requests.remove(request_id);
-
-    // Clean up the per-sender index
-    let sender = request.sender;
-    if (self.user_requests.contains(sender)) {
-        let sender_bag: &mut Bag = &mut self.user_requests[sender];
-        if (sender_bag.contains(request_id)) {
-            let _: bool = sender_bag.remove(request_id);
-        };
-    };
 
     let WithdrawalRequest {
         id,
@@ -506,20 +484,6 @@ public fun is_approved(self: &WithdrawalStatus): bool {
         WithdrawalStatus::Approved => true,
         _ => false,
     }
-}
-
-/// Check if a user has any requests indexed.
-public(package) fun has_user_requests(self: &WithdrawalRequestQueue, sender: address): bool {
-    self.user_requests.contains(sender)
-}
-
-/// Check if a specific request ID is in a user's index.
-public(package) fun user_has_request(
-    self: &WithdrawalRequestQueue,
-    sender: address,
-    request_id: address,
-): bool {
-    self.user_requests.contains(sender) && self.user_requests[sender].contains(request_id)
 }
 
 // ======== Events ========

--- a/packages/hashi/tests/deposit_tests.move
+++ b/packages/hashi/tests/deposit_tests.move
@@ -135,7 +135,7 @@ fun test_confirm_deposit_with_valid_certificate() {
     std::unit_test::destroy(hashi);
 }
 
-/// Recipient is indexed at confirmation time via index_by_user.
+/// Recipient is indexed at confirmation time via the unified user_requests on BitcoinState.
 /// No indexing happens at request creation time.
 #[test]
 fun test_confirm_deposit_indexes_recipient() {
@@ -153,24 +153,16 @@ fun test_confirm_deposit_indexes_recipient() {
     hashi.bitcoin_mut().deposit_queue_mut().insert_deposit(request);
 
     // Neither sender nor recipient should be indexed at request time
-    assert!(
-        !deposit_queue::user_has_request(hashi.bitcoin().deposit_queue(), REQUESTER, request_id),
-    );
-    assert!(
-        !deposit_queue::user_has_request(hashi.bitcoin().deposit_queue(), recipient, request_id),
-    );
+    assert!(!hashi.bitcoin().user_has_request(REQUESTER, request_id));
+    assert!(!hashi.bitcoin().user_has_request(recipient, request_id));
 
     // Simulate the indexing that confirm_deposit does
-    hashi.bitcoin_mut().deposit_queue_mut().index_by_user(request_id, recipient, ctx);
+    hashi.bitcoin_mut().index_user_request(recipient, request_id, ctx);
 
     // Recipient should now be indexed
-    assert!(
-        deposit_queue::user_has_request(hashi.bitcoin().deposit_queue(), recipient, request_id),
-    );
+    assert!(hashi.bitcoin().user_has_request(recipient, request_id));
     // Sender should NOT be indexed (only recipient is indexed on confirm)
-    assert!(
-        !deposit_queue::user_has_request(hashi.bitcoin().deposit_queue(), REQUESTER, request_id),
-    );
+    assert!(!hashi.bitcoin().user_has_request(REQUESTER, request_id));
 
     clock.destroy_for_testing();
     std::unit_test::destroy(hashi);

--- a/packages/hashi/tests/withdraw_tests.move
+++ b/packages/hashi/tests/withdraw_tests.move
@@ -31,7 +31,7 @@ fun setup_withdrawal_request(
         ctx,
     );
     let request_id = request.request_id().to_address();
-    hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal(request, ctx);
+    hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal(request);
     request_id
 }
 

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -47,7 +47,7 @@ fun setup_request(
         ctx,
     );
     let request_id = request.request_id().to_address();
-    queue.insert_withdrawal(request, ctx);
+    queue.insert_withdrawal(request);
     request_id
 }
 


### PR DESCRIPTION
## Summary
Stacked on #424.

Moves the per-user request index out of `DepositRequestQueue` and `WithdrawalRequestQueue` and into a single unified `user_requests: Table<address, Bag>` on `BitcoinState`. Both deposit and withdrawal request IDs now go into the same per-user Bag, giving clients a single place to look up all requests for an address.

- New `index_user_request` / `unindex_user_request` / `has_user_requests` / `user_has_request` helpers on `BitcoinState`
- `WithdrawalRequestQueue.insert_withdrawal` no longer takes `ctx` (indexing moved to entry function)
- `DepositRequestQueue.insert_processed` returns `(request_id, recipient)` so the caller can index
- Indexing calls moved to entry functions in `withdraw.move` and `deposit.move`
- Rust BCS types updated to match

## Test plan
- [x] 71/71 Move tests pass
- [x] `cargo check` and `cargo clippy` clean
- [x] Move and Rust formatters pass
- [ ] CI green