### PR TITLE
Add abort reconfig governance proposal

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -452,6 +452,10 @@ pub struct EmergencyPause {
     pub pause: bool,
 }
 
+/// Rust version of the Move hashi::abort_reconfig::AbortReconfig type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct AbortReconfig {}
+
 /// Rust version of the Move sui::vec_map::VecMap type.
 #[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct VecMap<K, V> {

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -454,7 +454,9 @@ pub struct EmergencyPause {
 
 /// Rust version of the Move hashi::abort_reconfig::AbortReconfig type.
 #[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
-pub struct AbortReconfig {}
+pub struct AbortReconfig {
+    pub epoch: u64,
+}
 
 /// Rust version of the Move sui::vec_map::VecMap type.
 #[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]
@@ -551,7 +553,6 @@ pub enum HashiEvent {
     UtxoSpentEvent(UtxoSpentEvent),
     StartReconfigEvent(StartReconfigEvent),
     EndReconfigEvent(EndReconfigEvent),
-    AbortReconfigEvent(AbortReconfigEvent),
 }
 
 impl HashiEvent {
@@ -614,7 +615,6 @@ impl HashiEvent {
             UtxoSpentEvent::MODULE_NAME => UtxoSpentEvent::from_bcs(bcs.value())?.into(),
             StartReconfigEvent::MODULE_NAME => StartReconfigEvent::from_bcs(bcs.value())?.into(),
             EndReconfigEvent::MODULE_NAME => EndReconfigEvent::from_bcs(bcs.value())?.into(),
-            AbortReconfigEvent::MODULE_NAME => AbortReconfigEvent::from_bcs(bcs.value())?.into(),
             PackageUpgradedEvent::MODULE_NAME => {
                 PackageUpgradedEvent::from_bcs(bcs.value())?.into()
             }
@@ -1121,22 +1121,6 @@ impl MoveType for EndReconfigEvent {
 impl From<EndReconfigEvent> for HashiEvent {
     fn from(value: EndReconfigEvent) -> Self {
         Self::EndReconfigEvent(value)
-    }
-}
-
-#[derive(Debug, serde_derive::Deserialize)]
-pub struct AbortReconfigEvent {
-    pub epoch: u64,
-}
-
-impl MoveType for AbortReconfigEvent {
-    const MODULE: &'static str = "reconfig";
-    const NAME: &'static str = "AbortReconfigEvent";
-}
-
-impl From<AbortReconfigEvent> for HashiEvent {
-    fn from(value: AbortReconfigEvent) -> Self {
-        Self::AbortReconfigEvent(value)
     }
 }
 

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -48,6 +48,9 @@ pub enum CreateProposalParams {
         version: u64,
         metadata: Vec<(String, String)>,
     },
+    AbortReconfig {
+        metadata: Vec<(String, String)>,
+    },
 }
 
 /// Live on-chain proposal detail fields not cached by `OnchainState`.
@@ -302,6 +305,11 @@ impl HashiClient {
                             bcs::from_bytes(value_bytes).context("deserialize EmergencyPause")?;
                         (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
                     }
+                    ProposalType::AbortReconfig => {
+                        let p: move_types::Proposal<move_types::AbortReconfig> =
+                            bcs::from_bytes(value_bytes).context("deserialize AbortReconfig")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
                     ProposalType::Unknown(s) => {
                         anyhow::bail!("Cannot fetch details for unknown proposal type: {s}")
                     }
@@ -408,6 +416,7 @@ impl HashiClient {
             ProposalType::EnableVersion => "enable_version",
             ProposalType::DisableVersion => "disable_version",
             ProposalType::EmergencyPause => "emergency_pause",
+            ProposalType::AbortReconfig => "abort_reconfig",
             ProposalType::Upgrade => {
                 anyhow::bail!(
                     "Upgrade proposals require the full upgrade flow (execute + publish + finalize)"
@@ -517,6 +526,17 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("propose"),
                 ),
                 vec![hashi_arg, version_arg, metadata_arg, clock_arg],
+            );
+        }
+        CreateProposalParams::AbortReconfig { metadata } => {
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    hashi_ids.package_id,
+                    Identifier::from_static("abort_reconfig"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![hashi_arg, metadata_arg, clock_arg],
             );
         }
     }
@@ -647,6 +667,7 @@ pub fn get_proposal_type_arg(
         ProposalType::EnableVersion => ("enable_version", "EnableVersion"),
         ProposalType::DisableVersion => ("disable_version", "DisableVersion"),
         ProposalType::EmergencyPause => ("emergency_pause", "EmergencyPause"),
+        ProposalType::AbortReconfig => ("abort_reconfig", "AbortReconfig"),
         ProposalType::Unknown(s) => {
             anyhow::bail!(
                 "Cannot vote on unknown proposal type '{}'. \

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -49,6 +49,7 @@ pub enum CreateProposalParams {
         metadata: Vec<(String, String)>,
     },
     AbortReconfig {
+        epoch: u64,
         metadata: Vec<(String, String)>,
     },
 }
@@ -528,7 +529,8 @@ pub fn build_create_proposal_transaction(
                 vec![hashi_arg, version_arg, metadata_arg, clock_arg],
             );
         }
-        CreateProposalParams::AbortReconfig { metadata } => {
+        CreateProposalParams::AbortReconfig { epoch, metadata } => {
+            let epoch_arg = builder.pure(&epoch);
             let metadata_arg = build_metadata(&mut builder, &metadata);
             builder.move_call(
                 Function::new(
@@ -536,7 +538,7 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("abort_reconfig"),
                     Identifier::from_static("propose"),
                 ),
-                vec![hashi_arg, metadata_arg, clock_arg],
+                vec![hashi_arg, epoch_arg, metadata_arg, clock_arg],
             );
         }
     }

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -588,10 +588,12 @@ pub async fn create_disable_version_proposal(
 /// Create an abort reconfig proposal
 pub async fn create_abort_reconfig_proposal(
     config: &CliConfig,
+    epoch: u64,
     metadata: Vec<(String, String)>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
     println!("\n{}", "Creating Abort Reconfig Proposal:".bold());
+    print_info(&format!("Target epoch: {epoch}"));
     print_metadata(&metadata);
 
     if !tx_opts.skip_confirm {
@@ -599,8 +601,8 @@ pub async fn create_abort_reconfig_proposal(
     }
 
     let mut client = HashiClient::new(config).await?;
-    let tx =
-        client.build_create_proposal_transaction(CreateProposalParams::AbortReconfig { metadata });
+    let tx = client
+        .build_create_proposal_transaction(CreateProposalParams::AbortReconfig { epoch, metadata });
 
     print_info("Transaction: abort_reconfig::propose");
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -585,6 +585,29 @@ pub async fn create_disable_version_proposal(
     Ok(())
 }
 
+/// Create an abort reconfig proposal
+pub async fn create_abort_reconfig_proposal(
+    config: &CliConfig,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    println!("\n{}", "Creating Abort Reconfig Proposal:".bold());
+    print_metadata(&metadata);
+
+    if !tx_opts.skip_confirm {
+        prompt_continue("create this abort reconfig proposal").await?;
+    }
+
+    let mut client = HashiClient::new(config).await?;
+    let tx =
+        client.build_create_proposal_transaction(CreateProposalParams::AbortReconfig { metadata });
+
+    print_info("Transaction: abort_reconfig::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
 // ============ Helper Functions ============
 
 fn print_proposal_detailed(

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -212,6 +212,10 @@ pub enum CreateProposalCommands {
 
     /// Propose aborting a pending Hashi reconfiguration
     AbortReconfig {
+        /// Pending Hashi epoch to abort
+        #[clap(long)]
+        epoch: u64,
+
         #[clap(flatten)]
         metadata: MetadataArgs,
     },
@@ -640,9 +644,10 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                     )
                     .await?;
                 }
-                CreateProposalCommands::AbortReconfig { metadata } => {
+                CreateProposalCommands::AbortReconfig { epoch, metadata } => {
                     commands::proposal::create_abort_reconfig_proposal(
                         &config,
+                        epoch,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -209,6 +209,12 @@ pub enum CreateProposalCommands {
         #[clap(flatten)]
         metadata: MetadataArgs,
     },
+
+    /// Propose aborting a pending Hashi reconfiguration
+    AbortReconfig {
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
 }
 
 /// Shared metadata arguments for proposal creation
@@ -629,6 +635,14 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                     commands::proposal::create_disable_version_proposal(
                         &config,
                         version,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::AbortReconfig { metadata } => {
+                    commands::proposal::create_abort_reconfig_proposal(
+                        &config,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/types.rs
+++ b/crates/hashi/src/cli/types.rs
@@ -54,6 +54,7 @@ pub mod display {
             ProposalType::EnableVersion => "EnableVersion".to_string(),
             ProposalType::DisableVersion => "DisableVersion".to_string(),
             ProposalType::EmergencyPause => "EmergencyPause".to_string(),
+            ProposalType::AbortReconfig => "AbortReconfig".to_string(),
             ProposalType::Unknown(s) => format!("Unknown({})", s),
         }
     }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -196,6 +196,12 @@ impl LeaderService {
                     Identifier::from_static("EmergencyPause"),
                     vec![],
                 ))),
+                ProposalType::AbortReconfig => TypeTag::Struct(Box::new(StructTag::new(
+                    hashi_ids.package_id,
+                    Identifier::from_static("abort_reconfig"),
+                    Identifier::from_static("AbortReconfig"),
+                    vec![],
+                ))),
                 ProposalType::Unknown(type_name) => {
                     error!(
                         "Cannot delete proposal {:?} with unknown type: {}",

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -1343,6 +1343,11 @@ async fn scrape_proposal_bag(
                     .ok()
                     .map(|p| (p.id, p.timestamp_ms))
             }
+            types::ProposalType::AbortReconfig => {
+                bcs::from_bytes::<move_types::Proposal<move_types::AbortReconfig>>(contents)
+                    .ok()
+                    .map(|p| (p.id, p.timestamp_ms))
+            }
             types::ProposalType::Unknown(_) => None,
         };
 
@@ -1387,6 +1392,7 @@ pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
         ("disable_version", "DisableVersion") => types::ProposalType::DisableVersion,
         ("upgrade", "Upgrade") => types::ProposalType::Upgrade,
         ("emergency_pause", "EmergencyPause") => types::ProposalType::EmergencyPause,
+        ("abort_reconfig", "AbortReconfig") => types::ProposalType::AbortReconfig,
         _ => types::ProposalType::Unknown(format!("{}::{}", inner_tag.module(), inner_tag.name())),
     }
 }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -457,6 +457,7 @@ pub enum ProposalType {
     DisableVersion,
     Upgrade,
     EmergencyPause,
+    AbortReconfig,
     Unknown(String),
 }
 
@@ -468,6 +469,7 @@ impl ProposalType {
             ProposalType::DisableVersion => "disable_version",
             ProposalType::Upgrade => "upgrade",
             ProposalType::EmergencyPause => "emergency_pause",
+            ProposalType::AbortReconfig => "abort_reconfig",
             ProposalType::Unknown(_) => "unknown",
         }
     }
@@ -479,6 +481,7 @@ impl ProposalType {
             "disable_version",
             "upgrade",
             "emergency_pause",
+            "abort_reconfig",
             "unknown",
         ]
     }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -5,7 +5,9 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use futures::StreamExt;
+use hashi_types::move_types::AbortReconfig;
 use hashi_types::move_types::BurnEvent;
+use hashi_types::move_types::HashiEvent;
 use hashi_types::move_types::MintEvent;
 use sui_rpc::Client;
 use sui_rpc::field::FieldMask;
@@ -25,7 +27,6 @@ use crate::onchain::types::DepositRequest;
 use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
 use crate::onchain::types::WithdrawalRequest;
-use hashi_types::move_types::HashiEvent;
 
 #[tracing::instrument(name = "watcher", skip_all)]
 pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Arc<Metrics>>) {
@@ -234,6 +235,26 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                             tracing::error!(
                                 "failed to refresh config after config-changing proposal: {e}"
                             );
+                        }
+                    }
+                }
+
+                if matches!(
+                    parse_proposal_type_from_type_tag(&proposal_executed_event.proposal_type),
+                    ProposalType::AbortReconfig
+                ) {
+                    match bcs::from_bytes::<AbortReconfig>(&proposal_executed_event.data_bcs) {
+                        Ok(abort_reconfig) => {
+                            let mut state = state.state_mut();
+                            state
+                                .hashi
+                                .committees
+                                .committees_mut()
+                                .remove(&abort_reconfig.epoch);
+                            state.hashi.committees.set_pending_epoch_change(None);
+                        }
+                        Err(e) => {
+                            tracing::error!("unable to decode AbortReconfig proposal data: {e}");
                         }
                     }
                 }
@@ -469,15 +490,6 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                     .set_epoch(end_reconfig_event.epoch)
                     .set_pending_epoch_change(None)
                     .set_mpc_public_key(end_reconfig_event.mpc_public_key.clone());
-            }
-            HashiEvent::AbortReconfigEvent(abort_reconfig_event) => {
-                let mut state = state.state_mut();
-                state
-                    .hashi
-                    .committees
-                    .committees_mut()
-                    .remove(&abort_reconfig_event.epoch);
-                state.hashi.committees.set_pending_epoch_change(None);
             }
         }
     }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -538,6 +538,7 @@ fn parse_proposal_type_from_type_tag(type_tag: &TypeTag) -> ProposalType {
         ("disable_version", "DisableVersion") => ProposalType::DisableVersion,
         ("upgrade", "Upgrade") => ProposalType::Upgrade,
         ("emergency_pause", "EmergencyPause") => ProposalType::EmergencyPause,
+        ("abort_reconfig", "AbortReconfig") => ProposalType::AbortReconfig,
         _ => ProposalType::Unknown(format!("{}::{}", struct_tag.module(), struct_tag.name())),
     }
 }

--- a/design/src/reconfiguration.md
+++ b/design/src/reconfiguration.md
@@ -105,3 +105,35 @@ for the epoch by running the presigning protocol to generate a batch of
 presignatures needed for the threshold Schnorr signing protocol (see [MPC
 protocol](./mpc-protocol.md)). Once presignatures are ready, normal operations
 resume for processing deposits and withdrawals.
+
+### Abort Reconfig
+
+```mermaid
+graph LR
+    A[Start Reconfig] --> B[DKG or Key Rotation] --> C[Abort Reconfig]:::active
+    C --> A
+    classDef active fill:#f9a825,stroke:#f57f17,color:#000
+```
+
+Reconfiguration can fail after `start_reconfig` has committed the pending
+committee but before `end_reconfig` can safely advance the Hashi epoch. Examples
+include:
+
+- The pending committee cannot complete initial DKG because too much registered
+  stake is offline or misconfigured.
+- Key rotation cannot complete because the old committee cannot supply enough
+  valid resharing material to the new committee.
+- The new committee completes the MPC protocol but cannot gather a threshold BLS
+  certificate over a single `ReconfigCompletionMessage`.
+- The MPC output is inconsistent with the on-chain invariant that the threshold
+  public key remains unchanged across key-rotation epochs.
+- A bad pending committee was formed from stale or incorrect validator metadata,
+  such as invalid endpoint, TLS, BLS, or encryption key updates.
+
+In these cases, governance can create and execute an
+`abort_reconfig::AbortReconfig` proposal. The proposal is voted on by the
+current committed committee. When quorum is reached, execution clears the
+pending epoch change, removes the pending committee, emits `AbortReconfigEvent`,
+and leaves the current Hashi epoch and MPC public key unchanged. Normal
+operations can then resume under the last committed committee, and a later Sui
+epoch notification can trigger a fresh `start_reconfig`.

--- a/design/src/reconfiguration.md
+++ b/design/src/reconfiguration.md
@@ -131,9 +131,11 @@ include:
   such as invalid endpoint, TLS, BLS, or encryption key updates.
 
 In these cases, governance can create and execute an
-`abort_reconfig::AbortReconfig` proposal. The proposal is voted on by the
-current committed committee. When quorum is reached, execution clears the
-pending epoch change, removes the pending committee, emits `AbortReconfigEvent`,
-and leaves the current Hashi epoch and MPC public key unchanged. Normal
-operations can then resume under the last committed committee, and a later Sui
-epoch notification can trigger a fresh `start_reconfig`.
+`abort_reconfig::AbortReconfig` proposal for the specific pending epoch being
+aborted. The proposal is voted on by the current committed committee. When
+quorum is reached, execution re-checks that the same epoch is still pending,
+clears the pending epoch change, removes the pending committee, and emits the
+standard `ProposalExecutedEvent<AbortReconfig>` with the aborted epoch in the
+proposal data. The current Hashi epoch and MPC public key remain unchanged.
+Normal operations can then resume under the last committed committee, and a
+later Sui epoch notification can trigger a fresh `start_reconfig`.

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -417,12 +417,20 @@ public(package) fun end_reconfig(
     next_epoch
 }
 
-// TODO include a cert from the current committee to abort a failed reconfig.
 public(package) fun abort_reconfig(self: &mut CommitteeSet, _ctx: &TxContext): u64 {
     assert!(self.is_reconfiguring());
     let next_epoch = self.pending_epoch_change.extract();
     self.remove_committee(next_epoch);
     next_epoch
+}
+
+#[test_only]
+public fun set_pending_reconfig_for_testing(self: &mut CommitteeSet, committee: Committee) {
+    let epoch = committee.epoch();
+    assert!(!self.is_reconfiguring());
+    assert!(!self.has_committee(epoch));
+    self.pending_epoch_change = option::some(epoch);
+    self.insert_committee(committee);
 }
 
 // ======== Test-only Functions ========

--- a/packages/hashi/sources/core/proposal/types/abort_reconfig.move
+++ b/packages/hashi/sources/core/proposal/types/abort_reconfig.move
@@ -9,25 +9,42 @@
 /// committee with stable on-chain voting power.
 module hashi::abort_reconfig;
 
-use hashi::{hashi::Hashi, proposal, reconfig};
+use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
 const THRESHOLD_BPS: u64 = 6667;
+const ENotReconfiguring: u64 = 0;
+const EWrongReconfigEpoch: u64 = 1;
 
-public struct AbortReconfig has drop, store {}
+public struct AbortReconfig has copy, drop, store {
+    epoch: u64,
+}
 
 public fun propose(
     hashi: &mut Hashi,
+    epoch: u64,
     metadata: VecMap<String, String>,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     hashi.config().assert_version_enabled();
-    proposal::create(hashi, AbortReconfig {}, THRESHOLD_BPS, metadata, clock, ctx)
+    assert!(hashi.committee_set().is_reconfiguring(), ENotReconfiguring);
+    assert!(
+        hashi.committee_set().pending_epoch_change().destroy_some() == epoch,
+        EWrongReconfigEpoch,
+    );
+    proposal::create(hashi, AbortReconfig { epoch }, THRESHOLD_BPS, metadata, clock, ctx)
 }
 
 public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock, ctx: &TxContext) {
-    let AbortReconfig {} = proposal::execute(hashi, proposal_id, clock);
-    reconfig::abort_reconfig(hashi, ctx);
+    let AbortReconfig { epoch } = proposal::execute(hashi, proposal_id, clock);
+    hashi.config().assert_version_enabled();
+    assert!(hashi.committee_set().is_reconfiguring(), ENotReconfiguring);
+    assert!(
+        hashi.committee_set().pending_epoch_change().destroy_some() == epoch,
+        EWrongReconfigEpoch,
+    );
+    let aborted_epoch = hashi.committee_set_mut().abort_reconfig(ctx);
+    assert!(aborted_epoch == epoch, EWrongReconfigEpoch);
 }

--- a/packages/hashi/sources/core/proposal/types/abort_reconfig.move
+++ b/packages/hashi/sources/core/proposal/types/abort_reconfig.move
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Governance proposal for aborting a pending Hashi reconfiguration.
+///
+/// This is intentionally governed by the current committee. If the pending
+/// next committee cannot complete DKG/key rotation or cannot produce the
+/// `end_reconfig` certificate, the last committed committee is the only
+/// committee with stable on-chain voting power.
+module hashi::abort_reconfig;
+
+use hashi::{hashi::Hashi, proposal, reconfig};
+use std::string::String;
+use sui::{clock::Clock, vec_map::VecMap};
+
+const THRESHOLD_BPS: u64 = 6667;
+
+public struct AbortReconfig has drop, store {}
+
+public fun propose(
+    hashi: &mut Hashi,
+    metadata: VecMap<String, String>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    hashi.config().assert_version_enabled();
+    proposal::create(hashi, AbortReconfig {}, THRESHOLD_BPS, metadata, clock, ctx)
+}
+
+public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock, ctx: &TxContext) {
+    let AbortReconfig {} = proposal::execute(hashi, proposal_id, clock);
+    reconfig::abort_reconfig(hashi, ctx);
+}

--- a/packages/hashi/sources/core/reconfig.move
+++ b/packages/hashi/sources/core/reconfig.move
@@ -56,13 +56,6 @@ entry fun end_reconfig(
     sui::event::emit(EndReconfigEvent { epoch, mpc_public_key });
 }
 
-public(package) fun abort_reconfig(self: &mut Hashi, ctx: &TxContext) {
-    self.config().assert_version_enabled();
-    assert!(self.committee_set().is_reconfiguring(), ENotReconfiguring);
-    let epoch = self.committee_set_mut().abort_reconfig(ctx);
-    sui::event::emit(AbortReconfigEvent { epoch });
-}
-
 public struct StartReconfigEvent has copy, drop {
     epoch: u64,
 }
@@ -71,9 +64,4 @@ public struct EndReconfigEvent has copy, drop {
     epoch: u64,
     /// The MPC committee's threshold public key.
     mpc_public_key: vector<u8>,
-}
-
-#[allow(unused_field)]
-public struct AbortReconfigEvent has copy, drop {
-    epoch: u64,
 }

--- a/packages/hashi/sources/core/reconfig.move
+++ b/packages/hashi/sources/core/reconfig.move
@@ -7,7 +7,6 @@ module hashi::reconfig;
 use hashi::{committee::CommitteeSignature, hashi::Hashi};
 
 const ENotReconfiguring: u64 = 0;
-const EAbortReconfigDisabled: u64 = 1;
 
 /// Message that committee members sign to confirm successful key rotation.
 public struct ReconfigCompletionMessage has copy, drop, store {
@@ -57,9 +56,11 @@ entry fun end_reconfig(
     sui::event::emit(EndReconfigEvent { epoch, mpc_public_key });
 }
 
-// TODO: Re-enable with committee certificate verification.
-entry fun abort_reconfig(_self: &mut Hashi, _ctx: &TxContext) {
-    abort EAbortReconfigDisabled
+public(package) fun abort_reconfig(self: &mut Hashi, ctx: &TxContext) {
+    self.config().assert_version_enabled();
+    assert!(self.committee_set().is_reconfiguring(), ENotReconfiguring);
+    let epoch = self.committee_set_mut().abort_reconfig(ctx);
+    sui::event::emit(AbortReconfigEvent { epoch });
 }
 
 public struct StartReconfigEvent has copy, drop {

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -357,7 +357,7 @@ fun test_abort_reconfig_proposal() {
     assert!(hashi.committee_set().pending_epoch_change().destroy_some() == 1);
     assert!(hashi.committee_set().has_committee(1));
 
-    let proposal_id = test_utils::create_abort_reconfig_proposal(&mut hashi, &clock, ctx1);
+    let proposal_id = test_utils::create_abort_reconfig_proposal(&mut hashi, 1, &clock, ctx1);
 
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
     proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx2);
@@ -375,17 +375,60 @@ fun test_abort_reconfig_proposal() {
 }
 
 #[test]
-#[expected_failure(abort_code = hashi::reconfig::ENotReconfiguring)]
-/// Test executing an abort reconfig proposal fails when no reconfig is pending
-fun test_abort_reconfig_proposal_fails_when_not_reconfiguring() {
+#[expected_failure(abort_code = hashi::abort_reconfig::ENotReconfiguring)]
+/// Test creating an abort reconfig proposal fails when no reconfig is pending
+fun test_abort_reconfig_proposal_fails_when_not_reconfiguring_at_propose() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
 
     let voters = vector[VOTER1];
     let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
     let clock = clock::create_for_testing(ctx);
 
-    let proposal_id = test_utils::create_abort_reconfig_proposal(&mut hashi, &clock, ctx);
-    hashi::abort_reconfig::execute(&mut hashi, proposal_id, &clock, ctx);
+    let _ = test_utils::create_abort_reconfig_proposal(&mut hashi, 1, &clock, ctx);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = hashi::abort_reconfig::EWrongReconfigEpoch)]
+/// Test creating an abort reconfig proposal fails if it names a different epoch
+fun test_abort_reconfig_proposal_fails_for_wrong_epoch_at_propose() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+    add_pending_committee_for_testing(&mut hashi, 1);
+
+    let _ = test_utils::create_abort_reconfig_proposal(&mut hashi, 2, &clock, ctx);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = hashi::abort_reconfig::EWrongReconfigEpoch)]
+/// Test executing a stale abort reconfig proposal cannot abort a later pending epoch
+fun test_abort_reconfig_proposal_fails_for_stale_epoch_at_execute() {
+    let ctx1 = &mut test_utils::new_tx_context(VOTER1, 0);
+
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx1);
+    let clock = clock::create_for_testing(ctx1);
+    add_pending_committee_for_testing(&mut hashi, 1);
+
+    let proposal_id = test_utils::create_abort_reconfig_proposal(&mut hashi, 1, &clock, ctx1);
+
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx2);
+    let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
+    proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx3);
+
+    let _ = hashi.committee_set_mut().abort_reconfig(ctx1);
+    add_pending_committee_for_testing(&mut hashi, 2);
+
+    hashi::abort_reconfig::execute(&mut hashi, proposal_id, &clock, ctx1);
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -5,8 +5,14 @@
 #[allow(implicit_const_copy, deprecated_usage, unused_variable)]
 module hashi::proposal_tests;
 
