### PR TITLE
[cli] chunk batch deposit requests to fit PTB cap

### DIFF
--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -272,9 +272,14 @@ async fn request_all(
     );
     println!("{}", "━".repeat(50).dimmed());
 
-    // Submit batch deposit request, chunked to fit within Sui's 1024-command PTB cap.
-    // Each deposit emits 3 move calls, so 300 deposits ≈ 900 commands + shared-object setup.
-    const CHUNK_SIZE: usize = 300;
+    // Submit batch deposit request, chunked to fit Sui's per-PTB runtime limits.
+    // Each `deposit` call does 3 dynamic-field ops on the shared Hashi object
+    // (two `contains` probes on the utxo pool + one `add` into the request bag),
+    // and the object-runtime caps store entries at 1000. So the binding ceiling
+    // is ⌊1000 / 3⌋ = 333 deposits/PTB — tighter than the 1024 command cap
+    // (which would allow 341). Shared objects and pure args are PTB inputs, not
+    // commands.
+    const CHUNK_SIZE: usize = 333;
 
     let sui_client = sui_rpc::Client::new(&config.sui_rpc_url)?;
     let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(sui_client, signer, hashi_ids);

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -272,13 +272,9 @@ async fn request_all(
     );
     println!("{}", "━".repeat(50).dimmed());
 
-    // Submit batch deposit request, chunked to fit Sui's per-PTB runtime limits.
-    // Each `deposit` call does 3 dynamic-field ops on the shared Hashi object
-    // (two `contains` probes on the utxo pool + one `add` into the request bag),
-    // and the object-runtime caps store entries at 1000. So the binding ceiling
-    // is ⌊1000 / 3⌋ = 333 deposits/PTB — tighter than the 1024 command cap
-    // (which would allow 341). Shared objects and pure args are PTB inputs, not
-    // commands.
+    // Each `deposit` call does 3 dynamic-field ops on the shared Hashi object,
+    // and Sui's object-runtime caps store entries at 1000 per PTB — so 333
+    // deposits/PTB is the ceiling.
     const CHUNK_SIZE: usize = 333;
 
     let sui_client = sui_rpc::Client::new(&config.sui_rpc_url)?;

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -272,22 +272,36 @@ async fn request_all(
     );
     println!("{}", "━".repeat(50).dimmed());
 
-    // Submit batch deposit request
+    // Submit batch deposit request, chunked to fit within Sui's 1024-command PTB cap.
+    // Each deposit emits 3 move calls, so 300 deposits ≈ 900 commands + shared-object setup.
+    const CHUNK_SIZE: usize = 300;
+
     let sui_client = sui_rpc::Client::new(&config.sui_rpc_url)?;
     let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(sui_client, signer, hashi_ids);
 
     let txid_address =
         sui_sdk_types::Address::new(bitcoin::hashes::Hash::to_byte_array(parsed_txid));
 
-    print_info("Submitting batch deposit request on Sui...");
+    let total = matching_utxos.len();
+    let mut all_request_ids: Vec<sui_sdk_types::Address> = Vec::with_capacity(total);
 
-    let request_ids = executor
-        .execute_create_deposit_requests_batch(txid_address, &matching_utxos, derivation_path)
-        .await?;
+    for (chunk_idx, chunk) in matching_utxos.chunks(CHUNK_SIZE).enumerate() {
+        print_info(&format!(
+            "Submitting batch {}/{} ({} deposits) on Sui...",
+            chunk_idx + 1,
+            total.div_ceil(CHUNK_SIZE),
+            chunk.len()
+        ));
+
+        let request_ids = executor
+            .execute_create_deposit_requests_batch(txid_address, chunk, derivation_path)
+            .await?;
+        all_request_ids.extend(request_ids);
+    }
 
     println!("\n{}", "Deposit requests created".bold().green());
     println!("{}", "━".repeat(50).dimmed());
-    for (i, request_id) in request_ids.iter().enumerate() {
+    for (i, request_id) in all_request_ids.iter().enumerate() {
         let (vout, amount) = matching_utxos[i];
         println!("  vout {}: {} sats -> request {}", vout, amount, request_id);
     }

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -272,9 +272,7 @@ async fn request_all(
     );
     println!("{}", "━".repeat(50).dimmed());
 
-    // Each `deposit` call does 3 dynamic-field ops on the shared Hashi object,
-    // and Sui's object-runtime caps store entries at 1000 per PTB — so 333
-    // deposits/PTB is the ceiling.
+    // 3 dynamic-field ops per deposit × 1000 object-runtime cap = 333/PTB.
     const CHUNK_SIZE: usize = 333;
 
     let sui_client = sui_rpc::Client::new(&config.sui_rpc_url)?;


### PR DESCRIPTION
## Summary
- `hashi deposit request` built one PTB per matching output (3 move calls each), tripping Sui's per-PTB limits well before the 1000-output case.
- Chunk `matching_utxos` into groups of **333** (tightest safe size: each deposit does 3 dynamic-field ops on the shared Hashi object, and the object-runtime caps store entries at 1000 — below the 1024 command cap).

## Test
Broadcast signet tx `5f1ad4af0f0e24db88f21fe4d15c963075a8803d72da61982e16851e0c2406fe` (1000 × 0.1 BTC).
SUI tx for the 1000 deposits on devnet in 4 chunks (333/333/333/1):
  - chunk 1: `Hi8jLT5FySYiRYAU49MQoY87XWhnqN84RRA68TrS2Ceu`
  - chunk 2: `GBfR6WMshLy4eD2EUM4JsoTU4A1Caa2F9ANzsnQ1wtkw`
  - chunk 3: `DQJRC8mADDjkKYoqgYR9DVt3SzRQ42jGZMQCjghVxSQ5`
  - chunk 4: `G7NTQRbGi4a3eKkWUbujgc3ymXnDkjaAr16gJPgea5jw`