### PR TITLE
Fix rotation reconstruction panic when `previous_output` is unset

### DIFF
--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -392,12 +392,16 @@ impl MpcManager {
         {
             return Ok(cached_response.clone());
         }
-        let messages = if cache_is_current
-            && let Some(m) = self.get_dealer_messages(
-                request.protocol_type,
-                &request.dealer,
-                request.batch_index,
-            ) {
+        let cached_messages = cache_is_current
+            .then(|| {
+                self.get_dealer_messages(
+                    request.protocol_type,
+                    &request.dealer,
+                    request.batch_index,
+                )
+            })
+            .flatten();
+        let messages = if let Some(m) = cached_messages {
             m
         } else {
             let from_db = match request.protocol_type {
@@ -411,19 +415,22 @@ impl MpcManager {
                     .get_rotation_messages(request.epoch, &request.dealer)
                     .map_err(|e| MpcError::StorageError(e.to_string()))?
                     .map(Messages::Rotation),
-                ProtocolTypeIndicator::NonceGeneration => match request.batch_index {
-                    Some(batch_index) => self
-                        .public_messages_store
-                        .get_nonce_message(request.epoch, batch_index, &request.dealer)
-                        .map_err(|e| MpcError::StorageError(e.to_string()))?
-                        .map(|msg| {
-                            Messages::NonceGeneration(NonceMessage {
-                                batch_index,
-                                message: msg,
-                            })
-                        }),
-                    None => None,
-                },
+                ProtocolTypeIndicator::NonceGeneration => request
+                    .batch_index
+                    .map(|batch_index| -> MpcResult<Option<Messages>> {
+                        Ok(self
+                            .public_messages_store
+                            .get_nonce_message(request.epoch, batch_index, &request.dealer)
+                            .map_err(|e| MpcError::StorageError(e.to_string()))?
+                            .map(|msg| {
+                                Messages::NonceGeneration(NonceMessage {
+                                    batch_index,
+                                    message: msg,
+                                })
+                            }))
+                    })
+                    .transpose()?
+                    .flatten(),
             };
             from_db.ok_or_else(|| MpcError::NotFound("No message from dealer".into()))?
         };
@@ -3403,14 +3410,14 @@ impl MpcManager {
                 }
                 ReconstructionOutcome::NeedsRotationComplaintRecovery {
                     dealer_address,
-                    share_index,
+                    share_index: complained_share_index,
                     complaint,
                     message: _message,
                 } => {
                     tracing::info!(
                         "Complaint during rotation reconstruction for dealer {:?} share {}, recovering via Complain RPC",
                         dealer_address,
-                        share_index,
+                        complained_share_index,
                     );
                     let (source_epoch, rotation_msgs) = {
                         let mgr = mpc_manager.read().unwrap();
@@ -3430,7 +3437,10 @@ impl MpcManager {
                     let signers = {
                         let mut mgr = mpc_manager.write().unwrap();
                         mgr.complaints_to_process.insert(
-                            ComplaintsToProcessKey::Rotation(dealer_address, share_index),
+                            ComplaintsToProcessKey::Rotation(
+                                dealer_address,
+                                complained_share_index,
+                            ),
                             complaint,
                         );
                         Self::collect_signers_for_dealer(

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -387,17 +387,46 @@ impl MpcManager {
             }
         };
         // It is safe to return a response from cache since we already know that dealer was malicious.
-        if let Some(cached_response) = self.complaint_responses.get(&cache_key) {
+        let cache_is_current = request.epoch == self.mpc_config.epoch;
+        if cache_is_current && let Some(cached_response) = self.complaint_responses.get(&cache_key)
+        {
             return Ok(cached_response.clone());
         }
-        let messages = self
-            .get_dealer_messages_with_db_fallback(
+        let messages = if cache_is_current
+            && let Some(m) = self.get_dealer_messages(
                 request.protocol_type,
                 &request.dealer,
-                request.epoch,
                 request.batch_index,
-            )
-            .ok_or_else(|| MpcError::NotFound("No message from dealer".into()))?;
+            ) {
+            m
+        } else {
+            let from_db = match request.protocol_type {
+                ProtocolTypeIndicator::Dkg => self
+                    .public_messages_store
+                    .get_dealer_message(request.epoch, &request.dealer)
+                    .map_err(|e| MpcError::StorageError(e.to_string()))?
+                    .map(Messages::Dkg),
+                ProtocolTypeIndicator::KeyRotation => self
+                    .public_messages_store
+                    .get_rotation_messages(request.epoch, &request.dealer)
+                    .map_err(|e| MpcError::StorageError(e.to_string()))?
+                    .map(Messages::Rotation),
+                ProtocolTypeIndicator::NonceGeneration => match request.batch_index {
+                    Some(batch_index) => self
+                        .public_messages_store
+                        .get_nonce_message(request.epoch, batch_index, &request.dealer)
+                        .map_err(|e| MpcError::StorageError(e.to_string()))?
+                        .map(|msg| {
+                            Messages::NonceGeneration(NonceMessage {
+                                batch_index,
+                                message: msg,
+                            })
+                        }),
+                    None => None,
+                },
+            };
+            from_db.ok_or_else(|| MpcError::NotFound("No message from dealer".into()))?
+        };
         let responses = match messages {
             Messages::Dkg(message) => {
                 let partial_output =
@@ -419,11 +448,6 @@ impl MpcManager {
                 ComplaintResponses::Dkg(complaint_response)
             }
             Messages::Rotation(rotation_messages) => {
-                let previous_output = self.previous_output.as_ref().ok_or_else(|| {
-                    MpcError::NotFound(
-                        "Rotation not started yet — previous output not available".into(),
-                    )
-                })?;
                 let complained_share_index =
                     request
                         .share_index
@@ -440,7 +464,6 @@ impl MpcManager {
                             &request.dealer,
                             share_index,
                             message,
-                            previous_output,
                             request.epoch,
                         )?,
                     );
@@ -457,10 +480,6 @@ impl MpcManager {
                     all_outputs.get(&complained_share_index).ok_or_else(|| {
                         MpcError::ProtocolFailed("No output for complained share".into())
                     })?;
-                let commitment = previous_output
-                    .commitments
-                    .get(&complained_share_index)
-                    .copied();
                 let session_id = self
                     .base_session_id_for_epoch(request.epoch, &ProtocolType::KeyRotation)
                     .rotation_session_id(&request.dealer, complained_share_index);
@@ -469,7 +488,7 @@ impl MpcManager {
                     party_id,
                     threshold,
                     session_id.to_vec(),
-                    commitment,
+                    None,
                     self.encryption_key.clone(),
                 );
                 let complained_response = receiver.handle_complaint(
@@ -514,8 +533,10 @@ impl MpcManager {
                 ComplaintResponses::NonceGeneration(complaint_response)
             }
         };
-        self.complaint_responses
-            .insert(cache_key, responses.clone());
+        if cache_is_current {
+            self.complaint_responses
+                .insert(cache_key, responses.clone());
+        }
         Ok(responses)
     }
 
@@ -1004,16 +1025,27 @@ impl MpcManager {
                     .mpc_complaint_recovery_duration_seconds
                     .with_label_values(&[MPC_LABEL_DKG])
                     .start_timer();
-                let (signers, epoch) = {
+                let (signers, epoch, message) = {
                     let mgr = mpc_manager.read().unwrap();
                     let signers = dkg_cert
                         .signers(&mgr.committee)
                         .expect("certificate verified above");
-                    (signers, mgr.mpc_config.epoch)
+                    let message = mgr
+                        .dkg_messages
+                        .get(&dealer)
+                        .ok_or_else(|| {
+                            MpcError::ProtocolFailed(format!(
+                                "No DKG message for dealer {:?} during complaint recovery",
+                                dealer
+                            ))
+                        })?
+                        .clone();
+                    (signers, mgr.mpc_config.epoch, message)
                 };
                 let recovered = Self::recover_shares_via_complaint(
                     mpc_manager,
                     &dealer,
+                    &message,
                     signers,
                     p2p_channel,
                     epoch,
@@ -1280,12 +1312,22 @@ impl MpcManager {
                 .await?;
                 drop(_timer);
             }
-            let (signers, epoch) = {
+            let (signers, epoch, rotation_msgs) = {
                 let mgr = mpc_manager.read().unwrap();
                 let signers = rotation_cert
                     .signers(&mgr.committee)
                     .expect("certificate verified above");
-                (signers, mgr.mpc_config.epoch)
+                let msgs = mgr
+                    .rotation_messages
+                    .get(&dealer)
+                    .ok_or_else(|| {
+                        MpcError::ProtocolFailed(format!(
+                            "No rotation messages for dealer {:?} during complaint recovery",
+                            dealer
+                        ))
+                    })?
+                    .clone();
+                (signers, mgr.mpc_config.epoch, msgs)
             };
             let _timer = metrics
                 .mpc_complaint_recovery_duration_seconds
@@ -1294,7 +1336,7 @@ impl MpcManager {
             let recovered = Self::recover_rotation_shares_via_complaints(
                 mpc_manager,
                 &dealer,
-                previous,
+                &rotation_msgs,
                 signers,
                 p2p_channel,
                 epoch,
@@ -2335,11 +2377,12 @@ impl MpcManager {
     async fn recover_shares_via_complaint(
         mpc_manager: &Arc<RwLock<Self>>,
         dealer: &Address,
+        message: &avss::Message,
         signers: Vec<Address>,
         p2p_channel: &impl P2PChannel,
         epoch: u64,
     ) -> MpcResult<avss::PartialOutput> {
-        let (complaint_request, receiver, message) = {
+        let (complaint_request, receiver) = {
             let mgr = mpc_manager.read().unwrap();
             let complaint = mgr
                 .complaints_to_process
@@ -2365,12 +2408,7 @@ impl MpcManager {
                 None,
                 mgr.encryption_key.clone(),
             );
-            let message = mgr
-                .dkg_messages
-                .get(dealer)
-                .expect("cannot have complaint without message")
-                .clone();
-            (complaint_request, receiver, message)
+            (complaint_request, receiver)
         };
         let receiver = Arc::new(receiver);
         let mut responses = Vec::new();
@@ -2530,7 +2568,7 @@ impl MpcManager {
     async fn recover_rotation_shares_via_complaints(
         mpc_manager: &Arc<RwLock<Self>>,
         dealer: &Address,
-        previous_dkg_output: &MpcOutput,
+        rotation_messages: &RotationMessages,
         signers: Vec<Address>,
         p2p_channel: &impl P2PChannel,
         epoch: u64,
@@ -2540,7 +2578,7 @@ impl MpcManager {
             let Some(RotationComplainContext {
                 request,
                 recovery_contexts,
-            }) = mgr.prepare_rotation_complain_request(dealer, previous_dkg_output, epoch)?
+            }) = mgr.prepare_rotation_complain_request(dealer, rotation_messages, epoch)?
             else {
                 return Ok(HashMap::new());
             };
@@ -2657,13 +2695,9 @@ impl MpcManager {
     fn prepare_rotation_complain_request(
         &self,
         dealer: &Address,
-        previous_dkg_output: &MpcOutput,
+        rotation_messages: &RotationMessages,
         epoch: u64,
     ) -> MpcResult<Option<RotationComplainContext>> {
-        let rotation_messages = self
-            .rotation_messages
-            .get(dealer)
-            .expect("cannot have complaint without message");
         let complained_shares: Vec<(ShareIndex, complaint::Complaint)> = self
             .complaints_to_process
             .iter()
@@ -2683,13 +2717,12 @@ impl MpcManager {
             HashMap::new();
         for (share_index, _complaint) in &complained_shares {
             let session_id = base_sid.rotation_session_id(dealer, *share_index);
-            let commitment = previous_dkg_output.commitments.get(share_index).copied();
             let receiver = avss::Receiver::new(
                 nodes.clone(),
                 party_id,
                 threshold,
                 session_id.to_vec(),
-                commitment,
+                None,
                 self.encryption_key.clone(),
             );
             let message = rotation_messages
@@ -3000,11 +3033,10 @@ impl MpcManager {
                     outputs.insert(dealer_party_id, output);
                 }
                 avss::ProcessedMessage::Complaint(complaint) => {
-                    return Ok(ReconstructionOutcome::NeedsComplaintRecovery {
+                    return Ok(ReconstructionOutcome::NeedsDkgComplaintRecovery {
                         dealer_address,
                         complaint,
                         message,
-                        protocol_type: ProtocolTypeIndicator::Dkg,
                     });
                 }
             }
@@ -3124,11 +3156,11 @@ impl MpcManager {
                         local_outputs.insert(share_index, output);
                     }
                     avss::ProcessedMessage::Complaint(complaint) => {
-                        return Ok(ReconstructionOutcome::NeedsComplaintRecovery {
+                        return Ok(ReconstructionOutcome::NeedsRotationComplaintRecovery {
                             dealer_address,
+                            share_index,
                             complaint,
                             message,
-                            protocol_type: ProtocolTypeIndicator::KeyRotation,
                         });
                     }
                 }
@@ -3333,110 +3365,128 @@ impl MpcManager {
             .await?
             {
                 ReconstructionOutcome::Success(output) => return Ok(output),
-                ReconstructionOutcome::NeedsComplaintRecovery {
+                ReconstructionOutcome::NeedsDkgComplaintRecovery {
                     dealer_address,
                     complaint,
                     message,
-                    protocol_type,
                 } => {
                     tracing::info!(
-                        "Complaint during {:?} reconstruction for dealer {:?}, recovering via Complain RPC",
-                        protocol_type,
+                        "Complaint during DKG reconstruction for dealer {:?}, recovering via Complain RPC",
                         dealer_address
                     );
                     let signers = {
                         let mut mgr = mpc_manager.write().unwrap();
-                        match protocol_type {
-                            ProtocolTypeIndicator::Dkg => {
-                                mgr.complaints_to_process
-                                    .insert(ComplaintsToProcessKey::Dkg(dealer_address), complaint);
-                                mgr.dkg_messages.insert(dealer_address, message);
-                            }
-                            ProtocolTypeIndicator::KeyRotation => {
-                                if let Ok(Some(rotation_msgs)) = mgr
-                                    .public_messages_store
-                                    .get_rotation_messages(mgr.source_epoch, &dealer_address)
-                                {
-                                    mgr.rotation_messages.insert(dealer_address, rotation_msgs);
-                                }
-                            }
-                            ProtocolTypeIndicator::NonceGeneration => unreachable!(
-                                "Nonce gen complaints are handled by reconstruct_presignatures_with_complaint_recovery"
-                            ),
-                        }
-                        let previous_committee = mgr
-                            .previous_committee
-                            .as_ref()
-                            .expect("previous_committee must be set");
-                        previous_certificates
-                            .iter()
-                            .filter_map(|c| {
-                                let msg = match c {
-                                    CertificateV1::Dkg(dc) => dc.message(),
-                                    CertificateV1::Rotation(rc) => rc.message(),
-                                    _ => return None,
-                                };
-                                if msg.dealer_address == dealer_address {
-                                    c.signers(previous_committee).ok()
-                                } else {
-                                    None
-                                }
-                            })
-                            .next()
-                            .unwrap_or_default()
+                        mgr.complaints_to_process
+                            .insert(ComplaintsToProcessKey::Dkg(dealer_address), complaint);
+                        Self::collect_signers_for_dealer(
+                            &mgr,
+                            previous_certificates,
+                            &dealer_address,
+                        )
                     };
-                    match protocol_type {
-                        ProtocolTypeIndicator::Dkg => {
-                            let source_epoch = mpc_manager.read().unwrap().source_epoch;
-                            let recovered = Self::recover_shares_via_complaint(
-                                mpc_manager,
-                                &dealer_address,
-                                signers,
-                                p2p_channel,
-                                source_epoch,
-                            )
-                            .await?;
-                            complaint_cache
-                                .insert(DealerOutputsKey::Dkg(dealer_address), recovered);
-                            mpc_manager
-                                .write()
-                                .unwrap()
-                                .complaints_to_process
-                                .remove(&ComplaintsToProcessKey::Dkg(dealer_address));
-                        }
-                        ProtocolTypeIndicator::KeyRotation => {
-                            let (previous_output, source_epoch) = {
-                                let mgr = mpc_manager.read().unwrap();
-                                (
-                                    mgr.previous_output
-                                        .clone()
-                                        .expect("previous_output must be set"),
-                                    mgr.source_epoch,
-                                )
-                            };
-                            let recovered = Self::recover_rotation_shares_via_complaints(
-                                mpc_manager,
-                                &dealer_address,
-                                &previous_output,
-                                signers,
-                                p2p_channel,
-                                source_epoch,
-                            )
-                            .await?;
-                            let mut mgr = mpc_manager.write().unwrap();
-                            for (share_index, output) in recovered {
-                                complaint_cache
-                                    .insert(DealerOutputsKey::Rotation(share_index), output);
-                                mgr.complaints_to_process.remove(
-                                    &ComplaintsToProcessKey::Rotation(dealer_address, share_index),
-                                );
-                            }
-                        }
-                        ProtocolTypeIndicator::NonceGeneration => {}
+                    let source_epoch = mpc_manager.read().unwrap().source_epoch;
+                    let recovered = Self::recover_shares_via_complaint(
+                        mpc_manager,
+                        &dealer_address,
+                        &message,
+                        signers,
+                        p2p_channel,
+                        source_epoch,
+                    )
+                    .await?;
+                    complaint_cache.insert(DealerOutputsKey::Dkg(dealer_address), recovered);
+                    mpc_manager
+                        .write()
+                        .unwrap()
+                        .complaints_to_process
+                        .remove(&ComplaintsToProcessKey::Dkg(dealer_address));
+                }
+                ReconstructionOutcome::NeedsRotationComplaintRecovery {
+                    dealer_address,
+                    share_index,
+                    complaint,
+                    message: _message,
+                } => {
+                    tracing::info!(
+                        "Complaint during rotation reconstruction for dealer {:?} share {}, recovering via Complain RPC",
+                        dealer_address,
+                        share_index,
+                    );
+                    let (source_epoch, rotation_msgs) = {
+                        let mgr = mpc_manager.read().unwrap();
+                        let source_epoch = mgr.source_epoch;
+                        let msgs = mgr
+                            .public_messages_store
+                            .get_rotation_messages(source_epoch, &dealer_address)
+                            .map_err(|e| MpcError::StorageError(e.to_string()))?
+                            .ok_or_else(|| {
+                                MpcError::NotFound(format!(
+                                    "Rotation messages not found for dealer {:?}",
+                                    dealer_address
+                                ))
+                            })?;
+                        (source_epoch, msgs)
+                    };
+                    let signers = {
+                        let mut mgr = mpc_manager.write().unwrap();
+                        mgr.complaints_to_process.insert(
+                            ComplaintsToProcessKey::Rotation(dealer_address, share_index),
+                            complaint,
+                        );
+                        Self::collect_signers_for_dealer(
+                            &mgr,
+                            previous_certificates,
+                            &dealer_address,
+                        )
+                    };
+                    let recovered = Self::recover_rotation_shares_via_complaints(
+                        mpc_manager,
+                        &dealer_address,
+                        &rotation_msgs,
+                        signers,
+                        p2p_channel,
+                        source_epoch,
+                    )
+                    .await?;
+                    let mut mgr = mpc_manager.write().unwrap();
+                    for (share_index, output) in recovered {
+                        complaint_cache.insert(DealerOutputsKey::Rotation(share_index), output);
+                        mgr.complaints_to_process
+                            .remove(&ComplaintsToProcessKey::Rotation(
+                                dealer_address,
+                                share_index,
+                            ));
                     }
                 }
             }
         }
+    }
+
+    fn collect_signers_for_dealer(
+        mgr: &Self,
+        previous_certificates: &[CertificateV1],
+        dealer_address: &Address,
+    ) -> Vec<Address> {
+        let previous_committee = mgr
+            .previous_committee
+            .as_ref()
+            .expect("previous_committee must be set");
+        previous_certificates
+            .iter()
+            .filter_map(|c| {
+                let msg = match c {
+                    CertificateV1::Dkg(dc) => dc.message(),
+                    CertificateV1::Rotation(rc) => rc.message(),
+                    _ => return None,
+                };
+                if msg.dealer_address == *dealer_address {
+                    c.signers(previous_committee).ok()
+                } else {
+                    None
+                }
+            })
+            .next()
+            .unwrap_or_default()
     }
 
     /// Reconstruct presignatures from DB, recovering via Complain RPCs if
@@ -3723,17 +3773,16 @@ impl MpcManager {
         dealer: &Address,
         share_index: ShareIndex,
         message: &avss::Message,
-        previous_output: &MpcOutput,
         epoch: u64,
     ) -> MpcResult<avss::PartialOutput> {
-        if let Some(output) = self
-            .dealer_outputs
-            .get(&DealerOutputsKey::Rotation(share_index))
+        if epoch == self.mpc_config.epoch
+            && let Some(output) = self
+                .dealer_outputs
+                .get(&DealerOutputsKey::Rotation(share_index))
         {
             return Ok(output.clone());
         }
         let (nodes, party_id, threshold) = self.config_for_epoch(epoch)?;
-        let commitment = previous_output.commitments.get(&share_index).copied();
         let base_sid = self.base_session_id_for_epoch(epoch, &ProtocolType::KeyRotation);
         let session_id = base_sid.rotation_session_id(dealer, share_index);
         match process_avss_message(
@@ -3743,7 +3792,7 @@ impl MpcManager {
             threshold,
             session_id.to_vec(),
             message,
-            commitment,
+            None,
         )? {
             avss::ProcessedMessage::Valid(output) => Ok(output),
             avss::ProcessedMessage::Complaint(_) => Err(MpcError::NotFound(
@@ -3772,45 +3821,6 @@ impl MpcManager {
                 self.nonce_messages
                     .get(&(batch_index, *dealer))
                     .map(|m| Messages::NonceGeneration(m.clone()))
-            }
-        }
-    }
-
-    fn get_dealer_messages_with_db_fallback(
-        &self,
-        protocol_type: ProtocolTypeIndicator,
-        dealer: &Address,
-        epoch: u64,
-        batch_index: Option<u32>,
-    ) -> Option<Messages> {
-        if let Some(messages) = self.get_dealer_messages(protocol_type, dealer, batch_index) {
-            return Some(messages);
-        }
-        match protocol_type {
-            ProtocolTypeIndicator::Dkg => self
-                .public_messages_store
-                .get_dealer_message(epoch, dealer)
-                .ok()
-                .flatten()
-                .map(Messages::Dkg),
-            ProtocolTypeIndicator::KeyRotation => self
-                .public_messages_store
-                .get_rotation_messages(epoch, dealer)
-                .ok()
-                .flatten()
-                .map(Messages::Rotation),
-            ProtocolTypeIndicator::NonceGeneration => {
-                let batch_index = batch_index?;
-                self.public_messages_store
-                    .get_nonce_message(epoch, batch_index, dealer)
-                    .ok()
-                    .flatten()
-                    .map(|msg| {
-                        Messages::NonceGeneration(NonceMessage {
-                            batch_index,
-                            message: msg,
-                        })
-                    })
             }
         }
     }

--- a/crates/hashi/src/mpc/mpc_except_signing_tests.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing_tests.rs
@@ -41,81 +41,18 @@ const TEST_BATCH_SIZE_PER_WEIGHT: u16 = 50;
 fn unwrap_reconstruction_success(outcome: ReconstructionOutcome) -> MpcOutput {
     match outcome {
         ReconstructionOutcome::Success(output) => output,
-        ReconstructionOutcome::NeedsComplaintRecovery { dealer_address, .. } => {
-            panic!("Expected Success, got NeedsComplaintRecovery for dealer {dealer_address}")
+        ReconstructionOutcome::NeedsDkgComplaintRecovery { dealer_address, .. } => {
+            panic!("Expected Success, got NeedsDkgComplaintRecovery for dealer {dealer_address}")
         }
-    }
-}
-
-struct MockPublicMessagesStore;
-
-impl PublicMessagesStore for MockPublicMessagesStore {
-    fn store_dealer_message(
-        &mut self,
-        _epoch: u64,
-        _dealer: &Address,
-        _message: &avss::Message,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    fn get_dealer_message(
-        &self,
-        _epoch: u64,
-        _dealer: &Address,
-    ) -> anyhow::Result<Option<avss::Message>> {
-        Ok(None)
-    }
-
-    fn list_all_dealer_messages(&self) -> anyhow::Result<Vec<(Address, Messages)>> {
-        Ok(vec![])
-    }
-
-    fn store_rotation_messages(
-        &mut self,
-        _epoch: u64,
-        _dealer: &Address,
-        _messages: &RotationMessages,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    fn get_rotation_messages(
-        &self,
-        _epoch: u64,
-        _dealer: &Address,
-    ) -> anyhow::Result<Option<RotationMessages>> {
-        Ok(None)
-    }
-
-    fn list_all_rotation_messages(&self) -> anyhow::Result<Vec<(Address, Messages)>> {
-        Ok(vec![])
-    }
-
-    fn store_nonce_message(
-        &mut self,
-        _epoch: u64,
-        _batch_index: u32,
-        _dealer: &Address,
-        _message: &batch_avss::Message,
-    ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    fn get_nonce_message(
-        &self,
-        _epoch: u64,
-        _batch_index: u32,
-        _dealer: &Address,
-    ) -> anyhow::Result<Option<batch_avss::Message>> {
-        Ok(None)
-    }
-
-    fn list_nonce_messages(
-        &self,
-        _batch_index: u32,
-    ) -> anyhow::Result<Vec<(Address, batch_avss::Message)>> {
-        Ok(vec![])
+        ReconstructionOutcome::NeedsRotationComplaintRecovery {
+            dealer_address,
+            share_index,
+            ..
+        } => {
+            panic!(
+                "Expected Success, got NeedsRotationComplaintRecovery for dealer {dealer_address} share {share_index}"
+            )
+        }
     }
 }
 
@@ -297,7 +234,10 @@ impl TestSetup {
     }
 
     fn create_manager(&self, validator_index: usize) -> MpcManager {
-        self.create_manager_with_store(validator_index, Box::new(MockPublicMessagesStore))
+        self.create_manager_with_store(
+            validator_index,
+            Box::new(InMemoryPublicMessagesStore::new()),
+        )
     }
 
     fn create_manager_with_store(
@@ -929,7 +869,7 @@ fn test_mpc_manager_new_from_committee_set() {
         session_id,
         encryption_key,
         signing_key,
-        Box::new(MockPublicMessagesStore),
+        Box::new(InMemoryPublicMessagesStore::new()),
         TEST_CHAIN_ID,
         None,
         TEST_BATCH_SIZE_PER_WEIGHT,
@@ -991,7 +931,7 @@ fn test_mpc_manager_new_fails_if_no_committee_for_epoch() {
         session_id,
         encryption_keys[0].clone(),
         signing_keys[0].clone(),
-        Box::new(MockPublicMessagesStore),
+        Box::new(InMemoryPublicMessagesStore::new()),
         "test",
         None,
         TEST_BATCH_SIZE_PER_WEIGHT,
@@ -3403,6 +3343,7 @@ async fn test_recover_shares_via_complaint_succeeds_with_exact_threshold() {
     let result = MpcManager::recover_shares_via_complaint(
         &party_manager,
         &dealer_addr,
+        inner_msg,
         signer_addresses,
         &mock_p2p,
         setup.epoch(),
@@ -3482,6 +3423,7 @@ async fn test_recover_shares_via_complaint_skips_failed_signers() {
     let result = MpcManager::recover_shares_via_complaint(
         &party_manager,
         &dealer_addr,
+        inner_msg,
         signer_addresses,
         &mock_p2p,
         setup.epoch(),
@@ -3548,6 +3490,7 @@ async fn test_recover_shares_via_complaint_no_complaint_for_dealer() {
     let result = MpcManager::recover_shares_via_complaint(
         &party_manager,
         &dealer_addr,
+        dealer_message_raw,
         signers,
         &mock_p2p,
         setup.epoch(),
@@ -3589,9 +3532,13 @@ async fn test_recover_shares_via_complaint_p2p_failure() {
     // Call recover_shares_via_complaint - should fail because P2P call fails
     // With retry logic, failed signers are skipped (continue), so we get ProtocolFailed
     // instead of BroadcastError
+    let Messages::Dkg(inner_msg) = &dealer_message else {
+        unreachable!()
+    };
     let result = MpcManager::recover_shares_via_complaint(
         &party_manager,
         &dealer_addr,
+        inner_msg,
         signer_addresses,
         &mock_p2p,
         setup.epoch(),
@@ -3656,6 +3603,7 @@ async fn test_recover_shares_via_complaint_insufficient_signers() {
     let result = MpcManager::recover_shares_via_complaint(
         &party_manager,
         &dealer_addr,
+        inner_msg,
         signer_addresses,
         &mock_p2p,
         setup.epoch(),
@@ -3674,54 +3622,6 @@ async fn test_recover_shares_via_complaint_insufficient_signers() {
         "Error message should indicate insufficient responses, got: {}",
         err
     );
-}
-
-#[tokio::test]
-#[should_panic(expected = "cannot have complaint without message")]
-async fn test_recover_shares_via_complaint_no_dealer_message() {
-    let mut rng = rand::thread_rng();
-    let setup = TestSetup::new(5);
-    let dealer_addr = setup.address(0);
-
-    // Create cheating message with corrupted shares for party 1
-    let cheating_message = Messages::Dkg(create_cheating_message(&setup, 0, 1, &mut rng));
-
-    // Party 1 receives corrupted message and creates complaint
-    let party_addr = setup.address(1);
-    let mut party_manager = setup.create_manager(1);
-    let Messages::Dkg(inner_msg) = &cheating_message else {
-        unreachable!()
-    };
-    party_manager
-        .store_dkg_message(party_manager.mpc_config.epoch, dealer_addr, inner_msg)
-        .unwrap();
-    party_manager
-        .process_certified_dkg_message(dealer_addr)
-        .unwrap();
-    // DKG: complaints keyed by dealer address
-    assert!(
-        party_manager
-            .complaints_to_process
-            .contains_key(&ComplaintsToProcessKey::Dkg(dealer_addr))
-    );
-
-    // Remove the dealer message to simulate the edge case
-    party_manager.dkg_messages.remove(&dealer_addr);
-
-    // Create mock P2P (empty is fine since we should fail before contacting anyone)
-    let mock_p2p = MockP2PChannel::new(HashMap::new(), party_addr);
-
-    let party_manager = Arc::new(RwLock::new(party_manager));
-
-    // Try to recover - should fail because dealer message is missing
-    let _ = MpcManager::recover_shares_via_complaint(
-        &party_manager,
-        &dealer_addr,
-        vec![Address::new([2; 32])],
-        &mock_p2p,
-        setup.epoch(),
-    )
-    .await;
 }
 
 #[tokio::test]
@@ -3803,6 +3703,7 @@ async fn test_recover_shares_via_complaint_crypto_error() {
     let result = MpcManager::recover_shares_via_complaint(
         &party_manager,
         &dealer_addr,
+        inner_msg,
         vec![addr3, addr4],
         &p2p,
         setup.epoch(),
@@ -6676,7 +6577,7 @@ async fn test_recover_rotation_shares_via_complaint_success() {
 
     // Create test party (validator 2, weight=4) - this party will be the victim
     let test_party_idx = 2;
-    let (mut test_manager, test_dkg_output) =
+    let (mut test_manager, _test_dkg_output) =
         rotation_setup.create_receiver_with_memory_store(test_party_idx);
     let test_addr = rotation_setup.setup.address(test_party_idx);
 
@@ -6811,7 +6712,7 @@ async fn test_recover_rotation_shares_via_complaint_success() {
     let result = MpcManager::recover_rotation_shares_via_complaints(
         &test_manager,
         &dealer_addr,
-        &test_dkg_output,
+        cheating_map_ref,
         signers,
         &mock_p2p,
         rotation_setup.setup.epoch(),

--- a/crates/hashi/src/mpc/types.rs
+++ b/crates/hashi/src/mpc/types.rs
@@ -196,11 +196,16 @@ pub struct RetrieveMessagesResponse {
 #[allow(clippy::large_enum_variant)]
 pub enum ReconstructionOutcome {
     Success(MpcOutput),
-    NeedsComplaintRecovery {
+    NeedsDkgComplaintRecovery {
         dealer_address: Address,
         complaint: complaint::Complaint,
         message: avss::Message,
-        protocol_type: ProtocolTypeIndicator,
+    },
+    NeedsRotationComplaintRecovery {
+        dealer_address: Address,
+        share_index: ShareIndex,
+        complaint: complaint::Complaint,
+        message: avss::Message,
     },
 }
 

--- a/crates/internal-tools/src/key_recovery.rs
+++ b/crates/internal-tools/src/key_recovery.rs
@@ -157,9 +157,18 @@ pub async fn run(args: Args, onchain_state: &OnchainState, chain_id: &str) -> an
                 recovered_pubkey = Some(output.public_key);
                 all_shares.extend(output.key_shares.shares.iter().cloned());
             }
-            ReconstructionOutcome::NeedsComplaintRecovery { dealer_address, .. } => {
+            ReconstructionOutcome::NeedsDkgComplaintRecovery { dealer_address, .. } => {
                 println!(
-                    "  Warning: needs complaint recovery for dealer {dealer_address}, skipping"
+                    "  Warning: needs DKG complaint recovery for dealer {dealer_address}, skipping"
+                );
+            }
+            ReconstructionOutcome::NeedsRotationComplaintRecovery {
+                dealer_address,
+                share_index,
+                ..
+            } => {
+                println!(
+                    "  Warning: needs rotation complaint recovery for dealer {dealer_address} share {share_index}, skipping"
                 );
             }
         }


### PR DESCRIPTION
#95 