### PR TITLE
[guardian][leader] use checkpoint timestamp for guardian flow

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -478,7 +478,22 @@ mod tests {
                 .local_limiter()
                 .expect("local limiter present after bootstrap")
                 .snapshot();
-            assert_eq!(local_state, guardian_state);
+            // `last_updated_at` can drift a few seconds — watcher uses the
+            // event-carrying checkpoint, guardian the leader's signing one.
+            assert_eq!(local_state.next_seq, guardian_state.next_seq);
+            assert_eq!(
+                local_state.num_tokens_available,
+                guardian_state.num_tokens_available,
+            );
+            let drift = local_state
+                .last_updated_at
+                .checked_sub(guardian_state.last_updated_at);
+            assert!(
+                matches!(drift, Some(0..=60)),
+                "local last_updated_at ({}) must be 0–60s after guardian's ({})",
+                local_state.last_updated_at,
+                guardian_state.last_updated_at,
+            );
         }
 
         info!("=== Bitcoin Withdrawal E2E Test{label} Passed ===");

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1361,10 +1361,14 @@ impl LeaderService {
         }
         info!("MPC signing withdrawal transaction");
 
+        // Fresh per-attempt timestamp from the leader's current checkpoint;
+        // using `txn.timestamp_ms` lets stuck batches age past the per-node
+        // `GUARDIAN_TIMESTAMP_TOLERANCE_SECS` check on retries.
+        let timestamp_secs = inner.onchain_state().latest_checkpoint_timestamp_ms() / 1000;
+
         // Fail fast before MPC if our own limiter would reject.
         let expected_limiter_seq = if let Some(limiter) = inner.local_limiter() {
             let amount_sats = crate::withdrawals::withdrawal_limiter_consumption_amount(&txn);
-            let timestamp_secs = txn.timestamp_ms / 1000;
             let next_seq = limiter.next_seq();
             let result = limiter.validate_consume(next_seq, timestamp_secs, amount_sats);
             inner.metrics.record_limiter_validate(
@@ -1404,9 +1408,10 @@ impl LeaderService {
             .map(|s| s.to_byte_array().to_vec())
             .collect();
 
-        // 3. Post-MPC: forward to guardian for the enclave signature.
+        // 3. Post-MPC: forward to guardian for the enclave signature. Reuses
+        // the `timestamp_secs` from the pre-MPC validate so the BLS-signed
+        // certificate covers a consistent `(timestamp, seq, amount)` triple.
         if let (Some(guardian), Some(seq)) = (inner.guardian_client(), expected_limiter_seq) {
-            let timestamp_secs = txn.timestamp_ms / 1000;
             Self::finalize_withdrawal_through_guardian(
                 &inner,
                 &txn,

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -143,7 +143,7 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
                 }
             }
 
-            handle_events(&mut client, &state, &events).await;
+            handle_events(&mut client, &state, timestamp_ms, &events).await;
 
             // Finally update the latest checkpoint info
             state.update_latest_checkpoint_info(CheckpointInfo {
@@ -159,7 +159,12 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
     }
 }
 
-async fn handle_events(client: &mut Client, state: &OnchainState, events: &[HashiEvent]) {
+async fn handle_events(
+    client: &mut Client,
+    state: &OnchainState,
+    checkpoint_timestamp_ms: u64,
+    events: &[HashiEvent],
+) {
     if events.is_empty() {
         return;
     }
@@ -442,6 +447,9 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                 tracing::info!(withdrawal_txn_id = %event.withdrawal_txn_id, "Withdrawal signatures stored on-chain");
                 // Watcher is the sole mutator of the local limiter
                 // post-bootstrap; advance it inline with the mirror update.
+                // Advance uses the event's checkpoint timestamp (~sign-time)
+                // rather than `txn.timestamp_ms` (creation time) to stay in
+                // lockstep with the guardian's `last_updated_at`.
                 let limiter_inputs = {
                     let mut state = state.state_mut();
                     state
@@ -452,7 +460,7 @@ async fn handle_events(client: &mut Client, state: &OnchainState, events: &[Hash
                         .map(|txn| {
                             txn.signatures = Some(event.signatures.clone());
                             let amount_sats = withdrawal_limiter_consumption_amount(txn);
-                            let timestamp_secs = txn.timestamp_ms / 1000;
+                            let timestamp_secs = checkpoint_timestamp_ms / 1000;
                             (amount_sats, timestamp_secs)
                         })
                 };


### PR DESCRIPTION
Previously, we were using the txn.timestamp_ms , which is set once at batch creation. this can cause issues if the guardian limit has reached and we have to wait, since it causes us to cross the 600 sec window `GUARDIAN_TIMESTAMP_TOLERANCE_SECS` .

## Changes
- Leader: derive the guardian-flow `timestamp_secs` from the current checkpoint instead of `txn.timestamp_ms`. Each retry gets a fresh one, so stuck batches don't age past the 600s tolerance check.
- Watcher: advance the local limiter using the event's checkpoint timestamp instead of `txn.timestamp_ms`. Keeps local in lockstep with the guardian's `last_updated_at`.