### PR TITLE
Migrate proposals from Bag to ObjectBag

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -42,7 +42,7 @@ pub struct Hashi {
     pub committees: CommitteeSet,
     pub config: Config,
     pub treasury: Treasury,
-    pub proposals: Bag,
+    pub proposals: ObjectBag,
     /// TOB certificates by (epoch, batch_index) -> EpochCertsV1
     pub tob: Bag,
     /// Number of presignatures consumed in the current epoch.

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -222,8 +222,8 @@ impl HashiClient {
     /// the proposals bag. Separate from the cached `fetch_proposal` because
     /// validators don't need these fields in their in-memory state.
     ///
-    /// The proposal type is derived from the matched field's `value_type` —
-    /// callers don't pass it, so they can't pass the wrong one.
+    /// The proposal type is derived from the matched child object's
+    /// `object_type` — callers don't pass it, so they can't pass the wrong one.
     pub async fn fetch_proposal_details(&self, proposal_id: Address) -> Result<ProposalDetails> {
         use crate::onchain::parse_proposal_type;
         use crate::onchain::types::ProposalType;
@@ -236,6 +236,9 @@ impl HashiClient {
 
         let proposals_bag_id = self.onchain_state.state().hashi().proposals.id;
         let client = self.onchain_state.client();
+        // Proposals are now stored in an `ObjectBag`, so each entry's payload
+        // lives on `child_object` (a standalone object), not inline on the
+        // `DynamicField` itself.
         let mut stream = Box::pin(
             client.list_dynamic_fields(
                 ListDynamicFieldsRequest::default()
@@ -243,8 +246,11 @@ impl HashiClient {
                     .with_page_size(u32::MAX)
                     .with_read_mask(FieldMask::from_paths([
                         DynamicField::path_builder().name().finish(),
-                        DynamicField::path_builder().value_type(),
-                        DynamicField::path_builder().value().finish(),
+                        DynamicField::path_builder().child_object().object_type(),
+                        DynamicField::path_builder()
+                            .child_object()
+                            .contents()
+                            .finish(),
                     ])),
             ),
         );
@@ -258,13 +264,13 @@ impl HashiClient {
                 continue;
             }
 
-            let value_type_str = field.value_type();
-            let type_tag: TypeTag = value_type_str
+            let object_type_str = field.child_object().object_type();
+            let type_tag: TypeTag = object_type_str
                 .parse()
-                .with_context(|| format!("parse value_type {value_type_str:?}"))?;
+                .with_context(|| format!("parse object_type {object_type_str:?}"))?;
             let proposal_type = parse_proposal_type(&type_tag);
 
-            let value_bytes = field.value().value();
+            let value_bytes = field.child_object().contents().value();
             let (creator, votes, quorum_threshold_bps, metadata) = match proposal_type {
                 ProposalType::UpdateConfig => {
                     let p: move_types::Proposal<move_types::UpdateConfig> =

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -1215,13 +1215,14 @@ async fn scrape_spent_utxos(
 
 async fn scrape_proposals(
     client: Client,
-    proposals_bag: move_types::Bag,
+    proposals_bag: move_types::ObjectBag,
 ) -> Result<types::Proposals> {
     let mut proposals: BTreeMap<Address, types::Proposal> = BTreeMap::new();
 
-    // Proposals live in a `0x2::bag::Bag` (dynamic FIELD, value stored inline),
-    // so we read `value_type` + `value` off the `DynamicField` proto itself —
-    // NOT `child_object` (that's only populated for DynamicObject kinds).
+    // Proposals live in a `0x2::object_bag::ObjectBag`, so each entry's
+    // payload is a standalone child object. Read `child_object` directly —
+    // fullnode gRPC populates `child_object.object_type` + BCS `contents`
+    // for dynamic-object-field kinds.
     let mut stream = client
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
@@ -1229,22 +1230,25 @@ async fn scrape_proposals(
                 .with_page_size(u32::MAX)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
-                    DynamicField::path_builder().value_type(),
-                    DynamicField::path_builder().value().finish(),
+                    DynamicField::path_builder().child_object().object_type(),
+                    DynamicField::path_builder()
+                        .child_object()
+                        .contents()
+                        .finish(),
                 ])),
         )
         .pipe(Box::pin);
 
     while let Some(field) = stream.try_next().await? {
-        // The value_type is the inner type, e.g.
+        // `child_object.object_type` is the fully-qualified type, e.g.
         //   <package>::proposal::Proposal<<package>::update_config::UpdateConfig>
-        let value_type = field.value_type_opt().unwrap_or("");
-        let type_tag: TypeTag = match value_type.parse() {
+        let object_type = field.child_object().object_type();
+        let type_tag: TypeTag = match object_type.parse() {
             Ok(t) => t,
             Err(e) => {
                 tracing::warn!(
-                    "skipping proposal dynamic field with unparseable value_type \
-                     {value_type:?}: {e}"
+                    "skipping proposal dynamic object field with unparseable type \
+                     {object_type:?}: {e}"
                 );
                 continue;
             }
@@ -1252,7 +1256,7 @@ async fn scrape_proposals(
         let proposal_type = parse_proposal_type(&type_tag);
 
         // Deserialize proposal based on the proposal type
-        let contents: &[u8] = field.value().value();
+        let contents: &[u8] = field.child_object().contents().value();
         let result: Option<(Address, u64)> = match &proposal_type {
             types::ProposalType::UpdateConfig => {
                 bcs::from_bytes::<move_types::Proposal<move_types::UpdateConfig>>(contents)

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -12,7 +12,7 @@ use hashi::{
     threshold,
     treasury::Treasury
 };
-use sui::{bag::{Self, Bag}, dynamic_field as df};
+use sui::{bag::{Self, Bag}, dynamic_field as df, object_bag::{Self, ObjectBag}};
 
 #[error]
 const ESystemPaused: vector<u8> = b"System is currently paused";
@@ -28,7 +28,7 @@ public struct Hashi has key {
     committee_set: CommitteeSet,
     config: Config,
     treasury: Treasury,
-    proposals: Bag,
+    proposals: ObjectBag,
     /// TOB certificates by (epoch, batch_index) -> EpochCertsV1
     tob: Bag,
     /// Number of presignatures consumed in the current epoch.
@@ -48,7 +48,7 @@ fun init(ctx: &mut TxContext) {
             config
         },
         treasury: hashi::treasury::create(ctx),
-        proposals: bag::new(ctx),
+        proposals: object_bag::new(ctx),
         tob: bag::new(ctx),
         num_consumed_presigs: 0,
     };
@@ -149,11 +149,11 @@ public(package) fun treasury_mut(self: &mut Hashi): &mut Treasury {
     &mut self.treasury
 }
 
-public(package) fun proposals(self: &Hashi): &Bag {
+public(package) fun proposals(self: &Hashi): &ObjectBag {
     &self.proposals
 }
 
-public(package) fun proposals_mut(self: &mut Hashi): &mut Bag {
+public(package) fun proposals_mut(self: &mut Hashi): &mut ObjectBag {
     &mut self.proposals
 }
 
@@ -204,7 +204,7 @@ public fun create_for_testing(
     committee_set: CommitteeSet,
     config: Config,
     treasury: Treasury,
-    proposals: Bag,
+    proposals: ObjectBag,
     tob: Bag,
     ctx: &mut TxContext,
 ): Hashi {

--- a/packages/hashi/tests/test_utils.move
+++ b/packages/hashi/tests/test_utils.move
@@ -15,7 +15,7 @@ use hashi::{
     hashi::Hashi,
     update_config
 };
-use sui::{bag, bls12381, clock::Clock, vec_map};
+use sui::{bag, bls12381, clock::Clock, object_bag, vec_map};
 
 // ======== Transaction Context Helpers ========
 
@@ -131,7 +131,7 @@ public fun create_hashi_with_weighted_committee(
     let treasury = hashi::treasury::create(ctx);
 
     // Create proposals bag
-    let proposals = bag::new(ctx);
+    let proposals = object_bag::new(ctx);
 
     // Create TOB bag
     let tob = bag::new(ctx);


### PR DESCRIPTION
## Summary

- Proposals now live in `0x2::object_bag::ObjectBag` instead of `0x2::bag::Bag`
- Each `Proposal<T>` gets a first-class Sui object identity — directly queryable via `sui_getObject`, visible in explorers
- Rust scraper and CLI `fetch_proposal_details` updated to read from `child_object` (DynamicObject kind) instead of inline `DynamicField` value fields
- `Proposal<T>` already had `key + store` abilities so no Move-side ability changes needed

Stacked on #458 → #456. Retarget to `main` once those land.

## Test plan

- [x] 74/74 Move tests pass
- [x] 282 Rust unit tests pass (240 hashi + 42 hashi-types)
- [x] Full workspace `cargo check --tests` + `cargo clippy` clean under `-Dwarnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)