### PR TITLE
[Guardian] hashi-monitor: replace 7d walk-back with S3 tree-walk for limiter recovery

### DIFF
--- a/crates/hashi-guardian/src/lib.rs
+++ b/crates/hashi-guardian/src/lib.rs
@@ -30,6 +30,8 @@ pub use test_utils::create_operator_initialized_enclave;
 #[cfg(any(test, feature = "test-utils"))]
 pub use test_utils::mock_logger;
 #[cfg(any(test, feature = "test-utils"))]
+pub use test_utils::mock_logger_with_layout;
+#[cfg(any(test, feature = "test-utils"))]
 pub use test_utils::FullyInitializedArgs;
 #[cfg(any(test, feature = "test-utils"))]
 pub use test_utils::OperatorInitTestArgs;

--- a/crates/hashi-guardian/src/s3_logger.rs
+++ b/crates/hashi-guardian/src/s3_logger.rs
@@ -309,10 +309,16 @@ impl S3Logger {
                     out.insert(p.to_string());
                 }
             }
-            match response.next_continuation_token() {
-                Some(token) => continuation_token = Some(token.to_string()),
-                None => break,
+            if response.is_truncated() != Some(true) {
+                break;
             }
+            let Some(token) = response.next_continuation_token() else {
+                return Err(S3Error(format!(
+                    "Truncated response but no next_continuation_token for prefix {}",
+                    prefix
+                )));
+            };
+            continuation_token = Some(token.to_string());
         }
         Ok(out.into_iter().collect())
     }

--- a/crates/hashi-guardian/src/s3_logger.rs
+++ b/crates/hashi-guardian/src/s3_logger.rs
@@ -279,6 +279,44 @@ impl S3Logger {
         self.ensure_no_duplicates_or_deletions(prefix).await
     }
 
+    /// Lists immediate subdirectories under `prefix` (S3 `CommonPrefixes`,
+    /// returned by `list_objects_v2` with `delimiter='/'`). Used to tree-walk
+    /// the hour-partitioned withdraw layout (`withdraw/YYYY/MM/DD/HH/`)
+    /// without paginating every object key. Returned prefixes are unique and
+    /// sorted lexicographically.
+    pub async fn list_common_prefixes(&self, prefix: &str) -> GuardianResult<Vec<String>> {
+        let mut continuation_token: Option<String> = None;
+        let mut out: BTreeSet<String> = BTreeSet::new();
+        loop {
+            let mut req = self
+                .client
+                .list_objects_v2()
+                .bucket(self.config.bucket_name())
+                .prefix(prefix)
+                .delimiter("/");
+            if let Some(ref token) = continuation_token {
+                req = req.continuation_token(token);
+            }
+            let response = req.send().await.map_err(|e| {
+                S3Error(format!(
+                    "Failed to list common prefixes under {}: {}",
+                    prefix,
+                    DisplayErrorContext(&e)
+                ))
+            })?;
+            for cp in response.common_prefixes() {
+                if let Some(p) = cp.prefix() {
+                    out.insert(p.to_string());
+                }
+            }
+            match response.next_continuation_token() {
+                Some(token) => continuation_token = Some(token.to_string()),
+                None => break,
+            }
+        }
+        Ok(out.into_iter().collect())
+    }
+
     /// Checks that all matching object keys do not have either deletions or overwrites.
     /// The prefix can either correspond to a directory or a complete object key.
     ///

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -27,6 +27,97 @@ pub fn mock_logger() -> S3Logger {
     S3Logger::from_client_for_tests(S3Config::mock_for_testing(), client)
 }
 
