### PR TITLE
Increase withdrawal batch capacity

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -35,11 +35,14 @@ mod tests {
 
     const MAX_TX_SIZE_BYTES: usize = 131_072;
     const MAX_SERIALIZED_TX_EFFECTS_SIZE_BYTES: usize = 524_288;
+    const MAX_NUM_CACHED_OBJECTS: usize = 1_000;
 
     struct EventWithEffects<T> {
         event: T,
         tx_size_bytes: usize,
         effects_size_bytes: usize,
+        changed_objects: usize,
+        unchanged_loaded_runtime_objects: usize,
     }
 
     fn assert_tx_size_under_sui_limit(stage: &str, tx_size_bytes: usize) {
@@ -68,6 +71,45 @@ mod tests {
             "{stage} effects size ({effects_size_bytes} bytes) exceeded Sui's \
              max_serialized_tx_effects_size_bytes ({MAX_SERIALIZED_TX_EFFECTS_SIZE_BYTES} bytes)"
         );
+    }
+
+    fn assert_changed_objects_under_sui_limit(stage: &str, changed_objects: usize) {
+        info!(
+            stage,
+            changed_objects,
+            limit = MAX_NUM_CACHED_OBJECTS,
+            "Observed changed objects in Sui transaction effects"
+        );
+        assert!(
+            changed_objects <= MAX_NUM_CACHED_OBJECTS,
+            "{stage} changed objects ({changed_objects}) exceeded Sui's \
+             max_num_cached_objects ({MAX_NUM_CACHED_OBJECTS})"
+        );
+    }
+
+    fn assert_runtime_object_count_under_sui_limit(
+        stage: &str,
+        changed_objects: usize,
+        unchanged_loaded_runtime_objects: usize,
+    ) {
+        let runtime_objects = changed_objects + unchanged_loaded_runtime_objects;
+        info!(
+            stage,
+            runtime_objects,
+            changed_objects,
+            unchanged_loaded_runtime_objects,
+            limit = MAX_NUM_CACHED_OBJECTS,
+            "Observed runtime object count from Sui transaction effects"
+        );
+        assert!(
+            runtime_objects <= MAX_NUM_CACHED_OBJECTS,
+            "{stage} runtime object count ({runtime_objects}) exceeded Sui's \
+             max_num_cached_objects ({MAX_NUM_CACHED_OBJECTS})"
+        );
+    }
+
+    fn runtime_object_count(event: &EventWithEffects<impl Sized>) -> usize {
+        event.changed_objects + event.unchanged_loaded_runtime_objects
     }
 
     fn tx_bcs_size(txn: &sui_rpc::proto::sui::rpc::v2::ExecutedTransaction) -> Result<usize> {
@@ -928,6 +970,16 @@ mod tests {
                 .effects()
                 .bcs()
                 .value(),
+            Checkpoint::path_builder()
+                .transactions()
+                .effects()
+                .changed_objects()
+                .object_id(),
+            Checkpoint::path_builder()
+                .transactions()
+                .effects()
+                .unchanged_loaded_runtime_objects()
+                .object_id(),
         ]);
         let mut subscription = sui_client
             .subscription_client()
@@ -960,6 +1012,11 @@ mod tests {
                                     event: data,
                                     tx_size_bytes: tx_bcs_size(txn)?,
                                     effects_size_bytes: effects_bcs_size(txn)?,
+                                    changed_objects: txn.effects().changed_objects().len(),
+                                    unchanged_loaded_runtime_objects: txn
+                                        .effects()
+                                        .unchanged_loaded_runtime_objects()
+                                        .len(),
                                 });
                             }
                             Ok(None) => {}
@@ -1696,40 +1753,39 @@ mod tests {
         Ok(())
     }
 
-    /// Verify that the large withdrawal path stays within Sui transaction-size
-    /// and effects-size limits, and that signature-commit chunking works when a
-    /// withdrawal transaction has enough inputs to push the BCS-encoded
-    /// `signatures` vector past the 16 KiB pure-argument limit.
+    /// Stress-test withdrawal at the production default batch size (50
+    /// requests / 500 inputs). Verifies that commit, sign, confirm, and
+    /// cleanup all stay within Sui's runtime-object and effects-size limits.
+    ///
+    /// Before the two-phase spent optimization, confirm at 50 req / 500 inputs
+    /// would exceed Sui's 1000-object limit (~1053 objects). After the
+    /// optimization, confirm emits events only (0 objects per input) and a
+    /// separate `cleanup_spent_utxos` transaction does the bookkeeping.
     ///
     /// Test outline:
-    /// 1. Create 500 deposits (one UTXO each) so the pool has 500 UTXOs.
-    /// 2. Submit 50 withdrawal requests that together require spending UTXOs;
-    ///    consolidation at low fee rates pulls in all remaining UTXOs up to the
+    /// 1. Create 500 deposits (one UTXO each).
+    /// 2. Submit 50 withdrawal requests; low-fee consolidation fills the
     ///    500-input cap.
-    /// 3. Wait for a single `WithdrawalPickedForProcessingEvent` with all 50
-    ///    requests batched and a large number of inputs selected.
-    /// 4. Assert the actual committed Sui transaction payload is below
-    ///    `max_tx_size_bytes` and commit/sign/confirm effects are below
-    ///    `max_serialized_tx_effects_size_bytes`.
-    /// 5. Mine blocks and wait for `WithdrawalConfirmedEvent`, which implies the
-    ///    signature-commit transaction succeeded (previously it would fail with
-    ///    "maximum pure argument size is 16384").
+    /// 3. Assert commit, sign, and confirm transactions are under all Sui
+    ///    limits (tx size, effects size, runtime objects).
+    /// 4. Mine blocks and wait for confirmation.
+    /// 5. Run `cleanup_spent_utxos` and verify it succeeds.
     #[tokio::test]
     async fn test_large_withdrawal_signature_chunking() -> Result<()> {
         init_test_logging();
-        info!("=== Starting Large Withdrawal Signature Chunking Test ===");
+        info!("=== Starting Large Withdrawal Stress Test ===");
+
+        let num_withdrawals: usize = 50;
+        let num_deposits: usize = 500;
 
         // 24-hour batching delay: the batch fires only at capacity (50), not
         // on a timer. This ensures all 50 requests end up in one Bitcoin tx.
         // With 4 nodes at weight 25 each (total_weight=100), the presig pool
-        // is batch_size_per_weight * total_weight. We need at least 500
-        // presignatures for 500 inputs, so set batch_size_per_weight to 10
-        // which gives 10 * 100 = 1000 presigs. However the pool is consumed
-        // per-batch (20 at a time), so we need a larger pool to avoid
-        // exhaustion during signing of 500 inputs.
+        // is batch_size_per_weight * total_weight. We need enough
+        // presignatures for 500 inputs.
         let mut networks = TestNetworksBuilder::new()
             .with_nodes(4)
-            .with_withdrawal_max_batch_size(50)
+            .with_withdrawal_max_batch_size(num_withdrawals)
             .with_withdrawal_batching_delay_ms(86_400_000)
             .with_batch_size_per_weight(100)
             .build()
@@ -1749,7 +1805,6 @@ mod tests {
         // for value and consolidation at low fee rates pulls in the rest up
         // to the 500-input cap.
         let deposit_amount_sats = 40_000u64;
-        let num_deposits: usize = 500;
         // With 500 inputs and 64-byte Schnorr signatures, the BCS-encoded
         // signatures vector is ~32.5 KiB -- well above the 16 KiB per-pure-arg
         // limit that the chunking fix addresses.
@@ -1808,9 +1863,9 @@ mod tests {
         }
         info!("All {} deposit requests submitted on Sui", num_deposits);
 
-        // Poll the on-chain deposit queue until all deposits are confirmed.
-        // The hashi node's watcher keeps OnchainState up-to-date; confirmed
-        // deposits leave the queue automatically.
+        // Poll the on-chain deposit queue until all deposits are confirmed
+        // and visible in the UTXO pool. The stress measurement below assumes
+        // coin selection has all UTXOs available.
         // Mine blocks in the background so the leader's BTC-block-driven
         // deposit processing loop keeps firing.
         let _deposit_miner = BackgroundMiner::start(&networks.bitcoin_node);
@@ -1827,28 +1882,37 @@ mod tests {
                     deposit_timeout,
                 ));
             }
