### PR TITLE
[1/n][guardian-integration] guardian local and dev deployment infra setup

### DIFF
--- a/.github/workflows/deterministic-build.yml
+++ b/.github/workflows/deterministic-build.yml
@@ -7,6 +7,7 @@ on:
       # - 'crates/**'
       - 'docker/hashi/**'
       - 'docker/hashi-screener/**'
+      - 'docker/hashi-guardian-k8s/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/deterministic-build.yml'
@@ -21,38 +22,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [hashi, hashi-screener]
         os: [ubuntu-latest, ubuntu-22.04]
+        image:
+          - name: hashi
+            dir: hashi
+          - name: hashi-screener
+            dir: hashi-screener
+          - name: hashi-guardian
+            dir: hashi-guardian-k8s
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build ${{ matrix.image }} image
+      - name: Build ${{ matrix.image.name }} image
         env:
           GIT_REVISION: ${{ github.sha }}
-          IMAGE_NAME: ${{ matrix.image }}
-        run: bash docker/${{ matrix.image }}/build.sh --no-cache
+          IMAGE_NAME: ${{ matrix.image.name }}
+        run: bash docker/${{ matrix.image.dir }}/build.sh --no-cache
 
       - name: Compute sha256
         id: hash
         run: |
-          BIN="out/${{ matrix.image }}"
+          BIN="out/${{ matrix.image.name }}"
           HASH=$(sha256sum "${BIN}" | awk '{print $1}')
           echo "sha256=${HASH}" >> "$GITHUB_OUTPUT"
-          echo "${HASH}  ${{ matrix.image }}" > "out/${{ matrix.image }}.sha256"
+          echo "${HASH}  ${{ matrix.image.name }}" > "out/${{ matrix.image.name }}.sha256"
 
       - name: Upload sha256
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.image }}-${{ matrix.os }}-sha256
-          path: out/${{ matrix.image }}.sha256
+          name: ${{ matrix.image.name }}-${{ matrix.os }}-sha256
+          path: out/${{ matrix.image.name }}.sha256
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.image }}-${{ matrix.os }}-binary
-          path: out/${{ matrix.image }}
+          name: ${{ matrix.image.name }}-${{ matrix.os }}-binary
+          path: out/${{ matrix.image.name }}
 
   verify:
     needs: build
@@ -60,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [hashi, hashi-screener]
+        image: [hashi, hashi-screener, hashi-guardian]
     steps:
       - name: Download ubuntu-latest hash
         uses: actions/download-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
+ "tonic-health",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/hashi-guardian/Cargo.toml
+++ b/crates/hashi-guardian/Cargo.toml
@@ -12,6 +12,7 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tonic.workspace = true
+tonic-health.workspace = true
 hashi-types = { path = "../hashi-types" }
 
 # Crypto dependencies
@@ -29,3 +30,8 @@ aws-credential-types = "1"
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.12.0", features = ["test-util"] }
 aws-smithy-mocks = "0.1"
+
+[features]
+# Stubs out the AWS Nitro NSM attestation call so the guardian can run outside
+# a Nitro enclave (local dev, plain Kubernetes). Do not enable for prod builds.
+non-enclave-dev = []