+/// Mock S3 logger whose `list_objects_v2(delimiter='/')` and
+/// `list_object_versions` responses are computed from an in-memory key set —
+/// useful for testing layered prefix tree-walks. PutObject also succeeds.
+///
+/// The dynamic responses depend on inspecting the request `prefix`; we capture
+/// it in a Mutex from `match_requests` and read it in `then_output` (the
+/// smithy-mocks API doesn't surface the request inside `then_output`). This
+/// is sound under a single-threaded async runtime — each S3 call's predicate
+/// runs immediately before its output factory.
+pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> S3Logger {
+    use aws_sdk_s3::operation::list_object_versions::ListObjectVersionsOutput;
+    use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
+    use aws_sdk_s3::operation::put_object::PutObjectOutput;
+    use aws_sdk_s3::types::CommonPrefix;
+    use aws_sdk_s3::types::ObjectVersion;
+    use aws_sdk_s3::Client;
+    use aws_smithy_mocks::mock;
+    use aws_smithy_mocks::mock_client;
+    use aws_smithy_mocks::RuleMode;
+    use hashi_types::guardian::S3Config;
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    let keys: Arc<BTreeSet<String>> = Arc::new(keys.into_iter().collect());
+
+    let v2_prefix: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let v2_prefix_w = v2_prefix.clone();
+    let v2_prefix_r = v2_prefix.clone();
+    let v2_keys = keys.clone();
+    let list_v2 = mock!(Client::list_objects_v2)
+        .match_requests(move |req| {
+            if req.delimiter() != Some("/") {
+                return false;
+            }
+            *v2_prefix_w.lock().unwrap() = req.prefix().map(|s| s.to_string());
+            true
+        })
+        .then_output(move || {
+            let prefix = v2_prefix_r.lock().unwrap().clone().unwrap_or_default();
+            let mut children: BTreeSet<String> = BTreeSet::new();
+            for key in v2_keys.iter() {
+                let Some(rest) = key.strip_prefix(&prefix) else {
+                    continue;
+                };
+                if let Some(slash) = rest.find('/') {
+                    let mut child = prefix.clone();
+                    child.push_str(&rest[..=slash]);
+                    children.insert(child);
+                }
+            }
+            let common_prefixes: Vec<CommonPrefix> = children
+                .into_iter()
+                .map(|c| CommonPrefix::builder().prefix(c).build())
+                .collect();
+            ListObjectsV2Output::builder()
+                .set_common_prefixes(Some(common_prefixes))
+                .build()
+        });
+
+    let lv_prefix: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let lv_prefix_w = lv_prefix.clone();
+    let lv_prefix_r = lv_prefix.clone();
+    let lv_keys = keys.clone();
+    let list_versions = mock!(Client::list_object_versions)
+        .match_requests(move |req| {
+            *lv_prefix_w.lock().unwrap() = req.prefix().map(|s| s.to_string());
+            true
+        })
+        .then_output(move || {
+            let prefix = lv_prefix_r.lock().unwrap().clone().unwrap_or_default();
+            let versions: Vec<ObjectVersion> = lv_keys
+                .iter()
+                .filter(|k| k.starts_with(&prefix))
+                .map(|k| ObjectVersion::builder().key(k).is_latest(true).build())
+                .collect();
+            ListObjectVersionsOutput::builder()
+                .set_versions(Some(versions))
+                .build()
+        });
+
+    let put_ok = mock!(Client::put_object).then_output(|| PutObjectOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[&list_v2, &list_versions, &put_ok]
+    );
+    S3Logger::from_client_for_tests(S3Config::mock_for_testing(), client)
+}
+
 pub struct OperatorInitTestArgs {
     pub network: Network,
     pub commitments: ShareCommitments,

--- a/crates/hashi-monitor/Cargo.toml
+++ b/crates/hashi-monitor/Cargo.toml
@@ -25,4 +25,5 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 e2e-tests = { path = "../e2e-tests" }
+hashi-guardian = { path = "../hashi-guardian", features = ["test-utils"] }
 tempfile.workspace = true

--- a/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
+++ b/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
@@ -37,11 +37,10 @@ use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use tracing::info;
 
-/// Returns `Some(post_state)` from the global max-seq Success log if one
-/// exists in the bucket; returns `None` if no Success log exists anywhere
-/// under `withdraw/`. Caller decides what to do with `None` (typically: fall
-/// back to genesis, since combined with the rotation-mode check it
-/// unambiguously means the prior enclave processed no withdrawals).
+/// Returns `Some(post_state)` from the global max-seq Success log under
+/// `withdraw/` if one exists; returns `None` if no Success log exists
+/// anywhere — either a first deployment or a rotation where the prior
+/// enclave processed no withdrawals. Caller falls back to genesis on `None`.
 pub async fn recover_limiter_state(s3_client: S3Logger) -> anyhow::Result<Option<LimiterState>> {
     let Some(bucket) = find_latest_success_bucket(&s3_client).await? else {
         return Ok(None);

--- a/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
+++ b/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
@@ -6,68 +6,62 @@
 //!
 //! Each successful withdrawal log carries the limiter `post_state` after that
 //! consume. seq is strictly monotonic across all rotations, so the global
-//! max-seq Success log holds the most recent state. To find it we walk back
-//! hour by hour from `now`, returning the post_state from the first non-empty
-//! bucket's max-seq log. We also peek one bucket further back to defend
-//! against sub-hour clock skew across hour boundaries.
+//! max-seq Success log holds the most recent state.
+//!
+//! Finding that log is a 4-level S3 tree-walk over the hour-partitioned layout
+//! (`withdraw/YYYY/MM/DD/HH/`): at each level we list `CommonPrefixes` (~one
+//! `list_objects_v2` call), pick the lex-greatest, and descend. The first
+//! hour bucket containing any `success-*` key is the latest non-empty bucket
+//! — we read it and one bucket back (sub-hour clock-skew defense across hour
+//! boundaries) and take the max-seq Success across both. No arbitrary
+//! walk-back time limit — the search is bounded by actual data on disk.
 //!
 //! Note we deliberately don't apply `GuardianPollerCore::is_readable`'s
-//! `DIR_WRITES_COMPLETION_DELAY` gate here. That gate exists for the
-//! polling/auditor case where the source might still be writing; if we used it
-//! here, an enclave that died late in an hour would have its final-hour bucket
-//! treated as not-yet-readable, and the recovery would skip past the most
-//! recent log. We instead rely on the caller invoking us only after
-//! `heartbeat_audit` has confirmed the prior session has been silent for at
-//! least `OTHER_SESSION_QUIET_PERIOD` (10 min), which combined with S3
-//! read-after-write consistency guarantees all of its writes are visible.
+//! `DIR_WRITES_COMPLETION_DELAY` gate when reading the found bucket. That
+//! gate exists for the polling/auditor case where the source might still be
+//! writing; if we used it here, an enclave that died late in an hour would
+//! have its final-hour bucket treated as not-yet-readable, and recovery would
+//! miss the most recent log. We instead rely on the caller invoking us only
+//! after `heartbeat_audit` has confirmed the prior session has been silent
+//! for at least `OTHER_SESSION_QUIET_PERIOD` (10 min), which combined with
+//! S3 read-after-write consistency guarantees its writes are visible.
 
-use crate::domain::now_unix_seconds;
 use crate::rpc::guardian::GuardianLogDir;
 use crate::rpc::guardian::GuardianPollerCore;
 use hashi_guardian::s3_logger::S3Logger;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::S3_DIR_WITHDRAW;
 use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::WithdrawalLogMessage;
+use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use tracing::info;
 
-/// Max hour buckets to walk back when searching for the most recent Success log.
-/// One week covers any realistic idleness; if no Success is found within this
-/// window the prior enclave is treated as having consumed nothing, and the
-/// caller falls back to a genesis limiter state.
-const MAX_WALK_BACK_HOURS: u64 = 7 * 24;
-
-/// Returns `Some(post_state)` from the global max-seq Success log if one is
-/// found within `MAX_WALK_BACK_HOURS`. Returns `None` if no Success log exists
-/// in that window — caller decides what to do (typically: fall back to
-/// genesis, since combined with the rotation-mode check this unambiguously
-/// means the prior enclave processed no withdrawals).
+/// Returns `Some(post_state)` from the global max-seq Success log if one
+/// exists in the bucket; returns `None` if no Success log exists anywhere
+/// under `withdraw/`. Caller decides what to do with `None` (typically: fall
+/// back to genesis, since combined with the rotation-mode check it
+/// unambiguously means the prior enclave processed no withdrawals).
 pub async fn recover_limiter_state(s3_client: S3Logger) -> anyhow::Result<Option<LimiterState>> {
-    let now = now_unix_seconds();
-    let mut poller = GuardianPollerCore::from_s3_client(s3_client, now, GuardianLogDir::Withdraw);
+    let Some(bucket) = find_latest_success_bucket(&s3_client).await? else {
+        return Ok(None);
+    };
 
-    let mut best: Option<LimiterState> = None;
-    for _ in 0..MAX_WALK_BACK_HOURS {
-        // NOTE (future optimization): read_cur_dir fetches and verifies every
-        // log body in the bucket, but we only need the max-seq Success body.
-        // The seq-prefixed key format (`success-{seq:020}-...`) lets us list
-        // keys, pick the lex-last `success-*` entry, and fetch only that
-        // single object — turning O(n) object reads per bucket into O(1).
-        if let Some(hit) = bucket_max_post_state(poller.read_cur_dir().await?) {
-            // First non-empty bucket. Peek one bucket back for clock-skew safety,
-            // then take the max across both.
-            poller.retreat_cursor();
-            let peek = bucket_max_post_state(poller.read_cur_dir().await?);
-            best = [Some(hit), peek]
-                .into_iter()
-                .flatten()
-                .max_by_key(|s| s.next_seq);
-            break;
-        }
-        poller.retreat_cursor();
-    }
+    let mut poller = GuardianPollerCore::from_s3_client(
+        s3_client,
+        bucket.to_unix_seconds(),
+        GuardianLogDir::Withdraw,
+    );
 
-    if let Some(state) = best {
+    // Read the found bucket + one bucket back, then take max-seq across both.
+    // The peek-back defends against sub-hour clock skew that may have placed
+    // a higher-seq log in the prior hour bucket.
+    let hit = bucket_max_post_state(poller.read_cur_dir().await?);
+    poller.retreat_cursor();
+    let peek = bucket_max_post_state(poller.read_cur_dir().await?);
+    let best = [hit, peek].into_iter().flatten().max_by_key(|s| s.next_seq);
+
+    if let Some(ref state) = best {
         info!(
             next_seq = state.next_seq,
             num_tokens_available = state.num_tokens_available,
@@ -76,6 +70,48 @@ pub async fn recover_limiter_state(s3_client: S3Logger) -> anyhow::Result<Option
         );
     }
     Ok(best)
+}
+
+/// Finds the latest hour bucket under `withdraw/` containing at least one
+/// `success-*` key, by descending the YYYY/MM/DD/HH tree in lex-greatest
+/// order at each level. Returns `None` if no Success log exists anywhere.
+async fn find_latest_success_bucket(
+    s3_client: &S3Logger,
+) -> anyhow::Result<Option<S3HourScopedDirectory>> {
+    let root = format!("{}/", S3_DIR_WITHDRAW);
+    let years = list_subdirs_desc(s3_client, &root).await?;
+    for year in years {
+        let months = list_subdirs_desc(s3_client, &year).await?;
+        for month in months {
+            let days = list_subdirs_desc(s3_client, &month).await?;
+            for day in days {
+                let hours = list_subdirs_desc(s3_client, &day).await?;
+                for hour in hours {
+                    if hour_bucket_has_success(s3_client, &hour).await? {
+                        return Ok(Some(S3HourScopedDirectory::from_path(&hour)?));
+                    }
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+async fn list_subdirs_desc(s3_client: &S3Logger, prefix: &str) -> anyhow::Result<Vec<String>> {
+    let mut subs = s3_client
+        .list_common_prefixes(prefix)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+    subs.sort_by(|a, b| b.cmp(a));
+    Ok(subs)
+}
+
+async fn hour_bucket_has_success(s3_client: &S3Logger, bucket: &str) -> anyhow::Result<bool> {
+    let keys = s3_client
+        .list_all_keys_in_dir(&format!("{bucket}success-"))
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+    Ok(!keys.is_empty())
 }
 
 fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {
@@ -166,5 +202,75 @@ mod tests {
         let logs = vec![failure_log(), success_log(2), failure_log(), success_log(9)];
         let got = bucket_max_post_state(logs).expect("non-empty success set");
         assert_eq!(got.next_seq, 9);
+    }
+
+    // ----- find_latest_success_bucket tests (S3 SDK-level mocking) -----
+
+    fn success_key(year: u16, month: u8, day: u8, hour: u8, seq: u64) -> String {
+        format!(
+            "withdraw/{year:04}/{month:02}/{day:02}/{hour:02}/success-{seq:020}-sess-widabc.json"
+        )
+    }
+
+    fn failure_key(year: u16, month: u8, day: u8, hour: u8, n: u32) -> String {
+        format!("withdraw/{year:04}/{month:02}/{day:02}/{hour:02}/failure-sess-widabc-{n:08x}.json")
+    }
+
+    fn assert_bucket(actual: Option<S3HourScopedDirectory>, expected_path: &str) {
+        let got = actual.expect("expected Some bucket");
+        assert_eq!(
+            got,
+            S3HourScopedDirectory::from_path(expected_path).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn find_latest_success_bucket_empty_returns_none() {
+        let s3 = hashi_guardian::test_utils::mock_logger_with_layout(std::iter::empty());
+        let got = find_latest_success_bucket(&s3).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_latest_success_bucket_single_success_returns_that_bucket() {
+        let keys = vec![success_key(2024, 3, 15, 14, 7)];
+        let s3 = hashi_guardian::test_utils::mock_logger_with_layout(keys);
+        let got = find_latest_success_bucket(&s3).await.unwrap();
+        assert_bucket(got, "withdraw/2024/03/15/14/");
+    }
+
+    #[tokio::test]
+    async fn find_latest_success_bucket_skips_latest_hour_with_only_failures() {
+        let keys = vec![
+            failure_key(2024, 3, 15, 14, 0xdead_beef),
+            success_key(2024, 3, 15, 13, 5),
+        ];
+        let s3 = hashi_guardian::test_utils::mock_logger_with_layout(keys);
+        let got = find_latest_success_bucket(&s3).await.unwrap();
+        assert_bucket(got, "withdraw/2024/03/15/13/");
+    }
+
+    #[tokio::test]
+    async fn find_latest_success_bucket_picks_lex_greatest_across_years() {
+        let keys = vec![
+            success_key(2023, 12, 31, 23, 1),
+            success_key(2024, 1, 1, 0, 2),
+        ];
+        let s3 = hashi_guardian::test_utils::mock_logger_with_layout(keys);
+        let got = find_latest_success_bucket(&s3).await.unwrap();
+        assert_bucket(got, "withdraw/2024/01/01/00/");
+    }
+
+    #[tokio::test]
+    async fn find_latest_success_bucket_backtracks_within_day() {
+        // Latest hour (15) has only failures; earlier hour (12) same day has a success.
+        let keys = vec![
+            failure_key(2024, 3, 15, 15, 1),
+            failure_key(2024, 3, 15, 14, 2),
+            success_key(2024, 3, 15, 12, 9),
+        ];
+        let s3 = hashi_guardian::test_utils::mock_logger_with_layout(keys);
+        let got = find_latest_success_bucket(&s3).await.unwrap();
+        assert_bucket(got, "withdraw/2024/03/15/12/");
     }
 }

--- a/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
+++ b/crates/hashi-monitor/src/provisioner/limiter_recovery.rs
@@ -13,18 +13,18 @@
 //! `list_objects_v2` call), pick the lex-greatest, and descend. The first
 //! hour bucket containing any `success-*` key is the latest non-empty bucket
 //! — we read it and one bucket back (sub-hour clock-skew defense across hour
-//! boundaries) and take the max-seq Success across both. No arbitrary
-//! walk-back time limit — the search is bounded by actual data on disk.
+//! boundaries) and take the max-seq Success across both.
 //!
-//! Note we deliberately don't apply `GuardianPollerCore::is_readable`'s
+//! Note we deliberately don't apply `GuardianPollerCore::writes_completed`'s
 //! `DIR_WRITES_COMPLETION_DELAY` gate when reading the found bucket. That
 //! gate exists for the polling/auditor case where the source might still be
 //! writing; if we used it here, an enclave that died late in an hour would
-//! have its final-hour bucket treated as not-yet-readable, and recovery would
+//! have its final-hour bucket treated as not-yet-complete, and recovery would
 //! miss the most recent log. We instead rely on the caller invoking us only
 //! after `heartbeat_audit` has confirmed the prior session has been silent
 //! for at least `OTHER_SESSION_QUIET_PERIOD` (10 min), which combined with
-//! S3 read-after-write consistency guarantees its writes are visible.
+//! S3 read-after-write consistency guarantees that all writes of the old session
+//! are completed.
 
 use crate::rpc::guardian::GuardianLogDir;
 use crate::rpc::guardian::GuardianPollerCore;

--- a/crates/hashi-monitor/src/provisioner/mod.rs
+++ b/crates/hashi-monitor/src/provisioner/mod.rs
@@ -13,7 +13,6 @@ use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::ProvisionerInitRequest;
 use hashi_types::guardian::ProvisionerInitState;
-use hashi_types::guardian::S3_DIR_INIT;
 use hashi_types::guardian::proto_conversions::provisioner_init_request_to_pb;
 use hashi_types::guardian::session_id_from_signing_pubkey;
 use hashi_types::guardian::verify_enclave_attestation;
@@ -41,31 +40,24 @@ pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
     expected_guardian_config.ensure_matches_info(&guardian_info)?;
     info!(session_id, "init checks passed for selected session");
 
-    // 3. Detect whether this is a first deployment or a rotation, and source
-    // the initial limiter state accordingly.
-    let mode = detect_deployment_mode(&s3_client, &session_id).await?;
-    info!(?mode, "detected deployment mode");
-    let limiter_state = match mode {
-        DeploymentMode::Rotation => {
-            match limiter_recovery::recover_limiter_state(s3_client.clone()).await? {
-                Some(mut recovered) => {
-                    // Cap to the current config's bucket capacity in case max capacity
-                    // was lowered across the rotation. (Raising is fine — refill will
-                    // fill it.)
-                    recovered.num_tokens_available = recovered
-                        .num_tokens_available
-                        .min(cfg.withdrawal_config.max_bucket_capacity_sats);
-                    recovered
-                }
-                None => {
-                    tracing::warn!(
-                        "rotation detected but prior enclave has no Success logs within walk-back window; falling back to genesis limiter state"
-                    );
-                    LimiterState::genesis(&cfg.withdrawal_config)
-                }
-            }
+    // 3. Source the initial limiter state. If a prior enclave left Success
+    // withdrawal logs we recover from them; otherwise (first deployment, or a
+    // rotation where the prior enclave processed no withdrawals) we initialize
+    // from genesis.
+    let limiter_state = match limiter_recovery::recover_limiter_state(s3_client.clone()).await? {
+        Some(mut recovered) => {
+            // Cap to the current config's bucket capacity in case max capacity
+            // was lowered across the rotation. (Raising is fine — refill will
+            // fill it.)
+            recovered.num_tokens_available = recovered
+                .num_tokens_available
+                .min(cfg.withdrawal_config.max_bucket_capacity_sats);
+            recovered
         }
-        DeploymentMode::Genesis => LimiterState::genesis(&cfg.withdrawal_config),
+        None => {
+            info!("no prior Success withdrawal logs found; initializing limiter from genesis");
+            LimiterState::genesis(&cfg.withdrawal_config)
+        }
     };
 
     let committee = cfg.hashi_committee.try_into()?;
@@ -103,55 +95,6 @@ pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
         .await?;
     }
     Ok(())
-}
-
-/// Whether this provisioner-init is for the very first enclave in this S3
-/// bucket or a rotation onto a successor enclave. Determined from S3 init logs
-/// — see [`detect_deployment_mode`] — and used to switch between sourcing
-/// initial state from config (genesis) vs. recovering it from the prior
-/// enclave's logs (rotation). Future genesis/rotation-aware behaviors (e.g.,
-/// committee fetch) can match on the same enum.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum DeploymentMode {
-    Genesis,
-    Rotation,
-}
-
-/// Inspects S3 init logs for any session other than `current_session_id`.
-/// Presence of one or more such session ⇒ Rotation; otherwise Genesis.
-///
-/// Bails on any key under `init/` that doesn't match the expected
-/// `{session_id}-{suffix}` layout — unexpected keys shouldn't exist there
-/// and silently ignoring them could mask a real prior session.
-async fn detect_deployment_mode(
-    s3_client: &S3Logger,
-    current_session_id: &str,
-) -> anyhow::Result<DeploymentMode> {
-    let prefix = format!("{}/", S3_DIR_INIT);
-    let keys = s3_client
-        .list_all_keys_in_dir(&prefix)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-    for key in keys {
-        let session_id = extract_session_id_from_init_key(&key, &prefix)?;
-        if session_id != current_session_id {
-            return Ok(DeploymentMode::Rotation);
-        }
-    }
-    Ok(DeploymentMode::Genesis)
-}
-
-/// Extracts the session_id from an `init/{session_id}-{suffix}.json` key.
-/// session_id is the lowercase hex of the enclave signing pubkey, so it
-/// contains no dashes — the first '-' after the prefix delimits it.
-fn extract_session_id_from_init_key<'a>(key: &'a str, prefix: &str) -> anyhow::Result<&'a str> {
-    let after_prefix = key
-        .strip_prefix(prefix)
-        .ok_or_else(|| anyhow::anyhow!("unexpected init log key (missing prefix): {key}"))?;
-    let (session_id, _suffix) = after_prefix
-        .split_once('-')
-        .ok_or_else(|| anyhow::anyhow!("unexpected init log key (no suffix delimiter): {key}"))?;
-    Ok(session_id)
 }
 
 /// Implements check B of IOP-225.
@@ -228,33 +171,4 @@ async fn prechecks(
     expected_guardian_config.ensure_matches_info(&info)?;
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn extract_session_id_strips_prefix_and_takes_up_to_first_dash() {
-        let session = "abcdef1234567890";
-        let key = format!("init/{session}-oi-attestation-unsigned.json");
-        assert_eq!(
-            extract_session_id_from_init_key(&key, "init/").unwrap(),
-            session
-        );
-    }
-
-    #[test]
-    fn extract_session_id_rejects_missing_prefix() {
-        let err = extract_session_id_from_init_key("withdraw/abc-suffix.json", "init/")
-            .expect_err("must fail on wrong prefix");
-        assert!(err.to_string().contains("missing prefix"));
-    }
-
-    #[test]
-    fn extract_session_id_rejects_missing_suffix_delimiter() {
-        let err = extract_session_id_from_init_key("init/abcdef.json", "init/")
-            .expect_err("must fail on no dash after prefix");
-        assert!(err.to_string().contains("no suffix delimiter"));
-    }
 }

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -112,7 +112,7 @@ impl GuardianPollerCore {
         }
     }
 
-    pub fn is_readable(&self) -> bool {
+    pub fn writes_completed(&self) -> bool {
         now_unix_seconds() >= self.cursor.write_completion_time()
     }
 
@@ -188,7 +188,7 @@ impl GuardianWithdrawalsPoller {
     /// Polls the Guardian S3 bucket for one hour worth of events.
     /// A more aggressive fetch, e.g., one day at a time, can also be done if needed.
     pub async fn poll_one_hour(&mut self) -> anyhow::Result<PollOutcome> {
-        if !self.0.is_readable() {
+        if !self.0.writes_completed() {
             return Ok(PollOutcome::CursorUnmoved);
         }
 

--- a/crates/hashi-types/src/guardian/s3_utils.rs
+++ b/crates/hashi-types/src/guardian/s3_utils.rs
@@ -78,7 +78,7 @@ impl S3HourScopedDirectory {
 
     /// Parses a directory path of the form `{prefix}/{yyyy}/{mm}/{dd}/{hh}/`
     /// (with or without the trailing slash) back into a directory value.
-    /// Inverse of [`Self::fmt`].
+    /// Inverse of the `Display` impl.
     pub fn from_path(path: &str) -> anyhow::Result<Self> {
         let parts: Vec<&str> = path.trim_end_matches('/').split('/').collect();
         anyhow::ensure!(

--- a/crates/hashi-types/src/guardian/s3_utils.rs
+++ b/crates/hashi-types/src/guardian/s3_utils.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::guardian::time_utils::UnixSeconds;
+use anyhow::Context;
 use std::convert::TryFrom;
 use std::fmt;
 use std::time::Duration;
@@ -67,15 +68,60 @@ impl S3HourScopedDirectory {
     }
 
     pub fn to_unix_seconds(&self) -> UnixSeconds {
-        let month = time::Month::try_from(self.month).expect("month should be valid");
-        let date =
-            Date::from_calendar_date(self.year, month, self.day).expect("date should be valid");
-        let time = Time::from_hms(self.hour, 0, 0).expect("hour should be valid");
+        let (date, time) = parse_calendar(self.year, self.month, self.day, self.hour)
+            .expect("invariants validated at construction");
         let ts = PrimitiveDateTime::new(date, time)
             .assume_utc()
             .unix_timestamp();
         UnixSeconds::try_from(ts).expect("timestamp should be non-negative")
     }
+
+    /// Parses a directory path of the form `{prefix}/{yyyy}/{mm}/{dd}/{hh}/`
+    /// (with or without the trailing slash) back into a directory value.
+    /// Inverse of [`Self::fmt`].
+    pub fn from_path(path: &str) -> anyhow::Result<Self> {
+        let parts: Vec<&str> = path.trim_end_matches('/').split('/').collect();
+        anyhow::ensure!(
+            parts.len() == 5,
+            "expected `{{prefix}}/YYYY/MM/DD/HH/` in {path}"
+        );
+        let prefix = parts[0];
+        let year: Year = parts[1]
+            .parse()
+            .with_context(|| format!("invalid year in {path}"))?;
+        let month: Month = parts[2]
+            .parse()
+            .with_context(|| format!("invalid month in {path}"))?;
+        let day: Day = parts[3]
+            .parse()
+            .with_context(|| format!("invalid day in {path}"))?;
+        let hour: Hour = parts[4]
+            .parse()
+            .with_context(|| format!("invalid hour in {path}"))?;
+        parse_calendar(year, month, day, hour).with_context(|| format!("invalid path {path}"))?;
+        Ok(Self {
+            prefix: prefix.to_string(),
+            year,
+            month,
+            day,
+            hour,
+        })
+    }
+}
+
+/// Validates the (year, month, day, hour) tuple and returns the corresponding
+/// `(Date, Time)` if every component is in range. Shared by [`S3HourScopedDirectory::from_path`]
+/// (which uses it to validate before construction) and
+/// [`S3HourScopedDirectory::to_unix_seconds`] (which is infallible because the
+/// struct invariant guarantees validity).
+fn parse_calendar(year: Year, month: Month, day: Day, hour: Hour) -> anyhow::Result<(Date, Time)> {
+    let month_enum =
+        time::Month::try_from(month).map_err(|e| anyhow::anyhow!("invalid month {month}: {e}"))?;
+    let date = Date::from_calendar_date(year, month_enum, day)
+        .map_err(|e| anyhow::anyhow!("invalid date {year}-{month:02}-{day:02}: {e}"))?;
+    let time =
+        Time::from_hms(hour, 0, 0).map_err(|e| anyhow::anyhow!("invalid hour {hour}: {e}"))?;
+    Ok((date, time))
 }
 
 impl fmt::Display for S3HourScopedDirectory {
@@ -123,6 +169,28 @@ mod tests {
         // Saturates at epoch.
         let epoch = S3HourScopedDirectory::new("withdraw", 0);
         assert_eq!(epoch.prev_dir(), epoch);
+    }
+
+    #[test]
+    fn test_from_path_roundtrips_with_display() {
+        let dir = S3HourScopedDirectory::new("withdraw", 1_700_000_000);
+        let displayed = dir.to_string();
+        let parsed = S3HourScopedDirectory::from_path(&displayed).expect("roundtrip");
+        assert_eq!(parsed, dir);
+        // Also accept the trailing-slash-stripped form.
+        let parsed_nopfx = S3HourScopedDirectory::from_path(displayed.trim_end_matches('/'))
+            .expect("roundtrip without trailing slash");
+        assert_eq!(parsed_nopfx, dir);
+    }
+
+    #[test]
+    fn test_from_path_rejects_wrong_shape() {
+        assert!(S3HourScopedDirectory::from_path("withdraw/2024/03/15/").is_err()); // missing hour
+        assert!(S3HourScopedDirectory::from_path("withdraw/2024/03/15/14/extra/").is_err()); // too many parts
+        assert!(S3HourScopedDirectory::from_path("withdraw/2024/13/15/14/").is_err()); // invalid month
+        assert!(S3HourScopedDirectory::from_path("withdraw/2024/02/30/14/").is_err()); // invalid day
+        assert!(S3HourScopedDirectory::from_path("withdraw/2024/02/15/24/").is_err()); // invalid hour
+        assert!(S3HourScopedDirectory::from_path("withdraw/notayear/03/15/14/").is_err()); // non-numeric
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #572. Replaces the arbitrary `MAX_WALK_BACK_HOURS = 7d` time window in `recover_limiter_state` with an S3 tree-walk that finds the latest non-empty hour bucket by descending `withdraw/YYYY/MM/DD/HH/` via `CommonPrefixes`. Bounded by actual data on disk, not by a wall-clock cliff.

### Behavior changes
- No 7-day cliff. If the prior enclave's last withdrawal is older than 7 days (idle period before rotation), we still find it.
- No warn-then-fallback-to-genesis on missed walk-back. `None` now means "no Success log exists anywhere under `withdraw/`" (caller still genesis-inits in that case).
- Same clock-skew defense: after finding the latest hour bucket with `success-*`, we also read the prior hour bucket and take max-seq across both.

### Implementation
- `hashi-guardian/src/s3_logger.rs`: new `list_common_prefixes` (`list_objects_v2` with `delimiter='/'`).
- `hashi-types/src/guardian/s3_utils.rs`: new `S3HourScopedDirectory::from_path` as the inverse of `Display`; factored shared `parse_calendar` helper between `from_path` and `to_unix_seconds`.
- `hashi-monitor/src/provisioner/limiter_recovery.rs`: 4-level tree descent at each level taking the lex-greatest subdir; at each candidate hour bucket, check for `success-*` keys; on first hit, read it + one bucket back and return max-seq `post_state`.

### Tests
- 5 new mock-S3 tests for `find_latest_success_bucket` covering: empty bucket, single hour with success, latest hour empty of success backs out to earlier hour, multi-year tree picks lex-greatest leaf, intra-day backtrack.
- Wired via a new `hashi_guardian::test_utils::mock_logger_with_layout` helper that synthesizes `list_objects_v2` / `list_object_versions` responses from an in-memory key set. hashi-monitor pulls hashi-guardian's `test-utils` feature for dev — no second copy of `aws-smithy-mocks`.

## Test plan

- [x] `make check-fmt && make clippy` clean.
- [x] `cargo nextest run -p hashi-monitor provisioner::limiter_recovery` — 9 pass (4 existing + 5 new).
- [ ] Manual: run provisioner-init against a staging bucket where the prior enclave has been idle for >7 days and verify recovery finds the older Success log (would have failed pre-PR).
- [ ] Manual: run provisioner-init against a fresh bucket (no `withdraw/` keys) and verify it returns `None` quickly without scanning a 168-hour window.