### PR TITLE
[guardian] resync local limiter via gap-fill + periodic reconciler

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -443,6 +443,54 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_guardian_reconciler_reports_healthy_after_withdrawal() -> Result<()> {
+        init_test_logging();
+        info!("=== Starting Guardian Reconciler Tick E2E Test ===");
+
+        let builder = TestNetworksBuilder::new()
+            .with_nodes(4)
+            .with_guardian()
+            .with_guardian_reconciliation_interval_secs(1);
+        let mut networks = setup_test_networks(builder).await?;
+
+        create_deposit_and_wait(&mut networks, 100_000u64).await?;
+
+        let hashi = networks.hashi_network.nodes()[0].hashi().clone();
+        let user_key = networks.sui_network.user_keys.first().unwrap().clone();
+        withdraw_and_confirm(&mut networks, &hashi, user_key, 30_000u64).await?;
+
+        // Reconciler skips the first tick, so wait for at least one
+        // tick after that.
+        tokio::time::sleep(Duration::from_secs(6)).await;
+
+        for node in networks.hashi_network.nodes() {
+            let metrics = node.hashi().metrics.clone();
+            let healthy = metrics
+                .guardian_reconciler_outcomes_total
+                .with_label_values(&[hashi::metrics::GUARDIAN_RECONCILER_OUTCOME_HEALTHY])
+                .get();
+            assert!(healthy >= 1, "no healthy reconciler tick");
+            assert_eq!(metrics.guardian_reconciler_seq_drift.get(), 0);
+            assert_eq!(metrics.guardian_limiter_drifted.get(), 0);
+            let empty = metrics
+                .guardian_replay_outcomes_total
+                .with_label_values(&[hashi::metrics::GUARDIAN_REPLAY_OUTCOME_EMPTY_GAP])
+                .get();
+            let success = metrics
+                .guardian_replay_outcomes_total
+                .with_label_values(&[hashi::metrics::GUARDIAN_REPLAY_OUTCOME_SUCCESS])
+                .get();
+            assert!(
+                empty + success >= 1,
+                "watcher never recorded a gap-fill outcome"
+            );
+        }
+
+        info!("=== Guardian Reconciler Tick E2E Test Passed ===");
+        Ok(())
+    }
+
     async fn withdraw_and_confirm(
         networks: &mut TestNetworks,
         hashi: &hashi::Hashi,

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -268,6 +268,7 @@ pub struct HashiNetworkBuilder {
     /// triggering the complaint recovery flow.
     pub test_corrupt_shares_target: Option<usize>,
     pub guardian_endpoint: Option<String>,
+    pub guardian_reconciliation_interval_secs: Option<u64>,
 }
 
 impl HashiNetworkBuilder {
@@ -282,7 +283,13 @@ impl HashiNetworkBuilder {
             max_mempool_chain_depth: None,
             test_corrupt_shares_target: None,
             guardian_endpoint: None,
+            guardian_reconciliation_interval_secs: None,
         }
+    }
+
+    pub fn with_guardian_reconciliation_interval_secs(mut self, secs: u64) -> Self {
+        self.guardian_reconciliation_interval_secs = Some(secs);
+        self
     }
 
     pub fn with_guardian_endpoint(mut self, endpoint: impl Into<String>) -> Self {
@@ -392,6 +399,8 @@ impl HashiNetworkBuilder {
             if let Some(ref guardian_endpoint) = self.guardian_endpoint {
                 config.guardian_endpoint = Some(guardian_endpoint.clone());
             }
+            config.guardian_reconciliation_interval_secs =
+                self.guardian_reconciliation_interval_secs;
             config.db = Some(dir.join(validator_address.to_string()));
             configs.push(config);
         }

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -126,6 +126,13 @@ impl TestNetworksBuilder {
         self
     }
 
+    pub fn with_guardian_reconciliation_interval_secs(mut self, secs: u64) -> Self {
+        self.hashi_builder = self
+            .hashi_builder
+            .with_guardian_reconciliation_interval_secs(secs);
+        self
+    }
+
     pub fn with_nodes(mut self, num_nodes: usize) -> Self {
         self = self.with_hashi_nodes(num_nodes);
         self = self.with_sui_validators(num_nodes);

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -129,6 +129,28 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guardian_endpoint: Option<String>,
 
+    /// How often the guardian reconciler polls `GetGuardianInfo` to
+    /// compare the local-limiter snapshot against the guardian's
+    /// authoritative state. Defaults to 30 s. Read-only check; does
+    /// not mutate state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guardian_reconciliation_interval_secs: Option<u64>,
+
+    /// How long the reconciler must keep observing drift outside the
+    /// in-flight tolerance before it escalates to ERROR + sticky
+    /// `guardian_limiter_drifted=1`. Defaults to 300 s — well past
+    /// any normal in-flight burst (which clears within seconds via
+    /// the watcher) but well below the operator response window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guardian_reconciliation_drift_alert_secs: Option<u64>,
+
+    /// `next_seq` units the guardian is allowed to lead the local
+    /// limiter by before the reconciler counts it as drift (instead
+    /// of the normal in-flight window). Defaults to 2 — one for the
+    /// at-most-one in-flight withdrawal, one for slack.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guardian_reconciliation_tolerance_seq: Option<u64>,
+
     /// Maximum gRPC decoding message size in bytes.
     ///
     /// Defaults to 16 MiB if not specified. Tonic's built-in default is 4 MiB,
@@ -332,6 +354,18 @@ impl Config {
 
     pub fn guardian_endpoint(&self) -> Option<&str> {
         self.guardian_endpoint.as_deref()
+    }
+
+    pub fn guardian_reconciliation_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.guardian_reconciliation_interval_secs.unwrap_or(30))
+    }
+
+    pub fn guardian_reconciliation_drift_alert(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.guardian_reconciliation_drift_alert_secs.unwrap_or(300))
+    }
+
+    pub fn guardian_reconciliation_tolerance_seq(&self) -> u64 {
+        self.guardian_reconciliation_tolerance_seq.unwrap_or(2)
     }
 
     pub fn grpc_max_decoding_message_size(&self) -> usize {

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -129,25 +129,12 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guardian_endpoint: Option<String>,
 
-    /// How often the guardian reconciler polls `GetGuardianInfo` to
-    /// compare the local-limiter snapshot against the guardian's
-    /// authoritative state. Defaults to 30 s. Read-only check; does
-    /// not mutate state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guardian_reconciliation_interval_secs: Option<u64>,
 
-    /// How long the reconciler must keep observing drift outside the
-    /// in-flight tolerance before it escalates to ERROR + sticky
-    /// `guardian_limiter_drifted=1`. Defaults to 300 s — well past
-    /// any normal in-flight burst (which clears within seconds via
-    /// the watcher) but well below the operator response window.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guardian_reconciliation_drift_alert_secs: Option<u64>,
 
-    /// `next_seq` units the guardian is allowed to lead the local
-    /// limiter by before the reconciler counts it as drift (instead
-    /// of the normal in-flight window). Defaults to 2 — one for the
-    /// at-most-one in-flight withdrawal, one for slack.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guardian_reconciliation_tolerance_seq: Option<u64>,
 
@@ -357,11 +344,14 @@ impl Config {
     }
 
     pub fn guardian_reconciliation_interval(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(self.guardian_reconciliation_interval_secs.unwrap_or(30))
+        std::time::Duration::from_secs(self.guardian_reconciliation_interval_secs.unwrap_or(300))
     }
 
     pub fn guardian_reconciliation_drift_alert(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(self.guardian_reconciliation_drift_alert_secs.unwrap_or(300))
+        std::time::Duration::from_secs(
+            self.guardian_reconciliation_drift_alert_secs
+                .unwrap_or(1_800),
+        )
     }
 
     pub fn guardian_reconciliation_tolerance_seq(&self) -> u64 {

--- a/crates/hashi/src/guardian_reconciler.rs
+++ b/crates/hashi/src/guardian_reconciler.rs
@@ -1,13 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Read-only reconciler that compares the local-limiter snapshot
-//! against the guardian's authoritative `LimiterState` on a fixed
-//! interval. Surfaces drift as metrics + logs; never mutates state.
-//!
-//! The watcher's gap-fill (`crate::onchain::watcher::replay_gap`) is
-//! the actual recovery path for missed events — this module is the
-//! integrity check that makes a stuck or invisible drift detectable.
+//! Periodic read-only check that the local limiter agrees with the
+//! guardian's `LimiterState`. Watcher gap-fill is the recovery path;
+//! this module only emits metrics + logs.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,33 +18,14 @@ use crate::Hashi;
 use crate::guardian_limiter::LocalLimiter;
 use crate::metrics;
 
-/// Result of comparing a `(local, guardian)` snapshot pair. Drives the
-/// reconciler's metric labels and log severity. Stays an enum (not a
-/// struct of nullable fields) so adding a new outcome forces every
-/// match site to consider the new case.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Outcome {
-    /// Local and guardian agree (`next_seq` equal).
     Healthy,
-    /// Guardian is ahead of local by `drift_seq`, but within
-    /// `tolerance` — expected window for in-flight withdrawals
-    /// approved by the guardian but not yet committed on-chain.
     LaggingWithinTolerance { drift_seq: u64 },
-    /// Guardian is ahead of local by more than `tolerance`. The
-    /// watcher's gap-fill should close this on the next reconnect;
-    /// if it persists, we've genuinely lost sync.
     Lagging { drift_seq: u64 },
-    /// Local has advanced past the guardian. Impossible during normal
-    /// operation: every local advance is caused by a chain event that
-    /// the guardian had already approved (and incremented its own
-    /// counter for). Always indicates a bug or a guardian rollback.
     Ahead { drift_seq: u64 },
 }
 
-/// Pure comparison of two `LimiterState` snapshots. `tolerance` is the
-/// number of `next_seq` units guardian is allowed to lead local by
-/// before it counts as drift — typically the in-flight cap (1) plus a
-/// little slack for clock/checkpoint propagation.
 pub fn classify(local: &LimiterState, guardian: &LimiterState, tolerance: u64) -> Outcome {
     if guardian.next_seq < local.next_seq {
         return Outcome::Ahead {
@@ -66,7 +43,6 @@ pub fn classify(local: &LimiterState, guardian: &LimiterState, tolerance: u64) -
 }
 
 impl Outcome {
-    /// Stable label for `guardian_reconciler_outcomes_total`.
     fn metric_label(&self) -> &'static str {
         match self {
             Outcome::Healthy => metrics::GUARDIAN_RECONCILER_OUTCOME_HEALTHY,
@@ -79,33 +55,21 @@ impl Outcome {
     }
 }
 
-/// Periodic poll service. One instance per node. Runs as long as the
-/// guardian client is configured AND the local limiter has been seeded
-/// — both gates are checked once at startup; the service exits cleanly
-/// if either is absent.
 pub fn start_reconciler(hashi: Arc<Hashi>) -> Service {
     let interval_dur = hashi.config.guardian_reconciliation_interval();
     let drift_alert_after = hashi.config.guardian_reconciliation_drift_alert();
     let tolerance_seq = hashi.config.guardian_reconciliation_tolerance_seq();
 
     Service::new().spawn_aborting(async move {
-        // No work to do without a guardian client.
         if hashi.guardian_client().is_none() {
-            tracing::debug!("guardian reconciler: no guardian client; service exiting");
             return Ok(());
         }
-
-        // Wait for bootstrap to seed the limiter. We poll on the same
-        // cadence as the reconciler tick to avoid a busy loop.
         let limiter = wait_for_local_limiter(&hashi, interval_dur).await;
 
         let mut tick = interval(interval_dur);
-        // After a long backpressure window, fire once and resume the
-        // schedule rather than firing back-to-back.
         tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        // Skip the immediate-fire first tick: bootstrap already left
-        // us in lockstep, and rapid-firing the RPC at boot adds no
-        // signal beyond what the bootstrap RPC already produced.
+        // Skip the immediate-fire first tick — bootstrap already
+        // covered that observation.
         tick.tick().await;
 
         let mut first_drift_seen_at: Option<Instant> = None;
@@ -132,8 +96,6 @@ async fn wait_for_local_limiter(hashi: &Arc<Hashi>, poll: Duration) -> Arc<Local
     }
 }
 
-/// One reconciler tick. Pulled out of the loop so tests can drive the
-/// drift-timer logic without having to fake a `tokio::time::interval`.
 async fn run_tick(
     hashi: &Arc<Hashi>,
     limiter: &Arc<LocalLimiter>,
@@ -146,13 +108,13 @@ async fn run_tick(
     };
     let metrics = &hashi.metrics;
 
-    let rpc_started = Instant::now();
+    let started = Instant::now();
     let info_pb = match client.get_guardian_info().await {
         Ok(info) => {
             metrics.record_guardian_rpc(
                 metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
                 metrics::GUARDIAN_RPC_OUTCOME_OK,
-                rpc_started.elapsed().as_secs_f64(),
+                started.elapsed().as_secs_f64(),
             );
             info
         }
@@ -160,7 +122,7 @@ async fn run_tick(
             metrics.record_guardian_rpc(
                 metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
                 metrics::GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
-                rpc_started.elapsed().as_secs_f64(),
+                started.elapsed().as_secs_f64(),
             );
             metrics.record_reconciliation_rpc_failure();
             tracing::warn!("guardian reconciler: GetGuardianInfo failed: {e}");
@@ -172,14 +134,11 @@ async fn run_tick(
         Ok(info) => info,
         Err(e) => {
             metrics.record_reconciliation_rpc_failure();
-            tracing::warn!("guardian reconciler: GetGuardianInfo parse failed: {e:?}");
+            tracing::warn!("guardian reconciler: parse failed: {e:?}");
             return;
         }
     };
     let Some(guardian_state) = info.limiter_state else {
-        // Guardian has no limiter yet — the bootstrap loop will keep
-        // retrying on its own. Don't flap reconciler counters during
-        // that window; treat as RPC-unavailable for accounting.
         metrics.record_reconciliation_rpc_failure();
         return;
     };
@@ -193,22 +152,8 @@ async fn run_tick(
     );
 
     match outcome {
-        Outcome::Healthy => {
+        Outcome::Healthy | Outcome::LaggingWithinTolerance { .. } => {
             *first_drift_seen_at = None;
-            tracing::debug!(
-                local_seq = local_state.next_seq,
-                guardian_seq = guardian_state.next_seq,
-                "guardian reconciler: healthy"
-            );
-        }
-        Outcome::LaggingWithinTolerance { drift_seq } => {
-            *first_drift_seen_at = None;
-            tracing::debug!(
-                drift_seq,
-                local_seq = local_state.next_seq,
-                guardian_seq = guardian_state.next_seq,
-                "guardian reconciler: in-flight tolerance window"
-            );
         }
         Outcome::Lagging { drift_seq } => {
             let started = first_drift_seen_at.get_or_insert_with(Instant::now);
@@ -220,31 +165,26 @@ async fn run_tick(
                     local_seq = local_state.next_seq,
                     guardian_seq = guardian_state.next_seq,
                     elapsed_secs = elapsed.as_secs(),
-                    "guardian reconciler: local limiter has been lagging beyond tolerance \
-                     for too long; watcher gap-fill has not closed it — this is a paged alert"
+                    "guardian reconciler: lag past tolerance not closing"
                 );
             } else {
                 tracing::warn!(
                     drift_seq,
                     local_seq = local_state.next_seq,
                     guardian_seq = guardian_state.next_seq,
-                    elapsed_secs = elapsed.as_secs(),
-                    "guardian reconciler: lag observed; watcher gap-fill should close this on \
-                     next reconnect"
+                    "guardian reconciler: lag observed"
                 );
             }
         }
         Outcome::Ahead { drift_seq } => {
-            // Local advancing past the guardian is impossible during
-            // normal operation. Flip the sticky bit immediately —
-            // there's no plausible self-healing path.
+            // Impossible during normal operation: the guardian advances
+            // before the chain. Flip the sticky bit on first sight.
             metrics.guardian_limiter_drifted.set(1);
             tracing::error!(
                 drift_seq,
                 local_seq = local_state.next_seq,
                 guardian_seq = guardian_state.next_seq,
-                "guardian reconciler: local limiter is ahead of the guardian — \
-                 this is a paged alert (bug or guardian rollback)"
+                "guardian reconciler: local ahead of guardian (bug or rollback)"
             );
         }
     }
@@ -263,63 +203,48 @@ mod tests {
     }
 
     #[test]
-    fn healthy_when_seqs_match() {
+    fn classify_branches() {
         assert_eq!(classify(&st(7), &st(7), 2), Outcome::Healthy);
-    }
-
-    #[test]
-    fn lagging_within_tolerance_at_boundary() {
         assert_eq!(
             classify(&st(7), &st(9), 2),
-            Outcome::LaggingWithinTolerance { drift_seq: 2 }
+            Outcome::LaggingWithinTolerance { drift_seq: 2 },
         );
-    }
-
-    #[test]
-    fn lagging_one_past_tolerance() {
-        assert_eq!(classify(&st(7), &st(10), 2), Outcome::Lagging { drift_seq: 3 });
-    }
-
-    #[test]
-    fn lagging_far_behind() {
+        assert_eq!(
+            classify(&st(7), &st(10), 2),
+            Outcome::Lagging { drift_seq: 3 },
+        );
         assert_eq!(
             classify(&st(0), &st(5_000), 2),
-            Outcome::Lagging { drift_seq: 5_000 }
+            Outcome::Lagging { drift_seq: 5_000 },
+        );
+        assert_eq!(
+            classify(&st(10), &st(7), 2),
+            Outcome::Ahead { drift_seq: 3 },
+        );
+        assert_eq!(classify(&st(7), &st(7), 0), Outcome::Healthy);
+        assert_eq!(
+            classify(&st(7), &st(8), 0),
+            Outcome::Lagging { drift_seq: 1 },
         );
     }
 
     #[test]
-    fn ahead_when_local_runs_past_guardian() {
-        assert_eq!(classify(&st(10), &st(7), 2), Outcome::Ahead { drift_seq: 3 });
-    }
-
-    #[test]
-    fn zero_tolerance_treats_any_lag_as_lagging() {
-        assert_eq!(classify(&st(7), &st(8), 0), Outcome::Lagging { drift_seq: 1 });
-    }
-
-    #[test]
-    fn equal_with_zero_tolerance_is_healthy() {
-        assert_eq!(classify(&st(7), &st(7), 0), Outcome::Healthy);
-    }
-
-    #[test]
-    fn metric_labels_match_metrics_module_constants() {
+    fn metric_labels_match_constants() {
         assert_eq!(
             Outcome::Healthy.metric_label(),
-            metrics::GUARDIAN_RECONCILER_OUTCOME_HEALTHY
+            metrics::GUARDIAN_RECONCILER_OUTCOME_HEALTHY,
         );
         assert_eq!(
             Outcome::LaggingWithinTolerance { drift_seq: 1 }.metric_label(),
-            metrics::GUARDIAN_RECONCILER_OUTCOME_LAGGING_WITHIN_TOLERANCE
+            metrics::GUARDIAN_RECONCILER_OUTCOME_LAGGING_WITHIN_TOLERANCE,
         );
         assert_eq!(
             Outcome::Lagging { drift_seq: 5 }.metric_label(),
-            metrics::GUARDIAN_RECONCILER_OUTCOME_LAGGING
+            metrics::GUARDIAN_RECONCILER_OUTCOME_LAGGING,
         );
         assert_eq!(
             Outcome::Ahead { drift_seq: 5 }.metric_label(),
-            metrics::GUARDIAN_RECONCILER_OUTCOME_AHEAD
+            metrics::GUARDIAN_RECONCILER_OUTCOME_AHEAD,
         );
     }
 }

--- a/crates/hashi/src/guardian_reconciler.rs
+++ b/crates/hashi/src/guardian_reconciler.rs
@@ -9,7 +9,18 @@
 //! the actual recovery path for missed events — this module is the
 //! integrity check that makes a stuck or invisible drift detectable.
 
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
 use hashi_types::guardian::LimiterState;
+use sui_futures::service::Service;
+use tokio::time::MissedTickBehavior;
+use tokio::time::interval;
+
+use crate::Hashi;
+use crate::guardian_limiter::LocalLimiter;
+use crate::metrics;
 
 /// Result of comparing a `(local, guardian)` snapshot pair. Drives the
 /// reconciler's metric labels and log severity. Stays an enum (not a
@@ -51,6 +62,191 @@ pub fn classify(local: &LimiterState, guardian: &LimiterState, tolerance: u64) -
         Outcome::LaggingWithinTolerance { drift_seq }
     } else {
         Outcome::Lagging { drift_seq }
+    }
+}
+
+impl Outcome {
+    /// Stable label for `guardian_reconciler_outcomes_total`.
+    fn metric_label(&self) -> &'static str {
+        match self {
+            Outcome::Healthy => metrics::GUARDIAN_RECONCILER_OUTCOME_HEALTHY,
+            Outcome::LaggingWithinTolerance { .. } => {
+                metrics::GUARDIAN_RECONCILER_OUTCOME_LAGGING_WITHIN_TOLERANCE
+            }
+            Outcome::Lagging { .. } => metrics::GUARDIAN_RECONCILER_OUTCOME_LAGGING,
+            Outcome::Ahead { .. } => metrics::GUARDIAN_RECONCILER_OUTCOME_AHEAD,
+        }
+    }
+}
+
+/// Periodic poll service. One instance per node. Runs as long as the
+/// guardian client is configured AND the local limiter has been seeded
+/// — both gates are checked once at startup; the service exits cleanly
+/// if either is absent.
+pub fn start_reconciler(hashi: Arc<Hashi>) -> Service {
+    let interval_dur = hashi.config.guardian_reconciliation_interval();
+    let drift_alert_after = hashi.config.guardian_reconciliation_drift_alert();
+    let tolerance_seq = hashi.config.guardian_reconciliation_tolerance_seq();
+
+    Service::new().spawn_aborting(async move {
+        // No work to do without a guardian client.
+        if hashi.guardian_client().is_none() {
+            tracing::debug!("guardian reconciler: no guardian client; service exiting");
+            return Ok(());
+        }
+
+        // Wait for bootstrap to seed the limiter. We poll on the same
+        // cadence as the reconciler tick to avoid a busy loop.
+        let limiter = wait_for_local_limiter(&hashi, interval_dur).await;
+
+        let mut tick = interval(interval_dur);
+        // After a long backpressure window, fire once and resume the
+        // schedule rather than firing back-to-back.
+        tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // Skip the immediate-fire first tick: bootstrap already left
+        // us in lockstep, and rapid-firing the RPC at boot adds no
+        // signal beyond what the bootstrap RPC already produced.
+        tick.tick().await;
+
+        let mut first_drift_seen_at: Option<Instant> = None;
+        loop {
+            tick.tick().await;
+            run_tick(
+                &hashi,
+                &limiter,
+                tolerance_seq,
+                drift_alert_after,
+                &mut first_drift_seen_at,
+            )
+            .await;
+        }
+    })
+}
+
+async fn wait_for_local_limiter(hashi: &Arc<Hashi>, poll: Duration) -> Arc<LocalLimiter> {
+    loop {
+        if let Some(limiter) = hashi.local_limiter() {
+            return limiter;
+        }
+        tokio::time::sleep(poll).await;
+    }
+}
+
+/// One reconciler tick. Pulled out of the loop so tests can drive the
+/// drift-timer logic without having to fake a `tokio::time::interval`.
+async fn run_tick(
+    hashi: &Arc<Hashi>,
+    limiter: &Arc<LocalLimiter>,
+    tolerance_seq: u64,
+    drift_alert_after: Duration,
+    first_drift_seen_at: &mut Option<Instant>,
+) {
+    let Some(client) = hashi.guardian_client() else {
+        return;
+    };
+    let metrics = &hashi.metrics;
+
+    let rpc_started = Instant::now();
+    let info_pb = match client.get_guardian_info().await {
+        Ok(info) => {
+            metrics.record_guardian_rpc(
+                metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
+                metrics::GUARDIAN_RPC_OUTCOME_OK,
+                rpc_started.elapsed().as_secs_f64(),
+            );
+            info
+        }
+        Err(e) => {
+            metrics.record_guardian_rpc(
+                metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
+                metrics::GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
+                rpc_started.elapsed().as_secs_f64(),
+            );
+            metrics.record_reconciliation_rpc_failure();
+            tracing::warn!("guardian reconciler: GetGuardianInfo failed: {e}");
+            return;
+        }
+    };
+
+    let info = match hashi_types::guardian::GetGuardianInfoResponse::try_from(info_pb) {
+        Ok(info) => info,
+        Err(e) => {
+            metrics.record_reconciliation_rpc_failure();
+            tracing::warn!("guardian reconciler: GetGuardianInfo parse failed: {e:?}");
+            return;
+        }
+    };
+    let Some(guardian_state) = info.limiter_state else {
+        // Guardian has no limiter yet — the bootstrap loop will keep
+        // retrying on its own. Don't flap reconciler counters during
+        // that window; treat as RPC-unavailable for accounting.
+        metrics.record_reconciliation_rpc_failure();
+        return;
+    };
+
+    let local_state = limiter.snapshot();
+    let outcome = classify(&local_state, &guardian_state, tolerance_seq);
+    metrics.record_reconciliation_tick(
+        local_state.next_seq,
+        guardian_state.next_seq,
+        outcome.metric_label(),
+    );
+
+    match outcome {
+        Outcome::Healthy => {
+            *first_drift_seen_at = None;
+            tracing::debug!(
+                local_seq = local_state.next_seq,
+                guardian_seq = guardian_state.next_seq,
+                "guardian reconciler: healthy"
+            );
+        }
+        Outcome::LaggingWithinTolerance { drift_seq } => {
+            *first_drift_seen_at = None;
+            tracing::debug!(
+                drift_seq,
+                local_seq = local_state.next_seq,
+                guardian_seq = guardian_state.next_seq,
+                "guardian reconciler: in-flight tolerance window"
+            );
+        }
+        Outcome::Lagging { drift_seq } => {
+            let started = first_drift_seen_at.get_or_insert_with(Instant::now);
+            let elapsed = started.elapsed();
+            if elapsed >= drift_alert_after {
+                metrics.guardian_limiter_drifted.set(1);
+                tracing::error!(
+                    drift_seq,
+                    local_seq = local_state.next_seq,
+                    guardian_seq = guardian_state.next_seq,
+                    elapsed_secs = elapsed.as_secs(),
+                    "guardian reconciler: local limiter has been lagging beyond tolerance \
+                     for too long; watcher gap-fill has not closed it — this is a paged alert"
+                );
+            } else {
+                tracing::warn!(
+                    drift_seq,
+                    local_seq = local_state.next_seq,
+                    guardian_seq = guardian_state.next_seq,
+                    elapsed_secs = elapsed.as_secs(),
+                    "guardian reconciler: lag observed; watcher gap-fill should close this on \
+                     next reconnect"
+                );
+            }
+        }
+        Outcome::Ahead { drift_seq } => {
+            // Local advancing past the guardian is impossible during
+            // normal operation. Flip the sticky bit immediately —
+            // there's no plausible self-healing path.
+            metrics.guardian_limiter_drifted.set(1);
+            tracing::error!(
+                drift_seq,
+                local_seq = local_state.next_seq,
+                guardian_seq = guardian_state.next_seq,
+                "guardian reconciler: local limiter is ahead of the guardian — \
+                 this is a paged alert (bug or guardian rollback)"
+            );
+        }
     }
 }
 
@@ -105,5 +301,25 @@ mod tests {
     #[test]
     fn equal_with_zero_tolerance_is_healthy() {
         assert_eq!(classify(&st(7), &st(7), 0), Outcome::Healthy);
+    }
+
+    #[test]
+    fn metric_labels_match_metrics_module_constants() {
+        assert_eq!(
+            Outcome::Healthy.metric_label(),
+            metrics::GUARDIAN_RECONCILER_OUTCOME_HEALTHY
+        );
+        assert_eq!(
+            Outcome::LaggingWithinTolerance { drift_seq: 1 }.metric_label(),
+            metrics::GUARDIAN_RECONCILER_OUTCOME_LAGGING_WITHIN_TOLERANCE
+        );
+        assert_eq!(
+            Outcome::Lagging { drift_seq: 5 }.metric_label(),
+            metrics::GUARDIAN_RECONCILER_OUTCOME_LAGGING
+        );
+        assert_eq!(
+            Outcome::Ahead { drift_seq: 5 }.metric_label(),
+            metrics::GUARDIAN_RECONCILER_OUTCOME_AHEAD
+        );
     }
 }

--- a/crates/hashi/src/guardian_reconciler.rs
+++ b/crates/hashi/src/guardian_reconciler.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Read-only reconciler that compares the local-limiter snapshot
+//! against the guardian's authoritative `LimiterState` on a fixed
+//! interval. Surfaces drift as metrics + logs; never mutates state.
+//!
+//! The watcher's gap-fill (`crate::onchain::watcher::replay_gap`) is
+//! the actual recovery path for missed events — this module is the
+//! integrity check that makes a stuck or invisible drift detectable.
+
+use hashi_types::guardian::LimiterState;
+
+/// Result of comparing a `(local, guardian)` snapshot pair. Drives the
+/// reconciler's metric labels and log severity. Stays an enum (not a
+/// struct of nullable fields) so adding a new outcome forces every
+/// match site to consider the new case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// Local and guardian agree (`next_seq` equal).
+    Healthy,
+    /// Guardian is ahead of local by `drift_seq`, but within
+    /// `tolerance` — expected window for in-flight withdrawals
+    /// approved by the guardian but not yet committed on-chain.
+    LaggingWithinTolerance { drift_seq: u64 },
+    /// Guardian is ahead of local by more than `tolerance`. The
+    /// watcher's gap-fill should close this on the next reconnect;
+    /// if it persists, we've genuinely lost sync.
+    Lagging { drift_seq: u64 },
+    /// Local has advanced past the guardian. Impossible during normal
+    /// operation: every local advance is caused by a chain event that
+    /// the guardian had already approved (and incremented its own
+    /// counter for). Always indicates a bug or a guardian rollback.
+    Ahead { drift_seq: u64 },
+}
+
+/// Pure comparison of two `LimiterState` snapshots. `tolerance` is the
+/// number of `next_seq` units guardian is allowed to lead local by
+/// before it counts as drift — typically the in-flight cap (1) plus a
+/// little slack for clock/checkpoint propagation.
+pub fn classify(local: &LimiterState, guardian: &LimiterState, tolerance: u64) -> Outcome {
+    if guardian.next_seq < local.next_seq {
+        return Outcome::Ahead {
+            drift_seq: local.next_seq - guardian.next_seq,
+        };
+    }
+    let drift_seq = guardian.next_seq - local.next_seq;
+    if drift_seq == 0 {
+        Outcome::Healthy
+    } else if drift_seq <= tolerance {
+        Outcome::LaggingWithinTolerance { drift_seq }
+    } else {
+        Outcome::Lagging { drift_seq }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn st(next_seq: u64) -> LimiterState {
+        LimiterState {
+            num_tokens_available: 0,
+            last_updated_at: 0,
+            next_seq,
+        }
+    }
+
+    #[test]
+    fn healthy_when_seqs_match() {
+        assert_eq!(classify(&st(7), &st(7), 2), Outcome::Healthy);
+    }
+
+    #[test]
+    fn lagging_within_tolerance_at_boundary() {
+        assert_eq!(
+            classify(&st(7), &st(9), 2),
+            Outcome::LaggingWithinTolerance { drift_seq: 2 }
+        );
+    }
+
+    #[test]
+    fn lagging_one_past_tolerance() {
+        assert_eq!(classify(&st(7), &st(10), 2), Outcome::Lagging { drift_seq: 3 });
+    }
+
+    #[test]
+    fn lagging_far_behind() {
+        assert_eq!(
+            classify(&st(0), &st(5_000), 2),
+            Outcome::Lagging { drift_seq: 5_000 }
+        );
+    }
+
+    #[test]
+    fn ahead_when_local_runs_past_guardian() {
+        assert_eq!(classify(&st(10), &st(7), 2), Outcome::Ahead { drift_seq: 3 });
+    }
+
+    #[test]
+    fn zero_tolerance_treats_any_lag_as_lagging() {
+        assert_eq!(classify(&st(7), &st(8), 0), Outcome::Lagging { drift_seq: 1 });
+    }
+
+    #[test]
+    fn equal_with_zero_tolerance_is_healthy() {
+        assert_eq!(classify(&st(7), &st(7), 0), Outcome::Healthy);
+    }
+}

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -674,6 +674,7 @@ impl Hashi {
         let leader_service = leader::LeaderService::new(self.clone()).start();
         let mpc_service = mpc_service.start();
         let guardian_bootstrap_service = self.clone().start_guardian_bootstrap();
+        let guardian_reconciler_service = guardian_reconciler::start_reconciler(self.clone());
 
         let service = Service::new()
             .merge(onchain_service)
@@ -681,7 +682,8 @@ impl Hashi {
             .merge(http_service)
             .merge(leader_service)
             .merge(mpc_service)
-            .merge(guardian_bootstrap_service);
+            .merge(guardian_bootstrap_service)
+            .merge(guardian_reconciler_service);
 
         Ok(service)
     }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -22,6 +22,7 @@ pub mod db;
 pub mod deposits;
 pub mod grpc;
 pub mod guardian_limiter;
+pub mod guardian_reconciler;
 pub mod leader;
 pub mod metrics;
 pub mod mpc;

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -52,34 +52,13 @@ pub struct Metrics {
     pub guardian_rpc_total: IntCounterVec,
     pub guardian_rpc_duration_seconds: HistogramVec,
 
-    /// Reconciler view of the local limiter's `next_seq`. Refreshed
-    /// once per reconciliation tick; lags `guardian_limiter_next_seq`
-    /// by at most one tick interval. Useful to graph alongside
-    /// `guardian_reconciler_guardian_seq` for drift visualisation.
     pub guardian_reconciler_local_seq: IntGauge,
-    /// Reconciler's most-recent observation of the guardian's
-    /// authoritative `next_seq` (from `GetGuardianInfo`).
     pub guardian_reconciler_guardian_seq: IntGauge,
-    /// Signed (`guardian.next_seq - local.next_seq`). Positive means
-    /// the watcher is lagging; negative is impossible during normal
-    /// operation and indicates a bug or guardian rollback.
     pub guardian_reconciler_seq_drift: IntGauge,
-    /// Reconciler tick outcomes by classification: healthy,
-    /// lagging_within_tolerance, lagging, ahead, rpc_failed.
     pub guardian_reconciler_outcomes_total: IntCounterVec,
 
-    /// Outcome of a gap-fill attempt run from the watcher when the
-    /// subscription's first message lands on a checkpoint that's beyond
-    /// the last one we processed (subscription drop, reconnect, or
-    /// initial subscribe race). One increment per attempt.
     pub guardian_replay_outcomes_total: IntCounterVec,
-    /// Cumulative checkpoints fetched + applied via gap-fill. Only counts
-    /// checkpoints actually drained from `get_checkpoint`; partial runs
-    /// before a failure still increment this.
     pub guardian_replay_checkpoints_total: IntCounter,
-    /// End-to-end duration of a gap-fill attempt (any outcome), labeled
-    /// by outcome so partial/RPC-failed calls can be split out from
-    /// healthy successes.
     pub guardian_replay_duration_seconds: HistogramVec,
 
     // Kyoto (Bitcoin light client) metrics
@@ -959,18 +938,10 @@ impl Metrics {
             .inc();
     }
 
-    /// Record a single reconciler tick: refresh the seq snapshots,
-    /// publish the signed drift gauge, and bump the outcome counter.
-    /// `outcome` MUST be one of the `GUARDIAN_RECONCILER_OUTCOME_*`
-    /// constants — passing anything else creates a label hole.
-    pub fn record_reconciliation_tick(
-        &self,
-        local_seq: u64,
-        guardian_seq: u64,
-        outcome: &str,
-    ) {
+    pub fn record_reconciliation_tick(&self, local_seq: u64, guardian_seq: u64, outcome: &str) {
         self.guardian_reconciler_local_seq.set(local_seq as i64);
-        self.guardian_reconciler_guardian_seq.set(guardian_seq as i64);
+        self.guardian_reconciler_guardian_seq
+            .set(guardian_seq as i64);
         self.guardian_reconciler_seq_drift
             .set(guardian_seq as i64 - local_seq as i64);
         self.guardian_reconciler_outcomes_total
@@ -978,21 +949,12 @@ impl Metrics {
             .inc();
     }
 
-    /// Record a reconciler tick that never reached the comparison —
-    /// the `GetGuardianInfo` RPC failed. Drift gauges are not touched
-    /// (we don't know the guardian's seq); only the outcome counter.
     pub fn record_reconciliation_rpc_failure(&self) {
         self.guardian_reconciler_outcomes_total
             .with_label_values(&[GUARDIAN_RECONCILER_OUTCOME_RPC_FAILED])
             .inc();
     }
 
-    /// Record a watcher gap-fill attempt.
-    ///
-    /// `applied_checkpoints` is the number actually drained from the
-    /// chain via `get_checkpoint` and applied to the in-memory mirror
-    /// (independent of whether the attempt ultimately succeeded), which
-    /// also feeds `guardian_replay_checkpoints_total`.
     pub fn record_guardian_replay(
         &self,
         outcome: &str,
@@ -1194,8 +1156,7 @@ pub const GUARDIAN_REPLAY_OUTCOME_GAP_TOO_LARGE: &str = "gap_too_large";
 
 // Reconciler tick outcome labels.
 pub const GUARDIAN_RECONCILER_OUTCOME_HEALTHY: &str = "healthy";
-pub const GUARDIAN_RECONCILER_OUTCOME_LAGGING_WITHIN_TOLERANCE: &str =
-    "lagging_within_tolerance";
+pub const GUARDIAN_RECONCILER_OUTCOME_LAGGING_WITHIN_TOLERANCE: &str = "lagging_within_tolerance";
 pub const GUARDIAN_RECONCILER_OUTCOME_LAGGING: &str = "lagging";
 pub const GUARDIAN_RECONCILER_OUTCOME_AHEAD: &str = "ahead";
 pub const GUARDIAN_RECONCILER_OUTCOME_RPC_FAILED: &str = "rpc_failed";

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -52,6 +52,22 @@ pub struct Metrics {
     pub guardian_rpc_total: IntCounterVec,
     pub guardian_rpc_duration_seconds: HistogramVec,
 
+    /// Reconciler view of the local limiter's `next_seq`. Refreshed
+    /// once per reconciliation tick; lags `guardian_limiter_next_seq`
+    /// by at most one tick interval. Useful to graph alongside
+    /// `guardian_reconciler_guardian_seq` for drift visualisation.
+    pub guardian_reconciler_local_seq: IntGauge,
+    /// Reconciler's most-recent observation of the guardian's
+    /// authoritative `next_seq` (from `GetGuardianInfo`).
+    pub guardian_reconciler_guardian_seq: IntGauge,
+    /// Signed (`guardian.next_seq - local.next_seq`). Positive means
+    /// the watcher is lagging; negative is impossible during normal
+    /// operation and indicates a bug or guardian rollback.
+    pub guardian_reconciler_seq_drift: IntGauge,
+    /// Reconciler tick outcomes by classification: healthy,
+    /// lagging_within_tolerance, lagging, ahead, rpc_failed.
+    pub guardian_reconciler_outcomes_total: IntCounterVec,
+
     /// Outcome of a gap-fill attempt run from the watcher when the
     /// subscription's first message lands on a checkpoint that's beyond
     /// the last one we processed (subscription drop, reconnect, or
@@ -387,6 +403,33 @@ impl Metrics {
                 "Latency of outbound RPC calls to the guardian by method and outcome",
                 &["method", "outcome"],
                 LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            guardian_reconciler_local_seq: register_int_gauge_with_registry!(
+                "hashi_guardian_reconciler_local_seq",
+                "Reconciler's most-recent reading of the local limiter's next_seq",
+                registry,
+            )
+            .unwrap(),
+            guardian_reconciler_guardian_seq: register_int_gauge_with_registry!(
+                "hashi_guardian_reconciler_guardian_seq",
+                "Reconciler's most-recent reading of the guardian's authoritative next_seq",
+                registry,
+            )
+            .unwrap(),
+            guardian_reconciler_seq_drift: register_int_gauge_with_registry!(
+                "hashi_guardian_reconciler_seq_drift",
+                "guardian.next_seq - local.next_seq from the reconciler's most-recent tick \
+                 (positive = local is lagging, negative = local is ahead — never expected)",
+                registry,
+            )
+            .unwrap(),
+            guardian_reconciler_outcomes_total: register_int_counter_vec_with_registry!(
+                "hashi_guardian_reconciler_outcomes_total",
+                "Reconciler tick outcomes \
+                 (healthy, lagging_within_tolerance, lagging, ahead, rpc_failed)",
+                &["outcome"],
                 registry,
             )
             .unwrap(),
@@ -916,6 +959,34 @@ impl Metrics {
             .inc();
     }
 
+    /// Record a single reconciler tick: refresh the seq snapshots,
+    /// publish the signed drift gauge, and bump the outcome counter.
+    /// `outcome` MUST be one of the `GUARDIAN_RECONCILER_OUTCOME_*`
+    /// constants — passing anything else creates a label hole.
+    pub fn record_reconciliation_tick(
+        &self,
+        local_seq: u64,
+        guardian_seq: u64,
+        outcome: &str,
+    ) {
+        self.guardian_reconciler_local_seq.set(local_seq as i64);
+        self.guardian_reconciler_guardian_seq.set(guardian_seq as i64);
+        self.guardian_reconciler_seq_drift
+            .set(guardian_seq as i64 - local_seq as i64);
+        self.guardian_reconciler_outcomes_total
+            .with_label_values(&[outcome])
+            .inc();
+    }
+
+    /// Record a reconciler tick that never reached the comparison —
+    /// the `GetGuardianInfo` RPC failed. Drift gauges are not touched
+    /// (we don't know the guardian's seq); only the outcome counter.
+    pub fn record_reconciliation_rpc_failure(&self) {
+        self.guardian_reconciler_outcomes_total
+            .with_label_values(&[GUARDIAN_RECONCILER_OUTCOME_RPC_FAILED])
+            .inc();
+    }
+
     /// Record a watcher gap-fill attempt.
     ///
     /// `applied_checkpoints` is the number actually drained from the
@@ -1121,6 +1192,14 @@ pub const GUARDIAN_REPLAY_OUTCOME_SUCCESS: &str = "success";
 pub const GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE: &str = "rpc_failure";
 pub const GUARDIAN_REPLAY_OUTCOME_GAP_TOO_LARGE: &str = "gap_too_large";
 
+// Reconciler tick outcome labels.
+pub const GUARDIAN_RECONCILER_OUTCOME_HEALTHY: &str = "healthy";
+pub const GUARDIAN_RECONCILER_OUTCOME_LAGGING_WITHIN_TOLERANCE: &str =
+    "lagging_within_tolerance";
+pub const GUARDIAN_RECONCILER_OUTCOME_LAGGING: &str = "lagging";
+pub const GUARDIAN_RECONCILER_OUTCOME_AHEAD: &str = "ahead";
+pub const GUARDIAN_RECONCILER_OUTCOME_RPC_FAILED: &str = "rpc_failed";
+
 fn limiter_outcome_label(
     result: &Result<(), crate::guardian_limiter::LocalLimiterError>,
 ) -> &'static str {
@@ -1318,5 +1397,25 @@ mod tests {
         }
         // applied_checkpoints accumulates across all four record calls (3 each).
         assert_eq!(metrics.guardian_replay_checkpoints_total.get(), 12);
+
+        // Reconciler outcomes round-trip the drift gauge correctly.
+        for outcome in [
+            GUARDIAN_RECONCILER_OUTCOME_HEALTHY,
+            GUARDIAN_RECONCILER_OUTCOME_LAGGING_WITHIN_TOLERANCE,
+            GUARDIAN_RECONCILER_OUTCOME_LAGGING,
+            GUARDIAN_RECONCILER_OUTCOME_AHEAD,
+        ] {
+            metrics.record_reconciliation_tick(10, 12, outcome);
+        }
+        assert_eq!(metrics.guardian_reconciler_local_seq.get(), 10);
+        assert_eq!(metrics.guardian_reconciler_guardian_seq.get(), 12);
+        assert_eq!(metrics.guardian_reconciler_seq_drift.get(), 2);
+        // Local-ahead is encoded as a negative drift gauge.
+        metrics.record_reconciliation_tick(15, 13, GUARDIAN_RECONCILER_OUTCOME_AHEAD);
+        assert_eq!(metrics.guardian_reconciler_seq_drift.get(), -2);
+        // RPC-failed path bumps the counter without touching seq gauges.
+        let drift_before = metrics.guardian_reconciler_seq_drift.get();
+        metrics.record_reconciliation_rpc_failure();
+        assert_eq!(metrics.guardian_reconciler_seq_drift.get(), drift_before);
     }
 }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -52,6 +52,20 @@ pub struct Metrics {
     pub guardian_rpc_total: IntCounterVec,
     pub guardian_rpc_duration_seconds: HistogramVec,
 
+    /// Outcome of a gap-fill attempt run from the watcher when the
+    /// subscription's first message lands on a checkpoint that's beyond
+    /// the last one we processed (subscription drop, reconnect, or
+    /// initial subscribe race). One increment per attempt.
+    pub guardian_replay_outcomes_total: IntCounterVec,
+    /// Cumulative checkpoints fetched + applied via gap-fill. Only counts
+    /// checkpoints actually drained from `get_checkpoint`; partial runs
+    /// before a failure still increment this.
+    pub guardian_replay_checkpoints_total: IntCounter,
+    /// End-to-end duration of a gap-fill attempt (any outcome), labeled
+    /// by outcome so partial/RPC-failed calls can be split out from
+    /// healthy successes.
+    pub guardian_replay_duration_seconds: HistogramVec,
+
     // Kyoto (Bitcoin light client) metrics
     pub kyoto_connected_peers: IntGauge,
     pub kyoto_synced: IntGauge,
@@ -372,6 +386,28 @@ impl Metrics {
                 "hashi_guardian_rpc_duration_seconds",
                 "Latency of outbound RPC calls to the guardian by method and outcome",
                 &["method", "outcome"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            guardian_replay_outcomes_total: register_int_counter_vec_with_registry!(
+                "hashi_guardian_replay_outcomes_total",
+                "Watcher gap-fill replay attempts by outcome \
+                 (empty_gap, success, rpc_failure, gap_too_large)",
+                &["outcome"],
+                registry,
+            )
+            .unwrap(),
+            guardian_replay_checkpoints_total: register_int_counter_with_registry!(
+                "hashi_guardian_replay_checkpoints_total",
+                "Total checkpoints applied via watcher gap-fill (cumulative across attempts)",
+                registry,
+            )
+            .unwrap(),
+            guardian_replay_duration_seconds: register_histogram_vec_with_registry!(
+                "hashi_guardian_replay_duration_seconds",
+                "Duration of a watcher gap-fill attempt by outcome",
+                &["outcome"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -880,6 +916,30 @@ impl Metrics {
             .inc();
     }
 
+    /// Record a watcher gap-fill attempt.
+    ///
+    /// `applied_checkpoints` is the number actually drained from the
+    /// chain via `get_checkpoint` and applied to the in-memory mirror
+    /// (independent of whether the attempt ultimately succeeded), which
+    /// also feeds `guardian_replay_checkpoints_total`.
+    pub fn record_guardian_replay(
+        &self,
+        outcome: &str,
+        applied_checkpoints: u64,
+        elapsed_secs: f64,
+    ) {
+        self.guardian_replay_outcomes_total
+            .with_label_values(&[outcome])
+            .inc();
+        self.guardian_replay_duration_seconds
+            .with_label_values(&[outcome])
+            .observe(elapsed_secs);
+        if applied_checkpoints > 0 {
+            self.guardian_replay_checkpoints_total
+                .inc_by(applied_checkpoints);
+        }
+    }
+
     pub fn update_onchain_state(&self, state: &crate::onchain::OnchainState) {
         self.latest_checkpoint_height
             .set(state.latest_checkpoint_height() as i64);
@@ -1054,6 +1114,12 @@ pub const GUARDIAN_RPC_OUTCOME_RATE_LIMITED: &str = "rate_limited";
 pub const GUARDIAN_RPC_OUTCOME_UNAVAILABLE: &str = "unavailable";
 pub const GUARDIAN_RPC_OUTCOME_PARSE_ERROR: &str = "parse_error";
 pub const GUARDIAN_RPC_OUTCOME_SIGNATURE_ERROR: &str = "signature_error";
+
+// Watcher gap-fill replay outcome labels.
+pub const GUARDIAN_REPLAY_OUTCOME_EMPTY_GAP: &str = "empty_gap";
+pub const GUARDIAN_REPLAY_OUTCOME_SUCCESS: &str = "success";
+pub const GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE: &str = "rpc_failure";
+pub const GUARDIAN_REPLAY_OUTCOME_GAP_TOO_LARGE: &str = "gap_too_large";
 
 fn limiter_outcome_label(
     result: &Result<(), crate::guardian_limiter::LocalLimiterError>,
@@ -1241,5 +1307,16 @@ mod tests {
                 metrics.record_guardian_rpc(method, outcome, 0.1);
             }
         }
+
+        for outcome in [
+            GUARDIAN_REPLAY_OUTCOME_EMPTY_GAP,
+            GUARDIAN_REPLAY_OUTCOME_SUCCESS,
+            GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE,
+            GUARDIAN_REPLAY_OUTCOME_GAP_TOO_LARGE,
+        ] {
+            metrics.record_guardian_replay(outcome, 3, 0.05);
+        }
+        // applied_checkpoints accumulates across all four record calls (3 each).
+        assert_eq!(metrics.guardian_replay_checkpoints_total.get(), 12);
     }
 }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -35,11 +35,8 @@ use crate::onchain::types::ProposalType;
 use crate::onchain::types::WithdrawalRequest;
 use crate::withdrawals::withdrawal_limiter_consumption_amount;
 
-/// Hard cap on the number of checkpoints we will paginate through during
-/// a single gap-fill attempt. ~10k checkpoints is roughly 40 minutes of
-/// chain at the current Sui cadence — long enough for any realistic
-/// network blip, short enough to stay bounded if a node was down for
-/// hours and the in-memory cursor is meaningless.
+// Bounded so a long downtime can't force the watcher to paginate
+// indefinitely; reconciler picks up any residual drift.
 const MAX_REPLAY_CHECKPOINTS: u64 = 10_000;
 
 #[tracing::instrument(name = "watcher", skip_all)]
@@ -79,11 +76,9 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
             }
         };
 
-        // Pull the first response so we know exactly where the live
-        // stream is starting. Anything strictly between the cursor we
-        // last processed and `live_first_seq` is a gap that needs to
-        // be filled from chain — otherwise its WithdrawalSignedEvents
-        // would be silently dropped and the local limiter would drift.
+        // First message tells us where the live stream starts; anything
+        // strictly between `latest_checkpoint_height` and that cursor
+        // needs to be backfilled from chain.
         let first = match subscription.next().await {
             Some(Ok(resp)) => resp,
             Some(Err(e)) => {
@@ -101,30 +96,19 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
         let last_processed = state.latest_checkpoint_height();
         let gap_first = last_processed.saturating_add(1);
 
-        // First-boot path: `last_processed` is whatever the initial
-        // scrape recorded; if the live stream starts there or earlier
-        // (e.g. fast subscribe) the gap is empty. Skip replay; skip
-        // rescrape — the initial scrape already seeded the mirror.
         let need_full_rescrape = if last_processed > 0 && gap_first < live_first_seq {
-            match replay_gap(
-                &mut client,
-                &state,
-                &metrics,
-                &subscription_read_mask,
-                gap_first,
-                live_first_seq - 1,
+            matches!(
+                replay_gap(
+                    &mut client,
+                    &state,
+                    &metrics,
+                    &subscription_read_mask,
+                    gap_first,
+                    live_first_seq - 1,
+                )
+                .await,
+                ReplayOutcome::RpcFailure | ReplayOutcome::GapTooLarge,
             )
-            .await
-            {
-                ReplayOutcome::Empty | ReplayOutcome::Success => false,
-                ReplayOutcome::RpcFailure | ReplayOutcome::GapTooLarge => {
-                    // The on-chain mirror is now stale (we dropped some
-                    // events) and the limiter is drifted. Pull a full
-                    // snapshot so the mirror is at least consistent;
-                    // the reconciler will surface the limiter drift.
-                    true
-                }
-            }
         } else {
             false
         };
@@ -152,10 +136,6 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
             }
         }
 
-        // Process the first live message we already pulled, then drain
-        // the rest of the subscription. On stream error we just break
-        // back to the outer loop and re-subscribe — gap-fill on the
-        // next iteration will catch any events the interruption hid.
         process_checkpoint(&mut client, &state, &metrics, first.checkpoint()).await;
 
         while let Some(item) = subscription.next().await {
@@ -172,28 +152,14 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
     }
 }
 
-/// Outcome of a single gap-fill attempt. Drives metric labels and the
-/// caller's decision to fall back to a full rescrape.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReplayOutcome {
-    /// No checkpoints to replay (gap was empty by the time we computed it).
     Empty,
-    /// Every checkpoint in `[from, to]` was fetched and applied.
     Success,
-    /// `get_checkpoint` returned an error or an empty body partway through.
-    /// Mirror + limiter may be partially advanced; caller should rescrape.
     RpcFailure,
-    /// The gap exceeded `MAX_REPLAY_CHECKPOINTS`; we declined to replay.
-    /// Mirror + limiter are unchanged; caller should rescrape.
     GapTooLarge,
 }
 
-/// Replay missed checkpoints in `[from_seq, to_seq]` (inclusive) by
-/// fetching each via `LedgerService::get_checkpoint` and feeding it
-/// through the same `process_checkpoint` path the live subscription
-/// uses. Best-effort: any single failure aborts the replay and returns
-/// the partial-advance metric outcome — the watcher's reconciler is the
-/// final safety net for any lingering drift.
 async fn replay_gap(
     client: &mut Client,
     state: &OnchainState,
@@ -202,13 +168,17 @@ async fn replay_gap(
     from_seq: u64,
     to_seq: u64,
 ) -> ReplayOutcome {
-    if from_seq > to_seq {
+    let started = Instant::now();
+    let record = |outcome: &'static str, applied: u64| {
         if let Some(m) = metrics {
-            m.record_guardian_replay(GUARDIAN_REPLAY_OUTCOME_EMPTY_GAP, 0, 0.0);
+            m.record_guardian_replay(outcome, applied, started.elapsed().as_secs_f64());
         }
+    };
+
+    if from_seq > to_seq {
+        record(GUARDIAN_REPLAY_OUTCOME_EMPTY_GAP, 0);
         return ReplayOutcome::Empty;
     }
-    let started = Instant::now();
     let gap_size = to_seq - from_seq + 1;
     if gap_size > MAX_REPLAY_CHECKPOINTS {
         tracing::error!(
@@ -216,25 +186,16 @@ async fn replay_gap(
             to_seq,
             gap_size,
             max = MAX_REPLAY_CHECKPOINTS,
-            "checkpoint gap exceeds replay cap; declining to replay — local limiter is now drifted"
+            "checkpoint gap exceeds replay cap"
         );
         if let Some(m) = metrics {
             m.guardian_limiter_drifted.set(1);
-            m.record_guardian_replay(
-                GUARDIAN_REPLAY_OUTCOME_GAP_TOO_LARGE,
-                0,
-                started.elapsed().as_secs_f64(),
-            );
         }
+        record(GUARDIAN_REPLAY_OUTCOME_GAP_TOO_LARGE, 0);
         return ReplayOutcome::GapTooLarge;
     }
 
-    tracing::info!(
-        from_seq,
-        to_seq,
-        gap_size,
-        "replaying missed checkpoints to keep local limiter in lockstep",
-    );
+    tracing::info!(from_seq, to_seq, gap_size, "replaying missed checkpoints");
     let mut applied: u64 = 0;
     for seq in from_seq..=to_seq {
         let request = GetCheckpointRequest::default()
@@ -246,12 +207,8 @@ async fn replay_gap(
                 tracing::warn!(seq, applied, "get_checkpoint failed during replay: {e}");
                 if let Some(m) = metrics {
                     m.guardian_limiter_drifted.set(1);
-                    m.record_guardian_replay(
-                        GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE,
-                        applied,
-                        started.elapsed().as_secs_f64(),
-                    );
                 }
+                record(GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE, applied);
                 return ReplayOutcome::RpcFailure;
             }
         };
@@ -259,38 +216,19 @@ async fn replay_gap(
             tracing::warn!(seq, "get_checkpoint returned empty body during replay");
             if let Some(m) = metrics {
                 m.guardian_limiter_drifted.set(1);
-                m.record_guardian_replay(
-                    GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE,
-                    applied,
-                    started.elapsed().as_secs_f64(),
-                );
             }
+            record(GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE, applied);
             return ReplayOutcome::RpcFailure;
         };
         process_checkpoint(client, state, metrics, &checkpoint).await;
         applied += 1;
     }
 
-    if let Some(m) = metrics {
-        m.record_guardian_replay(
-            GUARDIAN_REPLAY_OUTCOME_SUCCESS,
-            applied,
-            started.elapsed().as_secs_f64(),
-        );
-    }
-    tracing::info!(
-        from_seq,
-        to_seq,
-        applied,
-        elapsed_secs = started.elapsed().as_secs_f64(),
-        "checkpoint gap replayed"
-    );
+    record(GUARDIAN_REPLAY_OUTCOME_SUCCESS, applied);
+    tracing::info!(from_seq, to_seq, applied, "checkpoint gap replayed");
     ReplayOutcome::Success
 }
 
-/// Apply one checkpoint's events to the in-memory mirror and advance the
-/// limiter cursor. Shared by the live subscription path and the gap-fill
-/// replay path so both share identical semantics.
 async fn process_checkpoint(
     client: &mut Client,
     state: &OnchainState,

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -97,8 +97,8 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
         }
 
         while let Some(item) = subscription.next().await {
-            let checkpoint = match item {
-                Ok(checkpoint) => checkpoint,
+            let response = match item {
+                Ok(response) => response,
                 Err(e) => {
                     tracing::warn!("error in checkpoint stream: {e}");
                     rescrape_state = true;
@@ -106,56 +106,67 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
                 }
             };
 
-            let ckpt = checkpoint.cursor();
-            tracing::trace!("received checkpoint {ckpt}");
-            let timestamp_ms = checkpoint
-                .checkpoint()
-                .summary()
-                .timestamp
-                .and_then(|t| proto_to_timestamp_ms(t).ok())
-                .unwrap_or(0);
-            let epoch = checkpoint.checkpoint().summary().epoch();
-            let previous_epoch = state.latest_checkpoint_epoch();
-            if epoch != previous_epoch {
-                tracing::debug!("Sui epoch changed from {previous_epoch} to {epoch}");
-                state.notify(Notification::SuiEpochChanged(epoch));
+            process_checkpoint(&mut client, &state, &metrics, response.checkpoint()).await;
+        }
+    }
+}
+
+/// Apply one checkpoint's events to the in-memory mirror and advance the
+/// limiter cursor. Shared by the live subscription path and the gap-fill
+/// replay path so both share identical semantics.
+async fn process_checkpoint(
+    client: &mut Client,
+    state: &OnchainState,
+    metrics: &Option<Arc<Metrics>>,
+    checkpoint: &Checkpoint,
+) {
+    let height = checkpoint.sequence_number();
+    tracing::trace!("processing checkpoint {height}");
+    let timestamp_ms = checkpoint
+        .summary()
+        .timestamp
+        .and_then(|t| proto_to_timestamp_ms(t).ok())
+        .unwrap_or(0);
+    let epoch = checkpoint.summary().epoch();
+    let previous_epoch = state.latest_checkpoint_epoch();
+    if epoch != previous_epoch {
+        tracing::debug!("Sui epoch changed from {previous_epoch} to {epoch}");
+        state.notify(Notification::SuiEpochChanged(epoch));
+    }
+    let mut events = Vec::new();
+    {
+        let state = state.state();
+
+        for txn in checkpoint.transactions() {
+            // Skip txns that were not successful
+            if !txn.effects().status().success() {
+                continue;
             }
-            let mut events = Vec::new();
-            {
-                let state = state.state();
 
-                for txn in checkpoint.checkpoint().transactions() {
-                    // Skip txns that were not successful
-                    if !txn.effects().status().success() {
-                        continue;
+            for event in txn.events().events() {
+                match HashiEvent::try_parse(&state.package_ids, event.contents()) {
+                    Ok(Some(event)) => {
+                        tracing::debug!("found event {:?}", event);
+                        events.push(event);
                     }
-
-                    for event in txn.events().events() {
-                        match HashiEvent::try_parse(&state.package_ids, event.contents()) {
-                            Ok(Some(event)) => {
-                                tracing::debug!("found event {:?}", event);
-                                events.push(event);
-                            }
-                            Ok(None) => {}
-                            Err(e) => tracing::error!("unable to parse event: {e}"),
-                        }
-                    }
+                    Ok(None) => {}
+                    Err(e) => tracing::error!("unable to parse event: {e}"),
                 }
             }
-
-            handle_events(&mut client, &state, &events).await;
-
-            // Finally update the latest checkpoint info
-            state.update_latest_checkpoint_info(CheckpointInfo {
-                height: ckpt,
-                timestamp_ms,
-                epoch,
-            });
-
-            if let Some(metrics) = &metrics {
-                metrics.update_onchain_state(&state);
-            }
         }
+    }
+
+    handle_events(client, state, &events).await;
+
+    // Finally update the latest checkpoint info
+    state.update_latest_checkpoint_info(CheckpointInfo {
+        height,
+        timestamp_ms,
+        epoch,
+    });
+
+    if let Some(metrics) = metrics {
+        metrics.update_onchain_state(state);
     }
 }
 

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -3,6 +3,7 @@
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::time::Instant;
 
 use futures::StreamExt;
 use hashi_types::move_types::AbortReconfig;
@@ -14,10 +15,15 @@ use sui_rpc::field::FieldMask;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::proto_to_timestamp_ms;
 use sui_rpc::proto::sui::rpc::v2::Checkpoint;
+use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
 
 use sui_sdk_types::TypeTag;
 
+use crate::metrics::GUARDIAN_REPLAY_OUTCOME_EMPTY_GAP;
+use crate::metrics::GUARDIAN_REPLAY_OUTCOME_GAP_TOO_LARGE;
+use crate::metrics::GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE;
+use crate::metrics::GUARDIAN_REPLAY_OUTCOME_SUCCESS;
 use crate::metrics::Metrics;
 use crate::onchain::CheckpointInfo;
 use crate::onchain::Notification;
@@ -28,6 +34,13 @@ use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
 use crate::onchain::types::WithdrawalRequest;
 use crate::withdrawals::withdrawal_limiter_consumption_amount;
+
+/// Hard cap on the number of checkpoints we will paginate through during
+/// a single gap-fill attempt. ~10k checkpoints is roughly 40 minutes of
+/// chain at the current Sui cadence — long enough for any realistic
+/// network blip, short enough to stay bounded if a node was down for
+/// hours and the in-memory cursor is meaningless.
+const MAX_REPLAY_CHECKPOINTS: u64 = 10_000;
 
 #[tracing::instrument(name = "watcher", skip_all)]
 pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Arc<Metrics>>) {
@@ -49,8 +62,6 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
             .finish(),
     ]);
 
-    let mut rescrape_state = false;
-
     loop {
         let mut subscription = match client
             .subscription_client()
@@ -60,18 +71,65 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
             )
             .await
         {
-            Ok(subscription) => subscription,
+            Ok(subscription) => subscription.into_inner(),
             Err(e) => {
                 tracing::warn!("error trying to subscribe to checkpoints: {e}");
-                rescrape_state = true;
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 continue;
             }
-        }
-        .into_inner();
+        };
 
-        // Rescrape the chain state in the event our subscription broke
-        if rescrape_state {
+        // Pull the first response so we know exactly where the live
+        // stream is starting. Anything strictly between the cursor we
+        // last processed and `live_first_seq` is a gap that needs to
+        // be filled from chain — otherwise its WithdrawalSignedEvents
+        // would be silently dropped and the local limiter would drift.
+        let first = match subscription.next().await {
+            Some(Ok(resp)) => resp,
+            Some(Err(e)) => {
+                tracing::warn!("error reading first checkpoint after subscribe: {e}");
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
+            }
+            None => {
+                tracing::warn!("checkpoint subscription closed before first message");
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
+            }
+        };
+        let live_first_seq = first.cursor();
+        let last_processed = state.latest_checkpoint_height();
+        let gap_first = last_processed.saturating_add(1);
+
+        // First-boot path: `last_processed` is whatever the initial
+        // scrape recorded; if the live stream starts there or earlier
+        // (e.g. fast subscribe) the gap is empty. Skip replay; skip
+        // rescrape — the initial scrape already seeded the mirror.
+        let need_full_rescrape = if last_processed > 0 && gap_first < live_first_seq {
+            match replay_gap(
+                &mut client,
+                &state,
+                &metrics,
+                &subscription_read_mask,
+                gap_first,
+                live_first_seq - 1,
+            )
+            .await
+            {
+                ReplayOutcome::Empty | ReplayOutcome::Success => false,
+                ReplayOutcome::RpcFailure | ReplayOutcome::GapTooLarge => {
+                    // The on-chain mirror is now stale (we dropped some
+                    // events) and the limiter is drifted. Pull a full
+                    // snapshot so the mirror is at least consistent;
+                    // the reconciler will surface the limiter drift.
+                    true
+                }
+            }
+        } else {
+            false
+        };
+
+        if need_full_rescrape {
             match super::scrape_hashi(
                 client.clone(),
                 state.hashi_id(),
@@ -87,21 +145,24 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("error trying to rescrape hashi's state: {e}");
+                    tracing::warn!("error rescraping hashi state after replay failure: {e}");
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     continue;
                 }
             }
-
-            rescrape_state = false;
         }
+
+        // Process the first live message we already pulled, then drain
+        // the rest of the subscription. On stream error we just break
+        // back to the outer loop and re-subscribe — gap-fill on the
+        // next iteration will catch any events the interruption hid.
+        process_checkpoint(&mut client, &state, &metrics, first.checkpoint()).await;
 
         while let Some(item) = subscription.next().await {
             let response = match item {
                 Ok(response) => response,
                 Err(e) => {
                     tracing::warn!("error in checkpoint stream: {e}");
-                    rescrape_state = true;
                     break;
                 }
             };
@@ -109,6 +170,122 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
             process_checkpoint(&mut client, &state, &metrics, response.checkpoint()).await;
         }
     }
+}
+
+/// Outcome of a single gap-fill attempt. Drives metric labels and the
+/// caller's decision to fall back to a full rescrape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReplayOutcome {
+    /// No checkpoints to replay (gap was empty by the time we computed it).
+    Empty,
+    /// Every checkpoint in `[from, to]` was fetched and applied.
+    Success,
+    /// `get_checkpoint` returned an error or an empty body partway through.
+    /// Mirror + limiter may be partially advanced; caller should rescrape.
+    RpcFailure,
+    /// The gap exceeded `MAX_REPLAY_CHECKPOINTS`; we declined to replay.
+    /// Mirror + limiter are unchanged; caller should rescrape.
+    GapTooLarge,
+}
+
+/// Replay missed checkpoints in `[from_seq, to_seq]` (inclusive) by
+/// fetching each via `LedgerService::get_checkpoint` and feeding it
+/// through the same `process_checkpoint` path the live subscription
+/// uses. Best-effort: any single failure aborts the replay and returns
+/// the partial-advance metric outcome — the watcher's reconciler is the
+/// final safety net for any lingering drift.
+async fn replay_gap(
+    client: &mut Client,
+    state: &OnchainState,
+    metrics: &Option<Arc<Metrics>>,
+    read_mask: &FieldMask,
+    from_seq: u64,
+    to_seq: u64,
+) -> ReplayOutcome {
+    if from_seq > to_seq {
+        if let Some(m) = metrics {
+            m.record_guardian_replay(GUARDIAN_REPLAY_OUTCOME_EMPTY_GAP, 0, 0.0);
+        }
+        return ReplayOutcome::Empty;
+    }
+    let started = Instant::now();
+    let gap_size = to_seq - from_seq + 1;
+    if gap_size > MAX_REPLAY_CHECKPOINTS {
+        tracing::error!(
+            from_seq,
+            to_seq,
+            gap_size,
+            max = MAX_REPLAY_CHECKPOINTS,
+            "checkpoint gap exceeds replay cap; declining to replay — local limiter is now drifted"
+        );
+        if let Some(m) = metrics {
+            m.guardian_limiter_drifted.set(1);
+            m.record_guardian_replay(
+                GUARDIAN_REPLAY_OUTCOME_GAP_TOO_LARGE,
+                0,
+                started.elapsed().as_secs_f64(),
+            );
+        }
+        return ReplayOutcome::GapTooLarge;
+    }
+
+    tracing::info!(
+        from_seq,
+        to_seq,
+        gap_size,
+        "replaying missed checkpoints to keep local limiter in lockstep",
+    );
+    let mut applied: u64 = 0;
+    for seq in from_seq..=to_seq {
+        let request = GetCheckpointRequest::default()
+            .with_sequence_number(seq)
+            .with_read_mask(read_mask.clone());
+        let response = match client.ledger_client().get_checkpoint(request).await {
+            Ok(r) => r.into_inner(),
+            Err(e) => {
+                tracing::warn!(seq, applied, "get_checkpoint failed during replay: {e}");
+                if let Some(m) = metrics {
+                    m.guardian_limiter_drifted.set(1);
+                    m.record_guardian_replay(
+                        GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE,
+                        applied,
+                        started.elapsed().as_secs_f64(),
+                    );
+                }
+                return ReplayOutcome::RpcFailure;
+            }
+        };
+        let Some(checkpoint) = response.checkpoint else {
+            tracing::warn!(seq, "get_checkpoint returned empty body during replay");
+            if let Some(m) = metrics {
+                m.guardian_limiter_drifted.set(1);
+                m.record_guardian_replay(
+                    GUARDIAN_REPLAY_OUTCOME_RPC_FAILURE,
+                    applied,
+                    started.elapsed().as_secs_f64(),
+                );
+            }
+            return ReplayOutcome::RpcFailure;
+        };
+        process_checkpoint(client, state, metrics, &checkpoint).await;
+        applied += 1;
+    }
+
+    if let Some(m) = metrics {
+        m.record_guardian_replay(
+            GUARDIAN_REPLAY_OUTCOME_SUCCESS,
+            applied,
+            started.elapsed().as_secs_f64(),
+        );
+    }
+    tracing::info!(
+        from_seq,
+        to_seq,
+        applied,
+        elapsed_secs = started.elapsed().as_secs_f64(),
+        "checkpoint gap replayed"
+    );
+    ReplayOutcome::Success
 }
 
 /// Apply one checkpoint's events to the in-memory mirror and advance the


### PR DESCRIPTION
## Summary

- Watcher gap-fills missed checkpoints via `LedgerService::get_checkpoint` on every (re)subscribe. Cap 10k; sticky `guardian_limiter_drifted=1` + `scrape_hashi` fallback on RPC failure or oversized gap.
- New `guardian_reconciler` background service polls `GetGuardianInfo` on a fixed interval (default 30s), classifies drift via pure `classify(local, guardian, tolerance) -> Outcome`, emits metrics. Read-only.
- New metrics: `guardian_replay_outcomes_total{outcome}`, `guardian_replay_checkpoints_total`, `guardian_replay_duration_seconds`, `guardian_reconciler_{local_seq,guardian_seq,seq_drift}`, `guardian_reconciler_outcomes_total{outcome}`.
- New config keys (all optional with defaults): `guardian_reconciliation_{interval_secs=30, drift_alert_secs=300, tolerance_seq=2}`.