-use hashi::{proposal, test_utils, update_config::UpdateConfig};
-use sui::clock;
+use hashi::{
+    abort_reconfig::AbortReconfig,
+    committee,
+    proposal,
+    test_utils,
+    update_config::UpdateConfig
+};
+use sui::{bls12381, clock};
 
 // ======== Test Addresses ========
 const VOTER1: address = @0x1;
@@ -16,6 +22,21 @@ const NON_VOTER: address = @0x999;
 
 // ======== Constants ========
 const MAX_PROPOSAL_DURATION_MS: u64 = 1000 * 60 * 60 * 24 * 7; // 7 days
+
+fun add_pending_committee_for_testing(hashi: &mut hashi::hashi::Hashi, epoch: u64) {
+    let sk = test_utils::bls_sk_for_testing();
+    let public_key = bls12381::g1_to_uncompressed_g1(
+        &bls12381::g1_from_bytes(&test_utils::bls_min_pk_from_sk(&sk)),
+    );
+    let encryption_key = sk;
+    let members = vector[
+        committee::new_committee_member(VOTER1, public_key, encryption_key, 1),
+        committee::new_committee_member(VOTER2, public_key, encryption_key, 1),
+        committee::new_committee_member(VOTER3, public_key, encryption_key, 1),
+    ];
+    let pending_committee = committee::new_committee(epoch, members, 3334, 800, 3333);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(pending_committee);
+}
 
 // ======== Proposal Creation Tests ========
 
