### PR TITLE
[guardian-hardening][limiter] eagerly reconcile after a watcher rescrape

### DIFF
--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -834,36 +834,68 @@ impl Hashi {
         }
     }
 
+    /// Fetch the guardian's authoritative `LimiterState` and the live local
+    /// limiter handle. `None` if the limiter isn't seeded or the RPC fails.
+    async fn guardian_limiter_and_state(
+        &self,
+    ) -> Option<(
+        Arc<guardian_limiter::LocalLimiter>,
+        hashi_types::guardian::LimiterState,
+    )> {
+        let limiter = self.local_limiter()?;
+        let info_pb = self.fetch_guardian_info().await?;
+        let info = hashi_types::guardian::GetGuardianInfoResponse::try_from(info_pb).ok()?;
+        let state = info.limiter_state?;
+        Some((limiter, state))
+    }
+
+    /// Snap the local limiter to the guardian's authoritative state.
+    fn apply_limiter_reconcile(
+        &self,
+        limiter: &guardian_limiter::LocalLimiter,
+        state: hashi_types::guardian::LimiterState,
+    ) {
+        limiter.reconcile_to(state);
+        self.metrics.guardian_limiter_reconciled_total.inc();
+        self.metrics.record_limiter_state(&state, limiter.config());
+    }
+
     /// Snap the local limiter to the guardian once `tracker` confirms the
     /// drift has persisted past ordinary in-flight lag.
     async fn reconcile_guardian_limiter(
         &self,
         tracker: &mut guardian_limiter::LimiterStallTracker,
     ) {
-        let Some(limiter) = self.local_limiter() else {
+        let Some((limiter, state)) = self.guardian_limiter_and_state().await else {
             return;
         };
         let local_seq = limiter.next_seq();
-        let Some(info_pb) = self.fetch_guardian_info().await else {
-            return;
-        };
-        let Ok(info) = hashi_types::guardian::GetGuardianInfoResponse::try_from(info_pb) else {
-            return;
-        };
-        let Some(state) = info.limiter_state else {
-            return;
-        };
-        if !tracker.observe(local_seq, state.next_seq) {
-            return;
+        if tracker.observe(local_seq, state.next_seq) {
+            tracing::warn!(
+                local_seq,
+                guardian_seq = state.next_seq,
+                "Local guardian limiter stalled away from the guardian; reconciled to authoritative state",
+            );
+            self.apply_limiter_reconcile(&limiter, state);
         }
-        limiter.reconcile_to(state);
-        self.metrics.guardian_limiter_reconciled_total.inc();
-        self.metrics.record_limiter_state(&state, limiter.config());
-        tracing::warn!(
-            local_seq,
-            guardian_seq = state.next_seq,
-            "Local guardian limiter stalled away from the guardian; reconciled to authoritative state",
-        );
+    }
+
+    /// Forward-reconcile to the guardian immediately, bypassing the stall
+    /// detector. Triggered by a watcher rescrape, where a dropped event likely
+    /// left the mirror behind. Forward-only: the guardian's seq is monotonic.
+    async fn reconcile_guardian_limiter_eager(&self) {
+        let Some((limiter, state)) = self.guardian_limiter_and_state().await else {
+            return;
+        };
+        let local_seq = limiter.next_seq();
+        if state.next_seq > local_seq {
+            tracing::warn!(
+                local_seq,
+                guardian_seq = state.next_seq,
+                "Local guardian limiter behind guardian after watcher rescrape; reconciled to authoritative state",
+            );
+            self.apply_limiter_reconcile(&limiter, state);
+        }
     }
 
     fn start_guardian_bootstrap(self: Arc<Self>) -> Service {
@@ -889,13 +921,26 @@ impl Hashi {
             .await;
             tracing::info!("Guardian bootstrap complete");
 
-            // Safety net for the event-driven fast path: see `reconcile_guardian_limiter`.
+            // Safety net for the event-driven fast path: periodic tick catches
+            // slow drifts (stall-gated); rescrape notify catches them eagerly.
+            let reconcile_notify = self.onchain_state().limiter_reconcile_notify();
+            // Pinned + re-armed so a notify can't be lost to `select!` cancellation.
+            let rescraped = reconcile_notify.notified();
+            tokio::pin!(rescraped);
             let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             let mut tracker = guardian_limiter::LimiterStallTracker::default();
             loop {
-                interval.tick().await;
-                self.reconcile_guardian_limiter(&mut tracker).await;
+                tokio::select! {
+                    _ = interval.tick() => {
+                        self.reconcile_guardian_limiter(&mut tracker).await;
+                    }
+                    _ = &mut rescraped => {
+                        // Re-arm first so a rescrape during the reconcile isn't lost.
+                        rescraped.set(reconcile_notify.notified());
+                        self.reconcile_guardian_limiter_eager().await;
+                    }
+                }
             }
         })
     }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -880,9 +880,8 @@ impl Hashi {
         }
     }
 
