### PR TITLE
[6/n][guardian-integration] anchor local limiter to on-chain WithdrawalSignedEvent

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -342,6 +342,14 @@ mod tests {
                 .as_ref()
                 .expect("harness present when .with_guardian() is set");
             assert!(harness.enclave().is_fully_initialized());
+            futures::future::try_join_all(
+                networks
+                    .hashi_network
+                    .nodes()
+                    .iter()
+                    .map(|node| node.wait_for_local_limiter(Duration::from_secs(60))),
+            )
+            .await?;
         }
 
         let deposit_amount_sats = 100_000u64;

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -336,20 +336,15 @@ mod tests {
             for node in networks.hashi_network.nodes() {
                 assert!(node.hashi().config.guardian_endpoint().is_some());
                 assert!(node.hashi().guardian_client().is_some());
+                // The harness already waits for local-limiter bootstrap
+                // before `build()` returns, so we just sanity-check it.
+                assert!(node.hashi().local_limiter().is_some());
             }
             let harness = networks
                 .guardian_harness
                 .as_ref()
                 .expect("harness present when .with_guardian() is set");
             assert!(harness.enclave().is_fully_initialized());
-            futures::future::try_join_all(
-                networks
-                    .hashi_network
-                    .nodes()
-                    .iter()
-                    .map(|node| node.wait_for_local_limiter(Duration::from_secs(60))),
-            )
-            .await?;
         }
 
         let deposit_amount_sats = 100_000u64;

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -336,8 +336,7 @@ mod tests {
             for node in networks.hashi_network.nodes() {
                 assert!(node.hashi().config.guardian_endpoint().is_some());
                 assert!(node.hashi().guardian_client().is_some());
-                // The harness already waits for local-limiter bootstrap
-                // before `build()` returns, so we just sanity-check it.
+                // Harness waits for limiter bootstrap before returning.
                 assert!(node.hashi().local_limiter().is_some());
             }
             let harness = networks

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -162,10 +162,7 @@ impl HashiNodeHandle {
         }
     }
 
