### PR TITLE
[mpc] handle missing previous committee at genesis

### DIFF
--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -360,8 +360,6 @@ impl Hashi {
             validator_address,
             epoch,
         )?;
-        // Absent at genesis: pending_epoch_change=Some(target) but committees()
-        // has no entry for the current on-chain epoch yet.
         let previous_encryption_key = committee_set
             .previous_committee_for_target(epoch)
             .map(|(prev_ep, prev_committee)| {

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -360,21 +360,11 @@ impl Hashi {
             validator_address,
             epoch,
         )?;
-        let previous_epoch = if committee_set.pending_epoch_change().is_some() {
-            Some(committee_set.epoch())
-        } else {
-            committee_set
-                .committees()
-                .range(..epoch)
-                .next_back()
-                .map(|(&k, _)| k)
-        };
-        let previous_encryption_key = previous_epoch
-            .map(|prev_ep| {
-                let prev_committee = committee_set
-                    .committees()
-                    .get(&prev_ep)
-                    .ok_or_else(|| anyhow!("no committee for previous epoch {prev_ep}"))?;
+        // Absent at genesis: pending_epoch_change=Some(target) but committees()
+        // has no entry for the current on-chain epoch yet.
+        let previous_encryption_key = committee_set
+            .previous_committee_for_target(epoch)
+            .map(|(prev_ep, prev_committee)| {
                 self.find_encryption_key_for_committee(prev_committee, validator_address, prev_ep)
                     .map(Some)
                     .or_else(|e| {

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -152,10 +152,6 @@ impl CommitteeSet {
         self.committees().get(&self.epoch())
     }
 
-    /// Identify the committee that "re-shares" keys to the one for `target`:
-    /// during a pending epoch change, the current on-chain committee (may be
-    /// absent at genesis); otherwise the greatest committee strictly less than
-    /// `target`. Returns `None` when no such committee exists.
     pub fn previous_committee_for_target(&self, target: u64) -> Option<(u64, &Committee)> {
         if self.pending_epoch_change().is_some() {
             let prev_ep = self.epoch();
@@ -838,17 +834,12 @@ mod tests {
 
     #[test]
     fn previous_committee_for_target_is_none_at_genesis() {
-        // Initial DKG: pending change to 1, on-chain epoch still 0,
-        // only the bootstrap committee at key 1 exists. There is no
-        // previous committee to re-share from.
         let set = set_with(0, Some(1), &[1]);
         assert_eq!(set.previous_committee_for_target(1).map(|(e, _)| e), None);
     }
 
     #[test]
     fn previous_committee_for_target_during_pending_rotation() {
-        // Mid-rotation from epoch 1 → 2: previous is the current on-chain
-        // committee (epoch 1).
         let set = set_with(1, Some(2), &[1, 2]);
         assert_eq!(
             set.previous_committee_for_target(2).map(|(e, _)| e),
@@ -858,8 +849,6 @@ mod tests {
 
     #[test]
     fn previous_committee_for_target_recovery_with_no_pending_change() {
-        // Recovery / late-join: no pending change, the greatest committee
-        // strictly less than target is selected.
         let set = set_with(5, None, &[3, 5]);
         assert_eq!(
             set.previous_committee_for_target(6).map(|(e, _)| e),
@@ -869,7 +858,6 @@ mod tests {
 
     #[test]
     fn previous_committee_for_target_returns_none_when_no_earlier_committee() {
-        // No pending change and committees() has nothing strictly less than target.
         let set = set_with(3, None, &[3]);
         assert_eq!(set.previous_committee_for_target(3).map(|(e, _)| e), None);
     }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -152,6 +152,22 @@ impl CommitteeSet {
         self.committees().get(&self.epoch())
     }
 
+    /// Identify the committee that "re-shares" keys to the one for `target`:
+    /// during a pending epoch change, the current on-chain committee (may be
+    /// absent at genesis); otherwise the greatest committee strictly less than
+    /// `target`. Returns `None` when no such committee exists.
+    pub fn previous_committee_for_target(&self, target: u64) -> Option<(u64, &Committee)> {
+        if self.pending_epoch_change().is_some() {
+            let prev_ep = self.epoch();
+            self.committees().get(&prev_ep).map(|c| (prev_ep, c))
+        } else {
+            self.committees()
+                .range(..target)
+                .next_back()
+                .map(|(&k, c)| (k, c))
+        }
+    }
+
     pub fn epoch(&self) -> u64 {
         self.epoch
     }
@@ -797,5 +813,64 @@ impl Coin {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_committee(epoch: u64) -> Committee {
+        Committee::new(vec![], epoch, 10_000, 0, 5_000)
+    }
+
+    fn set_with(epoch: u64, pending: Option<u64>, committee_epochs: &[u64]) -> CommitteeSet {
+        let mut set = CommitteeSet::new(Address::new([0u8; 32]), Address::new([0u8; 32]));
+        set.set_epoch(epoch).set_pending_epoch_change(pending);
+        let committees: BTreeMap<u64, Committee> = committee_epochs
+            .iter()
+            .copied()
+            .map(|e| (e, empty_committee(e)))
+            .collect();
+        set.set_committees(committees);
+        set
+    }
+
+    #[test]
+    fn previous_committee_for_target_is_none_at_genesis() {
+        // Initial DKG: pending change to 1, on-chain epoch still 0,
+        // only the bootstrap committee at key 1 exists. There is no
+        // previous committee to re-share from.
+        let set = set_with(0, Some(1), &[1]);
+        assert_eq!(set.previous_committee_for_target(1).map(|(e, _)| e), None);
+    }
+
+    #[test]
+    fn previous_committee_for_target_during_pending_rotation() {
+        // Mid-rotation from epoch 1 → 2: previous is the current on-chain
+        // committee (epoch 1).
+        let set = set_with(1, Some(2), &[1, 2]);
+        assert_eq!(
+            set.previous_committee_for_target(2).map(|(e, _)| e),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn previous_committee_for_target_recovery_with_no_pending_change() {
+        // Recovery / late-join: no pending change, the greatest committee
+        // strictly less than target is selected.
+        let set = set_with(5, None, &[3, 5]);
+        assert_eq!(
+            set.previous_committee_for_target(6).map(|(e, _)| e),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn previous_committee_for_target_returns_none_when_no_earlier_committee() {
+        // No pending change and committees() has nothing strictly less than target.
+        let set = set_with(3, None, &[3]);
+        assert_eq!(set.previous_committee_for_target(3).map(|(e, _)| e), None);
     }
 }


### PR DESCRIPTION
Fixes a #502 regression. On a fresh devnet, `create_mpc_manager` errors with `no committee for previous epoch 0` and the initial DKG never starts — it demands a previous-epoch committee that doesn't exist yet. `MpcManager::new` already handles the genesis case, the outer wrapper just never reached it.

Moved the selection into `CommitteeSet::previous_committee_for_target` and added unit tests for the genesis / rotation / recovery cases.