### PR TITLE
docs: Fix Mermaid theme and address AF docs spec fail

### DIFF
--- a/design/docusaurus.config.js
+++ b/design/docusaurus.config.js
@@ -276,6 +276,15 @@ const config = {
             labelBoxBorderColor: '#6C7584',
             labelTextColor: '#FFFFFF',
             loopTextColor: '#FFFFFF',
+            // Below variables are not in the Sui diagram-standards palette,
+            // but mermaid's "base" theme defaults render these elements in
+            // a yellow/orange tone that clashes with the standards. Pinning
+            // them keeps autonumber circles + actor styling on-palette.
+            actorBkg: '#000000',
+            actorBorder: '#6C7584',
+            actorTextColor: '#FFFFFF',
+            actorLineColor: '#6C7584',
+            sequenceNumberColor: '#FFFFFF',
           },
         },
       },

--- a/design/scripts/copy-markdown-files.js
+++ b/design/scripts/copy-markdown-files.js
@@ -42,9 +42,15 @@ function cleanForMarkdown(raw, frontMatter) {
   let header = "";
   if (frontMatter?.title) {
     header = `# ${frontMatter.title}\n\n`;
-    if (frontMatter.description) {
-      header += `> ${frontMatter.description}\n\n`;
-    }
+  }
+  // Markdown llms.txt directive — agents fetching `.md` URLs discover the
+  // index from this line. Mirrors the Sui docs convention:
+  // https://agentdocsspec.com/spec/#llms-txt-directive-md
+  header +=
+    "*[Documentation index](/hashi/design/llms.txt) · " +
+    "[Full index](/hashi/design/llms-full.txt)*\n\n";
+  if (frontMatter?.description) {
+    header += `> ${frontMatter.description}\n\n`;
   }
 
   return header + body.trim() + "\n";


### PR DESCRIPTION
- Fix mermaid theme labeling arrows as orange
- Fix llms-txt-directive-md failing