--- a/crates/hashi-guardian/examples/bootstrap_operator_init.rs
+++ b/crates/hashi-guardian/examples/bootstrap_operator_init.rs
@@ -1,0 +1,91 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bootstrap a hashi-guardian via `OperatorInit` against an AWS S3 bucket.
+//! Skips `ProvisionerInit`, so the guardian heartbeats but cannot sign.
+//!
+//! Required env: `AWS_S3_BUCKET`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`,
+//! `AWS_SECRET_ACCESS_KEY`.
+//! Optional env: `GUARDIAN_ENDPOINT` (default `http://localhost:3000`),
+//! `BITCOIN_NETWORK` (default `signet`).
+
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use hashi_types::guardian::crypto::NUM_OF_SHARES;
+use hashi_types::proto::guardian_service_client::GuardianServiceClient;
+use hashi_types::proto::GuardianShareCommitment;
+use hashi_types::proto::GuardianShareId;
+use hashi_types::proto::Network as ProtoNetwork;
+use hashi_types::proto::OperatorInitRequest;
+use hashi_types::proto::S3Config as ProtoS3Config;
+use std::env;
+
+fn required_env(name: &str) -> Result<String> {
+    env::var(name).map_err(|_| anyhow!("required env var `{name}` is not set"))
+}
+
+fn parse_network(s: &str) -> Result<ProtoNetwork> {
+    ProtoNetwork::from_str_name(&s.to_ascii_uppercase()).ok_or_else(|| {
+        anyhow!("unknown BITCOIN_NETWORK `{s}`; expected mainnet/testnet/regtest/signet")
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let endpoint =
+        env::var("GUARDIAN_ENDPOINT").unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let bucket = required_env("AWS_S3_BUCKET")?;
+    let region = required_env("AWS_REGION")?;
+    let access_key = required_env("AWS_ACCESS_KEY_ID")?;
+    let secret_key = required_env("AWS_SECRET_ACCESS_KEY")?;
+    let network_str = env::var("BITCOIN_NETWORK").unwrap_or_else(|_| "signet".to_string());
+    let network = parse_network(&network_str)?;
+
+    tracing::info!(
+        endpoint = %endpoint,
+        bucket = %bucket,
+        region = %region,
+        network = ?network,
+        "connecting to guardian"
+    );
+
+    let mut client = GuardianServiceClient::connect(endpoint.clone())
+        .await
+        .with_context(|| format!("failed to connect to guardian at {endpoint}"))?;
+
+    let share_commitments: Vec<GuardianShareCommitment> = (1..=NUM_OF_SHARES as u32)
+        .map(|id| GuardianShareCommitment {
+            id: Some(GuardianShareId { id: Some(id) }),
+            digest_hex: Some(String::new()),
+        })
+        .collect();
+
+    let request = OperatorInitRequest {
+        s3_config: Some(ProtoS3Config {
+            access_key: Some(access_key),
+            secret_key: Some(secret_key),
+            bucket_name: Some(bucket),
+            region: Some(region),
+        }),
+        share_commitments,
+        network: Some(network as i32),
+    };
+
+    tracing::info!("calling OperatorInit");
+    let response = client
+        .operator_init(request)
+        .await
+        .context("operator_init RPC failed")?;
+    tracing::info!(?response, "OperatorInit returned successfully");
+    println!("OperatorInit complete.");
+    Ok(())
+}

--- a/crates/hashi-guardian/src/getters.rs
+++ b/crates/hashi-guardian/src/getters.rs
@@ -6,18 +6,19 @@ use hashi_types::guardian::*;
 use std::sync::Arc;
 use tracing::info;
 
-// Only needed in non-test builds (for NSM hardware interaction)
-#[cfg(not(test))]
+// Only needed in enclave builds (for NSM hardware interaction).
+// The `non-enclave-dev` feature and `cfg(test)` both route to the stub below.
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
 use crate::GuardianError;
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
 use nsm_api::api::Request as NsmRequest;
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
 use nsm_api::api::Response as NsmResponse;
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
 use nsm_api::driver;
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
 use serde_bytes::ByteBuf;
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
 use tracing::error;
 
 /// Endpoint that returns an attestation committed to the enclave's signing public key
@@ -33,7 +34,7 @@ pub async fn get_guardian_info(enclave: Arc<Enclave>) -> GuardianResult<GetGuard
     })
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
 pub fn get_attestation(signing_pk: &GuardianPubKey) -> GuardianResult<Attestation> {
     let signing_pk_bytes = signing_pk.to_bytes();
 
@@ -65,8 +66,7 @@ pub fn get_attestation(signing_pk: &GuardianPubKey) -> GuardianResult<Attestatio
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "non-enclave-dev"))]
 pub fn get_attestation(_: &GuardianPubKey) -> GuardianResult<Attestation> {
-    // Return a mock attestation for testing
-    Ok("mock_attestation_document_hex".as_bytes().to_vec())
+    Ok(b"mock_attestation_document_hex".to_vec())
 }