-    /// Forward-reconcile to the guardian immediately, bypassing the stall
-    /// detector. Triggered by a watcher rescrape, where a dropped event likely
-    /// left the mirror behind. Forward-only: the guardian's seq is monotonic.
+    /// Forward-only reconcile triggered by a watcher rescrape (which likely
+    /// dropped an event); skips the stall detector. Guardian seq is monotonic.
     async fn reconcile_guardian_limiter_eager(&self) {
         let Some((limiter, state)) = self.guardian_limiter_and_state().await else {
             return;

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -92,6 +92,9 @@ struct Inner {
     /// `LocalLimiter` carries its own `RwLock<LimiterState>`, so we just
     /// need set-once semantics for the slot itself.
     local_limiter: OnceLock<Arc<crate::guardian_limiter::LocalLimiter>>,
+    /// Pinged by the watcher after a reconnect rescrape, so the reconcile
+    /// loop can re-align the local limiter immediately.
+    guardian_reconcile_notify: Arc<tokio::sync::Notify>,
 }
 
 #[derive(Debug)]
@@ -147,6 +150,7 @@ impl OnchainState {
             grpc_max_decoding_message_size,
             metrics: metrics.clone(),
             local_limiter: OnceLock::new(),
+            guardian_reconcile_notify: Arc::new(tokio::sync::Notify::new()),
         }
         .pipe(Arc::new)
         .pipe(Self);
@@ -210,6 +214,16 @@ impl OnchainState {
         if self.0.local_limiter.set(limiter).is_err() {
             tracing::warn!("OnchainState::set_local_limiter called twice; ignoring");
         }
+    }
+
+    /// Ask the reconcile loop to re-align the local limiter now.
+    pub(crate) fn request_limiter_reconcile(&self) {
+        self.0.guardian_reconcile_notify.notify_one();
+    }
+
+    /// Handle the reconcile loop awaits on.
+    pub(crate) fn limiter_reconcile_notify(&self) -> Arc<tokio::sync::Notify> {
+        self.0.guardian_reconcile_notify.clone()
     }
 
     pub fn latest_checkpoint_timestamp_ms(&self) -> u64 {

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -95,8 +95,7 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
             }
 
             rescrape_state = false;
-            // Rescrape rebuilt state from chain, but the event-driven limiter
-            // just gapped — nudge the reconcile loop to re-align it now.
+            // Rescrape gapped the event-driven limiter; trigger an eager reconcile.
             state.request_limiter_reconcile();
         }
 

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -95,6 +95,9 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
             }
 
             rescrape_state = false;
+            // Rescrape rebuilt state from chain, but the event-driven limiter
+            // just gapped — nudge the reconcile loop to re-align it now.
+            state.request_limiter_reconcile();
         }
 
         while let Some(item) = subscription.next().await {


### PR DESCRIPTION
the sui checkpoint stream can disconnect, and then reconnect on the latest block, which can cause us to lose some blocks and lead to the local-limiter sequence number being out of sync from that of the guardian.

so , whenever there is a stream disconnect/reconnect, we are resyncing the local-limiter state from the latest state on the guardian.