### PR TITLE
[metrics] exclude /health from RPC metrics layer

### DIFF
--- a/crates/hashi/src/grpc/mod.rs
+++ b/crates/hashi/src/grpc/mod.rs
@@ -109,7 +109,10 @@ impl HttpService {
                 metrics_layer::RpcMetricsMakeCallbackHandler::server(self.inner.metrics.clone()),
             ));
 
-        let router = router.merge(health_endpoint).layer(layers);
+        // /health must be merged AFTER the metrics layer so it bypasses RPC
+        // metrics — otherwise its raw HTTP status="200" trips `status!="ok"`
+        // dashboards.
+        let router = router.layer(layers).merge(health_endpoint);
 
         let tls_config =
             crate::tls::make_server_config(self.inner.config.tls_private_key().unwrap());


### PR DESCRIPTION
## Summary

- Kubelet probes hit \`/health\` every 30s. The endpoint returns plain text, so the metrics middleware's non-gRPC branch records \`hashi_requests{path=\"/health\",status=\"200\"}\` (raw HTTP code) instead of \`status=\"ok\"\` — Grafana panels filtering on \`status!=\"ok\"\` then show 100% error rate for the probe path.
- Verified live on \`hashi-devnet/hashi-server-1\`: \`hashi_requests{path=\"/health\",role=\"server\",status=\"200\"} 85\` vs gRPC paths with \`status=\"ok\"\`.
- Fix: swap \`.merge(health_endpoint).layer(layers)\` → \`.layer(layers).merge(health_endpoint)\`. Axum applies layers only to routes present at the time of the \`.layer()\` call, so \`/health\` added afterwards bypasses both the metrics callback and the validator-lookup middleware (neither of which it needs).

## Test plan

- [ ] \`cargo nextest run -p hashi\`
- [ ] Deploy to devnet, confirm \`hashi_requests{path=\"/health\"}\` no longer appears in \`/metrics\`
- [ ] Confirm Grafana panel error rate returns to baseline