### PR TITLE
Add EmergencyPause and TimelockUnpause governance proposals

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -431,6 +431,12 @@ pub struct Upgrade {
     pub digest: Vec<u8>,
 }
 
+/// Rust version of the Move hashi::emergency_pause::EmergencyPause type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct EmergencyPause {
+    pub pause: bool,
+}
+
 /// Rust version of the Move sui::vec_map::VecMap type.
 #[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct VecMap<K, V> {

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -540,6 +540,7 @@ pub fn get_proposal_type_arg(
         ProposalType::UpdateConfig => ("update_config", "UpdateConfig"),
         ProposalType::EnableVersion => ("enable_version", "EnableVersion"),
         ProposalType::DisableVersion => ("disable_version", "DisableVersion"),
+        ProposalType::EmergencyPause => ("emergency_pause", "EmergencyPause"),
         ProposalType::Unknown(s) => {
             anyhow::bail!(
                 "Cannot vote on unknown proposal type '{}'. \

--- a/crates/hashi/src/cli/types.rs
+++ b/crates/hashi/src/cli/types.rs
@@ -53,6 +53,7 @@ pub mod display {
             ProposalType::UpdateConfig => "UpdateConfig".to_string(),
             ProposalType::EnableVersion => "EnableVersion".to_string(),
             ProposalType::DisableVersion => "DisableVersion".to_string(),
+            ProposalType::EmergencyPause => "EmergencyPause".to_string(),
             ProposalType::Unknown(s) => format!("Unknown({})", s),
         }
     }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -190,6 +190,12 @@ impl LeaderService {
                     Identifier::from_static("Upgrade"),
                     vec![],
                 ))),
+                ProposalType::EmergencyPause => TypeTag::Struct(Box::new(StructTag::new(
+                    hashi_ids.package_id,
+                    Identifier::from_static("emergency_pause"),
+                    Identifier::from_static("EmergencyPause"),
+                    vec![],
+                ))),
                 ProposalType::Unknown(type_name) => {
                     error!(
                         "Cannot delete proposal {:?} with unknown type: {}",

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -1242,6 +1242,11 @@ async fn scrape_proposals(
                     .ok()
                     .map(|p| (p.id, p.timestamp_ms))
             }
+            types::ProposalType::EmergencyPause => {
+                bcs::from_bytes::<move_types::Proposal<move_types::EmergencyPause>>(contents)
+                    .ok()
+                    .map(|p| (p.id, p.timestamp_ms))
+            }
             types::ProposalType::Unknown(_) => None,
         };
 
@@ -1289,6 +1294,7 @@ fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
         ("enable_version", "EnableVersion") => types::ProposalType::EnableVersion,
         ("disable_version", "DisableVersion") => types::ProposalType::DisableVersion,
         ("upgrade", "Upgrade") => types::ProposalType::Upgrade,
+        ("emergency_pause", "EmergencyPause") => types::ProposalType::EmergencyPause,
         _ => types::ProposalType::Unknown(format!("{}::{}", inner_tag.module(), inner_tag.name())),
     }
 }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -431,6 +431,7 @@ pub enum ProposalType {
     EnableVersion,
     DisableVersion,
     Upgrade,
+    EmergencyPause,
     Unknown(String),
 }
 
@@ -441,6 +442,7 @@ impl ProposalType {
             ProposalType::EnableVersion => "enable_version",
             ProposalType::DisableVersion => "disable_version",
             ProposalType::Upgrade => "upgrade",
+            ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::Unknown(_) => "unknown",
         }
     }
@@ -451,6 +453,7 @@ impl ProposalType {
             "enable_version",
             "disable_version",
             "upgrade",
+            "emergency_pause",
             "unknown",
         ]
     }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -204,21 +204,24 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                     .proposals
                     .remove(&proposal_executed_event.proposal_id);
 
