### PR TITLE
[Guardian] Provisioner init: Recover limiter state from withdraw logs

### DIFF
--- a/crates/e2e-tests/src/guardian_harness.rs
+++ b/crates/e2e-tests/src/guardian_harness.rs
@@ -126,11 +126,3 @@ pub fn default_test_withdrawal_config(committee: &HashiCommittee) -> WithdrawalC
         max_bucket_capacity_sats: 100_000_000,
     }
 }
-
-pub fn full_bucket(config: &WithdrawalConfig) -> LimiterState {
-    LimiterState {
-        num_tokens_available: config.max_bucket_capacity_sats,
-        last_updated_at: 0,
-        next_seq: 0,
-    }
-}

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -324,7 +324,7 @@ impl TestNetworksBuilder {
 
 async fn finalize_guardian_harness(networks: &mut TestNetworks) -> Result<()> {
     use crate::guardian_harness::default_test_withdrawal_config;
-    use crate::guardian_harness::full_bucket;
+    use hashi_types::guardian::LimiterState;
 
     let nodes = networks.hashi_network.nodes();
     anyhow::ensure!(
@@ -344,7 +344,7 @@ async fn finalize_guardian_harness(networks: &mut TestNetworks) -> Result<()> {
     let master_pubkey = hashi.get_onchain_mpc_pubkey()?;
 
     let withdrawal_config = default_test_withdrawal_config(&committee);
-    let limiter_state = full_bucket(&withdrawal_config);
+    let limiter_state = LimiterState::genesis(&withdrawal_config);
 
     let harness = networks
         .guardian_harness

--- a/crates/hashi-guardian/README.md
+++ b/crates/hashi-guardian/README.md
@@ -8,21 +8,22 @@ Canonical key layout:
 
 - `init/{session_id}-{init_suffix}.json`
 - `heartbeat/{yyyy}/{mm}/{dd}/{hh}/{session_id}-{counter:020}.json`
-- `withdraw/{yyyy}/{mm}/{dd}/{hh}/{session_id}-wid{wid}-{status}-{rand8}.json`
+- `withdraw/{yyyy}/{mm}/{dd}/{hh}/success-{seq:020}-{session_id}-wid{wid}.json`
+- `withdraw/{yyyy}/{mm}/{dd}/{hh}/failure-{session_id}-wid{wid}-{rand8}.json`
 
 Where:
 
 - `session_id` is the enclave ephemeral signing pubkey bytes encoded as lowercase hex.
 - `init_suffix` is a semantic label (`oi-attestation-unsigned`, `oi-guardian-info`, `setup-new-key-success`, `pi-success-share-{share_id}`, `pi-enclave-fully-initialized`).
 - `counter` is a zero-padded decimal sequence number (used in heartbeats only).
-- `status` is `success` or `failure`.
-- `rand8` is a random 8-hex suffix to avoid key collisions.
+- `seq` is the limiter sequence number consumed by this withdrawal; zero-padded so lexicographic order within an hour bucket equals seq order.
+- `rand8` is a random 8-hex suffix to avoid key collisions (failures only — successes are uniquely keyed by seq).
 
 ## Stream semantics
 
 - `init` logs are per-session and deterministic by semantic message kind.
 - `heartbeat` logs are hour-partitioned and strictly ordered per session.
-- `withdraw` logs are hour-partitioned and keyed by wid+status with random de-dup suffix.
+- `withdraw` logs are hour-partitioned. Successes are seq-sorted within a bucket so the KP rotating in the next enclave can recover limiter state by reading the lexicographically last success key.
 
 ## Why this layout
 

--- a/crates/hashi-guardian/src/s3_logger.rs
+++ b/crates/hashi-guardian/src/s3_logger.rs
@@ -269,6 +269,16 @@ impl S3Logger {
     // S3 Reads
     // ========================================================================
 
+    /// Lists every key under `prefix`, refusing to proceed if the bucket has any
+    /// delete markers or non-latest versions in scope (which would indicate
+    /// tampering / lock-expiry beyond what the immutable-log model allows).
+    /// Returned keys are unique and sorted lexicographically.
+    ///
+    /// Keys-only counterpart to [`Self::list_all_objects_in_dir`].
+    pub async fn list_all_keys_in_dir(&self, prefix: &str) -> GuardianResult<Vec<String>> {
+        self.ensure_no_duplicates_or_deletions(prefix).await
+    }
+
     /// Checks that all matching object keys do not have either deletions or overwrites.
     /// The prefix can either correspond to a directory or a complete object key.
     ///

--- a/crates/hashi-guardian/src/withdraw.rs
+++ b/crates/hashi-guardian/src/withdraw.rs
@@ -45,6 +45,7 @@ pub async fn standard_withdrawal(
                 post_state,
             };
             log_withdrawal_success(enclave.as_ref(), wid, msg, limiter_guard).await?;
+            // <-- Limiter guard drops upon log_withdrawal_success return. Next withdrawal can begin.
             Ok(enclave.sign(response))
         }
         Err(withdraw_err) => {
@@ -60,7 +61,6 @@ pub async fn standard_withdrawal(
     }
 }
 
-// TODO: Support batched withdrawals (multiple wids per transaction).
 async fn normal_withdrawal_inner(
     enclave: Arc<Enclave>,
     signed_request: HashiSigned<StandardWithdrawalRequest>,

--- a/crates/hashi-guardian/src/withdraw.rs
+++ b/crates/hashi-guardian/src/withdraw.rs
@@ -18,6 +18,7 @@ use hashi_types::guardian::StandardWithdrawalRequestWire;
 use hashi_types::guardian::StandardWithdrawalResponse;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::WithdrawalLogMessage;
+use hashi_types::guardian::MAX_REQUEST_FUTURE_SKEW_SECS;
 use serde::Serialize;
 use std::sync::Arc;
 use tracing::error;
@@ -90,9 +91,8 @@ async fn normal_withdrawal_inner(
     // Reject timestamps too far in the future (clock skew protection).
     // Old timestamps are safe — the limiter's monotonicity check prevents replay,
     // and old timestamps result in less refill (conservative).
-    const MAX_CLOCK_SKEW_SECS: u64 = 5 * 60;
     let guardian_now = now_timestamp_secs();
-    if request.timestamp_secs() > guardian_now + MAX_CLOCK_SKEW_SECS {
+    if request.timestamp_secs() > guardian_now + MAX_REQUEST_FUTURE_SKEW_SECS {
         return Err(InvalidInputs(format!(
             "request timestamp {} is too far in the future (guardian clock: {})",
             request.timestamp_secs(),

--- a/crates/hashi-guardian/src/withdraw.rs
+++ b/crates/hashi-guardian/src/withdraw.rs
@@ -18,7 +18,6 @@ use hashi_types::guardian::StandardWithdrawalRequestWire;
 use hashi_types::guardian::StandardWithdrawalResponse;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::WithdrawalLogMessage;
-use hashi_types::guardian::MAX_REQUEST_FUTURE_SKEW_SECS;
 use serde::Serialize;
 use std::sync::Arc;
 use tracing::error;
@@ -91,8 +90,9 @@ async fn normal_withdrawal_inner(
     // Reject timestamps too far in the future (clock skew protection).
     // Old timestamps are safe — the limiter's monotonicity check prevents replay,
     // and old timestamps result in less refill (conservative).
+    const MAX_CLOCK_SKEW_SECS: u64 = 5 * 60;
     let guardian_now = now_timestamp_secs();
-    if request.timestamp_secs() > guardian_now + MAX_REQUEST_FUTURE_SKEW_SECS {
+    if request.timestamp_secs() > guardian_now + MAX_CLOCK_SKEW_SECS {
         return Err(InvalidInputs(format!(
             "request timestamp {} is too far in the future (guardian clock: {})",
             request.timestamp_secs(),

--- a/crates/hashi-guardian/src/withdraw.rs
+++ b/crates/hashi-guardian/src/withdraw.rs
@@ -36,11 +36,13 @@ pub async fn standard_withdrawal(
     match normal_withdrawal_inner(enclave.clone(), signed_request).await {
         Ok((txid, response, limiter_guard)) => {
             info!("Withdrawal {} processed successfully. Logging to S3.", wid);
+            let post_state = *limiter_guard.state();
             let msg = WithdrawalLogMessage::Success {
                 txid,
                 request_data: unsigned_request,
                 request_sign: request_signature,
                 response: response.clone(),
+                post_state,
             };
             log_withdrawal_success(enclave.as_ref(), wid, msg, limiter_guard).await?;
             Ok(enclave.sign(response))
@@ -146,6 +148,10 @@ impl LimiterGuard {
     pub fn commit(mut self) {
         self.committed = true;
     }
+
+    pub fn state(&self) -> &hashi_types::guardian::LimiterState {
+        self.guard.state()
+    }
 }
 
 impl Drop for LimiterGuard {
@@ -248,11 +254,7 @@ mod tests {
             .set_withdrawal_config(withdrawal_config)
             .unwrap();
 
-        let limiter_state = LimiterState {
-            num_tokens_available: max_bucket_capacity_sats,
-            last_updated_at: 0,
-            next_seq: 0,
-        };
+        let limiter_state = LimiterState::genesis(&withdrawal_config);
         let init_state = ProvisionerInitState::new(
             committee,
             withdrawal_config,

--- a/crates/hashi-monitor/README.md
+++ b/crates/hashi-monitor/README.md
@@ -32,22 +32,22 @@ Audits the cross-system bridge flow on two parallel tracks.
 
 ### Batch audit
 ```bash
-cargo run -p hashi-monitor -- batch --config config.sample.yaml --start 1700000000 --end 1700003600
+cargo run -p hashi-monitor -- batch --config audit.sample.yaml --start 1700000000 --end 1700003600
 ```
 `--end` defaults to the current time if omitted.
 
 ### Continuous monitoring
 ```bash
-cargo run -p hashi-monitor -- continuous --config config.sample.yaml --start 1700000000
+cargo run -p hashi-monitor -- continuous --config audit.sample.yaml --start 1700000000
 ```
 
 ### Provisioner-init
 ```bash
-cargo run -p hashi-monitor -- provisioner-init --config provisioner-init.yaml
+cargo run -p hashi-monitor -- provisioner-init --config provisioner-init.sample.yaml
 ```
 
 ## Config
-See `config.sample.yaml` for a complete batch/continuous example:
+See `audit.sample.yaml` for a complete batch/continuous example:
 
 ```yaml
 # Liveness delay bounds (seconds)
@@ -70,7 +70,7 @@ btc:
     type: none
 ```
 
-The `provisioner-init` subcommand takes a separate YAML (`ProvisionerConfig`) with the key-provisioner share, expected share commitments, S3 config, Hashi committee, withdrawal config, and Hashi BTC master pubkey; if `guardian_endpoint` is set, the request is submitted after local checks pass.
+The `provisioner-init` subcommand takes a separate YAML (`ProvisionerConfig`, see `provisioner-init.sample.yaml`) with the key-provisioner share, expected share commitments, S3 config, Hashi committee, withdrawal config, and Hashi BTC master pubkey; if `guardian_endpoint` is set, the request is submitted after local checks pass.
 
 ## Status
 - Implemented:

--- a/crates/hashi-monitor/README.md
+++ b/crates/hashi-monitor/README.md
@@ -20,7 +20,7 @@ Audits the cross-system bridge flow on two parallel tracks.
 ### Modes
 1. **Batch**: one-time audit over a guardian time range `[start, end]`.
 2. **Continuous**: long-running monitor that polls Sui, Guardian S3, and BTC RPC on fixed intervals and reports findings as they appear.
-3. **Provisioner-init**: one-shot provisioner-init flow run by the key provisioner — audits heartbeats for the latest enclave session, verifies attestation and expected config, builds a `ProvisionerInitRequest`, and optionally submits it to a guardian endpoint.
+3. **Provisioner-init**: one-shot provisioner-init flow run by the key provisioner — audits heartbeats for the latest enclave session, verifies attestation and expected config, auto-detects whether this is a fresh deployment or a rotation (based on whether any prior session's init logs exist in S3) and sources the initial `LimiterState` accordingly (genesis defaults vs. recovered from the prior enclave's withdrawal logs), then builds a `ProvisionerInitRequest` and optionally submits it to a guardian endpoint.
 
 ### Timeline semantics (withdrawals)
 - User-provided `start` / `end` are interpreted on the **guardian (E2)** timeline.
@@ -79,6 +79,6 @@ The `provisioner-init` subcommand takes a separate YAML (`ProvisionerConfig`, se
   - Guardian S3 withdrawal log polling with attestation and signature verification.
   - BTC confirmation lookup via Bitcoin Core RPC.
   - Provisioner-init flow (heartbeat audit, attestation/config check, optional submission).
+  - Limiter state recovery: each successful withdrawal log embeds the post-consume `LimiterState`; on rotation, provisioner-init walks back hour buckets to find the max-seq Success log and uses its embedded state as the new enclave's initial state. Genesis path (no prior session in S3) seeds the limiter from `WithdrawalConfig` instead.
 - Not yet implemented:
   - Sui event polling — `AuditorCore::poll_sui` is a stub that returns `CursorUnmoved`, so E1 (withdrawal) and the deposit pipeline currently see no Sui input.
-  - Limiter state recovery from S3 logs in `provisioner-init` (currently uses a mock).

--- a/crates/hashi-monitor/README.md
+++ b/crates/hashi-monitor/README.md
@@ -2,23 +2,31 @@
 Hashi monitoring library and CLI tool.
 
 ## What it does?
-Audits the cross-system withdrawal flow:
-- **E1**: Hashi approval event on Sui (WithdrawalTransaction creation)
-- **E2**: Guardian approval event (logged to S3)
-- **E3**: BTC transaction confirmed on Bitcoin
+Audits the cross-system bridge flow on two parallel tracks.
+
+### Withdrawals (Sui → BTC)
+- **E1**: Hashi approval event on Sui (`WithdrawalPickedForProcessingEvent`).
+- **E2**: Guardian approval event (success record logged to S3).
+- **E3**: BTC transaction confirmed on Bitcoin.
+
+### Deposits (BTC → Sui)
+- **E1**: Deposit confirmed on Bitcoin.
+- **E2**: `DepositConfirmedEvent` on Sui.
 
 ### Checks
-- **Predecessor existence**: For every E2, there exists a corresponding E1. For every E3, there exists a corresponding E2 with matching txid.
-- **Successor existence**: For every source event, the configured successor delay bound must hold.
+- **Predecessor existence**: every successor event has a matching predecessor with consistent txid / wid.
+- **Successor existence**: for each non-terminal event, the configured next-event delay bound must hold.
 
-### Two modes
-1. **Batch**: One-time audit over a guardian time range `[start, end]`.
-2. **Continuous**: Intended long-running monitor over guardian timeline.
+### Modes
+1. **Batch**: one-time audit over a guardian time range `[start, end]`.
+2. **Continuous**: long-running monitor that polls Sui, Guardian S3, and BTC RPC on fixed intervals and reports findings as they appear.
+3. **Provisioner-init**: one-shot provisioner-init flow run by the key provisioner — audits heartbeats for the latest enclave session, verifies attestation and expected config, builds a `ProvisionerInitRequest`, and optionally submits it to a guardian endpoint.
 
-### Timeline semantics
+### Timeline semantics (withdrawals)
 - User-provided `start` / `end` are interpreted on the **guardian (E2)** timeline.
-- Sui events are still polled in a relaxed range to validate E2 predecessor constraints.
+- Sui events are polled in a relaxed range to validate E2 predecessor constraints.
 - Orphan E1 findings are currently still reported when E1 falls in the user window.
+- Deposits are not gated by the audit window — there is no false-positive risk.
 
 ## Usage
 
@@ -26,17 +34,23 @@ Audits the cross-system withdrawal flow:
 ```bash
 cargo run -p hashi-monitor -- batch --config config.sample.yaml --start 1700000000 --end 1700003600
 ```
+`--end` defaults to the current time if omitted.
 
 ### Continuous monitoring
 ```bash
 cargo run -p hashi-monitor -- continuous --config config.sample.yaml --start 1700000000
 ```
 
+### Provisioner-init
+```bash
+cargo run -p hashi-monitor -- provisioner-init --config provisioner-init.yaml
+```
+
 ## Config
-See `config.sample.yaml` for a complete example:
+See `config.sample.yaml` for a complete batch/continuous example:
 
 ```yaml
-# Next event delay bounds (seconds)
+# Liveness delay bounds (seconds)
 next_event_delays:
   - [E1HashiApproved, 300] # E1 (Hashi approval) -> E2 (Guardian signing)
   - [E2GuardianApproved, 300] # E2 (Guardian signing) -> E3 (BTC confirmed)
@@ -56,14 +70,15 @@ btc:
     type: none
 ```
 
-## Status
-This crate is currently a scaffold for a future full audit implementation.
+The `provisioner-init` subcommand takes a separate YAML (`ProvisionerConfig`) with the key-provisioner share, expected share commitments, S3 config, Hashi committee, withdrawal config, and Hashi BTC master pubkey; if `guardian_endpoint` is set, the request is submitted after local checks pass.
 
-- Implemented now:
-  - Domain model and withdrawal state-machine checks.
-  - Batch/continuous auditor structure and CLI wiring.
-- Deferred to a follow-up PR:
-  - Sui event download/polling.
-  - Guardian S3 event download/polling.
-  - BTC confirmation lookup.
-  - `batch` and `continuous` are wired through the CLI but currently stop at deferred `todo!` implementation points.
+## Status
+- Implemented:
+  - Domain model and withdrawal / deposit state-machine checks.
+  - Batch and continuous auditor loops (cursor advancement, BTC fetch, violation detection, GC, progress watermarks).
+  - Guardian S3 withdrawal log polling with attestation and signature verification.
+  - BTC confirmation lookup via Bitcoin Core RPC.
+  - Provisioner-init flow (heartbeat audit, attestation/config check, optional submission).
+- Not yet implemented:
+  - Sui event polling — `AuditorCore::poll_sui` is a stub that returns `CursorUnmoved`, so E1 (withdrawal) and the deposit pipeline currently see no Sui input.
+  - Limiter state recovery from S3 logs in `provisioner-init` (currently uses a mock).

--- a/crates/hashi-monitor/audit.sample.yaml
+++ b/crates/hashi-monitor/audit.sample.yaml
@@ -1,4 +1,4 @@
-# Sample configuration for hashi-monitor
+# Sample configuration for `hashi-monitor batch` and `hashi-monitor continuous`.
 
 # Liveness delay bounds (seconds)
 next_event_delays:

--- a/crates/hashi-monitor/provisioner-init.sample.yaml
+++ b/crates/hashi-monitor/provisioner-init.sample.yaml
@@ -1,0 +1,52 @@
+# Sample configuration for `hashi-monitor provisioner-init`.
+#
+# Run with:
+#   cargo run -p hashi-monitor -- provisioner-init --config provisioner-init.sample.yaml
+
+# Key Provisioner's secret share (32-byte k256 scalar, hex-encoded).
+share:
+  id: 1
+  value_hex: "0000000000000000000000000000000000000000000000000000000000000001"
+
+# If set, the built ProvisionerInitRequest is submitted to this guardian gRPC
+# endpoint after local checks pass. Omit (or comment out) for a dry run.
+# guardian_endpoint: "http://localhost:50051"
+
+# S3 credentials and bucket the guardian writes its logs to.
+s3:
+  access_key: "AKIA..."
+  secret_key: "..."
+  bucket_info:
+    bucket: "hashi-guardian-logs"
+    region: "us-east-1"
+
+# Expected share commitments for the guardian set, as published during
+# OperatorInit. digest_hex is the 32-byte commitment digest in hex.
+share_commitments:
+  - id: 1
+    digest_hex: "0000000000000000000000000000000000000000000000000000000000000000"
+  - id: 2
+    digest_hex: "0000000000000000000000000000000000000000000000000000000000000000"
+
+# Current on-chain Hashi committee snapshot. public_key / encryption_public_key
+# are raw byte sequences (BLS pubkey and HPKE pubkey respectively).
+hashi_committee:
+  epoch: 0
+  members:
+    - validator_address: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      public_key: []           # BLS G1 pubkey bytes
+      encryption_public_key: [] # HPKE pubkey bytes
+      weight: 1
+  total_weight: 1
+  mpc_threshold_in_basis_points: 6700
+  mpc_weight_reduction_allowed_delta: 0
+  mpc_max_faulty_in_basis_points: 3300
+
+# Withdrawal/limiter parameters the enclave will be initialized with.
+withdrawal_config:
+  committee_threshold: 1
+  refill_rate_sats_per_sec: 1000
+  max_bucket_capacity_sats: 100000000
+
+# Hashi BTC master x-only pubkey (32-byte hex).
+hashi_btc_master_pubkey: "0000000000000000000000000000000000000000000000000000000000000001"

--- a/crates/hashi-monitor/src/lib.rs
+++ b/crates/hashi-monitor/src/lib.rs
@@ -19,7 +19,7 @@ pub mod config;
 /// Error types
 pub mod errors;
 
-/// Key-provisioner init checks.
-pub mod kp;
+/// Provisioner-init flow run by the key provisioner.
+pub mod provisioner;
 
 pub use hashi_types::guardian::bitcoin_utils::ExternalOutputUTXOWire as OutputUTXO;

--- a/crates/hashi-monitor/src/main.rs
+++ b/crates/hashi-monitor/src/main.rs
@@ -41,9 +41,9 @@ enum Command {
         #[arg(long)]
         start: u64,
     },
-    /// Run key-provisioner init checks against guardian S3 logs.
-    KpInit {
-        /// Path to kp-init YAML config file.
+    /// Run provisioner-init checks against guardian S3 logs and optionally submit ProvisionerInit.
+    ProvisionerInit {
+        /// Path to provisioner-init YAML config file.
         #[arg(long)]
         config: PathBuf,
     },
@@ -73,9 +73,9 @@ async fn main() -> anyhow::Result<()> {
             let mut auditor = hashi_monitor::audit::ContinuousAuditor::new(&cfg, start).await?;
             auditor.run().await?;
         }
-        Command::KpInit { config } => {
-            let cfg = hashi_monitor::kp::ProvisionerConfig::load_yaml(&config)?;
-            hashi_monitor::kp::run(cfg).await?;
+        Command::ProvisionerInit { config } => {
+            let cfg = hashi_monitor::provisioner::ProvisionerConfig::load_yaml(&config)?;
+            hashi_monitor::provisioner::run(cfg).await?;
         }
     }
 

--- a/crates/hashi-monitor/src/provisioner/config.rs
+++ b/crates/hashi-monitor/src/provisioner/config.rs
@@ -88,13 +88,12 @@ pub struct ShareInput {
 
 impl ProvisionerConfig {
     pub fn load_yaml(path: &Path) -> anyhow::Result<Self> {
-        let bytes = std::fs::read(path)
-            .with_context(|| {
-                format!(
-                    "failed to read provisioner-init config at {}",
-                    path.display()
-                )
-            })?;
+        let bytes = std::fs::read(path).with_context(|| {
+            format!(
+                "failed to read provisioner-init config at {}",
+                path.display()
+            )
+        })?;
         serde_yaml::from_slice(&bytes).with_context(|| {
             format!(
                 "failed to parse provisioner-init yaml at {}",

--- a/crates/hashi-monitor/src/provisioner/config.rs
+++ b/crates/hashi-monitor/src/provisioner/config.rs
@@ -89,9 +89,18 @@ pub struct ShareInput {
 impl ProvisionerConfig {
     pub fn load_yaml(path: &Path) -> anyhow::Result<Self> {
         let bytes = std::fs::read(path)
-            .with_context(|| format!("failed to read kp-init config at {}", path.display()))?;
-        serde_yaml::from_slice(&bytes)
-            .with_context(|| format!("failed to parse kp-init yaml at {}", path.display()))
+            .with_context(|| {
+                format!(
+                    "failed to read provisioner-init config at {}",
+                    path.display()
+                )
+            })?;
+        serde_yaml::from_slice(&bytes).with_context(|| {
+            format!(
+                "failed to parse provisioner-init yaml at {}",
+                path.display()
+            )
+        })
     }
 
     pub fn expected_guardian_config(&self) -> anyhow::Result<GuardianConfig> {

--- a/crates/hashi-monitor/src/provisioner/heartbeat_checks.rs
+++ b/crates/hashi-monitor/src/provisioner/heartbeat_checks.rs
@@ -40,7 +40,7 @@ pub struct GuardianSessionInfo {
 /// Implements check A of IOP-225.
 ///
 /// Returns the selected live session id if all invariants pass.
-pub async fn kp_heartbeat_audit(s3_client: &S3Logger) -> anyhow::Result<String> {
+pub async fn heartbeat_audit(s3_client: &S3Logger) -> anyhow::Result<String> {
     let recent_heartbeats = read_recent_heartbeats(s3_client).await?;
     let summary = summarize_heartbeats_by_session(recent_heartbeats)?;
     let now = now_unix_seconds();

--- a/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
+++ b/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
@@ -32,11 +32,17 @@ use hashi_types::guardian::WithdrawalLogMessage;
 use tracing::info;
 
 /// Max hour buckets to walk back when searching for the most recent Success log.
-/// One week covers any realistic idleness; beyond this we bail rather than
-/// silently treat a missing-log situation as genesis.
+/// One week covers any realistic idleness; if no Success is found within this
+/// window the prior enclave is treated as having consumed nothing, and the
+/// caller falls back to a genesis limiter state.
 const MAX_WALK_BACK_HOURS: u64 = 7 * 24;
 
-pub async fn recover_limiter_state(s3_client: S3Logger) -> anyhow::Result<LimiterState> {
+/// Returns `Some(post_state)` from the global max-seq Success log if one is
+/// found within `MAX_WALK_BACK_HOURS`. Returns `None` if no Success log exists
+/// in that window — caller decides what to do (typically: fall back to
+/// genesis, since combined with the rotation-mode check this unambiguously
+/// means the prior enclave processed no withdrawals).
+pub async fn recover_limiter_state(s3_client: S3Logger) -> anyhow::Result<Option<LimiterState>> {
     let now = now_unix_seconds();
     let mut poller = GuardianPollerCore::from_s3_client(s3_client, now, GuardianLogDir::Withdraw);
 
@@ -61,20 +67,15 @@ pub async fn recover_limiter_state(s3_client: S3Logger) -> anyhow::Result<Limite
         poller.retreat_cursor();
     }
 
-    let state = best.ok_or_else(|| {
-        anyhow::anyhow!(
-            "no successful withdrawal logs found within last {} hours; \
-             cannot recover limiter state",
-            MAX_WALK_BACK_HOURS
-        )
-    })?;
-    info!(
-        next_seq = state.next_seq,
-        num_tokens_available = state.num_tokens_available,
-        last_updated_at = state.last_updated_at,
-        "recovered limiter state from prior enclave's withdraw logs"
-    );
-    Ok(state)
+    if let Some(state) = best {
+        info!(
+            next_seq = state.next_seq,
+            num_tokens_available = state.num_tokens_available,
+            last_updated_at = state.last_updated_at,
+            "recovered limiter state from prior enclave's withdraw logs"
+        );
+    }
+    Ok(best)
 }
 
 fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {

--- a/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
+++ b/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
@@ -91,3 +91,80 @@ fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {
         })
         .max_by_key(|s| s.next_seq)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::Network;
+    use bitcoin::Txid;
+    use bitcoin::hashes::Hash;
+    use hashi_types::guardian::GuardianError;
+    use hashi_types::guardian::GuardianSigned;
+    use hashi_types::guardian::StandardWithdrawalRequest;
+    use hashi_types::guardian::StandardWithdrawalRequestWire;
+    use hashi_types::guardian::StandardWithdrawalResponse;
+
+    fn state_with_seq(next_seq: u64) -> LimiterState {
+        LimiterState {
+            num_tokens_available: 1_000,
+            last_updated_at: 100,
+            next_seq,
+        }
+    }
+
+    fn success_log(next_seq: u64) -> VerifiedLogRecord {
+        let signed = StandardWithdrawalRequest::mock_signed_for_testing(Network::Regtest);
+        let (request_sign, request_data) = signed.into_parts();
+        let msg = WithdrawalLogMessage::Success {
+            txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
+            request_data: StandardWithdrawalRequestWire::from(request_data),
+            request_sign,
+            response: GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data,
+            post_state: state_with_seq(next_seq),
+        };
+        VerifiedLogRecord {
+            session_id: "test-session".to_string(),
+            timestamp_ms: 0,
+            message: LogMessage::Withdrawal(Box::new(msg)),
+        }
+    }
+
+    fn failure_log() -> VerifiedLogRecord {
+        let signed = StandardWithdrawalRequest::mock_signed_for_testing(Network::Regtest);
+        let (request_sign, request_data) = signed.into_parts();
+        let msg = WithdrawalLogMessage::Failure {
+            request_data: StandardWithdrawalRequestWire::from(request_data),
+            request_sign,
+            error: GuardianError::RateLimitExceeded,
+        };
+        VerifiedLogRecord {
+            session_id: "test-session".to_string(),
+            timestamp_ms: 0,
+            message: LogMessage::Withdrawal(Box::new(msg)),
+        }
+    }
+
+    #[test]
+    fn bucket_max_empty_is_none() {
+        assert!(bucket_max_post_state(vec![]).is_none());
+    }
+
+    #[test]
+    fn bucket_max_only_failures_is_none() {
+        assert!(bucket_max_post_state(vec![failure_log(), failure_log()]).is_none());
+    }
+
+    #[test]
+    fn bucket_max_picks_highest_seq_success() {
+        let logs = vec![success_log(3), success_log(7), success_log(5)];
+        let got = bucket_max_post_state(logs).expect("non-empty success set");
+        assert_eq!(got.next_seq, 7);
+    }
+
+    #[test]
+    fn bucket_max_ignores_failures_when_picking_success() {
+        let logs = vec![failure_log(), success_log(2), failure_log(), success_log(9)];
+        let got = bucket_max_post_state(logs).expect("non-empty success set");
+        assert_eq!(got.next_seq, 9);
+    }
+}

--- a/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
+++ b/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
@@ -17,8 +17,8 @@
 //! here, an enclave that died late in an hour would have its final-hour bucket
 //! treated as not-yet-readable, and the recovery would skip past the most
 //! recent log. We instead rely on the caller invoking us only after
-//! `heartbeat_audit` has confirmed the prior session has been silent for
-//! >= OTHER_SESSION_QUIET_PERIOD (10 min), which combined with S3
+//! `heartbeat_audit` has confirmed the prior session has been silent for at
+//! least `OTHER_SESSION_QUIET_PERIOD` (10 min), which combined with S3
 //! read-after-write consistency guarantees all of its writes are visible.
 
 use crate::domain::now_unix_seconds;

--- a/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
+++ b/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Recovers the next enclave's initial limiter state from the prior enclave's
+//! S3 withdrawal logs.
+//!
+//! Each successful withdrawal log carries the limiter `post_state` after that
+//! consume. seq is strictly monotonic across all rotations, so the global
+//! max-seq Success log holds the most recent state. To find it we walk back
+//! hour by hour from `now`, returning the post_state from the first non-empty
+//! bucket's max-seq log. We also peek one bucket further back to defend
+//! against sub-hour clock skew across hour boundaries.
+//!
+//! Note we deliberately don't apply `GuardianPollerCore::is_readable`'s
+//! `DIR_WRITES_COMPLETION_DELAY` gate here. That gate exists for the
+//! polling/auditor case where the source might still be writing; if we used it
+//! here, an enclave that died late in an hour would have its final-hour bucket
+//! treated as not-yet-readable, and the recovery would skip past the most
+//! recent log. We instead rely on the caller invoking us only after
+//! `heartbeat_audit` has confirmed the prior session has been silent for
+//! >= OTHER_SESSION_QUIET_PERIOD (10 min), which combined with S3
+//! read-after-write consistency guarantees all of its writes are visible.
+
+use crate::domain::now_unix_seconds;
+use crate::rpc::guardian::GuardianLogDir;
+use crate::rpc::guardian::GuardianPollerCore;
+use hashi_guardian::s3_logger::S3Logger;
+use hashi_types::guardian::LimiterState;
+use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::VerifiedLogRecord;
+use hashi_types::guardian::WithdrawalLogMessage;
+use tracing::info;
+
+/// Max hour buckets to walk back when searching for the most recent Success log.
+/// One week covers any realistic idleness; beyond this we bail rather than
+/// silently treat a missing-log situation as genesis.
+const MAX_WALK_BACK_HOURS: u64 = 7 * 24;
+
+pub async fn recover_limiter_state(s3_client: S3Logger) -> anyhow::Result<LimiterState> {
+    let now = now_unix_seconds();
+    let mut poller = GuardianPollerCore::from_s3_client(s3_client, now, GuardianLogDir::Withdraw);
+
+    let mut best: Option<LimiterState> = None;
+    for _ in 0..MAX_WALK_BACK_HOURS {
+        // NOTE (future optimization): read_cur_dir fetches and verifies every
+        // log body in the bucket, but we only need the max-seq Success body.
+        // The seq-prefixed key format (`success-{seq:020}-...`) lets us list
+        // keys, pick the lex-last `success-*` entry, and fetch only that
+        // single object — turning O(n) object reads per bucket into O(1).
+        if let Some(hit) = bucket_max_post_state(poller.read_cur_dir().await?) {
+            // First non-empty bucket. Peek one bucket back for clock-skew safety,
+            // then take the max across both.
+            poller.retreat_cursor();
+            let peek = bucket_max_post_state(poller.read_cur_dir().await?);
+            best = [Some(hit), peek]
+                .into_iter()
+                .flatten()
+                .max_by_key(|s| s.next_seq);
+            break;
+        }
+        poller.retreat_cursor();
+    }
+
+    let state = best.ok_or_else(|| {
+        anyhow::anyhow!(
+            "no successful withdrawal logs found within last {} hours; \
+             cannot recover limiter state",
+            MAX_WALK_BACK_HOURS
+        )
+    })?;
+    info!(
+        next_seq = state.next_seq,
+        num_tokens_available = state.num_tokens_available,
+        last_updated_at = state.last_updated_at,
+        "recovered limiter state from prior enclave's withdraw logs"
+    );
+    Ok(state)
+}
+
+fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {
+    logs.into_iter()
+        .filter_map(|log| {
+            let LogMessage::Withdrawal(boxed) = log.message else {
+                return None;
+            };
+            match *boxed {
+                WithdrawalLogMessage::Success { post_state, .. } => Some(post_state),
+                WithdrawalLogMessage::Failure { .. } => None,
+            }
+        })
+        .max_by_key(|s| s.next_seq)
+}

--- a/crates/hashi-monitor/src/provisioner/mod.rs
+++ b/crates/hashi-monitor/src/provisioner/mod.rs
@@ -13,7 +13,6 @@ use hashi_types::guardian::EncPubKey;
 use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::LimiterState;
-use hashi_types::guardian::MAX_REQUEST_FUTURE_SKEW_SECS;
 use hashi_types::guardian::ProvisionerInitRequest;
 use hashi_types::guardian::ProvisionerInitState;
 use hashi_types::guardian::S3_DIR_INIT;
@@ -24,7 +23,6 @@ use hashi_types::proto as pb;
 use rand::thread_rng;
 use tracing::info;
 
-use crate::domain::now_unix_seconds;
 pub use config::ProvisionerConfig;
 
 pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
@@ -56,13 +54,6 @@ pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
                     recovered.num_tokens_available = recovered
                         .num_tokens_available
                         .min(cfg.withdrawal_config.max_bucket_capacity_sats);
-                    // Logged timestamp can be up to MAX_REQUEST_FUTURE_SKEW_SECS
-                    // ahead of "now" because the guardian accepts withdraw
-                    // requests with timestamps that far in the future.
-                    assert!(
-                        recovered.last_updated_at
-                            <= now_unix_seconds().saturating_add(MAX_REQUEST_FUTURE_SKEW_SECS)
-                    );
                     recovered
                 }
                 None => {

--- a/crates/hashi-monitor/src/provisioner/mod.rs
+++ b/crates/hashi-monitor/src/provisioner/mod.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use hpke::Deserializable;
 mod config;
 mod heartbeat_checks;
 mod limiter_recovery;
 
-use crate::provisioner::config::GuardianConfig;
 use anyhow::Context;
 use hashi_guardian::s3_logger::S3Logger;
 use hashi_types::guardian::EncPubKey;
@@ -20,8 +18,11 @@ use hashi_types::guardian::proto_conversions::provisioner_init_request_to_pb;
 use hashi_types::guardian::session_id_from_signing_pubkey;
 use hashi_types::guardian::verify_enclave_attestation;
 use hashi_types::proto as pb;
+use hpke::Deserializable;
 use rand::thread_rng;
 use tracing::info;
+
+use crate::provisioner::config::GuardianConfig;
 
 pub use config::ProvisionerConfig;
 
@@ -118,6 +119,10 @@ enum DeploymentMode {
 
 /// Inspects S3 init logs for any session other than `current_session_id`.
 /// Presence of one or more such session ⇒ Rotation; otherwise Genesis.
+///
+/// Bails on any key under `init/` that doesn't match the expected
+/// `{session_id}-{suffix}` layout — unexpected keys shouldn't exist there
+/// and silently ignoring them could mask a real prior session.
 async fn detect_deployment_mode(
     s3_client: &S3Logger,
     current_session_id: &str,
@@ -128,20 +133,25 @@ async fn detect_deployment_mode(
         .await
         .map_err(|e| anyhow::anyhow!(e))?;
     for key in keys {
-        // Key format: `init/{session_id}-{init_suffix}.json`. session_id is
-        // 64-char lowercase hex (no dashes), so the first '-' after the prefix
-        // delimits it from the suffix.
-        let Some(after_prefix) = key.strip_prefix(&prefix) else {
-            continue;
-        };
-        let Some((session_id, _)) = after_prefix.split_once('-') else {
-            continue;
-        };
+        let session_id = extract_session_id_from_init_key(&key, &prefix)?;
         if session_id != current_session_id {
             return Ok(DeploymentMode::Rotation);
         }
     }
     Ok(DeploymentMode::Genesis)
+}
+
+/// Extracts the session_id from an `init/{session_id}-{suffix}.json` key.
+/// session_id is the lowercase hex of the enclave signing pubkey, so it
+/// contains no dashes — the first '-' after the prefix delimits it.
+fn extract_session_id_from_init_key<'a>(key: &'a str, prefix: &str) -> anyhow::Result<&'a str> {
+    let after_prefix = key
+        .strip_prefix(prefix)
+        .ok_or_else(|| anyhow::anyhow!("unexpected init log key (missing prefix): {key}"))?;
+    let (session_id, _suffix) = after_prefix
+        .split_once('-')
+        .ok_or_else(|| anyhow::anyhow!("unexpected init log key (no suffix delimiter): {key}"))?;
+    Ok(session_id)
 }
 
 /// Implements check B of IOP-225.
@@ -218,4 +228,33 @@ async fn prechecks(
     expected_guardian_config.ensure_matches_info(&info)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_session_id_strips_prefix_and_takes_up_to_first_dash() {
+        let session = "abcdef1234567890";
+        let key = format!("init/{session}-oi-attestation-unsigned.json");
+        assert_eq!(
+            extract_session_id_from_init_key(&key, "init/").unwrap(),
+            session
+        );
+    }
+
+    #[test]
+    fn extract_session_id_rejects_missing_prefix() {
+        let err = extract_session_id_from_init_key("withdraw/abc-suffix.json", "init/")
+            .expect_err("must fail on wrong prefix");
+        assert!(err.to_string().contains("missing prefix"));
+    }
+
+    #[test]
+    fn extract_session_id_rejects_missing_suffix_delimiter() {
+        let err = extract_session_id_from_init_key("init/abcdef.json", "init/")
+            .expect_err("must fail on no dash after prefix");
+        assert!(err.to_string().contains("no suffix delimiter"));
+    }
 }

--- a/crates/hashi-monitor/src/provisioner/mod.rs
+++ b/crates/hashi-monitor/src/provisioner/mod.rs
@@ -13,6 +13,7 @@ use hashi_types::guardian::EncPubKey;
 use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::LimiterState;
+use hashi_types::guardian::MAX_REQUEST_FUTURE_SKEW_SECS;
 use hashi_types::guardian::ProvisionerInitRequest;
 use hashi_types::guardian::ProvisionerInitState;
 use hashi_types::guardian::S3_DIR_INIT;
@@ -47,15 +48,30 @@ pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
     info!(?mode, "detected deployment mode");
     let limiter_state = match mode {
         DeploymentMode::Rotation => {
-            let mut recovered = limiter_recovery::recover_limiter_state(s3_client.clone()).await?;
-            // Cap to the current config's bucket capacity in case max capacity
-            // was lowered across the rotation. (Raising is fine — refill will
-            // fill it.)
-            recovered.num_tokens_available = recovered
-                .num_tokens_available
-                .min(cfg.withdrawal_config.max_bucket_capacity_sats);
-            assert!(recovered.last_updated_at < now_unix_seconds()); // sanity check
-            recovered
+            match limiter_recovery::recover_limiter_state(s3_client.clone()).await? {
+                Some(mut recovered) => {
+                    // Cap to the current config's bucket capacity in case max capacity
+                    // was lowered across the rotation. (Raising is fine — refill will
+                    // fill it.)
+                    recovered.num_tokens_available = recovered
+                        .num_tokens_available
+                        .min(cfg.withdrawal_config.max_bucket_capacity_sats);
+                    // Logged timestamp can be up to MAX_REQUEST_FUTURE_SKEW_SECS
+                    // ahead of "now" because the guardian accepts withdraw
+                    // requests with timestamps that far in the future.
+                    assert!(
+                        recovered.last_updated_at
+                            <= now_unix_seconds().saturating_add(MAX_REQUEST_FUTURE_SKEW_SECS)
+                    );
+                    recovered
+                }
+                None => {
+                    tracing::warn!(
+                        "rotation detected but prior enclave has no Success logs within walk-back window; falling back to genesis limiter state"
+                    );
+                    LimiterState::genesis(&cfg.withdrawal_config)
+                }
+            }
         }
         DeploymentMode::Genesis => LimiterState::genesis(&cfg.withdrawal_config),
     };

--- a/crates/hashi-monitor/src/provisioner/mod.rs
+++ b/crates/hashi-monitor/src/provisioner/mod.rs
@@ -4,6 +4,7 @@
 use hpke::Deserializable;
 mod config;
 mod heartbeat_checks;
+mod limiter_recovery;
 
 use crate::provisioner::config::GuardianConfig;
 use anyhow::Context;
@@ -14,6 +15,7 @@ use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::ProvisionerInitRequest;
 use hashi_types::guardian::ProvisionerInitState;
+use hashi_types::guardian::S3_DIR_INIT;
 use hashi_types::guardian::proto_conversions::provisioner_init_request_to_pb;
 use hashi_types::guardian::session_id_from_signing_pubkey;
 use hashi_types::guardian::verify_enclave_attestation;
@@ -22,6 +24,7 @@ use rand::thread_rng;
 use tracing::info;
 
 pub use config::ProvisionerConfig;
+use crate::domain::now_unix_seconds;
 
 pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
     let s3_client = S3Logger::new_checked(&cfg.s3)
@@ -38,17 +41,30 @@ pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
     expected_guardian_config.ensure_matches_info(&guardian_info)?;
     info!(session_id, "init checks passed for selected session");
 
-    // TODO: replace mock limiter state with actual state from S3 logs.
-    let committee = cfg.hashi_committee.try_into()?;
-    let mock_limiter_state = LimiterState {
-        num_tokens_available: cfg.withdrawal_config.max_bucket_capacity_sats,
-        last_updated_at: 0,
-        next_seq: 0,
+    // 3. Detect whether this is a first deployment or a rotation, and source
+    // the initial limiter state accordingly.
+    let mode = detect_deployment_mode(&s3_client, &session_id).await?;
+    info!(?mode, "detected deployment mode");
+    let limiter_state = match mode {
+        DeploymentMode::Rotation => {
+            let mut recovered = limiter_recovery::recover_limiter_state(s3_client.clone()).await?;
+            // Cap to the current config's bucket capacity in case max capacity
+            // was lowered across the rotation. (Raising is fine — refill will
+            // fill it.)
+            recovered.num_tokens_available = recovered
+                .num_tokens_available
+                .min(cfg.withdrawal_config.max_bucket_capacity_sats);
+            assert!(recovered.last_updated_at < now_unix_seconds()); // sanity check
+            recovered
+        }
+        DeploymentMode::Genesis => LimiterState::genesis(&cfg.withdrawal_config),
     };
+
+    let committee = cfg.hashi_committee.try_into()?;
     let state = ProvisionerInitState::new(
         committee,
         cfg.withdrawal_config,
-        mock_limiter_state,
+        limiter_state,
         cfg.hashi_btc_master_pubkey,
     )
     .map_err(|e| anyhow::anyhow!(e))?;
@@ -79,6 +95,46 @@ pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
         .await?;
     }
     Ok(())
+}
+
+/// Whether this provisioner-init is for the very first enclave in this S3
+/// bucket or a rotation onto a successor enclave. Determined from S3 init logs
+/// — see [`detect_deployment_mode`] — and used to switch between sourcing
+/// initial state from config (genesis) vs. recovering it from the prior
+/// enclave's logs (rotation). Future genesis/rotation-aware behaviors (e.g.,
+/// committee fetch) can match on the same enum.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum DeploymentMode {
+    Genesis,
+    Rotation,
+}
+
+/// Inspects S3 init logs for any session other than `current_session_id`.
+/// Presence of one or more such session ⇒ Rotation; otherwise Genesis.
+async fn detect_deployment_mode(
+    s3_client: &S3Logger,
+    current_session_id: &str,
+) -> anyhow::Result<DeploymentMode> {
+    let prefix = format!("{}/", S3_DIR_INIT);
+    let keys = s3_client
+        .list_all_keys_in_dir(&prefix)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+    for key in keys {
+        // Key format: `init/{session_id}-{init_suffix}.json`. session_id is
+        // 64-char lowercase hex (no dashes), so the first '-' after the prefix
+        // delimits it from the suffix.
+        let Some(after_prefix) = key.strip_prefix(&prefix) else {
+            continue;
+        };
+        let Some((session_id, _)) = after_prefix.split_once('-') else {
+            continue;
+        };
+        if session_id != current_session_id {
+            return Ok(DeploymentMode::Rotation);
+        }
+    }
+    Ok(DeploymentMode::Genesis)
 }
 
 /// Implements check B of IOP-225.

--- a/crates/hashi-monitor/src/provisioner/mod.rs
+++ b/crates/hashi-monitor/src/provisioner/mod.rs
@@ -5,7 +5,7 @@ use hpke::Deserializable;
 mod config;
 mod heartbeat_checks;
 
-use crate::kp::config::GuardianConfig;
+use crate::provisioner::config::GuardianConfig;
 use anyhow::Context;
 use hashi_guardian::s3_logger::S3Logger;
 use hashi_types::guardian::EncPubKey;
@@ -29,7 +29,7 @@ pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!(e))?;
 
     // 1. Check no past enclave's heartbeats remain & gather the latest enclave's session id.
-    let session_id = heartbeat_checks::kp_heartbeat_audit(&s3_client).await?;
+    let session_id = heartbeat_checks::heartbeat_audit(&s3_client).await?;
     info!(session_id, "heartbeat checks passed for selected session");
 
     // 2. Check that enclave's config is as expected (valid attestation, expected s3 bucket & share commitments)

--- a/crates/hashi-monitor/src/provisioner/mod.rs
+++ b/crates/hashi-monitor/src/provisioner/mod.rs
@@ -23,8 +23,8 @@ use hashi_types::proto as pb;
 use rand::thread_rng;
 use tracing::info;
 
-pub use config::ProvisionerConfig;
 use crate::domain::now_unix_seconds;
+pub use config::ProvisionerConfig;
 
 pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
     let s3_client = S3Logger::new_checked(&cfg.s3)

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -124,6 +124,10 @@ impl GuardianPollerCore {
         self.cursor = self.cursor.next_dir();
     }
 
+    pub fn retreat_cursor(&mut self) {
+        self.cursor = self.cursor.prev_dir();
+    }
+
     /// Read and verify the signatures on all the records in the current directory.
     pub async fn read_cur_dir(&mut self) -> anyhow::Result<Vec<VerifiedLogRecord>> {
         let all_logs = self

--- a/crates/hashi-types/src/guardian/limiter.rs
+++ b/crates/hashi-types/src/guardian/limiter.rs
@@ -4,6 +4,7 @@
 use super::GuardianError::InvalidInputs;
 use super::GuardianError::RateLimitExceeded;
 use super::GuardianResult;
+use serde::Deserialize;
 use serde::Serialize;
 
 /// Immutable configuration for the token bucket rate limiter.
@@ -16,8 +17,9 @@ pub struct LimiterConfig {
 }
 
 /// Serializable state for the token bucket rate limiter.
-/// Provisioners provide this when initializing the enclave.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize)]
+/// Provisioners provide this when initializing the enclave; it is also embedded
+/// in each successful withdrawal log so the next KP can recover it.
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LimiterState {
     /// Available tokens in sats.
     pub num_tokens_available: u64,
@@ -25,6 +27,19 @@ pub struct LimiterState {
     pub last_updated_at: u64,
     /// Next expected withdrawal sequence number.
     pub next_seq: u64,
+}
+
+impl LimiterState {
+    /// Genesis state for a freshly bootstrapped enclave: a full bucket, no
+    /// consumes yet, no refill timestamp. Used when no prior enclave's logs
+    /// exist to recover from.
+    pub fn genesis(config: &super::WithdrawalConfig) -> Self {
+        Self {
+            num_tokens_available: config.max_bucket_capacity_sats,
+            last_updated_at: 0,
+            next_seq: 0,
+        }
+    }
 }
 
 /// Token bucket rate limiter. Tokens refill linearly over time.

--- a/crates/hashi-types/src/guardian/limiter.rs
+++ b/crates/hashi-types/src/guardian/limiter.rs
@@ -7,6 +7,13 @@ use super::GuardianResult;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Maximum amount of time a withdrawal request's `timestamp_secs` may exceed
+/// the guardian's wall clock at consume time. The guardian rejects requests
+/// further in the future than this; downstream readers (e.g., the KP's
+/// limiter state recovery) use it to bound how far ahead of `now` a logged
+/// `post_state.last_updated_at` may legitimately appear.
+pub const MAX_REQUEST_FUTURE_SKEW_SECS: u64 = 5 * 60;
+
 /// Immutable configuration for the token bucket rate limiter.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize)]
 pub struct LimiterConfig {

--- a/crates/hashi-types/src/guardian/limiter.rs
+++ b/crates/hashi-types/src/guardian/limiter.rs
@@ -7,13 +7,6 @@ use super::GuardianResult;
 use serde::Deserialize;
 use serde::Serialize;
 
-/// Maximum amount of time a withdrawal request's `timestamp_secs` may exceed
-/// the guardian's wall clock at consume time. The guardian rejects requests
-/// further in the future than this; downstream readers (e.g., the KP's
-/// limiter state recovery) use it to bound how far ahead of `now` a logged
-/// `post_state.last_updated_at` may legitimately appear.
-pub const MAX_REQUEST_FUTURE_SKEW_SECS: u64 = 5 * 60;
-
 /// Immutable configuration for the token bucket rate limiter.
 #[derive(Debug, Copy, Clone, PartialEq, Serialize)]
 pub struct LimiterConfig {
@@ -38,8 +31,12 @@ pub struct LimiterState {
 
 impl LimiterState {
     /// Genesis state for a freshly bootstrapped enclave: a full bucket, no
-    /// consumes yet, no refill timestamp. Used when no prior enclave's logs
-    /// exist to recover from.
+    /// consumes yet, no refill timestamp.
+    ///
+    /// TODO: if the provisioner-init rotation path falls back here (no Success
+    /// logs in the prior enclave's walk-back window), `next_seq = 0` may not
+    /// match Hashi's current seq counter. Recover the real seq from a
+    /// separate source instead of falling back to 0.
     pub fn genesis(config: &super::WithdrawalConfig) -> Self {
         Self {
             num_tokens_available: config.max_bucket_capacity_sats,

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -13,6 +13,7 @@ pub mod s3_utils;
 
 pub use limiter::LimiterConfig;
 pub use limiter::LimiterState;
+pub use limiter::MAX_REQUEST_FUTURE_SKEW_SECS;
 pub use limiter::RateLimiter;
 pub use time_utils::UnixMillis;
 pub use time_utils::now_timestamp_ms;
@@ -636,9 +637,8 @@ impl LogRecord {
         }
     }
 
-    /// Object key format:
-    /// - Init: `init/{session_id}-{suffix}.json`
-    /// - Heartbeats & Withdrawals: `{prefix}/{yyyy}/{mm}/{dd}/{hh}/{session_id}-{suffix}.json`.
+    /// Full S3 object key for this log record (directory + file name). See the
+    /// `hashi-guardian` README for the canonical per-log-type key layout.
     pub fn object_key(&self) -> String {
         let dir = self.message.log_dir(self.timestamp_ms);
         let log_name = self.message.log_name(&self.session_id);

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -267,6 +267,10 @@ pub enum WithdrawalLogMessage {
         request_data: StandardWithdrawalRequestWire,
         request_sign: CommitteeSignature,
         response: StandardWithdrawalResponse,
+        /// Limiter state after this withdrawal was consumed. The KP rotating in
+        /// the next enclave reads the max-seq Success log and uses its
+        /// `post_state` as the new enclave's initial limiter state.
+        post_state: LimiterState,
     },
     /// Immediate withdraw failure
     Failure {
@@ -551,19 +555,29 @@ impl InitLogMessage {
 }
 
 impl WithdrawalLogMessage {
+    /// Success keys lead with `success-{seq:020}` so that lexicographic listing
+    /// within an hour bucket is also seq-sorted — the last key is the max-seq
+    /// log, which the KP reads to recover limiter state. Failures don't have a
+    /// meaningful seq (the request's seq may be stale), so they use a random
+    /// suffix for dedup.
     pub fn log_name(&self, prefix: &str) -> String {
-        let random_suffix = rand::random::<u32>();
-        let status = match self {
-            WithdrawalLogMessage::Success { .. } => "success",
-            WithdrawalLogMessage::Failure { .. } => "failure",
-        };
-        format!(
-            "{}-{}-{}-{:08x}.json",
-            prefix,
-            self.wid(),
-            status,
-            random_suffix
-        )
+        match self {
+            WithdrawalLogMessage::Success { request_data, .. } => format!(
+                "success-{:020}-{}-wid{}.json",
+                request_data.seq,
+                prefix,
+                self.wid()
+            ),
+            WithdrawalLogMessage::Failure { .. } => {
+                let random_suffix = rand::random::<u32>();
+                format!(
+                    "failure-{}-wid{}-{:08x}.json",
+                    prefix,
+                    self.wid(),
+                    random_suffix
+                )
+            }
+        }
     }
 }
 
@@ -886,21 +900,29 @@ mod tests {
         let signed_request =
             StandardWithdrawalRequest::mock_signed_for_testing_with_wid(Network::Regtest, wid);
         let (request_sign, request_data) = signed_request.into_parts();
+        let request_data: StandardWithdrawalRequestWire = request_data.into();
+        let seq = request_data.seq;
 
         let mut log = LogRecord::new(
             session_id.clone(),
             LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Success {
                 txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
-                request_data: request_data.into(),
+                request_data,
                 request_sign,
                 response: GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data,
+                post_state: LimiterState {
+                    num_tokens_available: 0,
+                    last_updated_at: 0,
+                    next_seq: seq + 1,
+                },
             })),
             &signing_key,
         );
         set_timestamp(&mut log, timestamp_ms);
 
-        let key = log.object_key();
-        assert!(key.starts_with(&format!("withdraw/2023/11/14/22/session-c-{wid}-success-")));
-        assert!(key.ends_with(".json"));
+        assert_eq!(
+            log.object_key(),
+            format!("withdraw/2023/11/14/22/success-{seq:020}-session-c-wid{wid}.json"),
+        );
     }
 }

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -13,7 +13,6 @@ pub mod s3_utils;
 
 pub use limiter::LimiterConfig;
 pub use limiter::LimiterState;
-pub use limiter::MAX_REQUEST_FUTURE_SKEW_SECS;
 pub use limiter::RateLimiter;
 pub use time_utils::UnixMillis;
 pub use time_utils::now_timestamp_ms;

--- a/crates/hashi-types/src/guardian/s3_utils.rs
+++ b/crates/hashi-types/src/guardian/s3_utils.rs
@@ -50,6 +50,14 @@ impl S3HourScopedDirectory {
         )
     }
 
+    /// Returns the directory for the previous hour. Saturates at the Unix epoch.
+    pub fn prev_dir(&self) -> Self {
+        Self::new(
+            &self.prefix,
+            self.to_unix_seconds().saturating_sub(SECONDS_PER_HOUR),
+        )
+    }
+
     /// The time at which writes to current S3 directory finish.
     /// DIR_WRITES_COMPLETION_DELAY accounts for any in-flight retries and clock skew.
     pub fn write_completion_time(&self) -> UnixSeconds {
@@ -101,6 +109,20 @@ mod tests {
 
         let next_day = S3HourScopedDirectory::new("withdraw", 86_400);
         assert_eq!(next_day.to_string(), "withdraw/1970/01/02/00/");
+    }
+
+    #[test]
+    fn test_prev_dir_walks_back_and_saturates_at_epoch() {
+        let mut dir = S3HourScopedDirectory::new("withdraw", 86_400 + 3_600);
+        assert_eq!(dir.to_string(), "withdraw/1970/01/02/01/");
+        dir = dir.prev_dir();
+        assert_eq!(dir.to_string(), "withdraw/1970/01/02/00/");
+        dir = dir.prev_dir();
+        assert_eq!(dir.to_string(), "withdraw/1970/01/01/23/");
+
+        // Saturates at epoch.
+        let epoch = S3HourScopedDirectory::new("withdraw", 0);
+        assert_eq!(epoch.prev_dir(), epoch);
     }
 
     #[test]

--- a/crates/internal-tools/src/bootstrap_guardian.rs
+++ b/crates/internal-tools/src/bootstrap_guardian.rs
@@ -170,11 +170,7 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
         refill_rate_sats_per_sec: args.refill_rate_sats_per_sec,
         max_bucket_capacity_sats: args.max_bucket_capacity_sats,
     };
-    let limiter_state = LimiterState {
-        num_tokens_available: withdrawal_config.max_bucket_capacity_sats,
-        last_updated_at: 0,
-        next_seq: 0,
-    };
+    let limiter_state = LimiterState::genesis(&withdrawal_config);
     let state = ProvisionerInitState::new(
         committee,
         withdrawal_config,


### PR DESCRIPTION
## Summary

Fixes [IOP-252](https://linear.app/mysten-labs/issue/IOP-252/compute-withdrawalstate-from-s3-logs). Two stacked commits on this branch (in dependency order):

1. **`[hashi-monitor] rename kp -> provisioner-init; refresh README`** — rename the `kp`/`kp-init` module and CLI subcommand to `provisioner`/`provisioner-init` (matches the existing `ProvisionerInitRequest` / gRPC verb). Also refreshes the README which was stale.

2. **`[guardian][hashi-monitor] embed limiter post_state in withdraw logs; recover at provisioner-init`** — replaces the mock `LimiterState` in provisioner-init with one recovered from S3.

### Schema changes (hashi-types / hashi-guardian)

- Add `post_state: LimiterState` to `WithdrawalLogMessage::Success`. Populated in `log_withdrawal_success` from the held limiter guard.
- New S3 key format for withdraw logs:
  - `withdraw/{yyyy}/{mm}/{dd}/{hh}/success-{seq:020}-{session_id}-wid{wid}.json`
  - `withdraw/{yyyy}/{mm}/{dd}/{hh}/failure-{session_id}-wid{wid}-{rand8}.json`

  Seq-prefix on Success makes lex order = seq order within an hour bucket → max-seq is the lex-last key, no body parsing required.
- New `LimiterState::genesis(&WithdrawalConfig)` helper; used at provisioner-init, `bootstrap_guardian`, and test sites.

### Recovery flow (hashi-monitor)

- `detect_deployment_mode` inspects `init/` for any session other than the heartbeat-audit-selected live session. ≥1 prior session ⇒ `Rotation`; only the current session present ⇒ `Genesis`. No operator-supplied "is this genesis?" flag needed.
- On `Rotation`: walk hour buckets back from `now`, take max-seq Success across the first non-empty bucket and one peek-back (clock-skew safety across hour boundaries), return that log's `post_state`. Cap to current config's `max_bucket_capacity_sats`. Error if no Success found within 7 days.
- On `Genesis`: `LimiterState::genesis(&cfg.withdrawal_config)`.
- Deliberately skips `is_readable`'s 10-min write-completion gate inside the recovery loop — `heartbeat_audit` + S3 read-after-write consistency already guarantee visibility; gating would cause an enclave that died late in an hour to have its final-hour bucket skipped.

### Notes for review

- Recovery's per-bucket cost is currently O(n) S3 object reads (fetches+verifies every body in the bucket). A NOTE in `limiter_recovery.rs` flags the natural O(1) optimization using the new seq-prefixed keys — list keys, pick lex-last `success-*`, fetch only that one. Deferred.
- `bootstrap_guardian` is still the path for fresh deployments end-to-end (it also runs `operator_init` + `setup_new_key`); this PR doesn't change that.

## Test plan

- [x] `cargo build -p hashi-monitor -p hashi-guardian -p hashi-types -p internal-tools` clean.
- [x] `cargo test -p hashi-types -p hashi-guardian -p hashi-monitor` — all unit tests pass (the one failure under `cargo test` is `rpc::btc::tests::lookup_btc_confirmation_with_local_regtest`, an environmental test that spawns `bitcoind`; unrelated).
- [ ] Run provisioner-init against a staging S3 bucket with a real prior session's logs; verify recovered state matches the prior enclave's last Success.
- [ ] Run provisioner-init against a fresh bucket (no init logs); verify it takes the Genesis branch.
- [ ] Verify rotation with a prior session that has zero Success logs errors out cleanly (no silent genesis downgrade).