### PR TITLE
[btc] Fix incorrect bitcoin fee estimation

### DIFF
--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -521,8 +521,16 @@ impl Monitor {
         conf_target: u16,
         result_tx: oneshot::Sender<Result<FeeRate>>,
     ) {
+        // ECONOMICAL tracks spot fees more closely than the default
+        // CONSERVATIVE, which blends in a long-horizon max.
         let result = btc_rpc_call(&bitcoind_rpc, move |rpc| {
-            rpc.estimate_smart_fee(conf_target as u32)
+            rpc.call::<corepc_client::types::v29::EstimateSmartFee>(
+                "estimatesmartfee",
+                &[
+                    serde_json::json!(conf_target as u32),
+                    serde_json::json!("ECONOMICAL"),
+                ],
+            )
         })
         .await
         .map_err(anyhow::Error::from)

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -170,6 +170,14 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_mempool_chain_depth: Option<usize>,
 
+    /// Confirmation target (blocks) passed to `estimatesmartfee` when
+    /// pricing withdrawal miner fees. Low-traffic chains (e.g. signet)
+    /// need a high value (≥ 49) so Core's long-horizon estimator is used.
+    ///
+    /// Defaults to 3.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub withdrawal_fee_conf_target: Option<u16>,
+
     /// Test-only: corrupt AVSS shares sent to this address, triggering the
     /// complaint recovery flow. Must not be set on mainnet or testnet.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -365,6 +373,10 @@ impl Config {
     pub fn max_mempool_chain_depth(&self) -> usize {
         self.max_mempool_chain_depth
             .unwrap_or(crate::utxo_pool::CoinSelectionParams::DEFAULT_MAX_MEMPOOL_CHAIN_DEPTH)
+    }
+
+    pub fn withdrawal_fee_conf_target(&self) -> u16 {
+        self.withdrawal_fee_conf_target.unwrap_or(3)
     }
 
     // Creates a new config suitable for testing. In particular this config will:

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -48,9 +48,6 @@ use thiserror::Error;
 
 const WITHDRAWAL_SIGNING_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Default confirmation target for fee estimation (3 blocks ~ 30 minutes).
-const WITHDRAWAL_FEE_CONF_TARGET: u16 = 3;
-
 /// Fee rate tolerance multiplier for validation.
 const FEE_RATE_TOLERANCE_MULTIPLIER: u64 = 5;
 
@@ -343,7 +340,7 @@ impl Hashi {
             // a floor of 1 sat/vB, then cap at the tolerance multiplier.
             let kyoto_fee_rate = self
                 .btc_monitor()
-                .get_recent_fee_rate(WITHDRAWAL_FEE_CONF_TARGET)
+                .get_recent_fee_rate(self.config.withdrawal_fee_conf_target())
                 .await?;
             let clamped_fee_rate = std::cmp::max(kyoto_fee_rate, min_fee_rate);
             let estimated_fee = clamped_fee_rate
@@ -731,7 +728,7 @@ impl Hashi {
         // fee rate threshold to avoid overpaying during fee spikes.
         let kyoto_fee_rate = self
             .btc_monitor()
-            .get_recent_fee_rate(WITHDRAWAL_FEE_CONF_TARGET)
+            .get_recent_fee_rate(self.config.withdrawal_fee_conf_target())
             .await
             .map_err(|e| WithdrawalCommitmentError::FeeEstimateFailed(anyhow!(e)))?;
         let min_fee_rate = CoinSelectionParams::DEFAULT_MIN_FEE_RATE;

--- a/design/src/fees.md
+++ b/design/src/fees.md
@@ -49,8 +49,10 @@ usually well below the worst case, so the user receives more.
 ## Fee rate estimation
 
 Hashi obtains the current fee rate from the connected Bitcoin Core
-node via `estimatesmartfee`, targeting confirmation within 3 blocks
-(~30 minutes).
+node via `estimatesmartfee` in `ECONOMICAL` mode, targeting
+confirmation within `withdrawal_fee_conf_target` blocks (default `3`,
+~30 minutes). Low-traffic chains like signet may need a higher target
+to route the estimator to its long-horizon bucket.
 
 The estimated fee rate is then capped at a high fee rate threshold
 (30 sat/vB by default). This prevents a single fee spike from


### PR DESCRIPTION
## Issue

Bitcoin Core's estimatesmartfee only looks at the last ~2 hours of mempool data on the default conf_target=3, but signet has so few transactions that those buckets are empty, so Core falls back to the lowest fee rate it has any sample for (~10 sat/vB, populated by occasional load-test txs)

Setting the conf_target to 100, uses the 1 week horizon which has plenty of 1 sat/vB samples and so the node reports the correct rate

## Changes

- Call `estimatesmartfee` in `ECONOMICAL` mode (was defaulting to `CONSERVATIVE`).
- Add `withdrawal_fee_conf_target` config field (default `3`) so deployments can override.

## Test
```
kubectl -n bitcoin-core-signet exec -i bitcoin-core-0 -c bitcoin-core -- bitcoin-cli -conf=/etc/bitcoin/bitcoin.conf -datadir=/bitcoin estimatesmartfee 100 ECONOMICAL

{
  "feerate": 0.00000977,
  "blocks": 100
}
```

MystenLabs/sui-operations#7691 sets the withdrawal_fee_conf_target to 100 for signet