### PR TITLE
Prevent invalid deposits from blocking the queue

### DIFF
--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -59,7 +59,7 @@ impl Hashi {
     pub async fn validate_deposit_request(
         &self,
         deposit_request: &DepositRequest,
-    ) -> Result<(), DepositValidationError> {
+    ) -> Result<(), DepositError> {
         self.validate_deposit_request_on_sui(deposit_request)?;
         self.validate_deposit_request_on_bitcoin(deposit_request)
             .await?;
@@ -70,10 +70,7 @@ impl Hashi {
     /// Run AML/Sanctions checks for the deposit request.
     /// If no screener client is configured, checks are skipped.
     #[tracing::instrument(level = "debug", skip_all, fields(deposit_id = %deposit_request.id))]
-    async fn screen_deposit(
-        &self,
-        deposit_request: &DepositRequest,
-    ) -> Result<(), DepositValidationError> {
+    async fn screen_deposit(&self, deposit_request: &DepositRequest) -> Result<(), DepositError> {
         let Some(screener) = self.screener_client() else {
             tracing::debug!("AML checks skipped: no screener configured");
             return Ok(());
@@ -95,10 +92,10 @@ impl Hashi {
                 &sui_chain_id,
             )
             .await
-            .map_err(|e| DepositValidationError::AmlServiceError(anyhow!(e)))?;
+            .map_err(|e| DepositError::AmlServiceError(anyhow!(e)))?;
 
         if !approved {
-            return Err(DepositValidationError::NeverRetry(anyhow!(
+            return Err(DepositError::AmlRejected(anyhow!(
                 "AML checks failed for source tx {source_tx_hash}, destination {destination_address}, bitcoin chain {bitcoin_chain_id}, sui chain {sui_chain_id}"
             )));
         }
@@ -111,18 +108,18 @@ impl Hashi {
     fn validate_deposit_request_on_sui(
         &self,
         deposit_request: &DepositRequest,
-    ) -> Result<(), DepositValidationError> {
+    ) -> Result<(), DepositError> {
         let state = self.onchain_state().state();
         let deposit_queue = &state.hashi().deposit_queue;
         match deposit_queue.requests().get(&deposit_request.id) {
             None => {
-                return Err(DepositValidationError::NeverRetry(anyhow!(
+                return Err(DepositError::InvalidOnchainRequest(anyhow!(
                     "Deposit request not found on Sui"
                 )));
             }
             Some(onchain_request) => {
                 if onchain_request != deposit_request {
-                    return Err(DepositValidationError::NeverRetry(anyhow!(
+                    return Err(DepositError::InvalidOnchainRequest(anyhow!(
                         "Deposit request fields do not match on-chain state"
                     )));
                 }
@@ -137,7 +134,7 @@ impl Hashi {
                 .spent_utxos()
                 .contains_key(&deposit_request.utxo.id)
         {
-            return Err(DepositValidationError::NeverRetry(anyhow!(
+            return Err(DepositError::DuplicateOrSpentOnSui(anyhow!(
                 "UTXO {:?} is already active or spent",
                 deposit_request.utxo.id
             )));
@@ -159,7 +156,7 @@ impl Hashi {
     async fn validate_deposit_request_on_bitcoin(
         &self,
         deposit_request: &DepositRequest,
-    ) -> Result<(), DepositValidationError> {
+    ) -> Result<(), DepositError> {
         let outpoint = bitcoin::OutPoint {
             txid: deposit_request.utxo.id.txid.into(),
             vout: deposit_request.utxo.id.vout,
@@ -171,14 +168,12 @@ impl Hashi {
             .map_err(|e| match e {
                 DepositConfirmError::UtxoSpent { .. } => {
                     self.metrics.deposits_rejected_utxo_spent.inc();
-                    DepositValidationError::NeverRetry(anyhow!(e))
+                    DepositError::BitcoinUtxoSpent(anyhow!(e))
                 }
-                DepositConfirmError::Other(err) => {
-                    DepositValidationError::BitcoinConfirmFailed(err)
-                }
+                DepositConfirmError::Other(err) => DepositError::BitcoinConfirmFailed(err),
             })?;
         if txout.value.to_sat() != deposit_request.utxo.amount {
-            return Err(DepositValidationError::NeverRetry(anyhow!(
+            return Err(DepositError::DepositDataMismatch(anyhow!(
                 "Bitcoin deposit amount mismatch: got {}, onchain is {}",
                 deposit_request.utxo.amount,
                 txout.value.to_sat(),
@@ -194,24 +189,22 @@ impl Hashi {
         &self,
         script_pubkey: &ScriptBuf,
         deposit_request: &DepositRequest,
-    ) -> Result<(), DepositValidationError> {
+    ) -> Result<(), DepositError> {
         let deposit_address =
             bitcoin::Address::from_script(script_pubkey, self.config.bitcoin_network()).map_err(
                 |e| {
-                    DepositValidationError::NeverRetry(anyhow!(
+                    DepositError::DepositDataMismatch(anyhow!(
                         "Failed to extract address from script_pubkey: {e}"
                     ))
                 },
             )?;
-        let hashi_pubkey = self
-            .get_hashi_pubkey()
-            .map_err(DepositValidationError::NotReady)?;
+        let hashi_pubkey = self.get_hashi_pubkey().map_err(DepositError::NotReady)?;
         let expected_address = self
             .get_deposit_address(&hashi_pubkey, deposit_request.utxo.derivation_path.as_ref())
-            .map_err(DepositValidationError::NeverRetry)?;
+            .map_err(DepositError::DepositDataMismatch)?;
 
         if deposit_address != expected_address {
-            return Err(DepositValidationError::NeverRetry(anyhow!(
+            return Err(DepositError::DepositDataMismatch(anyhow!(
                 "Expected address {expected_address}, got address {deposit_address}",
             )));
         }
@@ -332,8 +325,14 @@ impl Hashi {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum DepositErrorKind {
+    RetryOnNextBlock,
+    NeverRetry,
+}
+
 #[derive(Debug, Error)]
-pub enum DepositValidationError {
+pub enum DepositError {
     #[error("Failed to confirm Bitcoin deposit: {0}")]
     BitcoinConfirmFailed(#[source] anyhow::Error),
 
@@ -343,6 +342,53 @@ pub enum DepositValidationError {
     #[error("Not ready: {0}")]
     NotReady(#[source] anyhow::Error),
 
-    #[error("Never retry: {0}")]
-    NeverRetry(#[source] anyhow::Error),
+    #[error("Invalid on-chain deposit request: {0}")]
+    InvalidOnchainRequest(#[source] anyhow::Error),
+
+    #[error("UTXO is already active or spent on Sui: {0}")]
+    DuplicateOrSpentOnSui(#[source] anyhow::Error),
+
+    #[error("Deposit UTXO has already been spent on Bitcoin: {0}")]
+    BitcoinUtxoSpent(#[source] anyhow::Error),
+
+    #[error("Deposit data mismatch: {0}")]
+    DepositDataMismatch(#[source] anyhow::Error),
+
+    #[error("AML checks rejected deposit: {0}")]
+    AmlRejected(#[source] anyhow::Error),
+
+    #[error("Failed quorum: weight {weight} < {required_weight}")]
+    FailedQuorum { weight: u64, required_weight: u64 },
+
+    #[error("Failed to build deposit certificate: {0}")]
+    CertificateBuildFailed(#[source] anyhow::Error),
+
+    #[error("Failed to create Sui transaction executor: {0}")]
+    ExecutorInitFailed(#[source] anyhow::Error),
+
+    #[error("Failed to confirm deposit on Sui: {0}")]
+    ConfirmDepositFailed(#[source] anyhow::Error),
+
+    #[error("Deposit processing timed out after {0:?}")]
+    TimedOut(std::time::Duration),
+}
+
+impl DepositError {
+    pub(crate) fn kind(&self) -> DepositErrorKind {
+        match self {
+            Self::BitcoinConfirmFailed(_)
+            | Self::AmlServiceError(_)
+            | Self::NotReady(_)
+            | Self::FailedQuorum { .. }
+            | Self::CertificateBuildFailed(_)
+            | Self::ExecutorInitFailed(_)
+            | Self::ConfirmDepositFailed(_)
+            | Self::TimedOut(_) => DepositErrorKind::RetryOnNextBlock,
+            Self::InvalidOnchainRequest(_)
+            | Self::DuplicateOrSpentOnSui(_)
+            | Self::BitcoinUtxoSpent(_)
+            | Self::DepositDataMismatch(_)
+            | Self::AmlRejected(_) => DepositErrorKind::NeverRetry,
+        }
+    }
 }

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -8,6 +8,8 @@ pub(crate) use retry::RetryPolicy;
 use crate::Hashi;
 use crate::btc_monitor::monitor::TxStatus;
 use crate::config::ForceRunAsLeader;
+use crate::deposits::DepositError;
+use crate::deposits::DepositErrorKind;
 use crate::leader::retry::GlobalRetryTracker;
 use crate::leader::retry::RetryTracker;
 use crate::onchain::types::DepositConfirmationMessage;
@@ -59,8 +61,9 @@ pub struct LeaderService {
     inner: Arc<Hashi>,
     withdrawal_approval_retry_tracker: RetryTracker<WithdrawalApprovalErrorKind>,
     withdrawal_commitment_retry_tracker: GlobalRetryTracker<WithdrawalCommitmentErrorKind>,
-    deposit_tasks: JoinSet<(Address, anyhow::Result<()>)>,
-    deposit_refill_pending: bool,
+    deposit_tasks: JoinSet<(Address, Result<(), DepositError>)>,
+    pending_deposit_requests: Vec<DepositRequest>,
+    never_retry_deposit_ids: HashSet<Address>,
     inflight_deposits: HashSet<Address>,
     withdrawal_approval_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     withdrawal_commitment_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
@@ -79,7 +82,8 @@ impl LeaderService {
             withdrawal_approval_retry_tracker: RetryTracker::new(),
             withdrawal_commitment_retry_tracker: GlobalRetryTracker::new(),
             deposit_tasks: JoinSet::new(),
-            deposit_refill_pending: false,
+            pending_deposit_requests: Vec::new(),
+            never_retry_deposit_ids: HashSet::new(),
             inflight_deposits: HashSet::new(),
             withdrawal_approval_task: None,
             withdrawal_commitment_task: None,
@@ -141,8 +145,7 @@ impl LeaderService {
                     self.process_signed_withdrawal_txns();
                     self.check_delete_proposals(checkpoint_timestamp_ms);
 
-                    if self.deposit_refill_pending {
-                        self.deposit_refill_pending = false;
+                    if !self.pending_deposit_requests.is_empty() {
                         self.process_deposit_requests();
                     }
                 }
@@ -164,6 +167,7 @@ impl LeaderService {
                     debug!("New Bitcoin block {block_height}: processing deposit requests");
 
                     self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
+                    self.reload_pending_deposit_requests();
                     self.process_deposit_requests();
                 }
                 Some(result) = self.deposit_tasks.join_next() => {
@@ -171,11 +175,6 @@ impl LeaderService {
                     while let Some(result) = self.deposit_tasks.try_join_next() {
                         self.handle_completed_deposit_task(result);
                     }
-
-                    // Wait for the on-chain watcher to advance before refilling from the
-                    // cached deposit queue, otherwise we can immediately requeue a request
-                    // that was already removed on-chain by the completed task.
-                    self.deposit_refill_pending = true;
                 }
                 Some(result) = self.withdrawal_signing_tasks.join_next() => {
                     self.handle_completed_withdrawal_signing_task(result);
@@ -206,16 +205,31 @@ impl LeaderService {
 
     fn handle_completed_deposit_task(
         &mut self,
-        result: Result<(Address, anyhow::Result<()>), tokio::task::JoinError>,
+        result: Result<(Address, Result<(), DepositError>), tokio::task::JoinError>,
     ) {
-        let mapped = match result {
-            Ok((deposit_id, inner)) => {
+        match result {
+            Ok((deposit_id, result)) => {
                 self.inflight_deposits.remove(&deposit_id);
-                Ok(inner)
+                self.pending_deposit_requests
+                    .retain(|request| request.id != deposit_id);
+                match result {
+                    Ok(()) => {
+                        info!(deposit_id = %deposit_id, "Deposit processed successfully");
+                    }
+                    Err(err) => match err.kind() {
+                        DepositErrorKind::RetryOnNextBlock => {
+                            warn!(deposit_id = %deposit_id, "Deferring deposit until next block: {err:#}");
+                        }
+                        DepositErrorKind::NeverRetry => {
+                            self.never_retry_deposit_ids.insert(deposit_id);
+                            warn!(deposit_id = %deposit_id, "Marking deposit as never retry: {err:#}");
+                        }
+                    },
+                }
             }
-            Err(e) => Err(e),
-        };
-        Self::log_task_result("deposit", mapped);
+            Err(err) if err.is_panic() => error!("deposit task panicked: {err}"),
+            Err(err) => error!("deposit task failed to join: {err}"),
+        }
     }
 
     fn handle_completed_withdrawal_signing_task(
@@ -292,6 +306,26 @@ impl LeaderService {
         is_leader
     }
 
+    fn reload_pending_deposit_requests(&mut self) {
+        let mut deposit_requests = self.inner.onchain_state().deposit_requests();
+        deposit_requests.sort_by_key(|r| r.timestamp_ms);
+        let deposit_ids: HashSet<Address> =
+            deposit_requests.iter().map(|request| request.id).collect();
+        self.inflight_deposits
+            .retain(|deposit_id| deposit_ids.contains(deposit_id));
+        self.never_retry_deposit_ids
+            .retain(|deposit_id| deposit_ids.contains(deposit_id));
+        self.pending_deposit_requests = deposit_requests
+            .into_iter()
+            .filter(|request| !self.never_retry_deposit_ids.contains(&request.id))
+            .collect();
+        debug!(
+            pending_deposits = self.pending_deposit_requests.len(),
+            never_retry_deposits = self.never_retry_deposit_ids.len(),
+            "Reloaded pending deposit worklist"
+        );
+    }
+
     fn is_reconfiguring(&self) -> bool {
         self.inner
             .onchain_state()
@@ -305,27 +339,21 @@ impl LeaderService {
     fn process_deposit_requests(&mut self) {
         if self.inner.onchain_state().state().hashi().config.paused() || self.is_reconfiguring() {
             self.deposit_tasks.abort_all();
+            self.pending_deposit_requests.clear();
             self.inflight_deposits.clear();
             return;
         }
 
-        let mut deposit_requests = self.inner.onchain_state().deposit_requests();
-        deposit_requests.sort_by_key(|r| r.timestamp_ms);
-
-        let deposit_ids: Vec<Address> = deposit_requests.iter().map(|r| r.id).collect();
-        self.inflight_deposits
-            .retain(|deposit_id| deposit_ids.contains(deposit_id));
-
         let max_concurrent = self.inner.config.max_concurrent_leader_job_tasks();
-        for deposit_request in deposit_requests {
+        for deposit_request in self.pending_deposit_requests.clone() {
             if self.deposit_tasks.len() >= max_concurrent {
                 break;
             }
-            if self.inflight_deposits.contains(&deposit_request.id) {
+            let deposit_id = deposit_request.id;
+            if self.inflight_deposits.contains(&deposit_id) {
                 continue;
             }
 
-            let deposit_id = deposit_request.id;
             let inner = self.inner.clone();
 
             self.inflight_deposits.insert(deposit_id);
@@ -338,9 +366,7 @@ impl LeaderService {
 
                 let result = match result {
                     Ok(result) => result,
-                    Err(_) => Err(anyhow::anyhow!(
-                        "deposit {deposit_id} timed out after {LEADER_TASK_TIMEOUT:?}"
-                    )),
+                    Err(_) => Err(DepositError::TimedOut(LEADER_TASK_TIMEOUT)),
                 };
 
                 (deposit_id, result)
@@ -352,17 +378,14 @@ impl LeaderService {
     async fn process_deposit_request(
         inner: Arc<Hashi>,
         deposit_request: DepositRequest,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), DepositError> {
         info!("Processing deposit request");
 
         // Validate deposit_request before asking for signatures
         inner
             .validate_deposit_request(&deposit_request)
             .await
-            .map_err(|e| {
-                debug!("Deposit validation failed: {e}");
-                anyhow::anyhow!(e)
-            })?;
+            .inspect_err(|err| debug!("Deposit validation failed: {err}"))?;
 
         info!("Deposit request validated successfully");
 
@@ -406,14 +429,20 @@ impl LeaderService {
         }
 
         if aggregator.weight() < required_weight {
-            anyhow::bail!(
-                "Aggregate weight of signatures {} is less than required weight {required_weight}",
-                aggregator.weight()
-            );
+            return Err(DepositError::FailedQuorum {
+                weight: aggregator.weight(),
+                required_weight,
+            });
         }
 
-        let signed_message = aggregator.finish()?;
-        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        let signed_message = match aggregator.finish() {
+            Ok(signed_message) => signed_message,
+            Err(err) => return Err(DepositError::CertificateBuildFailed(err.into())),
+        };
+        let mut executor = match SuiTxExecutor::from_hashi(inner.clone()) {
+            Ok(executor) => executor,
+            Err(err) => return Err(DepositError::ExecutorInitFailed(err)),
+        };
         executor
             .execute_confirm_deposit(&deposit_request, signed_message)
             .await
@@ -433,7 +462,8 @@ impl LeaderService {
                     .sui_tx_submissions_total
                     .with_label_values(&["confirm_deposit", "failure"])
                     .inc();
-            })?;
+            })
+            .map_err(DepositError::ConfirmDepositFailed)?;
         Ok(())
     }
 


### PR DESCRIPTION
- Retry deposit requests at most once per Bitcoin block, instead of reprocessing transient failures on every refill.
- Mark permanently invalid deposits as non-retryable so they no longer block later valid deposits in the queue.
- Simplify deposit scheduling by tracking a per-block snapshot of pending requests in the leader.