### PR TITLE
Eliminate redundant Lagrange interpolation in RS recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.9"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d6539fd65ce7f9a5a786af3340e511b7dae454c1#d6539fd65ce7f9a5a786af3340e511b7dae454c1"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=b7c6bbef4ff289948de726b93efda77ac04f30cd#b7c6bbef4ff289948de726b93efda77ac04f30cd"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d6539fd65ce7f9a5a786af3340e511b7dae454c1#d6539fd65ce7f9a5a786af3340e511b7dae454c1"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=b7c6bbef4ff289948de726b93efda77ac04f30cd#b7c6bbef4ff289948de726b93efda77ac04f30cd"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2332,7 +2332,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d6539fd65ce7f9a5a786af3340e511b7dae454c1#d6539fd65ce7f9a5a786af3340e511b7dae454c1"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=b7c6bbef4ff289948de726b93efda77ac04f30cd#b7c6bbef4ff289948de726b93efda77ac04f30cd"
 dependencies = [
  "bcs",
  "digest 0.10.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ jiff = "0.2"
 tar = "0.4"
 
 # fastcrypto
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = "d6539fd65ce7f9a5a786af3340e511b7dae454c1" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = "d6539fd65ce7f9a5a786af3340e511b7dae454c1" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = "b7c6bbef4ff289948de726b93efda77ac04f30cd" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = "b7c6bbef4ff289948de726b93efda77ac04f30cd" }
 
 # Sui monorepo deps
 bin-version = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }

--- a/crates/hashi/src/mpc/signing.rs
+++ b/crates/hashi/src/mpc/signing.rs
@@ -5,7 +5,6 @@ use fastcrypto::error::FastCryptoError;
 use fastcrypto::groups::secp256k1::schnorr::SchnorrSignature;
 use fastcrypto::serde_helpers::ToFromByteArray;
 use fastcrypto_tbls::polynomial::Eval;
-use fastcrypto_tbls::polynomial::Poly;
 use fastcrypto_tbls::threshold_schnorr::Address as DerivationAddress;
 use fastcrypto_tbls::threshold_schnorr::G;
 use fastcrypto_tbls::threshold_schnorr::S;
@@ -13,6 +12,7 @@ use fastcrypto_tbls::threshold_schnorr::avss;
 use fastcrypto_tbls::threshold_schnorr::presigning::Presignatures;
 use fastcrypto_tbls::threshold_schnorr::reed_solomon::RSDecoder;
 use fastcrypto_tbls::threshold_schnorr::signing::aggregate_signatures;
+use fastcrypto_tbls::threshold_schnorr::signing::finalize_schnorr_signature;
 use fastcrypto_tbls::threshold_schnorr::signing::generate_partial_signatures;
 use hashi_types::committee::Committee;
 use std::collections::HashMap;
@@ -519,22 +519,14 @@ fn aggregate_signatures_with_recovery(
 ) -> Result<SchnorrSignature, FastCryptoError> {
     let indices: Vec<_> = partial_signatures.iter().map(|e| e.index).collect();
     let values: Vec<_> = partial_signatures.iter().map(|e| e.value).collect();
-    let decoder = RSDecoder::new(indices.clone(), threshold as usize);
-    let coefficients = decoder.decode(&values)?;
-    // TODO: This re-interpolates a polynomial we have already decoded. Refactor `fastcrypto` to
-    // expose the constant term directly from the RS decoded message, avoiding redundant work.
-    let poly = Poly::from(coefficients);
-    let corrected_sigs: Vec<Eval<S>> = indices
-        .iter()
-        .take(threshold as usize)
-        .map(|&idx| poly.eval(idx))
-        .collect();
-    aggregate_signatures(
+    let s = RSDecoder::new(indices, threshold as usize)
+        .compute_message_polynomial(&values)?
+        .into_c0();
+    finalize_schnorr_signature(
         message,
         public_presig,
         beacon_value,
-        &corrected_sigs,
-        threshold,
+        s,
         verifying_key,
         derivation_address,
     )
@@ -583,6 +575,7 @@ mod tests {
     use fastcrypto::groups::secp256k1::schnorr::SchnorrPublicKey;
     use fastcrypto::serde_helpers::ToFromByteArray;
     use fastcrypto::traits::AllowedRng;
+    use fastcrypto_tbls::polynomial::Poly;
     use fastcrypto_tbls::threshold_schnorr::batch_avss;
     use fastcrypto_tbls::types::ShareIndex;
     use hashi_types::committee::CommitteeMember;


### PR DESCRIPTION
Follow-up on https://github.com/MystenLabs/fastcrypto/pull/955

#179 #515 