-            let remaining = hashi.onchain_state().deposit_requests().len();
-            if remaining == 0 {
+            let state = hashi.onchain_state();
+            let remaining = state.deposit_requests().len();
+            let active_utxos = state.active_utxos().len();
+            if remaining == 0 && active_utxos >= num_deposits {
                 break;
             }
             let confirmed = num_deposits - remaining;
             if confirmed / 50 > last_logged / 50 {
-                info!("Deposit confirmations: {}/{}", confirmed, num_deposits);
+                info!(
+                    active_utxos,
+                    "Deposit confirmations: {}/{}", confirmed, num_deposits
+                );
                 last_logged = confirmed;
             }
             tokio::time::sleep(Duration::from_secs(2)).await;
         }
         info!("All deposits confirmed");
+        drop(_deposit_miner);
 
         // --- Submit 50 withdrawal requests ---
         let withdrawal_amount_sats = 30_000u64;
-        let num_withdrawals: usize = 50;
         info!(
             "Submitting {} withdrawal requests of {} sats each...",
             num_withdrawals, withdrawal_amount_sats
         );
 
-        for i in 0..num_withdrawals {
+        // Submit all but the last request first. With a 24-hour delay and max
+        // batch size, the leader cannot pick the batch yet, which lets this
+        // test subscribe for the picked event before the final request makes
+        // the batch full.
+        for i in 0..(num_withdrawals - 1) {
             let btc_destination = networks.bitcoin_node.get_new_address()?;
             let destination_bytes = extract_witness_program(&btc_destination)?;
             executor
@@ -1862,22 +1926,47 @@ mod tests {
                 );
             }
         }
-        info!("All withdrawal requests submitted");
 
         // Wait for the batched withdrawal to be picked for processing. The
-        // 24-hour delay means it fires only at capacity (50 requests).
+        // 24-hour delay means it fires only at the configured capacity.
         info!("Waiting for batched withdrawal to be picked...");
-        let picked_with_effects = wait_for_batched_withdrawal_picked_with_effects(
-            &mut networks.sui_network.client,
-            num_withdrawals,
-            Duration::from_secs(300),
-        )
-        .await?;
+        let mut picked_client = networks.sui_network.client.clone();
+        let picked_task = tokio::spawn(async move {
+            wait_for_batched_withdrawal_picked_with_effects(
+                &mut picked_client,
+                num_withdrawals,
+                Duration::from_secs(300),
+            )
+            .await
+        });
+
+        let btc_destination = networks.bitcoin_node.get_new_address()?;
+        let destination_bytes = extract_witness_program(&btc_destination)?;
+        executor
+            .execute_create_withdrawal_request(withdrawal_amount_sats, destination_bytes)
+            .await?;
+        info!(
+            "  Withdrawal requests submitted: {}/{}",
+            num_withdrawals, num_withdrawals
+        );
+        info!("All withdrawal requests submitted");
+
+        let picked_with_effects = picked_task.await??;
         assert_tx_size_under_sui_limit("commit_withdrawal_tx", picked_with_effects.tx_size_bytes);
         assert_effects_size_under_sui_limit(
             "commit_withdrawal_tx",
             picked_with_effects.effects_size_bytes,
         );
+        assert_changed_objects_under_sui_limit(
+            "commit_withdrawal_tx",
+            picked_with_effects.changed_objects,
+        );
+        assert_runtime_object_count_under_sui_limit(
+            "commit_withdrawal_tx",
+            picked_with_effects.changed_objects,
+            picked_with_effects.unchanged_loaded_runtime_objects,
+        );
+        let commit_runtime_objects = runtime_object_count(&picked_with_effects);
         let picked = picked_with_effects.event;
 
         info!(
@@ -1894,7 +1983,7 @@ mod tests {
             num_withdrawals,
         );
 
-        // With 500 UTXOs at 4,000 sats and 1,500,000 sats of withdrawals,
+        // With 500 UTXOs at 40,000 sats and 1,500,000 sats of withdrawals,
         // coin selection should pick most UTXOs for value and consolidate the
         // rest. Verify that enough inputs were selected to exceed the old
         // 16 KiB per-pure-arg limit (~252 signatures at 65 BCS bytes each).
@@ -1920,6 +2009,15 @@ mod tests {
             "sign_withdrawal",
             signed_with_effects.effects_size_bytes,
         );
+        assert_changed_objects_under_sui_limit(
+            "sign_withdrawal",
+            signed_with_effects.changed_objects,
+        );
+        assert_runtime_object_count_under_sui_limit(
+            "sign_withdrawal",
+            signed_with_effects.changed_objects,
+            signed_with_effects.unchanged_loaded_runtime_objects,
+        );
 
         // Mine blocks and wait for the withdrawal to be confirmed. This also
         // records the confirmation transaction's serialized effects size.
@@ -1934,9 +2032,29 @@ mod tests {
             "confirm_withdrawal",
             confirmed_with_effects.effects_size_bytes,
         );
+        assert_changed_objects_under_sui_limit(
+            "confirm_withdrawal",
+            confirmed_with_effects.changed_objects,
+        );
+        assert_runtime_object_count_under_sui_limit(
+            "confirm_withdrawal",
+            confirmed_with_effects.changed_objects,
+            confirmed_with_effects.unchanged_loaded_runtime_objects,
+        );
+        let confirm_runtime_objects = runtime_object_count(&confirmed_with_effects);
+        info!(
+            confirm_runtime_objects,
+            commit_runtime_objects, "Compared withdrawal commit and confirm runtime object counts"
+        );
         drop(miner);
 
-        info!("=== Large Withdrawal Signature Chunking Test Passed ===");
+        // --- Run cleanup_spent_utxos to finalize on-chain bookkeeping ---
+        info!("Running cleanup_spent_utxos...");
+        let utxo_ids: Vec<_> = picked.inputs.iter().map(|u| u.id).collect();
+        executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
+        info!("cleanup_spent_utxos succeeded");
+
+        info!("=== Large Withdrawal Stress Test Passed ===");
         Ok(())
     }
 }

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -259,7 +259,7 @@ pub struct HashiNetworkBuilder {
     /// Defaults to `Some(0)` (no delay) for tests.
     pub withdrawal_batching_delay_ms: Option<u64>,
     /// Overrides `withdrawal_max_batch_size` in each node's config.
-    /// `None` uses the production default (50).
+    /// `None` uses the production default (70).
     pub withdrawal_max_batch_size: Option<usize>,
     /// Overrides `max_mempool_chain_depth` in each node's config.
     /// `None` uses the production default (5).

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -370,6 +370,7 @@ pub struct UtxoRecord {
     pub utxo: Utxo,
     pub produced_by: Option<Address>,
     pub locked_by: Option<Address>,
+    pub spent_epoch: Option<u64>,
 }
 
 /// txid:vout

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -152,7 +152,7 @@ pub struct Config {
     /// transaction. The batch commits immediately once this many requests are
     /// ready, without waiting for `withdrawal_batching_delay_ms` to elapse.
     ///
-    /// Defaults to 50 (the algorithm's hard upper bound).
+    /// Defaults to 70 (the algorithm's hard upper bound).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_max_batch_size: Option<usize>,
 
@@ -349,7 +349,8 @@ impl Config {
 
     pub fn withdrawal_max_batch_size(&self) -> usize {
         self.withdrawal_max_batch_size
-            .unwrap_or(crate::utxo_pool::CoinSelectionParams::DEFAULT_MAX_WITHDRAWAL_REQUESTS)
+            .unwrap_or(crate::utxo_pool::CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)
+            .min(crate::utxo_pool::CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)
     }
 
     pub fn max_mempool_chain_depth(&self) -> usize {
@@ -466,5 +467,26 @@ mod tests {
         let port1 = get_available_port();
         let port2 = get_available_port();
         assert_ne!(port1, port2, "Should return different ports");
+    }
+
+    #[test]
+    fn test_withdrawal_max_batch_size_defaults_to_absolute_cap() {
+        let config = Config::default();
+        assert_eq!(
+            config.withdrawal_max_batch_size(),
+            crate::utxo_pool::CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        );
+    }
+
+    #[test]
+    fn test_withdrawal_max_batch_size_clamps_to_absolute_cap() {
+        let config = Config {
+            withdrawal_max_batch_size: Some(200),
+            ..Config::default()
+        };
+        assert_eq!(
+            config.withdrawal_max_batch_size(),
+            crate::utxo_pool::CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        );
     }
 }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -4,10 +4,14 @@
 //! Garbage collection for expired on-chain data.
 
 use super::LeaderService;
+use super::PendingUtxoCleanup;
 use crate::onchain::types::DepositRequest;
 use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
+use crate::onchain::types::UtxoId;
+use crate::onchain::types::UtxoRecord;
 use crate::sui_tx_executor::SuiTxExecutor;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use sui_sdk_types::Address;
 use tokio_util::task::AbortOnDropHandle;
@@ -131,6 +135,73 @@ impl LeaderService {
         })));
     }
 
