### PR TITLE
Allow guardian configuration at publish time

### DIFF
--- a/crates/e2e-tests/src/publish.rs
+++ b/crates/e2e-tests/src/publish.rs
@@ -22,5 +22,5 @@ pub async fn publish(
     };
     let compiled = hashi::publish::build_package(&params)?;
     let bitcoin_chain_id = hashi::constants::BITCOIN_REGTEST_CHAIN_ID;
-    hashi::publish::publish_and_init(client, private_key, compiled, bitcoin_chain_id).await
+    hashi::publish::publish_and_init(client, private_key, compiled, bitcoin_chain_id, None).await
 }

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -5,6 +5,7 @@
 //!
 //! Provides governance, committee, and configuration management commands.
 
+use anyhow::Context;
 use clap::Args;
 use clap::Subcommand;
 use clap::ValueEnum;
@@ -508,6 +509,14 @@ pub struct PublishOpts {
     #[clap(long)]
     pub bitcoin_chain_id: String,
 
+    /// Guardian gRPC endpoint URL (optional)
+    #[clap(long)]
+    pub guardian_url: Option<String>,
+
+    /// Guardian signing public key, hex-encoded (optional, requires --guardian-url)
+    #[clap(long)]
+    pub guardian_public_key: Option<String>,
+
     /// Enable verbose output
     #[clap(long, short)]
     pub verbose: bool,
@@ -888,11 +897,27 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
     // Connect to RPC
     let mut client = sui_rpc::Client::new(&opts.sui_rpc_url)?;
 
+    // Build optional guardian config
+    let guardian = match (opts.guardian_url, opts.guardian_public_key) {
+        (Some(url), Some(pk_hex)) => {
+            let public_key = hex::decode(pk_hex.strip_prefix("0x").unwrap_or(&pk_hex))
+                .context("Invalid hex for --guardian-public-key")?;
+            Some(crate::publish::GuardianConfig { url, public_key })
+        }
+        (None, None) => None,
+        _ => anyhow::bail!("--guardian-url and --guardian-public-key must both be provided or both omitted"),
+    };
+
     // Publish + init
     print_info("Publishing and initializing ...");
-    let ids =
-        crate::publish::publish_and_init(&mut client, &signer, compiled, &opts.bitcoin_chain_id)
-            .await?;
+    let ids = crate::publish::publish_and_init(
+        &mut client,
+        &signer,
+        compiled,
+        &opts.bitcoin_chain_id,
+        guardian.as_ref(),
+    )
+    .await?;
     print_success(&format!("package_id:      {}", ids.package_id));
     print_success(&format!("hashi_object_id: {}", ids.hashi_object_id));
 

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -905,7 +905,9 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
             Some(crate::publish::GuardianConfig { url, public_key })
         }
         (None, None) => None,
-        _ => anyhow::bail!("--guardian-url and --guardian-public-key must both be provided or both omitted"),
+        _ => anyhow::bail!(
+            "--guardian-url and --guardian-public-key must both be provided or both omitted"
+        ),
     };
 
     // Publish + init

--- a/crates/hashi/src/publish.rs
+++ b/crates/hashi/src/publish.rs
@@ -101,13 +101,19 @@ stderr: {}",
     })
 }
 
+/// Optional guardian configuration for post-publish initialization.
+pub struct GuardianConfig {
+    pub url: String,
+    pub public_key: Vec<u8>,
+}
+
 /// Publish the compiled package and run post-publish initialization.
 ///
 /// Executes two transactions:
 ///
 /// 1. **Publish** – publishes the modules, transfers the `UpgradeCap` to the sender.
 /// 2. **Init** – calls `hashi::finish_publish` to register BTC, the upgrade cap,
