### PR TITLE
[9/n][guardian-integration] hashi-node observability for guardian + local limiter

### DIFF
--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1047,7 +1047,17 @@ impl LeaderService {
 
             if batch.is_empty() {
                 // All-oversize (already warned) or refill-bound head.
+                self.inner
+                    .metrics
+                    .guardian_limiter_batch_stuck_head_total
+                    .inc();
                 return;
+            }
+            if at_capacity {
+                self.inner
+                    .metrics
+                    .guardian_limiter_batch_truncated_total
+                    .inc();
             }
             (batch, at_capacity)
         } else {
@@ -1328,7 +1338,12 @@ impl LeaderService {
             let amount_sats = crate::withdrawals::withdrawal_limiter_consumption_amount(&txn);
             let timestamp_secs = txn.timestamp_ms / 1000;
             let next_seq = limiter.next_seq();
-            if let Err(e) = limiter.validate_consume(next_seq, timestamp_secs, amount_sats) {
+            let result = limiter.validate_consume(next_seq, timestamp_secs, amount_sats);
+            inner.metrics.record_limiter_validate(
+                &result,
+                crate::metrics::GUARDIAN_LIMITER_CALLSITE_LEADER_PRE_MPC,
+            );
+            if let Err(e) = result {
                 warn!(
                     withdrawal_txn_id = %txn.id,
                     "Leader local limiter rejected withdrawal; will retry on next checkpoint: {e}"
@@ -2080,39 +2095,79 @@ impl LeaderService {
                 .await?;
         let proto_request = signed_standard_withdrawal_request_to_pb(&signed_request);
 
-        let response_pb = guardian
-            .standard_withdrawal(proto_request)
-            .await
-            .map_err(|status| {
-                let label = if status.message().contains("seq mismatch") {
-                    "GuardianSeqMismatch"
-                } else if status.message().contains("Rate limit exceeded") {
-                    warn!("Guardian rate-limited withdrawal, will retry later");
-                    "GuardianRateLimited"
-                } else {
-                    error!("Guardian call failed: {}", status.message());
-                    "GuardianUnavailable"
-                };
-                inner
-                    .metrics
-                    .leader_retries_total
-                    .with_label_values(&["withdrawal_signing", label])
-                    .inc();
-                anyhow::anyhow!("Guardian rejected withdrawal: {}", status.message())
-            })?;
+        let rpc_start = std::time::Instant::now();
+        let rpc_result = guardian.standard_withdrawal(proto_request).await;
+        let rpc_elapsed = rpc_start.elapsed().as_secs_f64();
+
+        let response_pb = rpc_result.map_err(|status| {
+            let (rpc_outcome, retry_label) = if status.message().contains("seq mismatch") {
+                (
+                    crate::metrics::GUARDIAN_RPC_OUTCOME_SEQ_MISMATCH,
+                    "GuardianSeqMismatch",
+                )
+            } else if status.message().contains("Rate limit exceeded") {
+                warn!("Guardian rate-limited withdrawal, will retry later");
+                (
+                    crate::metrics::GUARDIAN_RPC_OUTCOME_RATE_LIMITED,
+                    "GuardianRateLimited",
+                )
+            } else {
+                error!("Guardian call failed: {}", status.message());
+                (
+                    crate::metrics::GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
+                    "GuardianUnavailable",
+                )
+            };
+            Self::record_guardian_rpc_outcome(inner, rpc_outcome, rpc_elapsed);
+            inner
+                .metrics
+                .leader_retries_total
+                .with_label_values(&["withdrawal_signing", retry_label])
+                .inc();
+            anyhow::anyhow!("Guardian rejected withdrawal: {}", status.message())
+        })?;
 
         let pubkey = inner
             .guardian_signing_pubkey()
             .expect("guardian signing pubkey set during bootstrap");
         let signed_response: GuardianSigned<StandardWithdrawalResponse> = response_pb
             .try_into()
+            .inspect_err(|_| {
+                Self::record_guardian_rpc_outcome(
+                    inner,
+                    crate::metrics::GUARDIAN_RPC_OUTCOME_PARSE_ERROR,
+                    rpc_elapsed,
+                );
+            })
             .map_err(|e| anyhow::anyhow!("Failed to parse guardian withdrawal response: {e}"))?;
-        signed_response.verify(pubkey).map_err(|e| {
-            anyhow::anyhow!("Guardian response signature verification failed: {e:?}")
-        })?;
+        signed_response
+            .verify(pubkey)
+            .inspect_err(|_| {
+                Self::record_guardian_rpc_outcome(
+                    inner,
+                    crate::metrics::GUARDIAN_RPC_OUTCOME_SIGNATURE_ERROR,
+                    rpc_elapsed,
+                );
+            })
+            .map_err(|e| {
+                anyhow::anyhow!("Guardian response signature verification failed: {e:?}")
+            })?;
 
+        Self::record_guardian_rpc_outcome(
+            inner,
+            crate::metrics::GUARDIAN_RPC_OUTCOME_OK,
+            rpc_elapsed,
+        );
         info!(seq, "Guardian approved withdrawal");
         Ok(())
+    }
+
+    fn record_guardian_rpc_outcome(inner: &Arc<Hashi>, outcome: &str, elapsed_secs: f64) {
+        inner.metrics.record_guardian_rpc(
+            crate::metrics::GUARDIAN_RPC_METHOD_STANDARD_WITHDRAWAL,
+            outcome,
+            elapsed_secs,
+        );
     }
 
     async fn collect_guardian_withdrawal_signatures(

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -601,6 +601,9 @@ impl Hashi {
             None
         };
 
+        self.metrics
+            .guardian_enabled
+            .set(if guardian.is_some() { 1 } else { 0 });
         self.guardian_client
             .set(guardian)
             .map_err(|_| anyhow!("Guardian client already initialized"))?;
@@ -686,9 +689,28 @@ impl Hashi {
         let Some(client) = self.guardian_client() else {
             return false;
         };
-        let info_pb = match client.get_guardian_info().await {
-            Ok(info) => info,
+        self.metrics.guardian_bootstrap_attempts_total.inc();
+        let rpc_start = std::time::Instant::now();
+        let rpc_result = client.get_guardian_info().await;
+        let rpc_elapsed = rpc_start.elapsed().as_secs_f64();
+        let info_pb = match rpc_result {
+            Ok(info) => {
+                self.metrics.record_guardian_rpc(
+                    metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
+                    metrics::GUARDIAN_RPC_OUTCOME_OK,
+                    rpc_elapsed,
+                );
+                info
+            }
             Err(e) => {
+                self.metrics.record_guardian_rpc(
+                    metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
+                    metrics::GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
+                    rpc_elapsed,
+                );
+                self.metrics.record_guardian_bootstrap_outcome(
+                    metrics::GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE,
+                );
                 tracing::warn!("guardian bootstrap: GetGuardianInfo failed: {e}");
                 return false;
             }
@@ -696,12 +718,18 @@ impl Hashi {
         let info = match hashi_types::guardian::GetGuardianInfoResponse::try_from(info_pb) {
             Ok(info) => info,
             Err(e) => {
+                self.metrics.record_guardian_bootstrap_outcome(
+                    metrics::GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE,
+                );
                 tracing::warn!("guardian bootstrap: parse failed: {e:?}");
                 return false;
             }
         };
         let _ = self.guardian_signing_pubkey.set(Some(info.signing_pub_key));
         let (Some(state), Some(config)) = (info.limiter_state, info.limiter_config) else {
+            self.metrics.record_guardian_bootstrap_outcome(
+                metrics::GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET,
+            );
             tracing::debug!("guardian bootstrap: guardian has no limiter yet");
             return false;
         };
@@ -712,10 +740,14 @@ impl Hashi {
                 ?config,
                 "Local guardian limiter seeded from GetGuardianInfo",
             );
+            self.metrics.record_limiter_state(&state, &config);
+            self.metrics.guardian_limiter_initialized.set(1);
             // Hand the same Arc to OnchainState so the watcher can advance
             // it inline when WithdrawalSignedEvent fires.
             self.onchain_state().set_local_limiter(limiter);
         }
+        self.metrics
+            .record_guardian_bootstrap_outcome(metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SUCCESS);
         true
     }
 

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -33,6 +33,25 @@ pub struct Metrics {
 
     pub screener_enabled: IntGauge,
 
+    // Guardian / local-limiter metrics
+    pub guardian_enabled: IntGauge,
+    pub guardian_limiter_initialized: IntGauge,
+    pub guardian_limiter_drifted: IntGauge,
+    pub guardian_limiter_tokens_available: IntGauge,
+    pub guardian_limiter_max_capacity: IntGauge,
+    pub guardian_limiter_refill_rate_sats_per_sec: IntGauge,
+    pub guardian_limiter_next_seq: IntGauge,
+    pub guardian_limiter_last_updated_at_seconds: IntGauge,
+    pub guardian_bootstrap_attempts_total: IntCounter,
+    pub guardian_bootstrap_outcomes_total: IntCounterVec,
+    pub guardian_limiter_validate_total: IntCounterVec,
+    pub guardian_limiter_apply_total: IntCounterVec,
+    pub guardian_limiter_anchor_events_total: IntCounter,
+    pub guardian_limiter_batch_truncated_total: IntCounter,
+    pub guardian_limiter_batch_stuck_head_total: IntCounter,
+    pub guardian_rpc_total: IntCounterVec,
+    pub guardian_rpc_duration_seconds: HistogramVec,
+
     // Kyoto (Bitcoin light client) metrics
     pub kyoto_connected_peers: IntGauge,
     pub kyoto_synced: IntGauge,
@@ -243,6 +262,119 @@ impl Metrics {
             screener_enabled: register_int_gauge_with_registry!(
                 "hashi_screener_enabled",
                 "Whether AML screening is enabled (1) or disabled (0)",
+                registry,
+            )
+            .unwrap(),
+
+            // Guardian / local-limiter metrics
+            guardian_enabled: register_int_gauge_with_registry!(
+                "hashi_guardian_enabled",
+                "Whether the guardian endpoint is configured for this node (1) or not (0)",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_initialized: register_int_gauge_with_registry!(
+                "hashi_guardian_limiter_initialized",
+                "Whether the local guardian-limiter emulator has been seeded from the guardian (1) or not (0)",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_drifted: register_int_gauge_with_registry!(
+                "hashi_guardian_limiter_drifted",
+                "Sticky bit set to 1 when the local limiter has lost lockstep with the guardian \
+                 (broadcast lag or apply_consume failure); cleared only by process restart",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_tokens_available: register_int_gauge_with_registry!(
+                "hashi_guardian_limiter_tokens_available",
+                "Tokens currently available in the local guardian-limiter bucket (sats)",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_max_capacity: register_int_gauge_with_registry!(
+                "hashi_guardian_limiter_max_capacity",
+                "Maximum bucket capacity of the local guardian-limiter (sats), as configured by the guardian",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_refill_rate_sats_per_sec: register_int_gauge_with_registry!(
+                "hashi_guardian_limiter_refill_rate_sats_per_sec",
+                "Refill rate of the local guardian-limiter (sats per second), as configured by the guardian",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_next_seq: register_int_gauge_with_registry!(
+                "hashi_guardian_limiter_next_seq",
+                "Next withdrawal sequence number expected by the local guardian-limiter",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_last_updated_at_seconds: register_int_gauge_with_registry!(
+                "hashi_guardian_limiter_last_updated_at_seconds",
+                "Unix timestamp (seconds) of the last apply_consume on the local guardian-limiter",
+                registry,
+            )
+            .unwrap(),
+            guardian_bootstrap_attempts_total: register_int_counter_with_registry!(
+                "hashi_guardian_bootstrap_attempts_total",
+                "Total GetGuardianInfo bootstrap attempts (one per retry)",
+                registry,
+            )
+            .unwrap(),
+            guardian_bootstrap_outcomes_total: register_int_counter_vec_with_registry!(
+                "hashi_guardian_bootstrap_outcomes_total",
+                "Bootstrap outcomes by reason: success, rpc_failure, parse_failure, no_limiter_yet",
+                &["outcome"],
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_validate_total: register_int_counter_vec_with_registry!(
+                "hashi_guardian_limiter_validate_total",
+                "Local-limiter validate_consume calls by outcome and call site",
+                &["outcome", "callsite"],
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_apply_total: register_int_counter_vec_with_registry!(
+                "hashi_guardian_limiter_apply_total",
+                "Local-limiter apply_consume calls by outcome (also covers no_limiter and broadcast_lagged \
+                 observer events that prevent an apply)",
+                &["outcome"],
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_anchor_events_total: register_int_counter_with_registry!(
+                "hashi_guardian_limiter_anchor_events_total",
+                "Total on-chain WithdrawalSignedEvent observations applied to the local guardian-limiter",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_batch_truncated_total: register_int_counter_with_registry!(
+                "hashi_guardian_limiter_batch_truncated_total",
+                "Times the leader's approved batch was truncated by local-limiter capacity (the head fits, the tail does not)",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_batch_stuck_head_total: register_int_counter_with_registry!(
+                "hashi_guardian_limiter_batch_stuck_head_total",
+                "Times the head of the leader's approved batch already exceeded local-limiter capacity",
+                registry,
+            )
+            .unwrap(),
+            guardian_rpc_total: register_int_counter_vec_with_registry!(
+                "hashi_guardian_rpc_total",
+                "Outbound RPC calls to the guardian by method and outcome \
+                 (outcomes: ok, seq_mismatch, rate_limited, unavailable, parse_error, signature_error)",
+                &["method", "outcome"],
+                registry,
+            )
+            .unwrap(),
+            guardian_rpc_duration_seconds: register_histogram_vec_with_registry!(
+                "hashi_guardian_rpc_duration_seconds",
+                "Latency of outbound RPC calls to the guardian by method and outcome",
+                &["method", "outcome"],
+                LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
@@ -696,6 +828,60 @@ impl Metrics {
         }
     }
 
+    pub fn record_limiter_state(
+        &self,
+        state: &hashi_types::guardian::LimiterState,
+        config: &hashi_types::guardian::LimiterConfig,
+    ) {
+        self.guardian_limiter_tokens_available
+            .set(state.num_tokens_available as i64);
+        self.guardian_limiter_next_seq.set(state.next_seq as i64);
+        self.guardian_limiter_last_updated_at_seconds
+            .set(state.last_updated_at as i64);
+        self.guardian_limiter_max_capacity
+            .set(config.max_bucket_capacity as i64);
+        self.guardian_limiter_refill_rate_sats_per_sec
+            .set(config.refill_rate as i64);
+    }
+
+    pub fn record_limiter_validate(
+        &self,
+        result: &Result<(), crate::guardian_limiter::LocalLimiterError>,
+        callsite: &str,
+    ) {
+        let outcome = limiter_outcome_label(result);
+        self.guardian_limiter_validate_total
+            .with_label_values(&[outcome, callsite])
+            .inc();
+    }
+
+    /// `no_limiter` and `broadcast_lagged` paths don't have a `Result` and
+    /// must be recorded by the caller.
+    pub fn record_limiter_apply(
+        &self,
+        result: &Result<(), crate::guardian_limiter::LocalLimiterError>,
+    ) {
+        let outcome = limiter_outcome_label(result);
+        self.guardian_limiter_apply_total
+            .with_label_values(&[outcome])
+            .inc();
+    }
+
+    pub fn record_guardian_rpc(&self, method: &str, outcome: &str, elapsed_secs: f64) {
+        self.guardian_rpc_total
+            .with_label_values(&[method, outcome])
+            .inc();
+        self.guardian_rpc_duration_seconds
+            .with_label_values(&[method, outcome])
+            .observe(elapsed_secs);
+    }
+
+    pub fn record_guardian_bootstrap_outcome(&self, outcome: &str) {
+        self.guardian_bootstrap_outcomes_total
+            .with_label_values(&[outcome])
+            .inc();
+    }
+
     pub fn update_onchain_state(&self, state: &crate::onchain::OnchainState) {
         self.latest_checkpoint_height
             .set(state.latest_checkpoint_height() as i64);
@@ -844,6 +1030,47 @@ impl Metrics {
     }
 }
 
+// Guardian limiter validate/apply outcome labels.
+pub const GUARDIAN_LIMITER_OUTCOME_SUCCESS: &str = "success";
+pub const GUARDIAN_LIMITER_OUTCOME_SEQ_MISMATCH: &str = "seq_mismatch";
+pub const GUARDIAN_LIMITER_OUTCOME_STALE_TIMESTAMP: &str = "stale_timestamp";
+pub const GUARDIAN_LIMITER_OUTCOME_INSUFFICIENT_CAPACITY: &str = "insufficient_capacity";
+// Apply-only labels (no analogue on validate).
+pub const GUARDIAN_LIMITER_OUTCOME_NO_LIMITER: &str = "no_limiter";
+pub const GUARDIAN_LIMITER_OUTCOME_BROADCAST_LAGGED: &str = "broadcast_lagged";
+
+pub const GUARDIAN_LIMITER_CALLSITE_LEADER_PRE_MPC: &str = "leader_pre_mpc";
+pub const GUARDIAN_LIMITER_CALLSITE_MPC_SIGNING: &str = "mpc_signing";
+
+pub const GUARDIAN_BOOTSTRAP_OUTCOME_SUCCESS: &str = "success";
+pub const GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE: &str = "rpc_failure";
+pub const GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE: &str = "parse_failure";
+pub const GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET: &str = "no_limiter_yet";
+
+pub const GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO: &str = "get_guardian_info";
+pub const GUARDIAN_RPC_METHOD_STANDARD_WITHDRAWAL: &str = "standard_withdrawal";
+
+pub const GUARDIAN_RPC_OUTCOME_OK: &str = "ok";
+pub const GUARDIAN_RPC_OUTCOME_SEQ_MISMATCH: &str = "seq_mismatch";
+pub const GUARDIAN_RPC_OUTCOME_RATE_LIMITED: &str = "rate_limited";
+pub const GUARDIAN_RPC_OUTCOME_UNAVAILABLE: &str = "unavailable";
+pub const GUARDIAN_RPC_OUTCOME_PARSE_ERROR: &str = "parse_error";
+pub const GUARDIAN_RPC_OUTCOME_SIGNATURE_ERROR: &str = "signature_error";
+
+fn limiter_outcome_label(
+    result: &Result<(), crate::guardian_limiter::LocalLimiterError>,
+) -> &'static str {
+    use crate::guardian_limiter::LocalLimiterError;
+    match result {
+        Ok(()) => GUARDIAN_LIMITER_OUTCOME_SUCCESS,
+        Err(LocalLimiterError::SeqMismatch { .. }) => GUARDIAN_LIMITER_OUTCOME_SEQ_MISMATCH,
+        Err(LocalLimiterError::StaleTimestamp { .. }) => GUARDIAN_LIMITER_OUTCOME_STALE_TIMESTAMP,
+        Err(LocalLimiterError::InsufficientCapacity { .. }) => {
+            GUARDIAN_LIMITER_OUTCOME_INSUFFICIENT_CAPACITY
+        }
+    }
+}
+
 /// Create a metric that measures the uptime from when this metric was constructed.
 /// The metric is labeled with:
 /// - 'version': binary version, generally be of the format: 'semver-gitrevision'
@@ -906,5 +1133,119 @@ async fn metrics(
             http::StatusCode::INTERNAL_SERVER_ERROR,
             format!("unable to encode metrics: {error}"),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::guardian_limiter::LocalLimiterError;
+    use hashi_types::guardian::LimiterConfig;
+    use hashi_types::guardian::LimiterState;
+
+    #[test]
+    fn guardian_metric_helpers_cover_every_label() {
+        let registry = Registry::new();
+        let metrics = Metrics::new(&registry);
+
+        // Snapshot gauges.
+        metrics.record_limiter_state(
+            &LimiterState {
+                num_tokens_available: 1_234,
+                last_updated_at: 9_999,
+                next_seq: 17,
+            },
+            &LimiterConfig {
+                refill_rate: 50,
+                max_bucket_capacity: 100_000_000,
+            },
+        );
+        assert_eq!(metrics.guardian_limiter_tokens_available.get(), 1_234);
+        assert_eq!(metrics.guardian_limiter_next_seq.get(), 17);
+        assert_eq!(
+            metrics.guardian_limiter_last_updated_at_seconds.get(),
+            9_999
+        );
+        assert_eq!(metrics.guardian_limiter_max_capacity.get(), 100_000_000);
+        assert_eq!(metrics.guardian_limiter_refill_rate_sats_per_sec.get(), 50);
+
+        // Validate helper covers every error variant + Ok.
+        for callsite in [
+            GUARDIAN_LIMITER_CALLSITE_LEADER_PRE_MPC,
+            GUARDIAN_LIMITER_CALLSITE_MPC_SIGNING,
+        ] {
+            metrics.record_limiter_validate(&Ok(()), callsite);
+            metrics.record_limiter_validate(
+                &Err(LocalLimiterError::SeqMismatch {
+                    local: 0,
+                    incoming: 1,
+                }),
+                callsite,
+            );
+            metrics.record_limiter_validate(
+                &Err(LocalLimiterError::StaleTimestamp {
+                    local_last: 10,
+                    incoming: 5,
+                }),
+                callsite,
+            );
+            metrics.record_limiter_validate(
+                &Err(LocalLimiterError::InsufficientCapacity {
+                    needed: 100,
+                    available: 50,
+                }),
+                callsite,
+            );
+        }
+
+        // Apply helper covers every error variant + Ok.
+        metrics.record_limiter_apply(&Ok(()));
+        metrics.record_limiter_apply(&Err(LocalLimiterError::SeqMismatch {
+            local: 0,
+            incoming: 1,
+        }));
+        metrics.record_limiter_apply(&Err(LocalLimiterError::StaleTimestamp {
+            local_last: 10,
+            incoming: 5,
+        }));
+        metrics.record_limiter_apply(&Err(LocalLimiterError::InsufficientCapacity {
+            needed: 100,
+            available: 50,
+        }));
+
+        // Apply-only outcome labels need to be valid label values for this CounterVec.
+        metrics
+            .guardian_limiter_apply_total
+            .with_label_values(&[GUARDIAN_LIMITER_OUTCOME_NO_LIMITER])
+            .inc();
+        metrics
+            .guardian_limiter_apply_total
+            .with_label_values(&[GUARDIAN_LIMITER_OUTCOME_BROADCAST_LAGGED])
+            .inc();
+
+        for outcome in [
+            GUARDIAN_BOOTSTRAP_OUTCOME_SUCCESS,
+            GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE,
+            GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE,
+            GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET,
+        ] {
+            metrics.record_guardian_bootstrap_outcome(outcome);
+        }
+
+        for method in [
+            GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
+            GUARDIAN_RPC_METHOD_STANDARD_WITHDRAWAL,
+        ] {
+            for outcome in [
+                GUARDIAN_RPC_OUTCOME_OK,
+                GUARDIAN_RPC_OUTCOME_SEQ_MISMATCH,
+                GUARDIAN_RPC_OUTCOME_RATE_LIMITED,
+                GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
+                GUARDIAN_RPC_OUTCOME_PARSE_ERROR,
+                GUARDIAN_RPC_OUTCOME_SIGNATURE_ERROR,
+            ] {
+                metrics.record_guardian_rpc(method, outcome, 0.1);
+            }
+        }
     }
 }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -281,8 +281,7 @@ impl Metrics {
             .unwrap(),
             guardian_limiter_drifted: register_int_gauge_with_registry!(
                 "hashi_guardian_limiter_drifted",
-                "Sticky bit set to 1 when the local limiter has lost lockstep with the guardian \
-                 (broadcast lag or apply_consume failure); cleared only by process restart",
+                "Sticky bit set to 1 when the watcher's apply_consume fails — local limiter has lost lockstep with the guardian; cleared only by process restart",
                 registry,
             )
             .unwrap(),
@@ -338,8 +337,7 @@ impl Metrics {
             .unwrap(),
             guardian_limiter_apply_total: register_int_counter_vec_with_registry!(
                 "hashi_guardian_limiter_apply_total",
-                "Local-limiter apply_consume calls by outcome (also covers no_limiter and broadcast_lagged \
-                 observer events that prevent an apply)",
+                "Local-limiter apply_consume calls by outcome (also covers `no_limiter` watcher events that prevent an apply)",
                 &["outcome"],
                 registry,
             )
@@ -1035,9 +1033,9 @@ pub const GUARDIAN_LIMITER_OUTCOME_SUCCESS: &str = "success";
 pub const GUARDIAN_LIMITER_OUTCOME_SEQ_MISMATCH: &str = "seq_mismatch";
 pub const GUARDIAN_LIMITER_OUTCOME_STALE_TIMESTAMP: &str = "stale_timestamp";
 pub const GUARDIAN_LIMITER_OUTCOME_INSUFFICIENT_CAPACITY: &str = "insufficient_capacity";
-// Apply-only labels (no analogue on validate).
+// Apply-only label (no analogue on validate): watcher saw a
+// WithdrawalSignedEvent before the local limiter was bootstrapped.
 pub const GUARDIAN_LIMITER_OUTCOME_NO_LIMITER: &str = "no_limiter";
-pub const GUARDIAN_LIMITER_OUTCOME_BROADCAST_LAGGED: &str = "broadcast_lagged";
 
 pub const GUARDIAN_LIMITER_CALLSITE_LEADER_PRE_MPC: &str = "leader_pre_mpc";
 pub const GUARDIAN_LIMITER_CALLSITE_MPC_SIGNING: &str = "mpc_signing";
@@ -1213,14 +1211,10 @@ mod tests {
             available: 50,
         }));
 
-        // Apply-only outcome labels need to be valid label values for this CounterVec.
+        // Apply-only outcome label needs to be a valid label value for this CounterVec.
         metrics
             .guardian_limiter_apply_total
             .with_label_values(&[GUARDIAN_LIMITER_OUTCOME_NO_LIMITER])
-            .inc();
-        metrics
-            .guardian_limiter_apply_total
-            .with_label_values(&[GUARDIAN_LIMITER_OUTCOME_BROADCAST_LAGGED])
             .inc();
 
         for outcome in [

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -200,6 +200,10 @@ impl OnchainState {
         self.0.local_limiter.get().cloned()
     }
 
+    pub(crate) fn metrics(&self) -> Option<&Arc<crate::metrics::Metrics>> {
+        self.0.metrics.as_ref()
+    }
+
     /// Called once after guardian bootstrap.
     pub fn set_local_limiter(&self, limiter: Arc<crate::guardian_limiter::LocalLimiter>) {
         if self.0.local_limiter.set(limiter).is_err() {

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -454,24 +454,49 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                             (amount_sats, timestamp_secs)
                         })
                 };
-                if let Some((amount_sats, timestamp_secs)) = limiter_inputs
-                    && let Some(limiter) = state.local_limiter()
-                {
-                    let seq = limiter.next_seq();
-                    match limiter.apply_consume(seq, timestamp_secs, amount_sats) {
-                        Ok(()) => tracing::info!(
-                            seq,
-                            amount_sats,
-                            timestamp_secs,
-                            withdrawal_txn_id = %event.withdrawal_txn_id,
-                            "Local limiter advanced from on-chain WithdrawalSignedEvent",
-                        ),
-                        Err(e) => tracing::error!(
-                            ?e,
-                            seq,
-                            withdrawal_txn_id = %event.withdrawal_txn_id,
-                            "Local limiter apply_consume failed; node is now drifted from guardian"
-                        ),
+                if let Some((amount_sats, timestamp_secs)) = limiter_inputs {
+                    if let Some(limiter) = state.local_limiter() {
+                        let seq = limiter.next_seq();
+                        let result = limiter.apply_consume(seq, timestamp_secs, amount_sats);
+                        if let Some(metrics) = state.metrics() {
+                            metrics.record_limiter_apply(&result);
+                        }
+                        match &result {
+                            Ok(()) => {
+                                if let Some(metrics) = state.metrics() {
+                                    metrics.guardian_limiter_anchor_events_total.inc();
+                                    metrics.record_limiter_state(
+                                        &limiter.snapshot(),
+                                        limiter.config(),
+                                    );
+                                }
+                                tracing::info!(
+                                    seq,
+                                    amount_sats,
+                                    timestamp_secs,
+                                    withdrawal_txn_id = %event.withdrawal_txn_id,
+                                    "Local limiter advanced from on-chain WithdrawalSignedEvent",
+                                );
+                            }
+                            Err(e) => {
+                                if let Some(metrics) = state.metrics() {
+                                    metrics.guardian_limiter_drifted.set(1);
+                                }
+                                tracing::error!(
+                                    ?e,
+                                    seq,
+                                    withdrawal_txn_id = %event.withdrawal_txn_id,
+                                    "Local limiter apply_consume failed; node is now drifted from guardian"
+                                );
+                            }
+                        }
+                    } else if let Some(metrics) = state.metrics() {
+                        metrics
+                            .guardian_limiter_apply_total
+                            .with_label_values(&[
+                                crate::metrics::GUARDIAN_LIMITER_OUTCOME_NO_LIMITER,
+                            ])
+                            .inc();
                     }
                 }
             }

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -616,9 +616,12 @@ impl Hashi {
             (Some(limiter), Some(expected_seq)) => {
                 let amount_sats = withdrawal_limiter_consumption_amount(txn);
                 let timestamp_secs = txn.timestamp_ms / 1000;
-                limiter
-                    .validate_consume(expected_seq, timestamp_secs, amount_sats)
-                    .map_err(|e| anyhow!("Limiter rejected withdrawal {}: {e}", txn.id))?;
+                let result = limiter.validate_consume(expected_seq, timestamp_secs, amount_sats);
+                self.metrics.record_limiter_validate(
+                    &result,
+                    crate::metrics::GUARDIAN_LIMITER_CALLSITE_MPC_SIGNING,
+                );
+                result.map_err(|e| anyhow!("Limiter rejected withdrawal {}: {e}", txn.id))?;
             }
             (None, None) => {}
             (Some(_), None) => anyhow::bail!(


### PR DESCRIPTION
- Add new `hashi_guardian_*` metrics: 
  - enabled
  - limiter
  - bootstrap state
  - snapshot gauges (tokens, capacity, refill_rate, next_seq, last_updated_at)
  - validate/apply by error variant
  - on-chain anchor events
  - capacity-aware batching
  - outbound RPC latency/outcome by method.
- `hashi_guardian_limiter_drifted` is sticky (set on broadcast lag or `apply_consume`)
