### PR TITLE
Read bitcoin_confirmation_threshold live in deposit confirmation

### DIFF
--- a/crates/hashi/examples/testnet_monitor.rs
+++ b/crates/hashi/examples/testnet_monitor.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("  Network: {:?}", config.network);
     info!(
         "  Confirmations required: {}",
-        config.confirmation_threshold
+        config.confirmation_threshold.current()
     );
     info!("  Starting height: {}", config.start_height);
     info!("  bitcoind RPC URL: {}", config.bitcoind_rpc_url);

--- a/crates/hashi/examples/testnet_monitor.rs
+++ b/crates/hashi/examples/testnet_monitor.rs
@@ -91,7 +91,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = MonitorConfig::builder()
         .network(Network::Testnet4)
-        .confirmation_threshold(args.confirmations)
         .dns_peers(dns_peers)
         .start_height(args.start_height)
         .bitcoind_rpc_config(args.bitcoind_url.clone(), bitcoind_auth)
@@ -99,10 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Monitor configuration:");
     info!("  Network: {:?}", config.network);
-    info!(
-        "  Confirmations required: {}",
-        config.confirmation_threshold.current()
-    );
+    info!("  Confirmations required: {}", args.confirmations);
     info!("  Starting height: {}", config.start_height);
     info!("  bitcoind RPC URL: {}", config.bitcoind_rpc_url);
     info!("  Initial peers: {}", config.dns_peers.len());
@@ -148,8 +144,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                         // Spawn a task to confirm the deposit
                         let client = monitor_client.clone();
