### PR TITLE
metrics: observe RPC body sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2251,7 +2251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2830,6 +2830,7 @@ dependencies = [
  "futures",
  "hashi-types",
  "hex",
+ "http 1.4.0",
  "jiff",
  "jsonrpc",
  "prometheus",
@@ -3554,7 +3555,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3599,7 +3600,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3985,7 +3986,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4510,7 +4511,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5078,7 +5079,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5648,7 +5649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5769,9 +5770,9 @@ dependencies = [
 
 [[package]]
 name = "sui-http"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5960a90faeff75f086730b2f4413a6b8ee38e098d469b00d7440bf0b2f50e651"
+checksum = "c4bfea7568dcf01ad7d41749c071492b29d2fd450a720db1e3d063c557028d50"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5939,7 +5940,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6762,7 +6763,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "21
 sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "210e734ab50ab9a562e9a8ecf2ff5cfdb8c0f1b1" }
 sui-transaction-builder = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "210e734ab50ab9a562e9a8ecf2ff5cfdb8c0f1b1" }
 
-sui-http = "0.1.0"
+sui-http = "0.2.0"
 bitcoin = { version = "0.32.8", features =["serde"] }
 corepc-client = { version = "0.10.0", features = ["client-sync"] }
 jsonrpc = "0.18.0"

--- a/crates/hashi/Cargo.toml
+++ b/crates/hashi/Cargo.toml
@@ -25,6 +25,7 @@ tonic-prost.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 bytes.workspace = true
+http = "1.4"
 
 tonic-health.workspace = true
 serde.workspace = true

--- a/crates/hashi/src/grpc/client.rs
+++ b/crates/hashi/src/grpc/client.rs
@@ -1,13 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use axum::http;
 use tonic::Response;
+use tonic::body::Body;
 use tonic_rustls::Channel;
 use tonic_rustls::Endpoint;
+use tower::ServiceBuilder;
+use tower::util::BoxCloneService;
 
+use sui_http::middleware::callback::CallbackLayer;
+
+use crate::grpc::metrics_layer::RpcMetricsMakeCallbackHandler;
+use crate::metrics::Metrics;
 use crate::mpc::types::ComplainRequest;
 use crate::mpc::types::ComplaintResponses;
 use crate::mpc::types::GetPartialSignaturesRequest;
@@ -28,13 +36,31 @@ use hashi_types::proto::mpc_service_client::MpcServiceClient;
 type Result<T, E = tonic::Status> = std::result::Result<T, E>;
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// Type-erased transport handed to tonic-generated clients. Using a single
+/// boxed type keeps `Client` cloneable regardless of whether the metrics
+/// tower layer is attached.
+pub type BoxedChannel = BoxCloneService<http::Request<Body>, http::Response<Body>, tonic::Status>;
+
 const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     uri: http::Uri,
     channel: Channel,
     max_decoding_message_size: usize,
+    metrics: Option<Arc<Metrics>>,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Skip the prometheus registry — it has no meaningful Debug impl
+        // and it would bloat every `{:?}` containing a `Client`.
+        f.debug_struct("Client")
+            .field("uri", &self.uri)
+            .field("max_decoding_message_size", &self.max_decoding_message_size)
+            .field("metrics_enabled", &self.metrics.is_some())
+            .finish()
+    }
 }
 
 impl Client {
@@ -65,11 +91,20 @@ impl Client {
             uri,
             channel,
             max_decoding_message_size: DEFAULT_MAX_DECODING_MESSAGE_SIZE,
+            metrics: None,
         })
     }
 
     pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
         self.max_decoding_message_size = limit;
+        self
+    }
+
+    /// Attach the metrics registry so outbound RPCs are observed by
+    /// [`RpcMetricsMakeCallbackHandler`] via `sui_http`'s callback layer.
+    /// Without this, the client emits no RPC traffic metrics.
+    pub fn with_metrics(mut self, metrics: Arc<Metrics>) -> Self {
+        self.metrics = Some(metrics);
         self
     }
 
@@ -85,13 +120,46 @@ impl Client {
         &self.uri
     }
 
