### PR TITLE
Make emergency pause thresholds configurable via governance

### DIFF
--- a/packages/hashi/sources/btc/btc_config.move
+++ b/packages/hashi/sources/btc/btc_config.move
@@ -7,36 +7,9 @@ module hashi::btc_config;
 
 use hashi::{config::Config, config_value};
 
-// ======== Bitcoin Network Constants ========
-
 /// Minimum value (satoshis) for a Bitcoin output to be relayed (dust threshold).
 /// Uses the highest threshold (P2PKH 546 sats) as a conservative floor.
 const DUST_RELAY_MIN_VALUE: u64 = 546;
-
-// ======== Config Validation ========
-
-/// Returns true when `key` is a recognised BTC config key and `value`
-/// carries the type that key expects.
-#[allow(implicit_const_copy)]
-public(package) fun is_valid_config_entry(
-    key: &std::string::String,
-    value: &config_value::Value,
-): bool {
-    let k = key.as_bytes();
-    if (k == &b"bitcoin_deposit_minimum") {
-        value.is_u64()
-    } else if (k == &b"bitcoin_deposit_time_delay_ms") {
-        value.is_u64()
-    } else if (k == &b"bitcoin_withdrawal_minimum") {
-        value.is_u64()
-    } else if (k == &b"bitcoin_confirmation_threshold") {
-        value.is_u64()
-    } else if (k == &b"withdrawal_cancellation_cooldown_ms") {
-        value.is_u64()
-    } else {
-        false
-    }
-}
 
 // ======== Accessors ========
 

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -25,7 +25,8 @@ const PAUSED_KEY: vector<u8> = b"paused";
 const GUARDIAN_URL_KEY: vector<u8> = b"guardian_url";
 const GUARDIAN_PUBLIC_KEY_KEY: vector<u8> = b"guardian_public_key";
 const EMERGENCY_PAUSE_THRESHOLD_BPS_KEY: vector<u8> = b"governance_emergency_pause_threshold_bps";