+    /// If there are pending UTXO cleanups and no task in-flight, spawn a
+    /// background task to process the next one. When the queue is empty,
+    /// scans on-chain state for orphaned locked UTXOs whose withdrawal has
+    /// already been confirmed (handles the crash-between-confirm-and-cleanup
+    /// case).
+    pub(crate) fn check_cleanup_spent_utxos(&mut self) {
+        if self.utxo_cleanup_gc_task.is_some() {
+            debug!("UTXO cleanup GC task already in-flight, skipping");
+            return;
+        }
+
+        if self.pending_utxo_cleanups.is_empty() && self.utxo_cleanup_scan_needed {
+            self.discover_orphaned_utxo_cleanups();
+            if self.pending_utxo_cleanups.is_empty() {
+                self.utxo_cleanup_scan_needed = false;
+            }
+        }
+
+        let Some(cleanup) = self.pending_utxo_cleanups.pop_front() else {
+            return;
+        };
+
+        info!(
+            utxo_count = cleanup.utxo_ids.len(),
+            "Scheduling UTXO cleanup for spent UTXOs",
+        );
+
+        let inner = self.inner.clone();
+        self.utxo_cleanup_gc_task = Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
+            Self::cleanup_spent_utxos(inner, cleanup).await
+        })));
+    }
+
+    /// Scan local state for UTXOs with `spent_epoch` set — they have been
+    /// spent but their cleanup never ran (e.g. leader crashed).
+    fn discover_orphaned_utxo_cleanups(&mut self) {
+        let state = self.inner.onchain_state().state();
+        let utxo_records = state.hashi().utxo_pool.utxo_records();
+
+        let orphaned_ids = find_spent_utxos_pending_cleanup(utxo_records);
+
+        if !orphaned_ids.is_empty() {
+            info!(
+                "Discovered {} spent UTXO(s) pending cleanup",
+                orphaned_ids.len(),
+            );
+            self.pending_utxo_cleanups.push_back(PendingUtxoCleanup {
+                utxo_ids: orphaned_ids,
+            });
+        }
+    }
+
+    async fn cleanup_spent_utxos(
+        inner: Arc<crate::Hashi>,
+        cleanup: PendingUtxoCleanup,
+    ) -> anyhow::Result<()> {
+        let mut executor = SuiTxExecutor::from_hashi(inner)?;
+        executor
+            .execute_cleanup_spent_utxos(&cleanup.utxo_ids)
+            .await?;
+        info!(
+            utxo_count = cleanup.utxo_ids.len(),
+            "Successfully cleaned up spent UTXOs",
+        );
+        Ok(())
+    }
+
     async fn delete_expired_proposals(
         inner: Arc<crate::Hashi>,
         expired_proposals: Vec<Proposal>,
@@ -237,5 +308,106 @@ impl LeaderService {
             expired_proposals.len()
         );
         Ok(())
+    }
+}
+
+/// Return UTXO IDs whose `spent_epoch` is set — these are spent UTXOs
+/// still present in `utxo_records` that need to be cleaned up on-chain.
+///
+/// This is the pure-data core of [`LeaderService::discover_orphaned_utxo_cleanups`],
+/// extracted so it can be unit-tested without constructing a full `LeaderService`.
+pub(crate) fn find_spent_utxos_pending_cleanup(
+    utxo_records: &BTreeMap<UtxoId, UtxoRecord>,
+) -> Vec<UtxoId> {
+    utxo_records
+        .iter()
+        .filter(|(_, record)| record.spent_epoch.is_some())
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::onchain::types::Utxo;
+    use hashi_types::bitcoin_txid::BitcoinTxid;
+
+    /// Helper: build a `UtxoId` from a distinguishing byte and vout.
+    fn utxo_id(byte: u8, vout: u32) -> UtxoId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = byte;
+        UtxoId {
+            txid: BitcoinTxid::new(bytes),
+            vout,
+        }
+    }
+
+    /// Helper: build a `UtxoRecord` with the given `spent_epoch`.
+    fn record(spent_epoch: Option<u64>) -> UtxoRecord {
+        UtxoRecord {
+            utxo: Utxo {
+                id: utxo_id(0, 0),
+                amount: 1_000,
+                derivation_path: None,
+            },
+            produced_by: None,
+            locked_by: None,
+            spent_epoch,
+        }
+    }
+
+    #[test]
+    fn no_spent_utxos_returns_empty() {
+        let utxo_records: BTreeMap<UtxoId, UtxoRecord> =
+            BTreeMap::from([(utxo_id(1, 0), record(None)), (utxo_id(2, 0), record(None))]);
+
+        let result = find_spent_utxos_pending_cleanup(&utxo_records);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn spent_utxo_found_for_cleanup() {
+        let utxo_records = BTreeMap::from([(utxo_id(1, 0), record(Some(1)))]);
+
+        let result = find_spent_utxos_pending_cleanup(&utxo_records);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], utxo_id(1, 0));
+    }
+
+    #[test]
+    fn multiple_spent_utxos_found() {
+        let utxo_records = BTreeMap::from([
+            (utxo_id(1, 0), record(Some(1))),
+            (utxo_id(2, 0), record(Some(2))),
+            (utxo_id(3, 0), record(Some(1))),
+        ]);
+
+        let result = find_spent_utxos_pending_cleanup(&utxo_records);
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn mixed_spent_and_unspent() {
+        let utxo_records = BTreeMap::from([
+            // Unspent
+            (utxo_id(1, 0), record(None)),
+            (utxo_id(2, 0), record(None)),
+            // Spent
+            (utxo_id(3, 0), record(Some(1))),
+            (utxo_id(4, 0), record(Some(2))),
+        ]);
+
+        let result = find_spent_utxos_pending_cleanup(&utxo_records);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&utxo_id(3, 0)));
+        assert!(result.contains(&utxo_id(4, 0)));
+    }
+
+    #[test]
+    fn empty_utxo_records_returns_empty() {
+        let utxo_records: BTreeMap<UtxoId, UtxoRecord> = BTreeMap::new();
+
+        let result = find_spent_utxos_pending_cleanup(&utxo_records);
+        assert!(result.is_empty());
     }
 }

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -14,6 +14,7 @@ use crate::leader::retry::GlobalRetryTracker;
 use crate::leader::retry::RetryTracker;
 use crate::onchain::types::DepositConfirmationMessage;
 use crate::onchain::types::DepositRequest;
