### PR TITLE
docs: add GitHub Pages PR-preview workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,11 +34,36 @@ jobs:
       - name: Build Docusaurus site
         run: cd design && npm run build
 
-      - name: stage build artifacts
+      - name: Stage build artifacts
         run: |
-          mkdir site
+          mkdir -p site
           mv ./target/doc site/rustdoc
           mv design/build site/design
+
+      # We deploy with `force_orphan: true` so the gh-pages branch stays a
+      # single orphan commit (no history accumulation), but that wipes the
+      # branch contents — which would blow away the `pr-preview/` directory
+      # the .github/workflows/pages-preview.yaml workflow writes there.
+      #
+      # To keep both properties (single-commit history + live PR previews),
+      # we explicitly fetch any existing `pr-preview/` from gh-pages and
+      # carry it into the deploy folder so it round-trips through the
+      # orphan rewrite.
+      - name: Preserve pr-preview directories from prior gh-pages
+        run: |
+          set -euo pipefail
+          if git fetch origin gh-pages --depth=1 2>/dev/null; then
+            git worktree add /tmp/gh-pages-prev origin/gh-pages
+            if [ -d /tmp/gh-pages-prev/pr-preview ]; then
+              cp -R /tmp/gh-pages-prev/pr-preview site/pr-preview
+              echo "Preserved $(ls /tmp/gh-pages-prev/pr-preview | wc -l | tr -d ' ') PR preview directory(ies)"
+            else
+              echo "No pr-preview/ directory on gh-pages — nothing to preserve"
+            fi
+            git worktree remove --force /tmp/gh-pages-prev
+          else
+            echo "gh-pages branch does not exist yet — fresh deploy"
+          fi
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -1,0 +1,67 @@
+name: Build and deploy GitHub Pages preview for PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    paths:
+      - "design/**"
+      - ".github/workflows/pages-preview.yaml"
+
+concurrency: preview-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Validates that the docs build on every PR (link checks, MDX syntax,
+  # broken-anchor checks). Runs on all PR events except `closed`.
+  build-with-linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: design/package-lock.json
+        if: github.event.action != 'closed'
+      - name: Install dependencies
+        run: cd design && npm ci
+        if: github.event.action != 'closed'
+      - name: Build site
+        run: cd design && npm run build
+        if: github.event.action != 'closed'
+
+  # Publishes the built site to gh-pages under /hashi/pr-preview/pr-<N>/
+  # using rossjrw/pr-preview-action. On `closed`, the action removes the
+  # preview directory and updates the PR comment.
+  preview:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'MystenLabs'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: design/package-lock.json
+        if: github.event.action != 'closed'
+      - name: Install dependencies
+        run: cd design && npm ci
+        if: github.event.action != 'closed'
+      - name: Build site
+        run: cd design && DOCUSAURUS_BASE_URL="/hashi/pr-preview/pr-${{ github.event.number }}/" npm run build
+        if: github.event.action != 'closed'
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1.8.1
+        with:
+          source-dir: design/build
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/design/docusaurus.config.js
+++ b/design/docusaurus.config.js
@@ -17,6 +17,12 @@ const remarkGlossary =
   require('./src/shared/plugins/remark-glossary.js').default ||
   require('./src/shared/plugins/remark-glossary.js');
 
+// Base URL for the site. Production deploys (gh-pages.yml) leave this at the
+// default. PR-preview deploys (pages-preview.yaml) override it to
+// `/hashi/pr-preview/pr-<N>/` so static assets and routes resolve correctly
+// against the preview path.
+const baseUrl = process.env.DOCUSAURUS_BASE_URL || '/hashi/design/';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Hashi',
@@ -28,7 +34,7 @@ const config = {
   },
 
   url: 'https://mystenlabs.github.io',
-  baseUrl: '/hashi/design/',
+  baseUrl,
 
   organizationName: 'MystenLabs',
   projectName: 'hashi',
@@ -64,7 +70,7 @@ const config = {
       'data-modal-ask-ai-input-placeholder': 'Ask me anything about Hashi!',
       'data-modal-example-questions':
         'How does the deposit flow work?,What does the Guardian do?,How does Hashi handle Bitcoin reorganizations?,What are the MPC committee thresholds?',
-      'data-modal-image': '/hashi/design/img/logo.svg',
+      'data-modal-image': `${baseUrl}img/logo.svg`,
       async: true,
     },
   ],
@@ -84,7 +90,7 @@ const config = {
                 attributes: {
                   rel: 'alternate',
                   type: 'text/plain',
-                  href: '/hashi/design/llms.txt',
+                  href: `${baseUrl}llms.txt`,
                   title: 'LLMs.txt',
                 },
               },
@@ -142,7 +148,12 @@ const config = {
     [
       require.resolve('./src/shared/plugins/plausible'),
       {
-        domain: 'mystenlabs.github.io/hashi/design',
+        // Tracking is suppressed on PR previews so they don't pollute the
+        // production Plausible domain. The plugin's client bails out when
+        // `domain` is empty.
+        domain: process.env.DOCUSAURUS_BASE_URL
+          ? ''
+          : 'mystenlabs.github.io/hashi/design',
         enableInDev: false,
         trackOutboundLinks: true,
         hashMode: false,
@@ -233,7 +244,7 @@ const config = {
             position: 'right',
             value:
               '<button type="button" class="kapa-trigger-btn" onclick="window.Kapa && window.Kapa.open()" aria-label="Ask Hashi AI">' +
-              '<img src="/hashi/design/img/logo.svg" alt="" width="20" height="20" />' +
+              `<img src="${baseUrl}img/logo.svg" alt="" width="20" height="20" />` +
               '<span class="kapa-trigger-btn__label">Ask Hashi AI</span>' +
               '</button>',
           },


### PR DESCRIPTION
Mirrors the pages-preview workflow Seal uses:
https://github.com/MystenLabs/seal/blob/main/.github/workflows/pages-preview.yaml

On every PR that touches `design/**`:
- `build-with-linkcheck` job runs `npm run build` (catches broken links, MDX syntax errors, broken anchors before merge).
- `preview` job builds the site with `DOCUSAURUS_BASE_URL=/hashi/pr-preview/pr-<N>/` and publishes it to the gh-pages branch under `pr-preview/pr-<N>/` via `rossjrw/pr-preview-action`. The action posts a sticky comment on the PR with the preview URL and removes the directory when the PR is closed.

Config changes to support the preview build:
- `baseUrl` reads `DOCUSAURUS_BASE_URL` env var, falling back to the production path (`/hashi/design/`).
- Hardcoded `/hashi/design/...` paths in the kapa modal image, kapa navbar trigger img src, and the llms-txt directive link now use the computed `${baseUrl}` so they resolve under any deploy target.
- Plausible tracking is suppressed on previews (empty `domain:` makes the client bail out), so preview pageviews don't pollute prod analytics.

Verified both builds emit correct paths:
- prod: `data-modal-image="/hashi/design/img/logo.svg"` etc.
- preview: `data-modal-image="/hashi/pr-preview/pr-99/img/logo.svg"` etc.