-    pub fn bridge_service_client(&self) -> BridgeServiceClient<Channel> {
-        BridgeServiceClient::new(self.channel.clone())
+    /// Build a boxed transport, applying the metrics callback layer when
+    /// a registry is configured.
+    ///
+    /// `CallbackLayer` wraps the request body in `RequestBody<_, _>` and
+    /// the response body in `ResponseBody<_, _>`. `tonic_rustls::Channel`
+    /// is monomorphic over `tonic::body::Body`, so we rebox each side
+    /// back to `tonic::body::Body` before/after the channel sees it. The
+    /// inner `tonic_rustls::Error` is mapped to `tonic::Status` so
+    /// tonic's generated clients receive the error type they expect.
+    fn boxed_channel(&self) -> BoxedChannel {
+        let channel = self.channel.clone();
+        match &self.metrics {
+            Some(metrics) => {
+                let svc = ServiceBuilder::new()
+                    .map_err(tonic::Status::from_error)
+                    .map_response(|resp: http::Response<_>| resp.map(Body::new))
+                    .layer(CallbackLayer::new(RpcMetricsMakeCallbackHandler::client(
+                        metrics.clone(),
+                    )))
+                    .map_request(|req: http::Request<_>| req.map(Body::new))
+                    .map_err(|e: tonic_rustls::Error| -> BoxError { Box::new(e) })
+                    .service(channel);
+                BoxCloneService::new(svc)
+            }
+            None => {
+                let svc = ServiceBuilder::new()
+                    .map_err(|e: tonic_rustls::Error| tonic::Status::from_error(Box::new(e)))
+                    .service(channel);
+                BoxCloneService::new(svc)
+            }
+        }
+    }
+
+    pub fn bridge_service_client(&self) -> BridgeServiceClient<BoxedChannel> {
+        BridgeServiceClient::new(self.boxed_channel())
             .max_decoding_message_size(self.max_decoding_message_size)
     }
 
-    pub fn mpc_service_client(&self) -> MpcServiceClient<Channel> {
-        MpcServiceClient::new(self.channel.clone())
+    pub fn mpc_service_client(&self) -> MpcServiceClient<BoxedChannel> {
+        MpcServiceClient::new(self.boxed_channel())
             .max_decoding_message_size(self.max_decoding_message_size)
     }
 

--- a/crates/hashi/src/grpc/metrics_layer.rs
+++ b/crates/hashi/src/grpc/metrics_layer.rs
@@ -1,0 +1,382 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tower callback layer plumbing for HTTP/gRPC metrics.
+//!
+//! This module owns every [`sui_http::middleware::callback`] handler the
+//! crate uses. A single [`RpcMetricsMakeCallbackHandler`] type drives
+//! both the server-side handler attached to the axum router in
+//! `crate::grpc::HttpService::start` and the client-side handler attached
+//! to outbound `tonic_rustls::Channel`s in `crate::grpc::client::Client`;
+//! the per-role behavior is selected via the [`Role`] passed at
+//! construction. The actual prometheus registration lives in
+//! [`crate::metrics::Metrics`]; this module is purely the wiring that
+//! observes traffic and writes into those metrics.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::http;
+use bytes::Buf;
+use http::request;
+use http::response;
+use sui_http::middleware::callback;
+
+use crate::metrics::Metrics;
+
+/// Which RFC 9110 role this node is playing on the observed connection.
+///
+/// Selects the value written to the `role` label dimension and the
+/// direction each body travels relative to this node.
+#[derive(Clone, Copy, Debug)]
+pub enum Role {
+    Client,
+    Server,
+}
+
+impl Role {
+    /// Value for the `role` label dimension on every metric this module
+    /// writes.
+    fn label(self) -> &'static str {
+        match self {
+            Role::Client => "client",
+            Role::Server => "server",
+        }
+    }
+
+    /// Direction the request body travels from this node's perspective:
+    /// the client sends the request (outbound), the server receives it
+    /// (inbound).
+    fn request_direction(self) -> Direction {
+        match self {
+            Role::Client => Direction::Outbound,
+            Role::Server => Direction::Inbound,
+        }
+    }
+
+    /// Direction the response body travels from this node's perspective;
+    /// the inverse of [`Self::request_direction`].
+    fn response_direction(self) -> Direction {
+        match self {
+            Role::Client => Direction::Inbound,
+            Role::Server => Direction::Outbound,
+        }
+    }
+}
+
+/// Direction of HTTP body bytes from the perspective of this node.
+/// Selects which byte counter (`bytes_sent_total` vs
+/// `bytes_received_total`) the observed bytes are flushed to, and —
+/// together with [`Role`] — which body (request vs response) the tally
+/// was tracking.
+#[derive(Clone, Copy, Debug)]
+enum Direction {
+    Outbound,
+    Inbound,
+}
+
+/// Accumulates HTTP body bytes and, when the handler is dropped, flushes
+/// the total to both the per-path size histogram and the aggregate
+/// sent/received byte counter.
+///
+/// Flushing on `Drop` covers both the clean end-of-stream path and the
+/// partial-body path (cancellation, body error) in one place, so bytes
+/// that were actually transferred are always observed.
+struct SizeTally {
+    metrics: Arc<Metrics>,
+    path: Cow<'static, str>,
+    role: Role,
+    direction: Direction,
+    bytes: u64,
+}
+
+impl SizeTally {
+    fn new(
+        metrics: Arc<Metrics>,
+        path: Cow<'static, str>,
+        role: Role,
+        direction: Direction,
+    ) -> Self {
+        Self {
+            metrics,
+            path,
+            role,
+            direction,
+            bytes: 0,
+        }
+    }
+
+    fn add(&mut self, n: usize) {
+        self.bytes += n as u64;
+    }
+}
+
+impl Drop for SizeTally {
+    fn drop(&mut self) {
+        let labels = &[self.path.as_ref(), self.role.label()];
+
+        // (role, direction) uniquely determines whether this tally was
+        // tracking the request or the response body:
+        //   client + outbound = request sent; server + inbound = request received
+        //   client + inbound  = response received; server + outbound = response sent
+        let size_histogram = match (self.role, self.direction) {
+            (Role::Client, Direction::Outbound) | (Role::Server, Direction::Inbound) => {
+                &self.metrics.request_size_bytes
+            }
+            (Role::Client, Direction::Inbound) | (Role::Server, Direction::Outbound) => {
+                &self.metrics.response_size_bytes
+            }
+        };
+        size_histogram
+            .with_label_values(labels)
+            .observe(self.bytes as f64);
+
+        let bytes_counter = match self.direction {
+            Direction::Outbound => &self.metrics.bytes_sent_total,
+            Direction::Inbound => &self.metrics.bytes_received_total,
+        };
+        bytes_counter.with_label_values(labels).inc_by(self.bytes);
+    }
+}
+
+/// Single factory for the per-request handler pair used on both ends of
+/// the wire. Construct with [`Self::server`] for the axum-side
+/// CallbackLayer or [`Self::client`] for the tonic-channel-side
+/// CallbackLayer.
+#[derive(Clone)]
+pub struct RpcMetricsMakeCallbackHandler {
+    metrics: Arc<Metrics>,
+    role: Role,
+}
+
+impl RpcMetricsMakeCallbackHandler {
+    pub fn new(metrics: Arc<Metrics>, role: Role) -> Self {
+        Self { metrics, role }
+    }
+
+    pub fn server(metrics: Arc<Metrics>) -> Self {
+        Self::new(metrics, Role::Server)
+    }
+
+    pub fn client(metrics: Arc<Metrics>) -> Self {
+        Self::new(metrics, Role::Client)
+    }
+}
+
+impl callback::MakeCallbackHandler for RpcMetricsMakeCallbackHandler {
+    type RequestHandler = RequestHandler;
+    type ResponseHandler = ResponseHandler;
+
+    fn make_handler(
+        &self,
+        request: &request::Parts,
+    ) -> (Self::RequestHandler, Self::ResponseHandler) {
+        let metrics = self.metrics.clone();
+        let label = self.role.label();
+        let path = extract_path(request, self.role);
+
+        metrics
+            .inflight_requests
+            .with_label_values(&[path.as_ref(), label])
+            .inc();
+
+        let request_handler = RequestHandler {
+            tally: SizeTally::new(
+                metrics.clone(),
+                path.clone(),
+                self.role,
+                self.role.request_direction(),
+            ),
+        };
+        let response_handler = ResponseHandler {
+            tally: SizeTally::new(
+                metrics.clone(),
+                path.clone(),
+                self.role,
+                self.role.response_direction(),
+            ),
+            metrics,
+            role: self.role,
+            path,
+            start: Instant::now(),
+            counted_response: false,
+        };
+        (request_handler, response_handler)
+    }
+}
+
+/// Request-side handler. Tallies request body bytes; path-level metrics
+/// live on [`ResponseHandler`].
+pub struct RequestHandler {
+    tally: SizeTally,
+}
+
+impl callback::RequestHandler for RequestHandler {
+    fn on_body_chunk<B: Buf>(&mut self, chunk: &B) {
+        self.tally.add(chunk.remaining());
+    }
+}
+
+/// Response-side handler. Records path-level RPC metrics
+/// (`inflight_requests`, `request_latency`, the per-status `requests`
+/// counter) labeled by `role`, and tallies response body bytes.
+pub struct ResponseHandler {
+    metrics: Arc<Metrics>,
+    role: Role,
+    path: Cow<'static, str>,
+    start: Instant,
+    // Indicates if we successfully counted the response. In some cases when a request is
+    // prematurely canceled this will remain false.
+    counted_response: bool,
+    tally: SizeTally,
+}
+
+impl callback::ResponseHandler for ResponseHandler {
+    fn on_response(&mut self, response: &response::Parts) {
+        const GRPC_STATUS: http::HeaderName = http::HeaderName::from_static("grpc-status");
+
+        let status = if response
+            .headers
+            .get(&http::header::CONTENT_TYPE)
+            .is_some_and(|content_type| {
+                content_type
+                    .as_bytes()
+                    // check if the content-type starts_with 'application/grpc' in order to
+                    // consider this as a gRPC request. A prefix comparison is done instead of a
+                    // full equality check in order to account for the various types of
+                    // content-types that are considered as gRPC traffic.
+                    .starts_with(tonic::metadata::GRPC_CONTENT_TYPE.as_bytes())
+            }) {
+            let code = response
+                .headers
+                .get(&GRPC_STATUS)
+                .map(http::HeaderValue::as_bytes)
+                .map(tonic::Code::from_bytes)
+                .unwrap_or(tonic::Code::Ok);
+
+            code_as_str(code)
+        } else {
+            response.status.as_str()
+        };
+
+        self.metrics
+            .requests
+            .with_label_values(&[self.path.as_ref(), status, self.role.label()])
+            .inc();
+
+        self.counted_response = true;
+    }
+
+    fn on_service_error<E>(&mut self, _error: &E)
+    where
+        E: std::fmt::Display + 'static,
+    {
+        // Only reachable on the client role: axum requires server
+        // services to be infallible (Error = Infallible), so no service
+        // error can propagate to the server handler. Record under a
+        // distinct status so service-level failures are visible and
+        // aren't lumped in with canceled requests by the `Drop` fallback.
+        self.metrics
+            .requests
+            .with_label_values(&[self.path.as_ref(), "service-error", self.role.label()])
+            .inc();
+        self.counted_response = true;
+    }
+
+    fn on_body_chunk<B: Buf>(&mut self, chunk: &B) {
+        self.tally.add(chunk.remaining());
+    }
+}
+
+impl Drop for ResponseHandler {
+    fn drop(&mut self) {
+        let label = self.role.label();
+
+        self.metrics
+            .inflight_requests
+            .with_label_values(&[self.path.as_ref(), label])
+            .dec();
+
+        let latency = self.start.elapsed().as_secs_f64();
+        self.metrics
+            .request_latency
+            .with_label_values(&[self.path.as_ref(), label])
+            .observe(latency);
+
+        if !self.counted_response {
+            self.metrics
+                .requests
+                .with_label_values(&[self.path.as_ref(), "canceled", label])
+                .inc();
+        }
+    }
+}
+
+fn extract_path(request: &request::Parts, role: Role) -> Cow<'static, str> {
+    match role {
+        Role::Server => extract_server_path(request),
+        Role::Client => extract_client_path(request),
+    }
+}
+
+fn extract_server_path(request: &request::Parts) -> Cow<'static, str> {
+    if let Some(matched_path) = request.extensions.get::<axum::extract::MatchedPath>() {
+        if request
+            .headers
+            .get(&http::header::CONTENT_TYPE)
+            .is_some_and(|header| {
+                header
+                    .as_bytes()
+                    // check if the content-type starts_with 'application/grpc' in order to
+                    // consider this as a gRPC request. A prefix comparison is done instead of a
+                    // full equality check in order to account for the various types of
+                    // content-types that are considered as gRPC traffic.
+                    .starts_with(tonic::metadata::GRPC_CONTENT_TYPE.as_bytes())
+            })
+        {
+            Cow::Owned(request.uri.path().to_owned())
+        } else {
+            Cow::Owned(matched_path.as_str().to_owned())
+        }
+    } else {
+        Cow::Borrowed("unknown")
+    }
+}
+
+/// Build the client-side path label from tonic's [`GrpcMethod`]
+/// extension. Tonic-generated clients populate it with the gRPC service
+/// and method name before the request reaches our tower stack, giving us
+/// a stable label that matches the URI path the server sees. Falls back
+/// to the raw URI path for non-tonic callers.
+///
+/// [`GrpcMethod`]: tonic::GrpcMethod
+fn extract_client_path(request: &request::Parts) -> Cow<'static, str> {
+    if let Some(method) = request.extensions.get::<tonic::GrpcMethod<'static>>() {
+        Cow::Owned(format!("/{}/{}", method.service(), method.method()))
+    } else {
+        Cow::Owned(request.uri.path().to_owned())
+    }
+}
+
+fn code_as_str(code: tonic::Code) -> &'static str {
+    match code {
+        tonic::Code::Ok => "ok",
+        tonic::Code::Cancelled => "canceled",
+        tonic::Code::Unknown => "unknown",
+        tonic::Code::InvalidArgument => "invalid-argument",
+        tonic::Code::DeadlineExceeded => "deadline-exceeded",
+        tonic::Code::NotFound => "not-found",
+        tonic::Code::AlreadyExists => "already-exists",
+        tonic::Code::PermissionDenied => "permission-denied",
+        tonic::Code::ResourceExhausted => "resource-exhausted",
+        tonic::Code::FailedPrecondition => "failed-precondition",
+        tonic::Code::Aborted => "aborted",
+        tonic::Code::OutOfRange => "out-of-range",
+        tonic::Code::Unimplemented => "unimplemented",
+        tonic::Code::Internal => "internal",
+        tonic::Code::Unavailable => "unavailable",
+        tonic::Code::DataLoss => "data-loss",
+        tonic::Code::Unauthenticated => "unauthenticated",
+    }
+}

