### PR TITLE
[guardian-hardening][leader] pace guardian finalization on the local limiter

### DIFF
--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -134,14 +134,10 @@ fn project_capacity(config: &LimiterConfig, state: &LimiterState, timestamp_secs
         .min(config.max_bucket_capacity)
 }
 
-/// Whether a guardian finalize for `wid` at `next_seq` must be deferred: the
-/// guardian already consumed this seq for a *different* withdrawal and the local
-/// limiter — which advances only when the on-chain `WithdrawalSignedEvent` is
-/// observed — has not yet caught up, so sending `next_seq` now would draw a
-/// guardian `seq mismatch`. A same-wid retry at the same seq is *not* deferred:
-/// deferring it would stall its own recovery, since replaying that withdrawal is
-/// what lets the limiter advance. (When the guardian response cache is present it
-/// additionally serves such a retry idempotently.)
+/// Defer a finalize when the local limiter is still behind a seq the guardian
+/// already consumed for a *different* withdrawal — sending it now would draw a
+/// `seq mismatch`. Same-wid retries are allowed (replay drives the local
+/// advance; the response cache serves them idempotently).
 pub(crate) fn should_defer_guardian_finalize(
     next_seq: u64,
     last_finalized: Option<(u64, sui_sdk_types::Address)>,

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -134,10 +134,8 @@ fn project_capacity(config: &LimiterConfig, state: &LimiterState, timestamp_secs
         .min(config.max_bucket_capacity)
 }
 
-/// Defer a finalize when the local limiter is still behind a seq the guardian
-/// already consumed for a *different* withdrawal — sending it now would draw a
-/// `seq mismatch`. Same-wid retries are allowed (replay drives the local
-/// advance; the response cache serves them idempotently).
+/// Defer when the local limiter is behind a guardian-consumed seq for a
+/// *different* withdrawal; same-wid retries are served idempotently.
 pub(crate) fn should_defer_guardian_finalize(
     next_seq: u64,
     last_finalized: Option<(u64, sui_sdk_types::Address)>,
@@ -241,15 +239,10 @@ mod tests {
     fn defer_only_for_a_different_wid_at_an_already_consumed_seq() {
         let a = sui_sdk_types::Address::new([1u8; 32]);
         let b = sui_sdk_types::Address::new([2u8; 32]);
-        // Nothing finalized yet -> never defer.
         assert!(!should_defer_guardian_finalize(0, None, a));
-        // Different wid reusing a consumed seq (local limiter behind) -> defer.
         assert!(should_defer_guardian_finalize(5, Some((5, a)), b));
-        // A stale (lower) seq for a different wid -> defer.
         assert!(should_defer_guardian_finalize(4, Some((5, a)), b));
-        // Same wid retrying its own seq -> allowed (response cache serves it).
         assert!(!should_defer_guardian_finalize(5, Some((5, a)), a));
-        // Local limiter caught up (next_seq advanced) -> allowed.
         assert!(!should_defer_guardian_finalize(6, Some((5, a)), b));
     }
 }

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -134,6 +134,22 @@ fn project_capacity(config: &LimiterConfig, state: &LimiterState, timestamp_secs
         .min(config.max_bucket_capacity)
 }
 
+/// Whether a guardian finalize for `wid` at `next_seq` must be deferred: the
+/// guardian already consumed this seq for a *different* withdrawal and the local
+/// limiter — which advances only when the on-chain `WithdrawalSignedEvent` is
+/// observed — has not yet caught up, so sending `next_seq` now would draw a
+/// guardian `seq mismatch`. A same-wid retry at the same seq is *not* deferred:
+/// deferring it would stall its own recovery, since replaying that withdrawal is
+/// what lets the limiter advance. (When the guardian response cache is present it
+/// additionally serves such a retry idempotently.)
+pub(crate) fn should_defer_guardian_finalize(
+    next_seq: u64,
+    last_finalized: Option<(u64, sui_sdk_types::Address)>,
+    wid: sui_sdk_types::Address,
+) -> bool {
+    last_finalized.is_some_and(|(last_seq, last_wid)| next_seq <= last_seq && wid != last_wid)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -223,5 +239,21 @@ mod tests {
     fn test_next_seq_matches_snapshot() {
         let limiter = make_limiter(0, 0, 11);
         assert_eq!(limiter.next_seq(), 11);
+    }
+
+    #[test]
+    fn defer_only_for_a_different_wid_at_an_already_consumed_seq() {
+        let a = sui_sdk_types::Address::new([1u8; 32]);
+        let b = sui_sdk_types::Address::new([2u8; 32]);
+        // Nothing finalized yet -> never defer.
+        assert!(!should_defer_guardian_finalize(0, None, a));
+        // Different wid reusing a consumed seq (local limiter behind) -> defer.
+        assert!(should_defer_guardian_finalize(5, Some((5, a)), b));
+        // A stale (lower) seq for a different wid -> defer.
+        assert!(should_defer_guardian_finalize(4, Some((5, a)), b));
+        // Same wid retrying its own seq -> allowed (response cache serves it).
+        assert!(!should_defer_guardian_finalize(5, Some((5, a)), a));
+        // Local limiter caught up (next_seq advanced) -> allowed.
+        assert!(!should_defer_guardian_finalize(6, Some((5, a)), b));
     }
 }

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1382,14 +1382,12 @@ impl LeaderService {
                 );
                 return Ok(());
             }
-            // Pace guardian finalization. The local limiter only advances when
-            // the prior withdrawal's WithdrawalSignedEvent is observed on-chain,
-            // while the guardian advances synchronously at finalize time. Sending
-            // a *different* withdrawal before the local limiter catches up would
-            // reuse a seq the guardian already consumed -> `seq mismatch`. Defer
-            // and retry on a later checkpoint once the watcher applies the prior
-            // event. (A same-wid retry is allowed: replaying it is what advances
-            // the local limiter, and the response cache serves it idempotently.)
+            // Pace guardian finalization: the local limiter only advances on
+            // the prior withdrawal's on-chain `WithdrawalSignedEvent`, but the
+            // guardian advances synchronously, so finalizing a *different* wid
+            // before that catches up would reuse a consumed seq. Same-wid
+            // retries are allowed (replay drives the local advance, and the
+            // response cache serves them idempotently).
             if inner.guardian_client().is_some()
                 && inner.guardian_should_defer_finalize(next_seq, txn.id)
             {
@@ -1440,8 +1438,7 @@ impl LeaderService {
                 seq,
             )
             .await?;
-            // Guardian accepted seq; record it so the next (different) withdrawal
-            // waits for the local limiter to catch up before finalizing.
+            // Gate the next (different) finalize on the local limiter catching up.
             inner.record_guardian_finalized(seq, txn.id);
         }
 

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1382,6 +1382,25 @@ impl LeaderService {
                 );
                 return Ok(());
             }
+            // Pace guardian finalization. The local limiter only advances when
+            // the prior withdrawal's WithdrawalSignedEvent is observed on-chain,
+            // while the guardian advances synchronously at finalize time. Sending
+            // a *different* withdrawal before the local limiter catches up would
+            // reuse a seq the guardian already consumed -> `seq mismatch`. Defer
+            // and retry on a later checkpoint once the watcher applies the prior
+            // event. (A same-wid retry is allowed: replaying it is what advances
+            // the local limiter, and the response cache serves it idempotently.)
+            if inner.guardian_client().is_some()
+                && inner.guardian_should_defer_finalize(next_seq, txn.id)
+            {
+                debug!(
+                    withdrawal_txn_id = %txn.id,
+                    next_seq,
+                    "Deferring guardian finalize until local limiter catches up to guardian seq"
+                );
+                inner.metrics.guardian_finalize_deferred_total.inc();
+                return Ok(());
+            }
             Some(next_seq)
         } else {
             None
@@ -1421,6 +1440,9 @@ impl LeaderService {
                 seq,
             )
             .await?;
+            // Guardian accepted seq; record it so the next (different) withdrawal
+            // waits for the local limiter to catch up before finalizing.
+            inner.record_guardian_finalized(seq, txn.id);
         }
 
         // 4. Build the WithdrawalTxSigning and get BLS certificate via fan-out

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1382,12 +1382,7 @@ impl LeaderService {
                 );
                 return Ok(());
             }