+use crate::onchain::types::UtxoId;
 use crate::onchain::types::WithdrawalRequest;
 use crate::onchain::types::WithdrawalTransaction;
 use crate::sui_tx_executor::SuiTxExecutor;
@@ -41,6 +42,7 @@ use hashi_types::proto::SignWithdrawalTransactionRequest;
 use hashi_types::proto::SignWithdrawalTxConstructionRequest;
 use hashi_types::proto::SignWithdrawalTxSigningRequest;
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_futures::service::Service;
@@ -56,6 +58,14 @@ use x509_parser::nom::AsBytes;
 
 const NUM_CONSECUTIVE_LEADER_CHECKPOINTS: u64 = 100;
 const LEADER_TASK_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub(crate) struct PendingUtxoCleanup {
+    pub utxo_ids: Vec<UtxoId>,
+}
+
+/// Result of a withdrawal broadcast task: `Some(spent_utxo_ids)` when the
+/// withdrawal was confirmed on Sui, `None` when it was not yet ready.
+type WithdrawalBroadcastResult = anyhow::Result<Option<Vec<UtxoId>>>;
 
 #[derive(Clone, Copy, Debug)]
 enum DepositPhase {
@@ -75,11 +85,14 @@ pub struct LeaderService {
     withdrawal_commitment_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     withdrawal_signing_tasks: JoinSet<(Address, anyhow::Result<()>)>,
     inflight_withdrawal_signings: HashSet<Address>,
-    withdrawal_broadcast_tasks: JoinSet<(Address, anyhow::Result<()>)>,
+    withdrawal_broadcast_tasks: JoinSet<(Address, WithdrawalBroadcastResult)>,
     inflight_withdrawal_broadcasts: HashSet<Address>,
     stuck_withdrawal_warned: HashSet<Address>,
     deposit_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     proposal_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    pending_utxo_cleanups: VecDeque<PendingUtxoCleanup>,
+    utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    utxo_cleanup_scan_needed: bool,
 }
 
 impl LeaderService {
@@ -101,6 +114,9 @@ impl LeaderService {
             stuck_withdrawal_warned: HashSet::new(),
             deposit_gc_task: None,
             proposal_gc_task: None,
+            pending_utxo_cleanups: VecDeque::new(),
+            utxo_cleanup_gc_task: None,
+            utxo_cleanup_scan_needed: true,
         }
     }
 
@@ -152,6 +168,7 @@ impl LeaderService {
                     self.process_unsigned_withdrawal_txns();
                     self.process_signed_withdrawal_txns();
                     self.check_delete_proposals(checkpoint_timestamp_ms);
+                    self.check_cleanup_spent_utxos();
 
                     if !self.pending_deposit_requests.is_empty() {
                         self.process_deposit_requests();
@@ -209,6 +226,12 @@ impl LeaderService {
                     self.proposal_gc_task = None;
                     Self::log_task_result("proposal_gc", result);
                 }
+                Some(result) = OptionFuture::from(self.utxo_cleanup_gc_task.as_mut()) => {
+                    self.utxo_cleanup_gc_task = None;
+                    Self::log_task_result("utxo_cleanup_gc", result);
+                    self.utxo_cleanup_scan_needed = true;
+                    self.check_cleanup_spent_utxos();
+                }
 
             }
         }
@@ -263,12 +286,17 @@ impl LeaderService {
 
     fn handle_completed_withdrawal_broadcast_task(
         &mut self,
-        result: Result<(Address, anyhow::Result<()>), tokio::task::JoinError>,
+        result: Result<(Address, WithdrawalBroadcastResult), tokio::task::JoinError>,
     ) {
         let mapped = match result {
             Ok((withdrawal_id, inner)) => {
                 self.inflight_withdrawal_broadcasts.remove(&withdrawal_id);
-                Ok(inner)
+                if let Ok(Some(utxo_ids)) = &inner {
+                    self.pending_utxo_cleanups.push_back(PendingUtxoCleanup {
+                        utxo_ids: utxo_ids.clone(),
+                    });
+                }
+                Ok(inner.map(|_| ()))
             }
             Err(e) => Err(e),
         };
@@ -1496,11 +1524,14 @@ impl LeaderService {
 
     /// Check BTC tx status, broadcast/re-broadcast if needed, confirm when
     /// enough BTC confirmations are reached.
+    ///
+    /// Returns `Some(utxo_ids)` when the withdrawal was confirmed on Sui,
+    /// signalling that UTXO cleanup should be scheduled.
     #[tracing::instrument(level = "info", skip_all, fields(withdrawal_txn_id = %txn.id, bitcoin_txid))]
     async fn handle_signed_withdrawal(
         inner: Arc<Hashi>,
         txn: WithdrawalTransaction,
-    ) -> anyhow::Result<()> {
+    ) -> WithdrawalBroadcastResult {
         let confirmation_threshold = inner.onchain_state().bitcoin_confirmation_threshold();
         let txid: bitcoin::Txid = txn.txid.into();
         tracing::Span::current().record("bitcoin_txid", tracing::field::display(&txid));
@@ -1513,7 +1544,9 @@ impl LeaderService {
                     confirmations,
                     "Withdrawal tx confirmed, proceeding to on-chain confirmation"
                 );
+                let utxo_ids: Vec<UtxoId> = txn.inputs.iter().map(|u| u.id).collect();
                 Self::confirm_withdrawal_on_sui(&inner, &txn).await?;
+                return Ok(Some(utxo_ids));
             }
             Ok(TxStatus::Confirmed { confirmations }) => {
                 debug!(
@@ -1534,7 +1567,7 @@ impl LeaderService {
                 );
             }
         }
-        Ok(())
+        Ok(None)
     }
 
     /// Rebuild a fully signed Bitcoin transaction from on-chain WithdrawalTransaction
@@ -2039,6 +2072,7 @@ impl LeaderService {
             .await?;
 
         info!("Successfully confirmed withdrawal {:?}", withdrawal_txn_id);
+
         Ok(())
     }
 }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -332,6 +332,7 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                         utxo,
                         produced_by: None,
                         locked_by: None,
+                        spent_epoch: None,
                     },
                 );
             }