-///    and set the bitcoin chain ID.
+///    set the bitcoin chain ID, and optionally configure the guardian.
 ///
 /// Returns the [`HashiIds`] (package ID + Hashi shared-object ID) on success.
 pub async fn publish_and_init(
@@ -115,6 +121,7 @@ pub async fn publish_and_init(
     signer: &Ed25519PrivateKey,
     publish: sui_sdk_types::Publish,
     bitcoin_chain_id: &str,
+    guardian: Option<&GuardianConfig>,
 ) -> Result<HashiIds> {
     let sender = signer.public_key().derive_address();
 
@@ -204,6 +211,8 @@ pub async fn publish_and_init(
     );
     let upgrade_cap_arg = builder.object(ObjectInput::new(upgrade_cap_id).as_owned());
     let bitcoin_chain_id_arg = builder.pure(&bitcoin_chain_id_addr);
+    let guardian_url_arg = builder.pure(&guardian.map(|g| g.url.as_str()));
+    let guardian_public_key_arg = builder.pure(&guardian.map(|g| g.public_key.as_slice()));
     let coin_registry_arg = builder.object(
         ObjectInput::new(COIN_REGISTRY_OBJECT_ID)
             .as_shared()
@@ -220,6 +229,8 @@ pub async fn publish_and_init(
             hashi_arg,
             upgrade_cap_arg,
             bitcoin_chain_id_arg,
+            guardian_url_arg,
+            guardian_public_key_arg,
             coin_registry_arg,
         ],
     );

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -13,6 +13,7 @@ use hashi::{
     threshold,
     treasury::Treasury
 };
+use std::string::String;
 use sui::{bag::{Self, Bag}, dynamic_field as df};
 
 #[error]
@@ -101,6 +102,8 @@ entry fun finish_publish(
     self: &mut Hashi,
     upgrade_cap: sui::package::UpgradeCap,
     bitcoin_chain_id: address,
+    guardian_url: Option<String>,
+    guardian_public_key: Option<vector<u8>>,
     coin_registry: &mut sui::coin_registry::CoinRegistry,
     ctx: &mut TxContext,
 ) {
@@ -112,6 +115,16 @@ entry fun finish_publish(
 
     self.config_mut().set_upgrade_cap(upgrade_cap);
     hashi::btc_config::set_bitcoin_chain_id(self.config_mut(), bitcoin_chain_id);
+
+    if (guardian_url.is_some() && guardian_public_key.is_some()) {
+        self.config_mut().set_guardian(
+            guardian_url.destroy_some(),
+            guardian_public_key.destroy_some(),
+        );
+    } else {
+        guardian_url.destroy_none();
+        guardian_public_key.destroy_none();
+    };
 
     let (treasury_cap, metadata_cap) = hashi::btc::create(coin_registry, ctx);
     self.treasury.register_treasury_cap(treasury_cap);

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -117,10 +117,12 @@ entry fun finish_publish(
     hashi::btc_config::set_bitcoin_chain_id(self.config_mut(), bitcoin_chain_id);
 
     if (guardian_url.is_some() && guardian_public_key.is_some()) {
-        self.config_mut().set_guardian(
-            guardian_url.destroy_some(),
-            guardian_public_key.destroy_some(),
-        );
+        self
+            .config_mut()
+            .set_guardian(
+                guardian_url.destroy_some(),
+                guardian_public_key.destroy_some(),
+            );
     } else {
         guardian_url.destroy_none();
         guardian_public_key.destroy_none();


### PR DESCRIPTION
## Summary
- Adds optional `guardian_url` and `guardian_public_key` parameters to `finish_publish` so the guardian can be configured at deploy time instead of requiring a governance proposal
- Adds `--guardian-url` and `--guardian-public-key` CLI flags to the publish command
- Both must be provided together or both omitted; e2e tests pass `None` (no guardian in localnet)

## Test plan
- [ ] `sui move build` and `sui move test` pass
- [ ] `cargo build` passes
- [ ] Publish to devnet with guardian params and verify config is set
- [ ] Publish to devnet without guardian params and verify it still works