### PR TITLE
CLI: governance improvements

### DIFF
--- a/crates/e2e-tests/src/main.rs
+++ b/crates/e2e-tests/src/main.rs
@@ -303,22 +303,22 @@ async fn cmd_start(
         .to_pem()
         .context("Failed to serialize funded key as PEM")?;
     std::fs::create_dir_all(data_dir)?;
-    {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&funded_key_path)
-            .with_context(|| {
-                format!(
-                    "Failed to write funded key to {}",
-                    funded_key_path.display()
-                )
-            })?;
-        file.write_all(pem.as_bytes())?;
+    write_pem_to_disk(&funded_key_path, &pem)?;
+
+    // Write each validator's operator key so CLI governance commands can
+    // use them. The `hashi` CLI needs a committee-member key to propose /
+    // vote / execute; these aren't persisted anywhere else for localnet.
+    let validators_dir = data_dir.join("validators");
+    std::fs::create_dir_all(&validators_dir)?;
+    for (i, node) in test_networks.hashi_network().nodes().iter().enumerate() {
+        let operator_pem = node
+            .hashi()
+            .config
+            .operator_private_key
+            .as_ref()
+            .context("validator has no operator_private_key")?;
+        let path = validators_dir.join(format!("validator_{i}.pem"));
+        write_pem_to_disk(&path, operator_pem)?;
     }
 
     let state = LocalnetState {
@@ -805,6 +805,22 @@ fn cli_config_path(data_dir: &Path) -> std::path::PathBuf {
     data_dir.join("hashi-cli.toml")
 }
 
+/// Write a PEM-encoded key to disk with restrictive permissions (0600 on unix).
+fn write_pem_to_disk(path: &Path, pem: &str) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("Failed to open {} for writing", path.display()))?;
+    file.write_all(pem.as_bytes())
+        .with_context(|| format!("Failed to write PEM to {}", path.display()))?;
+    Ok(())
+}
+
 /// Write a `hashi-cli.toml` config file that the main `hashi` CLI can read.
 fn write_cli_config(data_dir: &Path, state: &LocalnetState) -> Result<()> {
     let config = hashi::cli::config::CliConfig {
@@ -853,6 +869,11 @@ fn print_connection_details(state: &LocalnetState) {
         "  {} {}",
         "CLI Config:".bold(),
         cli_config_path(&state.data_dir).display()
+    );
+    println!(
+        "  {} {}",
+        "Validator Keys:".bold(),
+        state.data_dir.join("validators").display()
     );
     println!("{}", "━".repeat(50));
 }

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -122,7 +122,21 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
 
     // 2. Build the upgrade
     tracing::info!("building upgrade package from {}", upgrade_path.display());
-    let (compiled, digest) = build_upgrade_package(sui_binary(), &upgrade_path, client_config)?;
+    let current_version = nodes[0]
+        .hashi()
+        .onchain_state()
+        .state()
+        .package_versions()
+        .keys()
+        .copied()
+        .max()
+        .ok_or_else(|| anyhow::anyhow!("onchain state has no package versions yet"))?;
+    let (compiled, digest) = build_upgrade_package(
+        sui_binary(),
+        &upgrade_path,
+        client_config,
+        current_version + 1,
+    )?;
     tracing::info!("upgrade package built, digest: {digest:?}");
 
     // 3. Propose the upgrade

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -179,6 +179,19 @@ impl HashiClient {
     // Read operations (delegating to OnchainState)
     // ========================================================================
 
+    /// Highest package version currently known on-chain, i.e. the version of
+    /// the latest published upgrade (or the original package before any
+    /// upgrade). Returns `None` only if the state hasn't been scraped yet,
+    /// which shouldn't happen after `HashiClient::new`.
+    pub fn highest_package_version(&self) -> Option<u64> {
+        self.onchain_state
+            .state()
+            .package_versions()
+            .keys()
+            .copied()
+            .max()
+    }
+
     /// Fetch current epoch from on-chain state
     pub fn fetch_epoch(&self) -> u64 {
         self.onchain_state.epoch()

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -50,6 +50,15 @@ pub enum CreateProposalParams {
     },
 }
 
+/// Live on-chain proposal detail fields not cached by `OnchainState`.
+#[derive(Debug)]
+pub struct ProposalDetails {
+    pub creator: Address,
+    pub votes: Vec<Address>,
+    pub quorum_threshold_bps: u64,
+    pub metadata: hashi_types::move_types::VecMap<String, String>,
+}
+
 /// Result of a transaction simulation (dry-run)
 #[derive(Debug)]
 pub struct SimulationResult {
@@ -188,6 +197,93 @@ impl HashiClient {
     /// Fetch committee members for the current epoch
     pub fn fetch_committee_members(&self) -> Vec<MemberInfo> {
         self.onchain_state.committee_members()
+    }
+
+    /// Fetch the current `Committee` (with weights). Returns `None` before DKG.
+    pub fn fetch_current_committee(&self) -> Option<hashi_types::committee::Committee> {
+        self.onchain_state.current_committee()
+    }
+
+    /// Live-fetch the full on-chain `Proposal<T>` (votes + quorum threshold +
+    /// metadata) for a specific proposal via one `list_dynamic_fields` call on
+    /// the proposals bag. Separate from the cached `fetch_proposal` because
+    /// validators don't need these fields in their in-memory state.
+    pub async fn fetch_proposal_details(
+        &self,
+        proposal_id: Address,
+        proposal_type: &crate::onchain::types::ProposalType,
+    ) -> Result<ProposalDetails> {
+        use crate::onchain::types::ProposalType;
+        use futures::TryStreamExt;
+        use hashi_types::move_types;
+        use sui_rpc::field::FieldMask;
+        use sui_rpc::field::FieldMaskUtil;
+        use sui_rpc::proto::sui::rpc::v2::DynamicField;
+        use sui_rpc::proto::sui::rpc::v2::ListDynamicFieldsRequest;
+
+        let proposals_bag_id = self.onchain_state.state().hashi().proposals.id;
+        let client = self.onchain_state.client();
+        let mut stream = Box::pin(
+            client.list_dynamic_fields(
+                ListDynamicFieldsRequest::default()
+                    .with_parent(proposals_bag_id)
+                    .with_page_size(u32::MAX)
+                    .with_read_mask(FieldMask::from_paths([
+                        DynamicField::path_builder().name().finish(),
+                        DynamicField::path_builder().value().finish(),
+                    ])),
+            ),
+        );
+
+        while let Some(field) = stream.try_next().await? {
+            // The bag key is BCS-encoded `ID`, which is equivalent to `Address`.
+            let Ok(key) = bcs::from_bytes::<Address>(field.name().value()) else {
+                continue;
+            };
+            if key != proposal_id {
+                continue;
+            }
+
+            let value_bytes = field.value().value();
+            let (creator, votes, quorum_threshold_bps, metadata) = match proposal_type {
+                ProposalType::UpdateConfig => {
+                    let p: move_types::Proposal<move_types::UpdateConfig> =
+                        bcs::from_bytes(value_bytes).context("deserialize UpdateConfig")?;
+                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                }
+                ProposalType::EnableVersion => {
+                    let p: move_types::Proposal<move_types::EnableVersion> =
+                        bcs::from_bytes(value_bytes).context("deserialize EnableVersion")?;
+                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                }
+                ProposalType::DisableVersion => {
+                    let p: move_types::Proposal<move_types::DisableVersion> =
+                        bcs::from_bytes(value_bytes).context("deserialize DisableVersion")?;
+                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                }
+                ProposalType::Upgrade => {
+                    let p: move_types::Proposal<move_types::Upgrade> =
+                        bcs::from_bytes(value_bytes).context("deserialize Upgrade")?;
+                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                }
+                ProposalType::EmergencyPause => {
+                    let p: move_types::Proposal<move_types::EmergencyPause> =
+                        bcs::from_bytes(value_bytes).context("deserialize EmergencyPause")?;
+                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                }
+                ProposalType::Unknown(s) => {
+                    anyhow::bail!("Cannot fetch details for unknown proposal type: {s}")
+                }
+            };
+            return Ok(ProposalDetails {
+                creator,
+                votes,
+                quorum_threshold_bps,
+                metadata,
+            });
+        }
+
+        anyhow::bail!("Proposal {proposal_id} not found in proposals bag")
     }
 
     /// Fetch the MPC public key bytes from on-chain state

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -221,11 +221,11 @@ impl HashiClient {
     /// metadata) for a specific proposal via one `list_dynamic_fields` call on
     /// the proposals bag. Separate from the cached `fetch_proposal` because
     /// validators don't need these fields in their in-memory state.
-    pub async fn fetch_proposal_details(
-        &self,
-        proposal_id: Address,
-        proposal_type: &crate::onchain::types::ProposalType,
-    ) -> Result<ProposalDetails> {
+    ///
+    /// The proposal type is derived from the matched field's `value_type` —
+    /// callers don't pass it, so they can't pass the wrong one.
+    pub async fn fetch_proposal_details(&self, proposal_id: Address) -> Result<ProposalDetails> {
+        use crate::onchain::parse_proposal_type;
         use crate::onchain::types::ProposalType;
         use futures::TryStreamExt;
         use hashi_types::move_types;
@@ -243,6 +243,7 @@ impl HashiClient {
                     .with_page_size(u32::MAX)
                     .with_read_mask(FieldMask::from_paths([
                         DynamicField::path_builder().name().finish(),
+                        DynamicField::path_builder().value_type(),
                         DynamicField::path_builder().value().finish(),
                     ])),
             ),
@@ -256,6 +257,12 @@ impl HashiClient {
             if key != proposal_id {
                 continue;
             }
+
+            let value_type_str = field.value_type();
+            let type_tag: TypeTag = value_type_str
+                .parse()
+                .with_context(|| format!("parse value_type {value_type_str:?}"))?;
+            let proposal_type = parse_proposal_type(&type_tag);
 
             let value_bytes = field.value().value();
             let (creator, votes, quorum_threshold_bps, metadata) = match proposal_type {

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -203,10 +203,7 @@ pub async fn view_proposal(config: &CliConfig, proposal_id: &str) -> Result<()> 
         .fetch_proposal(&proposal_addr)
         .ok_or_else(|| anyhow::anyhow!("Proposal not found: {}", proposal_id))?;
 
-    let details = client
-        .fetch_proposal_details(proposal_addr, &proposal.proposal_type)
-        .await
-        .ok();
+    let details = client.fetch_proposal_details(proposal_addr).await.ok();
     let committee = client.fetch_current_committee();
 
     println!();
@@ -281,7 +278,7 @@ pub async fn vote(
     // pushed us over quorum. `HashiClient`'s cached scrape is from CLI start,
     // so this has to be the live `list_dynamic_fields` call.
     let details = client
-        .fetch_proposal_details(proposal_addr, &proposal.proposal_type)
+        .fetch_proposal_details(proposal_addr)
         .await
         .context("failed to re-fetch proposal state after voting")?;
     let committee = client

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -408,15 +408,57 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
     Ok(())
 }
 
-/// Create an upgrade proposal
+/// Create an upgrade proposal.
+///
+/// Exactly one of `digest` or `package_path` must be `Some`. When
+/// `package_path` is provided, the CLI builds the package via `sui move build`
+/// and verifies that its `PACKAGE_VERSION` constant is exactly +1 of the
+/// currently published version (pre-flight check) before submitting the
+/// proposal. The `--digest` path skips that check and is retained only for
+/// callers with a pre-built package.
 pub async fn create_upgrade_proposal(
     config: &CliConfig,
-    digest: &str,
+    digest: Option<&str>,
+    package_path: Option<&std::path::Path>,
+    sui_binary: &std::path::Path,
+    sui_client_config: Option<&std::path::Path>,
     metadata: Vec<(String, String)>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
-    let digest_bytes =
-        hex::decode(digest.trim_start_matches("0x")).context("Invalid digest hex")?;
+    let mut client = HashiClient::new(config).await?;
+
+    let digest_bytes = match (digest, package_path) {
+        (Some(d), None) => {
+            print_warning(
+                "--digest skips pre-flight checks (PACKAGE_VERSION = current + 1). \
+                 Prefer --package-path.",
+            );
+            hex::decode(d.trim_start_matches("0x")).context("Invalid digest hex")?
+        }
+        (None, Some(path)) => {
+            let current_version = client.highest_package_version().context(
+                "could not determine current package version from on-chain state; \
+                 is the package deployed?",
+            )?;
+            let expected_version = current_version + 1;
+            print_info(&format!(
+                "Building upgrade package at {} (expecting PACKAGE_VERSION = {expected_version})",
+                path.display()
+            ));
+            let (_compiled, digest) = crate::cli::upgrade::build_upgrade_package(
+                sui_binary,
+                path,
+                sui_client_config,
+                expected_version,
+            )
+            .context("failed to build upgrade package")?;
+            digest
+        }
+        (None, None) => {
+            anyhow::bail!("must provide either --digest or --package-path");
+        }
+        (Some(_), Some(_)) => unreachable!("clap enforces mutual exclusion"),
+    };
 
     println!("\n{}", "Creating Upgrade Proposal:".bold());
     println!("  Digest: 0x{}", hex::encode(&digest_bytes));
@@ -426,7 +468,6 @@ pub async fn create_upgrade_proposal(
         prompt_continue("create this upgrade proposal").await?;
     }
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::Upgrade {
         digest: digest_bytes,
         metadata,

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -215,8 +215,14 @@ pub async fn view_proposal(config: &CliConfig, proposal_id: &str) -> Result<()> 
     Ok(())
 }
 
-/// Vote on a proposal
-pub async fn vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions) -> Result<()> {
+/// Vote on a proposal, optionally chaining an execute if this vote pushes
+/// the proposal over quorum.
+pub async fn vote(
+    config: &CliConfig,
+    proposal_id: &str,
+    execute: bool,
+    tx_opts: &TxOptions,
+) -> Result<()> {
     let mut client = HashiClient::new(config).await?;
 
     let proposal_addr = Address::from_hex(proposal_id)
@@ -248,7 +254,76 @@ pub async fn vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions) ->
         proposal_type_str, proposal_id
     ));
 
-    execute_or_simulate(&mut client, tx, tx_opts).await?;
+    let vote_response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+
+    if !execute {
+        return Ok(());
+    }
+
+    // `--execute` was requested. Only meaningful after a real execute (not a
+    // dry-run / missing-keypair).
+    if vote_response.is_none() {
+        return Ok(());
+    }
+
+    // Upgrade proposals require the dedicated upgrade flow — the generic
+    // `<module>::execute` path can't construct an UpgradeTicket.
+    use crate::onchain::types::ProposalType;
+    if matches!(proposal.proposal_type, ProposalType::Upgrade) {
+        print_warning(
+            "--execute is not supported for Upgrade proposals; run the \
+             dedicated upgrade flow once quorum is reached.",
+        );
+        return Ok(());
+    }
+
+    // Re-fetch live vote state to see whether the vote we just submitted
+    // pushed us over quorum. `HashiClient`'s cached scrape is from CLI start,
+    // so this has to be the live `list_dynamic_fields` call.
+    let details = client
+        .fetch_proposal_details(proposal_addr, &proposal.proposal_type)
+        .await
+        .context("failed to re-fetch proposal state after voting")?;
+    let committee = client
+        .fetch_current_committee()
+        .ok_or_else(|| anyhow::anyhow!("no committee available to compute quorum"))?;
+
+    let total_weight = committee.total_weight();
+    let voted_weight: u64 = details
+        .votes
+        .iter()
+        .map(|voter| {
+            committee
+                .members()
+                .iter()
+                .find(|m| m.validator_address() == *voter)
+                .map(|m| m.weight())
+                .unwrap_or(0)
+        })
+        .sum();
+    let threshold_weight = total_weight
+        .saturating_mul(details.quorum_threshold_bps)
+        .div_ceil(10_000);
+
+    if voted_weight < threshold_weight {
+        print_info(&format!(
+            "Quorum not reached yet ({voted_weight}/{threshold_weight} weight); \
+             skipping --execute."
+        ));
+        return Ok(());
+    }
+
+    print_info(&format!(
+        "Quorum reached ({voted_weight}/{threshold_weight} weight); executing..."
+    ));
+    let execute_tx =
+        client.build_execute_proposal_transaction(proposal_addr, &proposal.proposal_type)?;
+    print_info(&format!(
+        "Transaction: {}::execute on {}",
+        proposal.proposal_type.as_str(),
+        proposal_id
+    ));
+    execute_or_simulate(&mut client, execute_tx, tx_opts).await?;
     Ok(())
 }
 

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -6,6 +6,7 @@
 use anyhow::Context;
 use anyhow::Result;
 use colored::Colorize;
+use sui_rpc::proto::sui::rpc::v2::ExecuteTransactionResponse;
 use sui_sdk_types::Address;
 use tabled::Table;
 use tabled::Tabled;
@@ -57,35 +58,50 @@ fn print_simulation_result(result: &SimulationResult) {
     );
 }
 
-/// Execute or simulate a transaction based on tx_opts
+/// Execute or simulate a transaction based on tx_opts.
 ///
-/// Returns Ok(true) if execution/simulation succeeded, Ok(false) if no keypair configured.
+/// Returns `Some(response)` when a real transaction was executed, and `None`
+/// on dry-run or when no keypair is configured.
 async fn execute_or_simulate(
     client: &mut HashiClient,
     tx: sui_transaction_builder::TransactionBuilder,
     tx_opts: &TxOptions,
-) -> Result<bool> {
+) -> Result<Option<ExecuteTransactionResponse>> {
     if !client.can_execute() {
         print_warning("Transaction execution requires keypair configuration (--keypair).");
-        return Ok(false);
+        return Ok(None);
     }
 
     if tx_opts.dry_run {
         print_info("Simulating transaction (dry-run)...");
         let result = client.simulate(tx).await?;
         print_simulation_result(&result);
-    } else {
-        print_info("Executing transaction...");
-        let response = client.execute(tx).await?;
-        let digest = response.transaction().digest();
-        println!(
-            "\n{} Transaction submitted: {}",
-            "✓".green(),
-            digest.to_string().cyan()
-        );
+        return Ok(None);
     }
 
-    Ok(true)
+    print_info("Executing transaction...");
+    let response = client.execute(tx).await?;
+    let digest = response.transaction().digest();
+    println!(
+        "\n{} Transaction submitted: {}",
+        "✓".green(),
+        digest.to_string().cyan()
+    );
+    Ok(Some(response))
+}
+
+/// Print the newly-created proposal's ID after a `create_*_proposal` call,
+/// when the response is available (real execute, not dry-run).
+fn print_created_proposal_id(response: Option<&ExecuteTransactionResponse>) {
+    let Some(response) = response else {
+        return;
+    };
+    match crate::cli::upgrade::extract_proposal_id_from_response(response) {
+        Ok(id) => println!("  {} {}", "Proposal ID:".bold(), id.to_hex().cyan()),
+        Err(e) => {
+            tracing::warn!("Could not extract proposal ID from response: {e}");
+        }
+    }
 }
 
 /// List all active proposals
@@ -209,8 +225,8 @@ pub async fn vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions) ->
     println!("\n{}", "Proposal Details:".bold());
     println!("  Type: {}", proposal_type_str.cyan());
 
-    if !tx_opts.skip_confirm && !confirm_action("vote on this proposal").await? {
-        return Ok(());
+    if !tx_opts.skip_confirm {
+        prompt_continue("vote on this proposal").await?;
     }
 
     print_info("Building vote transaction...");
@@ -246,8 +262,8 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
     println!("\n{}", "Proposal Details:".bold());
     println!("  Type: {}", proposal_type_str.cyan());
 
-    if !tx_opts.skip_confirm && !confirm_action("remove your vote from this proposal").await? {
-        return Ok(());
+    if !tx_opts.skip_confirm {
+        prompt_continue("remove your vote from this proposal").await?;
     }
 
     print_info("Building remove_vote transaction...");
@@ -293,8 +309,8 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
     println!("  Type: {}", proposal_type_str.cyan());
     println!("  ID:   {}", proposal_id);
 
-    if !tx_opts.skip_confirm && !confirm_action("execute this proposal").await? {
-        return Ok(());
+    if !tx_opts.skip_confirm {
+        prompt_continue("execute this proposal").await?;
     }
 
     let tx = client.build_execute_proposal_transaction(proposal_addr, proposal_type)?;
@@ -323,8 +339,8 @@ pub async fn create_upgrade_proposal(
     println!("  Digest: 0x{}", hex::encode(&digest_bytes));
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm && !confirm_action("create this upgrade proposal").await? {
-        return Ok(());
+    if !tx_opts.skip_confirm {
+        prompt_continue("create this upgrade proposal").await?;
     }
 
     let mut client = HashiClient::new(config).await?;
@@ -334,7 +350,8 @@ pub async fn create_upgrade_proposal(
     });
 
     print_info("Transaction: upgrade::propose");
-    execute_or_simulate(&mut client, tx, tx_opts).await?;
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
     Ok(())
 }
 
@@ -354,8 +371,8 @@ pub async fn create_update_config_proposal(
     println!("  Value: {}", value_str);
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm && !confirm_action("create this config update proposal").await? {
-        return Ok(());
+    if !tx_opts.skip_confirm {
+        prompt_continue("create this config update proposal").await?;
     }
 
     let mut client = HashiClient::new(config).await?;
@@ -366,7 +383,8 @@ pub async fn create_update_config_proposal(
     });
 
     print_info("Transaction: update_config::propose");
-    execute_or_simulate(&mut client, tx, tx_opts).await?;
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
     Ok(())
 }
 
@@ -403,8 +421,8 @@ pub async fn create_enable_version_proposal(
     println!("  Version: {}", version);
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm && !confirm_action("create this enable version proposal").await? {
-        return Ok(());
+    if !tx_opts.skip_confirm {
+        prompt_continue("create this enable version proposal").await?;
     }
 
     let mut client = HashiClient::new(config).await?;
@@ -414,7 +432,8 @@ pub async fn create_enable_version_proposal(
     });
 
     print_info("Transaction: enable_version::propose");
-    execute_or_simulate(&mut client, tx, tx_opts).await?;
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
     Ok(())
 }
 
@@ -429,8 +448,8 @@ pub async fn create_disable_version_proposal(
     println!("  Version: {}", version);
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm && !confirm_action("create this disable version proposal").await? {
-        return Ok(());
+    if !tx_opts.skip_confirm {
+        prompt_continue("create this disable version proposal").await?;
     }
 
     let mut client = HashiClient::new(config).await?;
@@ -440,7 +459,8 @@ pub async fn create_disable_version_proposal(
     });
 
     print_info("Transaction: disable_version::propose");
-    execute_or_simulate(&mut client, tx, tx_opts).await?;
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
     Ok(())
 }
 
@@ -466,23 +486,18 @@ fn print_proposal_detailed(proposal: &Proposal) {
     println!("{}", "━".repeat(60).dimmed());
 }
 
-async fn confirm_action(action: &str) -> Result<bool> {
+/// Pause for user acknowledgement. Press enter to proceed, Ctrl+C to cancel.
+async fn prompt_continue(action: &str) -> Result<()> {
     use tokio::io::AsyncBufReadExt;
     use tokio::io::BufReader;
 
     println!(
         "\n{}",
-        format!("Are you sure you want to {}? (y/N)", action).yellow()
+        format!("Press enter to {action}, or Ctrl+C to cancel...").yellow()
     );
 
     let mut reader = BufReader::new(tokio::io::stdin());
     let mut input = String::new();
     reader.read_line(&mut input).await?;
-
-    if input.trim().eq_ignore_ascii_case("y") {
-        Ok(true)
-    } else {
-        print_warning("Cancelled.");
-        Ok(false)
-    }
+    Ok(())
 }

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -151,8 +151,10 @@ pub async fn list_proposals(
     println!("\n📋 Active Proposals:\n");
 
     if detailed {
+        // List mode skips the per-proposal vote/quorum fetch to avoid N extra
+        // network calls; use `proposal view <id>` for full vote progress.
         for proposal in &proposals {
-            print_proposal_detailed(proposal);
+            print_proposal_detailed(proposal, None, None);
             println!();
         }
     } else {
@@ -201,8 +203,14 @@ pub async fn view_proposal(config: &CliConfig, proposal_id: &str) -> Result<()> 
         .fetch_proposal(&proposal_addr)
         .ok_or_else(|| anyhow::anyhow!("Proposal not found: {}", proposal_id))?;
 
+    let details = client
+        .fetch_proposal_details(proposal_addr, &proposal.proposal_type)
+        .await
+        .ok();
+    let committee = client.fetch_current_committee();
+
     println!();
-    print_proposal_detailed(&proposal);
+    print_proposal_detailed(&proposal, details.as_ref(), committee.as_ref());
 
     Ok(())
 }
@@ -466,7 +474,11 @@ pub async fn create_disable_version_proposal(
 
 // ============ Helper Functions ============
 
-fn print_proposal_detailed(proposal: &Proposal) {
+fn print_proposal_detailed(
+    proposal: &Proposal,
+    details: Option<&crate::cli::client::ProposalDetails>,
+    committee: Option<&hashi_types::committee::Committee>,
+) {
     println!("{}", "━".repeat(60).dimmed());
     println!(
         "  {} {}",
@@ -483,6 +495,71 @@ fn print_proposal_detailed(proposal: &Proposal) {
         "Created:".bold(),
         display::format_timestamp(proposal.timestamp_ms)
     );
+
+    if let Some(details) = details {
+        println!(
+            "  {} {}",
+            "Creator:".bold(),
+            details.creator.to_hex().dimmed()
+        );
+
+        // Vote tally + quorum progress.
+        let total_weight = committee.map(|c| c.total_weight()).unwrap_or(0);
+        let voted_weight: u64 = details
+            .votes
+            .iter()
+            .map(|voter| {
+                committee
+                    .and_then(|c| c.members().iter().find(|m| m.validator_address() == *voter))
+                    .map(|m| m.weight())
+                    .unwrap_or(0)
+            })
+            .sum();
+        let threshold_weight = total_weight
+            .saturating_mul(details.quorum_threshold_bps)
+            .div_ceil(10_000);
+        let quorum_met = voted_weight >= threshold_weight && total_weight > 0;
+
+        let status = if quorum_met {
+            "QUORUM REACHED".green().bold()
+        } else {
+            format!(
+                "{}/{} weight ({} more needed)",
+                voted_weight,
+                threshold_weight,
+                threshold_weight.saturating_sub(voted_weight)
+            )
+            .yellow()
+        };
+        println!(
+            "  {} {} voter(s) — {} of total weight {} — {}",
+            "Votes:".bold(),
+            details.votes.len().to_string().cyan(),
+            voted_weight.to_string().cyan(),
+            total_weight.to_string().dimmed(),
+            status
+        );
+        println!(
+            "  {} {} bps ({:.2}%)",
+            "Threshold:".bold(),
+            details.quorum_threshold_bps,
+            details.quorum_threshold_bps as f64 / 100.0
+        );
+        if !details.votes.is_empty() {
+            println!("  {}", "Voters:".bold());
+            for voter in &details.votes {
+                println!("    - {}", voter.to_hex().dimmed());
+            }
+        }
+
+        if !details.metadata.contents.is_empty() {
+            println!("  {}", "Metadata:".bold());
+            for entry in &details.metadata.contents {
+                println!("    {}: {}", entry.key.dimmed(), entry.value);
+            }
+        }
+    }
+
     println!("{}", "━".repeat(60).dimmed());
 }
 

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -114,6 +114,13 @@ pub enum ProposalCommands {
     Vote {
         /// The proposal object ID to vote on
         proposal_id: String,
+
+        /// Also execute the proposal if this vote pushes it over quorum.
+        /// Skipped silently (with an info message) when quorum isn't reached.
+        /// Not supported for `Upgrade` proposals — use the dedicated upgrade
+        /// flow instead.
+        #[clap(long, short = 'e')]
+        execute: bool,
     },
 
     /// Remove your vote from a proposal
@@ -530,8 +537,11 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
             ProposalCommands::View { proposal_id } => {
                 commands::proposal::view_proposal(&config, &proposal_id).await?;
             }
-            ProposalCommands::Vote { proposal_id } => {
-                commands::proposal::vote(&config, &proposal_id, &tx_opts).await?;
+            ProposalCommands::Vote {
+                proposal_id,
+                execute,
+            } => {
+                commands::proposal::vote(&config, &proposal_id, execute, &tx_opts).await?;
             }
             ProposalCommands::RemoveVote { proposal_id } => {
                 commands::proposal::remove_vote(&config, &proposal_id, &tx_opts).await?;

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -145,9 +145,30 @@ pub enum ProposalCommands {
 #[derive(Subcommand)]
 pub enum CreateProposalCommands {
     /// Propose a package upgrade
+    ///
+    /// Exactly one of `--digest` or `--package-path` must be provided.
+    /// `--package-path` is recommended: the CLI builds the package, verifies
+    /// that its `PACKAGE_VERSION` constant is exactly +1 of the currently
+    /// published version, and derives the digest for the proposal.
     Upgrade {
-        /// The digest of the new package (hex encoded)
-        digest: String,
+        /// The digest of a pre-built package (hex encoded). Skips pre-flight
+        /// checks — prefer `--package-path`.
+        #[clap(long, conflicts_with = "package_path")]
+        digest: Option<String>,
+
+        /// Path to the upgrade package source. The CLI will run `sui move
+        /// build` and verify the `PACKAGE_VERSION` constant before submitting.
+        #[clap(long, value_name = "PATH")]
+        package_path: Option<std::path::PathBuf>,
+
+        /// Path to the `sui` CLI binary. Only used with `--package-path`.
+        #[clap(long, env = "SUI_BINARY", default_value = "sui")]
+        sui_binary: std::path::PathBuf,
+
+        /// Optional path to a sui `client.yaml` for dependency resolution.
+        /// Only used with `--package-path`.
+        #[clap(long)]
+        sui_client_config: Option<std::path::PathBuf>,
 
         #[clap(flatten)]
         metadata: MetadataArgs,
@@ -550,10 +571,19 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                 commands::proposal::execute(&config, &proposal_id, &tx_opts).await?;
             }
             ProposalCommands::Create { proposal } => match proposal {
-                CreateProposalCommands::Upgrade { digest, metadata } => {
+                CreateProposalCommands::Upgrade {
+                    digest,
+                    package_path,
+                    sui_binary,
+                    sui_client_config,
+                    metadata,
+                } => {
                     commands::proposal::create_upgrade_proposal(
                         &config,
-                        &digest,
+                        digest.as_deref(),
+                        package_path.as_deref(),
+                        &sui_binary,
+                        sui_client_config.as_deref(),
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/upgrade.rs
+++ b/crates/hashi/src/cli/upgrade.rs
@@ -31,6 +31,45 @@ use sui_transaction_builder::Function;
 use sui_transaction_builder::ObjectInput;
 use sui_transaction_builder::TransactionBuilder;
 
+/// Relative path (from a package root) to the Move source file declaring the
+/// `PACKAGE_VERSION` constant.
+const PACKAGE_VERSION_SOURCE: &str = "sources/core/config/config.move";
+
+/// Parse the `PACKAGE_VERSION` constant from `sources/core/config/config.move`
+/// in a package source tree.
+///
+/// This is the version gate enforced by `config::assert_version_enabled`; it
+/// must be bumped in every upgrade or the new package will reject all entry
+/// points guarded by that check.
+pub fn read_package_version(package_path: &Path) -> Result<u64> {
+    let source_path = package_path.join(PACKAGE_VERSION_SOURCE);
+    let source = std::fs::read_to_string(&source_path).map_err(|e| {
+        anyhow!(
+            "failed to read {} to parse PACKAGE_VERSION: {e}",
+            source_path.display()
+        )
+    })?;
+
+    let line = source
+        .lines()
+        .find(|l| l.trim_start().starts_with("const PACKAGE_VERSION"))
+        .ok_or_else(|| {
+            anyhow!(
+                "PACKAGE_VERSION declaration not found in {}",
+                source_path.display()
+            )
+        })?;
+
+    let rhs = line
+        .split_once('=')
+        .and_then(|(_, rhs)| rhs.split(';').next())
+        .ok_or_else(|| anyhow!("malformed PACKAGE_VERSION line: {line:?}"))?
+        .trim();
+
+    rhs.parse::<u64>()
+        .map_err(|e| anyhow!("PACKAGE_VERSION value {rhs:?} is not a u64: {e}"))
+}
+
 /// Build an upgrade package by invoking `sui move build --dump-bytecode-as-base64`
 /// and parsing the resulting JSON.
 ///
@@ -39,13 +78,25 @@ use sui_transaction_builder::TransactionBuilder;
 /// `client_config` is passed as `--client.config` when supplied, otherwise the
 /// `sui` binary's default client config is used.
 ///
+/// Runs a pre-flight check that the package declares `PACKAGE_VERSION ==
+/// expected_version`, failing before shelling out if the constant wasn't
+/// bumped. Callers typically pass `current_highest_version + 1`.
+///
 /// Returns the compiled `Publish` (modules + dependencies) plus the package
 /// digest — the latter is what goes into the `Upgrade` proposal.
 pub fn build_upgrade_package(
     sui_binary: &Path,
     package_path: &Path,
     client_config: Option<&Path>,
+    expected_version: u64,
 ) -> Result<(Publish, Vec<u8>)> {
+    let declared_version = read_package_version(package_path)?;
+    anyhow::ensure!(
+        declared_version == expected_version,
+        "upgrade package declares PACKAGE_VERSION = {declared_version}, expected {expected_version} \
+         (must be exactly +1 of the currently published version)"
+    );
+
     let mut cmd = std::process::Command::new(sui_binary);
     cmd.arg("move");
 

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -707,19 +707,6 @@ pub(crate) async fn scrape_hashi_config(
     Ok(convert_move_config(config))
 }
 
-/// Return the child object's type as a string, preferring the dedicated
-/// `object_type` field (always set by Sui indexing) and falling back to the
-/// BCS `contents.name` (which some fullnodes leave empty in dynamic-field
-/// list responses).
-fn child_object_type_name(child_object: &sui_rpc::proto::sui::rpc::v2::Object) -> &str {
-    let object_type = child_object.object_type_opt().unwrap_or("");
-    if !object_type.is_empty() {
-        object_type
-    } else {
-        child_object.contents().name()
-    }
-}
-
 fn convert_move_config(config: move_types::Config) -> types::Config {
     types::Config {
         config: config.config.into_iter().collect(),
@@ -753,12 +740,12 @@ async fn scrape_treasury(
         .pipe(Box::pin);
 
     while let Some(field) = stream.try_next().await? {
-        let name = child_object_type_name(field.child_object());
-        let type_tag: TypeTag = match name.parse() {
+        let object_type = field.child_object().object_type();
+        let type_tag: TypeTag = match object_type.parse() {
             Ok(t) => t,
             Err(e) => {
                 tracing::warn!(
-                    "skipping treasury dynamic field with unparseable type {name:?}: {e}"
+                    "skipping treasury dynamic field with unparseable type {object_type:?}: {e}"
                 );
                 continue;
             }
@@ -1316,7 +1303,7 @@ async fn scrape_proposals(
     })
 }
 
-fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
+pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
     let TypeTag::Struct(struct_tag) = type_tag else {
         return types::ProposalType::Unknown(format!("{:?}", type_tag));
     };

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -720,7 +720,6 @@ fn child_object_type_name(child_object: &sui_rpc::proto::sui::rpc::v2::Object) -
     }
 }
 
-
 fn convert_move_config(config: move_types::Config) -> types::Config {
     types::Config {
         config: config.config.into_iter().collect(),

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -707,6 +707,20 @@ pub(crate) async fn scrape_hashi_config(
     Ok(convert_move_config(config))
 }
 
+/// Return the child object's type as a string, preferring the dedicated
+/// `object_type` field (always set by Sui indexing) and falling back to the
+/// BCS `contents.name` (which some fullnodes leave empty in dynamic-field
+/// list responses).
+fn child_object_type_name(child_object: &sui_rpc::proto::sui::rpc::v2::Object) -> &str {
+    let object_type = child_object.object_type_opt().unwrap_or("");
+    if !object_type.is_empty() {
+        object_type
+    } else {
+        child_object.contents().name()
+    }
+}
+
+
 fn convert_move_config(config: move_types::Config) -> types::Config {
     types::Config {
         config: config.config.into_iter().collect(),
@@ -730,6 +744,7 @@ async fn scrape_treasury(
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder().value().finish(),
+                    DynamicField::path_builder().child_object().object_type(),
                     DynamicField::path_builder()
                         .child_object()
                         .contents()
@@ -739,7 +754,16 @@ async fn scrape_treasury(
         .pipe(Box::pin);
 
     while let Some(field) = stream.try_next().await? {
-        let type_tag = field.child_object().contents().name().parse()?;
+        let name = child_object_type_name(field.child_object());
+        let type_tag: TypeTag = match name.parse() {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    "skipping treasury dynamic field with unparseable type {name:?}: {e}"
+                );
+                continue;
+            }
+        };
         let contents = field.child_object().contents().value();
 
         if let Some(treasury_cap) = types::TreasuryCap::try_from_contents(&type_tag, contents) {
@@ -1209,6 +1233,9 @@ async fn scrape_proposals(
 ) -> Result<types::Proposals> {
     let mut proposals: BTreeMap<Address, types::Proposal> = BTreeMap::new();
 
+    // Proposals live in a `0x2::bag::Bag` (dynamic FIELD, value stored inline),
+    // so we read `value_type` + `value` off the `DynamicField` proto itself —
+    // NOT `child_object` (that's only populated for DynamicObject kinds).
     let mut stream = client
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
@@ -1216,22 +1243,30 @@ async fn scrape_proposals(
                 .with_page_size(u32::MAX)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
-                    DynamicField::path_builder()
-                        .child_object()
-                        .contents()
-                        .finish(),
+                    DynamicField::path_builder().value_type(),
+                    DynamicField::path_builder().value().finish(),
                 ])),
         )
         .pipe(Box::pin);
 
     while let Some(field) = stream.try_next().await? {
-        // Parse the proposal type from the type tag
-        // The type will be something like: <package>::proposal::Proposal<<package>::update_deposit_fee::UpdateDepositFee>
-        let type_tag: TypeTag = field.child_object().contents().name().parse()?;
+        // The value_type is the inner type, e.g.
+        //   <package>::proposal::Proposal<<package>::update_config::UpdateConfig>
+        let value_type = field.value_type_opt().unwrap_or("");
+        let type_tag: TypeTag = match value_type.parse() {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    "skipping proposal dynamic field with unparseable value_type \
+                     {value_type:?}: {e}"
+                );
+                continue;
+            }
+        };
         let proposal_type = parse_proposal_type(&type_tag);
 
         // Deserialize proposal based on the proposal type
-        let contents = field.child_object().contents().value();
+        let contents: &[u8] = field.value().value();
         let result: Option<(Address, u64)> = match &proposal_type {
             types::ProposalType::UpdateConfig => {
                 bcs::from_bytes::<move_types::Proposal<move_types::UpdateConfig>>(contents)


### PR DESCRIPTION
## Summary

A batch of CLI UX/ergonomics improvements for the governance (proposal) flow,
plus one correctness fix for on-chain state scraping and a small localnet
helper to make this stuff actually drivable against a local dev network.

Stacked on top of #456 — set base back to `main` once that lands.

### Commits

1. **Fix CLI on-chain state init for Bag-backed dynamic fields.** The
   scraper was reading `child_object.contents` for every dynamic field,
   but that's only populated for `ObjectBag` (DynamicObject) kinds. For
   plain `Bag` entries (proposals), the real payload is on the
   `DynamicField` itself via `value_type` + `value`. Without this,
   every governance CLI command errored with `unable to parse type ""`
   once the proposals bag had any entries.
2. **Friendlier prompt + print proposal ID on create.** `(y/N)` →
   `Press enter to X, or Ctrl+C to cancel`. After `proposal create ...`,
   print the new `Proposal ID: 0x…` so it can be copy/pasted into the
   follow-up `vote` / `view` / `execute` commands.
3. **Show votes + quorum progress in `proposal view`.** One extra
   `list_dynamic_fields` call pulls the full `Proposal<T>` envelope and
   displays creator, voter addresses, voted-vs-threshold weight, and
   whether quorum is reached. Scoped to the CLI — no new fields on
   `onchain::types::Proposal` or changes to the watcher.
4. **`--execute` flag on `proposal vote`.** Casts the vote and, if
   that vote pushes the proposal over quorum, chains an immediate
   `proposal::<module>::execute` in the same invocation. Skips silently
   (with an info message) when quorum isn't reached. Upgrade proposals
   are rejected — they need the dedicated upgrade flow.
5. **localnet: dump validator operator keys to disk.** Writes each
   validator's `operator_private_key` to
   `<data-dir>/validators/validator_<N>.pem` (0600) at `hashi-localnet
   start` time. Without this, the keys only live in-memory on the
   running validator processes, so there's no way to point the CLI at a
   committee-member key for `proposal create` / `vote` / `execute` on
   localnet.

## Test plan

Tested end-to-end against a 4-validator localnet:

- [x] `proposal create update-config bitcoin_confirmation_threshold u64:3`
      prints the new proposal ID and uses the press-enter prompt.
- [x] `proposal view <id>` shows `Creator`, `Votes: N voter(s) — <w> of total
      weight <total>`, `Threshold: <bps> (<pct>%)`, and the voter list.
- [x] `proposal vote <id> --execute` from the second validator prints
      "Quorum not reached yet (…); skipping --execute."
- [x] `proposal vote <id> --execute` from the third validator prints
      "Quorum reached (…); executing…" and submits both the vote and the
      execute transactions.
- [x] On-chain `bitcoin_confirmation_threshold` updated to `3` after
      the auto-execute.