@@ -431,6 +432,7 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                                 utxo: change_utxo,
                                 produced_by: Some(event.withdrawal_txn_id),
                                 locked_by: None,
+                                spent_epoch: None,
                             },
                         );
                     }
@@ -497,11 +499,15 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
             }
             HashiEvent::UtxoSpentEvent(utxo_spent_event) => {
                 let mut state = state.state_mut();
-                state
+                // Mark the local record as spent so the orphan scanner can discover it.
+                if let Some(record) = state
                     .hashi
                     .utxo_pool
                     .utxo_records
-                    .remove(&utxo_spent_event.utxo_id);
+                    .get_mut(&utxo_spent_event.utxo_id)
+                {
+                    record.spent_epoch = Some(utxo_spent_event.spent_epoch);
+                }
                 state
                     .hashi
                     .utxo_pool

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -92,14 +92,46 @@ fn build_chunked_vec_vec_u8_arg(
         let chunk_arg = builder.pure(&chunk);
         builder.move_call(
             Function::new(
-                Address::new([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 1,
-                ]),
+                MOVE_STDLIB_ADDRESS,
                 Identifier::from_static("vector"),
                 Identifier::from_static("append"),
             )
             .with_type_args(vec![vec_u8_type.clone()]),
+            vec![combined, chunk_arg],
+        );
+    }
+
+    combined
+}
+
+/// Maximum number of arguments to pass to a single `make_move_vec` command.
+///
+/// Sui enforces a 512-argument limit per PTB command. Keep this well below the
+/// ceiling so large withdrawal commits can assemble vectors of custom Move
+/// structs without making one command consume hundreds of arguments.
+const MAX_MOVE_VEC_ARGS_PER_CHUNK: usize = 250;
+
+/// Build a `vector<T>` PTB argument from existing element arguments, chunking
+/// the `make_move_vec` calls so no command gets close to Sui's 512-argument
+/// ceiling. Later chunks are appended into the first one with
+/// `0x1::vector::append<T>`.
+fn build_chunked_move_vec_arg(
+    builder: &mut TransactionBuilder,
+    elements: Vec<sui_transaction_builder::Argument>,
+    element_type: TypeTag,
+) -> sui_transaction_builder::Argument {
+    let mut iter = elements.chunks(MAX_MOVE_VEC_ARGS_PER_CHUNK);
+    let first_chunk = iter.next().unwrap_or_default().to_vec();
+    let combined = builder.make_move_vec(Some(element_type.clone()), first_chunk);
+    for chunk in iter {
+        let chunk_arg = builder.make_move_vec(Some(element_type.clone()), chunk.to_vec());
+        builder.move_call(
+            Function::new(
+                MOVE_STDLIB_ADDRESS,
+                Identifier::from_static("vector"),
+                Identifier::from_static("append"),
+            )
+            .with_type_args(vec![element_type.clone()]),
             vec![combined, chunk_arg],
         );
     }
@@ -183,9 +215,13 @@ use crate::onchain;
 use crate::onchain::OnchainState;
 use crate::onchain::types::DepositConfirmationMessage;
 use crate::onchain::types::DepositRequest;
+use crate::onchain::types::UtxoId;
 use crate::withdrawals::WithdrawalTxCommitment;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 10;
+
+/// Well-known Move stdlib package address (0x1)
+const MOVE_STDLIB_ADDRESS: Address = Address::from_static("0x1");
 
 /// Well-known Sui Clock object address (0x6)
 pub const SUI_CLOCK_OBJECT_ID: Address = Address::from_static("0x6");
@@ -1113,7 +1149,8 @@ impl SuiTxExecutor {
                 )
             })
             .collect();
-        let selected_utxos_arg = builder.make_move_vec(Some(utxo_id_type.into()), utxo_elements);
+        let selected_utxos_arg =
+            build_chunked_move_vec_arg(&mut builder, utxo_elements, utxo_id_type.into());
 
         let output_utxo_type = StructTag::new(
             self.hashi_ids.package_id,
@@ -1137,7 +1174,8 @@ impl SuiTxExecutor {
                 )
             })
             .collect();
-        let outputs_arg = builder.make_move_vec(Some(output_utxo_type.into()), output_elements);
+        let outputs_arg =
+            build_chunked_move_vec_arg(&mut builder, output_elements, output_utxo_type.into());
 
         let txid_arg = builder.pure(&approval.txid);
         let cert_arg = build_committee_signature_arg(&mut builder, self.hashi_ids.package_id, cert);
@@ -1352,6 +1390,72 @@ impl SuiTxExecutor {
                 "confirm_withdrawal failed: {:?}",
                 response.transaction().effects().status()
             );
