### PR TITLE
Lower emergency pause threshold from 51% to 5%

### DIFF
--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -98,7 +98,7 @@ public(package) fun set_guardian(self: &mut Config, url: String, public_key: vec
 }
 
 public(package) fun emergency_pause_threshold_bps(self: &Config): u64 {
-    self.try_get(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY).map!(|v| v.as_u64()).destroy_or!(5100)
+    self.try_get(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY).map!(|v| v.as_u64()).destroy_or!(500)
 }
 
 public(package) fun emergency_unpause_threshold_bps(self: &Config): u64 {
@@ -154,7 +154,7 @@ public(package) fun create(): Config {
 
     // Core defaults
     config.upsert(PAUSED_KEY, config_value::new_bool(false));
-    config.upsert(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(5100));
+    config.upsert(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(500));
     config.upsert(EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(6667));
 
     config

--- a/packages/hashi/sources/core/proposal/types/emergency_pause.move
+++ b/packages/hashi/sources/core/proposal/types/emergency_pause.move
@@ -4,7 +4,7 @@
 /// Emergency pause/unpause governance module.
 ///
 /// A single proposal type that can either pause or unpause the bridge.
-/// Pausing requires 51% quorum; unpausing requires ~67% quorum.
+/// Pausing uses a low quorum for fast response; unpausing requires supermajority.
 module hashi::emergency_pause;
 
 use hashi::{hashi::Hashi, proposal};


### PR DESCRIPTION
## Summary

- Lowers the emergency pause quorum from 5100 bps (51%) to 500 bps (5%)
- Unpause threshold unchanged at 6667 bps (66.67%)

## Rationale for 5%

The pause threshold should allow Mysten-operated validators to halt the bridge quickly during an incident without waiting for broad validator coordination.

Current Mysten validator voting power (queried 2026-05-22):

| Validator | Mainnet | Testnet |
|-----------|---------|---------|
| Mysten-1  | 284 bps | 299 bps |
| Mysten-2  | 253 bps | 350 bps |
| **Combined** | **537 bps** | **649 bps** |

500 bps (5%) sits just below the mainnet combined power of 537 bps, giving slight headroom for stake fluctuations while still requiring both Mysten validators to agree.

The asymmetry is intentional: pausing is a safety action that should be fast and low-friction, while unpausing resumes value flow and should require supermajority (66.67%) consensus.

## Test plan

- [x] All 100 Move unit tests pass (existing pause/unpause tests use single-voter committees with 100% weight, unaffected by threshold change)