-const EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY: vector<u8> = b"governance_emergency_unpause_threshold_bps";
+const EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY: vector<u8> =
+    b"governance_emergency_unpause_threshold_bps";
 
 public struct Config has store {
     config: VecMap<String, Value>,
@@ -97,15 +98,11 @@ public(package) fun set_guardian(self: &mut Config, url: String, public_key: vec
 }
 
 public(package) fun emergency_pause_threshold_bps(self: &Config): u64 {
-    self.try_get(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY)
-        .map!(|v| v.as_u64())
-        .destroy_or!(5100)
+    self.try_get(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY).map!(|v| v.as_u64()).destroy_or!(5100)
 }
 
 public(package) fun emergency_unpause_threshold_bps(self: &Config): u64 {
-    self.try_get(EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY)
-        .map!(|v| v.as_u64())
-        .destroy_or!(6667)
+    self.try_get(EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY).map!(|v| v.as_u64()).destroy_or!(6667)
 }
 
 // ======== Version Management ========

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -24,6 +24,8 @@ const EDisableCurrentVersion: vector<u8> = b"Cannot disable current version";
 const PAUSED_KEY: vector<u8> = b"paused";
 const GUARDIAN_URL_KEY: vector<u8> = b"guardian_url";
 const GUARDIAN_PUBLIC_KEY_KEY: vector<u8> = b"guardian_public_key";
+const EMERGENCY_PAUSE_THRESHOLD_BPS_KEY: vector<u8> = b"governance_emergency_pause_threshold_bps";
+const EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY: vector<u8> = b"governance_emergency_unpause_threshold_bps";
 
 public struct Config has store {
     config: VecMap<String, Value>,
@@ -58,16 +60,11 @@ public(package) fun upsert(self: &mut Config, key: vector<u8>, value: Value) {
     self.config.insert(key, value);
 }
 
-/// Returns true when `key` is a recognised core config key and `value`
-/// carries the type that key expects.
-#[allow(implicit_const_copy)]
-public(package) fun is_valid_core_config_entry(key: &String, value: &Value): bool {
-    let k = key.as_bytes();
-    if (k == &PAUSED_KEY) {
-        value.is_bool()
-    } else {
-        false
-    }
+/// Returns true when `key` exists in the config and `value` has the
+/// same type as the existing entry.
+public(package) fun is_valid_config_update(self: &Config, key: &String, value: &Value): bool {
+    if (!self.config.contains(key)) return false;
+    self.config.get(key).same_variant(value)
 }
 
 // ======== Core Accessors ========
@@ -97,6 +94,18 @@ public(package) fun guardian_public_key(self: &Config): Option<vector<u8>> {
 public(package) fun set_guardian(self: &mut Config, url: String, public_key: vector<u8>) {
     self.upsert(GUARDIAN_URL_KEY, config_value::new_string(url));
     self.upsert(GUARDIAN_PUBLIC_KEY_KEY, config_value::new_bytes(public_key));
+}
+
+public(package) fun emergency_pause_threshold_bps(self: &Config): u64 {
+    self.try_get(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY)
+        .map!(|v| v.as_u64())
+        .destroy_or!(5100)
+}
+
+public(package) fun emergency_unpause_threshold_bps(self: &Config): u64 {
+    self.try_get(EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY)
+        .map!(|v| v.as_u64())
+        .destroy_or!(6667)
 }
 
 // ======== Version Management ========
@@ -148,6 +157,8 @@ public(package) fun create(): Config {
 
     // Core defaults
     config.upsert(PAUSED_KEY, config_value::new_bool(false));
+    config.upsert(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(5100));
+    config.upsert(EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(6667));
 
     config
 }

--- a/packages/hashi/sources/core/config/config_value.move
+++ b/packages/hashi/sources/core/config/config_value.move
@@ -35,6 +35,16 @@ public fun new_bytes(value: vector<u8>): Value {
     Value::Bytes(value)
 }
 
+public(package) fun same_variant(self: &Value, other: &Value): bool {
+    match (self) {
+        Value::U64(_) => other.is_u64(),
+        Value::Address(_) => other.is_address(),
+        Value::String(_) => other.is_string(),
+        Value::Bool(_) => other.is_bool(),
+        Value::Bytes(_) => other.is_bytes(),
+    }
+}
+
 public(package) fun is_u64(value: &Value): bool {
     match (value) {
         Value::U64(_) => true,
@@ -42,9 +52,30 @@ public(package) fun is_u64(value: &Value): bool {
     }
 }
 
+public(package) fun is_address(value: &Value): bool {
+    match (value) {
+        Value::Address(_) => true,
+        _ => false,
+    }
+}
+
+public(package) fun is_string(value: &Value): bool {
+    match (value) {
+        Value::String(_) => true,
+        _ => false,
+    }
+}
+
 public(package) fun is_bool(value: &Value): bool {
     match (value) {
         Value::Bool(_) => true,
+        _ => false,
+    }
+}
+
+public(package) fun is_bytes(value: &Value): bool {
+    match (value) {
+        Value::Bytes(_) => true,
         _ => false,
     }
 }

--- a/packages/hashi/sources/core/mpc_config.move
+++ b/packages/hashi/sources/core/mpc_config.move
@@ -7,28 +7,9 @@ use hashi::{config::Config, config_value};
 
 const DEFAULT_THRESHOLD_IN_BASIS_POINTS: u64 = 3334;
 
-const MAX_BPS: u64 = 10000;
-
 const DEFAULT_WEIGHT_REDUCTION_ALLOWED_DELTA: u64 = 800;
 
 const DEFAULT_MAX_FAULTY_IN_BASIS_POINTS: u64 = 3333;
-
-#[allow(implicit_const_copy)]
-public(package) fun is_valid_config_entry(
-    key: &std::string::String,
-    value: &config_value::Value,
-): bool {
-    let k = key.as_bytes();
-    if (k == &b"mpc_threshold_in_basis_points") {
-        value.is_u64() && (*value).as_u64() > 0 && (*value).as_u64() <= MAX_BPS
-    } else if (k == &b"mpc_weight_reduction_allowed_delta") {
-        value.is_u64() && (*value).as_u64() <= MAX_BPS
-    } else if (k == &b"mpc_max_faulty_in_basis_points") {
-        value.is_u64() && (*value).as_u64() <= MAX_BPS
-    } else {
-        false
-    }
-}
 
 public(package) fun threshold_in_basis_points(config: &Config): u64 {
     config

--- a/packages/hashi/sources/core/proposal/types/emergency_pause.move
+++ b/packages/hashi/sources/core/proposal/types/emergency_pause.move
@@ -11,9 +11,6 @@ use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
-const PAUSE_THRESHOLD_BPS: u64 = 5100; // 51% - low quorum for emergencies
-const UNPAUSE_THRESHOLD_BPS: u64 = 6667; // ~2/3 - higher bar for resuming
-
 public struct EmergencyPause has copy, drop, store {
     pause: bool,
 }
@@ -27,9 +24,9 @@ public fun propose(
 ): ID {
     hashi.config().assert_version_enabled();
     let threshold = if (pause) {
-        PAUSE_THRESHOLD_BPS
+        hashi.config().emergency_pause_threshold_bps()
     } else {
-        UNPAUSE_THRESHOLD_BPS
+        hashi.config().emergency_unpause_threshold_bps()
     };
     proposal::create(hashi, EmergencyPause { pause }, threshold, metadata, clock, ctx)
 }

--- a/packages/hashi/sources/core/proposal/types/update_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_config.move
@@ -3,7 +3,7 @@
 
 module hashi::update_config;
 
-use hashi::{config, config_value::Value, hashi::Hashi, proposal};
+use hashi::{config_value::Value, hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
@@ -31,12 +31,7 @@ public fun propose(
 
 public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
     let UpdateConfig { key, value } = proposal::execute(hashi, proposal_id, clock);
-    assert!(
-        config::is_valid_core_config_entry(&key, &value)
-            || hashi::btc_config::is_valid_config_entry(&key, &value)
-            || hashi::mpc_config::is_valid_config_entry(&key, &value),
-        EInvalidConfigEntry,
-    );
+    assert!(hashi.config().is_valid_config_update(&key, &value), EInvalidConfigEntry);
     let bytes = *key.as_bytes();
     hashi.config_mut().upsert(bytes, value);
 }


### PR DESCRIPTION
## Summary
- Store emergency pause/unpause quorum thresholds in the on-chain config map so they can be tuned via `UpdateConfig` governance proposals without a package upgrade
- Replace the per-domain config validation functions (`is_valid_core_config_entry`, `btc_config::is_valid_config_entry`, `mpc_config::is_valid_config_entry`) with a single `is_valid_config_update` that checks the key exists and the new value's type matches the existing entry. This is safe because `init_defaults` establishes the schema — unknown keys are rejected since they don't exist in the map, and type mismatches are caught by `same_variant`. Per-field range checks are removed since the 2/3 committee vote is the real safety boundary, not validation logic. Adding a new config key now only requires a line in `init_defaults`.
- Add `same_variant` helper on `Value` enum for type-level comparison

## Test plan
- [x] All 84 Move tests pass
- [x] Rust crate builds cleanly
- [ ] Verify emergency pause proposal creation reads threshold from config
- [ ] Verify threshold can be changed via UpdateConfig proposal