+        }
+        Ok(())
+    }
+
+    /// Execute `withdraw::cleanup_spent_utxos` to finalize spent-UTXO
+    /// bookkeeping after a withdrawal has been confirmed.
+    ///
+    /// Large input sets are chunked across multiple transactions to stay
+    /// under the Sui object limit.
+    #[tracing::instrument(
+        level = "info",
+        skip_all,
+        fields(utxo_count = utxo_ids.len()),
+    )]
+    pub async fn execute_cleanup_spent_utxos(&mut self, utxo_ids: &[UtxoId]) -> anyhow::Result<()> {
+        const MAX_PER_TX: usize = 400;
+
+        for chunk in utxo_ids.chunks(MAX_PER_TX) {
+            let mut builder = TransactionBuilder::new();
+            let hashi_arg = builder.object(
+                ObjectInput::new(self.hashi_ids.hashi_object_id)
+                    .as_shared()
+                    .with_mutable(true),
+            );
+
+            // Build the vector<UtxoId> argument
+            let utxo_id_type = StructTag::new(
+                self.hashi_ids.package_id,
+                Identifier::from_static("utxo"),
+                Identifier::from_static("UtxoId"),
+                vec![],
+            );
+            let utxo_elements: Vec<_> = chunk
+                .iter()
+                .map(|id| {
+                    let txid_arg = builder.pure(&id.txid);
+                    let vout_arg = builder.pure(&id.vout);
+                    builder.move_call(
+                        Function::new(
+                            self.hashi_ids.package_id,
+                            Identifier::from_static("utxo"),
+                            Identifier::from_static("utxo_id"),
+                        ),
+                        vec![txid_arg, vout_arg],
+                    )
+                })
+                .collect();
+            let utxo_ids_arg =
+                build_chunked_move_vec_arg(&mut builder, utxo_elements, utxo_id_type.into());
+
+            builder.move_call(
+                Function::new(
+                    self.hashi_ids.package_id,
+                    Identifier::from_static("withdraw"),
+                    Identifier::from_static("cleanup_spent_utxos"),
+                ),
+                vec![hashi_arg, utxo_ids_arg],
+            );
+
+            let response = self.execute(builder).await?;
+            if !response.transaction().effects().status().success() {
+                anyhow::bail!(
+                    "cleanup_spent_utxos failed: {:?}",
+                    response.transaction().effects().status()
+                );
+            }
         }
         Ok(())
     }

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -339,16 +339,15 @@ impl CoinSelectionParams {
     /// will not propagate through the standard P2P network.
     pub const DEFAULT_MAX_TX_WEIGHT: Weight = Weight::from_wu(400_000);
 
-    /// Default maximum consolidation inputs beyond the minimum
-    /// required to fund withdrawals.
-    pub const DEFAULT_MAX_INPUTS: usize = 500;
+    /// Default maximum total inputs selected for a withdrawal transaction,
+    /// including both funding inputs and consolidation inputs.
+    pub const DEFAULT_MAX_INPUTS: usize = 700;
 
-    /// Default maximum number of withdrawal requests per batch. A
-    /// batch of 50 P2TR outputs is ~9.2 kWU (~2.3% of the 400 kWU
-    /// policy limit), so the weight limit is never the binding
-    /// constraint. Larger batches amortize the fixed transaction
-    /// overhead across more requests, reducing per-request fees.
-    pub const DEFAULT_MAX_WITHDRAWAL_REQUESTS: usize = 50;
+    /// Maximum number of withdrawal requests per batch. Larger
+    /// configured values are clamped to this because Sui runtime object
+    /// limits constrain the commit transaction to roughly
+    /// `inputs + 3 * requests + 12` runtime objects (budget: 922).
+    pub const MAX_WITHDRAWAL_REQUESTS: usize = 70;
 
     /// Default minimum fee rate floor (1 sat/vB), matching Bitcoin
     /// Core's minimum relay fee.
@@ -418,7 +417,7 @@ impl CoinSelectionParams {
         Self {
             max_tx_weight: Self::DEFAULT_MAX_TX_WEIGHT,
             max_inputs: Self::DEFAULT_MAX_INPUTS,
-            max_withdrawal_requests: Self::DEFAULT_MAX_WITHDRAWAL_REQUESTS,
+            max_withdrawal_requests: Self::MAX_WITHDRAWAL_REQUESTS,
             max_fee_per_request,
             min_fee_rate: Self::DEFAULT_MIN_FEE_RATE,
             long_term_fee_rate: Self::DEFAULT_LONG_TERM_FEE_RATE,

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -41,6 +41,18 @@ fn confirmed_utxo(n: u8, amount: u64) -> UtxoCandidate {
     }
 }
 
+fn confirmed_utxo_with_vout(vout: u32, amount: u64) -> UtxoCandidate {
+    UtxoCandidate {
+        id: UtxoId {
+            txid: Address::new([0xAA; 32]).into(),
+            vout,
+        },
+        amount,
+        spend_path: SpendPath::TaprootScriptPath2of2,
+        status: UtxoStatus::Confirmed,
+    }
+}
+
 /// Creates a pending UTXO with one 0-confirmation ancestor (mempool
 /// depth 1). The ancestor has weight 1000 WU and fee 500 sat.
 fn pending_utxo(n: u8, amount: u64) -> UtxoCandidate {
@@ -486,6 +498,36 @@ fn test_low_fee_consolidation_active_smallest_first() {
             "second-smallest should be consolidated: {extra_amounts:?}"
         );
     }
+    assert_conservation(&result);
+}
+
+#[test]
+fn test_low_fee_absolute_request_cap_can_use_default_input_cap() {
+    let utxos: Vec<UtxoCandidate> = (0..CoinSelectionParams::DEFAULT_MAX_INPUTS as u32)
+        .map(|i| confirmed_utxo_with_vout(i, 40_000))
+        .collect();
+    let requests: Vec<WithdrawalRequest> = (0..CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)
+        .map(|i| make_request(i as u8, 100_001, i as u64))
+        .collect();
+    let params = CoinSelectionParams {
+        max_inputs: CoinSelectionParams::DEFAULT_MAX_INPUTS,
+        max_withdrawal_requests: CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &requests,
+        &params,
+        FeeRate::from_sat_per_vb_unchecked(1),
+    )
+    .expect("should select the absolute request / default input envelope at low fee");
+
+    assert_eq!(
+        result.selected_requests.len(),
+        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+    );
+    assert_eq!(result.inputs.len(), CoinSelectionParams::DEFAULT_MAX_INPUTS);
     assert_conservation(&result);
 }
 

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -61,6 +61,17 @@ pub(crate) fn withdrawal_limiter_consumption_amount(txn: &WithdrawalTransaction)
     inputs.saturating_sub(change)
 }
 
+/// Conservative runtime-object budget for withdrawal commit transactions.
+///
+/// Sui's hard object-runtime cache limit is 1000 objects. Empirical
+/// measurements put withdrawal commit transactions at roughly
+/// `selected_utxos + 3 * requests + fixed_overhead` runtime objects. Target
+/// 922 to leave 7.8% headroom below the hard 1000 cap.
+const WITHDRAWAL_COMMIT_RUNTIME_OBJECT_BUDGET: usize = 922;
+const WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS: usize = 12;
+const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
+
 /// Full input weight (WU) for a 2-of-2 taproot script-path spend.
 /// TXIN_BASE_WEIGHT (164 WU) + satisfaction (234 WU) = 398 WU (100 vB).
 /// Used in fee validation where we calculate weight directly without
@@ -76,6 +87,32 @@ const P2TR_OUTPUT_WEIGHT_WU: u64 = 172;
 
 /// P2WPKH output weight: TXOUT_BASE(36) + OP_0 OP_PUSHBYTES_20 <20 bytes>(88) = 124 WU.
 const P2WPKH_OUTPUT_WEIGHT_WU: u64 = 124;
+
+fn safe_withdrawal_commit_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+    let request_objects =
+        request_count.saturating_mul(WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST);
+    let runtime_input_budget = WITHDRAWAL_COMMIT_RUNTIME_OBJECT_BUDGET
+        .saturating_sub(WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS)
+        .saturating_sub(request_objects);
+    let input_budget = runtime_input_budget / WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT;
+    configured_max_inputs.min(input_budget)
+}
+
+/// Confirm is no longer input-bound: spent UTXOs emit events only (0
+/// objects per input). The confirm transaction's object count is
+/// `requests + ~43` fixed overhead — well within the 1000-object limit
+/// for any practical request count. The commit path is the binding
+/// constraint.
+fn safe_withdrawal_flow_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+    let request_input_budget =
+        request_count.saturating_mul(CoinSelectionParams::DEFAULT_INPUT_BUDGET);
+    configured_max_inputs
+        .min(request_input_budget)
+        .min(safe_withdrawal_commit_max_inputs(
+            request_count,
+            configured_max_inputs,
+        ))
+}
 
 /// The data that validators BLS-sign over to approve a single withdrawal request.
 #[derive(Clone, Debug, serde_derive::Serialize)]
@@ -782,16 +819,9 @@ impl Hashi {
             .get_deposit_address(&hashi_pubkey, None)
             .map_err(WithdrawalCommitmentError::BtcTxBuildFailed)?;
 
-        // Build coin selection parameters from on-chain config. Override
-        // max_fee_per_request to match the Move contract's worst-case cap,
-        // and max_withdrawal_requests to honour the leader's configured
-        // batch cap.
-        let params = CoinSelectionParams {
-            max_fee_per_request: self.onchain_state().worst_case_network_fee(),
-            max_withdrawal_requests: self.config.withdrawal_max_batch_size(),
-            max_mempool_chain_depth: self.config.max_mempool_chain_depth(),
-            ..CoinSelectionParams::new(change_address.clone())
-        };
+        let configured_max_inputs = CoinSelectionParams::DEFAULT_MAX_INPUTS;
+        let configured_long_term_fee_rate = CoinSelectionParams::DEFAULT_LONG_TERM_FEE_RATE;
+        let configured_max_requests = self.config.withdrawal_max_batch_size().min(requests.len());
 
         // Snapshot both maps under a single read-lock so they are always
         // mutually consistent (e.g., a WithdrawalConfirmedEvent cannot update
@@ -837,8 +867,49 @@ impl Hashi {
             })
             .collect();
 
