### PR TITLE
[guardian-hardening][watcher] make WithdrawalSignedEvent applies idempotent

### DIFF
--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -352,7 +352,7 @@ impl Metrics {
             .unwrap(),
             guardian_limiter_anchor_events_skipped_total: register_int_counter_with_registry!(
                 "hashi_guardian_limiter_anchor_events_skipped_total",
-                "WithdrawalSignedEvent observations skipped because signatures were already recorded — covers checkpoint-stream redelivery and bootstrap-replay events",
+                "WithdrawalSignedEvent observations skipped as duplicates (checkpoint redelivery or bootstrap replay)",
                 registry,
             )
             .unwrap(),

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -47,6 +47,7 @@ pub struct Metrics {
     pub guardian_limiter_validate_total: IntCounterVec,
     pub guardian_limiter_apply_total: IntCounterVec,
     pub guardian_limiter_anchor_events_total: IntCounter,
+    pub guardian_limiter_anchor_events_skipped_total: IntCounter,
     pub guardian_limiter_batch_truncated_total: IntCounter,
     pub guardian_limiter_batch_stuck_head_total: IntCounter,
     pub guardian_rpc_total: IntCounterVec,
@@ -346,6 +347,12 @@ impl Metrics {
             guardian_limiter_anchor_events_total: register_int_counter_with_registry!(
                 "hashi_guardian_limiter_anchor_events_total",
                 "Total on-chain WithdrawalSignedEvent observations applied to the local guardian-limiter",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_anchor_events_skipped_total: register_int_counter_with_registry!(
+                "hashi_guardian_limiter_anchor_events_skipped_total",
+                "WithdrawalSignedEvent observations skipped because signatures were already recorded — covers checkpoint-stream redelivery and bootstrap-replay events",
                 registry,
             )
             .unwrap(),

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -451,10 +451,7 @@ async fn handle_events(
                 // Advance uses the event's checkpoint timestamp (~sign-time)
                 // rather than `txn.timestamp_ms` (creation time) to stay in
                 // lockstep with the guardian's `last_updated_at`.
-                // `signatures.is_some()` makes the apply idempotent — set
-                // here on the first observation and by `scrape_hashi` at
-                // bootstrap, so checkpoint redelivery and bootstrap-replay
-                // events are skipped.
+                // Gate on `signatures.is_none()` for idempotency across checkpoint redelivery and bootstrap replay.
                 let (limiter_inputs, pick_to_sign_ms) = {
                     let mut state = state.state_mut();
                     state

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -451,6 +451,14 @@ async fn handle_events(
                 // Advance uses the event's checkpoint timestamp (~sign-time)
                 // rather than `txn.timestamp_ms` (creation time) to stay in
                 // lockstep with the guardian's `last_updated_at`.
+                //
+                // `signatures.is_some()` doubles as a "have we already
+                // accounted for this txn?" flag, set on the first apply
+                // here and by `scrape_hashi` at bootstrap. It keeps the
+                // limiter idempotent if `SubscribeCheckpoints` redelivers
+                // a checkpoint, and it also skips historical events that
+                // the bootstrap snapshot already counted via the
+                // guardian's `next_seq`.
                 let (limiter_inputs, pick_to_sign_ms) = {
                     let mut state = state.state_mut();
                     state
@@ -462,7 +470,7 @@ async fn handle_events(
                         .withdrawal_txns
                         .get_mut(&event.withdrawal_txn_id)
                     {
-                        Some(txn) => {
+                        Some(txn) if txn.signatures.is_none() => {
                             txn.signatures = Some(event.signatures.clone());
                             let amount_sats = withdrawal_limiter_consumption_amount(txn);
                             let timestamp_secs = checkpoint_timestamp_ms / 1000;
@@ -470,9 +478,18 @@ async fn handle_events(
                                 checkpoint_timestamp_ms.saturating_sub(txn.timestamp_ms);
                             (Some((amount_sats, timestamp_secs)), Some(pick_to_sign))
                         }
-                        None => (None, None),
+                        _ => (None, None),
                     }
                 };
+                if limiter_inputs.is_none() {
+                    tracing::debug!(
+                        withdrawal_txn_id = %event.withdrawal_txn_id,
+                        "Skipping limiter apply: WithdrawalSignedEvent for already-signed txn"
+                    );
+                    if let Some(metrics) = state.metrics() {
+                        metrics.guardian_limiter_anchor_events_skipped_total.inc();
+                    }
+                }
                 if let Some(d) = pick_to_sign_ms
                     && let Some(metrics) = state.metrics()
                 {

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -451,14 +451,10 @@ async fn handle_events(
                 // Advance uses the event's checkpoint timestamp (~sign-time)
                 // rather than `txn.timestamp_ms` (creation time) to stay in
                 // lockstep with the guardian's `last_updated_at`.
-                //
-                // `signatures.is_some()` doubles as a "have we already
-                // accounted for this txn?" flag, set on the first apply
-                // here and by `scrape_hashi` at bootstrap. It keeps the
-                // limiter idempotent if `SubscribeCheckpoints` redelivers
-                // a checkpoint, and it also skips historical events that
-                // the bootstrap snapshot already counted via the
-                // guardian's `next_seq`.
+                // `signatures.is_some()` makes the apply idempotent — set
+                // here on the first observation and by `scrape_hashi` at
+                // bootstrap, so checkpoint redelivery and bootstrap-replay
+                // events are skipped.
                 let (limiter_inputs, pick_to_sign_ms) = {
                     let mut state = state.state_mut();
                     state


### PR DESCRIPTION
Sui's `SubscribeCheckpoints` can redeliver a checkpoint, which can cause a sequence drift between the local-limiter and the guardian.

so we are making the `WithdrawalSignedEvent` applies idempotent in the watcher.

## Changes:

- Gate the apply on `txn.signatures.is_none()`
  - the first apply sets it, so duplicates are skipped
- Add a new metric `guardian_limiter_anchor_events_skipped_total` to track skipped events