@@ -319,6 +340,53 @@ fun test_execute_after_gathering_votes() {
     assert!(hashi::btc_config::bitcoin_deposit_minimum(hashi.config()) == 1000);
 
     // Clean up
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// Test executing an abort reconfig proposal rolls back pending reconfig state
+fun test_abort_reconfig_proposal() {
+    let ctx1 = &mut test_utils::new_tx_context(VOTER1, 0);
+
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx1);
+    let clock = clock::create_for_testing(ctx1);
+    add_pending_committee_for_testing(&mut hashi, 1);
+
+    assert!(hashi.committee_set().pending_epoch_change().destroy_some() == 1);
+    assert!(hashi.committee_set().has_committee(1));
+
+    let proposal_id = test_utils::create_abort_reconfig_proposal(&mut hashi, &clock, ctx1);
+
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx2);
+    let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
+    proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx3);
+
+    hashi::abort_reconfig::execute(&mut hashi, proposal_id, &clock, ctx1);
+
+    assert!(hashi.committee_set().pending_epoch_change().is_none());
+    assert!(!hashi.committee_set().has_committee(1));
+    assert!(hashi.committee_set().has_committee(0));
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = hashi::reconfig::ENotReconfiguring)]
+/// Test executing an abort reconfig proposal fails when no reconfig is pending
+fun test_abort_reconfig_proposal_fails_when_not_reconfiguring() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let proposal_id = test_utils::create_abort_reconfig_proposal(&mut hashi, &clock, ctx);
+    hashi::abort_reconfig::execute(&mut hashi, proposal_id, &clock, ctx);
+
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
 }

