### PR TITLE
Skip certain leader operations when bridge is paused or reconfiguring

### DIFF
--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -233,6 +233,11 @@ impl LeaderService {
     }
 
     pub fn is_current_leader(&self, checkpoint_height: u64) -> bool {
+        if self.inner.onchain_state().state().hashi().config.paused() {
+            trace!("Bridge is paused, not acting as leader");
+            return false;
+        }
+
         match self.inner.config.force_run_as_leader() {
             ForceRunAsLeader::Always => return true,
             ForceRunAsLeader::Never => return false,

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -234,7 +234,7 @@ impl LeaderService {
 
     pub fn is_current_leader(&self, checkpoint_height: u64) -> bool {
         if self.inner.onchain_state().state().hashi().config.paused() {
-            trace!("Bridge is paused, not acting as leader");
+            debug!("Bridge is paused, not acting as leader");
             return false;
         }
 
@@ -269,8 +269,23 @@ impl LeaderService {
         is_leader
     }
 
+    fn is_reconfiguring(&self) -> bool {
+        self.inner
+            .onchain_state()
+            .state()
+            .hashi()
+            .committees
+            .pending_epoch_change()
+            .is_some()
+    }
+
     fn process_deposit_requests(&mut self, checkpoint_timestamp_ms: u64) {
         debug!("Entering process_deposit_requests");
+        if self.is_reconfiguring() {
+            debug!("Reconfig in progress, skipping deposit request processing");
+            return;
+        }
+
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
         // Sort deposit_requests by timestamp, from earliest to latest
         deposit_requests.sort_by_key(|r| r.timestamp_ms);
@@ -524,6 +539,10 @@ impl LeaderService {
 
     fn process_unapproved_withdrawal_requests(&mut self, checkpoint_timestamp_ms: u64) {
         debug!("Entering process_unapproved_withdrawal_requests");
+        if self.is_reconfiguring() {
+            debug!("Reconfig in progress, skipping withdrawal approval processing");
+            return;
+        }
 
         if self.withdrawal_approval_task.is_some() {
             debug!("Withdrawal approval task already in-flight, skipping");
@@ -842,6 +861,10 @@ impl LeaderService {
 
     fn process_approved_withdrawal_requests(&mut self, checkpoint_timestamp_ms: u64) {
         debug!("Entering process_approved_withdrawal_requests");
+        if self.is_reconfiguring() {
+            debug!("Reconfig in progress, skipping withdrawal commitment processing");
+            return;
+        }
 
         if self.withdrawal_commitment_task.is_some() {
             debug!("Withdrawal commitment task already in-flight, skipping");
@@ -1082,6 +1105,11 @@ impl LeaderService {
 
     fn process_unsigned_withdrawal_txns(&mut self) {
         debug!("Entering process_unsigned_withdrawal_txns");
+        if self.is_reconfiguring() {
+            debug!("Reconfig in progress, skipping withdrawal tx signing");
+            return;
+        }
+
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
         withdrawal_txns.retain(|p| p.signatures.is_none());
         withdrawal_txns.sort_by_key(|p| p.timestamp_ms);


### PR DESCRIPTION
## Summary

When the bridge is paused or undergoing a reconfig (epoch change), the leader loop continues to process deposits and withdrawals even though the on-chain Move contracts will reject these transactions. Instead we will detect when we can't perform leader operations, and don't try to perform them.

## Changes
- is_current_leader now checks the bridge pause state before anything else, including ForceRunAsLeader::Always. The pause state is read from locally-synced on-chain config, so there is no network call. This ensures that an emergency pause unconditionally stops all leader-driven processing.
- Added an is_reconfiguring helper on LeaderService that checks whether a pending_epoch_change is present in the locally-synced committee state.
- Added early-return reconfig guards to the 4 leader methods whose corresponding Move entry points call assert_not_reconfiguring:
  - process_deposit_requests
  - process_unapproved_withdrawal_requests
  - process_approved_withdrawal_requests
  - process_unsigned_withdrawal_txns
- Operations that the Move contracts allow during reconfig are intentionally left unguarded:
  - process_signed_withdrawal_txns (already-broadcast BTC transactions should still complete confirmation)
  - check_delete_proposals and check_delete_expired_deposit_requests (garbage collection)