--- a/crates/hashi/src/grpc/mod.rs
+++ b/crates/hashi/src/grpc/mod.rs
@@ -10,9 +10,11 @@ use tower::ServiceBuilder;
 use crate::Hashi;
 
 mod client;
+pub use client::BoxedChannel;
 pub use client::Client;
 
 pub mod bridge_service;
+pub mod metrics_layer;
 pub mod screener_client;
 
 /// Wrapper that triggers graceful HTTP server shutdown on drop.
@@ -98,7 +100,7 @@ impl HttpService {
             // Add middleware for mapping a request to a known validator
             .map_request(lookup_validator_middleware(self.inner.clone()))
             .layer(sui_http::middleware::callback::CallbackLayer::new(
-                crate::metrics::RpcMetricsMakeCallbackHandler::new(self.inner.metrics.clone()),
+                metrics_layer::RpcMetricsMakeCallbackHandler::server(self.inner.metrics.clone()),
             ));
 
         let router = router.merge(health_endpoint).layer(layers);

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1,11 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::http;
-use std::borrow::Cow;
-use std::sync::Arc;
-use std::time::Instant;
-
 use prometheus::HistogramVec;
 use prometheus::IntCounter;
 use prometheus::IntCounterVec;
@@ -17,15 +12,18 @@ use prometheus::register_int_counter_vec_with_registry;
 use prometheus::register_int_counter_with_registry;
 use prometheus::register_int_gauge_vec_with_registry;
 use prometheus::register_int_gauge_with_registry;
-use sui_http::middleware::callback::MakeCallbackHandler;
-use sui_http::middleware::callback::ResponseHandler;
 
 #[derive(Clone)]
 pub struct Metrics {
-    // RPC metrics
-    inflight_requests: IntGaugeVec,
-    requests: IntCounterVec,
-    request_latency: HistogramVec,
+    // RPC metrics. Visible to `crate::grpc::metrics_layer`, which owns
+    // the tower CallbackLayer handlers that write into them.
+    pub(crate) inflight_requests: IntGaugeVec,
+    pub(crate) requests: IntCounterVec,
+    pub(crate) request_latency: HistogramVec,
+    pub(crate) request_size_bytes: HistogramVec,
+    pub(crate) response_size_bytes: HistogramVec,
+    pub(crate) bytes_sent_total: IntCounterVec,
+    pub(crate) bytes_received_total: IntCounterVec,
 
     pub screener_enabled: IntGauge,
 
@@ -94,6 +92,22 @@ pub const CONFIRMATION_STATUS_LABELS: &[&str] = &[
     "6_plus",
 ];
 
+// Body-size buckets spanning 256 B through 32 MiB. Powers of four keep
+// the bucket count modest while still resolving small and large
+// payloads.
+const MESSAGE_SIZE_BYTES_BUCKETS: &[f64] = &[
+    256.,
+    1_024.,
+    4_096.,
+    16_384.,
+    65_536.,
+    262_144.,
+    1_048_576.,
+    4_194_304.,
+    16_777_216.,
+    33_554_432.,
+];
+
 impl Metrics {
     pub fn new_default() -> Self {
         Self::new(prometheus::default_registry())
@@ -104,22 +118,52 @@ impl Metrics {
             inflight_requests: register_int_gauge_vec_with_registry!(
                 "hashi_inflight_requests",
                 "Total in-flight RPC requests per route",
-                &["path"],
+                &["path", "role"],
                 registry,
             )
             .unwrap(),
             requests: register_int_counter_vec_with_registry!(
                 "hashi_requests",
                 "Total RPC requests per route and their http status",
-                &["path", "status"],
+                &["path", "status", "role"],
                 registry,
             )
             .unwrap(),
             request_latency: register_histogram_vec_with_registry!(
                 "hashi_request_latency",
                 "Latency of RPC requests per route",
-                &["path"],
+                &["path", "role"],
                 LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            request_size_bytes: register_histogram_vec_with_registry!(
+                "hashi_request_size_bytes",
+                "Size of RPC request bodies in bytes, per route",
+                &["path", "role"],
+                MESSAGE_SIZE_BYTES_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            response_size_bytes: register_histogram_vec_with_registry!(
+                "hashi_response_size_bytes",
+                "Size of RPC response bodies in bytes, per route",
+                &["path", "role"],
+                MESSAGE_SIZE_BYTES_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            bytes_sent_total: register_int_counter_vec_with_registry!(
+                "hashi_bytes_sent_total",
+                "Total bytes sent from this node over HTTP/gRPC bodies, per route",
+                &["path", "role"],
+                registry,
+            )
+            .unwrap(),
+            bytes_received_total: register_int_counter_vec_with_registry!(
+                "hashi_bytes_received_total",
+                "Total bytes received by this node over HTTP/gRPC bodies, per route",
+                &["path", "role"],
                 registry,
             )
             .unwrap(),
@@ -512,158 +556,6 @@ impl Metrics {
                 .with_label_values(&[&version_str, &package_id_str])
                 .set(1);
         }
-    }
-}
-
-#[derive(Clone)]
-pub struct RpcMetricsMakeCallbackHandler {
-    metrics: Arc<Metrics>,
-}
-
-impl RpcMetricsMakeCallbackHandler {
-    pub fn new(metrics: Arc<Metrics>) -> Self {
-        Self { metrics }
-    }
-}
-
-impl MakeCallbackHandler for RpcMetricsMakeCallbackHandler {
-    type Handler = RpcMetricsCallbackHandler;
-
-    fn make_handler(&self, request: &http::request::Parts) -> Self::Handler {
-        let start = Instant::now();
-        let metrics = self.metrics.clone();
-
-        let path =
-            if let Some(matched_path) = request.extensions.get::<axum::extract::MatchedPath>() {
-                if request
-                    .headers
-                    .get(&http::header::CONTENT_TYPE)
-                    .is_some_and(|header| {
-                        header
-                            .as_bytes()
-                            // check if the content-type starts_with 'application/grpc' in order to
-                            // consider this as a gRPC request. A prefix comparison is done instead of a
-                            // full equality check in order to account for the various types of
-                            // content-types that are considered as gRPC traffic.
-                            .starts_with(tonic::metadata::GRPC_CONTENT_TYPE.as_bytes())
-                    })
-                {
-                    Cow::Owned(request.uri.path().to_owned())
-                } else {
-                    Cow::Owned(matched_path.as_str().to_owned())
-                }
-            } else {
-                Cow::Borrowed("unknown")
-            };
-
-        metrics
-            .inflight_requests
-            .with_label_values(&[path.as_ref()])
-            .inc();
-
-        RpcMetricsCallbackHandler {
-            metrics,
-            path,
-            start,
-            counted_response: false,
-        }
-    }
-}
-
-pub struct RpcMetricsCallbackHandler {
-    metrics: Arc<Metrics>,
-    path: Cow<'static, str>,
-    start: Instant,
-    // Indicates if we successfully counted the response. In some cases when a request is
-    // prematurely canceled this will remain false
-    counted_response: bool,
-}
-
-impl ResponseHandler for RpcMetricsCallbackHandler {
-    fn on_response(&mut self, response: &http::response::Parts) {
-        const GRPC_STATUS: http::HeaderName = http::HeaderName::from_static("grpc-status");
-
-        let status = if response
-            .headers
-            .get(&http::header::CONTENT_TYPE)
-            .is_some_and(|content_type| {
-                content_type
-                    .as_bytes()
-                    // check if the content-type starts_with 'application/grpc' in order to
-                    // consider this as a gRPC request. A prefix comparison is done instead of a
-                    // full equality check in order to account for the various types of
-                    // content-types that are considered as gRPC traffic.
-                    .starts_with(tonic::metadata::GRPC_CONTENT_TYPE.as_bytes())
-            }) {
-            let code = response
-                .headers
-                .get(&GRPC_STATUS)
-                .map(http::HeaderValue::as_bytes)
-                .map(tonic::Code::from_bytes)
-                .unwrap_or(tonic::Code::Ok);
-
-            code_as_str(code)
-        } else {
-            response.status.as_str()
-        };
-
-        self.metrics
-            .requests
-            .with_label_values(&[self.path.as_ref(), status])
-            .inc();
-
-        self.counted_response = true;
-    }
-
-    fn on_error<E>(&mut self, _error: &E) {
-        // Do nothing if the whole service errored
-        //
-        // in Axum this isn't possible since all services are required to have an error type of
-        // Infallible
-    }
-}
-
-impl Drop for RpcMetricsCallbackHandler {
-    fn drop(&mut self) {
-        self.metrics
-            .inflight_requests
-            .with_label_values(&[self.path.as_ref()])
-            .dec();
-
-        let latency = self.start.elapsed().as_secs_f64();
-        self.metrics
-            .request_latency
-            .with_label_values(&[self.path.as_ref()])
-            .observe(latency);
-
-        if !self.counted_response {
-            self.metrics
-                .requests
-                .with_label_values(&[self.path.as_ref(), "canceled"])
-                .inc();
-        }
-    }
-}
-
-fn code_as_str(code: tonic::Code) -> &'static str {
-    match code {
-        tonic::Code::Ok => "ok",
-        tonic::Code::Cancelled => "canceled",
-        tonic::Code::Unknown => "unknown",
-        tonic::Code::InvalidArgument => "invalid-argument",
-        tonic::Code::DeadlineExceeded => "deadline-exceeded",
-        tonic::Code::NotFound => "not-found",
-        tonic::Code::AlreadyExists => "already-exists",
-        tonic::Code::PermissionDenied => "permission-denied",
-        tonic::Code::ResourceExhausted => "resource-exhausted",
-        tonic::Code::FailedPrecondition => "failed-precondition",
-        tonic::Code::Aborted => "aborted",
-        tonic::Code::OutOfRange => "out-of-range",
-        tonic::Code::Unimplemented => "unimplemented",
-        tonic::Code::Internal => "internal",
-        tonic::Code::Unavailable => "unavailable",
-        tonic::Code::DataLoss => "data-loss",
-        tonic::Code::Unauthenticated => "unauthenticated",
     }
 }
 

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -86,6 +86,7 @@ struct Inner {
     state: RwLock<State>,
     tls_private_key: Option<ed25519_dalek::SigningKey>,
     grpc_max_decoding_message_size: Option<usize>,
+    metrics: Option<Arc<crate::metrics::Metrics>>,
 }
 
 #[derive(Debug)]
@@ -124,6 +125,9 @@ impl OnchainState {
                 .committees
                 .set_grpc_max_decoding_message_size(limit);
         }
+        if let Some(metrics) = metrics.clone() {
+            state.hashi.committees.set_metrics(metrics);
+        }
 
         let (sender, _) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
         let (checkpoint, _) = watch::channel(checkpoint);
@@ -135,6 +139,7 @@ impl OnchainState {
             state: RwLock::new(state),
             tls_private_key,
             grpc_max_decoding_message_size,
+            metrics: metrics.clone(),
         }
         .pipe(Arc::new)
         .pipe(Self);
@@ -208,6 +213,9 @@ impl OnchainState {
         }
         if let Some(limit) = self.0.grpc_max_decoding_message_size {
             hashi.committees.set_grpc_max_decoding_message_size(limit);
+        }
+        if let Some(metrics) = &self.0.metrics {
+            hashi.committees.set_metrics(metrics.clone());
         }
         self.state_mut().hashi = hashi;
     }
@@ -408,8 +416,9 @@ impl OnchainState {
     pub fn bridge_service_client(
         &self,
         validator: &Address,
-    ) -> Option<hashi_types::proto::bridge_service_client::BridgeServiceClient<tonic_rustls::Channel>>
-    {
+    ) -> Option<
+        hashi_types::proto::bridge_service_client::BridgeServiceClient<crate::grpc::BoxedChannel>,
+    > {
         self.state()
             .hashi()
             .committees
@@ -420,7 +429,7 @@ impl OnchainState {
     pub fn mpc_service_client(
         &self,
         validator: &Address,
-    ) -> Option<hashi_types::proto::mpc_service_client::MpcServiceClient<tonic_rustls::Channel>>
+    ) -> Option<hashi_types::proto::mpc_service_client::MpcServiceClient<crate::grpc::BoxedChannel>>
     {
         self.state()
             .hashi()

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -65,6 +65,9 @@ pub struct CommitteeSet {
 
     tls_private_key: Option<ed25519_dalek::SigningKey>,
     grpc_max_decoding_message_size: Option<usize>,
+    // Optional metrics registry propagated to every outbound `Client`
+    // so the tower callback layer can observe RPC traffic.
+    metrics: Option<std::sync::Arc<crate::metrics::Metrics>>,
     clients: BTreeMap<Address, Client>,
 }
 
@@ -120,6 +123,7 @@ impl CommitteeSet {
             committees: BTreeMap::new(),
             tls_private_key: None,
             grpc_max_decoding_message_size: None,
+            metrics: None,
             clients: BTreeMap::new(),
         }
     }
@@ -183,6 +187,12 @@ impl CommitteeSet {
         self
     }
 
+    pub fn set_metrics(&mut self, metrics: std::sync::Arc<crate::metrics::Metrics>) -> &mut Self {
+        self.metrics = Some(metrics);
+        self.update_all_clients();
+        self
+    }
+
     pub fn set_members(&mut self, members: BTreeMap<Address, MemberInfo>) -> &mut Self {
         self.tls_public_key_to_address = members
             .values()
@@ -220,6 +230,9 @@ impl CommitteeSet {
                     .ok()?;
                 if let Some(limit) = self.grpc_max_decoding_message_size {
                     client = client.max_decoding_message_size(limit);
+                }
+                if let Some(metrics) = &self.metrics {
+                    client = client.with_metrics(metrics.clone());
                 }
                 Some((validator, client))
             })
@@ -259,6 +272,9 @@ impl CommitteeSet {
             {
                 if let Some(limit) = self.grpc_max_decoding_message_size {
                     client = client.max_decoding_message_size(limit);
+                }
+                if let Some(metrics) = &self.metrics {
+                    client = client.with_metrics(metrics.clone());
                 }
                 self.clients.insert(validator, client);
             }


### PR DESCRIPTION
Add a tower `CallbackLayer` wired up for both the axum server router and outbound tonic clients (via sui-http's `callback::MakeCallbackHandler`) that records per-route body size and byte-transfer metrics:

- `hashi_request_size_bytes` / `hashi_response_size_bytes` histograms
- `hashi_bytes_sent_total` / `hashi_bytes_received_total` counters

All four are labeled `path` and `role`, where `role` is RFC 9110 terminology for whether this node is acting as the `client` or `server` on the observed connection. The existing `hashi_inflight_requests`, `hashi_requests`, and `hashi_request_latency` metrics gain the same `role` dimension so client-side and server-side traffic can be separated in queries.

Client-side observation requires handing the `Metrics` registry to every outbound `grpc::Client`. `CommitteeSet::set_metrics` plumbs the registry through `OnchainState`, and `Client::with_metrics` attaches the callback layer to the `tonic_rustls::Channel` transport. A boxed transport type (`BoxedChannel`) keeps `Client` cloneable regardless of whether the layer is attached.

Also extract the tower wiring into `src/grpc/metrics_layer.rs` and bump `sui-http` to 0.2.0 for the updated `MakeCallbackHandler` trait.