-            // Pace guardian finalization: the local limiter only advances on
-            // the prior withdrawal's on-chain `WithdrawalSignedEvent`, but the
-            // guardian advances synchronously, so finalizing a *different* wid
-            // before that catches up would reuse a consumed seq. Same-wid
-            // retries are allowed (replay drives the local advance, and the
-            // response cache serves them idempotently).
+            // Pace guardian finalize on the local limiter to avoid reusing a consumed seq.
             if inner.guardian_client().is_some()
                 && inner.guardian_should_defer_finalize(next_seq, txn.id)
             {
@@ -1438,7 +1433,6 @@ impl LeaderService {
                 seq,
             )
             .await?;
-            // Gate the next (different) finalize on the local limiter catching up.
             inner.record_guardian_finalized(seq, txn.id);
         }
 

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -4,7 +4,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::RwLock;
 
@@ -64,10 +63,9 @@ pub struct Hashi {
     guardian_client: OnceLock<Option<grpc::guardian_client::GuardianClient>>,
     guardian_signing_pubkey: OnceLock<Option<hashi_types::guardian::GuardianPubKey>>,
     local_limiter: OnceLock<Arc<guardian_limiter::LocalLimiter>>,
-    /// (seq, wid) of the last withdrawal finalized through the guardian. Paces
-    /// finalization so the leader never reuses a seq the guardian already
-    /// consumed while the local limiter catches up on-chain.
-    guardian_last_finalized: Mutex<Option<(u64, sui_sdk_types::Address)>>,
+    /// `(seq, wid)` of the last withdrawal finalized through the guardian,
+    /// paced against the local limiter to avoid reusing a consumed seq.
+    guardian_last_finalized: RwLock<Option<(u64, sui_sdk_types::Address)>>,
     /// Reconfig completion signatures by epoch.
     reconfig_signatures: RwLock<HashMap<u64, Vec<u8>>>,
 }
