### PR TITLE
[mpc] recover current epoch from stored rotation messages

### DIFF
--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -1279,6 +1279,73 @@ mod tests {
         Ok(())
     }
 
+    /// All nodes restart simultaneously after `end_reconfig` for an epoch
+    /// completed. `current_output` is wiped on every node and the previous
+    /// epoch's rotation messages have been pruned, so neither of
+    /// `run_key_rotation`'s recovery sources is available. Nodes must
+    /// reconstruct `current_output` from the just-completed rotation's stored
+    /// messages and resume signing without waiting for a fresh rotation.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_coordinated_restart_after_rotation_recovers_without_new_rotation() -> Result<()> {
+        const TEST_NUM_NODES: usize = 4;
+
+        crate::test_helpers::init_test_logging();
+
+        let mut test_networks = TestNetworksBuilder::new()
+            .with_nodes(TEST_NUM_NODES)
+            .build()
+            .await?;
+
+        // Wait for initial DKG completion on all nodes.
+        assert_nodes_agree_on_mpc_key(test_networks.hashi_network().nodes()).await;
+        let initial_epoch = test_networks.hashi_network().nodes()[0]
+            .current_epoch()
+            .unwrap();
+
+        // Rotate once so the cluster reaches a state where the on-chain
+        // protocol_type is KeyRotation for the current epoch.
+        let rotation_epoch =
+            force_rotate_and_assert_key_agreement(&mut test_networks, initial_epoch + 1).await;
+        let key_after_rotation = get_mpc_key(test_networks.hashi_network().nodes());
+
+        // Coordinated restart of every node — this is the failure mode that
+        // `reconstruct_current_from_stored_rotation` exists to recover from.
+        test_networks.hashi_network_mut().restart().await?;
+
+        // Each node must come back with the same key at the same epoch,
+        // without an externally driven rotation.
+        let nodes = test_networks.hashi_network().nodes();
+        let mpc_key_futures: Vec<_> = nodes
+            .iter()
+            .map(|node| node.wait_for_mpc_key(DKG_TIMEOUT))
+            .collect();
+        let results: Vec<Result<()>> = futures::future::join_all(mpc_key_futures).await;
+        for (i, result) in results.into_iter().enumerate() {
+            result.unwrap_or_else(|e| {
+                panic!("Node {i} failed to recover MPC key after coordinated restart: {e}")
+            });
+        }
+        let key_after_restart = get_mpc_key(nodes);
+        assert_eq!(
+            key_after_rotation, key_after_restart,
+            "Recovered MPC key must match the pre-restart key",
+        );
+        for (i, node) in nodes.iter().enumerate().skip(1) {
+            let node_pk = node.hashi().mpc_handle().unwrap().public_key().unwrap();
+            assert_eq!(
+                key_after_restart, node_pk,
+                "Node {i} disagrees on the recovered MPC key",
+            );
+        }
+        assert_eq!(
+            nodes[0].current_epoch().unwrap(),
+            rotation_epoch,
+            "Recovery should not advance the epoch",
+        );
+
+        Ok(())
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_new_member_joins_key_rotation_after_dkg() -> Result<()> {
         const TOTAL_VALIDATORS: usize = 20;

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -2921,23 +2921,9 @@ impl MpcManager {
         })
     }
 