+                        let confirmations = args.confirmations;
                         tokio::spawn(async move {
-                            match client.confirm_deposit(outpoint).await {
+                            match client.confirm_deposit(outpoint, confirmations).await {
                                 Ok(txout) => {
                                     info!("✓ Deposit confirmed for {}", outpoint);
                                     info!("  Value: {} sats", txout.value.to_sat());

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -240,7 +240,8 @@ pub fn network_from_chain_id(chain_id: &str) -> Option<Network> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::atomic::AtomicU32;
+    use std::sync::atomic::Ordering;
 
     /// Test fake whose threshold can be mutated post-construction so we
     /// can verify the monitor reads the value live, not at boot.

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -5,19 +5,45 @@
 
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 
 pub use bitcoin::BlockHash;
 pub use bitcoin::Network;
 use bitcoin::blockdata::constants::genesis_block;
 pub use corepc_client;
 
-#[derive(Debug, Clone)]
+/// Live source of the BTC confirmation threshold, read on every deposit
+/// evaluation so on-chain governance changes (`update_config` for
+/// `bitcoin_confirmation_threshold`) take effect without a validator
+/// restart.
+///
+/// Implemented by `OnchainState` for production and by `StaticThreshold`
+/// for tests/examples that don't need live updates.
+pub trait ConfirmationThresholdSource: Send + Sync {
+    fn current(&self) -> u32;
+}
+
+/// Fixed-value implementation of `ConfirmationThresholdSource` for use
+/// in tests, the standalone `testnet_monitor` example, and as the
+/// fallback when no live source is wired in.
+#[derive(Debug, Clone, Copy)]
+pub struct StaticThreshold(pub u32);
+
+impl ConfirmationThresholdSource for StaticThreshold {
+    fn current(&self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Clone)]
 pub struct MonitorConfig {
     /// Bitcoin network to connect to
     pub network: Network,
 
-    /// Number of confirmations required for a transaction to be considered canonical
-    pub confirmation_threshold: u32,
+    /// Live source of the number of confirmations required for a
+    /// transaction to be considered canonical. Read at every deposit
+    /// evaluation so governance updates are picked up immediately.
+    pub confirmation_threshold: Arc<dyn ConfirmationThresholdSource>,
 
     /// Peers for P2P connections, identified by hostname (or IP) and port.
     /// Re-resolved via DNS on each connection attempt, so IP changes
@@ -41,7 +67,7 @@ impl Default for MonitorConfig {
     fn default() -> Self {
         Self {
             network: Network::Bitcoin,
-            confirmation_threshold: 6,
+            confirmation_threshold: Arc::new(StaticThreshold(6)),
             dns_peers: Vec::new(),
             start_height: 800_000,
             bitcoind_rpc_url: "http://localhost:8332".to_string(),
@@ -59,10 +85,10 @@ impl MonitorConfig {
 }
 
 /// Builder for constructing monitor configuration.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct MonitorConfigBuilder {
     network: Option<Network>,
-    confirmation_threshold: Option<u32>,
+    confirmation_threshold: Option<Arc<dyn ConfirmationThresholdSource>>,
     dns_peers: Vec<kyoto::DnsPeer>,
     start_height: u32,
     bitcoind_rpc_url: Option<String>,
@@ -77,9 +103,23 @@ impl MonitorConfigBuilder {
         self
     }
 
-    /// Set the confirmation threshold for deposits.
+    /// Set a fixed confirmation threshold for deposits. Useful for tests
+    /// and standalone tools that don't have a live governance source.
+    /// Production validators should use
+    /// [`Self::confirmation_threshold_source`] instead so on-chain
+    /// `update_config` actions take effect without a restart.
     pub fn confirmation_threshold(mut self, confirmations: u32) -> Self {
-        self.confirmation_threshold = Some(confirmations);
+        self.confirmation_threshold = Some(Arc::new(StaticThreshold(confirmations)));
+        self
+    }
+
+    /// Set a live source for the confirmation threshold, read at every
+    /// deposit evaluation.
+    pub fn confirmation_threshold_source(
+        mut self,
+        source: Arc<dyn ConfirmationThresholdSource>,
+    ) -> Self {
+        self.confirmation_threshold = Some(source);
         self
     }
 
@@ -200,6 +240,41 @@ pub fn network_from_chain_id(chain_id: &str) -> Option<Network> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Test fake whose threshold can be mutated post-construction so we
+    /// can verify the monitor reads the value live, not at boot.
+    struct AtomicThreshold(AtomicU32);
+
+    impl ConfirmationThresholdSource for AtomicThreshold {
+        fn current(&self) -> u32 {
+            self.0.load(Ordering::Relaxed)
+        }
+    }
+
+    #[test]
+    fn static_threshold_returns_stored_value() {
+        let source = StaticThreshold(6);
+        assert_eq!(source.current(), 6);
+    }
+
+    #[test]
+    fn builder_with_u32_wraps_in_static_source() {
+        let config = MonitorConfig::builder().confirmation_threshold(3).build();
+        assert_eq!(config.confirmation_threshold.current(), 3);
+    }
+
+    #[test]
+    fn live_source_picks_up_updates() {
+        let live = Arc::new(AtomicThreshold(AtomicU32::new(6)));
+        let config = MonitorConfig::builder()
+            .confirmation_threshold_source(live.clone())
+            .build();
+        assert_eq!(config.confirmation_threshold.current(), 6);
+
+        live.0.store(3, Ordering::Relaxed);
+        assert_eq!(config.confirmation_threshold.current(), 3);
+    }
 
     #[test]
     fn test_mainnet_genesis_mapping() {

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -5,45 +5,16 @@
 
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
 
 pub use bitcoin::BlockHash;
 pub use bitcoin::Network;
 use bitcoin::blockdata::constants::genesis_block;
 pub use corepc_client;
 
-/// Live source of the BTC confirmation threshold, read on every deposit
-/// evaluation so on-chain governance changes (`update_config` for
-/// `bitcoin_confirmation_threshold`) take effect without a validator
-/// restart.
-///
-/// Implemented by `OnchainState` for production and by `StaticThreshold`
-/// for tests/examples that don't need live updates.
-pub trait ConfirmationThresholdSource: Send + Sync {
-    fn current(&self) -> u32;
-}
-
-/// Fixed-value implementation of `ConfirmationThresholdSource` for use
-/// in tests, the standalone `testnet_monitor` example, and as the
-/// fallback when no live source is wired in.
-#[derive(Debug, Clone, Copy)]
-pub struct StaticThreshold(pub u32);
-
-impl ConfirmationThresholdSource for StaticThreshold {
-    fn current(&self) -> u32 {
-        self.0
-    }
-}
-
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MonitorConfig {
     /// Bitcoin network to connect to
     pub network: Network,
-
-    /// Live source of the number of confirmations required for a
-    /// transaction to be considered canonical. Read at every deposit
-    /// evaluation so governance updates are picked up immediately.
-    pub confirmation_threshold: Arc<dyn ConfirmationThresholdSource>,
 
     /// Peers for P2P connections, identified by hostname (or IP) and port.
     /// Re-resolved via DNS on each connection attempt, so IP changes
@@ -67,7 +38,6 @@ impl Default for MonitorConfig {
     fn default() -> Self {
         Self {
             network: Network::Bitcoin,
-            confirmation_threshold: Arc::new(StaticThreshold(6)),
             dns_peers: Vec::new(),
             start_height: 800_000,
             bitcoind_rpc_url: "http://localhost:8332".to_string(),
@@ -85,10 +55,9 @@ impl MonitorConfig {
 }
 
 /// Builder for constructing monitor configuration.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct MonitorConfigBuilder {
     network: Option<Network>,
-    confirmation_threshold: Option<Arc<dyn ConfirmationThresholdSource>>,
     dns_peers: Vec<kyoto::DnsPeer>,
     start_height: u32,
     bitcoind_rpc_url: Option<String>,
@@ -100,26 +69,6 @@ impl MonitorConfigBuilder {
     /// Set the Bitcoin network.
     pub fn network(mut self, network: Network) -> Self {
         self.network = Some(network);
-        self
-    }
-
-    /// Set a fixed confirmation threshold for deposits. Useful for tests
-    /// and standalone tools that don't have a live governance source.
-    /// Production validators should use
-    /// [`Self::confirmation_threshold_source`] instead so on-chain
-    /// `update_config` actions take effect without a restart.
-    pub fn confirmation_threshold(mut self, confirmations: u32) -> Self {
-        self.confirmation_threshold = Some(Arc::new(StaticThreshold(confirmations)));
-        self
-    }
-
-    /// Set a live source for the confirmation threshold, read at every
-    /// deposit evaluation.
-    pub fn confirmation_threshold_source(
-        mut self,
-        source: Arc<dyn ConfirmationThresholdSource>,
-    ) -> Self {
-        self.confirmation_threshold = Some(source);
         self
     }
 
@@ -158,9 +107,6 @@ impl MonitorConfigBuilder {
 
         MonitorConfig {
             network: self.network.unwrap_or(default.network),
-            confirmation_threshold: self
-                .confirmation_threshold
-                .unwrap_or(default.confirmation_threshold),
             dns_peers: self.dns_peers,
             start_height: self.start_height,
             bitcoind_rpc_url: self.bitcoind_rpc_url.unwrap_or(default.bitcoind_rpc_url),
@@ -240,42 +186,6 @@ pub fn network_from_chain_id(chain_id: &str) -> Option<Network> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::AtomicU32;
-    use std::sync::atomic::Ordering;
-
-    /// Test fake whose threshold can be mutated post-construction so we
-    /// can verify the monitor reads the value live, not at boot.
-    struct AtomicThreshold(AtomicU32);
-
-    impl ConfirmationThresholdSource for AtomicThreshold {
-        fn current(&self) -> u32 {
-            self.0.load(Ordering::Relaxed)
-        }
-    }
-
-    #[test]
-    fn static_threshold_returns_stored_value() {
-        let source = StaticThreshold(6);
-        assert_eq!(source.current(), 6);
-    }
-
-    #[test]
-    fn builder_with_u32_wraps_in_static_source() {
-        let config = MonitorConfig::builder().confirmation_threshold(3).build();
-        assert_eq!(config.confirmation_threshold.current(), 3);
-    }
-
-    #[test]
-    fn live_source_picks_up_updates() {
-        let live = Arc::new(AtomicThreshold(AtomicU32::new(6)));
-        let config = MonitorConfig::builder()
-            .confirmation_threshold_source(live.clone())
-            .build();
-        assert_eq!(config.confirmation_threshold.current(), 6);
-
-        live.0.store(3, Ordering::Relaxed);
-        assert_eq!(config.confirmation_threshold.current(), 3);
-    }
 
     #[test]
     fn test_mainnet_genesis_mapping() {

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -507,7 +507,7 @@ impl Monitor {
         self.pending_deposit_workers
             .spawn(Monitor::process_pending_deposit(
                 tip.to_owned(),
-                self.config.confirmation_threshold,
+                self.config.confirmation_threshold.current(),
                 self.bitcoind_rpc.clone(),
                 self.requester.clone(),
                 self.client_tx.clone(),
@@ -644,7 +644,7 @@ impl Monitor {
             self.pending_deposit_workers
                 .spawn(Monitor::process_pending_deposit(
                     tip.to_owned(),
-                    self.config.confirmation_threshold,
+                    self.config.confirmation_threshold.current(),
                     self.bitcoind_rpc.clone(),
                     self.requester.clone(),
                     self.client_tx.clone(),

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -504,10 +504,11 @@ impl Monitor {
             return;
         }
 
+        let confirmation_threshold = pending_deposit.confirmation_threshold;
         self.pending_deposit_workers
             .spawn(Monitor::process_pending_deposit(
                 tip.to_owned(),
-                self.config.confirmation_threshold.current(),
+                confirmation_threshold,
                 self.bitcoind_rpc.clone(),
                 self.requester.clone(),
                 self.client_tx.clone(),
@@ -641,10 +642,11 @@ impl Monitor {
             self.pending_deposits.len()
         );
         for pending_deposit in std::mem::take(&mut self.pending_deposits) {
+            let confirmation_threshold = pending_deposit.confirmation_threshold;
             self.pending_deposit_workers
                 .spawn(Monitor::process_pending_deposit(
                     tip.to_owned(),
-                    self.config.confirmation_threshold.current(),
+                    confirmation_threshold,
                     self.bitcoind_rpc.clone(),
                     self.requester.clone(),
                     self.client_tx.clone(),
@@ -920,6 +922,11 @@ async fn send_forget(
 #[derive(Debug)]
 struct PendingDeposit {
     outpoint: bitcoin::OutPoint,
+    /// Number of confirmations required to consider this deposit
+    /// canonical. Captured at submit time from `OnchainState` so the
+    /// monitor stays Sui-unaware. Stays with the deposit through any
+    /// re-enqueues by `PendingDepositGuard`.
+    confirmation_threshold: u32,
     block_info: Option<kyoto::HeaderCheckpoint>,
     result_tx: oneshot::Sender<Result<bitcoin::TxOut, DepositConfirmError>>,
     checked_at_height: u32,
@@ -990,10 +997,12 @@ impl MonitorClient {
     pub async fn confirm_deposit(
         &self,
         outpoint: bitcoin::OutPoint,
+        confirmation_threshold: u32,
     ) -> Result<bitcoin::TxOut, DepositConfirmError> {
         let (tx, rx) = oneshot::channel();
         let pending_deposit = PendingDeposit {
             outpoint,
+            confirmation_threshold,
             block_info: None,
             result_tx: tx,
             checked_at_height: 0,

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -161,9 +161,12 @@ impl Hashi {
             txid: deposit_request.utxo.id.txid.into(),
             vout: deposit_request.utxo.id.vout,
         };
+        // Read the threshold live from on-chain state so governance
+        // updates take effect for new deposits without a restart.
+        let confirmation_threshold = self.onchain_state().bitcoin_confirmation_threshold();
         let txout = self
             .btc_monitor()
-            .confirm_deposit(outpoint)
+            .confirm_deposit(outpoint, confirmation_threshold)
             .await
             .map_err(|e| match e {
                 DepositConfirmError::UtxoSpent { .. } => {

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -334,7 +334,7 @@ impl Hashi {
 
         let monitor_config = crate::btc_monitor::config::MonitorConfig::builder()
             .network(self.config.bitcoin_network())
-            .confirmation_threshold(self.onchain_state().bitcoin_confirmation_threshold())
+            .confirmation_threshold_source(std::sync::Arc::new(self.onchain_state().clone()))
             .start_height(self.config.bitcoin_start_height())
             .bitcoind_rpc_config(
                 self.config.bitcoin_rpc().to_string(),

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -334,7 +334,6 @@ impl Hashi {
 
         let monitor_config = crate::btc_monitor::config::MonitorConfig::builder()
             .network(self.config.bitcoin_network())
-            .confirmation_threshold_source(std::sync::Arc::new(self.onchain_state().clone()))
             .start_height(self.config.bitcoin_start_height())
             .bitcoind_rpc_config(
                 self.config.bitcoin_rpc().to_string(),

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -401,6 +401,15 @@ impl OnchainState {
     pub fn bitcoin_confirmation_threshold(&self) -> u32 {
         self.state().hashi().config.bitcoin_confirmation_threshold()
     }
+}
+
+impl crate::btc_monitor::config::ConfirmationThresholdSource for OnchainState {
+    fn current(&self) -> u32 {
+        self.bitcoin_confirmation_threshold()
+    }
+}
+
+impl OnchainState {
 
     pub fn mpc_threshold_in_basis_points(&self) -> u16 {
         self.state().hashi().config.mpc_threshold_in_basis_points()

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -401,15 +401,7 @@ impl OnchainState {
     pub fn bitcoin_confirmation_threshold(&self) -> u32 {
         self.state().hashi().config.bitcoin_confirmation_threshold()
     }
-}
 
-impl crate::btc_monitor::config::ConfirmationThresholdSource for OnchainState {
-    fn current(&self) -> u32 {
-        self.bitcoin_confirmation_threshold()
-    }
-}
-
-impl OnchainState {
     pub fn mpc_threshold_in_basis_points(&self) -> u16 {
         self.state().hashi().config.mpc_threshold_in_basis_points()
     }

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -410,7 +410,6 @@ impl crate::btc_monitor::config::ConfirmationThresholdSource for OnchainState {
 }
 
 impl OnchainState {
-
     pub fn mpc_threshold_in_basis_points(&self) -> u16 {
         self.state().hashi().config.mpc_threshold_in_basis_points()
     }


### PR DESCRIPTION
## Summary
The BTC monitor was caching `bitcoin_confirmation_threshold` into `MonitorConfig` once at validator startup, so an on-chain governance change to the threshold required every validator to restart before pending deposits could pick up the new value. Withdrawals already read the threshold live on each evaluation in the leader (`leader/mod.rs:1313`); deposits did not. This PR closes that asymmetry.

## Approach
Replace the cached `u32` with a tiny trait that the monitor calls per deposit evaluation:

```rust
pub trait ConfirmationThresholdSource: Send + Sync {
    fn current(&self) -> u32;
}
```

- `OnchainState` implements it by delegating to its existing `bitcoin_confirmation_threshold()` accessor — same source of truth as withdrawals, no parallel cache to keep in sync.
- `StaticThreshold(u32)` for tests and the standalone `testnet_monitor` example.
- The monitor stays Sui-unaware: it only sees `Arc<dyn ConfirmationThresholdSource>` injected via the builder.

## Why this and not other options
- **`watch::Receiver<u32>` synced by the watcher** — works but introduces a second source of truth that has to be kept in lockstep with `state.hashi.config`. Subtle drift bug risk for no real benefit; the read isn't on a hot path.
- **Move the comparison out of the monitor entirely** — gives architectural symmetry with withdrawals (Sui-aware layer does the compare) but requires unwinding the deposit pipeline. Larger blast radius for marginal benefit.
- **Inject `Arc<OnchainState>` directly** — couples the monitor crate to Sui state. Violates the existing boundary.

The trait approach gets us actual symmetry (both deposit and withdrawal threshold reads now bottom out in `OnchainState::bitcoin_confirmation_threshold()`) at minimum surface area.

## Audit of other governance-controlled configs
I traced every `OnchainState` consumer to find any other cache-at-boot bugs:

- ✅ Already live: `paused()`, `bitcoin_confirmation_threshold()` for withdrawals, deposit/withdrawal minimums (enforced on-chain at request creation), withdrawal/deposit queues, epoch, committee membership.
- ❌ The bug fixed here: deposit-side `bitcoin_confirmation_threshold`.
- ⚠️ Per-epoch snapshot, **likely intentional**: `mpc_threshold_in_basis_points`, `mpc_weight_reduction_allowed_delta`, `mpc_max_faulty_in_basis_points` are baked into the `Committee` struct at construction. Threshold-signature schemes generally need parameters stable within a protocol run, so this is probably deliberate — flagging for the MPC owners but not changing it here.

Nothing else cached.

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo test -p hashi --lib` — 274/274 pass
- [x] New unit tests in `btc_monitor::config::tests`:
  - `static_threshold_returns_stored_value`
  - `builder_with_u32_wraps_in_static_source`
  - `live_source_picks_up_updates` — flips an `AtomicU32` post-build and verifies the monitor sees the new value
- [ ] End-to-end on localnet: start a validator, fire an `update_config` proposal for `bitcoin_confirmation_threshold`, verify a pending deposit confirms at the new threshold without a restart