### PR TITLE
Add backup and restore of fjall db snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,6 +2076,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "e2e-tests"
 version = "0.0.0"
 dependencies = [
+ "age",
  "anyhow",
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "walkdir",
  "x509-parser",
 ]
 

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -39,5 +39,6 @@ name = "hashi-localnet"
 path = "src/main.rs"
 
 [dev-dependencies]
+age.workspace = true
 fastcrypto-tbls.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/e2e-tests/src/backup_restore.rs
+++ b/crates/e2e-tests/src/backup_restore.rs
@@ -1,0 +1,280 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end backup/restore round-trip test.
+//!
+//! Verifies that a node can be taken offline, have its config + DB backed
+//! up to an encrypted archive, have the rest of the network rotate several
+//! epochs without it, and then be restored from the archive and successfully
+//! rejoin the network.
+//!
+//! This complements the unit tests in `crates/hashi/src/backup.rs` and
+//! `crates/hashi/src/cli/commands/backup.rs`, which prove the archive format
+//! and on-disk layout correctness. The unique value this test adds is that
+//! the rest of the validator network actually accepts the restored node and
+//! drives it through a key rotation.
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::path::PathBuf;
+
+    use age::secrecy::ExposeSecret;
+    use age::x25519;
+    use anyhow::Result;
+    use hashi::cli::commands;
+    use hashi::cli::config::CliConfig;
+    use hashi::config::Config as HashiConfig;
+    use tempfile::TempDir;
+
+    use crate::HashiNodeHandle;
+    use crate::TestNetworksBuilder;
+
+    // Duplicated from the main `lib.rs` tests module so this file is
+    // self-contained. The values must stay in sync with `lib.rs`.
+    const DKG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+    const ROTATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(480);
+
+    fn assert_nodes_agree_on_mpc_key(nodes: &[HashiNodeHandle]) {
+        let pk = nodes[0].hashi().mpc_handle().unwrap().public_key().unwrap();
+        for (i, node) in nodes.iter().enumerate().skip(1) {
+            let node_pk = node.hashi().mpc_handle().unwrap().public_key().unwrap();
+            assert_eq!(pk, node_pk, "Node {i} public key differs from node 0");
+        }
+    }
+
+    async fn wait_for_rotation(nodes: &[HashiNodeHandle], target_epoch: u64) -> u64 {
+        let futures: Vec<_> = nodes
+            .iter()
+            .map(|node| node.wait_for_epoch(target_epoch, ROTATION_TIMEOUT))
+            .collect();
+        let results: Vec<Result<()>> = futures::future::join_all(futures).await;
+        for (i, result) in results.into_iter().enumerate() {
+            result.unwrap_or_else(|e| panic!("Node {i} failed to reach epoch {target_epoch}: {e}"));
+        }
+        nodes[0].current_epoch().unwrap()
+    }
+
+    /// Generate a fresh native x25519 age identity, write its secret to a
+    /// file, and return `(recipient_string, identity_file_path)` ready to be
+    /// passed to `backup::save` and `backup::restore` respectively.
+    fn generate_age_identity_pair(dir: &Path) -> (String, PathBuf) {
+        let identity = x25519::Identity::generate();
+        let recipient = identity.to_public().to_string();
+        let identity_path = dir.join("backup-identity.txt");
+        std::fs::write(&identity_path, identity.to_string().expose_secret()).unwrap();
+        (recipient, identity_path)
+    }
+
+    /// Materialise an in-memory `HashiConfig` (the node's runtime config) to
+    /// a TOML file on disk so the `hashi backup` CLI machinery can pick it
+    /// up via `CliConfig::node_config_path`. Returns the written path.
+    fn write_node_config_to_disk(config: &HashiConfig, dir: &Path) -> PathBuf {
+        let path = dir.join("node-config.toml");
+        config.save(&path).unwrap();
+        path
+    }
+
+    /// Build a minimal on-disk CLI config file suitable for driving
+    /// `backup::save`. Returns the written path.
+    ///
+    /// The CLI config needs `loaded_from_path` set (enforced by
+    /// `backup_file_paths`), so we write the file first, then reload it
+    /// through the normal loader so the path field is populated.
+    fn write_cli_config_to_disk(node_config_path: &Path, dir: &Path) -> (CliConfig, PathBuf) {
+        let path = dir.join("hashi-cli.toml");
+        let on_disk = CliConfig {
+            node_config_path: Some(node_config_path.to_path_buf()),
+            ..CliConfig::default()
+        };
+        on_disk.save_to_file(&path).unwrap();
+
+        // Mirror the struct with `loaded_from_path` populated so the backup
+        // logic knows which file to archive. Calling `CliConfig::load` here
+        // would also work but this avoids depending on its implementation.
+        let in_memory = CliConfig {
+            loaded_from_path: Some(path.clone()),
+            node_config_path: Some(node_config_path.to_path_buf()),
+            ..CliConfig::default()
+        };
+        (in_memory, path)
+    }
+
+    /// Find the single `hashi-config-backup-*.tar.age` produced under
+    /// `dir` by `backup::save`.
+    fn find_backup_tarball(dir: &Path) -> PathBuf {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .find(|p| {
+                p.extension().and_then(|e| e.to_str()) == Some("age")
+                    && p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|name| name.starts_with("hashi-config-backup-"))
+            })
+            .expect("backup::save did not produce a tarball")
+    }
+
+    /// Full round-trip test:
+    ///
+    /// 1. DKG on 4 nodes + one key rotation so node 0's DB contains entries
+    ///    across multiple keyspaces.
+    /// 2. Shut down node 0. Serialise its config, generate an age identity,
+    ///    and run `hashi backup save` to produce an encrypted tarball.
+    /// 3. Delete node 0's on-disk state entirely (simulating "machine lost,
+    ///    only the backup remains").
+    /// 4. Force two rotations without node 0 — the rest of the network
+    ///    continues operating several epochs ahead.
+    /// 5. Run `hashi backup restore --copy-to-original-paths` to put the
+    ///    files back exactly where the manifest says.
+    /// 6. Restart node 0 and force one more rotation so it rejoins as a
+    ///    catching-up member.
+    /// 7. Assert all 4 nodes agree on the current MPC public key.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_backup_restore_round_trip_and_rejoin() -> Result<()> {
+        const TEST_NUM_NODES: usize = 4;
+
+        tracing_subscriber::fmt()
+            .with_test_writer()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::from_default_env()
+                    .add_directive(tracing::Level::INFO.into()),
+            )
+            .try_init()
+            .ok();
+
+        let mut test_networks = TestNetworksBuilder::new()
+            .with_nodes(TEST_NUM_NODES)
+            .build()
+            .await?;
+
+        // 1. DKG on all 4 nodes.
+        {
+            let nodes = test_networks.hashi_network().nodes();
+            let futs: Vec<_> = nodes
+                .iter()
+                .map(|n| n.wait_for_mpc_key(DKG_TIMEOUT))
+                .collect();
+            let results: Vec<Result<()>> = futures::future::join_all(futs).await;
+            for (i, r) in results.into_iter().enumerate() {
+                r.unwrap_or_else(|e| panic!("Node {i} DKG failed: {e}"));
+            }
+            assert_nodes_agree_on_mpc_key(nodes);
+        }
+        let initial_epoch = test_networks.hashi_network().nodes()[0]
+            .current_epoch()
+            .unwrap();
+
+        // One pre-backup rotation so the DB has rotation_messages rows, not
+        // just the initial DKG state.
+        test_networks.sui_network.force_close_epoch().await?;
+        wait_for_rotation(test_networks.hashi_network().nodes(), initial_epoch + 1).await;
+        assert_nodes_agree_on_mpc_key(test_networks.hashi_network().nodes());
+
+        // 2. Stop node 0.
+        test_networks.hashi_network_mut().nodes_mut()[0]
+            .shutdown()
+            .await;
+
+        // Snapshot the config now, before any deletion below touches the
+        // filesystem layout.
+        let node0_config = test_networks.hashi_network().nodes()[0].config().clone();
+        let original_db_path = node0_config
+            .db
+            .as_ref()
+            .expect("node 0 must have a db path")
+            .clone();
+
+        // 3. Serialise config + cli config, generate age identity, save backup.
+        let backup_dir = tempfile::Builder::new()
+            .prefix("hashi-backup-e2e-")
+            .tempdir()?;
+        let node_config_path = write_node_config_to_disk(&node0_config, backup_dir.path());
+        let (cli_config, cli_config_path) =
+            write_cli_config_to_disk(&node_config_path, backup_dir.path());
+        let (recipient, identity_path) = generate_age_identity_pair(backup_dir.path());
+
+        let save_out_dir: TempDir = tempfile::Builder::new()
+            .prefix("hashi-backup-out-")
+            .tempdir()?;
+        commands::backup::save(&cli_config, Some(recipient), save_out_dir.path())?;
+        let tarball = find_backup_tarball(save_out_dir.path());
+
+        // 4. Destroy node 0's on-disk state so `restore --copy-to-original-paths`
+        //    actually has to put things back. The node config and CLI config
+        //    file both live under `backup_dir`; the DB lives under the
+        //    TestNetworks tempdir, which stays alive because the handle
+        //    still owns it.
+        std::fs::remove_dir_all(&original_db_path)?;
+        std::fs::remove_file(&node_config_path)?;
+        std::fs::remove_file(&cli_config_path)?;
+
+        // 5. Two more rotations without node 0. The surviving nodes advance
+        //    the Hashi epoch; node 0's backed-up DB is now several epochs
+        //    stale relative to the live network state.
+        for target in 2..=3 {
+            test_networks.sui_network.force_close_epoch().await?;
+            wait_for_rotation(
+                &test_networks.hashi_network().nodes()[1..],
+                initial_epoch + target,
+            )
+            .await;
+        }
+
+        // 6. Restore. `--copy-to-original-paths=true` uses the manifest's
+        //    absolute paths, which are the exact paths node 0's HashiConfig
+        //    still points at, so no reconfiguration is needed after this.
+        let restore_out_dir = tempfile::Builder::new()
+            .prefix("hashi-restore-out-")
+            .tempdir()?;
+        commands::backup::restore(
+            &tarball,
+            &identity_path,
+            restore_out_dir.path(),
+            /* copy_to_original_paths */ true,
+        )?;
+
+        // Sanity: the on-disk artefacts the node needs are back where the
+        // manifest said they belong.
+        assert!(
+            original_db_path.is_dir(),
+            "restore did not recreate db at {}",
+            original_db_path.display()
+        );
+        assert!(
+            node_config_path.is_file(),
+            "restore did not recreate node config at {}",
+            node_config_path.display()
+        );
+
+        // 7. Restart node 0. It may not have valid shares for the current
+        //    epoch yet — that's fine, we just need the server up so the
+        //    upcoming rotation can deliver fresh shares.
+        test_networks.hashi_network_mut().nodes_mut()[0]
+            .start()
+            .await?;
+        test_networks.hashi_network().nodes()[0]
+            .wait_for_mpc_key(ROTATION_TIMEOUT)
+            .await
+            .ok();
+
+        // 8. Force one more rotation; node 0 rejoins as a catching-up
+        //    member and must end up with the same MPC pubkey as the rest.
+        test_networks.sui_network.force_close_epoch().await?;
+        let nodes = test_networks.hashi_network().nodes();
+        let futs: Vec<_> = nodes
+            .iter()
+            .map(|n| n.wait_for_epoch(initial_epoch + 4, ROTATION_TIMEOUT))
+            .collect();
+        let results: Vec<Result<()>> = futures::future::join_all(futs).await;
+        for (i, r) in results.into_iter().enumerate() {
+            r.unwrap_or_else(|e| {
+                panic!("Node {i} failed to reach epoch {}: {e}", initial_epoch + 4)
+            });
+        }
+
+        assert_nodes_agree_on_mpc_key(test_networks.hashi_network().nodes());
+        Ok(())
+    }
+}

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -101,6 +101,13 @@ impl HashiNodeHandle {
         hashi::db::Database::open(db_path)
     }
 
