### PR TITLE
[readiness-probe] return ready during genesis

### DIFF
--- a/crates/hashi/src/grpc/mod.rs
+++ b/crates/hashi/src/grpc/mod.rs
@@ -176,8 +176,14 @@ async fn health() -> impl axum::response::IntoResponse {
 }
 
 async fn ready(hashi: Arc<Hashi>) -> impl axum::response::IntoResponse {
-    let epoch = hashi.onchain_state().epoch();
-    if hashi.signing_manager_for(epoch).is_some() {
+    let onchain_state = hashi.onchain_state();
+    let epoch = onchain_state.epoch();
+    // Treat genesis (no committee formed yet) as ready so OrderedReady can bring
+    // up the rest of the StatefulSet to register keys and run the initial DKG.
+    let awaiting_genesis = epoch == 0 && onchain_state.current_committee().is_none();
+    if awaiting_genesis {
+        (axum::http::StatusCode::OK, "ready (awaiting genesis)")
+    } else if hashi.signing_manager_for(epoch).is_some() {
         (axum::http::StatusCode::OK, "ready")
     } else {
         (


### PR DESCRIPTION
So currently the /ready endpoint only works after signing manager is ready. but since we do deployments 1 pod at a time, they won't be ready untill all nodes are up.

So I'm adding an exception for genesis here.

The other option is to switch the stateful set pod management policy to boot all 4 pods in parallel.

This PR should unblock the deployment. 