### PR TITLE
Keep executed proposals on-chain and emit data in ProposalExecutedEvent

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -42,7 +42,7 @@ pub struct Hashi {
     pub committees: CommitteeSet,
     pub config: Config,
     pub treasury: Treasury,
-    pub proposals: ObjectBag,
+    pub proposals: Proposals,
     /// TOB certificates by (epoch, batch_index) -> EpochCertsV1
     pub tob: Bag,
     /// Number of presignatures consumed in the current epoch.
@@ -222,6 +222,15 @@ pub struct MetadataCap {
 pub struct Coin {
     pub id: Address,
     pub balance: u64,
+}
+
+/// Rust version of the Move hashi::proposals::Proposals type.
+#[derive(Debug, serde_derive::Deserialize)]
+pub struct Proposals {
+    /// Proposals that have been created but not yet executed.
+    pub active: ObjectBag,
+    /// Proposals that have executed successfully (kept indefinitely).
+    pub executed: ObjectBag,
 }
 
 /// Rust version of the Move hashi::deposit_queue::DepositRequestQueue type.
@@ -410,7 +419,6 @@ pub struct Proposal<T> {
     pub timestamp_ms: u64,
     pub metadata: VecMap<String, String>,
     pub data: T,
-    pub executed: bool,
 }
 
 /// Rust version of the Move hashi::update_config::UpdateConfig type.

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -410,6 +410,7 @@ pub struct Proposal<T> {
     pub timestamp_ms: u64,
     pub metadata: VecMap<String, String>,
     pub data: T,
+    pub executed: bool,
 }
 
 /// Rust version of the Move hashi::update_config::UpdateConfig type.
@@ -768,15 +769,29 @@ impl From<ProposalDeletedEvent> for HashiEvent {
 pub struct ProposalExecutedEvent {
     pub proposal_id: Address,
     pub proposal_type: TypeTag,
+    /// BCS-encoded bytes of the proposal `data` payload (`T` in the Move
+    /// `ProposalExecutedEvent<T>`). Decode using `proposal_type` to get the
+    /// typed value.
+    pub data_bcs: Vec<u8>,
 }
 
 impl ProposalExecutedEvent {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let proposal_type = extract_type_param::<Self>(event_type)?;
-        let proposal_id: Address = bcs::from_bytes(bcs)?;
+        // Layout is `(proposal_id: Address, data: T)`; Address is a fixed
+        // 32-byte BCS encoding with no length prefix, so split there.
+        if bcs.len() < 32 {
+            anyhow::bail!(
+                "ProposalExecutedEvent payload too short: {} bytes",
+                bcs.len()
+            );
+        }
+        let proposal_id: Address = bcs::from_bytes(&bcs[..32])?;
+        let data_bcs = bcs[32..].to_vec();
         Ok(Self {
             proposal_id,
             proposal_type,
+            data_bcs,
         })
     }
 }

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -234,82 +234,88 @@ impl HashiClient {
         use sui_rpc::proto::sui::rpc::v2::DynamicField;
         use sui_rpc::proto::sui::rpc::v2::ListDynamicFieldsRequest;
 
-        let proposals_bag_id = self.onchain_state.state().hashi().proposals.id;
+        // The proposal could live in either the active or executed bag.
+        // Walk active first (the common case), then executed.
+        let (active_id, executed_id) = {
+            let state = self.onchain_state.state();
+            let proposals = &state.hashi().proposals;
+            (proposals.active_id(), proposals.executed_id())
+        };
         let client = self.onchain_state.client();
-        // Proposals are now stored in an `ObjectBag`, so each entry's payload
-        // lives on `child_object` (a standalone object), not inline on the
-        // `DynamicField` itself.
-        let mut stream = Box::pin(
-            client.list_dynamic_fields(
-                ListDynamicFieldsRequest::default()
-                    .with_parent(proposals_bag_id)
-                    .with_page_size(u32::MAX)
-                    .with_read_mask(FieldMask::from_paths([
-                        DynamicField::path_builder().name().finish(),
-                        DynamicField::path_builder().child_object().object_type(),
-                        DynamicField::path_builder()
-                            .child_object()
-                            .contents()
-                            .finish(),
-                    ])),
-            ),
-        );
 
-        while let Some(field) = stream.try_next().await? {
-            // The bag key is BCS-encoded `ID`, which is equivalent to `Address`.
-            let Ok(key) = bcs::from_bytes::<Address>(field.name().value()) else {
-                continue;
-            };
-            if key != proposal_id {
-                continue;
+        for bag_id in [active_id, executed_id] {
+            let mut stream = Box::pin(
+                client.list_dynamic_fields(
+                    ListDynamicFieldsRequest::default()
+                        .with_parent(bag_id)
+                        .with_page_size(u32::MAX)
+                        .with_read_mask(FieldMask::from_paths([
+                            DynamicField::path_builder().name().finish(),
+                            DynamicField::path_builder().child_object().object_type(),
+                            DynamicField::path_builder()
+                                .child_object()
+                                .contents()
+                                .finish(),
+                        ])),
+                ),
+            );
+
+            while let Some(field) = stream.try_next().await? {
+                // The bag key is BCS-encoded `ID`, which is equivalent to `Address`.
+                let Ok(key) = bcs::from_bytes::<Address>(field.name().value()) else {
+                    continue;
+                };
+                if key != proposal_id {
+                    continue;
+                }
+
+                let object_type_str = field.child_object().object_type();
+                let type_tag: TypeTag = object_type_str
+                    .parse()
+                    .with_context(|| format!("parse object_type {object_type_str:?}"))?;
+                let proposal_type = parse_proposal_type(&type_tag);
+
+                let value_bytes = field.child_object().contents().value();
+                let (creator, votes, quorum_threshold_bps, metadata) = match proposal_type {
+                    ProposalType::UpdateConfig => {
+                        let p: move_types::Proposal<move_types::UpdateConfig> =
+                            bcs::from_bytes(value_bytes).context("deserialize UpdateConfig")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
+                    ProposalType::EnableVersion => {
+                        let p: move_types::Proposal<move_types::EnableVersion> =
+                            bcs::from_bytes(value_bytes).context("deserialize EnableVersion")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
+                    ProposalType::DisableVersion => {
+                        let p: move_types::Proposal<move_types::DisableVersion> =
+                            bcs::from_bytes(value_bytes).context("deserialize DisableVersion")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
+                    ProposalType::Upgrade => {
+                        let p: move_types::Proposal<move_types::Upgrade> =
+                            bcs::from_bytes(value_bytes).context("deserialize Upgrade")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
+                    ProposalType::EmergencyPause => {
+                        let p: move_types::Proposal<move_types::EmergencyPause> =
+                            bcs::from_bytes(value_bytes).context("deserialize EmergencyPause")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
+                    ProposalType::Unknown(s) => {
+                        anyhow::bail!("Cannot fetch details for unknown proposal type: {s}")
+                    }
+                };
+                return Ok(ProposalDetails {
+                    creator,
+                    votes,
+                    quorum_threshold_bps,
+                    metadata,
+                });
             }
-
-            let object_type_str = field.child_object().object_type();
-            let type_tag: TypeTag = object_type_str
-                .parse()
-                .with_context(|| format!("parse object_type {object_type_str:?}"))?;
-            let proposal_type = parse_proposal_type(&type_tag);
-
-            let value_bytes = field.child_object().contents().value();
-            let (creator, votes, quorum_threshold_bps, metadata) = match proposal_type {
-                ProposalType::UpdateConfig => {
-                    let p: move_types::Proposal<move_types::UpdateConfig> =
-                        bcs::from_bytes(value_bytes).context("deserialize UpdateConfig")?;
-                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
-                }
-                ProposalType::EnableVersion => {
-                    let p: move_types::Proposal<move_types::EnableVersion> =
-                        bcs::from_bytes(value_bytes).context("deserialize EnableVersion")?;
-                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
-                }
-                ProposalType::DisableVersion => {
-                    let p: move_types::Proposal<move_types::DisableVersion> =
-                        bcs::from_bytes(value_bytes).context("deserialize DisableVersion")?;
-                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
-                }
-                ProposalType::Upgrade => {
-                    let p: move_types::Proposal<move_types::Upgrade> =
-                        bcs::from_bytes(value_bytes).context("deserialize Upgrade")?;
-                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
-                }
-                ProposalType::EmergencyPause => {
-                    let p: move_types::Proposal<move_types::EmergencyPause> =
-                        bcs::from_bytes(value_bytes).context("deserialize EmergencyPause")?;
-                    (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
-                }
-                ProposalType::Unknown(s) => {
-                    anyhow::bail!("Cannot fetch details for unknown proposal type: {s}")
-                }
-            };
-            return Ok(ProposalDetails {
-                creator,
-                votes,
-                quorum_threshold_bps,
-                metadata,
-            });
         }
 
-        anyhow::bail!("Proposal {proposal_id} not found in proposals bag")
+        anyhow::bail!("Proposal {proposal_id} not found in proposals bags")
     }
 
     /// Fetch the MPC public key bytes from on-chain state

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -754,7 +754,7 @@ impl Metrics {
         {
             use crate::onchain::types::ProposalType;
             let mut counts = std::collections::HashMap::<&str, i64>::new();
-            for proposal in hashi.proposals.proposals().values() {
+            for proposal in hashi.proposals.active().values() {
                 *counts.entry(proposal.proposal_type.as_str()).or_default() += 1;
             }
             for label in ProposalType::all_labels() {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -1280,42 +1280,43 @@ async fn scrape_proposals(
 
         // Deserialize proposal based on the proposal type
         let contents: &[u8] = field.child_object().contents().value();
-        let result: Option<(Address, u64)> = match &proposal_type {
+        let result: Option<(Address, u64, bool)> = match &proposal_type {
             types::ProposalType::UpdateConfig => {
                 bcs::from_bytes::<move_types::Proposal<move_types::UpdateConfig>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms))
+                    .map(|p| (p.id, p.timestamp_ms, p.executed))
             }
             types::ProposalType::EnableVersion => {
                 bcs::from_bytes::<move_types::Proposal<move_types::EnableVersion>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms))
+                    .map(|p| (p.id, p.timestamp_ms, p.executed))
             }
             types::ProposalType::DisableVersion => {
                 bcs::from_bytes::<move_types::Proposal<move_types::DisableVersion>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms))
+                    .map(|p| (p.id, p.timestamp_ms, p.executed))
             }
             types::ProposalType::Upgrade => {
                 bcs::from_bytes::<move_types::Proposal<move_types::Upgrade>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms))
+                    .map(|p| (p.id, p.timestamp_ms, p.executed))
             }
             types::ProposalType::EmergencyPause => {
                 bcs::from_bytes::<move_types::Proposal<move_types::EmergencyPause>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms))
+                    .map(|p| (p.id, p.timestamp_ms, p.executed))
             }
             types::ProposalType::Unknown(_) => None,
         };
 
-        if let Some((id, timestamp_ms)) = result {
+        if let Some((id, timestamp_ms, executed)) = result {
             proposals.insert(
                 id,
                 types::Proposal {
                     id,
                     timestamp_ms,
                     proposal_type,
+                    executed,
                 },
             );
         } else {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -257,20 +257,39 @@ impl OnchainState {
         self.state().hashi.committees.mpc_public_key().to_vec()
     }
 
-    /// Returns all active proposals.
+    /// Returns all active (not-yet-executed) proposals.
     pub fn proposals(&self) -> Vec<types::Proposal> {
         self.state()
             .hashi
             .proposals
-            .proposals()
+            .active()
             .values()
             .cloned()
             .collect()
     }
 
-    /// Returns a specific proposal by ID, if it exists.
+    /// Returns all executed proposals.
+    pub fn executed_proposals(&self) -> Vec<types::Proposal> {
+        self.state()
+            .hashi
+            .proposals
+            .executed()
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    /// Returns a specific proposal by ID, looking in active first then
+    /// executed.
     pub fn proposal(&self, id: &Address) -> Option<types::Proposal> {
-        self.state().hashi.proposals.proposals().get(id).cloned()
+        let state = self.state();
+        state
+            .hashi
+            .proposals
+            .active()
+            .get(id)
+            .or_else(|| state.hashi.proposals.executed().get(id))
+            .cloned()
     }
 
     /// Returns all committee members for the current epoch.
@@ -1238,8 +1257,26 @@ async fn scrape_spent_utxos(
 
 async fn scrape_proposals(
     client: Client,
-    proposals_bag: move_types::ObjectBag,
+    proposals: move_types::Proposals,
 ) -> Result<types::Proposals> {
+    let active_id = proposals.active.id;
+    let executed_id = proposals.executed.id;
+    let (active, executed) = tokio::try_join!(
+        scrape_proposal_bag(client.clone(), proposals.active),
+        scrape_proposal_bag(client, proposals.executed),
+    )?;
+    Ok(types::Proposals {
+        active_id,
+        executed_id,
+        active,
+        executed,
+    })
+}
+
+async fn scrape_proposal_bag(
+    client: Client,
+    bag: move_types::ObjectBag,
+) -> Result<BTreeMap<Address, types::Proposal>> {
     let mut proposals: BTreeMap<Address, types::Proposal> = BTreeMap::new();
 
     // Proposals live in a `0x2::object_bag::ObjectBag`, so each entry's
@@ -1249,7 +1286,7 @@ async fn scrape_proposals(
     let mut stream = client
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
-                .with_parent(proposals_bag.id)
+                .with_parent(bag.id)
                 .with_page_size(u32::MAX)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
@@ -1280,43 +1317,42 @@ async fn scrape_proposals(
 
         // Deserialize proposal based on the proposal type
         let contents: &[u8] = field.child_object().contents().value();
-        let result: Option<(Address, u64, bool)> = match &proposal_type {
+        let result: Option<(Address, u64)> = match &proposal_type {
             types::ProposalType::UpdateConfig => {
                 bcs::from_bytes::<move_types::Proposal<move_types::UpdateConfig>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms, p.executed))
+                    .map(|p| (p.id, p.timestamp_ms))
             }
             types::ProposalType::EnableVersion => {
                 bcs::from_bytes::<move_types::Proposal<move_types::EnableVersion>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms, p.executed))
+                    .map(|p| (p.id, p.timestamp_ms))
             }
             types::ProposalType::DisableVersion => {
                 bcs::from_bytes::<move_types::Proposal<move_types::DisableVersion>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms, p.executed))
+                    .map(|p| (p.id, p.timestamp_ms))
             }
             types::ProposalType::Upgrade => {
                 bcs::from_bytes::<move_types::Proposal<move_types::Upgrade>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms, p.executed))
+                    .map(|p| (p.id, p.timestamp_ms))
             }
             types::ProposalType::EmergencyPause => {
                 bcs::from_bytes::<move_types::Proposal<move_types::EmergencyPause>>(contents)
                     .ok()
-                    .map(|p| (p.id, p.timestamp_ms, p.executed))
+                    .map(|p| (p.id, p.timestamp_ms))
             }
             types::ProposalType::Unknown(_) => None,
         };
 
-        if let Some((id, timestamp_ms, executed)) = result {
+        if let Some((id, timestamp_ms)) = result {
             proposals.insert(
                 id,
                 types::Proposal {
                     id,
                     timestamp_ms,
                     proposal_type,
-                    executed,
                 },
             );
         } else {
@@ -1324,11 +1360,7 @@ async fn scrape_proposals(
         }
     }
 
-    Ok(types::Proposals {
-        id: proposals_bag.id,
-        size: proposals_bag.size,
-        proposals,
-    })
+    Ok(proposals)
 }
 
 pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -418,27 +418,41 @@ impl MemberInfo {
     }
 }
 
-/// Proposals bag - stores governance proposals by ID
+/// Two-bag store mirroring the on-chain `hashi::proposals::Proposals`
+/// shape. Active proposals are awaiting votes/execution; executed
+/// proposals are archived for historical inspection.
 #[derive(Debug)]
 pub struct Proposals {
-    pub id: Address,
-    pub size: u64,
-    pub(crate) proposals: BTreeMap<Address, Proposal>,
+    pub(crate) active_id: Address,
+    pub(crate) executed_id: Address,
+    pub(crate) active: BTreeMap<Address, Proposal>,
+    pub(crate) executed: BTreeMap<Address, Proposal>,
 }
 
 impl Proposals {
-    pub fn proposals(&self) -> &BTreeMap<Address, Proposal> {
-        &self.proposals
+    pub fn active_id(&self) -> Address {
+        self.active_id
+    }
+
+    pub fn executed_id(&self) -> Address {
+        self.executed_id
+    }
+
+    pub fn active(&self) -> &BTreeMap<Address, Proposal> {
+        &self.active
+    }
+
+    pub fn executed(&self) -> &BTreeMap<Address, Proposal> {
+        &self.executed
     }
 }
 
-/// A proposal stored in the proposals bag
+/// A proposal stored in either the active or executed bag.
 #[derive(Clone, Debug)]
 pub struct Proposal {
     pub id: Address,
     pub timestamp_ms: u64,
     pub proposal_type: ProposalType,
-    pub executed: bool,
 }
 
 /// The type of proposal data stored in a `Proposal<T>`

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -438,6 +438,7 @@ pub struct Proposal {
     pub id: Address,
     pub timestamp_ms: u64,
     pub proposal_type: ProposalType,
+    pub executed: bool,
 }
 
 /// The type of proposal data stored in a `Proposal<T>`

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -181,13 +181,12 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                     proposal_type: parse_proposal_type_from_type_tag(
                         &proposal_created_event.proposal_type,
                     ),
-                    executed: false,
                 };
                 state
                     .state_mut()
                     .hashi
                     .proposals
-                    .proposals
+                    .active
                     .insert(proposal.id, proposal);
             }
             HashiEvent::ProposalDeletedEvent(proposal_deleted_event) => {
@@ -195,21 +194,24 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                     .state_mut()
                     .hashi
                     .proposals
-                    .proposals
+                    .active
                     .remove(&proposal_deleted_event.proposal_id);
             }
             HashiEvent::ProposalExecutedEvent(proposal_executed_event) => {
-                // Executed proposals stay in the on-chain ObjectBag so they
-                // remain inspectable; mirror that here by marking the entry
-                // executed instead of removing it.
-                if let Some(proposal) = state
-                    .state_mut()
-                    .hashi
-                    .proposals
-                    .proposals
-                    .get_mut(&proposal_executed_event.proposal_id)
+                // Move the entry from `active` to `executed` to mirror
+                // the on-chain dual-bag layout. Scope the write lock so
+                // it's released before the async config refetch below.
                 {
-                    proposal.executed = true;
+                    let mut state_lock = state.state_mut();
+                    let proposals = &mut state_lock.hashi.proposals;
+                    if let Some(proposal) = proposals
+                        .active
+                        .remove(&proposal_executed_event.proposal_id)
+                    {
+                        proposals
+                            .executed
+                            .insert(proposal_executed_event.proposal_id, proposal);
+                    }
                 }
 
                 // When an UpdateConfig or EmergencyPause proposal executes,

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -181,6 +181,7 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                     proposal_type: parse_proposal_type_from_type_tag(
                         &proposal_created_event.proposal_type,
                     ),
+                    executed: false,
                 };
                 state
                     .state_mut()
@@ -198,17 +199,24 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                     .remove(&proposal_deleted_event.proposal_id);
             }
             HashiEvent::ProposalExecutedEvent(proposal_executed_event) => {
-                state
+                // Executed proposals stay in the on-chain ObjectBag so they
+                // remain inspectable; mirror that here by marking the entry
+                // executed instead of removing it.
+                if let Some(proposal) = state
                     .state_mut()
                     .hashi
                     .proposals
                     .proposals
-                    .remove(&proposal_executed_event.proposal_id);
+                    .get_mut(&proposal_executed_event.proposal_id)
+                {
+                    proposal.executed = true;
+                }
 
                 // When an UpdateConfig or EmergencyPause proposal executes,
-                // the Hashi object's config field changes on-chain. The event
-                // carries no key/value payload, so re-fetch the config from
-                // the Hashi object to keep the in-memory state current.
+                // the Hashi object's config field changes on-chain. Re-fetch
+                // the config from the Hashi object to keep the in-memory
+                // state current. (The event now carries the typed `data`,
+                // so this could be applied directly in the future.)
                 if matches!(
                     parse_proposal_type_from_type_tag(&proposal_executed_event.proposal_type),
                     ProposalType::UpdateConfig | ProposalType::EmergencyPause

--- a/packages/hashi/sources/core/proposal/events.move
+++ b/packages/hashi/sources/core/proposal/events.move
@@ -24,8 +24,9 @@ public struct ProposalDeletedEvent<phantom T> has copy, drop {
     proposal_id: ID,
 }
 
-public struct ProposalExecutedEvent<phantom T> has copy, drop {
+public struct ProposalExecutedEvent<T> has copy, drop {
     proposal_id: ID,
+    data: T,
 }
 
 public struct QuorumReachedEvent<phantom T> has copy, drop {
@@ -70,9 +71,10 @@ public(package) fun emit_proposal_deleted_event<T>(proposal_id: ID) {
     });
 }
 
-public(package) fun emit_proposal_executed_event<T>(proposal_id: ID) {
+public(package) fun emit_proposal_executed_event<T: copy + drop>(proposal_id: ID, data: T) {
     event::emit(ProposalExecutedEvent<T> {
         proposal_id,
+        data,
     });
 }
 

--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -19,7 +19,6 @@ public struct Proposal<T> has key, store {
     timestamp_ms: u64,
     metadata: VecMap<String, String>,
     data: T,
-    executed: bool,
 }
 
 // ~~~~~~~ Errors ~~~~~~~
@@ -62,11 +61,10 @@ public(package) fun create<T: store>(
         timestamp_ms,
         metadata,
         data,
-        executed: false,
     };
 
     let proposal_id = object::id(&proposal);
-    hashi.proposals_mut().add(proposal_id, proposal);
+    hashi.proposals_mut().active_mut().add(proposal_id, proposal);
     proposal_events::emit_proposal_created_event<T>(proposal_id, timestamp_ms);
     proposal_id
 }
@@ -78,15 +76,26 @@ public(package) fun execute<T: copy + drop + store>(
 ): T {
     hashi.config().assert_version_enabled();
 
-    let proposal: &Proposal<T> = hashi.proposals().borrow(proposal_id);
-    assert!(!proposal.executed, EProposalAlreadyExecuted);
+    // Bag membership is the re-execution gate: an already-executed
+    // proposal lives only in the executed bag. Check that explicitly so
+    // the failure surface is `EProposalAlreadyExecuted` rather than the
+    // ObjectBag's generic missing-key abort.
+    assert!(
+        !hashi.proposals().executed().contains(proposal_id.to_address()),
+        EProposalAlreadyExecuted,
+    );
+    let proposal: Proposal<T> = hashi
+        .proposals_mut()
+        .active_mut()
+        .remove(proposal_id);
+
     assert!(!proposal.is_expired(clock), EProposalExpired);
     assert!(proposal.quorum_reached(hashi), EQuorumNotReached);
 
-    let proposal: &mut Proposal<T> = hashi.proposals_mut().borrow_mut(proposal_id);
-    proposal.executed = true;
     let data = proposal.data;
     let id = proposal.id.to_inner();
+
+    hashi.proposals_mut().executed_mut().add(id.to_address(), proposal);
 
     proposal_events::emit_proposal_executed_event<T>(id, data);
     data
@@ -95,7 +104,7 @@ public(package) fun execute<T: copy + drop + store>(
 public fun vote<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock, ctx: &mut TxContext) {
     assert!(hashi.committee_set().has_member(ctx.sender()), EUnauthorizedCaller);
 
-    let proposal: &mut Proposal<T> = hashi.proposals_mut().borrow_mut(proposal_id);
+    let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
 
     assert!(!proposal.votes.contains(&ctx.sender()), EVoteAlreadyCounted);
     assert!(!proposal.is_expired(clock), EProposalExpired);
@@ -111,7 +120,7 @@ public fun vote<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock, ctx
 public fun remove_vote<T: store>(hashi: &mut Hashi, proposal_id: ID, ctx: &mut TxContext) {
     assert!(hashi.committee_set().has_member(ctx.sender()), EUnauthorizedCaller);
 
-    let proposal: &mut Proposal<T> = hashi.proposals_mut().borrow_mut(proposal_id);
+    let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
     let index = proposal.votes.find_index!(|v| v == &ctx.sender()).destroy_or!(abort ENoVoteFound);
 
     proposal.votes.remove(index);
@@ -137,9 +146,16 @@ public fun is_expired<T>(proposal: &Proposal<T>, clock: &Clock): bool {
 }
 
 public fun delete_expired<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock): T {
-    let proposal: Proposal<T> = hashi.proposals_mut().remove(proposal_id);
+    // Executed proposals are archived in the executed bag and must
+    // never be deletable, even after they expire. Refuse explicitly so
+    // the caller gets `EProposalAlreadyExecuted` instead of the bag's
+    // missing-key abort.
+    assert!(
+        !hashi.proposals().executed().contains(proposal_id.to_address()),
+        EProposalAlreadyExecuted,
+    );
+    let proposal: Proposal<T> = hashi.proposals_mut().active_mut().remove(proposal_id);
 
-    assert!(!proposal.executed, EProposalAlreadyExecuted);
     assert!(proposal.is_expired(clock), EProposalNotExpired);
     proposal.delete()
 }

--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -84,10 +84,7 @@ public(package) fun execute<T: copy + drop + store>(
         !hashi.proposals().executed().contains(proposal_id.to_address()),
         EProposalAlreadyExecuted,
     );
-    let proposal: Proposal<T> = hashi
-        .proposals_mut()
-        .active_mut()
-        .remove(proposal_id);
+    let proposal: Proposal<T> = hashi.proposals_mut().active_mut().remove(proposal_id);
 
     assert!(!proposal.is_expired(clock), EProposalExpired);
     assert!(proposal.quorum_reached(hashi), EQuorumNotReached);

--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -19,6 +19,7 @@ public struct Proposal<T> has key, store {
     timestamp_ms: u64,
     metadata: VecMap<String, String>,
     data: T,
+    executed: bool,
 }
 
 // ~~~~~~~ Errors ~~~~~~~
@@ -34,6 +35,8 @@ const ENoVoteFound: vector<u8> = b"Vote doesn't exist";
 const EProposalNotExpired: vector<u8> = b"Proposal not expired";
 #[error(code = 5)]
 const EProposalExpired: vector<u8> = b"Proposal expired";
+#[error(code = 6)]
+const EProposalAlreadyExecuted: vector<u8> = b"Proposal already executed";
 
 // ~~~~~~~ Public Functions ~~~~~~~
 
@@ -59,6 +62,7 @@ public(package) fun create<T: store>(
         timestamp_ms,
         metadata,
         data,
+        executed: false,
     };
 
     let proposal_id = object::id(&proposal);
@@ -67,16 +71,25 @@ public(package) fun create<T: store>(
     proposal_id
 }
 
-public(package) fun execute<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock): T {
-    let proposal: Proposal<T> = hashi.proposals_mut().remove(proposal_id);
-
-    assert!(proposal.quorum_reached(hashi), EQuorumNotReached);
-    assert!(!proposal.is_expired(clock), EProposalExpired);
-
+public(package) fun execute<T: copy + drop + store>(
+    hashi: &mut Hashi,
+    proposal_id: ID,
+    clock: &Clock,
+): T {
     hashi.config().assert_version_enabled();
 
-    proposal_events::emit_proposal_executed_event<T>(proposal.id.to_inner());
-    proposal.delete()
+    let proposal: &Proposal<T> = hashi.proposals().borrow(proposal_id);
+    assert!(!proposal.executed, EProposalAlreadyExecuted);
+    assert!(!proposal.is_expired(clock), EProposalExpired);
+    assert!(proposal.quorum_reached(hashi), EQuorumNotReached);
+
+    let proposal: &mut Proposal<T> = hashi.proposals_mut().borrow_mut(proposal_id);
+    proposal.executed = true;
+    let data = proposal.data;
+    let id = proposal.id.to_inner();
+
+    proposal_events::emit_proposal_executed_event<T>(id, data);
+    data
 }
 
 public fun vote<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock, ctx: &mut TxContext) {
@@ -126,6 +139,7 @@ public fun is_expired<T>(proposal: &Proposal<T>, clock: &Clock): bool {
 public fun delete_expired<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock): T {
     let proposal: Proposal<T> = hashi.proposals_mut().remove(proposal_id);
 
+    assert!(!proposal.executed, EProposalAlreadyExecuted);
     assert!(proposal.is_expired(clock), EProposalNotExpired);
     proposal.delete()
 }

--- a/packages/hashi/sources/core/proposal/proposals.move
+++ b/packages/hashi/sources/core/proposal/proposals.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module hashi::proposals;
+
+use sui::object_bag::{Self, ObjectBag};
+
+/// Two-bag store for governance proposals. Listing "active proposals"
+/// and "executed proposals" is then a direct walk over the relevant
+/// bag instead of a filter over a single combined bag.
+public struct Proposals has store {
+    /// Proposals that have been created but not yet executed.
+    active: ObjectBag,
+    /// Proposals that have executed successfully. Kept indefinitely
+    /// so historical governance actions remain inspectable.
+    executed: ObjectBag,
+}
+
+public(package) fun create(ctx: &mut TxContext): Proposals {
+    Proposals {
+        active: object_bag::new(ctx),
+        executed: object_bag::new(ctx),
+    }
+}
+
+public(package) fun active(self: &Proposals): &ObjectBag {
+    &self.active
+}
+
+public(package) fun active_mut(self: &mut Proposals): &mut ObjectBag {
+    &mut self.active
+}
+
+public(package) fun executed(self: &Proposals): &ObjectBag {
+    &self.executed
+}
+
+public(package) fun executed_mut(self: &mut Proposals): &mut ObjectBag {
+    &mut self.executed
+}

--- a/packages/hashi/sources/core/proposal/types/disable_version.move
+++ b/packages/hashi/sources/core/proposal/types/disable_version.move
@@ -9,7 +9,7 @@ use sui::{clock::Clock, vec_map::VecMap};
 
 const THRESHOLD_BPS: u64 = 10000;
 
-public struct DisableVersion has drop, store {
+public struct DisableVersion has copy, drop, store {
     version: u64,
 }
 

--- a/packages/hashi/sources/core/proposal/types/emergency_pause.move
+++ b/packages/hashi/sources/core/proposal/types/emergency_pause.move
@@ -14,7 +14,7 @@ use sui::{clock::Clock, vec_map::VecMap};
 const PAUSE_THRESHOLD_BPS: u64 = 5100; // 51% - low quorum for emergencies
 const UNPAUSE_THRESHOLD_BPS: u64 = 6667; // ~2/3 - higher bar for resuming
 
-public struct EmergencyPause has drop, store {
+public struct EmergencyPause has copy, drop, store {
     pause: bool,
 }
 

--- a/packages/hashi/sources/core/proposal/types/emergency_pause.move
+++ b/packages/hashi/sources/core/proposal/types/emergency_pause.move
@@ -26,7 +26,11 @@ public fun propose(
     ctx: &mut TxContext,
 ): ID {
     hashi.config().assert_version_enabled();
-    let threshold = if (pause) { PAUSE_THRESHOLD_BPS } else { UNPAUSE_THRESHOLD_BPS };
+    let threshold = if (pause) {
+        PAUSE_THRESHOLD_BPS
+    } else {
+        UNPAUSE_THRESHOLD_BPS
+    };
     proposal::create(hashi, EmergencyPause { pause }, threshold, metadata, clock, ctx)
 }
 

--- a/packages/hashi/sources/core/proposal/types/enable_version.move
+++ b/packages/hashi/sources/core/proposal/types/enable_version.move
@@ -9,7 +9,7 @@ use sui::{clock::Clock, vec_map::VecMap};
 
 const THRESHOLD_BPS: u64 = 10000;
 
-public struct EnableVersion has drop, store {
+public struct EnableVersion has copy, drop, store {
     version: u64,
 }
 

--- a/packages/hashi/sources/core/proposal/types/update_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_config.move
@@ -12,7 +12,7 @@ const EInvalidConfigEntry: vector<u8> = b"Unknown config key or wrong value type
 
 const THRESHOLD_BPS: u64 = 6667;
 
-public struct UpdateConfig has drop, store {
+public struct UpdateConfig has copy, drop, store {
     key: String,
     value: Value,
 }

--- a/packages/hashi/sources/core/proposal/types/upgrade.move
+++ b/packages/hashi/sources/core/proposal/types/upgrade.move
@@ -21,7 +21,7 @@ use sui::{clock::Clock, package::{UpgradeTicket, UpgradeReceipt}, vec_map::VecMa
 
 const THRESHOLD_BPS: u64 = 10000;
 
-public struct Upgrade has drop, store {
+public struct Upgrade has copy, drop, store {
     digest: vector<u8>,
 }
 

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -9,10 +9,11 @@ use hashi::{
     committee::{CertifiedMessage, Committee, CommitteeSignature},
     committee_set::CommitteeSet,
     config::Config,
+    proposals::{Self, Proposals},
     threshold,
     treasury::Treasury
 };
-use sui::{bag::{Self, Bag}, dynamic_field as df, object_bag::{Self, ObjectBag}};
+use sui::{bag::{Self, Bag}, dynamic_field as df};
 
 #[error]
 const ESystemPaused: vector<u8> = b"System is currently paused";
@@ -28,7 +29,7 @@ public struct Hashi has key {
     committee_set: CommitteeSet,
     config: Config,
     treasury: Treasury,
-    proposals: ObjectBag,
+    proposals: Proposals,
     /// TOB certificates by (epoch, batch_index) -> EpochCertsV1
     tob: Bag,
     /// Number of presignatures consumed in the current epoch.
@@ -48,7 +49,7 @@ fun init(ctx: &mut TxContext) {
             config
         },
         treasury: hashi::treasury::create(ctx),
-        proposals: object_bag::new(ctx),
+        proposals: proposals::create(ctx),
         tob: bag::new(ctx),
         num_consumed_presigs: 0,
     };
@@ -149,11 +150,11 @@ public(package) fun treasury_mut(self: &mut Hashi): &mut Treasury {
     &mut self.treasury
 }
 
-public(package) fun proposals(self: &Hashi): &ObjectBag {
+public(package) fun proposals(self: &Hashi): &Proposals {
     &self.proposals
 }
 
-public(package) fun proposals_mut(self: &mut Hashi): &mut ObjectBag {
+public(package) fun proposals_mut(self: &mut Hashi): &mut Proposals {
     &mut self.proposals
 }
 
@@ -204,7 +205,7 @@ public fun create_for_testing(
     committee_set: CommitteeSet,
     config: Config,
     treasury: Treasury,
-    proposals: ObjectBag,
+    proposals: Proposals,
     tob: Bag,
     ctx: &mut TxContext,
 ): Hashi {

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -353,6 +353,65 @@ fun test_vote_on_expired_proposal_fails() {
 }
 
 #[test]
+#[expected_failure(abort_code = proposal::EProposalAlreadyExecuted)]
+/// Test that re-executing an already-executed proposal fails
+fun test_re_execute_proposal_fails() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        1000,
+        &clock,
+        ctx,
+    );
+
+    // First execute succeeds.
+    hashi::update_config::execute(&mut hashi, proposal_id, &clock);
+
+    // Second execute on the same proposal must fail.
+    hashi::update_config::execute(&mut hashi, proposal_id, &clock);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = proposal::EProposalAlreadyExecuted)]
+/// Test that delete_expired refuses to delete a proposal that was already executed
+fun test_delete_expired_executed_proposal_fails() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        1000,
+        &clock,
+        ctx,
+    );
+
+    // Execute, then advance past expiry.
+    hashi::update_config::execute(&mut hashi, proposal_id, &clock);
+    clock::increment_for_testing(&mut clock, MAX_PROPOSAL_DURATION_MS + 1);
+
+    // delete_expired must refuse — executed proposals are kept forever.
+    let _ = proposal::delete_expired<hashi::update_config::UpdateConfig>(
+        &mut hashi,
+        proposal_id,
+        &clock,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
 #[expected_failure(abort_code = proposal::EProposalExpired)]
 /// Test that executing an expired proposal fails
 fun test_execute_expired_proposal_fails() {

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -180,7 +180,10 @@ fun test_remove_vote() {
 
     // Verify vote exists
     {
-        let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
+        let prop: &proposal::Proposal<UpdateConfig> = hashi
+            .proposals()
+            .active()
+            .borrow(proposal_id);
         assert!(prop.votes().length() == 1);
     };
 

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -37,10 +37,10 @@ fun test_create_proposal() {
     );
 
     // Verify proposal exists
-    assert!(hashi.proposals().contains(proposal_id));
+    assert!(hashi.proposals().active().contains(proposal_id));
 
     // Verify the creator voted automatically
-    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().borrow(proposal_id);
+    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
     assert!(prop.votes().length() == 1);
     assert!(prop.votes().contains(&VOTER1));
 
@@ -96,7 +96,7 @@ fun test_vote_on_proposal() {
     proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx2);
 
     // Verify vote count is now 2
-    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().borrow(proposal_id);
+    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
     assert!(prop.votes().length() == 2);
     assert!(prop.votes().contains(&VOTER1));
     assert!(prop.votes().contains(&VOTER2));
@@ -180,7 +180,7 @@ fun test_remove_vote() {
 
     // Verify vote exists
     {
-        let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().borrow(proposal_id);
+        let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
         assert!(prop.votes().length() == 1);
     };
 
@@ -188,7 +188,7 @@ fun test_remove_vote() {
     proposal::remove_vote<UpdateConfig>(&mut hashi, proposal_id, ctx);
 
     // Verify vote was removed
-    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().borrow(proposal_id);
+    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
     assert!(prop.votes().length() == 0);
 
     // Clean up
@@ -465,7 +465,7 @@ fun test_delete_expired_proposal() {
     std::unit_test::destroy(data);
 
     // Verify proposal no longer exists
-    assert!(!hashi.proposals().contains(proposal_id));
+    assert!(!hashi.proposals().active().contains(proposal_id));
 
     // Clean up
     clock::destroy_for_testing(clock);
@@ -521,7 +521,7 @@ fun test_weighted_quorum() {
     );
 
     // 50% is not enough for 66.67% quorum - verify we need more votes
-    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().borrow(proposal_id);
+    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
     assert!(!proposal::quorum_reached(prop, &hashi));
 
     // VOTER2 votes (now 5/6 = 83% total weight, exceeds 66.67% threshold)
@@ -529,7 +529,7 @@ fun test_weighted_quorum() {
     proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx2);
 
     // 83% exceeds the 66.67% quorum threshold
-    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().borrow(proposal_id);
+    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
     assert!(proposal::quorum_reached(prop, &hashi));
 
     // Execute should succeed
@@ -569,8 +569,8 @@ fun test_multiple_concurrent_proposals() {
     );
 
     // Both proposals should exist
-    assert!(hashi.proposals().contains(proposal_id_1));
-    assert!(hashi.proposals().contains(proposal_id_2));
+    assert!(hashi.proposals().active().contains(proposal_id_1));
+    assert!(hashi.proposals().active().contains(proposal_id_2));
 
     // Execute first proposal
     hashi::update_config::execute(&mut hashi, proposal_id_1, &clock);

--- a/packages/hashi/tests/test_utils.move
+++ b/packages/hashi/tests/test_utils.move
@@ -15,7 +15,7 @@ use hashi::{
     hashi::Hashi,
     update_config
 };
-use sui::{bag, bls12381, clock::Clock, object_bag, vec_map};
+use sui::{bag, bls12381, clock::Clock, vec_map};
 
 // ======== Transaction Context Helpers ========
 
@@ -130,8 +130,8 @@ public fun create_hashi_with_weighted_committee(
     // Create treasury
     let treasury = hashi::treasury::create(ctx);
 
-    // Create proposals bag
-    let proposals = object_bag::new(ctx);
+    // Create proposals store
+    let proposals = hashi::proposals::create(ctx);
 
     // Create TOB bag
     let tob = bag::new(ctx);


### PR DESCRIPTION
## Summary
- Stop deleting governance proposals on `execute` — they stay in the on-chain `ObjectBag` with an `executed: bool` flag so the actual action that was taken remains inspectable forever.
- `ProposalExecutedEvent<T>` now carries the typed `data: T` so off-chain consumers can see what was executed without re-fetching the (now-deleted) proposal.
- Adds `copy` to the five proposal data types so they can be embedded in the event.

## Why `copy` on the proposal data types is safe
The data types (`UpdateConfig`, `EnableVersion`, `DisableVersion`, `EmergencyPause`, `Upgrade`) are pure *descriptors* of governance intent: a key/value pair, a version number, a digest, a bool. The authority to act on them lives in the `Proposal<T>` lifecycle (quorum + `execute`), not in the descriptor itself, so duplicating the value carries no privilege. Every field already supports `copy` (`String`, `u64`, `bool`, `Value`, `vector<u8>`), so this is mechanically valid.

**Forward trade-off:** a future proposal type that carries a non-`copy` resource (e.g. an `EnableNewCoin` proposal that holds a `TreasuryCap<X>`) will not satisfy `T: copy + drop + store`. When that arrives we can add a separate `execute_consuming<T: store>` path that removes from the bag and emits a data-less event, leaving this descriptor path untouched. The current shape is opinionated for the descriptor case, not a ceiling.

## Re-execution and expiry guards
Keeping proposals around after execute requires guarding against re-execution. `execute` now asserts `!executed`, sets it to `true`, and emits/returns the data. `delete_expired` also refuses already-executed proposals so they're kept forever even past the 7-day expiry.

## Off-chain (Rust) changes
- `move_types::Proposal<T>` mirrors the new `executed` field — BCS positional, must match the on-chain layout.
- `move_types::ProposalExecutedEvent` exposes `data_bcs: Vec<u8>` (the proposal id is a fixed 32-byte `Address`, so the remaining bytes are the typed payload — decode per `proposal_type` downstream).
- `onchain::types::Proposal` carries `executed`; `scrape_proposals` plumbs it through.
- Watcher: `ProposalCreatedEvent` initializes `executed: false`; `ProposalExecutedEvent` no longer removes the entry, it marks `executed = true`.
- Existing config-refetch on `UpdateConfig`/`EmergencyPause` is left in place — applying the data directly from the event is a follow-up.

## Coordination
This change is wire-incompatible with previously deployed packages (BCS layout of `Proposal<T>` and `ProposalExecutedEvent` both grow). Rolling out requires a coordinated package upgrade + validator/CLI deploy.

## Test plan
- [x] `sui move test` — all 76 Move tests pass, including new `test_re_execute_proposal_fails` and `test_delete_expired_executed_proposal_fails`
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p hashi-types -p hashi --lib` — 42/42 pass
- [ ] End-to-end: run an `update_config` proposal on localnet, verify `ProposalExecutedEvent` carries the typed data and the proposal stays queryable on-chain with `executed: true`