@@ -97,7 +95,7 @@ impl Hashi {
             guardian_client: OnceLock::new(),
             guardian_signing_pubkey: OnceLock::new(),
             local_limiter: OnceLock::new(),
-            guardian_last_finalized: Mutex::new(None),
+            guardian_last_finalized: RwLock::new(None),
             reconfig_signatures: RwLock::new(HashMap::new()),
         }))
     }
@@ -127,27 +125,23 @@ impl Hashi {
             guardian_client: OnceLock::new(),
             guardian_signing_pubkey: OnceLock::new(),
             local_limiter: OnceLock::new(),
-            guardian_last_finalized: Mutex::new(None),
+            guardian_last_finalized: RwLock::new(None),
             reconfig_signatures: RwLock::new(HashMap::new()),
         }))
     }
 
-    /// Leader-side wrapper over
-    /// [`guardian_limiter::should_defer_guardian_finalize`], reading the last
-    /// `(seq, wid)` finalized through the guardian.
     pub(crate) fn guardian_should_defer_finalize(
         &self,
         next_seq: u64,
         wid: sui_sdk_types::Address,
     ) -> bool {
-        let last = *self.guardian_last_finalized.lock().unwrap();
+        let last = *self.guardian_last_finalized.read().unwrap();
         guardian_limiter::should_defer_guardian_finalize(next_seq, last, wid)
     }
 
