### PR TITLE
[Guardian] finalize_init threshold param + test_utils const grouping

### DIFF
--- a/crates/hashi-guardian/src/init.rs
+++ b/crates/hashi-guardian/src/init.rs
@@ -180,7 +180,7 @@ pub async fn provisioner_init(
     // 5) If we have enough shares, finish initialization: combine shares & set config
     if current_share_count >= threshold {
         let shares_vec: Vec<Share> = received_shares.iter().cloned().collect();
-        finalize_init(&shares_vec, &enclave, request.into_state()).await;
+        finalize_init(&shares_vec, threshold, &enclave, request.into_state()).await;
         // Log to S3 indicating that withdrawals can be expected henceforth
         enclave
             .log_init(PIEnclaveFullyInitialized)
@@ -201,14 +201,11 @@ pub async fn provisioner_init(
 /// Panics upon an error as the enclaves state is irrecoverable at this point.
 async fn finalize_init(
     shares: &[Share],
+    threshold: usize,
     enclave: &Arc<Enclave>,
     incoming_state: ProvisionerInitState,
 ) {
     info!("Threshold reached, combining shares.");
-    let threshold = enclave
-        .secret_sharing_config()
-        .expect("secret sharing config set during operator_init")
-        .threshold();
     let enclave_btc_keypair = combine_shares(shares, threshold).expect("Unable to combine shares");
 
     info!("Setting enclave keypair.");

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -26,9 +26,6 @@ use super::StandardWithdrawalResponse;
 use super::WithdrawalConfig;
 use super::WithdrawalID;
 
-// Default secret-sharing params used by mock_for_testing helpers.
-const TEST_N: usize = 5;
-const TEST_T: usize = 3;
 use super::bitcoin_utils::BTC_LIB;
 use super::bitcoin_utils::InputUTXO;
 use super::bitcoin_utils::OutputUTXO;
@@ -55,6 +52,10 @@ use sui_sdk_types::bcs::FromBcs;
 use crate::committee::DEFAULT_MPC_MAX_FAULTY_IN_BASIS_POINTS;
 use crate::committee::DEFAULT_MPC_THRESHOLD_IN_BASIS_POINTS;
 use crate::committee::DEFAULT_MPC_WEIGHT_REDUCTION_ALLOWED_DELTA;
+
+// Default secret-sharing params used by mock_for_testing helpers.
+const TEST_N: usize = 5;
+const TEST_T: usize = 3;
 
 // -------------------------------
 // Shared deterministic test values


### PR DESCRIPTION
## Summary

Small follow-up to #591.

- `finalize_init` now takes `threshold` as a parameter instead of looking it up via `secret_sharing_config()`. The caller already knows it; drops a redundant lookup + awkward `.expect()` at a position where the config is guaranteed to be set.
- Move `TEST_N`/`TEST_T` constants below the `use` block in `hashi-types/.../test_utils.rs` so all imports are grouped together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)