### PR TITLE
[ci] disable sui move build tree-shaking to fix flaky e2e

### DIFF
--- a/crates/hashi/src/cli/upgrade.rs
+++ b/crates/hashi/src/cli/upgrade.rs
@@ -109,7 +109,10 @@ pub fn build_upgrade_package(
         .arg("build")
         .arg("-e")
         .arg("testnet")
-        .arg("--dump-bytecode-as-base64");
+        // --no-tree-shaking: avoid the RPC call newer sui CLI makes during
+        // --dump-bytecode-as-base64; required for offline builds (CI, e2e).
+        .arg("--dump-bytecode-as-base64")
+        .arg("--no-tree-shaking");
 
     let output = cmd.output()?;
     anyhow::ensure!(

--- a/crates/hashi/src/publish.rs
+++ b/crates/hashi/src/publish.rs
@@ -70,7 +70,10 @@ pub fn build_package(params: &BuildParams<'_>) -> Result<sui_sdk_types::Publish>
         cmd.args(["-e", env]);
     }
 
-    cmd.arg("--dump-bytecode-as-base64");
+    // --no-tree-shaking: avoid the RPC call newer sui CLI makes during
+    // --dump-bytecode-as-base64; required for offline builds (CI, e2e).
+    cmd.arg("--dump-bytecode-as-base64")
+        .arg("--no-tree-shaking");
 
     let output = cmd.output()?;
 


### PR DESCRIPTION
## Summary

- Pass `--no-tree-shaking` to `sui move build --dump-bytecode-as-base64` in both the publish and upgrade paths to unblock CI.

## Investigation

CI's been extremely flaky on all PRs off main recently with the error:

```
sui move build failed
stdout: Failed to fetch package MoveStdlib
Caused by: tcp connect error
stderr: INCLUDING DEPENDENCY MoveStdlib ...
```

This error message is actually misleading. The package is already pinned in `Move.lock` and cached locally under `~/.move/git/...`. Nothing's actually being fetched from GitHub.

The real issue here is sui's tree-shaking.

Here's the explanation I got after investigating from claude:

> `sui move build --dump-bytecode-as-base64` does an RPC call to figure out which deps to drop from the published bytecode. The RPC target is the **active env** in `--client.config`'s `client.yaml` — *not* the build env from `-e testnet`. And `sui genesis` writes `active_env: localnet` pinned to `http://127.0.0.1:9000`, while our test harness binds the actual sui localnet to whatever port `get_available_port()` happens to return. So tree-shaking dials 127.0.0.1:9000, finds nothing listening, and the build dies with that misleading "fetch package" error.

> Why does this fail intermittently rather than always? When several e2e tests run in parallel, one of them occasionally lands on port 9000 by sheer luck of `get_available_port()`. Tree-shaking RPCs from other tests then hit *that* localnet and pass. Same `testnet-v1.71.1` binary passed on the 2026-05-06 main cron and failed on 2026-05-07 — pure port-allocation luck.


## Sui changenote

The flag itself comes from [sui#25444](https://github.com/MystenLabs/sui/pull/25444), released in `testnet-v1.69.1`:

> `sui move build --dump` can now be run without an active network connection if tree shaking is disabled.

So tree-shaking has been on by default since 1.69.x — `--no-tree-shaking` is the documented escape hatch for offline/CI builds. Our deps are already pinned in `Move.lock` and the bytecode-as-base64 dump doesn't care about the dropped deps, so this is a no-op aside from killing the RPC call.