--- a/packages/hashi/tests/test_utils.move
+++ b/packages/hashi/tests/test_utils.move
@@ -7,6 +7,7 @@
 module hashi::test_utils;
 
 use hashi::{
+    abort_reconfig,
     committee::{Self, CommitteeMember, CommitteeSignature},
     config_value,
     disable_version,
@@ -253,4 +254,13 @@ public fun create_emergency_pause_proposal(
 ): ID {
     let metadata = vec_map::empty();
     emergency_pause::propose(hashi, pause, metadata, clock, ctx)
+}
+
+/// Creates an abort reconfig proposal and returns its ID
+public fun create_abort_reconfig_proposal(
+    hashi: &mut Hashi,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    abort_reconfig::propose(hashi, vec_map::empty(), clock, ctx)
 }

--- a/packages/hashi/tests/test_utils.move
+++ b/packages/hashi/tests/test_utils.move
@@ -259,8 +259,9 @@ public fun create_emergency_pause_proposal(
 /// Creates an abort reconfig proposal and returns its ID
 public fun create_abort_reconfig_proposal(
     hashi: &mut Hashi,
+    epoch: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
-    abort_reconfig::propose(hashi, vec_map::empty(), clock, ctx)
+    abort_reconfig::propose(hashi, epoch, vec_map::empty(), clock, ctx)
 }


### PR DESCRIPTION
## Summary
- add an AbortReconfig governance proposal that clears pending reconfig state through current-committee quorum
- emit AbortReconfigEvent and keep the committed epoch/MPC key unchanged
- wire the proposal through Rust on-chain parsing, CLI, metrics labels, and proposal cleanup
- document reconfig failure scenarios that can require an abort

## Tests
- sui move test
- cargo check --workspace