-    pub(crate) async fn wait_for_local_limiter(
-        &self,
-        timeout: std::time::Duration,
-    ) -> Result<()> {
+    pub(crate) async fn wait_for_local_limiter(&self, timeout: std::time::Duration) -> Result<()> {
         tokio::time::timeout(timeout, self.wait_for_local_limiter_inner())
             .await
             .map_err(|_| anyhow::anyhow!("local limiter bootstrap timed out after {:?}", timeout))

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -162,6 +162,21 @@ impl HashiNodeHandle {
         }
     }
 
+    pub async fn wait_for_local_limiter(&self, timeout: std::time::Duration) -> Result<()> {
+        tokio::time::timeout(timeout, self.wait_for_local_limiter_inner())
+            .await
+            .map_err(|_| anyhow::anyhow!("local limiter bootstrap timed out after {:?}", timeout))
+    }
+
+    async fn wait_for_local_limiter_inner(&self) {
+        loop {
+            if self.hashi().local_limiter().is_some() {
+                return;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
     pub fn current_epoch(&self) -> Option<u64> {
         self.hashi()
             .onchain_state_opt()

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -162,7 +162,10 @@ impl HashiNodeHandle {
         }
     }
 
-    pub async fn wait_for_local_limiter(&self, timeout: std::time::Duration) -> Result<()> {
+    pub(crate) async fn wait_for_local_limiter(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Result<()> {
         tokio::time::timeout(timeout, self.wait_for_local_limiter_inner())
             .await
             .map_err(|_| anyhow::anyhow!("local limiter bootstrap timed out after {:?}", timeout))

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -335,10 +335,8 @@ async fn finalize_guardian_harness(networks: &mut TestNetworks) -> Result<()> {
         .await?;
     tracing::info!("guardian harness finalized");
 
-    // Each hashi node bootstraps its local limiter from the guardian
-    // asynchronously. Wait for all nodes to seed before returning, so
-    // tests can immediately initiate withdrawals without racing the
-    // bootstrap.
+    // Wait for every node's async limiter bootstrap to complete so
+    // tests don't race it.
     futures::future::try_join_all(
         networks
             .hashi_network

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -334,6 +334,20 @@ async fn finalize_guardian_harness(networks: &mut TestNetworks) -> Result<()> {
         .finalize(committee, master_pubkey, withdrawal_config, limiter_state)
         .await?;
     tracing::info!("guardian harness finalized");
+
+    // Each hashi node bootstraps its local limiter from the guardian
+    // asynchronously. Wait for all nodes to seed before returning, so
+    // tests can immediately initiate withdrawals without racing the
+    // bootstrap.
+    futures::future::try_join_all(
+        networks
+            .hashi_network
+            .nodes()
+            .iter()
+            .map(|node| node.wait_for_local_limiter(std::time::Duration::from_secs(60))),
+    )
+    .await?;
+    tracing::info!("all hashi nodes have bootstrapped their local limiter");
     Ok(())
 }
 

--- a/crates/hashi-guardian/src/withdraw.rs
+++ b/crates/hashi-guardian/src/withdraw.rs
@@ -99,7 +99,10 @@ async fn normal_withdrawal_inner(
     }
 
     info!("Checking rate limits.");
-    let consumed_amount_sats = request.utxos().external_out_amount().to_sat();
+    // Gross outflow (= inputs - change = external_out + miner_fee).
+    // Miner fee leaves the pool too, so it must consume the limit;
+    // change flows back, so it must not.
+    let consumed_amount_sats = request.utxos().gross_outflow_amount().to_sat();
     let limiter_guard = enclave
         .state
         .consume_from_limiter(
@@ -284,7 +287,7 @@ mod tests {
         let amount_sats = signed_request
             .message()
             .utxos()
-            .external_out_amount()
+            .gross_outflow_amount()
             .to_sat();
         // Set request amount as the max bucket capacity
         let enclave =
@@ -302,7 +305,7 @@ mod tests {
             100,
             0,
         );
-        let amount_sats = req1.message().utxos().external_out_amount().to_sat();
+        let amount_sats = req1.message().utxos().gross_outflow_amount().to_sat();
         // Bucket capacity == one withdrawal, so second will be rejected.
         let enclave =
             setup_fully_initialized_enclave(Network::Regtest, committee, amount_sats).await;

--- a/crates/hashi-types/src/guardian/bitcoin_utils.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils.rs
@@ -344,6 +344,23 @@ impl TxUTXOs {
             .sum()
     }
 
+    /// BTC that leaves the pool when this txn broadcasts: `inputs - change`,
+    /// equivalent to `external_out_amount + miner_fee`. The amount that
+    /// consumes the rate-limiter (miner fee leaves the pool too; change
+    /// flows back).
+    pub fn gross_outflow_amount(&self) -> Amount {
+        let inputs: Amount = self.inputs.iter().map(|i| i.amount).sum();
+        let internal: Amount = self
+            .outputs
+            .iter()
+            .filter_map(|utxo| match utxo {
+                OutputUTXO::Internal(x) => Some(x.amount),
+                OutputUTXO::External(_) => None,
+            })
+            .sum();
+        inputs - internal
+    }
+
     /// Constructs an unsigned Bitcoin transaction for these UTXOs.
     fn unsigned_tx(
         &self,

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -1,14 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Local emulator of the guardian's token-bucket limiter. Bootstrapped from
-//! the guardian at startup and advanced inline by the on-chain watcher on
-//! every observed `WithdrawalSignedEvent`. The MPC signing path uses
-//! `validate_consume` (read-only) — only the watcher calls `apply_consume`.
-//!
-//! State is held under `std::sync::RwLock` so the leader event loop can
-//! consult it without `.await` and the watcher can mutate it without
-//! handing off to a separate task.
+//! Local emulator of the guardian's token-bucket limiter. Bootstrapped
+//! from the guardian at startup and advanced by the watcher on every
+//! `WithdrawalSignedEvent`. MPC signing only `validate_consume`s.
 
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -2,18 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Local emulator of the guardian's token-bucket limiter. Bootstrapped from
-//! the guardian at startup and advanced on every observed
-//! `WithdrawalSignedEvent`. The MPC signing path uses `validate_consume`
-//! (read-only) — only the observer calls `apply_consume`.
+//! the guardian at startup and advanced inline by the on-chain watcher on
+//! every observed `WithdrawalSignedEvent`. The MPC signing path uses
+//! `validate_consume` (read-only) — only the watcher calls `apply_consume`.
+//!
+//! State is held under `std::sync::RwLock` so the leader event loop can
+//! consult it without `.await` and the watcher can mutate it without
+//! handing off to a separate task.
 
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
 use std::fmt;
-use tokio::sync::Mutex;
+use std::sync::RwLock;
 
 pub struct LocalLimiter {
     config: LimiterConfig,
-    state: Mutex<LimiterState>,
+    state: RwLock<LimiterState>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -40,7 +44,7 @@ impl LocalLimiter {
     pub fn new(config: LimiterConfig, state: LimiterState) -> Self {
         Self {
             config,
-            state: Mutex::new(state),
+            state: RwLock::new(state),
         }
     }
 
@@ -48,27 +52,27 @@ impl LocalLimiter {
         &self.config
     }
 
-    pub async fn snapshot(&self) -> LimiterState {
-        *self.state.lock().await
+    pub fn snapshot(&self) -> LimiterState {
+        *self.state.read().unwrap()
     }
 
-    pub async fn capacity_at(&self, timestamp_secs: u64) -> u64 {
-        let state = *self.state.lock().await;
+    pub fn capacity_at(&self, timestamp_secs: u64) -> u64 {
+        let state = *self.state.read().unwrap();
         project_capacity(&self.config, &state, timestamp_secs)
     }
 
-    pub async fn next_seq(&self) -> u64 {
-        self.state.lock().await.next_seq
+    pub fn next_seq(&self) -> u64 {
+        self.state.read().unwrap().next_seq
     }
 
     /// Validate a consume; does not mutate state.
-    pub async fn validate_consume(
+    pub fn validate_consume(
         &self,
         expected_seq: u64,
         timestamp_secs: u64,
         amount_sats: u64,
     ) -> Result<(), LocalLimiterError> {
-        let state = *self.state.lock().await;
+        let state = *self.state.read().unwrap();
         if expected_seq != state.next_seq {
             return Err(LocalLimiterError::SeqMismatch {
                 local: state.next_seq,
@@ -93,13 +97,13 @@ impl LocalLimiter {
 
     /// Advance local state to match an accepted consume. State is left
     /// untouched on error.
-    pub async fn apply_consume(
+    pub fn apply_consume(
         &self,
         applied_seq: u64,
         timestamp_secs: u64,
         amount_sats: u64,
     ) -> Result<(), LocalLimiterError> {
-        let mut guard = self.state.lock().await;
+        let mut guard = self.state.write().unwrap();
         if applied_seq != guard.next_seq {
             return Err(LocalLimiterError::SeqMismatch {
                 local: guard.next_seq,
@@ -156,16 +160,16 @@ mod tests {
         LocalLimiter::new(config, state)
     }
 
-    #[tokio::test]
-    async fn test_validate_consume_happy_path() {
+    #[test]
+    fn test_validate_consume_happy_path() {
         let limiter = make_limiter(0, 0, 7);
-        limiter.validate_consume(7, 100, 80_000).await.unwrap();
+        limiter.validate_consume(7, 100, 80_000).unwrap();
     }
 
-    #[tokio::test]
-    async fn test_validate_rejects_seq_mismatch() {
+    #[test]
+    fn test_validate_rejects_seq_mismatch() {
         let limiter = make_limiter(100_000, 0, 5);
-        let err = limiter.validate_consume(7, 100, 1_000).await.unwrap_err();
+        let err = limiter.validate_consume(7, 100, 1_000).unwrap_err();
         match err {
             LocalLimiterError::SeqMismatch { local, incoming } => {
                 assert_eq!(local, 5);
@@ -175,17 +179,17 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_validate_rejects_stale_timestamp() {
+    #[test]
+    fn test_validate_rejects_stale_timestamp() {
         let limiter = make_limiter(0, 100, 0);
-        let err = limiter.validate_consume(0, 50, 0).await.unwrap_err();
+        let err = limiter.validate_consume(0, 50, 0).unwrap_err();
         assert!(matches!(err, LocalLimiterError::StaleTimestamp { .. }));
     }
 
-    #[tokio::test]
-    async fn test_validate_rejects_over_capacity() {
+    #[test]
+    fn test_validate_rejects_over_capacity() {
         let limiter = make_limiter(0, 0, 0);
-        let err = limiter.validate_consume(0, 10, 50_000).await.unwrap_err();
+        let err = limiter.validate_consume(0, 10, 50_000).unwrap_err();
         match err {
             LocalLimiterError::InsufficientCapacity { needed, available } => {
                 assert_eq!(needed, 50_000);
@@ -195,34 +199,34 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_apply_bumps_seq_and_updates_last_updated_at() {
+    #[test]
+    fn test_apply_bumps_seq_and_updates_last_updated_at() {
         let limiter = make_limiter(0, 0, 42);
-        limiter.validate_consume(42, 100, 80_000).await.unwrap();
-        limiter.apply_consume(42, 100, 80_000).await.unwrap();
-        let snap = limiter.snapshot().await;
+        limiter.validate_consume(42, 100, 80_000).unwrap();
+        limiter.apply_consume(42, 100, 80_000).unwrap();
+        let snap = limiter.snapshot();
         assert_eq!(snap.next_seq, 43);
         assert_eq!(snap.last_updated_at, 100);
         assert_eq!(snap.num_tokens_available, 20_000);
     }
 
-    #[tokio::test]
-    async fn test_apply_rejects_seq_mismatch() {
+    #[test]
+    fn test_apply_rejects_seq_mismatch() {
         let limiter = make_limiter(0, 0, 0);
-        let err = limiter.apply_consume(5, 100, 1_000).await.unwrap_err();
+        let err = limiter.apply_consume(5, 100, 1_000).unwrap_err();
         assert!(matches!(err, LocalLimiterError::SeqMismatch { .. }));
     }
 
-    #[tokio::test]
-    async fn test_capacity_at_refills_linearly_and_clamps_to_ceiling() {
+    #[test]
+    fn test_capacity_at_refills_linearly_and_clamps_to_ceiling() {
         let limiter = make_limiter(100_000, 10, 0);
-        assert_eq!(limiter.capacity_at(15).await, 105_000);
-        assert_eq!(limiter.capacity_at(u64::MAX).await, 2_000_000);
+        assert_eq!(limiter.capacity_at(15), 105_000);
+        assert_eq!(limiter.capacity_at(u64::MAX), 2_000_000);
     }
 
-    #[tokio::test]
-    async fn test_next_seq_matches_snapshot() {
+    #[test]
+    fn test_next_seq_matches_snapshot() {
         let limiter = make_limiter(0, 0, 11);
-        assert_eq!(limiter.next_seq().await, 11);
+        assert_eq!(limiter.next_seq(), 11);
     }
 }

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Local emulator of the guardian's token-bucket limiter. Bootstrapped from
-//! the guardian at startup and advanced exclusively by
-//! `Hashi::start_guardian_limiter_observer` on each `WithdrawalSignedEvent`.
-//! The MPC signing path uses `validate_consume` (read-only) — it never calls
-//! `apply_consume`. This keeps every node in lockstep with the guardian via
-//! Sui's deterministic checkpoint stream.
+//! the guardian at startup and advanced on every observed
+//! `WithdrawalSignedEvent`. The MPC signing path uses `validate_consume`
+//! (read-only) — only the observer calls `apply_consume`.
 
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -1,8 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Local emulator of the guardian's token-bucket limiter. Bootstrapped
-//! from the guardian at startup and advanced on every accepted consume.
+//! Local emulator of the guardian's token-bucket limiter. Bootstrapped from
+//! the guardian at startup and advanced exclusively by
+//! `Hashi::start_guardian_limiter_observer` on each `WithdrawalSignedEvent`.
+//! The MPC signing path uses `validate_consume` (read-only) — it never calls
+//! `apply_consume`. This keeps every node in lockstep with the guardian via
+//! Sui's deterministic checkpoint stream.
 
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1446,7 +1446,9 @@ impl LeaderService {
         const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
         if tokio::time::timeout(
             VISIBILITY_TIMEOUT,
-            inner.onchain_state().wait_until_checkpoint(signed_checkpoint),
+            inner
+                .onchain_state()
+                .wait_until_checkpoint(signed_checkpoint),
         )
         .await
         .is_err()

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -998,7 +998,7 @@ impl LeaderService {
         // so we don't sit on excess demand for the full batching window.
         let (batch, at_capacity) = if let Some(limiter) = self.inner.local_limiter() {
             let timestamp_secs = checkpoint_timestamp_ms / 1000;
-            let capacity = limiter.capacity_at(timestamp_secs).await;
+            let capacity = limiter.capacity_at(timestamp_secs);
             let mut cumulative = 0u64;
             let mut take_count = 0;
             for req in &approved {
@@ -1306,11 +1306,8 @@ impl LeaderService {
         let expected_limiter_seq = if let Some(limiter) = inner.local_limiter() {
             let amount_sats: u64 = txn.withdrawal_outputs.iter().map(|o| o.amount).sum();
             let timestamp_secs = txn.timestamp_ms / 1000;
-            let next_seq = limiter.next_seq().await;
-            if let Err(e) = limiter
-                .validate_consume(next_seq, timestamp_secs, amount_sats)
-                .await
-            {
+            let next_seq = limiter.next_seq();
+            if let Err(e) = limiter.validate_consume(next_seq, timestamp_secs, amount_sats) {
                 warn!(
                     withdrawal_txn_id = %txn.id,
                     "Leader local limiter rejected withdrawal; will retry on next checkpoint: {e}"
@@ -2010,7 +2007,7 @@ impl LeaderService {
         let wait = async {
             loop {
                 let committed = match (inner.local_limiter(), leader_seq_used) {
-                    (Some(limiter), Some(seq)) => limiter.next_seq().await > seq,
+                    (Some(limiter), Some(seq)) => limiter.next_seq() > seq,
                     _ => inner
                         .onchain_state()
                         .withdrawal_txn(txn_id)

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -148,8 +148,7 @@ impl LeaderService {
                     }
 
                     self.process_unapproved_withdrawal_requests(checkpoint_timestamp_ms);
-                    self.process_approved_withdrawal_requests(checkpoint_timestamp_ms)
-                        .await;
+                    self.process_approved_withdrawal_requests(checkpoint_timestamp_ms);
                     self.process_unsigned_withdrawal_txns();
                     self.process_signed_withdrawal_txns();
                     self.check_delete_proposals(checkpoint_timestamp_ms);
@@ -939,7 +938,7 @@ impl LeaderService {
     // Step 2: Construct withdrawal tx for approved requests
     // ========================================================================
 
-    async fn process_approved_withdrawal_requests(&mut self, checkpoint_timestamp_ms: u64) {
+    fn process_approved_withdrawal_requests(&mut self, checkpoint_timestamp_ms: u64) {
         debug!("Entering process_approved_withdrawal_requests");
         if self.is_reconfiguring() {
             debug!("Reconfig in progress, skipping withdrawal commitment processing");
@@ -948,6 +947,16 @@ impl LeaderService {
 
         if self.withdrawal_commitment_task.is_some() {
             debug!("Withdrawal commitment task already in-flight, skipping");
+            return;
+        }
+
+        // Don't build a new commitment while a previous one is still
+        // awaiting witness signatures. This is defense-in-depth alongside
+        // the spawn-side `max_concurrent = 1` cap; here it ensures we
+        // also don't double-commit on consecutive checkpoints before the
+        // signing task has had a chance to spawn.
+        if self.inner.onchain_state().has_unsigned_withdrawal_txn() {
+            debug!("Unsigned withdrawal txn already on-chain, skipping commitment");
             return;
         }
 
@@ -993,41 +1002,59 @@ impl LeaderService {
             return;
         }
 
-        // Truncate to the longest timestamp-sorted prefix that fits the local
-        // limiter's available capacity; the dropped tail flips `at_capacity`
-        // so we don't sit on excess demand for the full batching window.
+        // Choose the timestamp-sorted prefix that fits the limiter:
+        //  - Skip past any oversize request whose amount > max_bucket_capacity:
+        //    it can never fit, so head-of-line blocks the rest forever
+        //    if we wait. Bump a metric and warn once; operator must raise
+        //    the cap or the user must cancel.
+        //  - Among the remaining (fits-eventually) requests, take the
+        //    longest prefix that fits the bucket's *current* capacity.
+        //  - The dropped fits-eventually tail flips `at_capacity` so we
+        //    don't sit on demand for the full batching window.
         let (batch, at_capacity) = if let Some(limiter) = self.inner.local_limiter() {
             let timestamp_secs = checkpoint_timestamp_ms / 1000;
+            let max_bucket = limiter.config().max_bucket_capacity;
             let capacity = limiter.capacity_at(timestamp_secs);
+
+            let mut batch: Vec<WithdrawalRequest> = Vec::new();
             let mut cumulative = 0u64;
-            let mut take_count = 0;
-            for req in &approved {
+            let mut at_capacity = false;
+            for req in approved {
+                if req.btc_amount > max_bucket {
+                    if self.stuck_withdrawal_warned.insert(req.id) {
+                        warn!(
+                            request_id = %req.id,
+                            btc_amount = req.btc_amount,
+                            max_bucket_capacity = max_bucket,
+                            "Withdrawal request exceeds limiter max_bucket_capacity; \
+                             skipping (operator must raise cap or user must cancel)"
+                        );
+                        self.inner
+                            .metrics
+                            .guardian_limiter_stuck_oversize_skipped_total
+                            .inc();
+                    }
+                    continue;
+                }
                 let Some(next) = cumulative.checked_add(req.btc_amount) else {
+                    at_capacity = true;
                     break;
                 };
                 if next > capacity {
+                    at_capacity = true;
                     break;
                 }
                 cumulative = next;
-                take_count += 1;
+                batch.push(req);
             }
-            if take_count == 0 {
-                // Head won't fit even with the bucket fully available; warn
-                // once and leave it queued for the next refill.
-                let stuck = &approved[0];
-                if self.stuck_withdrawal_warned.insert(stuck.id) {
-                    warn!(
-                        request_id = %stuck.id,
-                        btc_amount = stuck.btc_amount,
-                        available = capacity,
-                        "Withdrawal request exceeds local limiter capacity; staying in queue"
-                    );
-                }
+
+            if batch.is_empty() {
+                // Either every approved request is oversize (already
+                // warned + counted above) or the head fits the bucket
+                // but not the current capacity (refill-bound). Either
+                // way, nothing to do this round.
                 return;
             }
-            let at_capacity = take_count < approved.len();
-            let mut batch = approved;
-            batch.truncate(take_count);
             (batch, at_capacity)
         } else {
             (approved, false)

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -77,6 +77,9 @@ pub struct LeaderService {
     inflight_withdrawal_signings: HashSet<Address>,
     withdrawal_broadcast_tasks: JoinSet<(Address, anyhow::Result<()>)>,
     inflight_withdrawal_broadcasts: HashSet<Address>,
+    /// Withdrawal requests already warned about exceeding local limiter
+    /// capacity. Pruned each checkpoint to track only currently-pending ids.
+    stuck_withdrawal_warned: HashSet<Address>,
     deposit_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     proposal_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
 }
@@ -97,6 +100,7 @@ impl LeaderService {
             inflight_withdrawal_signings: HashSet::new(),
             withdrawal_broadcast_tasks: JoinSet::new(),
             inflight_withdrawal_broadcasts: HashSet::new(),
+            stuck_withdrawal_warned: HashSet::new(),
             deposit_gc_task: None,
             proposal_gc_task: None,
         }
@@ -146,7 +150,8 @@ impl LeaderService {
                     }
 
                     self.process_unapproved_withdrawal_requests(checkpoint_timestamp_ms);
-                    self.process_approved_withdrawal_requests(checkpoint_timestamp_ms);
+                    self.process_approved_withdrawal_requests(checkpoint_timestamp_ms)
+                        .await;
                     self.process_unsigned_withdrawal_txns();
                     self.process_signed_withdrawal_txns();
                     self.check_delete_proposals(checkpoint_timestamp_ms);
@@ -936,7 +941,7 @@ impl LeaderService {
     // Step 2: Construct withdrawal tx for approved requests
     // ========================================================================
 
-    fn process_approved_withdrawal_requests(&mut self, checkpoint_timestamp_ms: u64) {
+    async fn process_approved_withdrawal_requests(&mut self, checkpoint_timestamp_ms: u64) {
         debug!("Entering process_approved_withdrawal_requests");
         if self.is_reconfiguring() {
             debug!("Reconfig in progress, skipping withdrawal commitment processing");
@@ -957,6 +962,12 @@ impl LeaderService {
             .collect();
         approved.sort_by_key(|r| r.timestamp_ms);
 
+        // Drop stuck-warn entries for requests that are no longer pending,
+        // so a re-stuck request would warn again.
+        let pending_ids: HashSet<Address> = approved.iter().map(|r| r.id).collect();
+        self.stuck_withdrawal_warned
+            .retain(|id| pending_ids.contains(id));
+
         if self
             .withdrawal_commitment_retry_tracker
             .should_skip(checkpoint_timestamp_ms)
@@ -972,11 +983,6 @@ impl LeaderService {
             return;
         }
 
-        // Collect all approved requests and process them as a single batch.
-        // The coin selection algorithm picks up to
-        // max_withdrawal_requests oldest requests from the slice.
-        let batch: Vec<WithdrawalRequest> = approved.into_iter().collect();
-
         self.inner
             .metrics
             .leader_items_in_backoff
@@ -986,9 +992,45 @@ impl LeaderService {
                     .in_backoff_count(checkpoint_timestamp_ms) as i64,
             );
 
-        if batch.is_empty() {
+        if approved.is_empty() {
             return;
         }
+
+        // Capacity-aware batching: longest timestamp-sorted prefix that fits the
+        // local limiter's available capacity. Dropped tail bumps `at_capacity` so
+        // we don't sit on excess demand for the full batching window.
+        let (batch, at_capacity) = if let Some(limiter) = self.inner.local_limiter() {
+            let timestamp_secs = checkpoint_timestamp_ms / 1000;
+            let capacity = limiter.capacity_at(timestamp_secs).await;
+            let mut cumulative = 0u64;
+            let mut filtered: Vec<WithdrawalRequest> = Vec::with_capacity(approved.len());
+            for req in &approved {
+                let candidate = cumulative.saturating_add(req.btc_amount);
+                if candidate > capacity {
+                    break;
+                }
+                cumulative = candidate;
+                filtered.push(req.clone());
+            }
+            if filtered.is_empty() {
+                // Head exceeds available capacity (may fit after refill, or be
+                // permanently stuck). Leave it queued and warn once.
+                let stuck = &approved[0];
+                if self.stuck_withdrawal_warned.insert(stuck.id) {
+                    warn!(
+                        request_id = %stuck.id,
+                        btc_amount = stuck.btc_amount,
+                        available = capacity,
+                        "Withdrawal request exceeds local limiter capacity; staying in queue"
+                    );
+                }
+                return;
+            }
+            let at_capacity = filtered.len() < approved.len();
+            (filtered, at_capacity)
+        } else {
+            (approved, false)
+        };
 
         let max_batch = self.inner.config.withdrawal_max_batch_size();
         let delay_ms = self.inner.config.withdrawal_batching_delay_ms();
@@ -998,7 +1040,7 @@ impl LeaderService {
             .first()
             .is_some_and(|r| checkpoint_timestamp_ms >= r.timestamp_ms + delay_ms);
 
-        if !batch_is_full && !oldest_has_waited {
+        if !batch_is_full && !oldest_has_waited && !at_capacity {
             debug!(
                 "Holding {} approved request(s): oldest is {}ms old, \
                  waiting for {}ms delay or {} requests",
@@ -1196,7 +1238,16 @@ impl LeaderService {
         self.inflight_withdrawal_signings
             .retain(|id| pending_ids.contains(id));
 
-        let max_concurrent = self.inner.config.max_concurrent_leader_job_tasks();
+        // The observer advances `LocalLimiter::next_seq` sequentially on every
+        // `WithdrawalSignedEvent`, so concurrent MPC tasks would race against
+        // a stale `expected_limiter_seq` and fail per-node validation. Cap
+        // in-flight to 1 whenever the guardian (and therefore the limiter) is
+        // configured.
+        let max_concurrent = if self.inner.guardian_client().is_some() {
+            1
+        } else {
+            self.inner.config.max_concurrent_leader_job_tasks()
+        };
         for txn in withdrawal_txns {
             if self.withdrawal_signing_tasks.len() >= max_concurrent {
                 break;
@@ -1361,6 +1412,11 @@ impl LeaderService {
                 .with_label_values(&["sign_withdrawal", "failure"])
                 .inc();
         })?;
+
+        // Serialize against ourselves so the next checkpoint doesn't respawn
+        // and either double-submit sign_withdrawal (no-guardian) or hand the
+        // followers a stale `next_seq` (guardian).
+        Self::wait_until_signed_committed(&inner, &txn.id, expected_limiter_seq).await;
 
         Ok(())
     }
@@ -1941,6 +1997,46 @@ impl LeaderService {
         executor
             .execute_sign_withdrawal(withdrawal_id, request_ids, signatures, cert)
             .await
+    }
+
+    /// Block until the local limiter has advanced past `leader_seq_used`
+    /// (guardian path) or until the on-chain signatures are visible
+    /// (no-guardian). The limiter advance is the strictly stronger condition,
+    /// since the observer fires on the same `WithdrawalSignedEvent` that
+    /// drives visibility.
+    async fn wait_until_signed_committed(
+        inner: &Hashi,
+        txn_id: &Address,
+        leader_seq_used: Option<u64>,
+    ) {
+        const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
+        let mut checkpoint_rx = inner.onchain_state().subscribe_checkpoint();
+        let wait = async {
+            loop {
+                let committed = match (inner.local_limiter(), leader_seq_used) {
+                    (Some(limiter), Some(seq)) => limiter.next_seq().await > seq,
+                    _ => inner
+                        .onchain_state()
+                        .withdrawal_txn(txn_id)
+                        .is_some_and(|t| t.signatures.is_some()),
+                };
+                if committed {
+                    return;
+                }
+                let _ = checkpoint_rx.changed().await;
+            }
+        };
+        if tokio::time::timeout(VISIBILITY_TIMEOUT, wait)
+            .await
+            .is_err()
+        {
+            warn!(
+                withdrawal_txn_id = %txn_id,
+                ?leader_seq_used,
+                "Timeout waiting for local limiter advance / signed-visible; \
+                 a duplicate sign attempt may follow on the next checkpoint"
+            );
+        }
     }
 
     async fn submit_confirm_withdrawal(

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1401,7 +1401,7 @@ impl LeaderService {
 
         // 4. Submit sign_withdrawal to Sui (writes signatures on-chain).
         // Broadcast + confirm happens via process_signed_withdrawal_txns on the next tick.
-        let signed_checkpoint = Self::submit_sign_withdrawal(
+        let included_checkpoint_seq = Self::submit_sign_withdrawal(
             &inner,
             &txn.id,
             &txn.request_ids.clone(),
@@ -1424,22 +1424,23 @@ impl LeaderService {
                 .inc();
         })?;
 
-        // Wait for our watcher to catch up to `signed_checkpoint` before
-        // returning, so the next tick doesn't respawn with stale state.
+        // Wait for our watcher to catch up to the checkpoint that included
+        // the sign_withdrawal txn before returning, so the next tick
+        // doesn't respawn with stale state.
         const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
         if tokio::time::timeout(
             VISIBILITY_TIMEOUT,
             inner
                 .onchain_state()
-                .wait_until_checkpoint(signed_checkpoint),
+                .wait_until_checkpoint(included_checkpoint_seq),
         )
         .await
         .is_err()
         {
             warn!(
                 withdrawal_txn_id = %txn.id,
-                signed_checkpoint,
-                "Timeout waiting for watcher to reach signed checkpoint; \
+                included_checkpoint_seq,
+                "Timeout waiting for watcher to reach the included checkpoint; \
                  a duplicate sign attempt may follow"
             );
         }

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -77,8 +77,6 @@ pub struct LeaderService {
     inflight_withdrawal_signings: HashSet<Address>,
     withdrawal_broadcast_tasks: JoinSet<(Address, anyhow::Result<()>)>,
     inflight_withdrawal_broadcasts: HashSet<Address>,
-    /// Withdrawal requests already warned about exceeding local limiter
-    /// capacity. Pruned each checkpoint to track only currently-pending ids.
     stuck_withdrawal_warned: HashSet<Address>,
     deposit_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     proposal_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
@@ -962,8 +960,7 @@ impl LeaderService {
             .collect();
         approved.sort_by_key(|r| r.timestamp_ms);
 
-        // Drop stuck-warn entries for requests that are no longer pending,
-        // so a re-stuck request would warn again.
+        // Prune stuck-warn entries so a re-stuck request warns again.
         let pending_ids: HashSet<Address> = approved.iter().map(|r| r.id).collect();
         self.stuck_withdrawal_warned
             .retain(|id| pending_ids.contains(id));
@@ -996,25 +993,27 @@ impl LeaderService {
             return;
         }
 
-        // Capacity-aware batching: longest timestamp-sorted prefix that fits the
-        // local limiter's available capacity. Dropped tail bumps `at_capacity` so
-        // we don't sit on excess demand for the full batching window.
+        // Truncate to the longest timestamp-sorted prefix that fits the local
+        // limiter's available capacity; the dropped tail flips `at_capacity`
+        // so we don't sit on excess demand for the full batching window.
         let (batch, at_capacity) = if let Some(limiter) = self.inner.local_limiter() {
             let timestamp_secs = checkpoint_timestamp_ms / 1000;
             let capacity = limiter.capacity_at(timestamp_secs).await;
             let mut cumulative = 0u64;
-            let mut filtered: Vec<WithdrawalRequest> = Vec::with_capacity(approved.len());
+            let mut take_count = 0;
             for req in &approved {
-                let candidate = cumulative.saturating_add(req.btc_amount);
-                if candidate > capacity {
+                let Some(next) = cumulative.checked_add(req.btc_amount) else {
+                    break;
+                };
+                if next > capacity {
                     break;
                 }
-                cumulative = candidate;
-                filtered.push(req.clone());
+                cumulative = next;
+                take_count += 1;
             }
-            if filtered.is_empty() {
-                // Head exceeds available capacity (may fit after refill, or be
-                // permanently stuck). Leave it queued and warn once.
+            if take_count == 0 {
+                // Head won't fit even with the bucket fully available; warn
+                // once and leave it queued for the next refill.
                 let stuck = &approved[0];
                 if self.stuck_withdrawal_warned.insert(stuck.id) {
                     warn!(
@@ -1026,8 +1025,10 @@ impl LeaderService {
                 }
                 return;
             }
-            let at_capacity = filtered.len() < approved.len();
-            (filtered, at_capacity)
+            let at_capacity = take_count < approved.len();
+            let mut batch = approved;
+            batch.truncate(take_count);
+            (batch, at_capacity)
         } else {
             (approved, false)
         };
@@ -1238,11 +1239,9 @@ impl LeaderService {
         self.inflight_withdrawal_signings
             .retain(|id| pending_ids.contains(id));
 
-        // The observer advances `LocalLimiter::next_seq` sequentially on every
-        // `WithdrawalSignedEvent`, so concurrent MPC tasks would race against
-        // a stale `expected_limiter_seq` and fail per-node validation. Cap
-        // in-flight to 1 whenever the guardian (and therefore the limiter) is
-        // configured.
+        // Cap to 1 when the limiter is in play: concurrent MPC tasks would
+        // race on `expected_limiter_seq` since the observer bumps it on every
+        // signed event.
         let max_concurrent = if self.inner.guardian_client().is_some() {
             1
         } else {
@@ -1413,9 +1412,9 @@ impl LeaderService {
                 .inc();
         })?;
 
-        // Serialize against ourselves so the next checkpoint doesn't respawn
-        // and either double-submit sign_withdrawal (no-guardian) or hand the
-        // followers a stale `next_seq` (guardian).
+        // Block before returning so the next checkpoint can't respawn this
+        // task with a stale `next_seq` (guardian) or double-submit
+        // `sign_withdrawal` (no-guardian).
         Self::wait_until_signed_committed(&inner, &txn.id, expected_limiter_seq).await;
 
         Ok(())
@@ -1999,11 +1998,8 @@ impl LeaderService {
             .await
     }
 
-    /// Block until the local limiter has advanced past `leader_seq_used`
-    /// (guardian path) or until the on-chain signatures are visible
-    /// (no-guardian). The limiter advance is the strictly stronger condition,
-    /// since the observer fires on the same `WithdrawalSignedEvent` that
-    /// drives visibility.
+    /// Block until the local limiter advances past `leader_seq_used`
+    /// (guardian) or the on-chain signatures become visible (no-guardian).
     async fn wait_until_signed_committed(
         inner: &Hashi,
         txn_id: &Address,

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -950,11 +950,8 @@ impl LeaderService {
             return;
         }
 
-        // Don't build a new commitment while a previous one is still
-        // awaiting witness signatures. This is defense-in-depth alongside
-        // the spawn-side `max_concurrent = 1` cap; here it ensures we
-        // also don't double-commit on consecutive checkpoints before the
-        // signing task has had a chance to spawn.
+        // Pairs with the spawn-side `max_concurrent = 1` cap: don't
+        // double-commit before the prior signing task has spawned.
         if self.inner.onchain_state().has_unsigned_withdrawal_txn() {
             debug!("Unsigned withdrawal txn already on-chain, skipping commitment");
             return;
@@ -1002,15 +999,10 @@ impl LeaderService {
             return;
         }
 
-        // Choose the timestamp-sorted prefix that fits the limiter:
-        //  - Skip past any oversize request whose amount > max_bucket_capacity:
-        //    it can never fit, so head-of-line blocks the rest forever
-        //    if we wait. Bump a metric and warn once; operator must raise
-        //    the cap or the user must cancel.
-        //  - Among the remaining (fits-eventually) requests, take the
-        //    longest prefix that fits the bucket's *current* capacity.
-        //  - The dropped fits-eventually tail flips `at_capacity` so we
-        //    don't sit on demand for the full batching window.
+        // Skip oversize requests (would HOL-block forever) and take the
+        // longest prefix of the rest that fits current capacity. The
+        // dropped tail flips `at_capacity` so we don't sit on demand for
+        // the full batching window.
         let (batch, at_capacity) = if let Some(limiter) = self.inner.local_limiter() {
             let timestamp_secs = checkpoint_timestamp_ms / 1000;
             let max_bucket = limiter.config().max_bucket_capacity;
@@ -1026,8 +1018,7 @@ impl LeaderService {
                             request_id = %req.id,
                             btc_amount = req.btc_amount,
                             max_bucket_capacity = max_bucket,
-                            "Withdrawal request exceeds limiter max_bucket_capacity; \
-                             skipping (operator must raise cap or user must cancel)"
+                            "Withdrawal exceeds limiter max bucket; skipping"
                         );
                         self.inner
                             .metrics
@@ -1049,10 +1040,7 @@ impl LeaderService {
             }
 
             if batch.is_empty() {
-                // Either every approved request is oversize (already
-                // warned + counted above) or the head fits the bucket
-                // but not the current capacity (refill-bound). Either
-                // way, nothing to do this round.
+                // All-oversize (already warned) or refill-bound head.
                 return;
             }
             (batch, at_capacity)
@@ -1266,9 +1254,9 @@ impl LeaderService {
         self.inflight_withdrawal_signings
             .retain(|id| pending_ids.contains(id));
 
-        // Cap to 1 when the limiter is in play: concurrent MPC tasks would
-        // race on `expected_limiter_seq` since the observer bumps it on every
-        // signed event.
+        // Cap to 1 when the limiter is in play: concurrent MPC tasks
+        // would race on `expected_limiter_seq` since the watcher bumps
+        // it on every signed event.
         let max_concurrent = if self.inner.guardian_client().is_some() {
             1
         } else {
@@ -1436,13 +1424,8 @@ impl LeaderService {
                 .inc();
         })?;
 
-        // Block before returning so the next checkpoint can't respawn this
-        // task with stale state. The Sui executor already waited for the
-        // sign_withdrawal txn to land in `signed_checkpoint`; we just
-        // need to wait for our local watcher to process that checkpoint
-        // — at which point the limiter has been advanced and
-        // `WithdrawalTransaction.signatures` is visible. Same code path
-        // with or without guardian.
+        // Wait for our watcher to catch up to `signed_checkpoint` before
+        // returning, so the next tick doesn't respawn with stale state.
         const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
         if tokio::time::timeout(
             VISIBILITY_TIMEOUT,
@@ -1456,8 +1439,8 @@ impl LeaderService {
             warn!(
                 withdrawal_txn_id = %txn.id,
                 signed_checkpoint,
-                "Timeout waiting for local watcher to catch up to signed checkpoint; \
-                 a duplicate sign attempt may follow on the next checkpoint"
+                "Timeout waiting for watcher to reach signed checkpoint; \
+                 a duplicate sign attempt may follow"
             );
         }
 

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1413,7 +1413,7 @@ impl LeaderService {
 
         // 4. Submit sign_withdrawal to Sui (writes signatures on-chain).
         // Broadcast + confirm happens via process_signed_withdrawal_txns on the next tick.
-        Self::submit_sign_withdrawal(
+        let signed_checkpoint = Self::submit_sign_withdrawal(
             &inner,
             &txn.id,
             &txn.request_ids.clone(),
@@ -1421,7 +1421,7 @@ impl LeaderService {
             signed.committee_signature(),
         )
         .await
-        .inspect(|()| {
+        .inspect(|_| {
             inner
                 .metrics
                 .sui_tx_submissions_total
@@ -1437,9 +1437,27 @@ impl LeaderService {
         })?;
 
         // Block before returning so the next checkpoint can't respawn this
-        // task with a stale `next_seq` (guardian) or double-submit
-        // `sign_withdrawal` (no-guardian).
-        Self::wait_until_signed_committed(&inner, &txn.id, expected_limiter_seq).await;
+        // task with stale state. The Sui executor already waited for the
+        // sign_withdrawal txn to land in `signed_checkpoint`; we just
+        // need to wait for our local watcher to process that checkpoint
+        // — at which point the limiter has been advanced and
+        // `WithdrawalTransaction.signatures` is visible. Same code path
+        // with or without guardian.
+        const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
+        if tokio::time::timeout(
+            VISIBILITY_TIMEOUT,
+            inner.onchain_state().wait_until_checkpoint(signed_checkpoint),
+        )
+        .await
+        .is_err()
+        {
+            warn!(
+                withdrawal_txn_id = %txn.id,
+                signed_checkpoint,
+                "Timeout waiting for local watcher to catch up to signed checkpoint; \
+                 a duplicate sign attempt may follow on the next checkpoint"
+            );
+        }
 
         Ok(())
     }
@@ -2013,50 +2031,13 @@ impl LeaderService {
         request_ids: &[Address],
         signatures: &[Vec<u8>],
         cert: &CommitteeSignature,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<u64> {
         info!("Submitting sign_withdrawal for {:?}", withdrawal_id);
 
         let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
         executor
             .execute_sign_withdrawal(withdrawal_id, request_ids, signatures, cert)
             .await
-    }
-
-    /// Block until the local limiter advances past `leader_seq_used`
-    /// (guardian) or the on-chain signatures become visible (no-guardian).
-    async fn wait_until_signed_committed(
-        inner: &Hashi,
-        txn_id: &Address,
-        leader_seq_used: Option<u64>,
-    ) {
-        const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
-        let mut checkpoint_rx = inner.onchain_state().subscribe_checkpoint();
-        let wait = async {
-            loop {
-                let committed = match (inner.local_limiter(), leader_seq_used) {
-                    (Some(limiter), Some(seq)) => limiter.next_seq() > seq,
-                    _ => inner
-                        .onchain_state()
-                        .withdrawal_txn(txn_id)
-                        .is_some_and(|t| t.signatures.is_some()),
-                };
-                if committed {
-                    return;
-                }
-                let _ = checkpoint_rx.changed().await;
-            }
-        };
-        if tokio::time::timeout(VISIBILITY_TIMEOUT, wait)
-            .await
-            .is_err()
-        {
-            warn!(
-                withdrawal_txn_id = %txn_id,
-                ?leader_seq_used,
-                "Timeout waiting for local limiter advance / signed-visible; \
-                 a duplicate sign attempt may follow on the next checkpoint"
-            );
-        }
     }
 
     async fn submit_confirm_withdrawal(

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -670,7 +670,6 @@ impl Hashi {
         let leader_service = leader::LeaderService::new(self.clone()).start();
         let mpc_service = mpc_service.start();
         let guardian_bootstrap_service = self.clone().start_guardian_bootstrap();
-        let guardian_limiter_observer_service = self.clone().start_guardian_limiter_observer();
 
         let service = Service::new()
             .merge(onchain_service)
@@ -678,8 +677,7 @@ impl Hashi {
             .merge(http_service)
             .merge(leader_service)
             .merge(mpc_service)
-            .merge(guardian_bootstrap_service)
-            .merge(guardian_limiter_observer_service);
+            .merge(guardian_bootstrap_service);
 
         Ok(service)
     }
@@ -714,7 +712,11 @@ impl Hashi {
                 ?config,
                 "Local guardian limiter seeded from GetGuardianInfo",
             );
-            *slot = Some(Arc::new(guardian_limiter::LocalLimiter::new(config, state)));
+            let limiter = Arc::new(guardian_limiter::LocalLimiter::new(config, state));
+            // Hand the same Arc to OnchainState so the watcher can advance
+            // it inline when WithdrawalSignedEvent fires.
+            self.onchain_state().set_local_limiter(limiter.clone());
+            *slot = Some(limiter);
         }
         true
     }
@@ -740,64 +742,6 @@ impl Hashi {
             .await;
             tracing::info!("Guardian bootstrap complete");
             Ok(())
-        })
-    }
-
-    /// Sole mutator of `LocalLimiter` after bootstrap: advances on every
-    /// observed `WithdrawalSignedEvent`. Symmetric across leader and
-    /// follower since every node consumes the same Sui checkpoint stream.
-    fn start_guardian_limiter_observer(self: Arc<Self>) -> Service {
-        use tokio::sync::broadcast::error::RecvError;
-        Service::new().spawn_aborting(async move {
-            if self.guardian_client().is_none() {
-                return Ok(());
-            }
-            let mut rx = self.onchain_state().subscribe();
-            loop {
-                let notification = match rx.recv().await {
-                    Ok(n) => n,
-                    Err(RecvError::Closed) => return Ok(()),
-                    Err(RecvError::Lagged(n)) => {
-                        tracing::error!(
-                            skipped = n,
-                            "Limiter observer lagged on broadcast channel; \
-                             local limiter state is now drifted from guardian"
-                        );
-                        continue;
-                    }
-                };
-                let onchain::Notification::WithdrawalSigned {
-                    withdrawal_txn_id,
-                    amount_sats,
-                    timestamp_secs,
-                } = notification
-                else {
-                    continue;
-                };
-                let Some(limiter) = self.local_limiter() else {
-                    tracing::warn!(
-                        %withdrawal_txn_id,
-                        "Local limiter not yet bootstrapped; dropping observation"
-                    );
-                    continue;
-                };
-                let seq = limiter.next_seq();
-                match limiter.apply_consume(seq, timestamp_secs, amount_sats) {
-                    Ok(()) => tracing::info!(
-                        seq,
-                        amount_sats,
-                        timestamp_secs,
-                        %withdrawal_txn_id,
-                        "Local limiter advanced from on-chain WithdrawalSignedEvent",
-                    ),
-                    Err(e) => tracing::error!(
-                        ?e,
-                        seq,
-                        %withdrawal_txn_id,
-                        "Local limiter apply_consume failed; node is now drifted from guardian"
-                    ),
-                }
-            }
         })
     }
 

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -743,12 +743,9 @@ impl Hashi {
         })
     }
 
-    /// Sole mutator of `LocalLimiter` after bootstrap: advances the limiter
-    /// on every observed `WithdrawalSignedEvent`. Symmetric across leader
-    /// and follower (every node sees the same Sui checkpoint stream).
-    /// `signatures.is_some()` implies the guardian acked, because
-    /// `submit_sign_withdrawal` only runs after
-    /// `finalize_withdrawal_through_guardian` returns Ok.
+    /// Sole mutator of `LocalLimiter` after bootstrap: advances on every
+    /// observed `WithdrawalSignedEvent`. Symmetric across leader and
+    /// follower since every node consumes the same Sui checkpoint stream.
     fn start_guardian_limiter_observer(self: Arc<Self>) -> Service {
         use tokio::sync::broadcast::error::RecvError;
         Service::new().spawn_aborting(async move {
@@ -780,8 +777,7 @@ impl Hashi {
                 let Some(limiter) = self.local_limiter() else {
                     tracing::warn!(
                         %withdrawal_txn_id,
-                        "Local limiter not yet bootstrapped; dropping observation. \
-                         Bootstrap must complete before the first withdrawal."
+                        "Local limiter not yet bootstrapped; dropping observation"
                     );
                     continue;
                 };

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -781,11 +781,8 @@ impl Hashi {
                     );
                     continue;
                 };
-                let seq = limiter.next_seq().await;
-                match limiter
-                    .apply_consume(seq, timestamp_secs, amount_sats)
-                    .await
-                {
+                let seq = limiter.next_seq();
+                match limiter.apply_consume(seq, timestamp_secs, amount_sats) {
                     Ok(()) => tracing::info!(
                         seq,
                         amount_sats,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -670,6 +670,7 @@ impl Hashi {
         let leader_service = leader::LeaderService::new(self.clone()).start();
         let mpc_service = mpc_service.start();
         let guardian_bootstrap_service = self.clone().start_guardian_bootstrap();
+        let guardian_limiter_observer_service = self.clone().start_guardian_limiter_observer();
 
         let service = Service::new()
             .merge(onchain_service)
@@ -677,7 +678,8 @@ impl Hashi {
             .merge(http_service)
             .merge(leader_service)
             .merge(mpc_service)
-            .merge(guardian_bootstrap_service);
+            .merge(guardian_bootstrap_service)
+            .merge(guardian_limiter_observer_service);
 
         Ok(service)
     }
@@ -738,6 +740,71 @@ impl Hashi {
             .await;
             tracing::info!("Guardian bootstrap complete");
             Ok(())
+        })
+    }
+
+    /// Sole mutator of `LocalLimiter` after bootstrap: advances the limiter
+    /// on every observed `WithdrawalSignedEvent`. Symmetric across leader
+    /// and follower (every node sees the same Sui checkpoint stream).
+    /// `signatures.is_some()` implies the guardian acked, because
+    /// `submit_sign_withdrawal` only runs after
+    /// `finalize_withdrawal_through_guardian` returns Ok.
+    fn start_guardian_limiter_observer(self: Arc<Self>) -> Service {
+        use tokio::sync::broadcast::error::RecvError;
+        Service::new().spawn_aborting(async move {
+            if self.guardian_client().is_none() {
+                return Ok(());
+            }
+            let mut rx = self.onchain_state().subscribe();
+            loop {
+                let notification = match rx.recv().await {
+                    Ok(n) => n,
+                    Err(RecvError::Closed) => return Ok(()),
+                    Err(RecvError::Lagged(n)) => {
+                        tracing::error!(
+                            skipped = n,
+                            "Limiter observer lagged on broadcast channel; \
+                             local limiter state is now drifted from guardian"
+                        );
+                        continue;
+                    }
+                };
+                let onchain::Notification::WithdrawalSigned {
+                    withdrawal_txn_id,
+                    amount_sats,
+                    timestamp_secs,
+                } = notification
+                else {
+                    continue;
+                };
+                let Some(limiter) = self.local_limiter() else {
+                    tracing::warn!(
+                        %withdrawal_txn_id,
+                        "Local limiter not yet bootstrapped; dropping observation. \
+                         Bootstrap must complete before the first withdrawal."
+                    );
+                    continue;
+                };
+                let seq = limiter.next_seq().await;
+                match limiter
+                    .apply_consume(seq, timestamp_secs, amount_sats)
+                    .await
+                {
+                    Ok(()) => tracing::info!(
+                        seq,
+                        amount_sats,
+                        timestamp_secs,
+                        %withdrawal_txn_id,
+                        "Local limiter advanced from on-chain WithdrawalSignedEvent",
+                    ),
+                    Err(e) => tracing::error!(
+                        ?e,
+                        seq,
+                        %withdrawal_txn_id,
+                        "Local limiter apply_consume failed; node is now drifted from guardian"
+                    ),
+                }
+            }
         })
     }
 

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -60,7 +60,7 @@ pub struct Hashi {
     screener_client: OnceLock<Option<grpc::screener_client::ScreenerClient>>,
     guardian_client: OnceLock<Option<grpc::guardian_client::GuardianClient>>,
     guardian_signing_pubkey: OnceLock<Option<hashi_types::guardian::GuardianPubKey>>,
-    local_limiter: RwLock<Option<Arc<guardian_limiter::LocalLimiter>>>,
+    local_limiter: OnceLock<Arc<guardian_limiter::LocalLimiter>>,
     /// Reconfig completion signatures by epoch.
     reconfig_signatures: RwLock<HashMap<u64, Vec<u8>>>,
 }
@@ -84,7 +84,7 @@ impl Hashi {
             screener_client: OnceLock::new(),
             guardian_client: OnceLock::new(),
             guardian_signing_pubkey: OnceLock::new(),
-            local_limiter: RwLock::new(None),
+            local_limiter: OnceLock::new(),
             reconfig_signatures: RwLock::new(HashMap::new()),
         }))
     }
@@ -111,7 +111,7 @@ impl Hashi {
             screener_client: OnceLock::new(),
             guardian_client: OnceLock::new(),
             guardian_signing_pubkey: OnceLock::new(),
-            local_limiter: RwLock::new(None),
+            local_limiter: OnceLock::new(),
             reconfig_signatures: RwLock::new(HashMap::new()),
         }))
     }
@@ -214,7 +214,7 @@ impl Hashi {
     }
 
     pub fn local_limiter(&self) -> Option<Arc<guardian_limiter::LocalLimiter>> {
-        self.local_limiter.read().unwrap().clone()
+        self.local_limiter.get().cloned()
     }
 
     async fn initialize_onchain_state(&self) -> anyhow::Result<Service> {
@@ -705,18 +705,16 @@ impl Hashi {
             tracing::debug!("guardian bootstrap: guardian has no limiter yet");
             return false;
         };
-        let mut slot = self.local_limiter.write().unwrap();
-        if slot.is_none() {
+        let limiter = Arc::new(guardian_limiter::LocalLimiter::new(config, state));
+        if self.local_limiter.set(limiter.clone()).is_ok() {
             tracing::info!(
                 ?state,
                 ?config,
                 "Local guardian limiter seeded from GetGuardianInfo",
             );
-            let limiter = Arc::new(guardian_limiter::LocalLimiter::new(config, state));
             // Hand the same Arc to OnchainState so the watcher can advance
             // it inline when WithdrawalSignedEvent fires.
-            self.onchain_state().set_local_limiter(limiter.clone());
-            *slot = Some(limiter);
+            self.onchain_state().set_local_limiter(limiter);
         }
         true
     }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -75,6 +75,12 @@ pub struct Metrics {
     pub leader_retries_total: IntCounterVec,
     pub leader_items_in_backoff: IntGaugeVec,
 
+    /// Withdrawals skipped because their gross amount exceeds the
+    /// guardian's `max_bucket_capacity`. The request stays approved
+    /// on-chain (we never auto-reject); operator intervention is
+    /// required (raise the cap or have the user cancel).
+    pub guardian_limiter_stuck_oversize_skipped_total: IntCounter,
+
     pub btc_fee_rate_sat_per_kvb: IntGauge,
 
     pub mpc_sign_duration_seconds: HistogramVec,
@@ -457,6 +463,12 @@ impl Metrics {
                 "hashi_leader_items_in_backoff",
                 "Number of requests currently in retry backoff by operation",
                 &["operation"],
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_stuck_oversize_skipped_total: register_int_counter_with_registry!(
+                "hashi_guardian_limiter_stuck_oversize_skipped_total",
+                "Withdrawal requests skipped because their amount exceeds the limiter's max bucket capacity",
                 registry,
             )
             .unwrap(),

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -63,12 +63,6 @@ pub enum Notification {
     /// Reconfig started, transitioning to the given epoch.
     StartReconfig(u64),
     SuiEpochChanged(u64),
-    /// Witness signatures for a `WithdrawalTransaction` were stored on-chain.
-    WithdrawalSigned {
-        withdrawal_txn_id: Address,
-        amount_sats: u64,
-        timestamp_secs: u64,
-    },
 }
 
 /// Information about the latest processed checkpoint
@@ -93,6 +87,9 @@ struct Inner {
     tls_private_key: Option<ed25519_dalek::SigningKey>,
     grpc_max_decoding_message_size: Option<usize>,
     metrics: Option<Arc<crate::metrics::Metrics>>,
+    /// Set once after guardian bootstrap. Read by the watcher to advance
+    /// the limiter inline on each `WithdrawalSignedEvent`.
+    local_limiter: RwLock<Option<Arc<crate::guardian_limiter::LocalLimiter>>>,
 }
 
 #[derive(Debug)]
@@ -146,6 +143,7 @@ impl OnchainState {
             tls_private_key,
             grpc_max_decoding_message_size,
             metrics: metrics.clone(),
+            local_limiter: RwLock::new(None),
         }
         .pipe(Arc::new)
         .pipe(Self);
@@ -183,6 +181,33 @@ impl OnchainState {
 
     pub fn latest_checkpoint_height(&self) -> u64 {
         self.0.checkpoint.borrow().height
+    }
+
+    /// Block until the local watcher's view advances to `target_seq` or
+    /// later. Returns immediately if already past. The caller is
+    /// expected to wrap with `tokio::time::timeout` if a bound is
+    /// desired.
+    pub async fn wait_until_checkpoint(&self, target_seq: u64) {
+        let mut rx = self.subscribe_checkpoint();
+        while rx.borrow().height < target_seq {
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    pub fn local_limiter(&self) -> Option<Arc<crate::guardian_limiter::LocalLimiter>> {
+        self.0.local_limiter.read().unwrap().clone()
+    }
+
+    /// Called once after guardian bootstrap.
+    pub fn set_local_limiter(&self, limiter: Arc<crate::guardian_limiter::LocalLimiter>) {
+        let mut slot = self.0.local_limiter.write().unwrap();
+        if slot.is_some() {
+            tracing::warn!("OnchainState::set_local_limiter called twice; ignoring");
+            return;
+        }
+        *slot = Some(limiter);
     }
 
     pub fn latest_checkpoint_timestamp_ms(&self) -> u64 {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -63,6 +63,14 @@ pub enum Notification {
     /// Reconfig started, transitioning to the given epoch.
     StartReconfig(u64),
     SuiEpochChanged(u64),
+    /// A `WithdrawalTransaction` had its witness signatures stored on-chain.
+    /// Carries the per-withdrawal limiter inputs so subscribers don't have to
+    /// re-read the on-chain mirror.
+    WithdrawalSigned {
+        withdrawal_txn_id: Address,
+        amount_sats: u64,
+        timestamp_secs: u64,
+    },
 }
 
 /// Information about the latest processed checkpoint

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -63,9 +63,7 @@ pub enum Notification {
     /// Reconfig started, transitioning to the given epoch.
     StartReconfig(u64),
     SuiEpochChanged(u64),
-    /// A `WithdrawalTransaction` had its witness signatures stored on-chain.
-    /// Carries the per-withdrawal limiter inputs so subscribers don't have to
-    /// re-read the on-chain mirror.
+    /// Witness signatures for a `WithdrawalTransaction` were stored on-chain.
     WithdrawalSigned {
         withdrawal_txn_id: Address,
         amount_sats: u64,

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -87,8 +87,7 @@ struct Inner {
     tls_private_key: Option<ed25519_dalek::SigningKey>,
     grpc_max_decoding_message_size: Option<usize>,
     metrics: Option<Arc<crate::metrics::Metrics>>,
-    /// Set once after guardian bootstrap. Read by the watcher to advance
-    /// the limiter inline on each `WithdrawalSignedEvent`.
+    /// Set once after guardian bootstrap; advanced by the watcher.
     local_limiter: RwLock<Option<Arc<crate::guardian_limiter::LocalLimiter>>>,
 }
 
@@ -183,10 +182,8 @@ impl OnchainState {
         self.0.checkpoint.borrow().height
     }
 
-    /// Block until the local watcher's view advances to `target_seq` or
-    /// later. Returns immediately if already past. The caller is
-    /// expected to wrap with `tokio::time::timeout` if a bound is
-    /// desired.
+    /// Wait until the watcher reaches `target_seq`. Caller wraps with
+    /// `tokio::time::timeout` for a bound.
     pub async fn wait_until_checkpoint(&self, target_seq: u64) {
         let mut rx = self.subscribe_checkpoint();
         while rx.borrow().height < target_seq {
@@ -395,9 +392,7 @@ impl OnchainState {
             .collect()
     }
 
-    /// True if any committed `WithdrawalTransaction` is still awaiting
-    /// witness signatures. Used by the leader to avoid building a
-    /// second commitment while a prior one is mid-MPC.
+    /// True if any `WithdrawalTransaction` is still awaiting witness signatures.
     pub fn has_unsigned_withdrawal_txn(&self) -> bool {
         self.state()
             .hashi()

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -395,6 +395,18 @@ impl OnchainState {
             .collect()
     }
 
+    /// True if any committed `WithdrawalTransaction` is still awaiting
+    /// witness signatures. Used by the leader to avoid building a
+    /// second commitment while a prior one is mid-MPC.
+    pub fn has_unsigned_withdrawal_txn(&self) -> bool {
+        self.state()
+            .hashi()
+            .withdrawal_queue
+            .withdrawal_txns()
+            .values()
+            .any(|t| t.signatures.is_none())
+    }
+
     pub fn spent_utxos_entries(&self) -> Vec<(types::UtxoId, u64)> {
         self.state()
             .hashi()

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -9,6 +9,7 @@ use futures::TryStreamExt;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::sync::RwLockReadGuard;
 use std::sync::RwLockWriteGuard;
@@ -88,7 +89,9 @@ struct Inner {
     grpc_max_decoding_message_size: Option<usize>,
     metrics: Option<Arc<crate::metrics::Metrics>>,
     /// Set once after guardian bootstrap; advanced by the watcher.
-    local_limiter: RwLock<Option<Arc<crate::guardian_limiter::LocalLimiter>>>,
+    /// `LocalLimiter` carries its own `RwLock<LimiterState>`, so we just
+    /// need set-once semantics for the slot itself.
+    local_limiter: OnceLock<Arc<crate::guardian_limiter::LocalLimiter>>,
 }
 
 #[derive(Debug)]
@@ -142,7 +145,7 @@ impl OnchainState {
             tls_private_key,
             grpc_max_decoding_message_size,
             metrics: metrics.clone(),
-            local_limiter: RwLock::new(None),
+            local_limiter: OnceLock::new(),
         }
         .pipe(Arc::new)
         .pipe(Self);
@@ -194,17 +197,14 @@ impl OnchainState {
     }
 
     pub fn local_limiter(&self) -> Option<Arc<crate::guardian_limiter::LocalLimiter>> {
-        self.0.local_limiter.read().unwrap().clone()
+        self.0.local_limiter.get().cloned()
     }
 
     /// Called once after guardian bootstrap.
     pub fn set_local_limiter(&self, limiter: Arc<crate::guardian_limiter::LocalLimiter>) {
-        let mut slot = self.0.local_limiter.write().unwrap();
-        if slot.is_some() {
+        if self.0.local_limiter.set(limiter).is_err() {
             tracing::warn!("OnchainState::set_local_limiter called twice; ignoring");
-            return;
         }
-        *slot = Some(limiter);
     }
 
     pub fn latest_checkpoint_timestamp_ms(&self) -> u64 {

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -437,14 +437,30 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
             }
             HashiEvent::WithdrawalSignedEvent(event) => {
                 tracing::info!(withdrawal_txn_id = %event.withdrawal_txn_id, "Withdrawal signatures stored on-chain");
-                let mut state = state.state_mut();
-                if let Some(txn) = state
-                    .hashi
-                    .withdrawal_queue
-                    .withdrawal_txns
-                    .get_mut(&event.withdrawal_txn_id)
-                {
-                    txn.signatures = Some(event.signatures.clone());
+                // Capture the limiter inputs while we hold the state guard so
+                // subscribers don't have to re-read the mirror. `signed` is
+                // None if the txn has already been confirmed and removed.
+                let signed = {
+                    let mut state = state.state_mut();
+                    state
+                        .hashi
+                        .withdrawal_queue
+                        .withdrawal_txns
+                        .get_mut(&event.withdrawal_txn_id)
+                        .map(|txn| {
+                            txn.signatures = Some(event.signatures.clone());
+                            let amount_sats: u64 =
+                                txn.withdrawal_outputs.iter().map(|o| o.amount).sum();
+                            let timestamp_secs = txn.timestamp_ms / 1000;
+                            (amount_sats, timestamp_secs)
+                        })
+                };
+                if let Some((amount_sats, timestamp_secs)) = signed {
+                    state.notify(Notification::WithdrawalSigned {
+                        withdrawal_txn_id: event.withdrawal_txn_id,
+                        amount_sats,
+                        timestamp_secs,
+                    });
                 }
             }
             HashiEvent::WithdrawalConfirmedEvent(event) => {

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -456,24 +456,24 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                             (amount_sats, timestamp_secs)
                         })
                 };
-                if let Some((amount_sats, timestamp_secs)) = limiter_inputs {
-                    if let Some(limiter) = state.local_limiter() {
-                        let seq = limiter.next_seq();
-                        match limiter.apply_consume(seq, timestamp_secs, amount_sats) {
-                            Ok(()) => tracing::info!(
-                                seq,
-                                amount_sats,
-                                timestamp_secs,
-                                withdrawal_txn_id = %event.withdrawal_txn_id,
-                                "Local limiter advanced from on-chain WithdrawalSignedEvent",
-                            ),
-                            Err(e) => tracing::error!(
-                                ?e,
-                                seq,
-                                withdrawal_txn_id = %event.withdrawal_txn_id,
-                                "Local limiter apply_consume failed; node is now drifted from guardian"
-                            ),
-                        }
+                if let Some((amount_sats, timestamp_secs)) = limiter_inputs
+                    && let Some(limiter) = state.local_limiter()
+                {
+                    let seq = limiter.next_seq();
+                    match limiter.apply_consume(seq, timestamp_secs, amount_sats) {
+                        Ok(()) => tracing::info!(
+                            seq,
+                            amount_sats,
+                            timestamp_secs,
+                            withdrawal_txn_id = %event.withdrawal_txn_id,
+                            "Local limiter advanced from on-chain WithdrawalSignedEvent",
+                        ),
+                        Err(e) => tracing::error!(
+                            ?e,
+                            seq,
+                            withdrawal_txn_id = %event.withdrawal_txn_id,
+                            "Local limiter apply_consume failed; node is now drifted from guardian"
+                        ),
                     }
                 }
             }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -27,6 +27,7 @@ use crate::onchain::types::DepositRequest;
 use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
 use crate::onchain::types::WithdrawalRequest;
+use crate::withdrawals::withdrawal_limiter_consumption_amount;
 
 #[tracing::instrument(name = "watcher", skip_all)]
 pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Arc<Metrics>>) {
@@ -437,9 +438,11 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
             }
             HashiEvent::WithdrawalSignedEvent(event) => {
                 tracing::info!(withdrawal_txn_id = %event.withdrawal_txn_id, "Withdrawal signatures stored on-chain");
-                // Capture the limiter inputs alongside the signature update so
-                // subscribers don't re-read the mirror.
-                let signed = {
+                // Update the on-chain mirror, then advance the local
+                // limiter inline. The watcher is the sole mutator of the
+                // limiter post-bootstrap; leader and signing-path reads
+                // are uncontended.
+                let limiter_inputs = {
                     let mut state = state.state_mut();
                     state
                         .hashi
@@ -448,18 +451,30 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                         .get_mut(&event.withdrawal_txn_id)
                         .map(|txn| {
                             txn.signatures = Some(event.signatures.clone());
-                            let amount_sats: u64 =
-                                txn.withdrawal_outputs.iter().map(|o| o.amount).sum();
+                            let amount_sats = withdrawal_limiter_consumption_amount(txn);
                             let timestamp_secs = txn.timestamp_ms / 1000;
                             (amount_sats, timestamp_secs)
                         })
                 };
-                if let Some((amount_sats, timestamp_secs)) = signed {
-                    state.notify(Notification::WithdrawalSigned {
-                        withdrawal_txn_id: event.withdrawal_txn_id,
-                        amount_sats,
-                        timestamp_secs,
-                    });
+                if let Some((amount_sats, timestamp_secs)) = limiter_inputs {
+                    if let Some(limiter) = state.local_limiter() {
+                        let seq = limiter.next_seq();
+                        match limiter.apply_consume(seq, timestamp_secs, amount_sats) {
+                            Ok(()) => tracing::info!(
+                                seq,
+                                amount_sats,
+                                timestamp_secs,
+                                withdrawal_txn_id = %event.withdrawal_txn_id,
+                                "Local limiter advanced from on-chain WithdrawalSignedEvent",
+                            ),
+                            Err(e) => tracing::error!(
+                                ?e,
+                                seq,
+                                withdrawal_txn_id = %event.withdrawal_txn_id,
+                                "Local limiter apply_consume failed; node is now drifted from guardian"
+                            ),
+                        }
+                    }
                 }
             }
             HashiEvent::WithdrawalConfirmedEvent(event) => {

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -438,10 +438,8 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
             }
             HashiEvent::WithdrawalSignedEvent(event) => {
                 tracing::info!(withdrawal_txn_id = %event.withdrawal_txn_id, "Withdrawal signatures stored on-chain");
-                // Update the on-chain mirror, then advance the local
-                // limiter inline. The watcher is the sole mutator of the
-                // limiter post-bootstrap; leader and signing-path reads
-                // are uncontended.
+                // Watcher is the sole mutator of the local limiter
+                // post-bootstrap; advance it inline with the mirror update.
                 let limiter_inputs = {
                     let mut state = state.state_mut();
                     state

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -437,9 +437,8 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
             }
             HashiEvent::WithdrawalSignedEvent(event) => {
                 tracing::info!(withdrawal_txn_id = %event.withdrawal_txn_id, "Withdrawal signatures stored on-chain");
-                // Capture the limiter inputs while we hold the state guard so
-                // subscribers don't have to re-read the mirror. `signed` is
-                // None if the txn has already been confirmed and removed.
+                // Capture the limiter inputs alongside the signature update so
+                // subscribers don't re-read the mirror.
                 let signed = {
                     let mut state = state.state_mut();
                     state

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1239,10 +1239,7 @@ impl SuiTxExecutor {
                 response.transaction().effects().status()
             );
         }
-        // The Sui executor waits for checkpoint inclusion, so this is set.
-        // Callers can wait for the local watcher to catch up to this seq
-        // and then read the on-chain mirror — uniform for guardian and
-        // no-guardian deployments.
+        // `execute_transaction_and_wait_for_checkpoint` guarantees this is set.
         let checkpoint = response
             .transaction()
             .checkpoint_opt()

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1203,7 +1203,7 @@ impl SuiTxExecutor {
         request_ids: &[Address],
         signatures: &[Vec<u8>],
         cert: &CommitteeSignature,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<u64> {
         let mut builder = TransactionBuilder::new();
 
         let hashi_arg = builder.object(
@@ -1239,7 +1239,15 @@ impl SuiTxExecutor {
                 response.transaction().effects().status()
             );
         }
-        Ok(())
+        // The Sui executor waits for checkpoint inclusion, so this is set.
+        // Callers can wait for the local watcher to catch up to this seq
+        // and then read the on-chain mirror — uniform for guardian and
+        // no-guardian deployments.
+        let checkpoint = response
+            .transaction()
+            .checkpoint_opt()
+            .ok_or_else(|| anyhow::anyhow!("sign_withdrawal response missing checkpoint"))?;
+        Ok(checkpoint)
     }
 
     /// Execute `withdraw::cancel_withdrawal` to cancel a pending withdrawal request.

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -51,6 +51,24 @@ const WITHDRAWAL_SIGNING_TIMEOUT: Duration = Duration::from_secs(5);
 /// Fee rate tolerance multiplier for validation.
 const FEE_RATE_TOLERANCE_MULTIPLIER: u64 = 5;
 
+/// BTC the pool actually pays out when this withdrawal txn is broadcast —
+/// the gross outflow that consumes the guardian's token-bucket limit.
+///
+/// Equivalent identities (held by coin-selection invariants):
+///   inputs - change                                      (used here)
+///   sum(withdrawal_outputs) + miner_fee                  (output-form)
+///   sum(req.btc_amount)  for the batch's WithdrawalRequests (pre-construction form)
+///
+/// Why it isn't `sum(withdrawal_outputs)`: that excludes the miner fee,
+/// which is BTC that leaves the pool just like a user-bound output.
+/// Why it isn't `sum(inputs)`: that double-counts the change UTXO that
+/// flows back into the pool.
+pub(crate) fn withdrawal_limiter_consumption_amount(txn: &WithdrawalTransaction) -> u64 {
+    let inputs: u64 = txn.inputs.iter().map(|u| u.amount).sum();
+    let change: u64 = txn.change_output.as_ref().map_or(0, |c| c.amount);
+    inputs.saturating_sub(change)
+}
+
 /// Full input weight (WU) for a 2-of-2 taproot script-path spend.
 /// TXIN_BASE_WEIGHT (164 WU) + satisfaction (234 WU) = 398 WU (100 vB).
 /// Used in fee validation where we calculate weight directly without
@@ -569,7 +587,7 @@ impl Hashi {
         // `WithdrawalSignedEvent`, never from this path.
         match (self.local_limiter(), expected_limiter_seq) {
             (Some(limiter), Some(expected_seq)) => {
-                let amount_sats: u64 = txn.withdrawal_outputs.iter().map(|o| o.amount).sum();
+                let amount_sats = withdrawal_limiter_consumption_amount(txn);
                 let timestamp_secs = txn.timestamp_ms / 1000;
                 limiter
                     .validate_consume(expected_seq, timestamp_secs, amount_sats)
@@ -1237,4 +1255,81 @@ fn script_pubkey_from_raw_address(address_bytes: &[u8]) -> anyhow::Result<bitcoi
     let program = WitnessProgram::new(version, address_bytes)
         .map_err(|e| anyhow!("Invalid witness program: {e}"))?;
     Ok(bitcoin::ScriptBuf::new_witness_program(&program))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::onchain::types::OutputUtxo;
+    use crate::onchain::types::Utxo;
+    use crate::onchain::types::UtxoId;
+    use hashi_types::bitcoin_txid::BitcoinTxid;
+
+    fn input(amount: u64) -> Utxo {
+        Utxo {
+            id: UtxoId {
+                txid: BitcoinTxid::ZERO,
+                vout: 0,
+            },
+            amount,
+            derivation_path: None,
+        }
+    }
+
+    fn output(amount: u64) -> OutputUtxo {
+        OutputUtxo {
+            amount,
+            bitcoin_address: vec![0; 32],
+        }
+    }
+
+    fn make_txn(
+        inputs: Vec<u64>,
+        withdrawal_outputs: Vec<u64>,
+        change: Option<u64>,
+    ) -> WithdrawalTransaction {
+        WithdrawalTransaction {
+            id: Address::ZERO,
+            txid: BitcoinTxid::ZERO,
+            request_ids: vec![],
+            inputs: inputs.into_iter().map(input).collect(),
+            withdrawal_outputs: withdrawal_outputs.into_iter().map(output).collect(),
+            change_output: change.map(output),
+            timestamp_ms: 0,
+            randomness: vec![],
+            signatures: None,
+            presig_start_index: 0,
+            epoch: 0,
+        }
+    }
+
+    #[test]
+    fn consumption_amount_no_change() {
+        // 1_000 input, 950 to user, 50 fee, no change.
+        let txn = make_txn(vec![1_000], vec![950], None);
+        assert_eq!(withdrawal_limiter_consumption_amount(&txn), 1_000);
+    }
+
+    #[test]
+    fn consumption_amount_with_change() {
+        // 10_000 input, 7_000 to user, 50 fee, 2_950 change.
+        let txn = make_txn(vec![10_000], vec![7_000], Some(2_950));
+        assert_eq!(withdrawal_limiter_consumption_amount(&txn), 7_050);
+    }
+
+    #[test]
+    fn consumption_amount_multi_input_multi_output() {
+        // Two inputs: 6_000 + 4_000. Three users: 2_000 + 1_500 + 5_500. Fee 100, change 900.
+        let txn = make_txn(vec![6_000, 4_000], vec![2_000, 1_500, 5_500], Some(900));
+        let expected = 10_000 - 900; // inputs - change
+        let by_outputs = 9_000 + 100; // user_outputs + fee
+        assert_eq!(expected, by_outputs);
+        assert_eq!(withdrawal_limiter_consumption_amount(&txn), expected);
+    }
+
+    #[test]
+    fn consumption_amount_no_inputs_returns_zero() {
+        let txn = make_txn(vec![], vec![], None);
+        assert_eq!(withdrawal_limiter_consumption_amount(&txn), 0);
+    }
 }

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -565,7 +565,7 @@ impl Hashi {
                 epoch,
             );
         }
-        // Validate-only: the observer advances the limiter on
+        // Validate-only: the watcher advances the limiter on
         // `WithdrawalSignedEvent`, never from this path.
         match (self.local_limiter(), expected_limiter_seq) {
             (Some(limiter), Some(expected_seq)) => {
@@ -573,7 +573,6 @@ impl Hashi {
                 let timestamp_secs = txn.timestamp_ms / 1000;
                 limiter
                     .validate_consume(expected_seq, timestamp_secs, amount_sats)
-                    .await
                     .map_err(|e| anyhow!("Limiter rejected withdrawal {}: {e}", txn.id))?;
             }
             (None, None) => {}

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -565,9 +565,8 @@ impl Hashi {
                 epoch,
             );
         }
-        // Validate-only: the limiter advance happens in
-        // `start_guardian_limiter_observer` on `WithdrawalSignedEvent`,
-        // never on this signing path.
+        // Validate-only: the observer advances the limiter on
+        // `WithdrawalSignedEvent`, never from this path.
         match (self.local_limiter(), expected_limiter_seq) {
             (Some(limiter), Some(expected_seq)) => {
                 let amount_sats: u64 = txn.withdrawal_outputs.iter().map(|o| o.amount).sum();

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -51,18 +51,10 @@ const WITHDRAWAL_SIGNING_TIMEOUT: Duration = Duration::from_secs(5);
 /// Fee rate tolerance multiplier for validation.
 const FEE_RATE_TOLERANCE_MULTIPLIER: u64 = 5;
 
-/// BTC the pool actually pays out when this withdrawal txn is broadcast —
-/// the gross outflow that consumes the guardian's token-bucket limit.
-///
-/// Equivalent identities (held by coin-selection invariants):
-///   inputs - change                                      (used here)
-///   sum(withdrawal_outputs) + miner_fee                  (output-form)
-///   sum(req.btc_amount)  for the batch's WithdrawalRequests (pre-construction form)
-///
-/// Why it isn't `sum(withdrawal_outputs)`: that excludes the miner fee,
-/// which is BTC that leaves the pool just like a user-bound output.
-/// Why it isn't `sum(inputs)`: that double-counts the change UTXO that
-/// flows back into the pool.
+/// BTC that leaves the pool when this txn broadcasts — the amount that
+/// consumes the guardian's limit. Equivalent to
+/// `sum(withdrawal_outputs) + miner_fee`; we use `inputs - change` to
+/// avoid relying on a separate fee field.
 pub(crate) fn withdrawal_limiter_consumption_amount(txn: &WithdrawalTransaction) -> u64 {
     let inputs: u64 = txn.inputs.iter().map(|u| u.amount).sum();
     let change: u64 = txn.change_output.as_ref().map_or(0, |c| c.amount);

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -565,6 +565,9 @@ impl Hashi {
                 epoch,
             );
         }
+        // Validate-only: the limiter advance happens in
+        // `start_guardian_limiter_observer` on `WithdrawalSignedEvent`,
+        // never on this signing path.
         match (self.local_limiter(), expected_limiter_seq) {
             (Some(limiter), Some(expected_seq)) => {
                 let amount_sats: u64 = txn.withdrawal_outputs.iter().map(|o| o.amount).sum();


### PR DESCRIPTION
## Summary

In #495 , we started confirming with the `LocalLimiter` whenever we did MPC signing per node. 

However, we need to update the `LocalLimiter` whenever the transaction is submitted onchain. For that, we are using the `WithdrawalSignedEvent` as the anchor. Every node observes it from the same Sui checkpoint stream, so leader and follower advance in lockstep.

## Note
@bmwill , we are not currently doing a 'soft reserve' vs 'hard reserve' on the local limiter. As of now, we are validating with the LocalLimiter at every MPC signing event, and then updating the LocalLimiter on every WithdrawalSignedEvent .

This should work well, since we are using MPC concurrency cap of 1 when the guardian is configured. 

TODO: Later on I'll be adding a soft reserve per `WithdrawalID`.

## Changes
- New `start_guardian_limiter_observer` on every node. This listens for the new `Notification::WithdrawalSigned` and calls `apply_consume`.
- Watcher emits `WithdrawalSigned` with the limiter inputs (amount, timestamp) so the observer doesn't re-read the mirror.
- withdrawal selection is capacity-aware: leader truncates the approved batch to the longest timestamp-sorted prefix that fits the limiter.
- MPC concurrency capped at 1 when the limiter is in play.
- `wait_until_signed_committed` blocks the leader against itself so the next checkpoint can't respawn before the prior withdrawal is observed.
- e2e tests: `wait_for_local_limiter` helper so tests don't race observer bootstrap.