+    /// Read-only access to the node's underlying `HashiConfig`. Useful for
+    /// tests that need to serialise the config to disk (e.g. backup/restore
+    /// round-trip tests) without forcing every caller to build their own.
+    pub fn config(&self) -> &HashiConfig {
+        &self.config
+    }
+
     pub fn validator_address(&self) -> sui_sdk_types::Address {
         self.config
             .validator_address()

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -18,6 +18,7 @@ use std::process::Command;
 
 use anyhow::Result;
 
+pub mod backup_restore;
 pub mod bitcoin_node;
 pub mod e2e_flow;
 pub mod hashi_network;

--- a/crates/e2e-tests/src/main.rs
+++ b/crates/e2e-tests/src/main.rs
@@ -834,6 +834,7 @@ fn write_cli_config(data_dir: &Path, state: &LocalnetState) -> Result<()> {
             .map(std::path::PathBuf::from),
         backup_age_pubkey: None,
         gas_coin: None,
+        node_config_path: None,
         bitcoin: Some(hashi::cli::config::BitcoinConfig {
             rpc_url: Some(state.btc_rpc_url.clone()),
             rpc_user: Some(state.btc_rpc_user.clone()),

--- a/crates/hashi/Cargo.toml
+++ b/crates/hashi/Cargo.toml
@@ -73,10 +73,11 @@ tap.workspace = true
 backon.workspace = true
 jiff.workspace = true
 tar.workspace = true
+tempfile.workspace = true
+walkdir.workspace = true
 
 [dev-dependencies]
 ed25519-dalek.workspace = true
 test-strategy.workspace = true
 proptest.workspace = true
 tracing-test = "0.2"
-tempfile.workspace = true

--- a/crates/hashi/src/backup.rs
+++ b/crates/hashi/src/backup.rs
@@ -10,7 +10,6 @@
 
 use anyhow::Context;
 use anyhow::Result;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::fs::File;
@@ -19,6 +18,7 @@ use std::io;
 use std::io::ErrorKind;
 use std::io::Read;
 use std::os::unix::fs::OpenOptionsExt;
+use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 use tracing::info;
@@ -26,21 +26,61 @@ use tracing::info;
 use age::Encryptor;
 
 pub const BACKUP_MANIFEST_FILE_NAME: &str = "hashi-config-backup-manifest.toml";
+pub const DB_SNAPSHOT_TAR_PREFIX: &str = "hashi-db-snapshot";
 
-#[derive(serde::Deserialize, serde::Serialize)]
-pub struct BackupManifest {
-    pub files: Vec<BackupManifestFile>,
+/// Open `path` for writing with mode `0o600`, failing if anything already
+/// exists there. The `AlreadyExists` case is mapped to a clear "refusing to
+/// overwrite" error so callers don't have to repeat the same pattern.
+fn create_file_strict(path: &Path) -> Result<File> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| match e.kind() {
+            ErrorKind::AlreadyExists => {
+                anyhow::anyhow!("Refusing to overwrite existing file: {}", path.display())
+            }
+            _ => anyhow::Error::from(e).context(format!("Failed to create {}", path.display())),
+        })
+}
+
+/// Create directory `path` non-recursively, failing if anything already
+/// exists at that exact location. Caller is responsible for ensuring the
+/// parent exists.
+fn create_dir_strict(path: &Path) -> Result<()> {
+    fs::DirBuilder::new()
+        .recursive(false)
+        .create(path)
+        .map_err(|e| match e.kind() {
+            ErrorKind::AlreadyExists => {
+                anyhow::anyhow!(
+                    "Refusing to overwrite existing directory: {}",
+                    path.display()
+                )
+            }
+            _ => anyhow::Error::from(e)
+                .context(format!("Failed to create directory {}", path.display())),
+        })
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
-pub struct BackupManifestFile {
+pub struct BackupManifest {
+    pub paths: Vec<BackupManifestEntry>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct BackupManifestEntry {
     pub archive_name: PathBuf,
     pub original_path: PathBuf,
 }
 
-pub fn build_backup_manifest(files: &[PathBuf]) -> Result<BackupManifest> {
+pub fn build_backup_manifest(files: &[PathBuf], db_original_path: &Path) -> Result<BackupManifest> {
     let mut archive_names = HashSet::new();
-    let mut manifest_files = Vec::with_capacity(files.len());
+    // Reserve the db snapshot prefix so a user file with the same basename
+    // gets disambiguated instead of silently colliding with the db entry.
+    archive_names.insert(DB_SNAPSHOT_TAR_PREFIX.to_string());
+    let mut manifest_paths = Vec::new();
 
     for file in files {
         let base_name = file
@@ -78,19 +118,25 @@ pub fn build_backup_manifest(files: &[PathBuf]) -> Result<BackupManifest> {
             PathBuf::from(base_name.as_ref())
         };
 
-        manifest_files.push(BackupManifestFile {
+        manifest_paths.push(BackupManifestEntry {
             archive_name,
             original_path: file.clone(),
         });
     }
 
+    manifest_paths.push(BackupManifestEntry {
+        archive_name: PathBuf::from(DB_SNAPSHOT_TAR_PREFIX),
+        original_path: db_original_path.to_path_buf(),
+    });
+
     Ok(BackupManifest {
-        files: manifest_files,
+        paths: manifest_paths,
     })
 }
 
 pub fn encrypt_files_to_age_archive(
     manifest: &BackupManifest,
+    db_snapshot_dir: &Path,
     recipient: &dyn age::Recipient,
     output_path: &Path,
 ) -> Result<()> {
@@ -102,19 +148,71 @@ pub fn encrypt_files_to_age_archive(
         let mut archive = tar::Builder::new(&mut encrypted);
         append_backup_manifest(&mut archive, manifest)?;
 
-        for file in &manifest.files {
-            archive.append_path_with_name(&file.original_path, &file.archive_name)?;
+        for entry in &manifest.paths {
+            if entry.archive_name == Path::new(DB_SNAPSHOT_TAR_PREFIX) {
+                continue;
+            }
+            archive.append_path_with_name(&entry.original_path, &entry.archive_name)?;
             info!(
-                original = %file.original_path.display(),
-                archive_name = %file.archive_name.display(),
+                original = %entry.original_path.display(),
+                archive_name = %entry.archive_name.display(),
                 "Added file to backup archive",
             );
         }
+
+        append_dir_recursive(
+            &mut archive,
+            db_snapshot_dir,
+            Path::new(DB_SNAPSHOT_TAR_PREFIX),
+        )?;
+        info!("Added database snapshot to backup archive");
 
         archive.finish()?;
     }
     encrypted.finish()?;
 
+    Ok(())
+}
+
+/// Recursively append all files under `src_dir` into the tar archive under
+/// `tar_prefix`. For example, if `src_dir` contains `file.sst` and
+/// `tar_prefix` is `db`, the archive entry will be `db/file.sst`.
+///
+/// Symlinks are rejected: fjall does not create them in its data directories,
+/// so the presence of one is either tampering or misconfiguration, and the
+/// restore path does not currently handle symlink tar entries correctly.
+fn append_dir_recursive<W: std::io::Write>(
+    archive: &mut tar::Builder<W>,
+    src_dir: &Path,
+    tar_prefix: &Path,
+) -> Result<()> {
+    for entry in walkdir::WalkDir::new(src_dir).min_depth(1) {
+        let entry = entry.with_context(|| {
+            format!(
+                "Failed to walk database snapshot directory {}",
+                src_dir.display()
+            )
+        })?;
+
+        if entry.file_type().is_symlink() {
+            anyhow::bail!(
+                "Refusing to archive symlink inside database snapshot directory: {}",
+                entry.path().display()
+            );
+        }
+
+        let relative = entry
+            .path()
+            .strip_prefix(src_dir)
+            .expect("walkdir entry is always under src_dir");
+        let archive_path = tar_prefix.join(relative);
+
+        if entry.file_type().is_dir() {
+            archive.append_dir(&archive_path, entry.path())?;
+        } else {
+            archive.append_path_with_name(entry.path(), &archive_path)?;
+        }
+    }
     Ok(())
 }
 
@@ -148,9 +246,11 @@ fn append_backup_manifest<W: std::io::Write>(
 
 /// Determine the directory name to extract a backup tarball into.
 ///
-/// Uses the tarball's file name with the `.tar.age` suffix stripped, so
+/// Strips the `.tar.age` or `.age` suffix from the tarball's file name, so
 /// `hashi-config-backup-20260409T230419Z.tar.age` becomes
-/// `hashi-config-backup-20260409T230419Z`.
+/// `hashi-config-backup-20260409T230419Z`. An input without one of those
+/// suffixes is rejected rather than silently used verbatim, to avoid
+/// surprising extraction directory names when users point at the wrong file.
 pub fn extract_dir_name(backup_tarball: &Path) -> Result<PathBuf> {
     let file_name = backup_tarball
         .file_name()
@@ -165,11 +265,24 @@ pub fn extract_dir_name(backup_tarball: &Path) -> Result<PathBuf> {
     let stem = file_name
         .strip_suffix(".tar.age")
         .or_else(|| file_name.strip_suffix(".age"))
-        .unwrap_or(file_name);
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Backup tarball must have a .tar.age or .age suffix: {}",
+                backup_tarball.display()
+            )
+        })?;
 
-    if stem.is_empty() {
+    // Require the stem to be exactly one plain directory component when
+    // joined under the user's output dir. Catches both the empty case (zero
+    // components) and traversal attempts like `../../tmp/pwn.tar.age` (a
+    // `ParentDir` component, not `Normal`).
+    let stem_path = Path::new(stem);
+    let mut components = stem_path.components();
+    let only = components.next();
+    let extra = components.next();
+    if extra.is_some() || !matches!(only, Some(Component::Normal(_))) {
         anyhow::bail!(
-            "Cannot derive extract directory name from {}",
+            "Backup tarball file name must be a single path component without separators or `..`: {}",
             backup_tarball.display()
         );
     }
@@ -204,19 +317,7 @@ pub fn read_backup_manifest<R: Read>(
 
 pub fn write_manifest_to_extract_dir(extract_dir: &Path, manifest_toml: &str) -> Result<()> {
     let manifest_path = extract_dir.join(BACKUP_MANIFEST_FILE_NAME);
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(&manifest_path)
-        .map_err(|e| match e.kind() {
-            ErrorKind::AlreadyExists => anyhow::anyhow!(
-                "Refusing to overwrite existing file: {}",
-                manifest_path.display()
-            ),
-            _ => anyhow::Error::from(e)
-                .context(format!("Failed to create {}", manifest_path.display())),
-        })?;
+    let mut file = create_file_strict(&manifest_path)?;
     io::Write::write_all(&mut file, manifest_toml.as_bytes())
         .with_context(|| format!("Failed to write manifest to {}", manifest_path.display()))?;
     info!(path = %manifest_path.display(), "Restored manifest");
@@ -227,97 +328,143 @@ pub fn restore_backup_entries<R: Read>(
     entries: tar::Entries<'_, R>,
     output_dir: &Path,
     manifest: &BackupManifest,
-) -> Result<HashMap<PathBuf, PathBuf>> {
-    let expected_files: HashMap<_, _> = manifest
-        .files
+) -> Result<()> {
+    let db_prefix = Path::new(DB_SNAPSHOT_TAR_PREFIX);
+    let expected_files: HashSet<PathBuf> = manifest
+        .paths
         .iter()
-        .map(|file| (file.archive_name.clone(), file))
+        .filter(|entry| entry.archive_name != db_prefix)
+        .map(|entry| entry.archive_name.clone())
         .collect();
-    let mut restored_files = HashMap::new();
+    let mut restored_count: usize = 0;
 
     for entry in entries {
         let mut entry = entry?;
         let archive_path = entry.path()?.into_owned();
-        let archive_name = PathBuf::from(archive_path.file_name().ok_or_else(|| {
-            anyhow::anyhow!(
-                "Backup entry does not have a file name: {}",
-                archive_path.display()
-            )
-        })?);
 
-        let entry_type = entry.header().entry_type();
-        if entry_type != tar::EntryType::Regular {
-            anyhow::bail!(
-                "Backup entry {} has unexpected type {:?}; only regular files are supported",
-                archive_name.display(),
-                entry_type
-            );
+        if archive_path.starts_with(db_prefix) {
+            restore_db_entry(&mut entry, &archive_path, output_dir)?;
+        } else {
+            restore_config_entry(&mut entry, &archive_path, output_dir, &expected_files)?;
+            restored_count += 1;
         }
-
-        if archive_path != archive_name {
-            anyhow::bail!(
-                "Backup entry must be at the tar root: {}",
-                archive_path.display()
-            );
-        }
-
-        if !expected_files.contains_key(&archive_name) {
-            anyhow::bail!(
-                "Backup archive contains unexpected file: {}",
-                archive_name.display()
-            );
-        }
-
-        let output_path = output_dir.join(&archive_name);
-        let mut output_file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .open(&output_path)
-            .map_err(|e| match e.kind() {
-                ErrorKind::AlreadyExists => anyhow::anyhow!(
-                    "Refusing to overwrite existing file: {}",
-                    output_path.display()
-                ),
-                _ => anyhow::Error::from(e)
-                    .context(format!("Failed to create {}", output_path.display())),
-            })?;
-        io::copy(&mut entry, &mut output_file).with_context(|| {
-            format!(
-                "Failed to write restored file contents to {}",
-                output_path.display()
-            )
-        })?;
-        info!(
-            archive_name = %archive_name.display(),
-            output = %output_path.display(),
-            "Restored file",
-        );
-        restored_files.insert(archive_name, output_path);
     }
 
-    if restored_files.len() != manifest.files.len() {
+    if restored_count != expected_files.len() {
         anyhow::bail!(
             "Backup archive is missing file entries: expected {}, restored {}",
-            manifest.files.len(),
-            restored_files.len()
+            expected_files.len(),
+            restored_count
         );
     }
 
-    Ok(restored_files)
+    Ok(())
 }
 
+/// Extract a single tar entry that lives under the db/ prefix into
+/// `output_dir`, preserving the relative directory structure. Directory
+/// entries are created (recursively, since the tar may stream them in any
+/// order); file entries are written with mode 0o600.
+fn restore_db_entry<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    archive_path: &Path,
+    output_dir: &Path,
+) -> Result<()> {
+    let output_path = output_dir.join(archive_path);
+    if entry.header().entry_type() == tar::EntryType::Directory {
+        fs::create_dir_all(&output_path)
+            .with_context(|| format!("Failed to create directory {}", output_path.display()))?;
+        return Ok(());
+    }
+
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+    }
+    let mut output_file = create_file_strict(&output_path)?;
+    io::copy(entry, &mut output_file).with_context(|| {
+        format!(
+            "Failed to write restored file contents to {}",
+            output_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Extract a single config-file tar entry into `output_dir`. Config entries
+/// must be regular files at the tar root and must appear in the manifest;
+/// anything else is rejected so a tampered archive can't sneak unexpected
+/// files past the restore.
+fn restore_config_entry<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    archive_path: &Path,
+    output_dir: &Path,
+    expected_files: &HashSet<PathBuf>,
+) -> Result<()> {
+    let archive_name = PathBuf::from(archive_path.file_name().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Backup entry does not have a file name: {}",
+            archive_path.display()
+        )
+    })?);
+
+    let entry_type = entry.header().entry_type();
+    if entry_type != tar::EntryType::Regular {
+        anyhow::bail!(
+            "Backup entry {} has unexpected type {entry_type:?}; only regular files are supported",
+            archive_name.display(),
+        );
+    }
+
+    if archive_path != archive_name {
+        anyhow::bail!(
+            "Backup entry must be at the tar root: {}",
+            archive_path.display()
+        );
+    }
+
+    if !expected_files.contains(&archive_name) {
+        anyhow::bail!(
+            "Backup archive contains unexpected file: {}",
+            archive_name.display()
+        );
+    }
+
+    let output_path = output_dir.join(&archive_name);
+    let mut output_file = create_file_strict(&output_path)?;
+    io::copy(entry, &mut output_file).with_context(|| {
+        format!(
+            "Failed to write restored file contents to {}",
+            output_path.display()
+        )
+    })?;
+    info!(
+        archive_name = %archive_name.display(),
+        output = %output_path.display(),
+        "Restored file",
+    );
+    Ok(())
+}
+
+/// Copy each restored config file from the extract directory to its original
+/// path as recorded in the manifest. Refuses to overwrite anything.
+///
+/// `extract_dir` is where the tarball was unpacked; this function joins it
+/// with each entry's `archive_name` to find the source. The DB entry is
+/// skipped — restoring the snapshot dir is handled by
+/// [`copy_db_snapshot_to_original_path`].
 pub fn copy_restored_files_to_original_paths(
-    restored_files: &HashMap<PathBuf, PathBuf>,
+    extract_dir: &Path,
     manifest: &BackupManifest,
 ) -> Result<()> {
-    for file in &manifest.files {
-        let restored_path = restored_files.get(&file.archive_name).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Restored file missing for archive entry {}",
-                file.archive_name.display()
-            )
-        })?;
+    let db_prefix = Path::new(DB_SNAPSHOT_TAR_PREFIX);
+
+    for file in manifest
+        .paths
+        .iter()
+        .filter(|entry| entry.archive_name != db_prefix)
+    {
+        let restored_path = extract_dir.join(&file.archive_name);
 
         if let Some(parent) = file.original_path.parent() {
             fs::create_dir_all(parent).with_context(|| {
@@ -325,8 +472,11 @@ pub fn copy_restored_files_to_original_paths(
             })?;
         }
 
-        let mut source = File::open(restored_path)
+        let mut source = File::open(&restored_path)
             .with_context(|| format!("Failed to open {}", restored_path.display()))?;
+        // Custom AlreadyExists message: "original path" hints that the
+        // collision is with a path the manifest pointed at, not a freshly
+        // chosen output location.
         let mut dest = OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -355,4 +505,214 @@ pub fn copy_restored_files_to_original_paths(
     }
 
     Ok(())
+}
+
+/// Copy the extracted database snapshot directory to its original path.
+///
+/// Looks up the DB entry in the manifest to determine the original path,
+/// then recursively copies the extracted `db/` directory into a sibling
+/// staging directory and renames it into place on success. The rename is
+/// atomic on a single filesystem, so a crash mid-copy leaves the staging
+/// directory behind without ever creating a half-populated DB at `dest`.
+///
+/// Fails if `dest` already exists.
+pub fn copy_db_snapshot_to_original_path(
+    extract_dir: &Path,
+    manifest: &BackupManifest,
+) -> Result<()> {
+    let db_prefix = Path::new(DB_SNAPSHOT_TAR_PREFIX);
+    let db_entry = manifest
+        .paths
+        .iter()
+        .find(|entry| entry.archive_name == db_prefix)
+        .ok_or_else(|| anyhow::anyhow!("Backup manifest does not contain a database entry"))?;
+
+    let source = extract_dir.join(DB_SNAPSHOT_TAR_PREFIX);
+    let dest = &db_entry.original_path;
+
+    // Pre-flight: refuse early if the destination already exists. This is
+    // checked again implicitly by the final rename, but failing here gives a
+    // clear error before doing all the copy work.
+    if dest
+        .try_exists()
+        .with_context(|| format!("Failed to stat database destination {}", dest.display()))?
+    {
+        anyhow::bail!(
+            "Refusing to overwrite existing database directory: {}",
+            dest.display()
+        );
+    }
+
+    let parent = dest.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Database destination has no parent directory: {}",
+            dest.display()
+        )
+    })?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("Failed to create parent directory {}", parent.display()))?;
+
+    // Stage into a sibling temp directory so the entire copy is invisible
+    // until the final rename. Using a sibling guarantees we're on the same
+    // filesystem, which is required for `rename` to be atomic.
+    let staging = tempfile::Builder::new()
+        .prefix(".hashi-db-restore-")
+        .tempdir_in(parent)
+        .with_context(|| {
+            format!(
+                "Failed to create db staging directory in {}",
+                parent.display()
+            )
+        })?;
+
+    copy_dir_recursive_strict(&source, staging.path()).with_context(|| {
+        format!(
+            "Failed to copy database snapshot from {} to staging directory {}",
+            source.display(),
+            staging.path().display()
+        )
+    })?;
+
+    // Disarm the TempDir guard before rename so it doesn't try to delete the
+    // path we just moved away.
+    let staging_path = staging.keep();
+    fs::rename(&staging_path, dest).map_err(|e| {
+        // Best-effort cleanup of the staging directory if the rename failed,
+        // since `into_path` consumed the auto-deleting guard.
+        let _ = fs::remove_dir_all(&staging_path);
+        match e.kind() {
+            ErrorKind::AlreadyExists => anyhow::anyhow!(
+                "Refusing to overwrite existing database directory: {}",
+                dest.display()
+            ),
+            _ => anyhow::Error::from(e).context(format!(
+                "Failed to move staged database into place at {}",
+                dest.display()
+            )),
+        }
+    })?;
+
+    info!(
+        from = %source.display(),
+        to = %dest.display(),
+        "Copied database snapshot to original path",
+    );
+
+    Ok(())
+}
+
+/// Recursively copy a directory tree from `src` to `dest` without ever
+/// overwriting existing files.
+///
+/// - The root `dest` is assumed to have already been created by the caller.
+/// - Subdirectories below the root use `create_dir` (non-recursive), so any
+///   collision surfaces as an error rather than merging into existing state.
+/// - Files are opened with `create_new(true)` and mode `0o600`, matching the
+///   protection `copy_restored_files_to_original_paths` applies to config
+///   files. fjall on-disk files are not sensitive individually, but we keep
+///   the mode consistent so the restored DB never advertises looser
+///   permissions than the backup did.
+/// - Symlinks are rejected outright.
+fn copy_dir_recursive_strict(src: &Path, dest: &Path) -> Result<()> {
+    for entry in walkdir::WalkDir::new(src).min_depth(1) {
+        let entry = entry?;
+
+        if entry.file_type().is_symlink() {
+            anyhow::bail!(
+                "Refusing to restore symlink from database snapshot: {}",
+                entry.path().display()
+            );
+        }
+
+        let relative = entry.path().strip_prefix(src).expect("walkdir under src");
+        let target = dest.join(relative);
+
+        if entry.file_type().is_dir() {
+            create_dir_strict(&target)?;
+        } else {
+            let mut source_file = File::open(entry.path())
+                .with_context(|| format!("Failed to open {}", entry.path().display()))?;
+            let mut dest_file = create_file_strict(&target)?;
+            io::copy(&mut source_file, &mut dest_file).with_context(|| {
+                format!(
+                    "Failed to copy {} to {}",
+                    entry.path().display(),
+                    target.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_disambiguates_user_file_colliding_with_db_prefix() {
+        // A user-backed-up file whose basename equals DB_SNAPSHOT_TAR_PREFIX
+        // must be renamed so it doesn't collide with the db snapshot entry.
+        let files = vec![PathBuf::from("/etc/hashi/hashi-db-snapshot")];
+        let db_path = PathBuf::from("/var/lib/hashi/db");
+
+        let manifest = build_backup_manifest(&files, &db_path).unwrap();
+
+        assert_eq!(manifest.paths.len(), 2);
+
+        // The user's file should have been renamed away from the reserved prefix.
+        let user_entry = &manifest.paths[0];
+        assert_eq!(
+            user_entry.original_path,
+            PathBuf::from("/etc/hashi/hashi-db-snapshot")
+        );
+        assert_ne!(
+            user_entry.archive_name,
+            PathBuf::from(DB_SNAPSHOT_TAR_PREFIX)
+        );
+        assert_eq!(
+            user_entry.archive_name,
+            PathBuf::from("hashi-db-snapshot-2")
+        );
+
+        // The db snapshot entry should still own the reserved prefix.
+        let db_entry = &manifest.paths[1];
+        assert_eq!(db_entry.archive_name, PathBuf::from(DB_SNAPSHOT_TAR_PREFIX));
+        assert_eq!(db_entry.original_path, db_path);
+    }
+
+    #[test]
+    fn manifest_disambiguates_chain_of_collisions_with_db_prefix() {
+        // Two user files: one basenamed `hashi-db-snapshot` (collides with
+        // the reserved db prefix) and one basenamed `hashi-db-snapshot-2`
+        // (collides with the first file's renamed slot).
+        //
+        // The disambiguator always derives its candidate suffixes from the
+        // original basename, so the second file lands at
+        // `hashi-db-snapshot-2-2` rather than `hashi-db-snapshot-3`. Both
+        // names are unique and deterministic, which is all we need; this
+        // test pins that exact behaviour so a future refactor doesn't
+        // silently change the output layout.
+        let files = vec![
+            PathBuf::from("/etc/hashi/hashi-db-snapshot"),
+            PathBuf::from("/etc/hashi/hashi-db-snapshot-2"),
+        ];
+        let db_path = PathBuf::from("/var/lib/hashi/db");
+
+        let manifest = build_backup_manifest(&files, &db_path).unwrap();
+
+        assert_eq!(manifest.paths.len(), 3);
+        assert_eq!(
+            manifest.paths[0].archive_name,
+            PathBuf::from("hashi-db-snapshot-2")
+        );
+        assert_eq!(
+            manifest.paths[1].archive_name,
+            PathBuf::from("hashi-db-snapshot-2-2")
+        );
+        assert_eq!(
+            manifest.paths[2].archive_name,
+            PathBuf::from(DB_SNAPSHOT_TAR_PREFIX)
+        );
+    }
 }

--- a/crates/hashi/src/backup.rs
+++ b/crates/hashi/src/backup.rs
@@ -67,6 +67,7 @@ fn create_dir_strict(path: &Path) -> Result<()> {
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct BackupManifest {
     pub paths: Vec<BackupManifestEntry>,
+    pub db_archive_entries: Vec<PathBuf>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
@@ -75,7 +76,11 @@ pub struct BackupManifestEntry {
     pub original_path: PathBuf,
 }
 
-pub fn build_backup_manifest(files: &[PathBuf], db_original_path: &Path) -> Result<BackupManifest> {
+pub fn build_backup_manifest(
+    files: &[PathBuf],
+    db_original_path: &Path,
+    db_snapshot_dir: &Path,
+) -> Result<BackupManifest> {
     let mut archive_names = HashSet::new();
     // Reserve the db snapshot prefix so a user file with the same basename
     // gets disambiguated instead of silently colliding with the db entry.
@@ -131,7 +136,40 @@ pub fn build_backup_manifest(files: &[PathBuf], db_original_path: &Path) -> Resu
 
     Ok(BackupManifest {
         paths: manifest_paths,
+        db_archive_entries: collect_db_archive_entries(
+            db_snapshot_dir,
+            Path::new(DB_SNAPSHOT_TAR_PREFIX),
+        )?,
     })
+}
+
+fn collect_db_archive_entries(src_dir: &Path, tar_prefix: &Path) -> Result<Vec<PathBuf>> {
+    let mut archive_entries = Vec::new();
+
+    for entry in walkdir::WalkDir::new(src_dir).min_depth(1) {
+        let entry = entry.with_context(|| {
+            format!(
+                "Failed to walk database snapshot directory {}",
+                src_dir.display()
+            )
+        })?;
+
+        if entry.file_type().is_symlink() {
+            anyhow::bail!(
+                "Refusing to archive symlink inside database snapshot directory: {}",
+                entry.path().display()
+            );
+        }
+
+        let relative = entry
+            .path()
+            .strip_prefix(src_dir)
+            .expect("walkdir entry is always under src_dir");
+        archive_entries.push(tar_prefix.join(relative));
+    }
+
+    archive_entries.sort();
+    Ok(archive_entries)
 }
 
 pub fn encrypt_files_to_age_archive(
@@ -140,8 +178,7 @@ pub fn encrypt_files_to_age_archive(
     recipient: &dyn age::Recipient,
     output_path: &Path,
 ) -> Result<()> {
-    let output = File::create(output_path)
-        .with_context(|| format!("Failed to create {}", output_path.display()))?;
+    let output = create_file_strict(output_path)?;
     let encryptor = Encryptor::with_recipients(std::iter::once(recipient))?;
     let mut encrypted = encryptor.wrap_output(output)?;
     {
@@ -336,6 +373,9 @@ pub fn restore_backup_entries<R: Read>(
         .filter(|entry| entry.archive_name != db_prefix)
         .map(|entry| entry.archive_name.clone())
         .collect();
+    let expected_db_entries: HashSet<PathBuf> =
+        manifest.db_archive_entries.iter().cloned().collect();
+    let mut restored_db_entries = HashSet::new();
     let mut restored_count: usize = 0;
 
     for entry in entries {
@@ -343,6 +383,19 @@ pub fn restore_backup_entries<R: Read>(
         let archive_path = entry.path()?.into_owned();
 
         if archive_path.starts_with(db_prefix) {
+            validate_db_archive_path(&archive_path)?;
+            if !expected_db_entries.contains(&archive_path) {
+                anyhow::bail!(
+                    "Backup archive contains unexpected database entry: {}",
+                    archive_path.display()
+                );
+            }
+            if !restored_db_entries.insert(archive_path.clone()) {
+                anyhow::bail!(
+                    "Backup archive contains duplicate database entry: {}",
+                    archive_path.display()
+                );
+            }
             restore_db_entry(&mut entry, &archive_path, output_dir)?;
         } else {
             restore_config_entry(&mut entry, &archive_path, output_dir, &expected_files)?;
@@ -358,6 +411,22 @@ pub fn restore_backup_entries<R: Read>(
         );
     }
 
+    if restored_db_entries != expected_db_entries {
+        let mut missing_db_entries: Vec<_> = expected_db_entries
+            .difference(&restored_db_entries)
+            .cloned()
+            .collect();
+        missing_db_entries.sort();
+        anyhow::bail!(
+            "Backup archive is missing database entries: {}",
+            missing_db_entries
+                .into_iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
     Ok(())
 }
 
@@ -365,6 +434,31 @@ pub fn restore_backup_entries<R: Read>(
 /// `output_dir`, preserving the relative directory structure. Directory
 /// entries are created (recursively, since the tar may stream them in any
 /// order); file entries are written with mode 0o600.
+fn validate_db_archive_path(archive_path: &Path) -> Result<()> {
+    let mut components = archive_path.components();
+    if !matches!(components.next(), Some(Component::Normal(prefix)) if prefix == DB_SNAPSHOT_TAR_PREFIX)
+    {
+        anyhow::bail!(
+            "Database entry must live under {}: {}",
+            DB_SNAPSHOT_TAR_PREFIX,
+            archive_path.display()
+        );
+    }
+
+    if archive_path
+        .components()
+        .skip(1)
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        anyhow::bail!(
+            "Database entry must not contain `..`, `.`, or absolute path components: {}",
+            archive_path.display()
+        );
+    }
+
+    Ok(())
+}
+
 fn restore_db_entry<R: Read>(
     entry: &mut tar::Entry<'_, R>,
     archive_path: &Path,
@@ -514,6 +608,9 @@ pub fn copy_restored_files_to_original_paths(
 /// staging directory and renames it into place on success. The rename is
 /// atomic on a single filesystem, so a crash mid-copy leaves the staging
 /// directory behind without ever creating a half-populated DB at `dest`.
+/// The staging directory is created with `tempdir_in(dest.parent())`, so it
+/// lives on the same filesystem as `dest`; that same-filesystem placement is
+/// required because `rename` does not work across mount points.
 ///
 /// Fails if `dest` already exists.
 pub fn copy_db_snapshot_to_original_path(
@@ -573,9 +670,12 @@ pub fn copy_db_snapshot_to_original_path(
         )
     })?;
 
-    // Disarm the TempDir guard before rename so it doesn't try to delete the
-    // path we just moved away.
+    // Convert the TempDir into an owned path before rename so we can do
+    // explicit best-effort cleanup ourselves if the rename fails.
     let staging_path = staging.keep();
+    // `staging_path` was created as a sibling of `dest`, so this rename stays
+    // on one filesystem rather than crossing mounts; `fs::rename` does not
+    // work across mount points.
     fs::rename(&staging_path, dest).map_err(|e| {
         // Best-effort cleanup of the staging directory if the rename failed,
         // since `into_path` consumed the auto-deleting guard.
@@ -648,6 +748,49 @@ fn copy_dir_recursive_strict(src: &Path, dest: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
+
+    fn create_empty_db_snapshot_dir() -> tempfile::TempDir {
+        let parent = tempfile::tempdir().unwrap();
+        fs::create_dir(parent.path().join("db")).unwrap();
+        parent
+    }
+
+    fn db_only_manifest(db_archive_entries: Vec<PathBuf>) -> BackupManifest {
+        BackupManifest {
+            paths: vec![BackupManifestEntry {
+                archive_name: PathBuf::from(DB_SNAPSHOT_TAR_PREFIX),
+                original_path: PathBuf::from("/var/lib/hashi/db"),
+            }],
+            db_archive_entries,
+        }
+    }
+
+    fn append_regular_file<W: std::io::Write>(
+        archive: &mut tar::Builder<W>,
+        path: &str,
+        contents: &[u8],
+    ) {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(0o600);
+        header.set_size(contents.len() as u64);
+        header.set_cksum();
+        archive.append_data(&mut header, path, contents).unwrap();
+    }
+
+    fn build_archive_bytes(manifest: &BackupManifest, db_files: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut tar_bytes = Vec::new();
+        {
+            let mut archive = tar::Builder::new(&mut tar_bytes);
+            append_backup_manifest(&mut archive, manifest).unwrap();
+            for (path, contents) in db_files {
+                append_regular_file(&mut archive, path, contents);
+            }
+            archive.finish().unwrap();
+        }
+        tar_bytes
+    }
 
     #[test]
     fn manifest_disambiguates_user_file_colliding_with_db_prefix() {
@@ -655,10 +798,13 @@ mod tests {
         // must be renamed so it doesn't collide with the db snapshot entry.
         let files = vec![PathBuf::from("/etc/hashi/hashi-db-snapshot")];
         let db_path = PathBuf::from("/var/lib/hashi/db");
+        let snapshot_parent = create_empty_db_snapshot_dir();
 
-        let manifest = build_backup_manifest(&files, &db_path).unwrap();
+        let manifest =
+            build_backup_manifest(&files, &db_path, &snapshot_parent.path().join("db")).unwrap();
 
         assert_eq!(manifest.paths.len(), 2);
+        assert!(manifest.db_archive_entries.is_empty());
 
         // The user's file should have been renamed away from the reserved prefix.
         let user_entry = &manifest.paths[0];
@@ -698,10 +844,13 @@ mod tests {
             PathBuf::from("/etc/hashi/hashi-db-snapshot-2"),
         ];
         let db_path = PathBuf::from("/var/lib/hashi/db");
+        let snapshot_parent = create_empty_db_snapshot_dir();
 
-        let manifest = build_backup_manifest(&files, &db_path).unwrap();
+        let manifest =
+            build_backup_manifest(&files, &db_path, &snapshot_parent.path().join("db")).unwrap();
 
         assert_eq!(manifest.paths.len(), 3);
+        assert!(manifest.db_archive_entries.is_empty());
         assert_eq!(
             manifest.paths[0].archive_name,
             PathBuf::from("hashi-db-snapshot-2")
@@ -713,6 +862,90 @@ mod tests {
         assert_eq!(
             manifest.paths[2].archive_name,
             PathBuf::from(DB_SNAPSHOT_TAR_PREFIX)
+        );
+    }
+
+    #[test]
+    fn manifest_records_db_archive_entries() {
+        let files = Vec::new();
+        let db_path = PathBuf::from("/var/lib/hashi/db");
+        let snapshot_parent = tempfile::tempdir().unwrap();
+        let snapshot_dir = snapshot_parent.path().join("db");
+        fs::create_dir(&snapshot_dir).unwrap();
+        fs::create_dir(snapshot_dir.join("partitions")).unwrap();
+        fs::write(snapshot_dir.join("CURRENT"), b"manifest").unwrap();
+        fs::write(snapshot_dir.join("partitions").join("0001.sst"), b"sst").unwrap();
+
+        let manifest = build_backup_manifest(&files, &db_path, &snapshot_dir).unwrap();
+
+        assert_eq!(
+            manifest.db_archive_entries,
+            vec![
+                PathBuf::from("hashi-db-snapshot/CURRENT"),
+                PathBuf::from("hashi-db-snapshot/partitions"),
+                PathBuf::from("hashi-db-snapshot/partitions/0001.sst"),
+            ]
+        );
+    }
+
+    #[test]
+    fn restore_backup_entries_rejects_missing_db_entries() {
+        let manifest = db_only_manifest(vec![PathBuf::from("hashi-db-snapshot/CURRENT")]);
+        let tar_bytes = build_archive_bytes(&manifest, &[]);
+        let mut archive = tar::Archive::new(Cursor::new(tar_bytes));
+        let mut entries = archive.entries().unwrap();
+        let manifest_entry = entries.next().unwrap().unwrap();
+        let (parsed_manifest, _) = read_backup_manifest(manifest_entry).unwrap();
+        let output_dir = tempfile::tempdir().unwrap();
+
+        let err = restore_backup_entries(entries, output_dir.path(), &parsed_manifest).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Backup archive is missing database entries: hashi-db-snapshot/CURRENT")
+        );
+    }
+
+    #[test]
+    fn restore_backup_entries_rejects_unexpected_db_entries() {
+        let manifest = db_only_manifest(vec![PathBuf::from("hashi-db-snapshot/CURRENT")]);
+        let tar_bytes = build_archive_bytes(
+            &manifest,
+            &[
+                ("hashi-db-snapshot/CURRENT", b"ok"),
+                ("hashi-db-snapshot/EXTRA", b"nope"),
+            ],
+        );
+        let mut archive = tar::Archive::new(Cursor::new(tar_bytes));
+        let mut entries = archive.entries().unwrap();
+        let manifest_entry = entries.next().unwrap().unwrap();
+        let (parsed_manifest, _) = read_backup_manifest(manifest_entry).unwrap();
+        let output_dir = tempfile::tempdir().unwrap();
+
+        let err = restore_backup_entries(entries, output_dir.path(), &parsed_manifest).unwrap_err();
+
+        assert!(err.to_string().contains(
+            "Backup archive contains unexpected database entry: hashi-db-snapshot/EXTRA"
+        ));
+    }
+
+    #[test]
+    fn restore_backup_entries_rejects_db_parent_dir_traversal() {
+        let err = validate_db_archive_path(Path::new("hashi-db-snapshot/../escape")).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Database entry must not contain `..`, `.`, or absolute path components")
+        );
+    }
+
+    #[test]
+    fn restore_backup_entries_rejects_absolute_db_path() {
+        let err = validate_db_archive_path(Path::new("/hashi-db-snapshot/escape")).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Database entry must live under hashi-db-snapshot")
         );
     }
 }

--- a/crates/hashi/src/backup.rs
+++ b/crates/hashi/src/backup.rs
@@ -1,0 +1,358 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Core backup logic for creating and restoring encrypted backup archives.
+//!
+//! This module handles the mechanics of building backup manifests, encrypting
+//! files into age-wrapped tar archives, and extracting them. CLI-specific
+//! orchestration (config loading, recipient resolution, user output) lives in
+//! [`crate::cli::commands::backup`].
+
+use anyhow::Context;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fs;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io;
+use std::io::ErrorKind;
+use std::io::Read;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+use tracing::info;
+
+use age::Encryptor;
+
+pub const BACKUP_MANIFEST_FILE_NAME: &str = "hashi-config-backup-manifest.toml";
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct BackupManifest {
+    pub files: Vec<BackupManifestFile>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct BackupManifestFile {
+    pub archive_name: PathBuf,
+    pub original_path: PathBuf,
+}
+
+pub fn build_backup_manifest(files: &[PathBuf]) -> Result<BackupManifest> {
+    let mut archive_names = HashSet::new();
+    let mut manifest_files = Vec::with_capacity(files.len());
+
+    for file in files {
+        let base_name = file
+            .file_name()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Backup input does not have a file name: {}", file.display())
+            })?
+            .to_string_lossy();
+
+        let archive_name = if archive_names.contains(base_name.as_ref()) {
+            let stem = Path::new(base_name.as_ref())
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy();
+            let ext = Path::new(base_name.as_ref())
+                .extension()
+                .map(|e| format!(".{}", e.to_string_lossy()))
+                .unwrap_or_default();
+
+            let mut suffix = 2u32;
+            loop {
+                let candidate = format!("{stem}-{suffix}{ext}");
+                if archive_names.insert(candidate.clone()) {
+                    info!(
+                        original = %file.display(),
+                        renamed = %candidate,
+                        "Archive name collision for {base_name}",
+                    );
+                    break PathBuf::from(candidate);
+                }
+                suffix += 1;
+            }
+        } else {
+            archive_names.insert(base_name.to_string());
+            PathBuf::from(base_name.as_ref())
+        };
+
+        manifest_files.push(BackupManifestFile {
+            archive_name,
+            original_path: file.clone(),
+        });
+    }
+
+    Ok(BackupManifest {
+        files: manifest_files,
+    })
+}
+
+pub fn encrypt_files_to_age_archive(
+    manifest: &BackupManifest,
+    recipient: &dyn age::Recipient,
+    output_path: &Path,
+) -> Result<()> {
+    let output = File::create(output_path)
+        .with_context(|| format!("Failed to create {}", output_path.display()))?;
+    let encryptor = Encryptor::with_recipients(std::iter::once(recipient))?;
+    let mut encrypted = encryptor.wrap_output(output)?;
+    {
+        let mut archive = tar::Builder::new(&mut encrypted);
+        append_backup_manifest(&mut archive, manifest)?;
+
+        for file in &manifest.files {
+            archive.append_path_with_name(&file.original_path, &file.archive_name)?;
+            info!(
+                original = %file.original_path.display(),
+                archive_name = %file.archive_name.display(),
+                "Added file to backup archive",
+            );
+        }
+
+        archive.finish()?;
+    }
+    encrypted.finish()?;
+
+    Ok(())
+}
+
+pub fn encrypted_backup_file_name() -> PathBuf {
+    // ISO 8601 basic format in UTC, e.g. 20260409T230419Z. Compact, sorts
+    // lexicographically, and contains no characters that need escaping on any
+    // common filesystem.
+    let timestamp = jiff::Timestamp::now()
+        .to_zoned(jiff::tz::TimeZone::UTC)
+        .strftime("%Y%m%dT%H%M%SZ")
+        .to_string();
+    PathBuf::from(format!("hashi-config-backup-{timestamp}.tar.age"))
+}
+
+fn append_backup_manifest<W: std::io::Write>(
+    archive: &mut tar::Builder<W>,
+    manifest: &BackupManifest,
+) -> Result<()> {
+    let manifest_bytes = toml::to_string_pretty(manifest)?.into_bytes();
+    let mut header = tar::Header::new_gnu();
+    header.set_size(manifest_bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    archive.append_data(
+        &mut header,
+        BACKUP_MANIFEST_FILE_NAME,
+        manifest_bytes.as_slice(),
+    )?;
+    Ok(())
+}
+
+/// Determine the directory name to extract a backup tarball into.
+///
+/// Uses the tarball's file name with the `.tar.age` suffix stripped, so
+/// `hashi-config-backup-20260409T230419Z.tar.age` becomes
+/// `hashi-config-backup-20260409T230419Z`.
+pub fn extract_dir_name(backup_tarball: &Path) -> Result<PathBuf> {
+    let file_name = backup_tarball
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Backup tarball path has no file name: {}",
+                backup_tarball.display()
+            )
+        })?;
+
+    let stem = file_name
+        .strip_suffix(".tar.age")
+        .or_else(|| file_name.strip_suffix(".age"))
+        .unwrap_or(file_name);
+
+    if stem.is_empty() {
+        anyhow::bail!(
+            "Cannot derive extract directory name from {}",
+            backup_tarball.display()
+        );
+    }
+
+    Ok(PathBuf::from(stem))
+}
+
+pub fn read_backup_manifest<R: Read>(
+    mut entry: tar::Entry<'_, R>,
+) -> Result<(BackupManifest, String)> {
+    let path = entry.path()?.into_owned();
+    let file_name = path.file_name().ok_or_else(|| {
+        anyhow::anyhow!(
+            "First tar entry does not have a file name: {}",
+            path.display()
+        )
+    })?;
+    if file_name != BACKUP_MANIFEST_FILE_NAME {
+        anyhow::bail!(
+            "Expected backup manifest {} as the first tar entry, found {}",
+            BACKUP_MANIFEST_FILE_NAME,
+            path.display()
+        );
+    }
+
+    let mut manifest_toml = String::new();
+    entry.read_to_string(&mut manifest_toml)?;
+    let manifest: BackupManifest = toml::from_str(&manifest_toml)?;
+
+    Ok((manifest, manifest_toml))
+}
+
+pub fn write_manifest_to_extract_dir(extract_dir: &Path, manifest_toml: &str) -> Result<()> {
+    let manifest_path = extract_dir.join(BACKUP_MANIFEST_FILE_NAME);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&manifest_path)
+        .map_err(|e| match e.kind() {
+            ErrorKind::AlreadyExists => anyhow::anyhow!(
+                "Refusing to overwrite existing file: {}",
+                manifest_path.display()
+            ),
+            _ => anyhow::Error::from(e)
+                .context(format!("Failed to create {}", manifest_path.display())),
+        })?;
+    io::Write::write_all(&mut file, manifest_toml.as_bytes())
+        .with_context(|| format!("Failed to write manifest to {}", manifest_path.display()))?;
+    info!(path = %manifest_path.display(), "Restored manifest");
+    Ok(())
+}
+
+pub fn restore_backup_entries<R: Read>(
+    entries: tar::Entries<'_, R>,
+    output_dir: &Path,
+    manifest: &BackupManifest,
+) -> Result<HashMap<PathBuf, PathBuf>> {
+    let expected_files: HashMap<_, _> = manifest
+        .files
+        .iter()
+        .map(|file| (file.archive_name.clone(), file))
+        .collect();
+    let mut restored_files = HashMap::new();
+
+    for entry in entries {
+        let mut entry = entry?;
+        let archive_path = entry.path()?.into_owned();
+        let archive_name = PathBuf::from(archive_path.file_name().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Backup entry does not have a file name: {}",
+                archive_path.display()
+            )
+        })?);
+
+        let entry_type = entry.header().entry_type();
+        if entry_type != tar::EntryType::Regular {
+            anyhow::bail!(
+                "Backup entry {} has unexpected type {:?}; only regular files are supported",
+                archive_name.display(),
+                entry_type
+            );
+        }
+
+        if archive_path != archive_name {
+            anyhow::bail!(
+                "Backup entry must be at the tar root: {}",
+                archive_path.display()
+            );
+        }
+
+        if !expected_files.contains_key(&archive_name) {
+            anyhow::bail!(
+                "Backup archive contains unexpected file: {}",
+                archive_name.display()
+            );
+        }
+
+        let output_path = output_dir.join(&archive_name);
+        let mut output_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&output_path)
+            .map_err(|e| match e.kind() {
+                ErrorKind::AlreadyExists => anyhow::anyhow!(
+                    "Refusing to overwrite existing file: {}",
+                    output_path.display()
+                ),
+                _ => anyhow::Error::from(e)
+                    .context(format!("Failed to create {}", output_path.display())),
+            })?;
+        io::copy(&mut entry, &mut output_file).with_context(|| {
+            format!(
+                "Failed to write restored file contents to {}",
+                output_path.display()
+            )
+        })?;
+        info!(
+            archive_name = %archive_name.display(),
+            output = %output_path.display(),
+            "Restored file",
+        );
+        restored_files.insert(archive_name, output_path);
+    }
+
+    if restored_files.len() != manifest.files.len() {
+        anyhow::bail!(
+            "Backup archive is missing file entries: expected {}, restored {}",
+            manifest.files.len(),
+            restored_files.len()
+        );
+    }
+
+    Ok(restored_files)
+}
+
+pub fn copy_restored_files_to_original_paths(
+    restored_files: &HashMap<PathBuf, PathBuf>,
+    manifest: &BackupManifest,
+) -> Result<()> {
+    for file in &manifest.files {
+        let restored_path = restored_files.get(&file.archive_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Restored file missing for archive entry {}",
+                file.archive_name.display()
+            )
+        })?;
+
+        if let Some(parent) = file.original_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create parent directory {}", parent.display())
+            })?;
+        }
+
+        let mut source = File::open(restored_path)
+            .with_context(|| format!("Failed to open {}", restored_path.display()))?;
+        let mut dest = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&file.original_path)
+            .map_err(|e| match e.kind() {
+                ErrorKind::AlreadyExists => anyhow::anyhow!(
+                    "Refusing to overwrite existing original path: {}",
+                    file.original_path.display()
+                ),
+                _ => anyhow::Error::from(e)
+                    .context(format!("Failed to create {}", file.original_path.display())),
+            })?;
+        io::copy(&mut source, &mut dest).with_context(|| {
+            format!(
+                "Failed to copy {} to {}",
+                restored_path.display(),
+                file.original_path.display()
+            )
+        })?;
+        info!(
+            from = %restored_path.display(),
+            to = %file.original_path.display(),
+            "Copied restored file to original path",
+        );
+    }
+
+    Ok(())
+}

--- a/crates/hashi/src/cli/commands/backup.rs
+++ b/crates/hashi/src/cli/commands/backup.rs
@@ -1,45 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Backup command implementations
+//! CLI backup command implementations
+//!
+//! Orchestrates config loading, recipient/identity resolution, and user-facing
+//! output. The core archive logic lives in [`crate::backup`].
 
 use age::Decryptor;
-use age::Encryptor;
 use age::IdentityFile;
 use age::cli_common::UiCallbacks;
 use age::plugin;
 use anyhow::Context;
 use anyhow::Result;
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fs;
 use std::fs::File;
-use std::fs::OpenOptions;
-use std::io;
-use std::io::ErrorKind;
-use std::io::Read;
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
-use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::backup;
 use crate::cli::config::BackupRecipient;
 use crate::cli::config::CliConfig;
 use crate::cli::print_info;
 use crate::cli::print_success;
-
-const BACKUP_MANIFEST_FILE_NAME: &str = "hashi-config-backup-manifest.toml";
-
-#[derive(serde::Deserialize, serde::Serialize)]
-struct BackupManifest {
-    files: Vec<BackupManifestFile>,
-}
-
-#[derive(serde::Deserialize, serde::Serialize)]
-struct BackupManifestFile {
-    archive_name: PathBuf,
-    original_path: PathBuf,
-}
 
 /// Save an encrypted backup of the current config and referenced files
 pub fn save(
@@ -74,7 +56,7 @@ pub fn save(
     fs::create_dir_all(output_dir)
         .with_context(|| format!("Failed to create output directory {}", output_dir.display()))?;
 
-    let manifest = build_backup_manifest(&files)?;
+    let manifest = backup::build_backup_manifest(&files)?;
 
     print_info(&format!(
         "Backing up {} file(s) using age recipient {}",
@@ -84,8 +66,8 @@ pub fn save(
 
     let encryptor_recipient = build_encryptor_recipient(&recipient)?;
 
-    let output_path = output_dir.join(encrypted_backup_file_name());
-    encrypt_files_to_age_archive(&manifest, encryptor_recipient.as_ref(), &output_path)?;
+    let output_path = output_dir.join(backup::encrypted_backup_file_name());
+    backup::encrypt_files_to_age_archive(&manifest, encryptor_recipient.as_ref(), &output_path)?;
 
     print_success(&format!("Backup completed: {}", output_path.display()));
 
@@ -122,7 +104,7 @@ pub fn restore(
 ) -> Result<()> {
     let identities = load_backup_identities(backup_age_identity)?;
 
-    let extract_dir = output_dir.join(extract_dir_name(backup_tarball)?);
+    let extract_dir = output_dir.join(backup::extract_dir_name(backup_tarball)?);
     fs::create_dir_all(&extract_dir).with_context(|| {
         format!(
             "Failed to create output directory {}",
@@ -149,12 +131,12 @@ pub fn restore(
         .next()
         .transpose()?
         .ok_or_else(|| anyhow::anyhow!("Backup archive is empty"))?;
-    let (manifest, manifest_toml) = read_backup_manifest(manifest_entry)?;
-    write_manifest_to_extract_dir(&extract_dir, &manifest_toml)?;
-    let restored_files = restore_backup_entries(entries, &extract_dir, &manifest)?;
+    let (manifest, manifest_toml) = backup::read_backup_manifest(manifest_entry)?;
+    backup::write_manifest_to_extract_dir(&extract_dir, &manifest_toml)?;
+    let restored_files = backup::restore_backup_entries(entries, &extract_dir, &manifest)?;
 
     if copy_to_original_paths {
-        copy_restored_files_to_original_paths(&restored_files, &manifest)?;
+        backup::copy_restored_files_to_original_paths(&restored_files, &manifest)?;
     }
 
     print_success(&format!(
@@ -163,167 +145,6 @@ pub fn restore(
         extract_dir.display()
     ));
 
-    Ok(())
-}
-
-/// Determine the directory name to extract a backup tarball into.
-///
-/// Uses the tarball's file name with the `.tar.age` suffix stripped, so
-/// `hashi-config-backup-20260409T230419Z.tar.age` becomes
-/// `hashi-config-backup-20260409T230419Z`.
-fn extract_dir_name(backup_tarball: &Path) -> Result<PathBuf> {
-    let file_name = backup_tarball
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Backup tarball path has no file name: {}",
-                backup_tarball.display()
-            )
-        })?;
-
-    let stem = file_name
-        .strip_suffix(".tar.age")
-        .or_else(|| file_name.strip_suffix(".age"))
-        .unwrap_or(file_name);
-
-    if stem.is_empty() {
-        anyhow::bail!(
-            "Cannot derive extract directory name from {}",
-            backup_tarball.display()
-        );
-    }
-
-    Ok(PathBuf::from(stem))
-}
-
-/// Write the raw manifest TOML into the extract directory so the user can
-/// inspect it alongside the restored files.
-fn write_manifest_to_extract_dir(extract_dir: &Path, manifest_toml: &str) -> Result<()> {
-    let manifest_path = extract_dir.join(BACKUP_MANIFEST_FILE_NAME);
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(&manifest_path)
-        .map_err(|e| match e.kind() {
-            ErrorKind::AlreadyExists => anyhow::anyhow!(
-                "Refusing to overwrite existing file: {}",
-                manifest_path.display()
-            ),
-            _ => anyhow::Error::from(e)
-                .context(format!("Failed to create {}", manifest_path.display())),
-        })?;
-    io::Write::write_all(&mut file, manifest_toml.as_bytes())
-        .with_context(|| format!("Failed to write manifest to {}", manifest_path.display()))?;
-    print_info(&format!("Restored manifest to {}", manifest_path.display()));
-    Ok(())
-}
-
-fn encrypt_files_to_age_archive(
-    manifest: &BackupManifest,
-    recipient: &dyn age::Recipient,
-    output_path: &Path,
-) -> Result<()> {
-    let output = File::create(output_path)
-        .with_context(|| format!("Failed to create {}", output_path.display()))?;
-    let encryptor = Encryptor::with_recipients(std::iter::once(recipient))?;
-    let mut encrypted = encryptor.wrap_output(output)?;
-    {
-        let mut archive = tar::Builder::new(&mut encrypted);
-        append_backup_manifest(&mut archive, manifest)?;
-
-        for file in &manifest.files {
-            archive.append_path_with_name(&file.original_path, &file.archive_name)?;
-            print_info(&format!(
-                "Added {} to {}",
-                file.original_path.display(),
-                file.archive_name.display()
-            ));
-        }
-
-        archive.finish()?;
-    }
-    encrypted.finish()?;
-
-    Ok(())
-}
-
-fn encrypted_backup_file_name() -> PathBuf {
-    // ISO 8601 basic format in UTC, e.g. 20260409T230419Z. Compact, sorts
-    // lexicographically, and contains no characters that need escaping on any
-    // common filesystem.
-    let timestamp = jiff::Timestamp::now()
-        .to_zoned(jiff::tz::TimeZone::UTC)
-        .strftime("%Y%m%dT%H%M%SZ")
-        .to_string();
-    PathBuf::from(format!("hashi-config-backup-{timestamp}.tar.age"))
-}
-
-fn build_backup_manifest(files: &[PathBuf]) -> Result<BackupManifest> {
-    let mut archive_names = HashSet::new();
-    let mut manifest_files = Vec::with_capacity(files.len());
-
-    for file in files {
-        let base_name = file
-            .file_name()
-            .ok_or_else(|| {
-                anyhow::anyhow!("Backup input does not have a file name: {}", file.display())
-            })?
-            .to_string_lossy();
-
-        let archive_name = if archive_names.contains(base_name.as_ref()) {
-            let stem = Path::new(base_name.as_ref())
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy();
-            let ext = Path::new(base_name.as_ref())
-                .extension()
-                .map(|e| format!(".{}", e.to_string_lossy()))
-                .unwrap_or_default();
-
-            let mut suffix = 2u32;
-            loop {
-                let candidate = format!("{stem}-{suffix}{ext}");
-                if archive_names.insert(candidate.clone()) {
-                    print_info(&format!(
-                        "Archive name collision for {base_name}: renamed to {candidate} (original: {})",
-                        file.display()
-                    ));
-                    break PathBuf::from(candidate);
-                }
-                suffix += 1;
-            }
-        } else {
-            archive_names.insert(base_name.to_string());
-            PathBuf::from(base_name.as_ref())
-        };
-
-        manifest_files.push(BackupManifestFile {
-            archive_name,
-            original_path: file.clone(),
-        });
-    }
-
-    Ok(BackupManifest {
-        files: manifest_files,
-    })
-}
-
-fn append_backup_manifest<W: std::io::Write>(
-    archive: &mut tar::Builder<W>,
-    manifest: &BackupManifest,
-) -> Result<()> {
-    let manifest_bytes = toml::to_string_pretty(manifest)?.into_bytes();
-    let mut header = tar::Header::new_gnu();
-    header.set_size(manifest_bytes.len() as u64);
-    header.set_mode(0o644);
-    header.set_cksum();
-    archive.append_data(
-        &mut header,
-        BACKUP_MANIFEST_FILE_NAME,
-        manifest_bytes.as_slice(),
-    )?;
     Ok(())
 }
 
@@ -342,169 +163,14 @@ fn load_backup_identities(
         .map_err(Into::into)
 }
 
-fn read_backup_manifest<R: Read>(mut entry: tar::Entry<'_, R>) -> Result<(BackupManifest, String)> {
-    let path = entry.path()?.into_owned();
-    let file_name = path.file_name().ok_or_else(|| {
-        anyhow::anyhow!(
-            "First tar entry does not have a file name: {}",
-            path.display()
-        )
-    })?;
-    if file_name != BACKUP_MANIFEST_FILE_NAME {
-        anyhow::bail!(
-            "Expected backup manifest {} as the first tar entry, found {}",
-            BACKUP_MANIFEST_FILE_NAME,
-            path.display()
-        );
-    }
-
-    let mut manifest_toml = String::new();
-    entry.read_to_string(&mut manifest_toml)?;
-    let manifest: BackupManifest = toml::from_str(&manifest_toml)?;
-
-    Ok((manifest, manifest_toml))
-}
-
-fn restore_backup_entries<R: Read>(
-    entries: tar::Entries<'_, R>,
-    output_dir: &Path,
-    manifest: &BackupManifest,
-) -> Result<HashMap<PathBuf, PathBuf>> {
-    let expected_files: HashMap<_, _> = manifest
-        .files
-        .iter()
-        .map(|file| (file.archive_name.clone(), file))
-        .collect();
-    let mut restored_files = HashMap::new();
-
-    for entry in entries {
-        let mut entry = entry?;
-        let archive_path = entry.path()?.into_owned();
-        let archive_name = PathBuf::from(archive_path.file_name().ok_or_else(|| {
-            anyhow::anyhow!(
-                "Backup entry does not have a file name: {}",
-                archive_path.display()
-            )
-        })?);
-
-        let entry_type = entry.header().entry_type();
-        if entry_type != tar::EntryType::Regular {
-            anyhow::bail!(
-                "Backup entry {} has unexpected type {:?}; only regular files are supported",
-                archive_name.display(),
-                entry_type
-            );
-        }
-
-        if archive_path != archive_name {
-            anyhow::bail!(
-                "Backup entry must be at the tar root: {}",
-                archive_path.display()
-            );
-        }
-
-        if !expected_files.contains_key(&archive_name) {
-            anyhow::bail!(
-                "Backup archive contains unexpected file: {}",
-                archive_name.display()
-            );
-        }
-
-        let output_path = output_dir.join(&archive_name);
-        let mut output_file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .open(&output_path)
-            .map_err(|e| match e.kind() {
-                ErrorKind::AlreadyExists => anyhow::anyhow!(
-                    "Refusing to overwrite existing file: {}",
-                    output_path.display()
-                ),
-                _ => anyhow::Error::from(e)
-                    .context(format!("Failed to create {}", output_path.display())),
-            })?;
-        io::copy(&mut entry, &mut output_file).with_context(|| {
-            format!(
-                "Failed to write restored file contents to {}",
-                output_path.display()
-            )
-        })?;
-        print_info(&format!(
-            "Restored {} to {}",
-            archive_name.display(),
-            output_path.display()
-        ));
-        restored_files.insert(archive_name, output_path);
-    }
-
-    if restored_files.len() != manifest.files.len() {
-        anyhow::bail!(
-            "Backup archive is missing file entries: expected {}, restored {}",
-            manifest.files.len(),
-            restored_files.len()
-        );
-    }
-
-    Ok(restored_files)
-}
-
-fn copy_restored_files_to_original_paths(
-    restored_files: &HashMap<PathBuf, PathBuf>,
-    manifest: &BackupManifest,
-) -> Result<()> {
-    for file in &manifest.files {
-        let restored_path = restored_files.get(&file.archive_name).ok_or_else(|| {
-            anyhow::anyhow!(
-                "Restored file missing for archive entry {}",
-                file.archive_name.display()
-            )
-        })?;
-
-        if let Some(parent) = file.original_path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("Failed to create parent directory {}", parent.display())
-            })?;
-        }
-
-        let mut source = File::open(restored_path)
-            .with_context(|| format!("Failed to open {}", restored_path.display()))?;
-        let mut dest = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .open(&file.original_path)
-            .map_err(|e| match e.kind() {
-                ErrorKind::AlreadyExists => anyhow::anyhow!(
-                    "Refusing to overwrite existing original path: {}",
-                    file.original_path.display()
-                ),
-                _ => anyhow::Error::from(e)
-                    .context(format!("Failed to create {}", file.original_path.display())),
-            })?;
-        io::copy(&mut source, &mut dest).with_context(|| {
-            format!(
-                "Failed to copy {} to {}",
-                restored_path.display(),
-                file.original_path.display()
-            )
-        })?;
-        print_info(&format!(
-            "Copied {} to {}",
-            restored_path.display(),
-            file.original_path.display()
-        ));
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::cli::config::BitcoinConfig;
     use age::secrecy::ExposeSecret;
     use age::x25519;
+    use std::path::Path;
+    use std::path::PathBuf;
     use tempfile::TempDir;
 
     const CONFIG_CONTENTS: &[u8] = b"sui_rpc_url = \"https://fullnode.mainnet.sui.io:443\"\n";
@@ -618,7 +284,7 @@ mod tests {
     /// Compute the nested directory that `restore` will extract into, given the
     /// tarball path and the user-supplied output directory.
     fn expected_extract_dir(tarball: &Path, output_dir: &Path) -> PathBuf {
-        output_dir.join(super::extract_dir_name(tarball).unwrap())
+        output_dir.join(backup::extract_dir_name(tarball).unwrap())
     }
 
     #[test]
@@ -640,7 +306,7 @@ mod tests {
         assert_mode_0600(&extract_dir.join("btc.wif"));
 
         // The manifest should also be extracted alongside the restored files.
-        let manifest_path = extract_dir.join(BACKUP_MANIFEST_FILE_NAME);
+        let manifest_path = extract_dir.join(backup::BACKUP_MANIFEST_FILE_NAME);
         assert!(
             manifest_path.exists(),
             "manifest not extracted to {}",

--- a/crates/hashi/src/cli/commands/backup.rs
+++ b/crates/hashi/src/cli/commands/backup.rs
@@ -120,7 +120,7 @@ pub fn save(
     fs::create_dir_all(output_dir)
         .with_context(|| format!("Failed to create output directory {}", output_dir.display()))?;
 
-    let manifest = backup::build_backup_manifest(&files, db_path)?;
+    let manifest = backup::build_backup_manifest(&files, db_path, &snapshot_path)?;
 
     info!(
         file_count = files.len(),

--- a/crates/hashi/src/cli/commands/backup.rs
+++ b/crates/hashi/src/cli/commands/backup.rs
@@ -17,13 +17,14 @@ use std::fs::File;
 use std::path::Path;
 use std::str::FromStr;
 
+use tracing::info;
+
 use crate::backup;
 use crate::cli::config::BackupRecipient;
 use crate::cli::config::CliConfig;
-use crate::cli::print_info;
 use crate::cli::print_success;
 
-/// Save an encrypted backup of the current config and referenced files
+/// Save an encrypted backup of the current config, referenced files, and database
 pub fn save(
     config: &CliConfig,
     backup_age_pubkey_override: Option<String>,
@@ -39,13 +40,10 @@ pub fn save(
             )
         })?;
 
-    if config.loaded_from_path.is_none() {
-        anyhow::bail!(
-            "No config file is currently in use. Pass --config with a config file path before running backup."
-        );
-    }
-
-    let files = config.backup_file_paths();
+    // `backup_file_paths` enforces all the structural invariants we need
+    // (CLI config in use, node config path set, node config loadable, key
+    // file paths actually exist).
+    let files = config.backup_file_paths()?;
 
     for file in &files {
         if !file.exists() {
@@ -53,21 +51,93 @@ pub fn save(
         }
     }
 
+    // The DB path lives in the node config and isn't part of `files`, so we
+    // load the node config a second time here. `backup_file_paths` already
+    // proved this load succeeds, so an error here would have to be a TOCTOU
+    // — fine to surface as-is.
+    let node_config_path = config
+        .node_config_path
+        .as_ref()
+        .expect("backup_file_paths verified node_config_path is set");
+    let node_config = crate::config::Config::load(node_config_path).with_context(|| {
+        format!(
+            "Failed to load node config from {}",
+            node_config_path.display()
+        )
+    })?;
+    let db_path = node_config.db.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Node config at {} does not specify a database path",
+            node_config_path.display()
+        )
+    })?;
+
+    // Refuse to silently create an empty DB at a typo'd path. `fjall` would
+    // otherwise happily `create_dir_all` on open and we'd ship a zero-row
+    // backup with no warning.
+    if !db_path
+        .try_exists()
+        .with_context(|| format!("Failed to stat database path {}", db_path.display()))?
+    {
+        anyhow::bail!(
+            "Database path {} does not exist. Fix the `db` field in {} before running backup save.",
+            db_path.display(),
+            node_config_path.display(),
+        );
+    }
+
+    // Open the database — fails with a clear message if the node is running.
+    // `Database::open` preserves `fjall::Error` as the source, so the
+    // downcast below matches on the underlying variant.
+    let db = crate::db::Database::open(db_path).map_err(|e| {
+        if e.downcast_ref::<fjall::Error>()
+            .is_some_and(|fe| matches!(fe, fjall::Error::Locked))
+        {
+            anyhow::anyhow!(
+                "Cannot open database at {}: it is locked by a running hashi node. \
+                 Stop the node before running backup save.",
+                db_path.display()
+            )
+        } else {
+            e.context(format!("Failed to open database at {}", db_path.display()))
+        }
+    })?;
+
+    // Snapshot the database into a subdirectory of a temp dir. `snapshot_to_path`
+    // requires a non-existent destination, so we create the parent tempdir and
+    // point at a yet-to-be-created child.
+    let tmp_parent = tempfile::Builder::new()
+        .prefix("hashi-db-snapshot-")
+        .tempdir()
+        .context("Failed to create temp directory for database snapshot")?;
+    let snapshot_path = tmp_parent.path().join("db");
+    db.snapshot_to_path(&snapshot_path)
+        .context("Failed to snapshot database")?;
+    drop(db);
+
+    info!(source = %db_path.display(), "Database snapshot created");
+
     fs::create_dir_all(output_dir)
         .with_context(|| format!("Failed to create output directory {}", output_dir.display()))?;
 
-    let manifest = backup::build_backup_manifest(&files)?;
+    let manifest = backup::build_backup_manifest(&files, db_path)?;
 
-    print_info(&format!(
-        "Backing up {} file(s) using age recipient {}",
-        files.len(),
-        recipient
-    ));
+    info!(
+        file_count = files.len(),
+        %recipient,
+        "Backing up files + database",
+    );
 
     let encryptor_recipient = build_encryptor_recipient(&recipient)?;
 
     let output_path = output_dir.join(backup::encrypted_backup_file_name());
-    backup::encrypt_files_to_age_archive(&manifest, encryptor_recipient.as_ref(), &output_path)?;
+    backup::encrypt_files_to_age_archive(
+        &manifest,
+        &snapshot_path,
+        encryptor_recipient.as_ref(),
+        &output_path,
+    )?;
+    drop(tmp_parent);
 
     print_success(&format!("Backup completed: {}", output_path.display()));
 
@@ -105,12 +175,31 @@ pub fn restore(
     let identities = load_backup_identities(backup_age_identity)?;
 
     let extract_dir = output_dir.join(backup::extract_dir_name(backup_tarball)?);
-    fs::create_dir_all(&extract_dir).with_context(|| {
-        format!(
-            "Failed to create output directory {}",
+    if extract_dir
+        .try_exists()
+        .with_context(|| format!("Failed to stat {}", extract_dir.display()))?
+    {
+        anyhow::bail!(
+            "Refusing to overwrite existing extract directory: {}",
             extract_dir.display()
-        )
-    })?;
+        );
+    }
+    fs::create_dir_all(output_dir)
+        .with_context(|| format!("Failed to create output directory {}", output_dir.display()))?;
+
+    // Extract into a sibling staging directory and rename into place on
+    // success. A failure mid-extract leaves the staging dir behind (auto-
+    // cleaned on `TempDir` drop) so the user can retry without manual cleanup
+    // and the final `extract_dir` never appears half-populated.
+    let staging = tempfile::Builder::new()
+        .prefix(".hashi-restore-")
+        .tempdir_in(output_dir)
+        .with_context(|| {
+            format!(
+                "Failed to create staging directory in {}",
+                output_dir.display()
+            )
+        })?;
 
     let input = File::open(backup_tarball)
         .with_context(|| format!("Failed to open backup tarball {}", backup_tarball.display()))?;
@@ -132,11 +221,27 @@ pub fn restore(
         .transpose()?
         .ok_or_else(|| anyhow::anyhow!("Backup archive is empty"))?;
     let (manifest, manifest_toml) = backup::read_backup_manifest(manifest_entry)?;
-    backup::write_manifest_to_extract_dir(&extract_dir, &manifest_toml)?;
-    let restored_files = backup::restore_backup_entries(entries, &extract_dir, &manifest)?;
+    backup::restore_backup_entries(entries, staging.path(), &manifest)?;
+    // Manifest is written last so it acts as a marker that extraction finished
+    // successfully. Any earlier failure leaves the staging dir without a
+    // manifest, so partial state can never be confused for a complete restore.
+    backup::write_manifest_to_extract_dir(staging.path(), &manifest_toml)?;
+
+    // Promote the staged dir into its final location atomically. Same-
+    // filesystem rename is required for atomicity, which `tempdir_in` of a
+    // sibling guarantees.
+    let staging_path = staging.keep();
+    fs::rename(&staging_path, &extract_dir).map_err(|e| {
+        let _ = fs::remove_dir_all(&staging_path);
+        anyhow::Error::from(e).context(format!(
+            "Failed to move staged restore into place at {}",
+            extract_dir.display()
+        ))
+    })?;
 
     if copy_to_original_paths {
-        backup::copy_restored_files_to_original_paths(&restored_files, &manifest)?;
+        backup::copy_restored_files_to_original_paths(&extract_dir, &manifest)?;
+        backup::copy_db_snapshot_to_original_path(&extract_dir, &manifest)?;
     }
 
     print_success(&format!(
@@ -187,20 +292,40 @@ mod tests {
     }
 
     impl TestFixture {
-        /// Create a new fixture with a config file and two referenced key files on disk.
+        fn db_path(&self) -> PathBuf {
+            let node_config =
+                crate::config::Config::load(self.config.node_config_path.as_ref().unwrap())
+                    .unwrap();
+            node_config.db.unwrap()
+        }
+
+        /// Create a new fixture with a config file, two referenced key files,
+        /// a node config pointing to a database, and an empty database on disk.
         fn new() -> Self {
             let src = tempfile::Builder::new().tempdir().unwrap();
             let config_path = src.path().join("hashi-cli.toml");
             let keypair_path = src.path().join("keypair.pem");
             let btc_key_path = src.path().join("btc.wif");
+            let db_path = src.path().join("db");
 
             fs::write(&config_path, CONFIG_CONTENTS).unwrap();
             fs::write(&keypair_path, KEYPAIR_CONTENTS).unwrap();
             fs::write(&btc_key_path, BTC_KEY_CONTENTS).unwrap();
 
+            // Create a node config file with a db path and initialise the database.
+            // Drop the handle immediately so subsequent opens can acquire the lock.
+            let node_config_path = src.path().join("config.toml");
+            let node_config = crate::config::Config {
+                db: Some(db_path.clone()),
+                ..Default::default()
+            };
+            node_config.save(&node_config_path).unwrap();
+            drop(crate::db::Database::open(&db_path).unwrap());
+
             let config = CliConfig {
                 loaded_from_path: Some(config_path.clone()),
                 keypair_path: Some(keypair_path.clone()),
+                node_config_path: Some(node_config_path),
                 bitcoin: Some(BitcoinConfig {
                     private_key_path: Some(btc_key_path.clone()),
                     ..BitcoinConfig::default()
@@ -226,13 +351,13 @@ mod tests {
     }
 
     /// Run `save` with a freshly generated age identity and return everything `restore` needs.
-    fn save_with_fresh_identity(config: &CliConfig) -> SavedBackup {
+    fn save_with_fresh_identity(fixture: &TestFixture) -> SavedBackup {
         let dir = tempfile::Builder::new().tempdir().unwrap();
 
         let identity = x25519::Identity::generate();
         let recipient = identity.to_public();
 
-        save(config, Some(recipient.to_string()), dir.path()).unwrap();
+        save(&fixture.config, Some(recipient.to_string()), dir.path()).unwrap();
 
         let tarball = fs::read_dir(dir.path())
             .unwrap()
@@ -290,7 +415,7 @@ mod tests {
     #[test]
     fn round_trip_restores_files_to_output_dir() {
         let fixture = TestFixture::new();
-        let backup = save_with_fresh_identity(&fixture.config);
+        let backup = save_with_fresh_identity(&fixture);
 
         let out = tempfile::Builder::new().tempdir().unwrap();
         restore(&backup.tarball, &backup.identity_file, out.path(), false).unwrap();
@@ -323,12 +448,16 @@ mod tests {
     #[test]
     fn round_trip_copy_to_original_paths_rewrites_originals() {
         let fixture = TestFixture::new();
-        let backup = save_with_fresh_identity(&fixture.config);
+        let backup = save_with_fresh_identity(&fixture);
+
+        let db_path = fixture.db_path();
 
         // Delete the originals so copy_to_original_paths can recreate them.
         fs::remove_file(&fixture.config_path).unwrap();
+        fs::remove_file(fixture.config.node_config_path.as_ref().unwrap()).unwrap();
         fs::remove_file(&fixture.keypair_path).unwrap();
         fs::remove_file(&fixture.btc_key_path).unwrap();
+        fs::remove_dir_all(&db_path).unwrap();
 
         let out = tempfile::Builder::new().tempdir().unwrap();
         restore(&backup.tarball, &backup.identity_file, out.path(), true).unwrap();
@@ -346,12 +475,15 @@ mod tests {
         assert_mode_0600(&fixture.config_path);
         assert_mode_0600(&fixture.keypair_path);
         assert_mode_0600(&fixture.btc_key_path);
+
+        // The restored database should be openable.
+        let _db = crate::db::Database::open(&db_path).unwrap();
     }
 
     #[test]
     fn restore_refuses_to_overwrite_existing_original_paths() {
         let fixture = TestFixture::new();
-        let backup = save_with_fresh_identity(&fixture.config);
+        let backup = save_with_fresh_identity(&fixture);
 
         // Delete keypair and btc key but leave the config in place. The config file is
         // the first entry in `backup_file_paths()`, so the copy-back loop will bail on
@@ -390,14 +522,24 @@ mod tests {
 
         let keypair_path = sui_dir.join("key.pem");
         let btc_key_path = btc_dir.join("key.pem");
+        let db_path = src.path().join("db");
 
         fs::write(&config_path, CONFIG_CONTENTS).unwrap();
         fs::write(&keypair_path, KEYPAIR_CONTENTS).unwrap();
         fs::write(&btc_key_path, BTC_KEY_CONTENTS).unwrap();
 
+        let node_config_path = src.path().join("config.toml");
+        let node_config = crate::config::Config {
+            db: Some(db_path.clone()),
+            ..Default::default()
+        };
+        node_config.save(&node_config_path).unwrap();
+        drop(crate::db::Database::open(&db_path).unwrap());
+
         let config = CliConfig {
             loaded_from_path: Some(config_path.clone()),
             keypair_path: Some(keypair_path.clone()),
+            node_config_path: Some(node_config_path),
             bitcoin: Some(BitcoinConfig {
                 private_key_path: Some(btc_key_path.clone()),
                 ..BitcoinConfig::default()
@@ -405,7 +547,15 @@ mod tests {
             ..CliConfig::default()
         };
 
-        let backup = save_with_fresh_identity(&config);
+        let fixture = TestFixture {
+            _src: src,
+            config,
+            config_path: config_path.clone(),
+            keypair_path: keypair_path.clone(),
+            btc_key_path: btc_key_path.clone(),
+        };
+
+        let backup = save_with_fresh_identity(&fixture);
 
         // Verify the archive contains both key.pem and key-2.pem.
         let out = tempfile::Builder::new().tempdir().unwrap();
@@ -417,14 +567,259 @@ mod tests {
 
         // Now test that --copy-to-original-paths uses the real paths, not the
         // disambiguated archive names.
+        let db_path = fixture.db_path();
         fs::remove_file(&config_path).unwrap();
+        fs::remove_file(fixture.config.node_config_path.as_ref().unwrap()).unwrap();
         fs::remove_file(&keypair_path).unwrap();
         fs::remove_file(&btc_key_path).unwrap();
+        fs::remove_dir_all(&db_path).unwrap();
 
         let out2 = tempfile::Builder::new().tempdir().unwrap();
         restore(&backup.tarball, &backup.identity_file, out2.path(), true).unwrap();
 
         assert_file_eq(&keypair_path, KEYPAIR_CONTENTS);
         assert_file_eq(&btc_key_path, BTC_KEY_CONTENTS);
+    }
+
+    #[test]
+    fn round_trip_preserves_db_contents_after_extraction() {
+        use hashi_types::committee::EncryptionPrivateKey;
+
+        let fixture = TestFixture::new();
+        let db_path = fixture.db_path();
+
+        // Write a known row to the source db before taking the backup.
+        let enc_key = EncryptionPrivateKey::new(&mut rand::thread_rng());
+        {
+            let db = crate::db::Database::open(&db_path).unwrap();
+            db.store_encryption_key(42, &enc_key).unwrap();
+        }
+
+        let backup = save_with_fresh_identity(&fixture);
+
+        let out = tempfile::Builder::new().tempdir().unwrap();
+        restore(&backup.tarball, &backup.identity_file, out.path(), false).unwrap();
+
+        // Open the extracted snapshot directory directly — no copy-to-original step.
+        // This is the real test of the stated goal: a decrypted/extracted snapshot
+        // dir is immediately usable as a fjall db.
+        let extract_dir = expected_extract_dir(&backup.tarball, out.path());
+        let snapshot_dir = extract_dir.join(backup::DB_SNAPSHOT_TAR_PREFIX);
+        let restored_db = crate::db::Database::open(&snapshot_dir).unwrap();
+
+        let restored_key = restored_db.get_encryption_key(42).unwrap().unwrap();
+        assert_eq!(restored_key, enc_key);
+    }
+
+    #[test]
+    fn save_errors_when_node_config_path_unset() {
+        // If the CLI config doesn't declare `node_config_path`, save must
+        // refuse — otherwise we'd silently back up without the DB.
+        let fixture = TestFixture::new();
+        let mut config = fixture.config.clone();
+        config.node_config_path = None;
+
+        let out = tempfile::Builder::new().tempdir().unwrap();
+        let identity = x25519::Identity::generate();
+        let err = save(&config, Some(identity.to_public().to_string()), out.path()).unwrap_err();
+
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("node_config_path is not set"),
+            "expected node_config_path error, got: {chain}"
+        );
+    }
+
+    #[test]
+    fn save_errors_when_db_path_does_not_exist() {
+        // A typo'd `db` field in the node config would otherwise let fjall
+        // silently `create_dir_all` and produce an empty backup.
+        let fixture = TestFixture::new();
+        let db_path = fixture.db_path();
+        fs::remove_dir_all(&db_path).unwrap();
+
+        let out = tempfile::Builder::new().tempdir().unwrap();
+        let identity = x25519::Identity::generate();
+        let err = save(
+            &fixture.config,
+            Some(identity.to_public().to_string()),
+            out.path(),
+        )
+        .unwrap_err();
+
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("does not exist"),
+            "expected missing-db error, got: {chain}"
+        );
+        assert!(
+            chain.contains(&db_path.display().to_string()),
+            "error chain did not mention db path: {chain}"
+        );
+        // The DB directory must not have been created as a side-effect.
+        assert!(
+            !db_path.exists(),
+            "save should not create the db dir when it was missing"
+        );
+    }
+
+    #[test]
+    fn save_surfaces_locked_db_error_when_node_is_running() {
+        // Simulate a running node by holding the fjall lock ourselves while
+        // save runs. The friendly "node is running" message proves the
+        // fjall::Error::Locked downcast in save() is actually reachable,
+        // which was broken before because Database::open stringified errors.
+        let fixture = TestFixture::new();
+        let db_path = fixture.db_path();
+        let _running_node = crate::db::Database::open(&db_path).unwrap();
+
+        let out = tempfile::Builder::new().tempdir().unwrap();
+        let identity = x25519::Identity::generate();
+        let err = save(
+            &fixture.config,
+            Some(identity.to_public().to_string()),
+            out.path(),
+        )
+        .unwrap_err();
+
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("locked by a running hashi node"),
+            "expected locked-db friendly error, got: {chain}"
+        );
+    }
+
+    #[test]
+    fn save_includes_path_style_node_config_key_files() {
+        // `tls_private_key` / `operator_private_key` in the node config are
+        // path-or-inline-PEM strings. When a path is used, the referenced
+        // file must be captured in the backup so the key material survives.
+        let fixture = TestFixture::new();
+
+        // Point the node config at two real key files on disk.
+        let tls_key_path = fixture._src.path().join("tls.pem");
+        let op_key_path = fixture._src.path().join("operator.pem");
+        fs::write(&tls_key_path, b"tls-key-bytes").unwrap();
+        fs::write(&op_key_path, b"operator-key-bytes").unwrap();
+
+        let mut node_config =
+            crate::config::Config::load(fixture.config.node_config_path.as_ref().unwrap()).unwrap();
+        node_config.tls_private_key = Some(tls_key_path.to_string_lossy().into_owned());
+        node_config.operator_private_key = Some(op_key_path.to_string_lossy().into_owned());
+        node_config
+            .save(fixture.config.node_config_path.as_ref().unwrap())
+            .unwrap();
+
+        let backup = save_with_fresh_identity(&fixture);
+
+        let out = tempfile::Builder::new().tempdir().unwrap();
+        restore(&backup.tarball, &backup.identity_file, out.path(), false).unwrap();
+
+        let extract_dir = expected_extract_dir(&backup.tarball, out.path());
+        assert_file_eq(&extract_dir.join("tls.pem"), b"tls-key-bytes");
+        assert_file_eq(&extract_dir.join("operator.pem"), b"operator-key-bytes");
+    }
+
+    #[test]
+    fn save_errors_when_node_config_key_path_does_not_exist() {
+        // A path-shaped value pointing at a missing file is almost certainly a
+        // typo. Silently skipping it would produce a backup that can't restore
+        // the node, so we bail instead.
+        let fixture = TestFixture::new();
+
+        let mut node_config =
+            crate::config::Config::load(fixture.config.node_config_path.as_ref().unwrap()).unwrap();
+        node_config.tls_private_key = Some("/this/path/definitely/does/not/exist.pem".to_string());
+        node_config
+            .save(fixture.config.node_config_path.as_ref().unwrap())
+            .unwrap();
+
+        let out = tempfile::Builder::new().tempdir().unwrap();
+        let identity = x25519::Identity::generate();
+        let err = save(
+            &fixture.config,
+            Some(identity.to_public().to_string()),
+            out.path(),
+        )
+        .unwrap_err();
+
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("tls_private_key"),
+            "expected error to name the offending field, got: {chain}"
+        );
+        assert!(
+            chain.contains("neither inline PEM nor an existing file"),
+            "expected missing-key error, got: {chain}"
+        );
+    }
+
+    #[test]
+    fn save_ignores_inline_pem_node_config_key_values() {
+        // When tls_private_key is inline PEM (not a real file), it must not
+        // leak into backup_file_paths as a bogus path. The node config file
+        // itself already captures inline values.
+        let fixture = TestFixture::new();
+
+        let mut node_config =
+            crate::config::Config::load(fixture.config.node_config_path.as_ref().unwrap()).unwrap();
+        node_config.tls_private_key = Some(
+            "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIA==\n-----END PRIVATE KEY-----\n"
+                .to_string(),
+        );
+        node_config
+            .save(fixture.config.node_config_path.as_ref().unwrap())
+            .unwrap();
+
+        // Just running save without error is the assertion: if the inline
+        // PEM were treated as a path, the pre-flight `file.exists()` check
+        // in save() would bail.
+        let _ = save_with_fresh_identity(&fixture);
+    }
+
+    #[test]
+    fn restore_rejects_tarball_without_age_suffix() {
+        let fixture = TestFixture::new();
+        let backup = save_with_fresh_identity(&fixture);
+
+        // Rename the tarball to strip the suffix entirely.
+        let bad = backup.tarball.with_file_name("totally-not-a-backup");
+        fs::rename(&backup.tarball, &bad).unwrap();
+
+        let out = tempfile::Builder::new().tempdir().unwrap();
+        let err = restore(&bad, &backup.identity_file, out.path(), false).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains(".tar.age or .age suffix"),
+            "expected suffix-required error, got: {chain}"
+        );
+    }
+
+    #[test]
+    fn restore_copy_to_original_paths_refuses_to_overwrite_existing_db_dir() {
+        let fixture = TestFixture::new();
+        let backup = save_with_fresh_identity(&fixture);
+
+        let db_path = fixture.db_path();
+
+        // Delete the config-file originals so the config-copy loop succeeds and we
+        // reach the db-copy step, but leave the db dir in place.
+        fs::remove_file(&fixture.config_path).unwrap();
+        fs::remove_file(fixture.config.node_config_path.as_ref().unwrap()).unwrap();
+        fs::remove_file(&fixture.keypair_path).unwrap();
+        fs::remove_file(&fixture.btc_key_path).unwrap();
+        assert!(db_path.exists(), "db dir should still exist for this test");
+
+        let out = tempfile::Builder::new().tempdir().unwrap();
+        let err = restore(&backup.tarball, &backup.identity_file, out.path(), true).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("Refusing to overwrite existing database directory"),
+            "error chain did not mention db overwrite refusal: {chain}"
+        );
+        assert!(
+            chain.contains(&db_path.display().to_string()),
+            "error chain did not mention the colliding db path: {chain}"
+        );
     }
 }

--- a/crates/hashi/src/cli/config.rs
+++ b/crates/hashi/src/cli/config.rs
@@ -98,6 +98,10 @@ pub struct CliConfig {
     /// Optional: Gas coin object ID to use for transactions
     pub gas_coin: Option<Address>,
 
+    /// Path to the validator node config file (same as used by `hashi server`).
+    /// Required for backup commands that need access to the database.
+    pub node_config_path: Option<PathBuf>,
+
     /// Optional Bitcoin configuration for deposit/withdrawal commands
     #[serde(default)]
     pub bitcoin: Option<BitcoinConfig>,
@@ -105,6 +109,52 @@ pub struct CliConfig {
 
 fn default_sui_rpc_url() -> String {
     "https://fullnode.mainnet.sui.io:443".to_string()
+}
+
+/// Return the set of external files referenced by path-style node config
+/// fields.
+///
+/// Both `tls_private_key` and `operator_private_key` are `Option<String>`
+/// interpreted as path-first, inline-PEM-fallback by the node. We classify
+/// the value here so the backup either includes the referenced file or, when
+/// the value is inline PEM, relies on the node config file itself to capture
+/// the key material. A path-shaped value that doesn't resolve to a file is
+/// an error: it would mean the node config points at a missing key, and
+/// silently skipping it would produce a backup that can't actually restore
+/// the node.
+fn node_config_referenced_files(node_config: &crate::config::Config) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+
+    for (field_name, raw) in [
+        ("tls_private_key", node_config.tls_private_key.as_deref()),
+        (
+            "operator_private_key",
+            node_config.operator_private_key.as_deref(),
+        ),
+    ] {
+        let Some(raw) = raw else { continue };
+
+        if is_inline_pem(raw) {
+            continue;
+        }
+
+        let candidate = Path::new(raw);
+        if !candidate.is_file() {
+            anyhow::bail!(
+                "node config field `{field_name}` is set to {raw:?} which is neither inline PEM nor an existing file. \
+                 Fix the value or remove it before running backup."
+            );
+        }
+        paths.push(candidate.to_path_buf());
+    }
+
+    Ok(paths)
+}
+
+/// Heuristic: PEM blobs start with the armor header `-----BEGIN`, optionally
+/// after some leading whitespace. A real path on any sane filesystem won't.
+fn is_inline_pem(value: &str) -> bool {
+    value.trim_start().starts_with("-----BEGIN")
 }
 
 /// Default path for the CLI config file written by `hashi-localnet start`.
@@ -120,6 +170,7 @@ impl Default for CliConfig {
             keypair_path: None,
             backup_age_pubkey: None,
             gas_coin: None,
+            node_config_path: None,
             bitcoin: None,
         }
     }
@@ -306,12 +357,41 @@ sui_rpc_url = "https://fullnode.mainnet.sui.io:443"
     }
 
     /// All file paths which must be backed up to enable full node recovery
-    pub fn backup_file_paths(&self) -> Vec<PathBuf> {
-        let mut paths = Vec::new();
+    /// (other than the db, which is backed up separately).
+    ///
+    /// Requires both `loaded_from_path` (the CLI config in use) and
+    /// `node_config_path` to be set — without them the resulting archive
+    /// can't fully restore the node, and any caller (today or future) should
+    /// fail loudly rather than ship a half-complete backup.
+    ///
+    /// The node config's `tls_private_key` and `operator_private_key` fields
+    /// are path-or-inline-PEM strings. When they resolve to an existing file,
+    /// that file is added here so the referenced key material isn't left
+    /// behind; inline PEM values are already captured by backing up the node
+    /// config file itself.
+    pub fn backup_file_paths(&self) -> Result<Vec<PathBuf>> {
+        let cli_config_path = self.loaded_from_path.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No config file is currently in use. Pass --config with a config file path before running backup."
+            )
+        })?;
+        let node_config_path = self.node_config_path.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "node_config_path is not set in the CLI config file. Set it before running backup save."
+            )
+        })?;
 
-        if let Some(path) = &self.loaded_from_path {
-            paths.push(path.clone());
-        }
+        // Load the node config eagerly: a broken node config should fail the
+        // backup loudly rather than produce a subtly incomplete archive.
+        let node_config = crate::config::Config::load(node_config_path).with_context(|| {
+            format!(
+                "Failed to load node config from {} while collecting backup paths",
+                node_config_path.display()
+            )
+        })?;
+
+        let mut paths = vec![cli_config_path.clone(), node_config_path.clone()];
+        paths.extend(node_config_referenced_files(&node_config)?);
 
         if let Some(path) = &self.keypair_path {
             paths.push(path.clone());
@@ -323,7 +403,7 @@ sui_rpc_url = "https://fullnode.mainnet.sui.io:443"
             paths.push(path.clone());
         }
 
-        paths
+        Ok(paths)
     }
 
     /// Get a Bitcoin RPC client from the config, if configured.

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -274,7 +274,13 @@ pub enum BackupCommands {
         output_dir: std::path::PathBuf,
     },
 
-    /// Restore files from an encrypted config backup
+    /// Restore files from an encrypted config backup.
+    ///
+    /// When `--copy-to-original-paths` is set, files are written to the
+    /// absolute paths stored in the manifest at backup time. If the restore
+    /// is running on a different host or with a different filesystem layout,
+    /// those paths will be used verbatim — extract without the flag and copy
+    /// files manually in that case.
     Restore {
         /// Path to the encrypted backup tarball
         backup_tarball: std::path::PathBuf,
@@ -287,7 +293,10 @@ pub enum BackupCommands {
         #[clap(long, default_value = ".")]
         output_dir: std::path::PathBuf,
 
-        /// Copy restored files to their original paths after extraction
+        /// Copy restored files to their original paths after extraction.
+        ///
+        /// Uses the absolute paths captured in the backup manifest. Intended
+        /// for in-place recovery on the same host the backup came from.
         #[clap(long)]
         copy_to_original_paths: bool,
     },

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -9,6 +9,7 @@ use fastcrypto_tbls::threshold_schnorr::avss;
 use fastcrypto_tbls::threshold_schnorr::batch_avss;
 use fjall::Keyspace;
 use fjall::KeyspaceCreateOptions;
+use fjall::Readable;
 use fjall::Result;
 use sui_sdk_types::Address;
 
@@ -19,7 +20,6 @@ use serde::de::DeserializeOwned;
 use crate::mpc::types::RotationMessages;
 
 pub struct Database {
-    #[allow(unused)]
     db: fjall::Database,
     // keyspaces
 
@@ -72,6 +72,47 @@ impl Database {
             rotation_messages,
             nonce_messages,
         })
+    }
+
+    /// Returns all keyspaces paired with their names. When adding a new
+    /// keyspace, add it here so that it is included in snapshots and backups.
+    fn all_keyspaces(&self) -> [(&str, &Keyspace); 4] {
+        [
+            (ENCRYPTION_KEYS_CF_NAME, &self.encryption_keys),
+            (DEALER_MESSAGES_CF_NAME, &self.dealer_messages),
+            (ROTATION_MESSAGES_CF_NAME, &self.rotation_messages),
+            (NONCE_MESSAGES_CF_NAME, &self.nonce_messages),
+        ]
+    }
+
+    /// Create a consistent snapshot of this database and write it as a new fjall
+    /// database at `dest`.
+    ///
+    /// Uses fjall's MVCC snapshot to get a point-in-time view of all keyspaces
+    /// while the source database remains open for writes. The destination is a
+    /// fully self-contained fjall database that can later be opened with
+    /// [`Database::open`].
+    pub fn snapshot_to_path(&self, dest: &Path) -> anyhow::Result<()> {
+        let snapshot = self.db.snapshot();
+
+        let dest_db = fjall::Database::builder(dest).open().map_err(|e| {
+            anyhow::anyhow!(
+                "failed to open destination database at {}: {e}",
+                dest.display()
+            )
+        })?;
+
+        for (name, source_ks) in self.all_keyspaces() {
+            let dest_ks = dest_db.keyspace(name, KeyspaceCreateOptions::default)?;
+            for guard in snapshot.iter(source_ks) {
+                let (key, value) = guard.into_inner()?;
+                dest_ks.insert(&*key, &*value)?;
+            }
+        }
+
+        dest_db.persist(fjall::PersistMode::SyncAll)?;
+
+        Ok(())
     }
 
     /// Store encryption key for the given epoch.
@@ -999,5 +1040,70 @@ mod tests {
             store.get_rotation_messages(87, &dealer).unwrap().is_none(),
             "rotation messages must not leak to the store's self.epoch=87"
         );
+    }
+
+    #[test]
+    fn test_snapshot_to_path() {
+        use std::collections::BTreeMap;
+        use std::num::NonZeroU16;
+
+        let src_dir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(src_dir.path()).unwrap();
+
+        let dealer1 = Address::new([1u8; 32]);
+        let dealer2 = Address::new([2u8; 32]);
+        let enc_key = EncryptionPrivateKey::new(&mut rand::thread_rng());
+        let dealer_msg = create_test_message();
+        let nonce_msg = create_test_nonce_message();
+        let mut rotation_msgs: BTreeMap<NonZeroU16, avss::Message> = BTreeMap::new();
+        rotation_msgs.insert(NonZeroU16::new(1).unwrap(), create_test_message());
+
+        db.store_encryption_key(10, &enc_key).unwrap();
+        db.store_dealer_message(10, &dealer1, &dealer_msg).unwrap();
+        db.store_rotation_messages(10, &dealer2, &rotation_msgs)
+            .unwrap();
+        db.store_nonce_message(10, 0, &dealer1, &nonce_msg).unwrap();
+
+        let dest_dir = tempfile::Builder::new().tempdir().unwrap();
+        db.snapshot_to_path(dest_dir.path()).unwrap();
+
+        // Drop the source so we know we're reading from the destination
+        drop(db);
+
+        let restored = Database::open(dest_dir.path()).unwrap();
+
+        // Verify encryption key
+        assert_eq!(restored.get_encryption_key(10).unwrap().unwrap(), enc_key);
+
+        // Verify dealer message
+        let restored_dealer = restored.get_dealer_message(10, &dealer1).unwrap().unwrap();
+        assert_eq!(
+            bcs::to_bytes(&restored_dealer).unwrap(),
+            bcs::to_bytes(&dealer_msg).unwrap()
+        );
+
+        // Verify rotation messages
+        let restored_rotation = restored.list_all_rotation_messages(10).unwrap();
+        assert_eq!(restored_rotation.len(), 1);
+        assert_eq!(restored_rotation[0].0, dealer2);
+
+        // Verify nonce messages
+        let restored_nonces = restored.list_nonce_messages(10, 0).unwrap();
+        assert_eq!(restored_nonces.len(), 1);
+        assert_eq!(restored_nonces[0].0, dealer1);
+    }
+
+    #[test]
+    fn test_snapshot_to_path_empty_db() {
+        let src_dir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(src_dir.path()).unwrap();
+
+        let dest_dir = tempfile::Builder::new().tempdir().unwrap();
+        db.snapshot_to_path(dest_dir.path()).unwrap();
+        drop(db);
+
+        let restored = Database::open(dest_dir.path()).unwrap();
+        assert!(restored.latest_encryption_key_epoch().unwrap().is_none());
+        assert!(restored.list_all_dealer_messages(0).unwrap().is_empty());
     }
 }

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -3,6 +3,7 @@
 
 use std::path::Path;
 
+use anyhow::Context as _;
 use fastcrypto::groups::ristretto255::RistrettoScalar;
 use fastcrypto::serde_helpers::ToFromByteArray;
 use fastcrypto_tbls::threshold_schnorr::avss;
@@ -55,9 +56,13 @@ const NONCE_MESSAGES_CF_NAME: &str = "nonce_messages";
 
 impl Database {
     pub fn open(path: &Path) -> anyhow::Result<Self> {
-        let db = fjall::Database::builder(path)
-            .open()
-            .map_err(|e| anyhow::anyhow!("failed to open database at {}: {e}", path.display()))?;
+        // Preserve the underlying `fjall::Error` as the source so callers can
+        // `downcast_ref::<fjall::Error>()` and match on variants like
+        // `fjall::Error::Locked`. Using `anyhow!("...: {e}")` with a format
+        // string would stringify the error and drop the source chain.
+        let db = fjall::Database::builder(path).open().map_err(|e| {
+            anyhow::Error::new(e).context(format!("failed to open database at {}", path.display()))
+        })?;
         let encryption_keys =
             db.keyspace(ENCRYPTION_KEYS_CF_NAME, KeyspaceCreateOptions::default)?;
         let dealer_messages =
@@ -76,8 +81,13 @@ impl Database {
 
     /// Returns all keyspaces paired with their names. When adding a new
     /// keyspace, add it here so that it is included in snapshots and backups.
-    fn all_keyspaces(&self) -> [(&str, &Keyspace); 4] {
-        [
+    ///
+    /// Returns a `Vec` rather than a fixed-size array so callers don't have
+    /// to know the keyspace count, and so adding a new keyspace is a one-line
+    /// change here. Only invoked on the snapshot path, so the per-call
+    /// allocation is irrelevant.
+    fn all_keyspaces(&self) -> Vec<(&str, &Keyspace)> {
+        vec![
             (ENCRYPTION_KEYS_CF_NAME, &self.encryption_keys),
             (DEALER_MESSAGES_CF_NAME, &self.dealer_messages),
             (ROTATION_MESSAGES_CF_NAME, &self.rotation_messages),
@@ -92,24 +102,71 @@ impl Database {
     /// while the source database remains open for writes. The destination is a
     /// fully self-contained fjall database that can later be opened with
     /// [`Database::open`].
+    ///
+    /// `dest` must not already exist. The function refuses to write into an
+    /// existing directory because fjall would otherwise happily merge the
+    /// snapshot rows into whatever's already there, producing a hybrid DB that
+    /// looks valid but isn't a true point-in-time snapshot.
     pub fn snapshot_to_path(&self, dest: &Path) -> anyhow::Result<()> {
+        // Bound batch memory by serialized payload size rather than entry
+        // count: keyspaces in this DB hold values ranging from 32-byte
+        // scalars to multi-MB BCS-encoded MPC messages, so a fixed entry
+        // count would spike memory unpredictably for the large-value keyspaces.
+        //
+        // 16 MiB is a comfortable middle ground: small enough that the
+        // worst-case batch fits easily in RAM on any host that can run a
+        // validator, large enough to amortise per-batch journal commit cost.
+        const BATCH_BYTE_BUDGET: usize = 16 * 1024 * 1024;
+
+        if dest
+            .try_exists()
+            .with_context(|| format!("failed to stat snapshot destination {}", dest.display()))?
+        {
+            anyhow::bail!(
+                "snapshot destination {} already exists; refusing to merge into an existing directory",
+                dest.display()
+            );
+        }
+
         let snapshot = self.db.snapshot();
 
         let dest_db = fjall::Database::builder(dest).open().map_err(|e| {
-            anyhow::anyhow!(
-                "failed to open destination database at {}: {e}",
+            anyhow::Error::new(e).context(format!(
+                "failed to open destination database at {}",
                 dest.display()
-            )
+            ))
         })?;
 
         for (name, source_ks) in self.all_keyspaces() {
             let dest_ks = dest_db.keyspace(name, KeyspaceCreateOptions::default)?;
+            let mut batch = dest_db.batch();
+            let mut batch_bytes = 0usize;
+
             for guard in snapshot.iter(source_ks) {
                 let (key, value) = guard.into_inner()?;
-                dest_ks.insert(&*key, &*value)?;
+                let entry_bytes = key.len() + value.len();
+                batch.insert(&dest_ks, &*key, &*value);
+                batch_bytes += entry_bytes;
+
+                if batch_bytes >= BATCH_BYTE_BUDGET {
+                    batch.commit()?;
+                    batch = dest_db.batch();
+                    batch_bytes = 0;
+                }
+            }
+
+            if batch_bytes > 0 {
+                batch.commit()?;
             }
         }
 
+        // `persist(SyncAll)` fsyncs the destination journal. Freshly inserted
+        // rows live in the active memtable and are recovered from the journal
+        // on next open, so the destination directory is self-contained and
+        // safe to archive after this call returns. We do not fsync the dest
+        // directory entry here: this function's caller immediately tars the
+        // directory in the same process, so a crash before archival just
+        // discards an incomplete backup and loses no committed state.
         dest_db.persist(fjall::PersistMode::SyncAll)?;
 
         Ok(())
@@ -1064,13 +1121,14 @@ mod tests {
             .unwrap();
         db.store_nonce_message(10, 0, &dealer1, &nonce_msg).unwrap();
 
-        let dest_dir = tempfile::Builder::new().tempdir().unwrap();
-        db.snapshot_to_path(dest_dir.path()).unwrap();
+        let dest_parent = tempfile::Builder::new().tempdir().unwrap();
+        let dest_path = dest_parent.path().join("snapshot");
+        db.snapshot_to_path(&dest_path).unwrap();
 
         // Drop the source so we know we're reading from the destination
         drop(db);
 
-        let restored = Database::open(dest_dir.path()).unwrap();
+        let restored = Database::open(&dest_path).unwrap();
 
         // Verify encryption key
         assert_eq!(restored.get_encryption_key(10).unwrap().unwrap(), enc_key);
@@ -1098,12 +1156,30 @@ mod tests {
         let src_dir = tempfile::Builder::new().tempdir().unwrap();
         let db = Database::open(src_dir.path()).unwrap();
 
-        let dest_dir = tempfile::Builder::new().tempdir().unwrap();
-        db.snapshot_to_path(dest_dir.path()).unwrap();
+        let dest_parent = tempfile::Builder::new().tempdir().unwrap();
+        let dest_path = dest_parent.path().join("snapshot");
+        db.snapshot_to_path(&dest_path).unwrap();
         drop(db);
 
-        let restored = Database::open(dest_dir.path()).unwrap();
+        let restored = Database::open(&dest_path).unwrap();
         assert!(restored.latest_encryption_key_epoch().unwrap().is_none());
         assert!(restored.list_all_dealer_messages(0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_snapshot_to_path_rejects_existing_destination() {
+        // Refusing to merge into an existing dir is the snapshot API's
+        // contract — silently merging would produce a hybrid DB that's not a
+        // true point-in-time snapshot.
+        let src_dir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(src_dir.path()).unwrap();
+
+        let dest_dir = tempfile::Builder::new().tempdir().unwrap();
+        let err = db.snapshot_to_path(dest_dir.path()).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("already exists"),
+            "expected already-exists error, got: {chain}"
+        );
     }
 }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::RwLock;
 use anyhow::anyhow;
 use sui_futures::service::Service;
 
+pub mod backup;
 pub mod btc_monitor;
 pub mod cli;
 pub mod communication;


### PR DESCRIPTION
## Summary
Adds encrypted backup and restore of the fjall database snapshot plus the node's config files, and proves the round trip end-to-end with a new e2e test that takes a node offline, backs it up, destroys its state, lets the rest of the network rotate several epochs without it, restores from the backup, and verifies it rejoins the committee.
## What's new
- `hashi backup save` produces an age-encrypted `.tar.age` archive containing the CLI config, node config, any referenced key files, and a consistent MVCC snapshot of the fjall database (all four keyspaces). Accepts native x25519 and age plugin recipients (YubiKey etc.).
- `hashi backup restore` decrypts the archive, validates the manifest, and either extracts into a target directory or puts every file back at its original path with `--copy-to-original-paths`. Extraction and DB restoration are both atomic (stage into a sibling temp dir, rename on success) so a failure mid-flight never leaves half-populated state.
- `Database::snapshot_to_path` takes a fjall MVCC snapshot while the source DB stays open for writes. Chunks the copy by a 16 MiB payload budget to bound memory independently of value size. Refuses a pre-existing destination so a typo can't silently merge.
- Symlinks rejected on both archive and restore paths. Restored files written with mode 0o600.
- Locked-DB detection produces a clear "stop the node first" error instead of a fjall internal.
## Testing
- 14 unit tests in `crates/hashi/src/backup.rs` and `crates/hashi/src/cli/commands/backup.rs` cover manifest disambiguation, round-trip DB integrity, refusal to overwrite, inline-PEM vs path classification for node config fields, and the locked-DB error path.
- New e2e test `test_backup_restore_round_trip_and_rejoin` takes node 0 offline, runs `backup save`, deletes its db and config files, forces two rotations without it, runs `backup restore`, restarts node 0, and asserts all 4 nodes agree on the MPC pubkey after one more rotation. Runs in ~100s under nextest.
## Notes for reviewers
- New `backup_age_pubkey` field on `CliConfig` accepts native or plugin recipients via a single serde representation.
- `backup_file_paths()` is the single source of truth for "what must be archived", and bails when `node_config_path` is unset or points at a broken/incomplete node config — so a typo can't produce a silently-incomplete backup.
- Added `tempfile` and `walkdir` to `hashi`'s runtime dependencies (previously only dev), needed for atomic staging during restore.
- Added `age` as a dev-dep on `e2e-tests` for the new test.