### PR TITLE
docker: invalidate cargo fingerprints via mtime touch

### DIFF
--- a/.github/workflows/deterministic-build.yml
+++ b/.github/workflows/deterministic-build.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     paths:
       # for now don't run on every change
-      # - 'docker/hashi/**'
-      # - 'docker/hashi-screener/**'
       # - 'crates/**'
+      - 'docker/hashi/**'
+      - 'docker/hashi-screener/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/deterministic-build.yml'

--- a/docker/hashi-screener/Containerfile
+++ b/docker/hashi-screener/Containerfile
@@ -45,8 +45,8 @@ ENV GIT_REVISION=${GIT_REVISION}
 COPY crates/hashi-screener /src/crates/hashi-screener
 COPY crates/hashi-types /src/crates/hashi-types
 
-# Rebuild local crates without injecting wall-clock mtimes into the source tree.
-RUN cargo clean --target "$TARGET" -p hashi-screener -p hashi-types
+# Touch source files to invalidate cargo's fingerprint cache for local crates
+RUN find crates/ -name "*.rs" -exec touch {} +
 
 RUN --network=none cargo build --release --frozen --target "$TARGET" --bin hashi-screener
 

--- a/docker/hashi/Containerfile
+++ b/docker/hashi/Containerfile
@@ -44,8 +44,8 @@ ENV GIT_REVISION=${GIT_REVISION}
 COPY crates/hashi /src/crates/hashi
 COPY crates/hashi-types /src/crates/hashi-types
 
-# Rebuild local crates without injecting wall-clock mtimes into the source tree.
-RUN cargo clean --target "$TARGET" -p hashi -p hashi-types
+# Touch source files to invalidate cargo's fingerprint cache for local crates
+RUN find crates/ -name "*.rs" -exec touch {} +
 
 RUN --network=none cargo build --release --frozen --target "$TARGET" --bin hashi
 


### PR DESCRIPTION
The deps stage builds external dependencies against a `fn main(){}` stub for the local crates. When the build stage then copies the real sources in, `cargo build --frozen` may not detect that the local crates need to be rebuilt — its fingerprint compares source mtimes against the cached build artifacts, and the freshly-COPYed files can end up with mtimes older than the stub-built artifacts.

Previously, we tried clearing the stale artifacts with `cargo clean -p <crate>`. That turned out to silently leave the stub binary in place: the resulting image shipped a 545 KB `fn main(){}` binary instead of the real one.

Restore the working approach of touching every `.rs` file under `crates/` so cargo's fingerprint check sees the local crates as newer than the stub-built artifacts and rebuilds them. Apply the same fix to the hashi-screener Containerfile, which had inherited the broken `cargo clean -p` pattern from hashi.