-    /// Record a successful guardian finalize (monotonic in seq) so subsequent
-    /// finalizes pace on the local limiter catching up.
+    /// Record a successful guardian finalize; monotonic in `seq`.
     pub(crate) fn record_guardian_finalized(&self, seq: u64, wid: sui_sdk_types::Address) {
-        let mut last = self.guardian_last_finalized.lock().unwrap();
+        let mut last = self.guardian_last_finalized.write().unwrap();
         match *last {
             Some((prev_seq, _)) if seq < prev_seq => {}
             _ => *last = Some((seq, wid)),

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -63,8 +63,7 @@ pub struct Hashi {
     guardian_client: OnceLock<Option<grpc::guardian_client::GuardianClient>>,
     guardian_signing_pubkey: OnceLock<Option<hashi_types::guardian::GuardianPubKey>>,
     local_limiter: OnceLock<Arc<guardian_limiter::LocalLimiter>>,
-    /// `(seq, wid)` of the last withdrawal finalized through the guardian,
-    /// paced against the local limiter to avoid reusing a consumed seq.
+    /// `(seq, wid)` of the last guardian-finalized withdrawal, for pacing.
     guardian_last_finalized: RwLock<Option<(u64, sui_sdk_types::Address)>>,
     /// Reconfig completion signatures by epoch.
     reconfig_signatures: RwLock<HashMap<u64, Vec<u8>>>,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::RwLock;
 
@@ -63,6 +64,10 @@ pub struct Hashi {
     guardian_client: OnceLock<Option<grpc::guardian_client::GuardianClient>>,
     guardian_signing_pubkey: OnceLock<Option<hashi_types::guardian::GuardianPubKey>>,
     local_limiter: OnceLock<Arc<guardian_limiter::LocalLimiter>>,
+    /// (seq, wid) of the last withdrawal finalized through the guardian. Paces
+    /// finalization so the leader never reuses a seq the guardian already
+    /// consumed while the local limiter catches up on-chain.
+    guardian_last_finalized: Mutex<Option<(u64, sui_sdk_types::Address)>>,
     /// Reconfig completion signatures by epoch.
     reconfig_signatures: RwLock<HashMap<u64, Vec<u8>>>,
 }
@@ -92,6 +97,7 @@ impl Hashi {
             guardian_client: OnceLock::new(),
             guardian_signing_pubkey: OnceLock::new(),
             local_limiter: OnceLock::new(),
+            guardian_last_finalized: Mutex::new(None),
             reconfig_signatures: RwLock::new(HashMap::new()),
         }))
     }
@@ -121,8 +127,31 @@ impl Hashi {
             guardian_client: OnceLock::new(),
             guardian_signing_pubkey: OnceLock::new(),
             local_limiter: OnceLock::new(),
+            guardian_last_finalized: Mutex::new(None),
             reconfig_signatures: RwLock::new(HashMap::new()),
         }))
+    }
+
+    /// Leader-side wrapper over
+    /// [`guardian_limiter::should_defer_guardian_finalize`], reading the last
+    /// `(seq, wid)` finalized through the guardian.
+    pub(crate) fn guardian_should_defer_finalize(
+        &self,
+        next_seq: u64,
+        wid: sui_sdk_types::Address,
+    ) -> bool {
+        let last = *self.guardian_last_finalized.lock().unwrap();
+        guardian_limiter::should_defer_guardian_finalize(next_seq, last, wid)
+    }
+
+    /// Record a successful guardian finalize (monotonic in seq) so subsequent
+    /// finalizes pace on the local limiter catching up.
+    pub(crate) fn record_guardian_finalized(&self, seq: u64, wid: sui_sdk_types::Address) {
+        let mut last = self.guardian_last_finalized.lock().unwrap();
+        match *last {
+            Some((prev_seq, _)) if seq < prev_seq => {}
+            _ => *last = Some((seq, wid)),
+        }
     }
 
     pub fn onchain_state(&self) -> &onchain::OnchainState {

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -50,6 +50,7 @@ pub struct Metrics {
     pub guardian_limiter_anchor_events_skipped_total: IntCounter,
     pub guardian_limiter_batch_truncated_total: IntCounter,
     pub guardian_limiter_batch_stuck_head_total: IntCounter,
+    pub guardian_finalize_deferred_total: IntCounter,
     pub guardian_rpc_total: IntCounterVec,
     pub guardian_rpc_duration_seconds: HistogramVec,
 
@@ -365,6 +366,12 @@ impl Metrics {
             guardian_limiter_batch_stuck_head_total: register_int_counter_with_registry!(
                 "hashi_guardian_limiter_batch_stuck_head_total",
                 "Times the head of the leader's approved batch already exceeded local-limiter capacity",
+                registry,
+            )
+            .unwrap(),
+            guardian_finalize_deferred_total: register_int_counter_with_registry!(
+                "hashi_guardian_finalize_deferred_total",
+                "Times the leader deferred a guardian finalize while waiting for the local limiter to catch up to the guardian's consumed seq (prevents stale-seq mismatches)",
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
After processing a withdrawal (which increments the sequence number on guardian), the leader doesn't start processing a new withdrawal until the `WithdrawalSignedEvent` is observed onchain, which increments the local limiter for the hashi nodes.

This reduces round trips during MPC signing because of the nodes not having the updated limiter sequence number.

Also adds a new `guardian_finalize_deferred_total` metric to track this.