-        let result = utxo_pool::select_coins(&candidates, &mapped_requests, &params, fee_rate)
-            .map_err(|e| WithdrawalCommitmentError::UtxoSelectionFailed(anyhow!(e)))?;
+        let mut last_selection_error = None;
+        let mut result = None;
+        for request_count in (1..=configured_max_requests).rev() {
+            let max_inputs = safe_withdrawal_flow_max_inputs(request_count, configured_max_inputs);
+            if max_inputs == 0 {
+                continue;
+            }
+
+            let params = CoinSelectionParams {
+                max_inputs,
+                long_term_fee_rate: configured_long_term_fee_rate,
+                max_fee_per_request: self.onchain_state().worst_case_network_fee(),
+                max_withdrawal_requests: request_count,
+                max_mempool_chain_depth: self.config.max_mempool_chain_depth(),
+                ..CoinSelectionParams::new(change_address.clone())
+            };
+
+            match utxo_pool::select_coins(&candidates, &mapped_requests, &params, fee_rate) {
+                Ok(selection) => {
+                    if request_count < configured_max_requests {
+                        tracing::info!(
+                            selected_requests = selection.selected_requests.len(),
+                            selected_inputs = selection.inputs.len(),
+                            configured_max_requests,
+                            configured_max_inputs,
+                            max_inputs,
+                            "Reduced withdrawal batch to stay within Sui commit limits",
+                        );
+                    }
+                    result = Some(selection);
+                    break;
+                }
+                Err(e) => last_selection_error = Some(e),
+            }
+        }
+
+        let result = result.ok_or_else(|| {
+            WithdrawalCommitmentError::UtxoSelectionFailed(anyhow!(
+                last_selection_error
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "no withdrawal request count fits Sui commit limits".into())
+            ))
+        })?;
 
         // Build outputs: one per selected request (net amount already deducted),
         // plus an optional change output.
@@ -1255,6 +1326,7 @@ mod tests {
     use crate::onchain::types::OutputUtxo;
     use crate::onchain::types::Utxo;
     use crate::onchain::types::UtxoId;
+    use crate::utxo_pool::CoinSelectionParams;
     use hashi_types::bitcoin_txid::BitcoinTxid;
 
     fn input(amount: u64) -> Utxo {
@@ -1323,5 +1395,38 @@ mod tests {
     fn consumption_amount_no_inputs_returns_zero() {
         let txn = make_txn(vec![], vec![], None);
         assert_eq!(withdrawal_limiter_consumption_amount(&txn), 0);
+    }
+
+    #[test]
+    fn withdrawal_flow_budget_at_absolute_cap() {
+        assert_eq!(CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS, 70);
+        assert_eq!(
+            safe_withdrawal_commit_max_inputs(70, 700),
+            700,
+            "70 requests × 10 inputs = 700, exactly fits the 922 commit budget",
+        );
+        assert_eq!(
+            safe_withdrawal_flow_max_inputs(70, 700),
+            700,
+            "commit and per-request budgets align at 70 requests / 700 inputs",
+        );
+    }
+
+    #[test]
+    fn withdrawal_flow_budget_scales_inputs_with_request_count() {
+        assert_eq!(
+            safe_withdrawal_flow_max_inputs(10, CoinSelectionParams::DEFAULT_MAX_INPUTS),
+            10 * CoinSelectionParams::DEFAULT_INPUT_BUDGET,
+            "at low request counts, the per-request input budget is binding",
+        );
+    }
+
+    #[test]
+    fn withdrawal_flow_budget_at_default_batch_size() {
+        assert_eq!(
+            safe_withdrawal_flow_max_inputs(50, CoinSelectionParams::DEFAULT_MAX_INPUTS),
+            500,
+            "50 requests × 10 inputs/request = 500, per-request budget is binding",
+        );
     }
 }

--- a/packages/hashi/sources/btc/utxo_pool.move
+++ b/packages/hashi/sources/btc/utxo_pool.move
@@ -28,6 +28,7 @@ public struct UtxoRecord has store {
     utxo: Utxo,
     produced_by: Option<address>,
     locked_by: Option<address>,
+    spent_epoch: Option<u64>,
 }
 
 public struct UtxoPool has store {
@@ -58,6 +59,7 @@ public(package) fun insert_active(self: &mut UtxoPool, utxo: Utxo) {
                 utxo,
                 produced_by: option::none(),
                 locked_by: option::none(),
+                spent_epoch: option::none(),
             },
         )
 }
@@ -77,6 +79,7 @@ public(package) fun insert_pending(self: &mut UtxoPool, utxo: Utxo, withdrawal_i
                 utxo,
                 produced_by: option::some(withdrawal_id),
                 locked_by: option::none(),
+                spent_epoch: option::none(),
             },
         )
 }
@@ -94,13 +97,24 @@ public(package) fun get_utxo(self: &UtxoPool, utxo_id: UtxoId): hashi::utxo::Utx
     record.utxo
 }
 
