### PR TITLE
Add proposal execute CLI command

### DIFF
--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -305,7 +305,9 @@ impl HashiClient {
             ProposalType::DisableVersion => "disable_version",
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::Upgrade => {
-                anyhow::bail!("Upgrade proposals require the full upgrade flow (execute + publish + finalize)");
+                anyhow::bail!(
+                    "Upgrade proposals require the full upgrade flow (execute + publish + finalize)"
+                );
             }
             ProposalType::Unknown(s) => {
                 anyhow::bail!("Cannot execute unknown proposal type: {s}");

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -286,6 +286,56 @@ impl HashiClient {
     ) -> TransactionBuilder {
         build_create_proposal_transaction(self.hashi_ids, params)
     }
+
+    /// Build a transaction to execute a proposal that has reached quorum.
+    ///
+    /// Each proposal type has its own `module::execute(hashi, proposal_id, clock)`
+    /// entry point. This method dispatches to the correct one based on the
+    /// on-chain proposal type.
+    pub fn build_execute_proposal_transaction(
+        &self,
+        proposal_id: Address,
+        proposal_type: &crate::onchain::types::ProposalType,
+    ) -> anyhow::Result<TransactionBuilder> {
+        use crate::onchain::types::ProposalType;
+
+        let module_name = match proposal_type {
+            ProposalType::UpdateConfig => "update_config",
+            ProposalType::EnableVersion => "enable_version",
+            ProposalType::DisableVersion => "disable_version",
+            ProposalType::EmergencyPause => "emergency_pause",
+            ProposalType::Upgrade => {
+                anyhow::bail!("Upgrade proposals require the full upgrade flow (execute + publish + finalize)");
+            }
+            ProposalType::Unknown(s) => {
+                anyhow::bail!("Cannot execute unknown proposal type: {s}");
+            }
+        };
+
+        let mut builder = TransactionBuilder::new();
+        let hashi_arg = builder.object(
+            ObjectInput::new(self.hashi_ids.hashi_object_id)
+                .as_shared()
+                .with_mutable(true),
+        );
+        let proposal_id_arg = builder.pure(&proposal_id);
+        let clock_arg = builder.object(
+            ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+                .as_shared()
+                .with_mutable(false),
+        );
+
+        builder.move_call(
+            Function::new(
+                self.hashi_ids.package_id,
+                Identifier::new(module_name)?,
+                Identifier::from_static("execute"),
+            ),
+            vec![hashi_arg, proposal_id_arg, clock_arg],
+        );
+
+        Ok(builder)
+    }
 }
 
 /// Build a `TransactionBuilder` for creating a proposal, given `HashiIds` and params.

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -265,6 +265,50 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
     Ok(())
 }
 
+/// Execute a proposal that has reached quorum
+pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions) -> Result<()> {
+    let mut client = HashiClient::new(config).await?;
+
+    let proposal_addr = Address::from_hex(proposal_id)
+        .with_context(|| format!("Invalid proposal ID: {}", proposal_id))?;
+
+    print_info(&format!("Fetching proposal {}...", proposal_id));
+
+    let proposal = client
+        .fetch_proposal(&proposal_addr)
+        .ok_or_else(|| anyhow::anyhow!("Proposal not found: {}", proposal_id))?;
+
+    let proposal_type = &proposal.proposal_type;
+    let proposal_type_str = display::format_proposal_type(proposal_type);
+
+    use crate::onchain::types::ProposalType;
+    if matches!(proposal_type, ProposalType::Upgrade) {
+        anyhow::bail!(
+            "Upgrade proposals cannot be executed via the CLI. \
+             Use the full upgrade flow (execute + publish + finalize) instead."
+        );
+    }
+
+    println!("\n{}", "Execute Proposal:".bold());
+    println!("  Type: {}", proposal_type_str.cyan());
+    println!("  ID:   {}", proposal_id);
+
+    if !tx_opts.skip_confirm && !confirm_action("execute this proposal").await? {
+        return Ok(());
+    }
+
+    let tx = client.build_execute_proposal_transaction(proposal_addr, proposal_type)?;
+
+    print_info(&format!(
+        "Transaction: {}::execute on {}",
+        proposal_type.as_str(),
+        proposal_id
+    ));
+
+    execute_or_simulate(&mut client, tx, tx_opts).await?;
+    Ok(())
+}
+
 /// Create an upgrade proposal
 pub async fn create_upgrade_proposal(
     config: &CliConfig,

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -121,6 +121,12 @@ pub enum ProposalCommands {
         proposal_id: String,
     },
 
+    /// Execute a proposal that has reached quorum
+    Execute {
+        /// The proposal object ID to execute
+        proposal_id: String,
+    },
+
     /// Create a new proposal
     Create {
         #[clap(subcommand)]
@@ -528,6 +534,9 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
             }
             ProposalCommands::RemoveVote { proposal_id } => {
                 commands::proposal::remove_vote(&config, &proposal_id, &tx_opts).await?;
+            }
+            ProposalCommands::Execute { proposal_id } => {
+                commands::proposal::execute(&config, &proposal_id, &tx_opts).await?;
             }
             ProposalCommands::Create { proposal } => match proposal {
                 CreateProposalCommands::Upgrade { digest, metadata } => {


### PR DESCRIPTION
## Summary
Adds `hashi proposal execute <PROPOSAL_ID>` to execute proposals that have reached quorum.

## Usage
```bash
# On each validator node:
# 1. Create the proposal (auto-votes)
hashi proposal create update-config bitcoin_confirmation_threshold u64:3

# 2. Other validators vote
hashi proposal vote <PROPOSAL_ID>

# 3. Once quorum is reached, any validator executes
hashi proposal execute <PROPOSAL_ID>
```

## Supported proposal types
- `UpdateConfig` — updates config key/value
- `EnableVersion` / `DisableVersion` — version management
- `EmergencyPause` — pause/unpause the bridge
- `Upgrade` — rejected with guidance to use the full upgrade flow

## Test plan
- [x] `cargo check -p hashi` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)