### PR TITLE
[publish] Allow bitcoin config overrides at publish time

### DIFF
--- a/crates/e2e-tests/src/publish.rs
+++ b/crates/e2e-tests/src/publish.rs
@@ -22,5 +22,13 @@ pub async fn publish(
     };
     let compiled = hashi::publish::build_package(&params)?;
     let bitcoin_chain_id = hashi::constants::BITCOIN_REGTEST_CHAIN_ID;
-    hashi::publish::publish_and_init(client, private_key, compiled, bitcoin_chain_id, None).await
+    hashi::publish::publish_and_init(
+        client,
+        private_key,
+        compiled,
+        bitcoin_chain_id,
+        None,
+        &hashi::publish::BitcoinConfigOverrides::default(),
+    )
+    .await
 }

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -517,6 +517,16 @@ pub struct PublishOpts {
     #[clap(long)]
     pub guardian_public_key: Option<String>,
 
+    /// Override `bitcoin_confirmation_threshold` on-chain at publish time.
+    /// Falls back to the Move package's `init_defaults` (currently 6) when omitted.
+    #[clap(long)]
+    pub bitcoin_confirmation_threshold: Option<u64>,
+
+    /// Override `bitcoin_deposit_time_delay_ms` on-chain at publish time.
+    /// Falls back to the Move package's `init_defaults` (currently 600_000) when omitted.
+    #[clap(long)]
+    pub bitcoin_deposit_time_delay_ms: Option<u64>,
+
     /// Enable verbose output
     #[clap(long, short)]
     pub verbose: bool,
@@ -910,6 +920,11 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
         ),
     };
 
+    let bitcoin_overrides = crate::publish::BitcoinConfigOverrides {
+        confirmation_threshold: opts.bitcoin_confirmation_threshold,
+        deposit_time_delay_ms: opts.bitcoin_deposit_time_delay_ms,
+    };
+
     // Publish + init
     print_info("Publishing and initializing ...");
     let ids = crate::publish::publish_and_init(
@@ -918,6 +933,7 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
         compiled,
         &opts.bitcoin_chain_id,
         guardian.as_ref(),
+        &bitcoin_overrides,
     )
     .await?;
     print_success(&format!("package_id:      {}", ids.package_id));

--- a/crates/hashi/src/publish.rs
+++ b/crates/hashi/src/publish.rs
@@ -107,13 +107,22 @@ pub struct GuardianConfig {
     pub public_key: Vec<u8>,
 }
 
+/// Optional Bitcoin config overrides applied during `finish_publish`. Any
+/// `None` field falls back to the Move package's `init_defaults` value.
+#[derive(Default)]
+pub struct BitcoinConfigOverrides {
+    pub confirmation_threshold: Option<u64>,
+    pub deposit_time_delay_ms: Option<u64>,
+}
+
 /// Publish the compiled package and run post-publish initialization.
 ///
 /// Executes two transactions:
 ///
 /// 1. **Publish** – publishes the modules, transfers the `UpgradeCap` to the sender.
 /// 2. **Init** – calls `hashi::finish_publish` to register BTC, the upgrade cap,
-///    set the bitcoin chain ID, and optionally configure the guardian.
+///    set the bitcoin chain ID, and optionally configure the guardian and
+///    bitcoin config overrides.
 ///
 /// Returns the [`HashiIds`] (package ID + Hashi shared-object ID) on success.
 pub async fn publish_and_init(
@@ -122,6 +131,7 @@ pub async fn publish_and_init(
     publish: sui_sdk_types::Publish,
     bitcoin_chain_id: &str,
     guardian: Option<&GuardianConfig>,
+    bitcoin_overrides: &BitcoinConfigOverrides,
 ) -> Result<HashiIds> {
     let sender = signer.public_key().derive_address();
 
@@ -213,6 +223,8 @@ pub async fn publish_and_init(
     let bitcoin_chain_id_arg = builder.pure(&bitcoin_chain_id_addr);
     let guardian_url_arg = builder.pure(&guardian.map(|g| g.url.as_str()));
     let guardian_public_key_arg = builder.pure(&guardian.map(|g| g.public_key.as_slice()));
+    let confirmation_threshold_arg = builder.pure(&bitcoin_overrides.confirmation_threshold);
+    let deposit_time_delay_ms_arg = builder.pure(&bitcoin_overrides.deposit_time_delay_ms);
     let coin_registry_arg = builder.object(
         ObjectInput::new(COIN_REGISTRY_OBJECT_ID)
             .as_shared()
@@ -231,6 +243,8 @@ pub async fn publish_and_init(
             bitcoin_chain_id_arg,
             guardian_url_arg,
             guardian_public_key_arg,
+            confirmation_threshold_arg,
+            deposit_time_delay_ms_arg,
             coin_registry_arg,
         ],
     );

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -104,6 +104,8 @@ entry fun finish_publish(
     bitcoin_chain_id: address,
     guardian_url: Option<String>,
     guardian_public_key: Option<vector<u8>>,
+    bitcoin_confirmation_threshold: Option<u64>,
+    bitcoin_deposit_time_delay_ms: Option<u64>,
     coin_registry: &mut sui::coin_registry::CoinRegistry,
     ctx: &mut TxContext,
 ) {
@@ -126,6 +128,24 @@ entry fun finish_publish(
     } else {
         guardian_url.destroy_none();
         guardian_public_key.destroy_none();
+    };
+
+    if (bitcoin_confirmation_threshold.is_some()) {
+        hashi::btc_config::set_bitcoin_confirmation_threshold(
+            self.config_mut(),
+            bitcoin_confirmation_threshold.destroy_some(),
+        );
+    } else {
+        bitcoin_confirmation_threshold.destroy_none();
+    };
+
+    if (bitcoin_deposit_time_delay_ms.is_some()) {
+        hashi::btc_config::set_bitcoin_deposit_time_delay_ms(
+            self.config_mut(),
+            bitcoin_deposit_time_delay_ms.destroy_some(),
+        );
+    } else {
+        bitcoin_deposit_time_delay_ms.destroy_none();
     };
 
     let (treasury_cap, metadata_cap) = hashi::btc::create(coin_registry, ctx);


### PR DESCRIPTION
## Summary

- Adds `--bitcoin-confirmation-threshold` and `--bitcoin-deposit-time-delay-ms` flags on `hashi publish` for per-deployment overrides of the values otherwise locked in by Move's `init_defaults` (currently `6` confirmations and `600_000` ms delay).
