### PR TITLE
[guardian-hardening][limiter] reconcile to guardian on stall

### DIFF
--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -123,6 +123,16 @@ impl LocalLimiter {
         guard.next_seq += 1;
         Ok(())
     }
+
+    /// Overwrite local state with the guardian's authoritative `state`. The
+    /// guardian is the source of truth; this is the recovery path for a mirror
+    /// that has drifted and that the watcher's event stream cannot re-sync on
+    /// its own — e.g. a `WithdrawalSignedEvent` dropped across a
+    /// checkpoint-subscription reconnect, then skipped on redelivery via
+    /// `signatures.is_some()`. Config is immutable and left unchanged.
+    pub fn reconcile_to(&self, state: LimiterState) {
+        *self.state.write().unwrap() = state;
+    }
 }
 
 fn project_capacity(config: &LimiterConfig, state: &LimiterState, timestamp_secs: u64) -> u64 {
@@ -142,6 +152,52 @@ pub(crate) fn should_defer_guardian_finalize(
     wid: sui_sdk_types::Address,
 ) -> bool {
     last_finalized.is_some_and(|(last_seq, last_wid)| next_seq <= last_seq && wid != last_wid)
+}
+
+/// Consecutive reconcile ticks the local limiter must stay drifted from the
+/// guardian *at the same local seq* before we treat it as a genuine stall. This
+/// rules out normal in-flight lag, where the mirror trails the guardian by a
+/// little but keeps advancing as `WithdrawalSignedEvent`s arrive (so the local
+/// seq changes between ticks and the streak resets).
+pub(crate) const STALL_RECONCILE_TICKS: u32 = 4;
+
+/// Detects a local limiter that has drifted from the guardian and stayed frozen
+/// long enough to be a genuine stall rather than transient lag. Fed one
+/// observation per reconcile tick; a positive result means the caller should
+/// [`LocalLimiter::reconcile_to`] the guardian's authoritative state.
+#[derive(Default)]
+pub(crate) struct LimiterStallTracker {
+    frozen_at_seq: Option<u64>,
+    frozen_ticks: u32,
+}
+
+impl LimiterStallTracker {
+    /// Record the latest local/guardian seqs; returns true once the mirror has
+    /// been stalled long enough that it should be reconciled. Resets after
+    /// signalling, so the caller reconciles at most once per detected stall.
+    pub(crate) fn observe(&mut self, local_seq: u64, guardian_seq: u64) -> bool {
+        if local_seq == guardian_seq {
+            self.reset();
+            return false;
+        }
+        if self.frozen_at_seq == Some(local_seq) {
+            self.frozen_ticks += 1;
+        } else {
+            self.frozen_at_seq = Some(local_seq);
+            self.frozen_ticks = 1;
+        }
+        if self.frozen_ticks >= STALL_RECONCILE_TICKS {
+            self.reset();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn reset(&mut self) {
+        self.frozen_at_seq = None;
+        self.frozen_ticks = 0;
+    }
 }
 
 #[cfg(test)]
@@ -244,5 +300,63 @@ mod tests {
         assert!(should_defer_guardian_finalize(4, Some((5, a)), b));
         assert!(!should_defer_guardian_finalize(5, Some((5, a)), a));
         assert!(!should_defer_guardian_finalize(6, Some((5, a)), b));
+    }
+
+    #[test]
+    fn reconcile_to_overwrites_state_in_either_direction() {
+        let limiter = make_limiter(0, 0, 21);
+        // Forward: recover a mirror stuck behind the guardian.
+        limiter.reconcile_to(LimiterState {
+            num_tokens_available: 500,
+            last_updated_at: 100,
+            next_seq: 30,
+        });
+        let s = limiter.snapshot();
+        assert_eq!(s.next_seq, 30);
+        assert_eq!(s.num_tokens_available, 500);
+        assert_eq!(s.last_updated_at, 100);
+        // Backward: correct an overshoot back to the source of truth.
+        limiter.reconcile_to(LimiterState {
+            num_tokens_available: 1,
+            last_updated_at: 200,
+            next_seq: 25,
+        });
+        assert_eq!(limiter.snapshot().next_seq, 25);
+    }
+
+    #[test]
+    fn stall_tracker_ignores_normal_advancing_lag() {
+        let mut tracker = LimiterStallTracker::default();
+        // Mirror trails the guardian by one but keeps advancing -> never a stall.
+        for seq in 5..5 + 3 * u64::from(STALL_RECONCILE_TICKS) {
+            assert!(!tracker.observe(seq, seq + 1));
+        }
+    }
+
+    #[test]
+    fn stall_tracker_resets_when_caught_up() {
+        let mut tracker = LimiterStallTracker::default();
+        assert!(!tracker.observe(21, 22));
+        assert!(!tracker.observe(22, 22)); // caught up -> reset
+        assert!(!tracker.observe(22, 23)); // streak starts over
+    }
+
+    #[test]
+    fn stall_tracker_fires_after_persistent_freeze_then_resets() {
+        let mut tracker = LimiterStallTracker::default();
+        for _ in 0..STALL_RECONCILE_TICKS - 1 {
+            assert!(!tracker.observe(21, 22));
+        }
+        assert!(tracker.observe(21, 22)); // genuine stall
+        assert!(!tracker.observe(21, 22)); // reset after firing
+    }
+
+    #[test]
+    fn stall_tracker_fires_for_overshoot_too() {
+        let mut tracker = LimiterStallTracker::default();
+        for _ in 0..STALL_RECONCILE_TICKS - 1 {
+            assert!(!tracker.observe(24, 22)); // local ahead of the guardian
+        }
+        assert!(tracker.observe(24, 22));
     }
 }

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -124,9 +124,7 @@ impl LocalLimiter {
         Ok(())
     }
 
-    /// Overwrite local state with the guardian's authoritative `state` (the
-    /// recovery path when the watcher's event stream can't re-sync on its own,
-    /// e.g. an event dropped across a checkpoint-subscription reconnect).
+    /// Overwrite local state with the guardian's authoritative `state`.
     pub fn reconcile_to(&self, state: LimiterState) {
         *self.state.write().unwrap() = state;
     }
@@ -151,15 +149,12 @@ pub(crate) fn should_defer_guardian_finalize(
     last_finalized.is_some_and(|(last_seq, last_wid)| next_seq <= last_seq && wid != last_wid)
 }
 
-/// Consecutive reconcile ticks the mirror must stay drifted *at the same local
-/// seq* before we treat it as a genuine stall (vs. normal in-flight lag, where
-/// `local_seq` keeps advancing between ticks). 20 ticks ≈ 5 min at 15 s — wide
-/// enough that a slow guardian-RPC → on-chain-event round-trip doesn't trip a
-/// false stall and over-advance the mirror.
+/// Ticks the mirror must stay frozen at the same local seq before we treat
+/// it as a real stall. 20 ticks ≈ 5 min at 15 s — wide enough that a slow
+/// guardian-RPC → on-chain-event RTT doesn't trip a false stall.
 pub(crate) const STALL_RECONCILE_TICKS: u32 = 20;
 
-/// Detects a frozen mirror over a streak of reconcile ticks; returns `true`
-/// once the streak crosses [`STALL_RECONCILE_TICKS`] and resets afterwards.
+/// Detects a mirror frozen at the same `local_seq` for [`STALL_RECONCILE_TICKS`] consecutive ticks.
 #[derive(Default)]
 pub(crate) struct LimiterStallTracker {
     frozen_at_seq: Option<u64>,

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -149,9 +149,7 @@ pub(crate) fn should_defer_guardian_finalize(
     last_finalized.is_some_and(|(last_seq, last_wid)| next_seq <= last_seq && wid != last_wid)
 }
 
-/// Ticks the mirror must stay frozen at the same local seq before we treat
-/// it as a real stall. 20 ticks ≈ 5 min at 15 s — wide enough that a slow
-/// guardian-RPC → on-chain-event RTT doesn't trip a false stall.
+/// 20 ticks ≈ 5 min at 15 s — beyond a slow guardian→on-chain RTT.
 pub(crate) const STALL_RECONCILE_TICKS: u32 = 20;
 
 /// Detects a mirror frozen at the same `local_seq` for [`STALL_RECONCILE_TICKS`] consecutive ticks.

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -7,6 +7,7 @@
 
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
+use std::collections::VecDeque;
 use std::fmt;
 use std::sync::RwLock;
 
@@ -149,39 +150,44 @@ pub(crate) fn should_defer_guardian_finalize(
     last_finalized.is_some_and(|(last_seq, last_wid)| next_seq <= last_seq && wid != last_wid)
 }
 
-/// 20 ticks ≈ 5 min.
-pub(crate) const STALL_RECONCILE_TICKS: u32 = 20;
+/// 20 ticks ≈ 5 min at the reconcile cadence.
+pub(crate) const STALL_RECONCILE_TICKS: usize = 20;
 
-/// Detects a mirror frozen at the same `local_seq` for [`STALL_RECONCILE_TICKS`] consecutive ticks.
+/// Flags a local mirror that has fallen out of lockstep with the guardian.
+///
+/// The guardian bumps `next_seq` at finalize-request time but a node only
+/// advances on the matching on-chain `WithdrawalSignedEvent`, so `local <
+/// guardian` is ordinary in-flight lag and must not, on its own, trip a
+/// reconcile (forward-snapping a healthy mirror would double-count the event
+/// still in flight). We fire only when the mirror has failed to reach the
+/// seq the guardian held a full [`STALL_RECONCILE_TICKS`] window ago — by
+/// now those withdrawals have certainly emitted their events, so a mirror
+/// still short has genuinely dropped one — or when it runs ahead of the
+/// guardian, which can only happen once lockstep is already lost.
 #[derive(Default)]
 pub(crate) struct LimiterStallTracker {
-    frozen_at_seq: Option<u64>,
-    frozen_ticks: u32,
+    /// Guardian `next_seq` seen on each of the last [`STALL_RECONCILE_TICKS`] ticks.
+    guardian_seq_window: VecDeque<u64>,
 }
 
 impl LimiterStallTracker {
     pub(crate) fn observe(&mut self, local_seq: u64, guardian_seq: u64) -> bool {
-        if local_seq == guardian_seq {
-            self.reset();
-            return false;
+        // Once the window is full its front is the guardian seq from a full
+        // window ago; the mirror should have reached it by now.
+        let stalled = self.guardian_seq_window.len() == STALL_RECONCILE_TICKS
+            && self
+                .guardian_seq_window
+                .front()
+                .is_some_and(|&windowed_seq| local_seq < windowed_seq || local_seq > guardian_seq);
+        if stalled {
+            self.guardian_seq_window.clear();
+            return true;
         }
-        if self.frozen_at_seq == Some(local_seq) {
-            self.frozen_ticks += 1;
-        } else {
-            self.frozen_at_seq = Some(local_seq);
-            self.frozen_ticks = 1;
+        self.guardian_seq_window.push_back(guardian_seq);
+        if self.guardian_seq_window.len() > STALL_RECONCILE_TICKS {
+            self.guardian_seq_window.pop_front();
         }
-        if self.frozen_ticks >= STALL_RECONCILE_TICKS {
-            self.reset();
-            true
-        } else {
-            false
-        }
-    }
-
-    fn reset(&mut self) {
-        self.frozen_at_seq = None;
-        self.frozen_ticks = 0;
+        false
     }
 }
 
@@ -310,38 +316,69 @@ mod tests {
     }
 
     #[test]
-    fn stall_tracker_ignores_normal_advancing_lag() {
+    fn stall_tracker_ignores_normal_in_flight_lag() {
         let mut tracker = LimiterStallTracker::default();
-        // Mirror trails the guardian by one but keeps advancing -> never a stall.
-        for seq in 5..5 + 3 * u64::from(STALL_RECONCILE_TICKS) {
-            assert!(!tracker.observe(seq, seq + 1));
+        // Guardian advances every tick; the mirror trails by one (an event in
+        // flight) but always reaches the seq the guardian held a window ago.
+        // Spanning several full windows, this normal skew must never fire.
+        for tick in 0..(3 * STALL_RECONCILE_TICKS) as u64 {
+            assert!(!tracker.observe(100 + tick, 101 + tick));
         }
     }
 
     #[test]
-    fn stall_tracker_resets_when_caught_up() {
+    fn stall_tracker_does_not_fire_once_the_mirror_catches_up() {
         let mut tracker = LimiterStallTracker::default();
-        assert!(!tracker.observe(21, 22));
-        assert!(!tracker.observe(22, 22)); // caught up -> reset
-        assert!(!tracker.observe(22, 23)); // streak starts over
-    }
-
-    #[test]
-    fn stall_tracker_fires_after_persistent_freeze_then_resets() {
-        let mut tracker = LimiterStallTracker::default();
+        // Behind for most of a window, then the in-flight events land and the
+        // mirror reaches the guardian -> no stall, even across later windows.
         for _ in 0..STALL_RECONCILE_TICKS - 1 {
-            assert!(!tracker.observe(21, 22));
+            assert!(!tracker.observe(40, 45));
         }
-        assert!(tracker.observe(21, 22)); // genuine stall
-        assert!(!tracker.observe(21, 22)); // reset after firing
+        for _ in 0..2 * STALL_RECONCILE_TICKS {
+            assert!(!tracker.observe(45, 45));
+        }
     }
 
     #[test]
-    fn stall_tracker_fires_for_overshoot_too() {
+    fn stall_tracker_stays_quiet_until_a_full_window_of_history() {
         let mut tracker = LimiterStallTracker::default();
-        for _ in 0..STALL_RECONCILE_TICKS - 1 {
-            assert!(!tracker.observe(24, 22)); // local ahead of the guardian
+        // A mirror behind from the first tick is still granted a full window
+        // before any reconcile, so a cold/booting limiter isn't acted on.
+        for _ in 0..STALL_RECONCILE_TICKS {
+            assert!(!tracker.observe(0, 9));
         }
-        assert!(tracker.observe(24, 22));
+    }
+
+    #[test]
+    fn stall_tracker_fires_when_frozen_behind_a_stalled_guardian() {
+        let mut tracker = LimiterStallTracker::default();
+        // Leader deficit: mirror wedged at 50 while the guardian sits at 52
+        // (the stuck leader finalizes nothing new). Fires after a full window.
+        for _ in 0..STALL_RECONCILE_TICKS {
+            assert!(!tracker.observe(50, 52));
+        }
+        assert!(tracker.observe(50, 52));
+    }
+
+    #[test]
+    fn stall_tracker_fires_when_advancing_mirror_stays_below_the_window() {
+        let mut tracker = LimiterStallTracker::default();
+        // The mirror creeps up each tick but started so far behind a plateaued
+        // guardian that it still hasn't reached where the guardian was a full
+        // window ago -> a real dropped event, not in-flight lag.
+        for tick in 0..STALL_RECONCILE_TICKS as u64 {
+            assert!(!tracker.observe(100 + tick, 200));
+        }
+        assert!(tracker.observe(100 + STALL_RECONCILE_TICKS as u64, 200));
+    }
+
+    #[test]
+    fn stall_tracker_fires_for_a_mirror_running_ahead() {
+        let mut tracker = LimiterStallTracker::default();
+        // local ahead of the guardian can only happen once lockstep is lost.
+        for _ in 0..STALL_RECONCILE_TICKS {
+            assert!(!tracker.observe(30, 28));
+        }
+        assert!(tracker.observe(30, 28));
     }
 }

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -153,8 +153,10 @@ pub(crate) fn should_defer_guardian_finalize(
 
 /// Consecutive reconcile ticks the mirror must stay drifted *at the same local
 /// seq* before we treat it as a genuine stall (vs. normal in-flight lag, where
-/// `local_seq` keeps advancing between ticks).
-pub(crate) const STALL_RECONCILE_TICKS: u32 = 4;
+/// `local_seq` keeps advancing between ticks). 20 ticks ≈ 5 min at 15 s — wide
+/// enough that a slow guardian-RPC → on-chain-event round-trip doesn't trip a
+/// false stall and over-advance the mirror.
+pub(crate) const STALL_RECONCILE_TICKS: u32 = 20;
 
 /// Detects a frozen mirror over a streak of reconcile ticks; returns `true`
 /// once the streak crosses [`STALL_RECONCILE_TICKS`] and resets afterwards.

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -124,12 +124,9 @@ impl LocalLimiter {
         Ok(())
     }
 
-    /// Overwrite local state with the guardian's authoritative `state`. The
-    /// guardian is the source of truth; this is the recovery path for a mirror
-    /// that has drifted and that the watcher's event stream cannot re-sync on
-    /// its own — e.g. a `WithdrawalSignedEvent` dropped across a
-    /// checkpoint-subscription reconnect, then skipped on redelivery via
-    /// `signatures.is_some()`. Config is immutable and left unchanged.
+    /// Overwrite local state with the guardian's authoritative `state` (the
+    /// recovery path when the watcher's event stream can't re-sync on its own,
+    /// e.g. an event dropped across a checkpoint-subscription reconnect).
     pub fn reconcile_to(&self, state: LimiterState) {
         *self.state.write().unwrap() = state;
     }
@@ -154,17 +151,13 @@ pub(crate) fn should_defer_guardian_finalize(
     last_finalized.is_some_and(|(last_seq, last_wid)| next_seq <= last_seq && wid != last_wid)
 }
 
-/// Consecutive reconcile ticks the local limiter must stay drifted from the
-/// guardian *at the same local seq* before we treat it as a genuine stall. This
-/// rules out normal in-flight lag, where the mirror trails the guardian by a
-/// little but keeps advancing as `WithdrawalSignedEvent`s arrive (so the local
-/// seq changes between ticks and the streak resets).
+/// Consecutive reconcile ticks the mirror must stay drifted *at the same local
+/// seq* before we treat it as a genuine stall (vs. normal in-flight lag, where
+/// `local_seq` keeps advancing between ticks).
 pub(crate) const STALL_RECONCILE_TICKS: u32 = 4;
 
-/// Detects a local limiter that has drifted from the guardian and stayed frozen
-/// long enough to be a genuine stall rather than transient lag. Fed one
-/// observation per reconcile tick; a positive result means the caller should
-/// [`LocalLimiter::reconcile_to`] the guardian's authoritative state.
+/// Detects a frozen mirror over a streak of reconcile ticks; returns `true`
+/// once the streak crosses [`STALL_RECONCILE_TICKS`] and resets afterwards.
 #[derive(Default)]
 pub(crate) struct LimiterStallTracker {
     frozen_at_seq: Option<u64>,
@@ -172,9 +165,6 @@ pub(crate) struct LimiterStallTracker {
 }
 
 impl LimiterStallTracker {
-    /// Record the latest local/guardian seqs; returns true once the mirror has
-    /// been stalled long enough that it should be reconciled. Resets after
-    /// signalling, so the caller reconciles at most once per detected stall.
     pub(crate) fn observe(&mut self, local_seq: u64, guardian_seq: u64) -> bool {
         if local_seq == guardian_seq {
             self.reset();

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -149,7 +149,7 @@ pub(crate) fn should_defer_guardian_finalize(
     last_finalized.is_some_and(|(last_seq, last_wid)| next_seq <= last_seq && wid != last_wid)
 }
 
-/// 20 ticks ≈ 5 min at 15 s — beyond a slow guardian→on-chain RTT.
+/// 20 ticks ≈ 5 min.
 pub(crate) const STALL_RECONCILE_TICKS: u32 = 20;
 
 /// Detects a mirror frozen at the same `local_seq` for [`STALL_RECONCILE_TICKS`] consecutive ticks.

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -807,8 +807,7 @@ impl Hashi {
         true
     }
 
-    /// GetGuardianInfo RPC, recording the outbound RPC metric. Shared by the
-    /// initial seed and the periodic limiter reconcile. `None` on RPC failure.
+    /// `GetGuardianInfo` RPC + outbound RPC metric; `None` on failure.
     async fn fetch_guardian_info(&self) -> Option<hashi_types::proto::GetGuardianInfoResponse> {
         let client = self.guardian_client()?;
         let rpc_start = std::time::Instant::now();
@@ -835,14 +834,8 @@ impl Hashi {
         }
     }
 
-    /// Re-align the local limiter to the guardian when it has stalled. The
-    /// watcher advances the limiter from the on-chain `WithdrawalSignedEvent`
-    /// stream (the fast path), but that stream can gap across a
-    /// checkpoint-subscription reconnect — `scrape_hashi` re-marks the in-flight
-    /// txn signed, so the redelivered event is skipped via `signatures.is_some()`
-    /// and the mirror is left stuck behind the guardian. The guardian is
-    /// authoritative, so snap to it, but only once `tracker` confirms the drift
-    /// has persisted long enough to not be ordinary in-flight lag.
+    /// Snap the local limiter to the guardian once `tracker` confirms the
+    /// drift has persisted past ordinary in-flight lag.
     async fn reconcile_guardian_limiter(
         &self,
         tracker: &mut guardian_limiter::LimiterStallTracker,
@@ -896,9 +889,7 @@ impl Hashi {
             .await;
             tracing::info!("Guardian bootstrap complete");
 
-            // Reconciliation safety net: re-align the local mirror to the
-            // authoritative guardian whenever the event-driven fast path has
-            // demonstrably stalled (see `reconcile_guardian_limiter`).
+            // Safety net for the event-driven fast path: see `reconcile_guardian_limiter`.
             let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             let mut tracker = guardian_limiter::LimiterStallTracker::default();

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -765,34 +765,11 @@ impl Hashi {
     }
 
     async fn try_seed_guardian_state(&self) -> bool {
-        let Some(client) = self.guardian_client() else {
-            return false;
-        };
         self.metrics.guardian_bootstrap_attempts_total.inc();
-        let rpc_start = std::time::Instant::now();
-        let rpc_result = client.get_guardian_info().await;
-        let rpc_elapsed = rpc_start.elapsed().as_secs_f64();
-        let info_pb = match rpc_result {
-            Ok(info) => {
-                self.metrics.record_guardian_rpc(
-                    metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
-                    metrics::GUARDIAN_RPC_OUTCOME_OK,
-                    rpc_elapsed,
-                );
-                info
-            }
-            Err(e) => {
-                self.metrics.record_guardian_rpc(
-                    metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
-                    metrics::GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
-                    rpc_elapsed,
-                );
-                self.metrics.record_guardian_bootstrap_outcome(
-                    metrics::GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE,
-                );
-                tracing::warn!("guardian bootstrap: GetGuardianInfo failed: {e}");
-                return false;
-            }
+        let Some(info_pb) = self.fetch_guardian_info().await else {
+            self.metrics
+                .record_guardian_bootstrap_outcome(metrics::GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE);
+            return false;
         };
         let info = match hashi_types::guardian::GetGuardianInfoResponse::try_from(info_pb) {
             Ok(info) => info,
@@ -830,8 +807,76 @@ impl Hashi {
         true
     }
 
+    /// GetGuardianInfo RPC, recording the outbound RPC metric. Shared by the
+    /// initial seed and the periodic limiter reconcile. `None` on RPC failure.
+    async fn fetch_guardian_info(&self) -> Option<hashi_types::proto::GetGuardianInfoResponse> {
+        let client = self.guardian_client()?;
+        let rpc_start = std::time::Instant::now();
+        let rpc_result = client.get_guardian_info().await;
+        let rpc_elapsed = rpc_start.elapsed().as_secs_f64();
+        match rpc_result {
+            Ok(info) => {
+                self.metrics.record_guardian_rpc(
+                    metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
+                    metrics::GUARDIAN_RPC_OUTCOME_OK,
+                    rpc_elapsed,
+                );
+                Some(info)
+            }
+            Err(e) => {
+                self.metrics.record_guardian_rpc(
+                    metrics::GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO,
+                    metrics::GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
+                    rpc_elapsed,
+                );
+                tracing::warn!("GetGuardianInfo RPC failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// Re-align the local limiter to the guardian when it has stalled. The
+    /// watcher advances the limiter from the on-chain `WithdrawalSignedEvent`
+    /// stream (the fast path), but that stream can gap across a
+    /// checkpoint-subscription reconnect — `scrape_hashi` re-marks the in-flight
+    /// txn signed, so the redelivered event is skipped via `signatures.is_some()`
+    /// and the mirror is left stuck behind the guardian. The guardian is
+    /// authoritative, so snap to it, but only once `tracker` confirms the drift
+    /// has persisted long enough to not be ordinary in-flight lag.
+    async fn reconcile_guardian_limiter(
+        &self,
+        tracker: &mut guardian_limiter::LimiterStallTracker,
+    ) {
+        let Some(limiter) = self.local_limiter() else {
+            return;
+        };
+        let local_seq = limiter.next_seq();
+        let Some(info_pb) = self.fetch_guardian_info().await else {
+            return;
+        };
+        let Ok(info) = hashi_types::guardian::GetGuardianInfoResponse::try_from(info_pb) else {
+            return;
+        };
+        let Some(state) = info.limiter_state else {
+            return;
+        };
+        if !tracker.observe(local_seq, state.next_seq) {
+            return;
+        }
+        limiter.reconcile_to(state);
+        self.metrics.guardian_limiter_reconciled_total.inc();
+        self.metrics.record_limiter_state(&state, limiter.config());
+        tracing::warn!(
+            local_seq,
+            guardian_seq = state.next_seq,
+            "Local guardian limiter stalled away from the guardian; reconciled to authoritative state",
+        );
+    }
+
     fn start_guardian_bootstrap(self: Arc<Self>) -> Service {
         use backon::Retryable;
+        // Cadence for the limiter reconciliation safety net below.
+        const RECONCILE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
         Service::new().spawn_aborting(async move {
             if self.guardian_client().is_none() {
                 return Ok(());
@@ -850,7 +895,17 @@ impl Hashi {
             .retry(policy)
             .await;
             tracing::info!("Guardian bootstrap complete");
-            Ok(())
+
+            // Reconciliation safety net: re-align the local mirror to the
+            // authoritative guardian whenever the event-driven fast path has
+            // demonstrably stalled (see `reconcile_guardian_limiter`).
+            let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut tracker = guardian_limiter::LimiterStallTracker::default();
+            loop {
+                interval.tick().await;
+                self.reconcile_guardian_limiter(&mut tracker).await;
+            }
         })
     }
 

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -51,6 +51,7 @@ pub struct Metrics {
     pub guardian_limiter_batch_truncated_total: IntCounter,
     pub guardian_limiter_batch_stuck_head_total: IntCounter,
     pub guardian_finalize_deferred_total: IntCounter,
+    pub guardian_limiter_reconciled_total: IntCounter,
     pub guardian_rpc_total: IntCounterVec,
     pub guardian_rpc_duration_seconds: HistogramVec,
 
@@ -375,6 +376,12 @@ impl Metrics {
             guardian_finalize_deferred_total: register_int_counter_with_registry!(
                 "hashi_guardian_finalize_deferred_total",
                 "Times the leader deferred a guardian finalize while waiting for the local limiter to catch up to the guardian's consumed seq (prevents stale-seq mismatches)",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_reconciled_total: register_int_counter_with_registry!(
+                "hashi_guardian_limiter_reconciled_total",
+                "Times the local limiter was reconciled to the guardian's authoritative state after stalling behind/ahead — recovers a WithdrawalSignedEvent dropped across a checkpoint-subscription reconnect",
                 registry,
             )
             .unwrap(),

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -381,7 +381,7 @@ impl Metrics {
             .unwrap(),
             guardian_limiter_reconciled_total: register_int_counter_with_registry!(
                 "hashi_guardian_limiter_reconciled_total",
-                "Times the local limiter was reconciled to the guardian's authoritative state after stalling behind/ahead — recovers a WithdrawalSignedEvent dropped across a checkpoint-subscription reconnect",
+                "Local limiter reconciled to the guardian after a stall (recovers events dropped across a checkpoint-subscription reconnect)",
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
If the local-limiter and guardian sequence numbers diverge for over `STALL_RECONCILE_TICKS` (set to 5 min wait for now) , then we reset the local limiter back to that of the guardian.

Also add a metric `guardian_limiter_reconciled_total` for tracking this.