-                // When an UpdateConfig proposal executes, the Hashi object's
-                // config field changes on-chain. The event carries no key/value
-                // payload, so re-fetch the config from the Hashi object to
-                // keep the in-memory state current.
-                if parse_proposal_type_from_type_tag(&proposal_executed_event.proposal_type)
-                    == ProposalType::UpdateConfig
-                {
+                // When an UpdateConfig or EmergencyPause proposal executes,
+                // the Hashi object's config field changes on-chain. The event
+                // carries no key/value payload, so re-fetch the config from
+                // the Hashi object to keep the in-memory state current.
+                if matches!(
+                    parse_proposal_type_from_type_tag(&proposal_executed_event.proposal_type),
+                    ProposalType::UpdateConfig | ProposalType::EmergencyPause
+                ) {
                     match super::scrape_hashi_config(client.clone(), state.hashi_id()).await {
                         Ok(config) => {
                             state.state_mut().hashi.config = config;
-                            tracing::info!("on-chain config refreshed after UpdateConfig proposal");
+                            tracing::info!(
+                                "on-chain config refreshed after config-changing proposal"
+                            );
                         }
                         Err(e) => {
                             tracing::error!(
-                                "failed to refresh config after UpdateConfig proposal: {e}"
+                                "failed to refresh config after config-changing proposal: {e}"
                             );
                         }
                     }
@@ -523,6 +526,7 @@ fn parse_proposal_type_from_type_tag(type_tag: &TypeTag) -> ProposalType {
         ("enable_version", "EnableVersion") => ProposalType::EnableVersion,
         ("disable_version", "DisableVersion") => ProposalType::DisableVersion,
         ("upgrade", "Upgrade") => ProposalType::Upgrade,
+        ("emergency_pause", "EmergencyPause") => ProposalType::EmergencyPause,
         _ => ProposalType::Unknown(format!("{}::{}", struct_tag.module(), struct_tag.name())),
     }
 }

--- a/packages/hashi/sources/core/proposal/types/emergency_pause.move
+++ b/packages/hashi/sources/core/proposal/types/emergency_pause.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Emergency pause/unpause governance module.
+///
+/// A single proposal type that can either pause or unpause the bridge.
+/// Pausing requires 51% quorum; unpausing requires ~67% quorum.
+module hashi::emergency_pause;
+
+use hashi::{hashi::Hashi, proposal};
+use std::string::String;
+use sui::{clock::Clock, vec_map::VecMap};
+
+const PAUSE_THRESHOLD_BPS: u64 = 5100; // 51% - low quorum for emergencies
+const UNPAUSE_THRESHOLD_BPS: u64 = 6667; // ~2/3 - higher bar for resuming
+
+public struct EmergencyPause has drop, store {
+    pause: bool,
+}
+
+public fun propose(
+    hashi: &mut Hashi,
+    pause: bool,
+    metadata: VecMap<String, String>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    hashi.config().assert_version_enabled();
+    let threshold = if (pause) { PAUSE_THRESHOLD_BPS } else { UNPAUSE_THRESHOLD_BPS };
+    proposal::create(hashi, EmergencyPause { pause }, threshold, metadata, clock, ctx)
+}
+
+public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
+    hashi.config().assert_version_enabled();
+    let EmergencyPause { pause } = proposal::execute(hashi, proposal_id, clock);
+    hashi.config_mut().set_paused(pause);
+}

--- a/packages/hashi/tests/pause_proposal_tests.move
+++ b/packages/hashi/tests/pause_proposal_tests.move
@@ -1,0 +1,85 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+#[allow(implicit_const_copy)]
+module hashi::pause_proposal_tests;
+
+use hashi::{emergency_pause, test_utils};
+use sui::clock;
+
+// ======== Test Addresses ========
+const VOTER1: address = @0x1;
+
+// ======== Pause Tests ========
+
+#[test]
+/// Test basic emergency pause: propose, execute, verify paused
+fun test_emergency_pause_basic() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // Verify not paused initially
+    assert!(!hashi.config().paused());
+
+    // Create emergency pause proposal
+    let proposal_id = test_utils::create_emergency_pause_proposal(
+        &mut hashi,
+        true,
+        &clock,
+        ctx,
+    );
+
+    // Execute the proposal
+    emergency_pause::execute(&mut hashi, proposal_id, &clock);
+
+    // Verify paused
+    assert!(hashi.config().paused());
+
+    // Clean up
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+// ======== Unpause Tests ========
+
+#[test]
+/// Test unpause: pause first, then propose unpause, execute
+fun test_unpause_basic() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // First, pause the system
+    let pause_id = test_utils::create_emergency_pause_proposal(
+        &mut hashi,
+        true,
+        &clock,
+        ctx,
+    );
+    emergency_pause::execute(&mut hashi, pause_id, &clock);
+    assert!(hashi.config().paused());
+
+    // Now propose unpause
+    let unpause_id = test_utils::create_emergency_pause_proposal(
+        &mut hashi,
+        false,
+        &clock,
+        ctx,
+    );
+
+    // Execute unpause
+    emergency_pause::execute(&mut hashi, unpause_id, &clock);
+
+    // Verify unpaused
+    assert!(!hashi.config().paused());
+
+    // Clean up
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/test_utils.move
+++ b/packages/hashi/tests/test_utils.move
@@ -10,6 +10,7 @@ use hashi::{
     committee::{Self, CommitteeMember, CommitteeSignature},
     config_value,
     disable_version,
+    emergency_pause,
     enable_version,
     hashi::Hashi,
     update_config
@@ -241,4 +242,15 @@ public fun create_disable_version_proposal(
     ctx: &mut TxContext,
 ): ID {
     disable_version::propose(hashi, version, vec_map::empty(), clock, ctx)
+}
+
+/// Creates an emergency pause/unpause proposal and returns its ID
+public fun create_emergency_pause_proposal(
+    hashi: &mut Hashi,
+    pause: bool,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    let metadata = vec_map::empty();
+    emergency_pause::propose(hashi, pause, metadata, clock, ctx)
 }


### PR DESCRIPTION
## Summary
- Adds `EmergencyPause` governance proposal type with a single `pause: bool` field
- Pausing requires 51% quorum for fast emergency response
- Unpausing requires ~67% quorum for broader consensus
- Full Rust-side support: proposal type parsing, config re-scrape on execute, display formatting, garbage collection

## Changes

**Move:**
- `emergency_pause.move` — new proposal type with asymmetric thresholds (5100 BPS to pause, 6667 BPS to unpause)
- `pause_proposal_tests.move` — tests for pause and unpause lifecycle
- `test_utils.move` — `create_emergency_pause_proposal` helper

**Rust:**
- `ProposalType::EmergencyPause` enum variant + `as_str()`, `all_labels()`, display
- Watcher: type tag parsing + config re-scrape on execute
- BCS deserialization in `mod.rs`
- CLI type tag mapping in `get_proposal_type_arg`
- Garbage collection support for expired proposals

## Test plan
- [x] `sui move test -p packages/hashi` — 73/73 pass
- [x] `cargo check -p hashi` — compiles clean
- [x] `prettier-move -c` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)