-    /// Reconstruct **this node's** `MpcOutput` for `self.mpc_config.epoch` from
-    /// the rotation messages on disk under that same epoch.
-    ///
-    /// `reconstruct_from_rotation_certificates` reconstructs the *previous*
-    /// epoch's output (the input to a not-yet-completed rotation). That path
-    /// can't be taken after a coordinated restart: `prune_messages_below(N)`
-    /// runs at the end of epoch `N`'s reconfig and wipes the previous epoch's
-    /// rotation messages, while `previous_output`/`current_output` are
-    /// in-memory only. There is no source of truth left to redo the
-    /// `N-1 -> N` rotation from.
-    ///
-    /// What *is* still on disk is each peer's rotation messages from the
-    /// just-completed `N-1 -> N` run, stored under epoch `N`. This method
-    /// uses those, decrypted with the current epoch's encryption key, to
-    /// re-derive this node's key shares for epoch `N` directly — the same
-    /// computation that `run_key_rotation_as_party` performs at the end of
-    /// the live protocol.
+    /// Re-derive this node's `MpcOutput` for `self.mpc_config.epoch` from the
+    /// rotation messages on disk under that same epoch — the data is exactly
+    /// what `run_key_rotation_as_party` would have produced live.
     pub fn reconstruct_current_from_stored_rotation(
         &mut self,
         certificates: &[CertificateV1],
@@ -2946,19 +2932,12 @@ impl MpcManager {
         let nodes = self.mpc_config.nodes.clone();
         let my_party_id = self.party_id;
         let output_threshold = self.mpc_config.threshold;
-        // Combining partial outputs needs the threshold of the source
-        // polynomial — i.e. the previous committee's threshold, which is the
-        // output threshold of the rotation that produced the shares we're
-        // decrypting.
         let input_threshold = self.previous_reconfig_output_threshold.ok_or_else(|| {
             MpcError::InvalidConfig(
                 "current-output reconstruction requires previous reconfig's output threshold"
                     .into(),
             )
         })?;
-        // Dealers used `SessionId::new(chain_id, mpc_config.epoch, KeyRotation)`
-        // when generating these messages (that's what `setup_key_rotation`
-        // sets `session_id` to before `create_rotation_messages` runs).
         let source_session_id =
             SessionId::new(&self.chain_id, current_epoch, &ProtocolType::KeyRotation);
         let mut local_outputs: HashMap<ShareIndex, avss::PartialOutput> = HashMap::new();
@@ -3005,11 +2984,7 @@ impl MpcManager {
                         local_outputs.insert(share_index, output);
                     }
                     avss::ProcessedMessage::Complaint(_) => {
-                        // A complaint here means *this* node received an
-                        // invalid share from a certified dealer, which can't
-                        // happen in a quorum that already produced a valid
-                        // on-chain certificate. Bail loudly rather than
-                        // pretending to recover.
+                        // Invalid share from an on-chain-certified dealer: bail rather than mask.
                         return Err(MpcError::ProtocolFailed(format!(
                             "Stored rotation message from dealer {:?} share {} is invalid \
                              despite being certified on-chain; cluster needs manual recovery",

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -2921,6 +2921,159 @@ impl MpcManager {
         })
     }
 
+    /// Reconstruct **this node's** `MpcOutput` for `self.mpc_config.epoch` from
+    /// the rotation messages on disk under that same epoch.
+    ///
+    /// `reconstruct_from_rotation_certificates` reconstructs the *previous*
+    /// epoch's output (the input to a not-yet-completed rotation). That path
+    /// can't be taken after a coordinated restart: `prune_messages_below(N)`
+    /// runs at the end of epoch `N`'s reconfig and wipes the previous epoch's
+    /// rotation messages, while `previous_output`/`current_output` are
+    /// in-memory only. There is no source of truth left to redo the
+    /// `N-1 -> N` rotation from.
+    ///
+    /// What *is* still on disk is each peer's rotation messages from the
+    /// just-completed `N-1 -> N` run, stored under epoch `N`. This method
+    /// uses those, decrypted with the current epoch's encryption key, to
+    /// re-derive this node's key shares for epoch `N` directly — the same
+    /// computation that `run_key_rotation_as_party` performs at the end of
+    /// the live protocol.
+    pub fn reconstruct_current_from_stored_rotation(
+        &mut self,
+        certificates: &[CertificateV1],
+    ) -> MpcResult<MpcOutput> {
+        let current_epoch = self.mpc_config.epoch;
+        let nodes = self.mpc_config.nodes.clone();
+        let my_party_id = self.party_id;
+        let output_threshold = self.mpc_config.threshold;
+        // Combining partial outputs needs the threshold of the source
+        // polynomial — i.e. the previous committee's threshold, which is the
+        // output threshold of the rotation that produced the shares we're
+        // decrypting.
+        let input_threshold = self.previous_reconfig_output_threshold.ok_or_else(|| {
+            MpcError::InvalidConfig(
+                "current-output reconstruction requires previous reconfig's output threshold"
+                    .into(),
+            )
+        })?;
+        // Dealers used `SessionId::new(chain_id, mpc_config.epoch, KeyRotation)`
+        // when generating these messages (that's what `setup_key_rotation`
+        // sets `session_id` to before `create_rotation_messages` runs).
+        let source_session_id =
+            SessionId::new(&self.chain_id, current_epoch, &ProtocolType::KeyRotation);
+        let mut local_outputs: HashMap<ShareIndex, avss::PartialOutput> = HashMap::new();
+        let mut certified_share_indices: Vec<ShareIndex> = Vec::new();
+        for cert in certificates {
+            let CertificateV1::Rotation(rotation_cert) = cert else {
+                return Err(MpcError::InvalidCertificate(
+                    "current-output reconstruction expects all Rotation certificates".into(),
+                ));
+            };
+            let cert_msg = rotation_cert.message();
+            let dealer_address = cert_msg.dealer_address;
+            let rotation_msgs = self
+                .public_messages_store
+                .get_rotation_messages(current_epoch, &dealer_address)
+                .map_err(|e| MpcError::StorageError(e.to_string()))?
+                .ok_or_else(|| {
+                    MpcError::StorageError(format!(
+                        "Rotation messages not found for dealer: {:?}",
+                        dealer_address
+                    ))
+                })?;
+            let actual_hash = compute_messages_hash(&Messages::Rotation(rotation_msgs.clone()));
+            if actual_hash != cert_msg.messages_hash {
+                return Err(MpcError::ProtocolFailed(format!(
+                    "Message hash mismatch for dealer {:?}: stored message does not match certificate",
+                    dealer_address
+                )));
+            }
+            for (share_index, message) in rotation_msgs {
+                let session_id = source_session_id
+                    .rotation_session_id(&dealer_address, share_index)
+                    .to_vec();
+                match process_avss_message(
+                    &self.encryption_key,
+                    nodes.clone(),
+                    my_party_id,
+                    output_threshold,
+                    session_id,
+                    &message,
+                    None,
+                )? {
+                    avss::ProcessedMessage::Valid(output) => {
+                        local_outputs.insert(share_index, output);
+                    }
+                    avss::ProcessedMessage::Complaint(_) => {
+                        // A complaint here means *this* node received an
+                        // invalid share from a certified dealer, which can't
+                        // happen in a quorum that already produced a valid
+                        // on-chain certificate. Bail loudly rather than
+                        // pretending to recover.
+                        return Err(MpcError::ProtocolFailed(format!(
+                            "Stored rotation message from dealer {:?} share {} is invalid \
+                             despite being certified on-chain; cluster needs manual recovery",
+                            dealer_address, share_index
+                        )));
+                    }
+                }
+                certified_share_indices.push(share_index);
+            }
+        }
+        if certified_share_indices.len() < input_threshold as usize {
+            return Err(MpcError::NotEnoughApprovals {
+                needed: input_threshold as usize,
+                got: certified_share_indices.len(),
+            });
+        }
+        let indexed_outputs: Vec<IndexedValue<avss::PartialOutput>> = certified_share_indices
+            .iter()
+            .take(input_threshold as usize)
+            .map(|&share_index| {
+                let output = local_outputs.get(&share_index).ok_or_else(|| {
+                    MpcError::ProtocolFailed(format!(
+                        "No rotation output found for share index: {}",
+                        share_index
+                    ))
+                })?;
+                Ok(IndexedValue {
+                    index: share_index,
+                    value: output.clone(),
+                })
+            })
+            .collect::<Result<_, MpcError>>()?;
+        let used_indices: Vec<_> = indexed_outputs.iter().map(|o| o.index).collect();
+        tracing::info!(
+            "reconstruct_current_from_stored_rotation: {} share_indices={:?}, \
+             output_threshold={output_threshold}, input_threshold={input_threshold}",
+            used_indices.len(),
+            used_indices,
+        );
+        let combined = avss::ReceiverOutput::complete_key_rotation(
+            input_threshold,
+            my_party_id,
+            &nodes,
+            &indexed_outputs,
+        )
+        .expect(EXPECT_THRESHOLD_MET);
+        tracing::info!(
+            "reconstruct_current_from_stored_rotation: result vk={}",
+            hex::encode(combined.vk.to_byte_array()),
+        );
+        let output = MpcOutput {
+            public_key: combined.vk,
+            key_shares: combined.my_shares,
+            commitments: combined
+                .commitments
+                .into_iter()
+                .map(|c| (c.index, c.value))
+                .collect(),
+            threshold: output_threshold,
+        };
+        self.current_output = Some(output.clone());
+        Ok(output)
+    }
+
     pub fn reconstruct_previous_output(
         &self,
         certificates: &[CertificateV1],

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -126,6 +126,28 @@ pub struct MpcManager {
     test_corrupt_shares_for: Option<Address>,
 }
 
+/// The "view" of a key rotation from one committee's perspective: which
+/// committee's nodes/encryption key to use to decrypt shares and what
+/// thresholds apply. The same on-disk rotation messages can be reconstructed
+/// from two views — the new committee's view (to rebuild the current epoch's
+/// shares) or the old committee's view (to rebuild the previous epoch's
+/// shares as input to a fresh rotation).
+struct RotationReconstructionView<'a> {
+    /// Epoch under which the rotation messages were stored on disk.
+    epoch: u64,
+    /// Receiver committee for this view.
+    nodes: &'a Nodes<EncryptionGroupElement>,
+    /// This node's party index within `nodes`.
+    party_id: PartyId,
+    /// Output threshold of `nodes`.
+    output_threshold: u16,
+    /// Threshold of the committee whose shares were rotated (the rotation's
+    /// "input" committee).
+    input_threshold: u16,
+    /// Decryption key for shares destined for `party_id` in `nodes`.
+    encryption_key: &'a PrivateKey<EncryptionGroupElement>,
+}
+
 impl MpcManager {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -2928,125 +2950,32 @@ impl MpcManager {
         &mut self,
         certificates: &[CertificateV1],
     ) -> MpcResult<MpcOutput> {
-        let current_epoch = self.mpc_config.epoch;
-        let nodes = self.mpc_config.nodes.clone();
-        let my_party_id = self.party_id;
-        let output_threshold = self.mpc_config.threshold;
         let input_threshold = self.previous_reconfig_output_threshold.ok_or_else(|| {
             MpcError::InvalidConfig(
                 "current-output reconstruction requires previous reconfig's output threshold"
                     .into(),
             )
         })?;
-        let source_session_id =
-            SessionId::new(&self.chain_id, current_epoch, &ProtocolType::KeyRotation);
-        let mut local_outputs: HashMap<ShareIndex, avss::PartialOutput> = HashMap::new();
-        let mut certified_share_indices: Vec<ShareIndex> = Vec::new();
-        for cert in certificates {
-            let CertificateV1::Rotation(rotation_cert) = cert else {
-                return Err(MpcError::InvalidCertificate(
-                    "current-output reconstruction expects all Rotation certificates".into(),
-                ));
-            };
-            let cert_msg = rotation_cert.message();
-            let dealer_address = cert_msg.dealer_address;
-            let rotation_msgs = self
-                .public_messages_store
-                .get_rotation_messages(current_epoch, &dealer_address)
-                .map_err(|e| MpcError::StorageError(e.to_string()))?
-                .ok_or_else(|| {
-                    MpcError::StorageError(format!(
-                        "Rotation messages not found for dealer: {:?}",
-                        dealer_address
-                    ))
-                })?;
-            let actual_hash = compute_messages_hash(&Messages::Rotation(rotation_msgs.clone()));
-            if actual_hash != cert_msg.messages_hash {
-                return Err(MpcError::ProtocolFailed(format!(
-                    "Message hash mismatch for dealer {:?}: stored message does not match certificate",
-                    dealer_address
-                )));
-            }
-            for (share_index, message) in rotation_msgs {
-                let session_id = source_session_id
-                    .rotation_session_id(&dealer_address, share_index)
-                    .to_vec();
-                match process_avss_message(
-                    &self.encryption_key,
-                    nodes.clone(),
-                    my_party_id,
-                    output_threshold,
-                    session_id,
-                    &message,
-                    None,
-                )? {
-                    avss::ProcessedMessage::Valid(output) => {
-                        local_outputs.insert(share_index, output);
-                    }
-                    avss::ProcessedMessage::Complaint(_) => {
-                        // Invalid share from an on-chain-certified dealer: bail rather than mask.
-                        return Err(MpcError::ProtocolFailed(format!(
-                            "Stored rotation message from dealer {:?} share {} is invalid \
-                             despite being certified on-chain; cluster needs manual recovery",
-                            dealer_address, share_index
-                        )));
-                    }
-                }
-                certified_share_indices.push(share_index);
-            }
-        }
-        if certified_share_indices.len() < input_threshold as usize {
-            return Err(MpcError::NotEnoughApprovals {
-                needed: input_threshold as usize,
-                got: certified_share_indices.len(),
-            });
-        }
-        let indexed_outputs: Vec<IndexedValue<avss::PartialOutput>> = certified_share_indices
-            .iter()
-            .take(input_threshold as usize)
-            .map(|&share_index| {
-                let output = local_outputs.get(&share_index).ok_or_else(|| {
-                    MpcError::ProtocolFailed(format!(
-                        "No rotation output found for share index: {}",
-                        share_index
-                    ))
-                })?;
-                Ok(IndexedValue {
-                    index: share_index,
-                    value: output.clone(),
-                })
-            })
-            .collect::<Result<_, MpcError>>()?;
-        let used_indices: Vec<_> = indexed_outputs.iter().map(|o| o.index).collect();
-        tracing::info!(
-            "reconstruct_current_from_stored_rotation: {} share_indices={:?}, \
-             output_threshold={output_threshold}, input_threshold={input_threshold}",
-            used_indices.len(),
-            used_indices,
-        );
-        let combined = avss::ReceiverOutput::complete_key_rotation(
+        let view = RotationReconstructionView {
+            epoch: self.mpc_config.epoch,
+            nodes: &self.mpc_config.nodes,
+            party_id: self.party_id,
+            output_threshold: self.mpc_config.threshold,
             input_threshold,
-            my_party_id,
-            &nodes,
-            &indexed_outputs,
-        )
-        .expect(EXPECT_THRESHOLD_MET);
-        tracing::info!(
-            "reconstruct_current_from_stored_rotation: result vk={}",
-            hex::encode(combined.vk.to_byte_array()),
-        );
-        let output = MpcOutput {
-            public_key: combined.vk,
-            key_shares: combined.my_shares,
-            commitments: combined
-                .commitments
-                .into_iter()
-                .map(|c| (c.index, c.value))
-                .collect(),
-            threshold: output_threshold,
+            encryption_key: &self.encryption_key,
         };
-        self.current_output = Some(output.clone());
-        Ok(output)
+        match self.reconstruct_rotation_in_view(&view, certificates, None)? {
+            ReconstructionOutcome::Success(output) => {
+                self.current_output = Some(output.clone());
+                Ok(output)
+            }
+            // `complaint_cache: None` turns any complaint into ProtocolFailed,
+            // so no NeedsComplaintRecovery outcome can reach this point.
+            ReconstructionOutcome::NeedsDkgComplaintRecovery { .. }
+            | ReconstructionOutcome::NeedsRotationComplaintRecovery { .. } => unreachable!(
+                "reconstruct_rotation_in_view without a complaint cache returns only Success or an error"
+            ),
+        }
     }
 
     pub fn reconstruct_previous_output(
@@ -3207,10 +3136,10 @@ impl MpcManager {
         certificates: &[CertificateV1],
         complaint_cache: &HashMap<DealerOutputsKey, avss::PartialOutput>,
     ) -> MpcResult<ReconstructionOutcome> {
-        let previous_nodes = self.previous_nodes.clone().ok_or_else(|| {
+        let previous_nodes = self.previous_nodes.as_ref().ok_or_else(|| {
             MpcError::InvalidConfig("Rotation reconstruction requires previous nodes".into())
         })?;
-        let previous_committee = self.previous_committee.clone().ok_or_else(|| {
+        let previous_committee = self.previous_committee.as_ref().ok_or_else(|| {
             MpcError::InvalidConfig("Rotation reconstruction requires previous committee".into())
         })?;
         let previous_party_id = previous_committee.index_of(&self.address).ok_or_else(|| {
@@ -3228,27 +3157,57 @@ impl MpcManager {
                     .into(),
             )
         })?;
-        let source_session_id = SessionId::new(
-            &self.chain_id,
-            self.previous_epoch,
-            &ProtocolType::KeyRotation,
-        );
-        // Each dealer only rotates their own shares from the previous epoch, so share indices
-        // are unique across dealers (no duplicates in `certified_share_indices`).
+        let previous_encryption_key = self.previous_encryption_key.as_ref().ok_or_else(|| {
+            MpcError::InvalidConfig(
+                "Rotation reconstruction requires previous encryption key".into(),
+            )
+        })?;
+        let view = RotationReconstructionView {
+            epoch: self.previous_epoch,
+            nodes: previous_nodes,
+            party_id: previous_party_id,
+            output_threshold,
+            input_threshold,
+            encryption_key: previous_encryption_key,
+        };
+        self.reconstruct_rotation_in_view(&view, certificates, Some(complaint_cache))
+    }
+
+    /// Walks the rotation `certificates`, decrypts the on-disk rotation
+    /// messages they cover for the receiver described by `view`, and combines
+    /// the resulting shares into an `MpcOutput`.
+    ///
+    /// `complaint_cache` controls how invalid-share complaints are handled:
+    /// - `None` — the caller has no recovery loop (e.g. post-`end_reconfig`
+    ///   recovery, where the stored data is by construction valid). Any
+    ///   complaint becomes `ProtocolFailed`.
+    /// - `Some(cache)` — the caller is iterating with complaint recovery. The
+    ///   cache is consulted before processing each share, and a complaint is
+    ///   surfaced as `NeedsRotationComplaintRecovery` for the caller to drive.
+    ///
+    /// Each dealer only rotates their own shares, so share indices are unique
+    /// across dealers (no duplicates in `certified_share_indices`).
+    fn reconstruct_rotation_in_view(
+        &self,
+        view: &RotationReconstructionView<'_>,
+        certificates: &[CertificateV1],
+        complaint_cache: Option<&HashMap<DealerOutputsKey, avss::PartialOutput>>,
+    ) -> MpcResult<ReconstructionOutcome> {
+        let source_session_id =
+            SessionId::new(&self.chain_id, view.epoch, &ProtocolType::KeyRotation);
         let mut local_outputs: HashMap<ShareIndex, avss::PartialOutput> = HashMap::new();
-        let mut certified_share_indices = Vec::new();
+        let mut certified_share_indices: Vec<ShareIndex> = Vec::new();
         for cert in certificates {
             let CertificateV1::Rotation(rotation_cert) = cert else {
                 return Err(MpcError::InvalidCertificate(
                     "Mixed certificate types: expected all Rotation certificates".into(),
                 ));
             };
-            let msg = rotation_cert.message();
-            let dealer_address = msg.dealer_address;
-            let previous_epoch = self.previous_epoch;
+            let cert_msg = rotation_cert.message();
+            let dealer_address = cert_msg.dealer_address;
             let rotation_msgs = self
                 .public_messages_store
-                .get_rotation_messages(previous_epoch, &dealer_address)
+                .get_rotation_messages(view.epoch, &dealer_address)
                 .map_err(|e| MpcError::StorageError(e.to_string()))?
                 .ok_or_else(|| {
                     MpcError::StorageError(format!(
@@ -3256,19 +3215,19 @@ impl MpcManager {
                         dealer_address
                     ))
                 })?;
-            let messages = Messages::Rotation(rotation_msgs.clone());
-            let actual_hash = compute_messages_hash(&messages);
-            if actual_hash != msg.messages_hash {
+            let actual_hash = compute_messages_hash(&Messages::Rotation(rotation_msgs.clone()));
+            if actual_hash != cert_msg.messages_hash {
                 return Err(MpcError::ProtocolFailed(format!(
                     "Message hash mismatch for dealer {:?}: stored message does not match certificate",
                     dealer_address
                 )));
             }
             for (share_index, message) in rotation_msgs {
-                if let Some(output) = complaint_cache.get(&DealerOutputsKey::Rotation(share_index))
+                if let Some(cache) = complaint_cache
+                    && let Some(output) = cache.get(&DealerOutputsKey::Rotation(share_index))
                 {
                     tracing::info!(
-                        "reconstruct_from_rotation_certificates: complaint cache hit for \
+                        "reconstruct_rotation_in_view: complaint cache hit for \
                          dealer {:?} share_index={share_index}",
                         dealer_address,
                     );
@@ -3279,17 +3238,11 @@ impl MpcManager {
                 let session_id = source_session_id
                     .rotation_session_id(&dealer_address, share_index)
                     .to_vec();
-                let previous_encryption_key =
-                    self.previous_encryption_key.as_ref().ok_or_else(|| {
-                        MpcError::InvalidConfig(
-                            "Rotation reconstruction requires previous encryption key".into(),
-                        )
-                    })?;
                 match process_avss_message(
-                    previous_encryption_key,
-                    previous_nodes.clone(),
-                    previous_party_id,
-                    output_threshold,
+                    view.encryption_key,
+                    view.nodes.clone(),
+                    view.party_id,
+                    view.output_threshold,
                     session_id,
                     &message,
                     None,
@@ -3298,28 +3251,38 @@ impl MpcManager {
                         local_outputs.insert(share_index, output);
                     }
                     avss::ProcessedMessage::Complaint(complaint) => {
-                        return Ok(ReconstructionOutcome::NeedsRotationComplaintRecovery {
-                            dealer_address,
-                            share_index,
-                            complaint,
-                            message,
-                        });
+                        return match complaint_cache {
+                            // Invalid share from an on-chain-certified dealer:
+                            // bail rather than mask.
+                            None => Err(MpcError::ProtocolFailed(format!(
+                                "Stored rotation message from dealer {:?} share {} is invalid \
+                                 despite being certified on-chain; cluster needs manual recovery",
+                                dealer_address, share_index
+                            ))),
+                            Some(_) => Ok(ReconstructionOutcome::NeedsRotationComplaintRecovery {
+                                dealer_address,
+                                share_index,
+                                complaint,
+                                message,
+                            }),
+                        };
                     }
                 }
                 certified_share_indices.push(share_index);
             }
         }
-        // Unlike normal flow which accumulates until threshold in a loop, reconstruction
-        // receives all certificates at once. Check threshold for better error handling.
-        if certified_share_indices.len() < input_threshold as usize {
+        // Unlike normal flow which accumulates until threshold in a loop,
+        // reconstruction receives all certificates at once. Check threshold for
+        // better error handling.
+        if certified_share_indices.len() < view.input_threshold as usize {
             return Err(MpcError::NotEnoughApprovals {
-                needed: input_threshold as usize,
+                needed: view.input_threshold as usize,
                 got: certified_share_indices.len(),
             });
         }
         let indexed_outputs: Vec<IndexedValue<avss::PartialOutput>> = certified_share_indices
             .iter()
-            .take(input_threshold as usize)
+            .take(view.input_threshold as usize)
             .map(|&share_index| {
                 let output = local_outputs.get(&share_index).ok_or_else(|| {
                     MpcError::ProtocolFailed(format!(
@@ -3335,20 +3298,24 @@ impl MpcManager {
             .collect::<Result<_, MpcError>>()?;
         let used_indices: Vec<_> = indexed_outputs.iter().map(|o| o.index).collect();
         tracing::info!(
-            "reconstruct_from_rotation_certificates: {} share_indices={:?}, \
-             output_threshold={output_threshold}, input_threshold={input_threshold}",
+            "reconstruct_rotation_in_view: epoch={} {} share_indices={:?}, \
+             output_threshold={}, input_threshold={}",
+            view.epoch,
             used_indices.len(),
             used_indices,
+            view.output_threshold,
+            view.input_threshold,
         );
         let combined = avss::ReceiverOutput::complete_key_rotation(
-            input_threshold,
-            previous_party_id,
-            &previous_nodes,
+            view.input_threshold,
+            view.party_id,
+            view.nodes,
             &indexed_outputs,
         )
         .expect(EXPECT_THRESHOLD_MET);
         tracing::info!(
-            "reconstruct_from_rotation_certificates: result vk={}",
+            "reconstruct_rotation_in_view: epoch={} result vk={}",
+            view.epoch,
             hex::encode(combined.vk.to_byte_array()),
         );
         Ok(ReconstructionOutcome::Success(MpcOutput {
@@ -3359,7 +3326,7 @@ impl MpcManager {
                 .into_iter()
                 .map(|c| (c.index, c.value))
                 .collect(),
-            threshold: output_threshold,
+            threshold: view.output_threshold,
         }))
     }
 

--- a/crates/hashi/src/mpc/mpc_except_signing_tests.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing_tests.rs
@@ -8271,6 +8271,190 @@ fn test_reconstruct_from_rotation_certificates_with_shifted_party_ids() {
     );
 }
 
+/// Recovers the current epoch's `MpcOutput` from rotation messages stored on
+/// disk under that same epoch. This is the fast-path used after a coordinated
+/// restart that loses `current_output` from memory but leaves the just-
+/// completed rotation's messages intact on disk.
+#[test]
+fn test_reconstruct_current_from_stored_rotation() {
+    let mut rng = rand::thread_rng();
+
+    // Step 1: complete DKG at epoch 100 with 5 weighted members
+    // (weights [3, 2, 4, 1, 2], total = 12, threshold = 4).
+    let rotation_setup = RotationTestSetup::new();
+    let dkg_epoch = rotation_setup.setup.epoch();
+    let mut dkg_outputs = Vec::new();
+    for i in 0..5 {
+        let (_, output) = rotation_setup.create_receiver_with_completed_dkg(i);
+        dkg_outputs.push(output);
+    }
+    let expected_public_key = dkg_outputs[0].public_key;
+
+    // Step 2: stage a rotation to epoch 101 keeping the same 5 members and
+    // produce rotation certificates from three dealers (weights 3+2+2 = 7
+    // ≥ threshold 4).
+    let rotation_epoch = dkg_epoch + 1;
+    let members: Vec<_> = rotation_setup.setup.committee().members().to_vec();
+    let committee_at_100 = Committee::new(
+        members.clone(),
+        dkg_epoch,
+        TEST_THRESHOLD_IN_BASIS_POINTS,
+        TEST_WEIGHT_REDUCTION_ALLOWED_DELTA,
+        TEST_MAX_FAULTY_IN_BASIS_POINTS,
+    );
+    let committee_at_101 = Committee::new(
+        members.clone(),
+        rotation_epoch,
+        TEST_THRESHOLD_IN_BASIS_POINTS,
+        TEST_WEIGHT_REDUCTION_ALLOWED_DELTA,
+        TEST_MAX_FAULTY_IN_BASIS_POINTS,
+    );
+    let mut rotation_committee_set = CommitteeSet::new(Address::ZERO, Address::ZERO);
+    let mut rotation_committees = BTreeMap::new();
+    rotation_committees.insert(dkg_epoch, committee_at_100.clone());
+    rotation_committees.insert(rotation_epoch, committee_at_101.clone());
+    rotation_committee_set
+        .set_epoch(dkg_epoch)
+        .set_pending_epoch_change(Some(rotation_epoch))
+        .set_committees(rotation_committees);
+
+    let dealer_indices = [0usize, 1, 4];
+    let mut rotation_certificates = Vec::new();
+    let mut rotation_messages_by_dealer: Vec<(Address, RotationMessages)> = Vec::new();
+
+    for &dealer_idx in &dealer_indices {
+        let dealer_addr = rotation_setup.setup.address(dealer_idx);
+        let mut dealer_manager = MpcManager::new(
+            dealer_addr,
+            &rotation_committee_set,
+            rotation_epoch,
+            SessionId::new(TEST_CHAIN_ID, rotation_epoch, &ProtocolType::KeyRotation),
+            rotation_setup.setup.encryption_keys[dealer_idx].clone(),
+            None,
+            rotation_setup.setup.signing_keys[dealer_idx].clone(),
+            Box::new(InMemoryPublicMessagesStore::new()),
+            TEST_CHAIN_ID,
+            None,
+            TEST_BATCH_SIZE_PER_WEIGHT,
+            None,
+        )
+        .unwrap();
+        dealer_manager.previous_output = Some(dkg_outputs[dealer_idx].clone());
+
+        let msgs = dealer_manager.create_rotation_messages(&dkg_outputs[dealer_idx], &mut rng);
+        let rotation_messages = Messages::Rotation(msgs.clone());
+        dealer_manager
+            .rotation_messages
+            .insert(dealer_addr, msgs.clone());
+
+        let own_sig = dealer_manager
+            .try_sign_rotation_messages(&dkg_outputs[dealer_idx], dealer_addr, &rotation_messages)
+            .unwrap();
+        let other_idx = if dealer_idx == 0 { 1 } else { 0 };
+        let other_addr = rotation_setup.setup.address(other_idx);
+        let mut other_manager = MpcManager::new(
+            other_addr,
+            &rotation_committee_set,
+            rotation_epoch,
+            SessionId::new(TEST_CHAIN_ID, rotation_epoch, &ProtocolType::KeyRotation),
+            rotation_setup.setup.encryption_keys[other_idx].clone(),
+            None,
+            rotation_setup.setup.signing_keys[other_idx].clone(),
+            Box::new(InMemoryPublicMessagesStore::new()),
+            TEST_CHAIN_ID,
+            None,
+            TEST_BATCH_SIZE_PER_WEIGHT,
+            None,
+        )
+        .unwrap();
+        other_manager.previous_output = Some(dkg_outputs[other_idx].clone());
+        let other_sig = other_manager
+            .try_sign_rotation_messages(&dkg_outputs[other_idx], dealer_addr, &rotation_messages)
+            .unwrap();
+
+        let cert = create_rotation_test_certificate(
+            &committee_at_101,
+            &rotation_messages,
+            dealer_addr,
+            vec![
+                MemberSignature::new(rotation_epoch, dealer_addr, own_sig),
+                MemberSignature::new(rotation_epoch, other_addr, other_sig),
+            ],
+        )
+        .unwrap();
+        rotation_certificates.push(CertificateV1::Rotation(cert));
+        rotation_messages_by_dealer.push((dealer_addr, msgs));
+    }
+
+    // Step 3: stage a post-restart receiver at epoch 101 — end_reconfig has
+    // completed (epoch=101, no pending_epoch_change) and current_output has
+    // been lost, but the rotation messages remain on disk under rotation_epoch.
+    let mut post_rotation_committee_set = CommitteeSet::new(Address::ZERO, Address::ZERO);
+    let mut post_committees = BTreeMap::new();
+    post_committees.insert(dkg_epoch, committee_at_100);
+    post_committees.insert(rotation_epoch, committee_at_101);
+    post_rotation_committee_set
+        .set_epoch(rotation_epoch)
+        .set_pending_epoch_change(None)
+        .set_committees(post_committees);
+
+    let receiver_index = 2usize;
+    let receiver_addr = rotation_setup.setup.address(receiver_index);
+
+    let mut store = InMemoryPublicMessagesStore::new();
+    for (dealer_addr, msgs) in &rotation_messages_by_dealer {
+        store
+            .store_rotation_messages(rotation_epoch, dealer_addr, msgs)
+            .unwrap();
+    }
+
+    let mut receiver_manager = MpcManager::new(
+        receiver_addr,
+        &post_rotation_committee_set,
+        rotation_epoch,
+        SessionId::new(TEST_CHAIN_ID, rotation_epoch, &ProtocolType::KeyRotation),
+        rotation_setup.setup.encryption_keys[receiver_index].clone(),
+        Some(rotation_setup.setup.encryption_keys[receiver_index].clone()),
+        rotation_setup.setup.signing_keys[receiver_index].clone(),
+        Box::new(store),
+        TEST_CHAIN_ID,
+        None,
+        TEST_BATCH_SIZE_PER_WEIGHT,
+        None,
+    )
+    .unwrap();
+    assert!(
+        receiver_manager.current_output.is_none(),
+        "Fresh post-restart manager must not start with a cached current_output",
+    );
+
+    // Step 4: reconstruct and verify.
+    let reconstructed = receiver_manager
+        .reconstruct_current_from_stored_rotation(&rotation_certificates)
+        .unwrap();
+
+    assert_eq!(
+        reconstructed.public_key, expected_public_key,
+        "Reconstructed public key should match the DKG public key",
+    );
+    assert!(
+        !reconstructed.key_shares.shares.is_empty(),
+        "Receiver should hold at least one share after reconstruction",
+    );
+    assert_eq!(
+        reconstructed.threshold, receiver_manager.mpc_config.threshold,
+        "Output threshold should match the receiver's committee threshold",
+    );
+    assert_eq!(
+        receiver_manager
+            .current_output
+            .as_ref()
+            .map(|o| o.public_key),
+        Some(expected_public_key),
+        "Manager should cache the reconstructed output as current_output",
+    );
+}
+
 fn create_nonce_dealer_message(
     setup: &TestSetup,
     dealer_index: usize,

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -279,16 +279,9 @@ impl MpcService {
         let output = match protocol_type {
             Some(hashi_types::move_types::ProtocolType::KeyRotation) => {
                 self.setup_key_rotation(epoch)?;
-                // Fast path: the just-completed rotation N-1 -> N left its
-                // messages on disk under epoch N. If they're still here, we
-                // can re-derive this node's shares for epoch N directly,
-                // without redoing the live protocol — which would otherwise
-                // be impossible after end_reconfig pruned the (N-1)-keyed
-                // dealer/rotation messages.
                 if let Some(out) = self.try_recover_from_stored_rotation(epoch).await? {
                     info!(
-                        "recover_mpc_state: recovered epoch {epoch} from stored rotation \
-                         messages (fast path)"
+                        "recover_mpc_state: recovered epoch {epoch} from stored rotation messages"
                     );
                     Ok(out)
                 } else {
@@ -307,13 +300,9 @@ impl MpcService {
         Ok(output)
     }
 
-    /// Restart-recovery fast path for `recover_mpc_state`. Returns `Ok(Some)`
-    /// only when the local DB has rotation messages for the current epoch
-    /// (the just-completed `N-1 -> N` rotation) and reconstruction from them
-    /// succeeds. Any other case — including reconstruction errors that would
-    /// indicate genuine cluster damage — surfaces via `Ok(None)` so the
-    /// caller falls back to the live protocol path and logs the original
-    /// errors there.
+    /// Returns `Ok(Some)` only when the current epoch's rotation messages are
+    /// on disk and reconstruct cleanly; otherwise `Ok(None)` so the caller
+    /// runs the live protocol.
     async fn try_recover_from_stored_rotation(
         &self,
         epoch: u64,
@@ -325,14 +314,9 @@ impl MpcService {
             .into_iter()
             .map(|(_, cert)| cert)
             .collect();
-        if certificates.is_empty() {
-            return Ok(None);
-        }
         if !matches!(certificates.first(), Some(CertificateV1::Rotation(_))) {
             return Ok(None);
         }
-        // Cheap pre-check: if even one expected dealer's rotation messages
-        // aren't on disk, this path can't work — defer to the live protocol.
         for cert in &certificates {
             let CertificateV1::Rotation(rotation_cert) = cert else {
                 return Ok(None);
@@ -345,8 +329,7 @@ impl MpcService {
                 .is_none()
             {
                 debug!(
-                    "try_recover_from_stored_rotation: missing rotation messages for dealer \
-                     {dealer} at epoch {epoch}; deferring to live protocol",
+                    "try_recover_from_stored_rotation: missing rotation messages for dealer {dealer} at epoch {epoch}"
                 );
                 return Ok(None);
             }
@@ -363,8 +346,7 @@ impl MpcService {
             Ok(output) => Ok(Some(output)),
             Err(e) => {
                 warn!(
-                    "try_recover_from_stored_rotation: reconstruction failed ({e}); \
-                     falling back to live protocol"
+                    "try_recover_from_stored_rotation: reconstruction failed ({e}); falling back to live protocol"
                 );
                 Ok(None)
             }

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -279,7 +279,21 @@ impl MpcService {
         let output = match protocol_type {
             Some(hashi_types::move_types::ProtocolType::KeyRotation) => {
                 self.setup_key_rotation(epoch)?;
-                self.run_key_rotation(epoch).await
+                // Fast path: the just-completed rotation N-1 -> N left its
+                // messages on disk under epoch N. If they're still here, we
+                // can re-derive this node's shares for epoch N directly,
+                // without redoing the live protocol — which would otherwise
+                // be impossible after end_reconfig pruned the (N-1)-keyed
+                // dealer/rotation messages.
+                if let Some(out) = self.try_recover_from_stored_rotation(epoch).await? {
+                    info!(
+                        "recover_mpc_state: recovered epoch {epoch} from stored rotation \
+                         messages (fast path)"
+                    );
+                    Ok(out)
+                } else {
+                    self.run_key_rotation(epoch).await
+                }
             }
             _ => {
                 self.setup_initial_dkg(epoch)?;
@@ -291,6 +305,70 @@ impl MpcService {
             hex::encode(output.public_key.to_byte_array())
         );
         Ok(output)
+    }
+
+    /// Restart-recovery fast path for `recover_mpc_state`. Returns `Ok(Some)`
+    /// only when the local DB has rotation messages for the current epoch
+    /// (the just-completed `N-1 -> N` rotation) and reconstruction from them
+    /// succeeds. Any other case — including reconstruction errors that would
+    /// indicate genuine cluster damage — surfaces via `Ok(None)` so the
+    /// caller falls back to the live protocol path and logs the original
+    /// errors there.
+    async fn try_recover_from_stored_rotation(
+        &self,
+        epoch: u64,
+    ) -> anyhow::Result<Option<MpcOutput>> {
+        let onchain_state = self.inner.onchain_state().clone();
+        let certificates: Vec<CertificateV1> = fetch_certificates(&onchain_state, epoch, None)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to fetch certificates for epoch {epoch}: {e}"))?
+            .into_iter()
+            .map(|(_, cert)| cert)
+            .collect();
+        if certificates.is_empty() {
+            return Ok(None);
+        }
+        if !matches!(certificates.first(), Some(CertificateV1::Rotation(_))) {
+            return Ok(None);
+        }
+        // Cheap pre-check: if even one expected dealer's rotation messages
+        // aren't on disk, this path can't work — defer to the live protocol.
+        for cert in &certificates {
+            let CertificateV1::Rotation(rotation_cert) = cert else {
+                return Ok(None);
+            };
+            let dealer = rotation_cert.message().dealer_address;
+            if self
+                .inner
+                .db
+                .get_rotation_messages(epoch, &dealer)?
+                .is_none()
+            {
+                debug!(
+                    "try_recover_from_stored_rotation: missing rotation messages for dealer \
+                     {dealer} at epoch {epoch}; deferring to live protocol",
+                );
+                return Ok(None);
+            }
+        }
+        let mpc_manager = self
+            .inner
+            .mpc_manager()
+            .ok_or_else(|| anyhow::anyhow!("MpcManager not initialized for fast-path recovery"))?;
+        let result = {
+            let mut mgr = mpc_manager.write().unwrap();
+            mgr.reconstruct_current_from_stored_rotation(&certificates)
+        };
+        match result {
+            Ok(output) => Ok(Some(output)),
+            Err(e) => {
+                warn!(
+                    "try_recover_from_stored_rotation: reconstruction failed ({e}); \
+                     falling back to live protocol"
+                );
+                Ok(None)
+            }
+        }
     }
 
     #[tracing::instrument(level = "info", skip_all, fields(target_epoch))]

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -343,7 +343,20 @@ impl MpcService {
             mgr.reconstruct_current_from_stored_rotation(&certificates)
         };
         match result {
-            Ok(output) => Ok(Some(output)),
+            Ok(output) => {
+                let recovered_key = bcs::to_bytes(&output.public_key)
+                    .expect("public key serialization should succeed");
+                if recovered_key != onchain_state.mpc_public_key() {
+                    warn!(
+                        "try_recover_from_stored_rotation: reconstructed key {} \
+                         does not match on-chain key {}; falling back to live protocol",
+                        hex::encode(&recovered_key),
+                        hex::encode(onchain_state.mpc_public_key()),
+                    );
+                    return Ok(None);
+                }
+                Ok(Some(output))
+            }
             Err(e) => {
                 warn!(
                     "try_recover_from_stored_rotation: reconstruction failed ({e}); falling back to live protocol"


### PR DESCRIPTION
## Issue

After `end_reconfig` for epoch N, every node's `current_output` is in-memory only and messages from the rotation that produced epoch N-1's shares have been pruned. A coordinated restart at that point leaves `run_key_rotation` with neither recovery source — the cluster stops signing and stays stuck until an externally driven reconfig to N+1 gives it new rotation messages to reconstruct from. This PR closes that gap.

## Changes

- What's still on disk after `end_reconfig` for N: the rotation messages from the just-completed `N-1 → N` run, stored under epoch N. Decrypting them with this node's epoch-N encryption key reproduces this node's shares — same result as `run_key_rotation_as_party`.
- Add `reconstruct_current_from_stored_rotation`, sharing the decrypt/combine body with `reconstruct_from_rotation_certificates` via a new `RotationReconstructionView` helper.
- `recover_mpc_state` calls it as a fast path before falling back to `run_key_rotation`. After reconstruction we cross-check the recovered public key against the on-chain `mpc_public_key`; on mismatch we fall back to the live protocol.
- Tests: unit test for the new reconstruction path, plus an e2e test that restarts every node after a rotation and asserts the cluster recovers without advancing the epoch.