### PR TITLE
[leader] reload deposit worklist after the deposit time-delay

### DIFF
--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -62,6 +62,7 @@ use x509_parser::nom::AsBytes;
 
 const NUM_CONSECUTIVE_LEADER_CHECKPOINTS: u64 = 100;
 const LEADER_TASK_TIMEOUT: Duration = Duration::from_secs(60);
+const DEPOSIT_WORKLIST_REFRESH_INTERVAL_MS: u64 = 30_000;
 
 #[derive(Clone, Copy, Debug)]
 enum DepositPhase {
@@ -75,6 +76,7 @@ pub struct LeaderService {
     withdrawal_commitment_retry_tracker: GlobalRetryTracker<WithdrawalCommitmentErrorKind>,
     deposit_tasks: JoinSet<(Address, Result<(), DepositError>)>,
     pending_deposit_requests: Vec<DepositRequest>,
+    last_deposit_worklist_reload_ts_ms: u64,
     never_retry_deposit_ids: HashSet<Address>,
     inflight_deposits: HashSet<Address>,
     withdrawal_approval_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
@@ -96,6 +98,7 @@ impl LeaderService {
             withdrawal_commitment_retry_tracker: GlobalRetryTracker::new(),
             deposit_tasks: JoinSet::new(),
             pending_deposit_requests: Vec::new(),
+            last_deposit_worklist_reload_ts_ms: 0,
             never_retry_deposit_ids: HashSet::new(),
             inflight_deposits: HashSet::new(),
             withdrawal_approval_task: None,
@@ -159,6 +162,7 @@ impl LeaderService {
                     self.process_signed_withdrawal_txns();
                     self.check_delete_proposals(checkpoint_timestamp_ms);
 
+                    self.maybe_reload_pending_deposit_requests(checkpoint_timestamp_ms);
                     if !self.pending_deposit_requests.is_empty() {
                         self.process_deposit_requests();
                     }
@@ -176,7 +180,7 @@ impl LeaderService {
 
                     // We want to unconditionally reload deposits, even if we aren't the leader to
                     // avoid only the leader being able to reload the moment a block is seen.
-                    self.reload_pending_deposit_requests();
+                    self.reload_pending_deposit_requests(checkpoint_timestamp_ms);
 
                     if !self.is_current_leader(checkpoint_height) {
                         continue;
@@ -327,7 +331,7 @@ impl LeaderService {
         is_leader
     }
 
-    fn reload_pending_deposit_requests(&mut self) {
+    fn reload_pending_deposit_requests(&mut self, checkpoint_timestamp_ms: u64) {
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
         deposit_requests.sort_by_key(|r| r.timestamp_ms);
         let deposit_ids: HashSet<Address> =
@@ -344,11 +348,23 @@ impl LeaderService {
             .into_iter()
             .filter(|request| !self.never_retry_deposit_ids.contains(&request.id))
             .collect();
+        self.last_deposit_worklist_reload_ts_ms = checkpoint_timestamp_ms;
         debug!(
             pending_deposits = self.pending_deposit_requests.len(),
             never_retry_deposits = self.never_retry_deposit_ids.len(),
             "Reloaded pending deposit worklist"
         );
+    }
+
+    // Time-based reload bound so Confirm-phase transitions still fire when
+    // BTC blocks are sparse, while keeping retry pressure rate-limited.
+    fn maybe_reload_pending_deposit_requests(&mut self, checkpoint_timestamp_ms: u64) {
+        if checkpoint_timestamp_ms.saturating_sub(self.last_deposit_worklist_reload_ts_ms)
+            < DEPOSIT_WORKLIST_REFRESH_INTERVAL_MS
+        {
+            return;
+        }
+        self.reload_pending_deposit_requests(checkpoint_timestamp_ms);
     }
 
     fn is_reconfiguring(&self) -> bool {

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -156,6 +156,12 @@ impl LeaderService {
         let mut checkpoint_rx = self.inner.onchain_state().subscribe_checkpoint();
         let mut btc_block_rx = self.inner.btc_monitor().subscribe_block_height();
 
+        // Re-armed each Bitcoin block to reload the worklist once after the deposit
+        // time-delay, so Sui-clock-gated Confirm transitions aren't stuck between blocks.
+        let deferred_deposit_reload = tokio::time::sleep(Duration::ZERO);
+        tokio::pin!(deferred_deposit_reload);
+        let mut deferred_deposit_reload_armed = false;
+
         loop {
             trace!("Waiting for next checkpoint or task completion...");
             tokio::select! {
@@ -205,6 +211,12 @@ impl LeaderService {
                     // avoid only the leader being able to reload the moment a block is seen.
                     self.reload_pending_deposit_requests();
 
+                    let delay_ms = self.inner.onchain_state().bitcoin_deposit_time_delay_ms();
+                    deferred_deposit_reload
+                        .as_mut()
+                        .reset(tokio::time::Instant::now() + Duration::from_millis(delay_ms));
+                    deferred_deposit_reload_armed = true;
+
                     if !self.is_current_leader(checkpoint_height) {
                         continue;
                     }
@@ -213,6 +225,16 @@ impl LeaderService {
 
                     self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
                     self.process_deposit_requests();
+                }
+                () = &mut deferred_deposit_reload, if deferred_deposit_reload_armed => {
+                    deferred_deposit_reload_armed = false;
+                    // Reload for all (like the block arm); only the leader processes.
+                    self.reload_pending_deposit_requests();
+                    let checkpoint_height = checkpoint_rx.borrow().height;
+                    if self.is_current_leader(checkpoint_height) {
+                        debug!("Deposit time-delay elapsed; re-processing deposit worklist");
+                        self.process_deposit_requests();
+                    }
                 }
                 Some(result) = self.deposit_tasks.join_next() => {
                     self.handle_completed_deposit_task(result);


### PR DESCRIPTION
## Issue

We only reload the deposit worklist when a new Bitcoin block arrives. But a deposit's Confirm phase is gated on the Sui clock (`bitcoin_deposit_time_delay_ms`), and a successful Approve task drops the deposit from the worklist — so once approved, a deposit's confirmation waits for the *next Bitcoin block* to reload the worklist, even though the delay it's waiting on is a Sui-clock quantity. With sparse blocks, approved deposits sit idle between blocks.

## Changes

Re-arm a one-shot timer on each Bitcoin block that fires `bitcoin_deposit_time_delay_ms` later and reloads the worklist once. Once a deposit is back in the worklist the existing per-checkpoint re-evaluation handles the precise Confirm timing.

Reloads stay block-paced (at most ~2 per block) so transient-failure retries remain rate-limited per #480 — unlike a fixed-interval poll, which would retry failures unboundedly when the queue can't drain in time and revive the log spam #480 fixed.
