### PR TITLE
Add on chain Guardian management

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -464,6 +464,13 @@ pub struct AbortReconfig {
     pub epoch: u64,
 }
 
+/// Rust version of the Move hashi::update_guardian::UpdateGuardian type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct UpdateGuardian {
+    pub url: String,
+    pub public_key: Vec<u8>,
+}
+
 /// Rust version of the Move sui::vec_map::VecMap type.
 #[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct VecMap<K, V> {

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -52,6 +52,11 @@ pub enum CreateProposalParams {
         epoch: u64,
         metadata: Vec<(String, String)>,
     },
+    UpdateGuardian {
+        url: String,
+        public_key: Vec<u8>,
+        metadata: Vec<(String, String)>,
+    },
 }
 
 /// Live on-chain proposal detail fields not cached by `OnchainState`.
@@ -311,6 +316,11 @@ impl HashiClient {
                             bcs::from_bytes(value_bytes).context("deserialize AbortReconfig")?;
                         (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
                     }
+                    ProposalType::UpdateGuardian => {
+                        let p: move_types::Proposal<move_types::UpdateGuardian> =
+                            bcs::from_bytes(value_bytes).context("deserialize UpdateGuardian")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
                     ProposalType::Unknown(s) => {
                         anyhow::bail!("Cannot fetch details for unknown proposal type: {s}")
                     }
@@ -418,6 +428,7 @@ impl HashiClient {
             ProposalType::DisableVersion => "disable_version",
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::AbortReconfig => "abort_reconfig",
+            ProposalType::UpdateGuardian => "update_guardian",
             ProposalType::Upgrade => {
                 anyhow::bail!(
                     "Upgrade proposals require the full upgrade flow (execute + publish + finalize)"
@@ -539,6 +550,23 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("propose"),
                 ),
                 vec![hashi_arg, epoch_arg, metadata_arg, clock_arg],
+            );
+        }
+        CreateProposalParams::UpdateGuardian {
+            url,
+            public_key,
+            metadata,
+        } => {
+            let url_arg = builder.pure(&url);
+            let public_key_arg = builder.pure(&public_key);
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    hashi_ids.package_id,
+                    Identifier::from_static("update_guardian"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![hashi_arg, url_arg, public_key_arg, metadata_arg, clock_arg],
             );
         }
     }
@@ -670,6 +698,7 @@ pub fn get_proposal_type_arg(
         ProposalType::DisableVersion => ("disable_version", "DisableVersion"),
         ProposalType::EmergencyPause => ("emergency_pause", "EmergencyPause"),
         ProposalType::AbortReconfig => ("abort_reconfig", "AbortReconfig"),
+        ProposalType::UpdateGuardian => ("update_guardian", "UpdateGuardian"),
         ProposalType::Unknown(s) => {
             anyhow::bail!(
                 "Cannot vote on unknown proposal type '{}'. \

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -618,9 +618,8 @@ pub async fn create_update_guardian_proposal(
     metadata: Vec<(String, String)>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
-    let public_key =
-        hex::decode(public_key_hex.strip_prefix("0x").unwrap_or(public_key_hex))
-            .context("Invalid hex for public key")?;
+    let public_key = hex::decode(public_key_hex.strip_prefix("0x").unwrap_or(public_key_hex))
+        .context("Invalid hex for public key")?;
 
     println!("\n{}", "Creating Update Guardian Proposal:".bold());
     println!("  URL:        {}", url);

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -610,6 +610,40 @@ pub async fn create_abort_reconfig_proposal(
     Ok(())
 }
 
+/// Create an update guardian proposal
+pub async fn create_update_guardian_proposal(
+    config: &CliConfig,
+    url: &str,
+    public_key_hex: &str,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let public_key =
+        hex::decode(public_key_hex.strip_prefix("0x").unwrap_or(public_key_hex))
+            .context("Invalid hex for public key")?;
+
+    println!("\n{}", "Creating Update Guardian Proposal:".bold());
+    println!("  URL:        {}", url);
+    println!("  Public Key: 0x{}", hex::encode(&public_key));
+    print_metadata(&metadata);
+
+    if !tx_opts.skip_confirm {
+        prompt_continue("create this update guardian proposal").await?;
+    }
+
+    let mut client = HashiClient::new(config).await?;
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateGuardian {
+        url: url.to_string(),
+        public_key,
+        metadata,
+    });
+
+    print_info("Transaction: update_guardian::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
 // ============ Helper Functions ============
 
 fn print_proposal_detailed(

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -219,6 +219,20 @@ pub enum CreateProposalCommands {
         #[clap(flatten)]
         metadata: MetadataArgs,
     },
+
+    /// Propose updating the guardian URL and public key
+    UpdateGuardian {
+        /// The guardian gRPC endpoint URL
+        #[clap(long)]
+        url: String,
+
+        /// The guardian's signing public key (hex encoded)
+        #[clap(long)]
+        public_key: String,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
 }
 
 /// Shared metadata arguments for proposal creation
@@ -648,6 +662,20 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                     commands::proposal::create_abort_reconfig_proposal(
                         &config,
                         epoch,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::UpdateGuardian {
+                    url,
+                    public_key,
+                    metadata,
+                } => {
+                    commands::proposal::create_update_guardian_proposal(
+                        &config,
+                        &url,
+                        &public_key,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/types.rs
+++ b/crates/hashi/src/cli/types.rs
@@ -55,6 +55,7 @@ pub mod display {
             ProposalType::DisableVersion => "DisableVersion".to_string(),
             ProposalType::EmergencyPause => "EmergencyPause".to_string(),
             ProposalType::AbortReconfig => "AbortReconfig".to_string(),
+            ProposalType::UpdateGuardian => "UpdateGuardian".to_string(),
             ProposalType::Unknown(s) => format!("Unknown({})", s),
         }
     }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -202,6 +202,12 @@ impl LeaderService {
                     Identifier::from_static("AbortReconfig"),
                     vec![],
                 ))),
+                ProposalType::UpdateGuardian => TypeTag::Struct(Box::new(StructTag::new(
+                    hashi_ids.package_id,
+                    Identifier::from_static("update_guardian"),
+                    Identifier::from_static("UpdateGuardian"),
+                    vec![],
+                ))),
                 ProposalType::Unknown(type_name) => {
                     error!(
                         "Cannot delete proposal {:?} with unknown type: {}",

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -410,7 +410,19 @@ impl Hashi {
             .set(screener)
             .map_err(|_| anyhow!("Screener client already initialized"))?;
 
-        let guardian = if let Some(endpoint) = self.config.guardian_endpoint() {
+        // Verify Sui RPC is on the expected chain before loading any state.
+        self.verify_sui_chain_id().await?;
+
+        // Initialize on-chain state first so we can read guardian config from it.
+        let onchain_service = self.initialize_onchain_state().await?;
+
+        let guardian_endpoint = {
+            let state = self.onchain_state().state();
+            state.hashi().config.guardian_url().map(|s| s.to_string())
+        }
+        .or_else(|| self.config.guardian_endpoint().map(|s| s.to_string()));
+
+        let guardian = if let Some(endpoint) = guardian_endpoint.as_deref() {
             match grpc::guardian_client::GuardianClient::new(endpoint) {
                 Ok(client) => {
                     tracing::info!("Guardian client configured for {}", client.endpoint());
@@ -433,12 +445,6 @@ impl Hashi {
         self.guardian_client
             .set(guardian)
             .map_err(|_| anyhow!("Guardian client already initialized"))?;
-
-        // Verify Sui RPC is on the expected chain before loading any state.
-        self.verify_sui_chain_id().await?;
-
-        // Initialize
-        let onchain_service = self.initialize_onchain_state().await?;
 
         // Verify the local bitcoin_chain_id matches the on-chain value.
         self.verify_bitcoin_chain_id()?;

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -1352,6 +1352,11 @@ async fn scrape_proposal_bag(
                     .ok()
                     .map(|p| (p.id, p.timestamp_ms))
             }
+            types::ProposalType::UpdateGuardian => {
+                bcs::from_bytes::<move_types::Proposal<move_types::UpdateGuardian>>(contents)
+                    .ok()
+                    .map(|p| (p.id, p.timestamp_ms))
+            }
             types::ProposalType::Unknown(_) => None,
         };
 
@@ -1397,6 +1402,7 @@ pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
         ("upgrade", "Upgrade") => types::ProposalType::Upgrade,
         ("emergency_pause", "EmergencyPause") => types::ProposalType::EmergencyPause,
         ("abort_reconfig", "AbortReconfig") => types::ProposalType::AbortReconfig,
+        ("update_guardian", "UpdateGuardian") => types::ProposalType::UpdateGuardian,
         _ => types::ProposalType::Unknown(format!("{}::{}", inner_tag.module(), inner_tag.name())),
     }
 }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -458,6 +458,7 @@ pub enum ProposalType {
     Upgrade,
     EmergencyPause,
     AbortReconfig,
+    UpdateGuardian,
     Unknown(String),
 }
 
@@ -470,6 +471,7 @@ impl ProposalType {
             ProposalType::Upgrade => "upgrade",
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::AbortReconfig => "abort_reconfig",
+            ProposalType::UpdateGuardian => "update_guardian",
             ProposalType::Unknown(_) => "unknown",
         }
     }
@@ -482,6 +484,7 @@ impl ProposalType {
             "upgrade",
             "emergency_pause",
             "abort_reconfig",
+            "update_guardian",
             "unknown",
         ]
     }
@@ -578,6 +581,20 @@ impl Config {
                 u16::try_from(*v).expect("mpc_max_faulty_in_basis_points exceeds u16::MAX")
             }
             _ => DEFAULT_MPC_MAX_FAULTY_IN_BASIS_POINTS,
+        }
+    }
+
+    pub fn guardian_url(&self) -> Option<&str> {
+        match self.config.get("guardian_url") {
+            Some(ConfigValue::String(v)) => Some(v.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn guardian_public_key(&self) -> Option<&[u8]> {
+        match self.config.get("guardian_public_key") {
+            Some(ConfigValue::Bytes(v)) => Some(v.as_slice()),
+            _ => None,
         }
     }
 }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -222,7 +222,9 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                 // so this could be applied directly in the future.)
                 if matches!(
                     parse_proposal_type_from_type_tag(&proposal_executed_event.proposal_type),
-                    ProposalType::UpdateConfig | ProposalType::EmergencyPause
+                    ProposalType::UpdateConfig
+                        | ProposalType::EmergencyPause
+                        | ProposalType::UpdateGuardian
                 ) {
                     match super::scrape_hashi_config(client.clone(), state.hashi_id()).await {
                         Ok(config) => {
@@ -566,6 +568,7 @@ fn parse_proposal_type_from_type_tag(type_tag: &TypeTag) -> ProposalType {
         ("upgrade", "Upgrade") => ProposalType::Upgrade,
         ("emergency_pause", "EmergencyPause") => ProposalType::EmergencyPause,
         ("abort_reconfig", "AbortReconfig") => ProposalType::AbortReconfig,
+        ("update_guardian", "UpdateGuardian") => ProposalType::UpdateGuardian,
         _ => ProposalType::Unknown(format!("{}::{}", struct_tag.module(), struct_tag.name())),
     }
 }

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -22,6 +22,8 @@ const EVersionDisabled: vector<u8> = b"Version disabled";
 const EDisableCurrentVersion: vector<u8> = b"Cannot disable current version";
 
 const PAUSED_KEY: vector<u8> = b"paused";
+const GUARDIAN_URL_KEY: vector<u8> = b"guardian_url";
+const GUARDIAN_PUBLIC_KEY_KEY: vector<u8> = b"guardian_public_key";
 
 public struct Config has store {
     config: VecMap<String, Value>,
@@ -82,6 +84,19 @@ public(package) fun paused(self: &Config): bool {
 
 public(package) fun set_paused(self: &mut Config, paused: bool) {
     self.upsert(PAUSED_KEY, config_value::new_bool(paused))
+}
+
+public(package) fun guardian_url(self: &Config): Option<String> {
+    self.try_get(GUARDIAN_URL_KEY).map!(|v| v.as_string())
+}
+
+public(package) fun guardian_public_key(self: &Config): Option<vector<u8>> {
+    self.try_get(GUARDIAN_PUBLIC_KEY_KEY).map!(|v| v.as_bytes())
+}
+
+public(package) fun set_guardian(self: &mut Config, url: String, public_key: vector<u8>) {
+    self.upsert(GUARDIAN_URL_KEY, config_value::new_string(url));
+    self.upsert(GUARDIAN_PUBLIC_KEY_KEY, config_value::new_bytes(public_key));
 }
 
 // ======== Version Management ========

--- a/packages/hashi/sources/core/proposal/types/update_guardian.move
+++ b/packages/hashi/sources/core/proposal/types/update_guardian.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module hashi::update_guardian;
+
+use hashi::{hashi::Hashi, proposal};
+use std::string::String;
+use sui::{clock::Clock, vec_map::VecMap};
+
+const THRESHOLD_BPS: u64 = 6667;
+
+public struct UpdateGuardian has copy, drop, store {
+    url: String,
+    public_key: vector<u8>,
+}
+
+public fun propose(
+    hashi: &mut Hashi,
+    url: String,
+    public_key: vector<u8>,
+    metadata: VecMap<String, String>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    hashi.config().assert_version_enabled();
+    proposal::create(
+        hashi,
+        UpdateGuardian { url, public_key },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
+}
+
+public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
+    let UpdateGuardian { url, public_key } = proposal::execute(hashi, proposal_id, clock);
+    hashi.config_mut().set_guardian(url, public_key);
+}


### PR DESCRIPTION
## Summary
- New `UpdateGuardian` proposal type that atomically stores a guardian URL and public key in the on-chain core config
- Guardian config accessors (`guardian_url`, `guardian_public_key`, `set_guardian`) added to `config.move` using `try_get` (guardian is optional, not initialized at genesis)
- Rust side reads guardian endpoint from on-chain config first, falling back to node config file
- Full CLI support: `hashi proposal create update-guardian --url <url> --public-key <hex>`

## Test plan
- [ ] Move package builds cleanly
- [ ] Rust `cargo check` passes
- [ ] Verify `update_guardian::propose` and `update_guardian::execute` work in e2e tests
- [ ] Verify guardian client initialization reads from on-chain config when available
- [ ] Verify fallback to node config when no on-chain guardian config exists