--- a/crates/hashi-guardian/src/main.rs
+++ b/crates/hashi-guardian/src/main.rs
@@ -20,6 +20,7 @@ use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::time::Duration;
 use tonic::transport::Server;
+use tonic_health::server::health_reporter;
 use tracing::info;
 
 mod getters;
@@ -131,7 +132,14 @@ async fn main() -> Result<()> {
     let addr = "0.0.0.0:3000".parse()?;
     info!("gRPC server listening on {}.", addr);
 
+    // gRPC health reporter — used by the K8s gRPC probe and GKE HealthCheckPolicy.
+    let (health_reporter, health_service) = health_reporter();
+    health_reporter
+        .set_serving::<GuardianServiceServer<GuardianGrpc>>()
+        .await;
+
     let server_future = Server::builder()
+        .add_service(health_service)
         .add_service(GuardianServiceServer::new(svc))
         .serve(addr);
 

--- a/crates/hashi-guardian/src/s3_logger.rs
+++ b/crates/hashi-guardian/src/s3_logger.rs
@@ -64,9 +64,7 @@ impl S3Logger {
             .load()
             .await;
 
-        // `AWS_ENDPOINT_URL_S3` is picked up automatically by aws-config. Path-style
-        // addressing (required by MinIO) has no SDK env, so we read it explicitly.
-        // Both knobs are only used for local dev against MinIO / LocalStack.
+        // Path-style addressing (required by MinIO) has no SDK env, so read it explicitly.
         let mut s3_builder = aws_sdk_s3::config::Builder::from(&aws_config);
         if std::env::var("AWS_S3_FORCE_PATH_STYLE")
             .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1"))

--- a/crates/hashi-guardian/src/s3_logger.rs
+++ b/crates/hashi-guardian/src/s3_logger.rs
@@ -63,7 +63,18 @@ impl S3Logger {
             .retry_config(retry_config)
             .load()
             .await;
-        let client = S3Client::new(&aws_config);
+
+        // `AWS_ENDPOINT_URL_S3` is picked up automatically by aws-config. Path-style
+        // addressing (required by MinIO) has no SDK env, so we read it explicitly.
+        // Both knobs are only used for local dev against MinIO / LocalStack.
+        let mut s3_builder = aws_sdk_s3::config::Builder::from(&aws_config);
+        if std::env::var("AWS_S3_FORCE_PATH_STYLE")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1"))
+            .unwrap_or(false)
+        {
+            s3_builder = s3_builder.force_path_style(true);
+        }
+        let client = S3Client::from_conf(s3_builder.build());
 
         Self {
             client,

--- a/crates/hashi-guardian/src/s3_logger.rs
+++ b/crates/hashi-guardian/src/s3_logger.rs
@@ -64,12 +64,10 @@ impl S3Logger {
             .load()
             .await;
 
-        // Path-style addressing (required by MinIO) has no SDK env, so read it explicitly.
+        // A custom endpoint implies an S3-compatible service (MinIO, LocalStack), which
+        // need path-style addressing.
         let mut s3_builder = aws_sdk_s3::config::Builder::from(&aws_config);
-        if std::env::var("AWS_S3_FORCE_PATH_STYLE")
-            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1"))
-            .unwrap_or(false)
-        {
+        if std::env::var_os("AWS_ENDPOINT_URL_S3").is_some() {
             s3_builder = s3_builder.force_path_style(true);
         }
         let client = S3Client::from_conf(s3_builder.build());

--- a/docker/hashi-guardian-k8s/Containerfile
+++ b/docker/hashi-guardian-k8s/Containerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1
+
+# Plain Kubernetes (non-enclave) build of hashi-guardian.
+# Mirrors docker/hashi-screener/Containerfile. The sibling
+# docker/hashi-guardian/Containerfile is the Nitro enclave build and produces
+# an EIF, not a runnable OCI image — do not conflate the two.
+
+FROM stagex/pallet-rust@sha256:84621c4c29330c8a969489671d46227a0a43f52cdae243f5b91e95781dbfe5ed AS pallet-rust
+FROM stagex/busybox@sha256:3d128909dbc8e7b6c4b8c3c31f4583f01a307907ea179934bb42c4ef056c7efd AS busybox
+FROM stagex/core-filesystem@sha256:da28831927652291b0fa573092fd41c8c96ca181ea224df7bff40e1833c3db13 AS core-filesystem
+
+#
+# Deps stage: fetch and compile external dependencies (cached until Cargo.toml/Cargo.lock change)
+#
+FROM pallet-rust AS deps
+
+# Shell needed by cc-based build scripts (blst, ring, etc.)
+COPY --from=busybox . /
+
+# Copy only manifests
+COPY Cargo.toml Cargo.lock /src/
+COPY crates/hashi-guardian/Cargo.toml /src/crates/hashi-guardian/Cargo.toml
+COPY crates/hashi-types/Cargo.toml /src/crates/hashi-types/Cargo.toml
+
+WORKDIR /src
+
+# Create stub source files so cargo can resolve and compile all external deps
+RUN mkdir -p crates/hashi-guardian/src \
+ && echo 'fn main(){}' > crates/hashi-guardian/src/main.rs \
+ && touch crates/hashi-guardian/src/lib.rs \
+ && mkdir -p crates/hashi-types/src \
+ && touch crates/hashi-types/src/lib.rs
+
+ENV TARGET=x86_64-unknown-linux-musl
+ENV OPENSSL_STATIC=true
+ENV CARGO_INCREMENTAL=0
+ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64"
+
+RUN cargo fetch
+RUN --network=none cargo build --release --frozen --target "$TARGET" -p hashi-guardian --features non-enclave-dev --bin hashi-guardian
+
+#
+# Build stage: compile with real source (only local crates recompile)
+#
+FROM deps AS build
+
+ARG GIT_REVISION=unknown
+ENV GIT_REVISION=${GIT_REVISION}
+
+COPY crates/hashi-guardian /src/crates/hashi-guardian
+COPY crates/hashi-types /src/crates/hashi-types
+
+# Touch source files to invalidate cargo's fingerprint cache for local crates
+RUN find crates/ -name "*.rs" -exec touch {} +
+
+RUN --network=none cargo build --release --frozen --target "$TARGET" -p hashi-guardian --features non-enclave-dev --bin hashi-guardian
+
+#
+# Package stage: minimal runtime image
+#
+FROM core-filesystem
+COPY --from=build /src/target/x86_64-unknown-linux-musl/release/hashi-guardian /usr/bin/hashi-guardian
+ENTRYPOINT ["/usr/bin/hashi-guardian"]

--- a/docker/hashi-guardian-k8s/build.sh
+++ b/docker/hashi-guardian-k8s/build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright (c), Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Builds the hashi-guardian binary as a plain Kubernetes (non-enclave) image.
+#
+# Usage:
+#   bash docker/hashi-guardian-k8s/build.sh              # build with cache
+#   GIT_REVISION=test bash docker/hashi-guardian-k8s/build.sh --no-cache && sha256sum out/hashi-guardian   # build without cache, useful to check reproducibility
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+IMAGE_NAME="${IMAGE_NAME:-hashi-guardian}"
+GIT_REVISION="${GIT_REVISION:-$(git -C "$REPO_ROOT" describe --always --exclude '*' --dirty --abbrev=8)}"
+IMAGE_TAG="${IMAGE_TAG:-${GIT_REVISION}}"
+OUT_DIR="${OUT_DIR:-${REPO_ROOT}/out}"
+
+EXTRA_ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --no-cache) EXTRA_ARGS+=("--no-cache") ;;
+        *) echo "Unknown argument: $arg"; exit 1 ;;
+    esac
+done
+
+mkdir -p "${OUT_DIR}"
+
+echo "Building ${IMAGE_NAME}:${IMAGE_TAG} (revision: ${GIT_REVISION})"
+
+docker build \
+    -f "${SCRIPT_DIR}/Containerfile" \
+    --platform linux/amd64 \
+    --build-arg "GIT_REVISION=${GIT_REVISION}" \
+    --provenance=false \
+    "${EXTRA_ARGS[@]}" \
+    -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+    -t "${IMAGE_NAME}:latest" \
+    "${REPO_ROOT}"
+
+echo "Successfully built ${IMAGE_NAME}:${IMAGE_TAG}"
+
+# Extract the binary from the image
+CID=$(docker create "${IMAGE_NAME}:${IMAGE_TAG}")
+docker cp "${CID}:/usr/bin/hashi-guardian" "${OUT_DIR}/hashi-guardian"
+docker rm "${CID}" > /dev/null
+
+echo ""
+echo "Binary: ${OUT_DIR}/hashi-guardian"
+echo "SHA-256: $(sha256sum "${OUT_DIR}/hashi-guardian" | awk '{print $1}')"

--- a/docker/hashi-guardian-k8s/build.sh
+++ b/docker/hashi-guardian-k8s/build.sh
@@ -34,7 +34,7 @@ docker build \
     --platform linux/amd64 \
     --build-arg "GIT_REVISION=${GIT_REVISION}" \
     --provenance=false \
-    "${EXTRA_ARGS[@]}" \
+    ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
     -t "${IMAGE_NAME}:${IMAGE_TAG}" \
     -t "${IMAGE_NAME}:latest" \
     "${REPO_ROOT}"

--- a/docker/hashi-guardian-k8s/compose.yaml
+++ b/docker/hashi-guardian-k8s/compose.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Local MinIO with an Object-Lock-enabled bucket, standing in for AWS S3.
+# Console: http://localhost:9001 (minioadmin / minioadmin).
+
+name: hashi-guardian-dev
+
+services:
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/live || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  bucket-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        mc alias set local http://minio:9000 minioadmin minioadmin
+        if ! mc ls local/hashi-guardian-dev >/dev/null 2>&1; then
+          mc mb --with-lock local/hashi-guardian-dev
+          echo "Created hashi-guardian-dev with Object Lock enabled"
+        else
+          echo "Bucket hashi-guardian-dev already exists"
+        fi
+
+volumes:
+  minio-data:


### PR DESCRIPTION
## Summary

- Plain-Kubernetes (non-enclave) Containerfile for hashi-guardian + `grpc.health.v1.Health` registration in the binary
- New `non-enclave-dev` cargo feature that stubs the AWS Nitro NSM attestation call so the guardian runs outside an enclave; enabled by the K8s image
- `docker/hashi-guardian-k8s/compose.yaml` — MinIO-based local dev stack with an Object-Lock bucket pre-created;
- `crates/hashi-guardian/examples/bootstrap_operator_init.rs` — example script that drives `OperatorInit` against the local stack

The service is already running in the dev cluster: 
- deployment: https://app.pulumi.com/mysten/hashi-guardian/dev/updates/3
- PR: MystenLabs/sui-operations#7617

## Run locally

```bash
# Terminal 1 — MinIO
docker compose -f docker/hashi-guardian-k8s/compose.yaml up -d

# Terminal 2 — guardian
AWS_ENDPOINT_URL_S3=http://localhost:9000 \
cargo run --release -p hashi-guardian --features non-enclave-dev

# Terminal 3 — bootstrap operator_init
GUARDIAN_ENDPOINT=http://localhost:3000 \
AWS_S3_BUCKET=hashi-guardian-dev \
AWS_REGION=us-east-1 \
AWS_ACCESS_KEY_ID=minioadmin \
AWS_SECRET_ACCESS_KEY=minioadmin \
BITCOIN_NETWORK=signet \
cargo run --release -p hashi-guardian --features non-enclave-dev --example bootstrap_operator_init

# Teardown:
docker compose -f docker/hashi-guardian-k8s/compose.yaml down -v
```