-/// Mark a UTXO as confirmed-spent once its spending withdrawal is confirmed
-/// on Bitcoin. Removes the record from the pool and records the spent epoch.
-public(package) fun confirm_spent(self: &mut UtxoPool, utxo_id: UtxoId, epoch: u64) {
-    let UtxoRecord { utxo, produced_by: _, locked_by: _ } = self.utxo_records.remove(utxo_id);
-    utxo.delete();
-    self.spent_utxos.add(utxo_id, epoch);
+public(package) fun mark_spent(self: &mut UtxoPool, utxo_id: UtxoId, epoch: u64) {
+    let record: &mut UtxoRecord = self.utxo_records.borrow_mut(utxo_id);
+    record.spent_epoch = option::some(epoch);
     sui::event::emit(UtxoSpentEvent { utxo_id, spent_epoch: epoch });
+}
+
+/// Deferred bookkeeping for a spent UTXO: remove from `utxo_records` and
+/// record in `spent_utxos`. Aborts if the UTXO has not been marked spent.
+/// No-ops if the record has already been cleaned up.
+public(package) fun cleanup_spent(self: &mut UtxoPool, utxo_id: UtxoId) {
+    if (self.utxo_records.contains(utxo_id)) {
+        let UtxoRecord { utxo, produced_by: _, locked_by: _, spent_epoch } = self
+            .utxo_records
+            .remove(utxo_id);
+        let epoch = spent_epoch.destroy_some();
+        utxo.delete();
+        self.spent_utxos.add(utxo_id, epoch);
+    };
 }
 
 /// Promote a pending change UTXO to confirmed once its producing withdrawal
@@ -117,4 +131,14 @@ public(package) fun confirm_pending(self: &mut UtxoPool, utxo_id: UtxoId) {
 public struct UtxoSpentEvent has copy, drop {
     utxo_id: UtxoId,
     spent_epoch: u64,
+}
+
+#[test_only]
+public(package) fun has_active_record(self: &UtxoPool, utxo_id: UtxoId): bool {
+    self.utxo_records.contains(utxo_id)
+}
+
+#[test_only]
+public(package) fun has_spent_record(self: &UtxoPool, utxo_id: UtxoId): bool {
+    self.spent_utxos.contains(utxo_id)
 }

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -283,10 +283,11 @@ entry fun confirm_withdrawal(hashi: &mut Hashi, withdrawal_id: address, cert: Co
 
     let epoch = hashi.committee_set().epoch();
 
-    // Move each locked input to the spent set now that the Bitcoin transaction
-    // has been confirmed on-chain.
+    // Mark each input UTXO as spent and emit spent events. The actual record
+    // removal from utxo_records is deferred to `cleanup_spent_utxos` so this
+    // transaction stays well under Sui's 1000-object runtime cache limit.
     txn.withdrawal_txn_inputs().do_ref!(|utxo| {
-        hashi.bitcoin_mut().utxo_pool_mut().confirm_spent(utxo.id(), epoch);
+        hashi.bitcoin_mut().utxo_pool_mut().mark_spent(utxo.id(), epoch);
     });
 
     // Promote the change UTXO from unconfirmed to confirmed. If the change was
@@ -300,6 +301,17 @@ entry fun confirm_withdrawal(hashi: &mut Hashi, withdrawal_id: address, cert: Co
 
     // Move the txn to the cold (historical) bag.
     hashi.bitcoin_mut().withdrawal_queue_mut().insert_confirmed_txn(txn);
+}
+
+/// Finalize the on-chain bookkeeping for spent UTXOs. Moves each UTXO's
+/// record from `utxo_records` to `spent_utxos`, reading the spent epoch
+/// from the record's `spent_epoch` field (set by `mark_spent` during
+/// `confirm_withdrawal`). Callers pass the individual UTXO IDs to clean up.
+entry fun cleanup_spent_utxos(hashi: &mut Hashi, utxo_ids: vector<UtxoId>) {
+    hashi.config().assert_version_enabled();
+    utxo_ids.do!(|utxo_id| {
+        hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
+    });
 }
 
 /// Cancel a pending withdrawal request and return the stored BTC to the requester.

--- a/packages/hashi/tests/deposit_tests.move
+++ b/packages/hashi/tests/deposit_tests.move
@@ -72,8 +72,9 @@ fun test_spent_utxo_cannot_be_redeposited() {
     // Simulate: deposit confirmed (UTXO inserted into active pool)
     hashi.bitcoin_mut().utxo_pool_mut().insert_active(utxo);
 
-    // Simulate: UTXO spent in a withdrawal (moved to spent_utxos)
-    hashi.bitcoin_mut().utxo_pool_mut().confirm_spent(utxo_id, 0);
+    // Simulate: UTXO spent in a withdrawal (mark then cleanup to spent_utxos)
+    hashi.bitcoin_mut().utxo_pool_mut().mark_spent(utxo_id, 0);
+    hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
 
     // Attempt to deposit the same UTXO again — should abort because
     // is_spent_or_active() returns true.

--- a/packages/hashi/tests/utxo_spent_tests.move
+++ b/packages/hashi/tests/utxo_spent_tests.move
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module hashi::utxo_spent_tests;
+
+use hashi::test_utils;
+
+const REQUESTER: address = @0x100;
+const VOTER1: address = @0x1;
+const VOTER2: address = @0x2;
+const VOTER3: address = @0x3;
+
+// ======== mark_spent marks but keeps record ========
+
+/// mark_spent sets the spent_epoch flag and emits an event; the UTXO must
+/// remain in utxo_records and must NOT appear in spent_utxos.
+#[test]
+fun test_mark_spent_marks_but_keeps_record() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    let utxo_id = hashi::utxo::utxo_id(@0xCAFE, 0);
+    let utxo = hashi::utxo::utxo(utxo_id, 50_000, option::none());
+
+    hashi.bitcoin_mut().utxo_pool_mut().insert_active(utxo);
+
+    hashi.bitcoin_mut().utxo_pool_mut().mark_spent(utxo_id, 0);
+
+    let pool = hashi.bitcoin().utxo_pool();
+    assert!(pool.has_active_record(utxo_id));
+    assert!(!pool.has_spent_record(utxo_id));
+
+    std::unit_test::destroy(hashi);
+}
+
+// ======== cleanup_spent moves record ========
+
+/// cleanup_spent removes the UTXO from utxo_records and adds it to
+/// spent_utxos.
+#[test]
+fun test_cleanup_spent_moves_record() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    let utxo_id = hashi::utxo::utxo_id(@0xCAFE, 0);
+    let utxo = hashi::utxo::utxo(utxo_id, 50_000, option::none());
+
+    hashi.bitcoin_mut().utxo_pool_mut().insert_active(utxo);
+    hashi.bitcoin_mut().utxo_pool_mut().mark_spent(utxo_id, 0);
+    hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
+
+    let pool = hashi.bitcoin().utxo_pool();
+    assert!(!pool.has_active_record(utxo_id));
+    assert!(pool.has_spent_record(utxo_id));
+
+    std::unit_test::destroy(hashi);
+}
+
+// ======== cleanup_spent is idempotent ========
+
+/// A second cleanup_spent call for the same UTXO is a no-op (must not abort).
+#[test]
+fun test_cleanup_spent_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    let utxo_id = hashi::utxo::utxo_id(@0xCAFE, 0);
+    let utxo = hashi::utxo::utxo(utxo_id, 50_000, option::none());
+
+    hashi.bitcoin_mut().utxo_pool_mut().insert_active(utxo);
+
+    // Mark as spent, then cleanup -- moves to spent_utxos.
+    hashi.bitcoin_mut().utxo_pool_mut().mark_spent(utxo_id, 0);
+    hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
+    // Second cleanup -- should no-op, not abort.
+    hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
+
+    let pool = hashi.bitcoin().utxo_pool();
+    assert!(!pool.has_active_record(utxo_id));
+    assert!(pool.has_spent_record(utxo_id));
+
+    std::unit_test::destroy(hashi);
+}


### PR DESCRIPTION
## Summary

- Decouple `confirm_withdrawal` from UTXO count by switching from `confirm_spent` (2 objects/input) to `mark_spent` (event-only, 0 objects/input). Actual record cleanup is deferred to a new `cleanup_spent_utxos` background GC task.
- Raise batch limits to 70 requests / 700 inputs (922 commit objects, 7.8% margin below Sui's 1000-object hard cap).
- Add orphan discovery at startup so crashed nodes recover pending cleanups.

## How it works

The withdrawal confirm path was the binding constraint — each input touched 2 dynamic field objects for `confirm_spent`. With the two-phase approach:

1. **Confirm** calls `mark_spent` which emits a `UtxoSpentEvent` but touches zero objects per input. The watcher updates local state from the event.
2. **Cleanup** runs as a background GC task (like deposit/proposal GC), calling `cleanup_spent_utxos` which moves records from `utxo_records` to `spent_utxos`. Chunked at 400 inputs/tx.
3. **Orphan discovery** scans `utxo_records` for UTXOs locked by withdrawals not in the active set, catching any cleanups lost to crashes.

## Commit object model

```
runtime_objects = 1 * inputs + 3 * requests + 12
```

At max capacity: `1 × 700 + 3 × 70 + 12 = 922` (7.8% below 1000).

Confirm is no longer input-bound: `requests + ~43` fixed overhead.

## Test plan

- [x] All 84 Move tests pass
- [x] All 296 Rust unit tests pass
- [x] Withdrawal budget tests updated for new constants (70 req / 700 inputs / 922 budget)
- [x] E2E stress test asserts commit, sign, and confirm stay under all Sui limits (tx size, effects size, runtime objects)
- [x] E2E stress test runs `cleanup_spent_utxos` after confirm