### PR TITLE
docs(ecosystem): add Epoch BTC vesting use-case page

### DIFF
--- a/design/docs/ecosystem/epoch-vesting.mdx
+++ b/design/docs/ecosystem/epoch-vesting.mdx
@@ -1,0 +1,121 @@
+---
+sidebar_label: Epoch — BTC Vesting
+description: How Epoch uses hBTC from Hashi to enable trustless, on-chain Bitcoin vesting schedules on Sui.
+keywords: [hBTC, vesting, Epoch, Sui, Bitcoin, DeFi, token vesting, BTC]
+---
+
+# Epoch — Trustless BTC Vesting with hBTC
+
+[Epoch](https://github.com/epochprotocol) is an on-chain vesting protocol on Sui that lets teams and individuals lock tokens inside smart-contract vaults and release them to beneficiaries over a configurable schedule. Because Epoch vaults are generic (`Vault<phantom T>`) they accept any `Coin<T>` — including `Coin<hBTC>` minted by Hashi.
+
+This page shows how hBTC unlocks a use case that was previously impossible without a trusted custodian: **Bitcoin vesting schedules enforced entirely by Sui smart contracts**.
+
+---
+
+## The problem: BTC has no native programmability
+
+BTC holders who want to vest tokens to employees, investors, or grant recipients today face an unpleasant choice:
+
+- **Custodied wrappers** (WBTC, etc.) — trust a centralised issuer to hold the underlying BTC.
+- **Off-chain agreements** — rely on legal contracts with no on-chain enforcement.
+- **Native Bitcoin scripts** — limited time-lock primitives, no rich vesting logic (cliff, linear, partial claims).
+
+Hashi solves the custody problem. Epoch solves the programmability problem. Together they close the gap.
+
+---
+
+## How it works
+
+### 1. Deposit BTC → receive hBTC
+
+The user sends BTC to their unique Hashi deposit address on Bitcoin (see [User Flows](./user-flows) and [Deposit](./deposit) for the full flow). After the Hashi committee reaches quorum and the time-delay window elapses, an equivalent amount of `hBTC` is minted into the user's Sui wallet:
+
+```
+BTC (Bitcoin L1) ──Hashi──► Coin<hBTC> (Sui)
+```
+
+`hBTC` is a standard Sui fungible token. It can be transferred, held in wallets, and passed into any Move function that accepts a `Coin<T>`.
+
+### 2. Create a vesting vault on Epoch
+
+With `hBTC` in hand, the grantor calls Epoch's `create_vault` entry function, specifying the beneficiary address, vesting schedule, and cliff period:
+
+```move
+public entry fun create_vault<T>(
+    coin: Coin<T>,          // Coin<hBTC> from Hashi
+    beneficiary: address,
+    start_timestamp_ms: u64,
+    cliff_duration_ms: u64,
+    vesting_duration_ms: u64,
+    ctx: &mut TxContext,
+)
+```
+
+Because `T` is phantom, the vault contract requires zero changes to support `hBTC` — it already works.
+
+### 3. Beneficiary claims over time
+
+As time passes, the vested portion of `hBTC` becomes claimable. The beneficiary calls `claim` and receives `Coin<hBTC>` proportional to how much of the schedule has elapsed:
+
+```move
+public entry fun claim<T>(
+    vault: &mut Vault<T>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+)
+```
+
+### 4. Withdraw hBTC → redeem BTC
+
+When the beneficiary wants native BTC back, they initiate a Hashi withdrawal (see [Withdraw](./withdraw)). `hBTC` is burned and the corresponding BTC is sent to their Bitcoin address.
+
+```
+Coin<hBTC> (Sui) ──Hashi──► BTC (Bitcoin L1)
+```
+
+---
+
+## End-to-end flow
+
+```
+Grantor                  Hashi                   Epoch Vault              Beneficiary
+  │                        │                          │                        │
+  │── Send BTC ───────────►│                          │                        │
+  │                        │── mint hBTC ────────────►│                        │
+  │── create_vault(hBTC) ──────────────────────────► │                        │
+  │                        │                          │                        │
+  │                        │              (time passes — cliff + linear)       │
+  │                        │                          │                        │
+  │                        │                          │◄─── claim() ──────────│
+  │                        │                          │                        │
+  │                        │◄─── withdraw(hBTC) ──────────────────────────────│
+  │                        │── send BTC ──────────────────────────────────────►│
+```
+
+---
+
+## Why this matters
+
+| Property | Custodied WBTC vesting | Epoch + hBTC |
+|---|---|---|
+| BTC custody | Centralised issuer | Hashi MPC committee |
+| Vesting logic enforcement | Off-chain / legal | Sui smart contract |
+| Cliff & linear schedule | Manual, trust-based | Enforced on-chain |
+| Early termination | Requires issuer cooperation | Grantor can cancel vault |
+| Beneficiary claim | Requires issuer cooperation | Permissionless |
+| Auditability | Issuer transparency reports | Fully on-chain |
+
+---
+
+## Relevant links
+
+- **Epoch repository**: [github.com/epochprotocol](https://github.com/epochprotocol)
+- **Hashi deposit flow**: [Deposit](./deposit)
+- **Hashi withdraw flow**: [Withdraw](./withdraw)
+- **hBTC on Sui**: see [Introduction](./README.mdx) for the `Coin<BTC>` type details
+
+---
+
+:::info Community contribution
+This page was contributed by the Epoch team. If you are building on hBTC and would like to document your integration, open a pull request against the [Hashi repository](https://github.com/MystenLabs/hashi).
+:::

--- a/design/docs/ecosystem/epoch-vesting.mdx
+++ b/design/docs/ecosystem/epoch-vesting.mdx
@@ -1,14 +1,12 @@
 ---
-sidebar_label: Epoch — BTC Vesting
-description: How Epoch uses hBTC from Hashi to enable trustless, on-chain Bitcoin vesting schedules on Sui.
+sidebar_label: Epoch - BTC Vesting
+description: How Epoch uses hBTC from Hashi to enable trustless, onchain Bitcoin vesting schedules on Sui.
 keywords: [hBTC, vesting, Epoch, Sui, Bitcoin, DeFi, token vesting, BTC]
 ---
 
-# Epoch — Trustless BTC Vesting with hBTC
+[Epoch](https://epochsui.com) is an onchain vesting protocol on Sui that lets teams and individuals lock tokens inside smart-contract vaults and release them to beneficiaries over a configurable schedule. Because Epoch vaults are generic (`Vault<phantom T>`), they accept any `Coin<T>`, including `Coin<hBTC>` minted by Hashi.
 
-[Epoch](https://epochsui.com) is an on-chain vesting protocol on Sui that lets teams and individuals lock tokens inside smart-contract vaults and release them to beneficiaries over a configurable schedule. Because Epoch vaults are generic (`Vault<phantom T>`) they accept any `Coin<T>` — including `Coin<hBTC>` minted by Hashi.
-
-This page shows how hBTC unlocks a use case that was previously impossible without a trusted custodian: **Bitcoin vesting schedules enforced entirely by Sui smart contracts**.
+This page shows how hBTC unlocks a use case that was previously impossible without a trusted custodian: Bitcoin vesting schedules enforced entirely by Sui smart contracts.
 
 ---
 
@@ -16,9 +14,9 @@ This page shows how hBTC unlocks a use case that was previously impossible witho
 
 BTC holders who want to vest tokens to employees, investors, or grant recipients today face an unpleasant choice:
 
-- **Custodied wrappers** (WBTC, etc.) — trust a centralised issuer to hold the underlying BTC.
-- **Off-chain agreements** — rely on legal contracts with no on-chain enforcement.
-- **Native Bitcoin scripts** — limited time-lock primitives, no rich vesting logic (cliff, linear, partial claims).
+- **Custodied wrappers** (WBTC and so on): trust a centralised issuer to hold the underlying BTC.
+- **Offchain agreements**: rely on legal contracts with no onchain enforcement.
+- **Native Bitcoin scripts**: limited time-lock primitives, no rich vesting logic (cliff, linear, partial claims).
 
 Hashi solves the custody problem. Epoch solves the programmability problem. Together they close the gap.
 
@@ -26,7 +24,7 @@ Hashi solves the custody problem. Epoch solves the programmability problem. Toge
 
 ## How it works
 
-### 1. Deposit BTC → receive hBTC
+### 1. Deposit BTC and receive hBTC
 
 The user sends BTC to their unique Hashi deposit address on Bitcoin (see [User Flows](./user-flows) and [Deposit](./deposit) for the full flow). After the Hashi committee reaches quorum and the time-delay window elapses, an equivalent amount of `hBTC` is minted into the user's Sui wallet:
 
@@ -51,7 +49,7 @@ public entry fun create_vault<T>(
 )
 ```
 
-Because `T` is phantom, the vault contract requires zero changes to support `hBTC` — it already works.
+Because `T` is phantom, the vault contract requires zero changes to support `hBTC`. It already works.
 
 ### 3. Beneficiary claims over time
 
@@ -65,7 +63,7 @@ public entry fun claim<T>(
 )
 ```
 
-### 4. Withdraw hBTC → redeem BTC
+### 4. Withdraw hBTC and redeem BTC
 
 When the beneficiary wants native BTC back, they initiate a Hashi withdrawal (see [Withdraw](./withdraw)). `hBTC` is burned and the corresponding BTC is sent to their Bitcoin address.
 
@@ -84,7 +82,7 @@ Grantor                  Hashi                   Epoch Vault              Benefi
   │                        │── mint hBTC ────────────►│                        │
   │── create_vault(hBTC) ──────────────────────────► │                        │
   │                        │                          │                        │
-  │                        │              (time passes — cliff + linear)       │
+  │                        │         (time passes, cliff and linear schedule)  │
   │                        │                          │                        │
   │                        │                          │◄─── claim() ──────────│
   │                        │                          │                        │
@@ -96,14 +94,14 @@ Grantor                  Hashi                   Epoch Vault              Benefi
 
 ## Why this matters
 
-| Property | Custodied WBTC vesting | Epoch + hBTC |
+| Property | Custodied WBTC vesting | Epoch and hBTC |
 |---|---|---|
 | BTC custody | Centralised issuer | Hashi MPC committee |
-| Vesting logic enforcement | Off-chain / legal | Sui smart contract |
-| Cliff & linear schedule | Manual, trust-based | Enforced on-chain |
+| Vesting logic enforcement | Offchain / legal | Sui smart contract |
+| Cliff and linear schedule | Manual, trust-based | Enforced onchain |
 | Early termination | Requires issuer cooperation | Grantor can cancel vault |
 | Beneficiary claim | Requires issuer cooperation | Permissionless |
-| Auditability | Issuer transparency reports | Fully on-chain |
+| Auditability | Issuer transparency reports | Fully onchain |
 
 ---
 

--- a/design/docs/ecosystem/epoch-vesting.mdx
+++ b/design/docs/ecosystem/epoch-vesting.mdx
@@ -24,7 +24,7 @@ Hashi solves the custody problem. Epoch solves the programmability problem. Toge
 
 ## How it works
 
-### 1. Deposit BTC and receive hBTC
+### 1. Deposit BTC
 
 The user sends BTC to their unique Hashi deposit address on Bitcoin (see [User Flows](./user-flows) and [Deposit](./deposit) for the full flow). After the Hashi committee reaches quorum and the time-delay window elapses, an equivalent amount of `hBTC` is minted into the user's Sui wallet:
 
@@ -34,7 +34,7 @@ BTC (Bitcoin L1) ──Hashi──► Coin<hBTC> (Sui)
 
 `hBTC` is a standard Sui fungible token. It can be transferred, held in wallets, and passed into any Move function that accepts a `Coin<T>`.
 
-### 2. Create a vesting vault on Epoch
+### 2. Create a vesting vault
 
 With `hBTC` in hand, the grantor calls Epoch's `create_vault` entry function, specifying the beneficiary address, vesting schedule, and cliff period:
 
@@ -63,7 +63,7 @@ public entry fun claim<T>(
 )
 ```
 
-### 4. Withdraw hBTC and redeem BTC
+### 4. Redeem BTC
 
 When the beneficiary wants native BTC back, they initiate a Hashi withdrawal (see [Withdraw](./withdraw)). `hBTC` is burned and the corresponding BTC is sent to their Bitcoin address.
 

--- a/design/docs/ecosystem/epoch-vesting.mdx
+++ b/design/docs/ecosystem/epoch-vesting.mdx
@@ -6,7 +6,7 @@ keywords: [hBTC, vesting, Epoch, Sui, Bitcoin, DeFi, token vesting, BTC]
 
 # Epoch — Trustless BTC Vesting with hBTC
 
-[Epoch](https://github.com/epochprotocol) is an on-chain vesting protocol on Sui that lets teams and individuals lock tokens inside smart-contract vaults and release them to beneficiaries over a configurable schedule. Because Epoch vaults are generic (`Vault<phantom T>`) they accept any `Coin<T>` — including `Coin<hBTC>` minted by Hashi.
+[Epoch](https://epochsui.com) is an on-chain vesting protocol on Sui that lets teams and individuals lock tokens inside smart-contract vaults and release them to beneficiaries over a configurable schedule. Because Epoch vaults are generic (`Vault<phantom T>`) they accept any `Coin<T>` — including `Coin<hBTC>` minted by Hashi.
 
 This page shows how hBTC unlocks a use case that was previously impossible without a trusted custodian: **Bitcoin vesting schedules enforced entirely by Sui smart contracts**.
 
@@ -109,7 +109,7 @@ Grantor                  Hashi                   Epoch Vault              Benefi
 
 ## Relevant links
 
-- **Epoch repository**: [github.com/epochprotocol](https://github.com/epochprotocol)
+- **Epoch**: [epochsui.com](https://epochsui.com)
 - **Hashi deposit flow**: [Deposit](./deposit)
 - **Hashi withdraw flow**: [Withdraw](./withdraw)
 - **hBTC on Sui**: see [Introduction](./README.mdx) for the `Coin<BTC>` type details

--- a/design/docs/ecosystem/epoch-vesting.mdx
+++ b/design/docs/ecosystem/epoch-vesting.mdx
@@ -24,7 +24,7 @@ Hashi solves the custody problem. Epoch solves the programmability problem. Toge
 
 ## How it works
 
-### 1. Deposit BTC
+### 1. Deposit
 
 The user sends BTC to their unique Hashi deposit address on Bitcoin (see [User Flows](./user-flows) and [Deposit](./deposit) for the full flow). After the Hashi committee reaches quorum and the time-delay window elapses, an equivalent amount of `hBTC` is minted into the user's Sui wallet:
 
@@ -63,7 +63,7 @@ public entry fun claim<T>(
 )
 ```
 
-### 4. Redeem BTC
+### 4. Redeem
 
 When the beneficiary wants native BTC back, they initiate a Hashi withdrawal (see [Withdraw](./withdraw)). `hBTC` is burned and the corresponding BTC is sent to their Bitcoin address.
 

--- a/design/sidebars.js
+++ b/design/sidebars.js
@@ -32,6 +32,14 @@ const sidebars = {
         'withdraw',
       ],
     },
+    {
+      type: 'category',
+      label: 'Ecosystem',
+      collapsed: false,
+      items: [
+        'ecosystem/epoch-vesting',
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
# PR: docs(ecosystem): add Epoch BTC vesting use-case page

## Summary

Adds a new **Ecosystem** section to the Hashi design docs with a first entry documenting how [Epoch](https://epochsui.com), an on-chain vesting protocol on Sui, uses `Coin<hBTC>` to implement trustless Bitcoin vesting schedules.

## What this PR changes

### New file
`design/docs/ecosystem/epoch-vesting.mdx`

A documentation page (matching existing Docusaurus v3 MDX style) that covers:
- The problem: BTC has no native programmability for vesting
- Step-by-step integration flow: deposit BTC → receive hBTC → lock in Epoch vault → beneficiary claims → redeem BTC
- Move code snippets for `create_vault<T>` and `claim<T>`
- ASCII end-to-end flow diagram
- Comparison table vs. custodied WBTC vesting

### Sidebar change (sidebars.js / sidebars.ts)
Add a new top-level category `Ecosystem` with the new page:

```js
{
  type: 'category',
  label: 'Ecosystem',
  items: ['ecosystem/epoch-vesting'],
},
```

---

## Why this is relevant to Hashi

Epoch vaults are `Vault<phantom T>`, so they accept **any** `Coin<T>` with zero contract changes — including `Coin<hBTC>`. This makes hBTC → Epoch vesting a zero-integration, fully trustless path to programmatic BTC vesting on Sui.

The page demonstrates a concrete, production-ready use case for hBTC that:
1. Shows real DeFi utility beyond collateral/lending
2. Illustrates Hashi's composability with the broader Sui ecosystem
3. Gives developers a reference pattern for generic-coin integrations

---

## Checklist

- [x] MDX frontmatter matches existing pages (`sidebar_label`, `description`, `keywords`)
- [x] Prose style matches existing Hashi docs (technical, concise, third-person)
- [x] Code blocks use `move` syntax highlighting for Move snippets
- [x] Links use relative paths (`./deposit`, `./withdraw`, `./user-flows`)
- [x] `:::info` admonition at bottom invites future ecosystem contributions
- [x] No changes to existing pages

---

## How to test locally

```bash
cd design
npm install
npm run start
# Navigate to http://localhost:3000/hashi/design/ecosystem/epoch-vesting
```
