### PR TITLE
Generalize MPC signing for multi-protocol support

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -46,8 +46,8 @@ pub struct Hashi {
     pub proposals: Proposals,
     /// TOB certificates by (epoch, batch_index) -> EpochCertsV1
     pub tob: Bag,
-    /// Number of presignatures consumed in the current epoch.
-    pub num_consumed_presigs: u64,
+    /// Number of presignatures consumed in the current epoch, per protocol.
+    pub num_consumed_presigs: VecMap<u8, u64>,
 }
 
 /// Rust version of the Move hashi::bitcoin_state::BitcoinStateKey type.
@@ -74,8 +74,8 @@ pub struct CommitteeSet {
     pub committees: Bag,
     pub pending_epoch_change: Option<PendingEpochChange>,
 
-    /// The MPC committee's threshold public key.
-    pub mpc_public_key: Vec<u8>,
+    /// The MPC committee's threshold public keys, one per protocol.
+    pub mpc_public_keys: VecMap<u8, Vec<u8>>,
 }
 
 /// Rust version of the Move hashi::committee_set::PendingEpochChange type.
@@ -650,9 +650,9 @@ pub struct UtxoPool {
 /// Rust version of the Move hashi::tob::ProtocolType enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde_derive::Deserialize, serde_derive::Serialize)]
 pub enum ProtocolType {
-    Dkg,
-    KeyRotation,
-    NonceGeneration,
+    Dkg { protocol_id: u8 },
+    KeyRotation { protocol_id: u8 },
+    NonceGeneration { protocol_id: u8 },
 }
 
 /// Rust version of the Move struct `hashi::reconfig::ReconfigCompletionMessage`.
@@ -660,8 +660,8 @@ pub enum ProtocolType {
 pub struct ReconfigCompletionMessage {
     /// The epoch being transitioned to.
     pub epoch: u64,
-    /// The MPC committee's threshold public key.
-    pub mpc_public_key: Vec<u8>,
+    /// The MPC committee's threshold public keys, one per protocol.
+    pub protocol_keys: VecMap<u8, Vec<u8>>,
 }
 
 /// Rust version of the Move hashi::proposal::Proposal type.
@@ -1453,7 +1453,7 @@ impl From<StartReconfigEvent> for HashiEvent {
 pub struct EndReconfigEvent {
     pub from_epoch: u64,
     pub epoch: u64,
-    pub mpc_public_key: Vec<u8>,
+    pub protocol_keys: VecMap<u8, Vec<u8>>,
 }
 
 impl MoveType for EndReconfigEvent {

--- a/crates/hashi/src/communication/sui_tob.rs
+++ b/crates/hashi/src/communication/sui_tob.rs
@@ -48,6 +48,7 @@ impl From<TobError> for ChannelError {
 pub struct SuiTobChannel {
     hashi_ids: HashiIds,
     onchain_state: OnchainState,
+    protocol_id: u8,
     epoch: u64,
     batch_index: Option<u32>,
     signer: Ed25519PrivateKey,
@@ -61,6 +62,7 @@ impl SuiTobChannel {
     pub fn new(
         hashi_ids: HashiIds,
         onchain_state: OnchainState,
+        protocol_id: u8,
         epoch: u64,
         batch_index: Option<u32>,
         signer: Ed25519PrivateKey,
@@ -68,6 +70,7 @@ impl SuiTobChannel {
         Self {
             hashi_ids,
             onchain_state,
+            protocol_id,
             epoch,
             batch_index,
             signer,
@@ -88,11 +91,12 @@ impl SuiTobChannel {
 
 pub async fn fetch_certificates(
     onchain_state: &OnchainState,
+    protocol_id: u8,
     epoch: u64,
     batch_index: Option<u32>,
 ) -> Result<Vec<(Address, CertificateV1)>, TobError> {
     let Some((protocol_type, raw_certs)) = onchain_state
-        .fetch_certs(epoch, batch_index)
+        .fetch_certs(protocol_id, epoch, batch_index)
         .await
         .map_err(|e| TobError::RpcError(e.to_string()))?
     else {
@@ -112,16 +116,21 @@ pub async fn fetch_certificates(
 impl OrderedBroadcastChannel<CertificateV1> for SuiTobChannel {
     async fn publish(&self, cert: CertificateV1) -> ChannelResult<()> {
         let dealer = cert.dealer_address();
-        let existing = fetch_certificates(&self.onchain_state, self.epoch, self.batch_index)
-            .await
-            .map_err(ChannelError::from)?;
+        let existing = fetch_certificates(
+            &self.onchain_state,
+            self.protocol_id,
+            self.epoch,
+            self.batch_index,
+        )
+        .await
+        .map_err(ChannelError::from)?;
         if existing.iter().any(|(d, _)| *d == dealer) {
             return Ok(());
         }
 
         let mut executor = self.create_executor();
         executor
-            .execute_submit_certificate(&cert)
+            .execute_submit_certificate(self.protocol_id, &cert)
             .await
             .map_err(|e| ChannelError::Other(e.to_string()))
     }
@@ -132,9 +141,14 @@ impl OrderedBroadcastChannel<CertificateV1> for SuiTobChannel {
                 return Ok(cert);
             }
             // TODO: Optimize by checking table size first to avoid redundant fetches.
-            let all_certs = fetch_certificates(&self.onchain_state, self.epoch, self.batch_index)
-                .await
-                .map_err(ChannelError::from)?;
+            let all_certs = fetch_certificates(
+                &self.onchain_state,
+                self.protocol_id,
+                self.epoch,
+                self.batch_index,
+            )
+            .await
+            .map_err(ChannelError::from)?;
             for (dealer, cert) in all_certs {
                 if !self.seen_dealers.contains(&dealer) {
                     self.seen_dealers.insert(dealer);
@@ -148,8 +162,13 @@ impl OrderedBroadcastChannel<CertificateV1> for SuiTobChannel {
     }
 
     async fn certified_dealers(&mut self) -> Vec<Address> {
-        if let Ok(all_certs) =
-            fetch_certificates(&self.onchain_state, self.epoch, self.batch_index).await
+        if let Ok(all_certs) = fetch_certificates(
+            &self.onchain_state,
+            self.protocol_id,
+            self.epoch,
+            self.batch_index,
+        )
+        .await
         {
             for (dealer, cert) in all_certs {
                 if !self.seen_dealers.contains(&dealer) {

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -693,7 +693,11 @@ impl LeaderService {
         // indices beyond the current pool.
         {
             let num_inputs = approval.selected_utxos.len() as u64;
-            let num_consumed = inner.onchain_state().state().hashi().num_consumed_presigs;
+            let num_consumed = inner
+                .onchain_state()
+                .state()
+                .hashi()
+                .schnorr_consumed_presigs();
             let needed_end = num_consumed + num_inputs;
             if let Some(signing_manager) = inner.current_signing_manager() {
                 let available_end = signing_manager.available_presig_end_index();

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1089,7 +1089,7 @@ impl Metrics {
             }
         }
         self.num_consumed_presigs
-            .set(hashi.num_consumed_presigs as i64);
+            .set(hashi.schnorr_consumed_presigs() as i64);
         for (type_tag, cap) in &hashi.treasury.treasury_caps {
             if let sui_sdk_types::TypeTag::Struct(struct_tag) = type_tag {
                 self.treasury_supply

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -40,7 +40,9 @@ use hashi_types::committee::BLS12381Signature;
 use hashi_types::committee::BlsSignatureAggregator;
 use hashi_types::committee::Committee;
 use hashi_types::committee::certificate_threshold;
+use hashi_types::move_types::Entry;
 use hashi_types::move_types::ReconfigCompletionMessage;
+use hashi_types::move_types::VecMap;
 
 const RETRY_INTERVAL: Duration = Duration::from_secs(10);
 const RPC_TIMEOUT: Duration = Duration::from_secs(5);
@@ -272,7 +274,7 @@ impl MpcService {
         let onchain_state = self.inner.onchain_state().clone();
         let epoch = onchain_state.epoch();
         let protocol_type = onchain_state
-            .fetch_certs(epoch, None)
+            .fetch_certs(0, epoch, None)
             .await?
             .map(|(pt, _)| pt);
         let onchain_mpc_key = onchain_state.mpc_public_key();
@@ -282,7 +284,7 @@ impl MpcService {
             onchain_mpc_key.len(),
         );
         let output = match protocol_type {
-            Some(hashi_types::move_types::ProtocolType::KeyRotation) => {
+            Some(hashi_types::move_types::ProtocolType::KeyRotation { .. }) => {
                 self.recover_current_rotation(epoch, &onchain_mpc_key).await
             }
             _ => self.recover_current_dkg(epoch, &onchain_mpc_key).await,
@@ -301,7 +303,7 @@ impl MpcService {
     ) -> anyhow::Result<MpcOutput> {
         self.setup_initial_dkg(epoch)?;
         let onchain_state = self.inner.onchain_state().clone();
-        let certs: Vec<CertificateV1> = fetch_certificates(&onchain_state, epoch, None)
+        let certs: Vec<CertificateV1> = fetch_certificates(&onchain_state, 0, epoch, None)
             .await
             .map_err(|e| anyhow::anyhow!("failed to fetch DKG certs for epoch {epoch}: {e}"))?
             .into_iter()
@@ -345,14 +347,14 @@ impl MpcService {
             .mpc_manager()
             .ok_or_else(|| anyhow::anyhow!("MpcManager not initialized for rotation recovery"))?;
         let previous_epoch = mpc_manager.read().unwrap().previous_epoch;
-        let current_certs: Vec<CertificateV1> = fetch_certificates(&onchain_state, epoch, None)
+        let current_certs: Vec<CertificateV1> = fetch_certificates(&onchain_state, 0, epoch, None)
             .await
             .map_err(|e| anyhow::anyhow!("failed to fetch rotation certs for epoch {epoch}: {e}"))?
             .into_iter()
             .map(|(_, cert)| cert)
             .collect();
         let previous_certs: Vec<CertificateV1> =
-            fetch_certificates(&onchain_state, previous_epoch, None)
+            fetch_certificates(&onchain_state, 0, previous_epoch, None)
                 .await
                 .map_err(|e| {
                     anyhow::anyhow!(
@@ -402,6 +404,7 @@ impl MpcService {
         let mut tob_channel = SuiTobChannel::new(
             self.inner.config.hashi_ids(),
             onchain_state,
+            0, // protocol_id: Schnorr
             target_epoch,
             None,
             signer,
@@ -441,6 +444,7 @@ impl MpcService {
         let mut tob_channel = SuiTobChannel::new(
             self.inner.config.hashi_ids(),
             onchain_state,
+            0, // protocol_id: Schnorr
             epoch,
             Some(batch_index),
             signer,
@@ -504,7 +508,7 @@ impl MpcService {
         let (num_consumed, epoch, committee) = {
             let state = self.inner.onchain_state().state();
             let hashi = state.hashi();
-            let num_consumed = hashi.num_consumed_presigs;
+            let num_consumed = hashi.schnorr_consumed_presigs();
             let epoch = hashi.committees.epoch();
             let committee = hashi
                 .committees
@@ -639,7 +643,7 @@ impl MpcService {
     ) -> anyhow::Result<Presignatures> {
         let onchain_state = self.inner.onchain_state().clone();
         let (_, certs) = onchain_state
-            .fetch_certs(epoch, Some(batch_index))
+            .fetch_certs(0, epoch, Some(batch_index))
             .await?
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -930,7 +934,7 @@ impl MpcService {
             "run_key_rotation: target_epoch={target_epoch}, previous_epoch={previous_epoch}, \
              onchain_epoch={onchain_epoch}, onchain_mpc_key={onchain_mpc_key}",
         );
-        let previous_certs = fetch_certificates(&onchain_state, previous_epoch, None)
+        let previous_certs = fetch_certificates(&onchain_state, 0, previous_epoch, None)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to fetch previous certificates: {e}"))?;
         let previous_certs: Vec<CertificateV1> =
@@ -945,6 +949,7 @@ impl MpcService {
         let mut tob_channel = SuiTobChannel::new(
             self.inner.config.hashi_ids(),
             onchain_state,
+            0, // protocol_id: Schnorr
             target_epoch,
             None,
             signer,
@@ -974,9 +979,15 @@ impl MpcService {
             .get(&epoch)
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("no committee found for epoch {}", epoch))?;
+        let protocol_keys = VecMap {
+            contents: vec![Entry {
+                key: 0u8,
+                value: mpc_public_key.clone(),
+            }],
+        };
         let message = ReconfigCompletionMessage {
             epoch,
-            mpc_public_key: mpc_public_key.clone(),
+            protocol_keys: protocol_keys.clone(),
         };
         let my_address = self.inner.config.validator_address()?;
         let signing_key =
@@ -1011,8 +1022,13 @@ impl MpcService {
             let result = async {
                 let mut executor =
                     crate::sui_tx_executor::SuiTxExecutor::from_hashi(self.inner.clone())?;
+                let keys_for_ptb: Vec<(u8, Vec<u8>)> = protocol_keys
+                    .contents
+                    .iter()
+                    .map(|e| (e.key, e.value.clone()))
+                    .collect();
                 executor
-                    .execute_end_reconfig(&mpc_public_key, cert.committee_signature())
+                    .execute_end_reconfig(&keys_for_ptb, cert.committee_signature())
                     .await
             };
             match result.await {
@@ -1134,7 +1150,12 @@ impl MpcService {
     ) -> anyhow::Result<hashi_types::committee::SignedMessage<ReconfigCompletionMessage>> {
         let message = ReconfigCompletionMessage {
             epoch,
-            mpc_public_key: mpc_public_key.to_vec(),
+            protocol_keys: VecMap {
+                contents: vec![Entry {
+                    key: 0u8,
+                    value: mpc_public_key.to_vec(),
+                }],
+            },
         };
         let my_address = self.inner.config.validator_address()?;
         let my_sig_bytes = self

--- a/crates/hashi/src/mpc/types.rs
+++ b/crates/hashi/src/mpc/types.rs
@@ -387,9 +387,11 @@ impl CertificateV1 {
         cert: DealerCertificate,
     ) -> Self {
         match protocol_type {
-            hashi_types::move_types::ProtocolType::Dkg => CertificateV1::Dkg(cert),
-            hashi_types::move_types::ProtocolType::KeyRotation => CertificateV1::Rotation(cert),
-            hashi_types::move_types::ProtocolType::NonceGeneration => {
+            hashi_types::move_types::ProtocolType::Dkg { .. } => CertificateV1::Dkg(cert),
+            hashi_types::move_types::ProtocolType::KeyRotation { .. } => {
+                CertificateV1::Rotation(cert)
+            }
+            hashi_types::move_types::ProtocolType::NonceGeneration { .. } => {
                 CertificateV1::NonceGeneration {
                     batch_index: batch_index.expect("batch_index required for NonceGeneration"),
                     cert,

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -115,6 +115,7 @@ pub struct State {
 
 #[derive(serde_derive::Serialize)]
 struct TobKey {
+    protocol_id: u8,
     epoch: u64,
     batch_index: Option<u32>,
 }
@@ -595,11 +596,16 @@ impl OnchainState {
     // TODO: Cache this data in State and update via watcher events instead of fetching on-demand.
     pub async fn fetch_epoch_certs(
         &self,
+        protocol_id: u8,
         epoch: u64,
         batch_index: Option<u32>,
     ) -> Result<Option<move_types::EpochCertsV1>> {
         let tob_id = self.tob_id();
-        let key = TobKey { epoch, batch_index };
+        let key = TobKey {
+            protocol_id,
+            epoch,
+            batch_index,
+        };
         let key_bcs = bcs::to_bytes(&key)?;
         let mut stream = self
             .0
@@ -628,6 +634,7 @@ impl OnchainState {
     /// Returns the protocol type and raw move types; caller is responsible for conversion.
     pub async fn fetch_certs(
         &self,
+        protocol_id: u8,
         epoch: u64,
         batch_index: Option<u32>,
     ) -> Result<
@@ -636,7 +643,10 @@ impl OnchainState {
             Vec<(Address, move_types::DealerSubmissionV1)>,
         )>,
     > {
-        let epoch_certs = match self.fetch_epoch_certs(epoch, batch_index).await? {
+        let epoch_certs = match self
+            .fetch_epoch_certs(protocol_id, epoch, batch_index)
+            .await?
+        {
             Some(certs) => certs,
             None => return Ok(None),
         };
@@ -826,7 +836,14 @@ async fn scrape_hashi(
     committee_set
         .set_epoch(committees.epoch)
         .set_pending_epoch_change(committees.pending_epoch_change.map(|pending| pending.epoch))
-        .set_mpc_public_key(committees.mpc_public_key)
+        .set_mpc_public_keys(
+            committees
+                .mpc_public_keys
+                .contents
+                .into_iter()
+                .map(|e| (e.key, e.value))
+                .collect(),
+        )
         .set_members(member_info)
         .set_committees(committees_per_epoch)
         .set_committee_handoffs(committee_handoffs);
@@ -843,7 +860,11 @@ async fn scrape_hashi(
             utxo_pool,
             proposals,
             tob_id: tob.id,
-            num_consumed_presigs,
+            num_consumed_presigs: num_consumed_presigs
+                .contents
+                .into_iter()
+                .map(|e| (e.key, e.value))
+                .collect(),
         },
     ))
 }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -46,7 +46,20 @@ pub struct Hashi {
     pub utxo_pool: UtxoPool,
     pub proposals: Proposals,
     pub tob_id: Address,
-    pub num_consumed_presigs: u64,
+    pub num_consumed_presigs: BTreeMap<u8, u64>,
+}
+
+impl Hashi {
+    pub fn num_consumed_presigs_for_protocol(&self, protocol_id: u8) -> u64 {
+        self.num_consumed_presigs
+            .get(&protocol_id)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    pub fn schnorr_consumed_presigs(&self) -> u64 {
+        self.num_consumed_presigs_for_protocol(0)
+    }
 }
 
 pub struct CommitteeSet {
@@ -58,8 +71,8 @@ pub struct CommitteeSet {
     epoch: u64,
     pending_epoch_change: Option<u64>,
 
-    /// The MPC committee's threshold public key.
-    mpc_public_key: Vec<u8>,
+    /// The MPC committee's threshold public keys, one per protocol.
+    mpc_public_keys: BTreeMap<u8, Vec<u8>>,
 
     /// Id of the `Bag` containing the committee's per epoch
     committees_id: Address,
@@ -97,10 +110,7 @@ impl fmt::Debug for CommitteeSet {
             .field("tls_public_key_to_address", &tls_key_map)
             .field("epoch", &self.epoch)
             .field("pending_epoch_change", &self.pending_epoch_change)
-            .field(
-                "mpc_public_key",
-                &Base64("MpcPublicKey", &self.mpc_public_key),
-            )
+            .field("mpc_public_keys", &self.mpc_public_keys)
             .field("committees_id", &self.committees_id)
             .field("committees", &self.committees)
             .field("committee_handoffs", &self.committee_handoffs.keys())
@@ -122,7 +132,7 @@ impl CommitteeSet {
             tls_public_key_to_address: BTreeMap::new(),
             epoch: 0,
             pending_epoch_change: None,
-            mpc_public_key: Vec::new(),
+            mpc_public_keys: BTreeMap::new(),
             committees_id,
             committees: BTreeMap::new(),
             committee_handoffs: BTreeMap::new(),
@@ -171,8 +181,16 @@ impl CommitteeSet {
         self.epoch
     }
 
+    pub fn mpc_public_keys(&self) -> &BTreeMap<u8, Vec<u8>> {
+        &self.mpc_public_keys
+    }
+
+    pub fn mpc_public_key_for_protocol(&self, protocol_id: u8) -> Option<&[u8]> {
+        self.mpc_public_keys.get(&protocol_id).map(|k| k.as_slice())
+    }
+
     pub fn mpc_public_key(&self) -> &[u8] {
-        &self.mpc_public_key
+        self.mpc_public_key_for_protocol(0).unwrap_or(&[])
     }
 
     pub fn pending_epoch_change(&self) -> Option<u64> {
@@ -322,9 +340,17 @@ impl CommitteeSet {
         self
     }
 
+    pub fn set_mpc_public_keys(&mut self, keys: BTreeMap<u8, Vec<u8>>) -> &mut Self {
+        assert!(self.mpc_public_keys.is_empty() || self.mpc_public_keys == keys);
+        self.mpc_public_keys = keys;
+        self
+    }
+
     pub fn set_mpc_public_key(&mut self, mpc_public_key: Vec<u8>) -> &mut Self {
-        assert!(self.mpc_public_key.is_empty() || self.mpc_public_key == mpc_public_key);
-        self.mpc_public_key = mpc_public_key;
+        if let Some(existing) = self.mpc_public_keys.get(&0) {
+            assert!(existing.is_empty() || *existing == mpc_public_key);
+        }
+        self.mpc_public_keys.insert(0, mpc_public_key);
         self
     }
 

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -718,6 +718,12 @@ async fn handle_events(
                 let committees_id = state.state().hashi().committees.committees_id();
                 let scraped_committees =
                     super::scrape_committees(client.clone(), committees_id).await;
+                let protocol_keys = end_reconfig_event
+                    .protocol_keys
+                    .contents
+                    .iter()
+                    .map(|e| (e.key, e.value.clone()))
+                    .collect();
                 let mut state = state.state_mut();
                 match scraped_committees {
                     Ok((committees, committee_handoffs)) => {
@@ -737,7 +743,7 @@ async fn handle_events(
                     .committees
                     .set_epoch(end_reconfig_event.epoch)
                     .set_pending_epoch_change(None)
-                    .set_mpc_public_key(end_reconfig_event.mpc_public_key.clone());
+                    .set_mpc_public_keys(protocol_keys);
             }
         }
     }

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -225,6 +225,9 @@ const DEFAULT_TIMEOUT_SECS: u64 = 10;
 /// Well-known Move stdlib package address (0x1)
 const MOVE_STDLIB_ADDRESS: Address = Address::from_static("0x1");
 
+/// Well-known Sui framework package address (0x2)
+const SUI_FRAMEWORK_ADDRESS: Address = Address::from_static("0x2");
+
 /// Well-known Sui Clock object address (0x6)
 pub const SUI_CLOCK_OBJECT_ID: Address = Address::from_static("0x6");
 const SUI_SYSTEM_STATE_OBJECT_ID: Address = Address::from_static("0x5");
@@ -1017,8 +1020,8 @@ impl SuiTxExecutor {
     #[tracing::instrument(level = "info", skip_all)]
     pub async fn execute_end_reconfig(
         &mut self,
-        mpc_public_key: &[u8],
-        mpc_cert: &CommitteeSignature,
+        protocol_keys: &[(u8, Vec<u8>)],
+        cert: &CommitteeSignature,
     ) -> anyhow::Result<()> {
         let mut builder = TransactionBuilder::new();
         let hashi_arg = builder.object(
@@ -1026,16 +1029,38 @@ impl SuiTxExecutor {
                 .as_shared()
                 .with_mutable(true),
         );
-        let mpc_public_key_arg = builder.pure(&mpc_public_key.to_vec());
-        let mpc_cert_arg =
-            build_committee_signature_arg(&mut builder, self.hashi_ids.package_id, mpc_cert);
+        let u8_type = TypeTag::U8;
+        let vec_u8_type = TypeTag::Vector(Box::new(TypeTag::U8));
+        let map_arg = builder.move_call(
+            Function::new(
+                SUI_FRAMEWORK_ADDRESS,
+                Identifier::from_static("vec_map"),
+                Identifier::from_static("empty"),
+            )
+            .with_type_args(vec![u8_type.clone(), vec_u8_type.clone()]),
+            vec![],
+        );
+        for (protocol_id, key) in protocol_keys {
+            let id_arg = builder.pure(protocol_id);
+            let key_arg = builder.pure(key);
+            builder.move_call(
+                Function::new(
+                    SUI_FRAMEWORK_ADDRESS,
+                    Identifier::from_static("vec_map"),
+                    Identifier::from_static("insert"),
+                )
+                .with_type_args(vec![u8_type.clone(), vec_u8_type.clone()]),
+                vec![map_arg, id_arg, key_arg],
+            );
+        }
+        let cert_arg = build_committee_signature_arg(&mut builder, self.hashi_ids.package_id, cert);
         builder.move_call(
             Function::new(
                 self.hashi_ids.package_id,
                 Identifier::from_static("reconfig"),
                 Identifier::from_static("end_reconfig"),
             ),
-            vec![hashi_arg, mpc_public_key_arg, mpc_cert_arg],
+            vec![hashi_arg, map_arg, cert_arg],
         );
         let response = self.execute(builder).await?;
         let status = response.transaction().effects().status();
@@ -1184,7 +1209,11 @@ impl SuiTxExecutor {
         skip_all,
         fields(cert_kind = tracing::field::Empty),
     )]
-    pub async fn execute_submit_certificate(&mut self, cert: &CertificateV1) -> anyhow::Result<()> {
+    pub async fn execute_submit_certificate(
+        &mut self,
+        protocol_id: u8,
+        cert: &CertificateV1,
+    ) -> anyhow::Result<()> {
         let (inner_cert, function_name, batch_index) = match cert {
             CertificateV1::Dkg(c) => (c, "submit_dkg_cert", None),
             CertificateV1::Rotation(c) => (c, "submit_rotation_cert", None),
@@ -1208,8 +1237,9 @@ impl SuiTxExecutor {
                 .as_shared()
                 .with_mutable(true),
         );
+        let protocol_id_arg = builder.pure(&protocol_id);
         let epoch_arg = builder.pure(&epoch);
-        let mut args = vec![hashi_arg, epoch_arg];
+        let mut args = vec![hashi_arg, protocol_id_arg, epoch_arg];
         if let Some(bi) = batch_index {
             args.push(builder.pure(&bi));
         }

--- a/crates/internal-tools/src/key_recovery.rs
+++ b/crates/internal-tools/src/key_recovery.rs
@@ -131,7 +131,7 @@ pub async fn run(args: Args, onchain_state: &OnchainState, chain_id: &str) -> an
         previous_committee.members().len()
     );
 
-    let raw_certs = fetch_certificates(onchain_state, previous_epoch, None)
+    let raw_certs = fetch_certificates(onchain_state, 0, previous_epoch, None)
         .await
         .map_err(|e| anyhow!("failed to fetch certificates: {e}"))?;
     let certificates: Vec<CertificateV1> = raw_certs.into_iter().map(|(_, cert)| cert).collect();

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -32,6 +32,8 @@ const ECooldownNotElapsed: vector<u8> = b"Cancellation cooldown has not elapsed"
 const ECannotCancelProcessingWithdrawal: vector<u8> =
     b"Cannot cancel a withdrawal that is already being processed";
 
+const PROTOCOL_SCHNORR: u8 = 0;
+
 // MESSAGE STEP 1
 public struct RequestApprovalMessage has copy, drop, store {
     request_id: address,
@@ -203,7 +205,10 @@ entry fun commit_withdrawal_tx(
     let request_infos = hashi.bitcoin().withdrawal_queue().extract_request_infos(&request_ids);
 
     // Allocate presigs from core counter
-    let presig_start_index = hashi.allocate_presigs(inputs.length());
+    let presig_start_index = hashi.allocate_presigs(
+        PROTOCOL_SCHNORR,
+        inputs.length(),
+    );
 
     let mut rng = sui::random::new_generator(r, ctx);
     let randomness = rng.generate_bytes(32);
@@ -264,7 +269,7 @@ entry fun reallocate_presigs(hashi: &mut Hashi, withdrawal_id: address) {
     hashi.assert_not_reconfiguring();
     let current_epoch = hashi.committee_set().epoch();
     let pending = hashi.bitcoin().withdrawal_queue().withdrawal_txn_pending_count(withdrawal_id);
-    let new_base = hashi.allocate_presigs(pending);
+    let new_base = hashi.allocate_presigs(PROTOCOL_SCHNORR, pending);
     hashi
         .bitcoin_mut()
         .withdrawal_queue_mut()

--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -7,18 +7,19 @@ use hashi::{committee::CommitteeSignature, hashi::Hashi, tob::ProtocolType};
 
 entry fun submit_dkg_cert(
     hashi: &mut Hashi,
+    protocol_id: u8,
     epoch: u64,
     dealer: address,
     messages_hash: vector<u8>,
     cert: CommitteeSignature,
     ctx: &mut TxContext,
 ) {
-    let key = hashi::tob::tob_key(epoch, option::none());
+    let key = hashi::tob::tob_key(protocol_id, epoch, option::none());
     submit_cert_internal(
         hashi,
         key,
         epoch,
-        hashi::tob::protocol_type_dkg(),
+        hashi::tob::protocol_type_dkg(protocol_id),
         dealer,
         messages_hash,
         &cert,
@@ -28,18 +29,19 @@ entry fun submit_dkg_cert(
 
 entry fun submit_rotation_cert(
     hashi: &mut Hashi,
+    protocol_id: u8,
     epoch: u64,
     dealer: address,
     messages_hash: vector<u8>,
     cert: CommitteeSignature,
     ctx: &mut TxContext,
 ) {
-    let key = hashi::tob::tob_key(epoch, option::none());
+    let key = hashi::tob::tob_key(protocol_id, epoch, option::none());
     submit_cert_internal(
         hashi,
         key,
         epoch,
-        hashi::tob::protocol_type_key_rotation(),
+        hashi::tob::protocol_type_key_rotation(protocol_id),
         dealer,
         messages_hash,
         &cert,
@@ -49,6 +51,7 @@ entry fun submit_rotation_cert(
 
 entry fun submit_nonce_cert(
     hashi: &mut Hashi,
+    protocol_id: u8,
     epoch: u64,
     batch_index: u32,
     dealer: address,
@@ -56,12 +59,12 @@ entry fun submit_nonce_cert(
     cert: CommitteeSignature,
     ctx: &mut TxContext,
 ) {
-    let key = hashi::tob::tob_key(epoch, option::some(batch_index));
+    let key = hashi::tob::tob_key(protocol_id, epoch, option::some(batch_index));
     submit_cert_internal(
         hashi,
         key,
         epoch,
-        hashi::tob::protocol_type_nonce_generation(),
+        hashi::tob::protocol_type_nonce_generation(protocol_id),
         dealer,
         messages_hash,
         &cert,
@@ -96,9 +99,14 @@ fun submit_cert_internal(
     );
 }
 
-entry fun destroy_all_certs(hashi: &mut Hashi, epoch: u64, batch_index: Option<u32>) {
+entry fun destroy_all_certs(
+    hashi: &mut Hashi,
+    protocol_id: u8,
+    epoch: u64,
+    batch_index: Option<u32>,
+) {
     hashi.versioning().assert_version_enabled();
-    let key = hashi::tob::tob_key(epoch, batch_index);
+    let key = hashi::tob::tob_key(protocol_id, epoch, batch_index);
     let current_epoch = hashi.committee_set().epoch();
     let epoch_certs: hashi::tob::EpochCertsV1 = hashi.tob_mut().remove(key);
     hashi::tob::destroy_all(epoch_certs, current_epoch);

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -10,7 +10,8 @@ use sui::{
     bag::Bag,
     bcs,
     bls12381::{UncompressedG1, bls12381_min_pk_verify, g1_from_bytes, g1_to_uncompressed_g1},
-    group_ops::Element
+    group_ops::Element,
+    vec_map::{Self, VecMap}
 };
 
 //
@@ -27,8 +28,8 @@ public struct CommitteeSet has store {
     epoch: u64,
     committees: Bag,
     pending_epoch_change: Option<PendingEpochChange>,
-    /// The MPC committee's threshold public key.
-    mpc_public_key: vector<u8>,
+    /// Per-protocol MPC threshold public keys.
+    mpc_public_keys: VecMap<u8, vector<u8>>,
 }
 
 public(package) fun create(ctx: &mut TxContext): CommitteeSet {
@@ -37,7 +38,7 @@ public(package) fun create(ctx: &mut TxContext): CommitteeSet {
         epoch: 0,
         committees: sui::bag::new(ctx),
         pending_epoch_change: option::none(),
-        mpc_public_key: std::vector::empty(),
+        mpc_public_keys: vec_map::empty(),
     }
 }
 
@@ -323,8 +324,8 @@ public(package) fun epoch(self: &CommitteeSet): u64 {
     self.epoch
 }
 
-public(package) fun mpc_public_key(self: &CommitteeSet): &vector<u8> {
-    &self.mpc_public_key
+public(package) fun mpc_public_keys(self: &CommitteeSet): &VecMap<u8, vector<u8>> {
+    &self.mpc_public_keys
 }
 
 // Verifies that the provided bls public key is valid and there is a valid
@@ -471,7 +472,7 @@ public(package) fun start_reconfig(
     // unconditionally -- enforcing a floor on a normal reconfig would let
     // validators brick reconfiguration (and with it all deposits/withdrawals)
     // by withholding registration.
-    if (self.mpc_public_key.is_empty()) {
+    if (self.mpc_public_keys.is_empty()) {
         let mut sui_system_weight = 0;
         let (_, weights) = sui_system.active_validator_voting_powers().into_keys_values();
         weights.do!(|weight| {
@@ -497,7 +498,7 @@ public(package) fun start_reconfig(
 
 public(package) fun end_reconfig(
     self: &mut CommitteeSet,
-    mpc_public_key: vector<u8>,
+    protocol_keys: VecMap<u8, vector<u8>>,
     _ctx: &TxContext,
 ): (u64, Option<committee::CommitteeSignature>) {
     assert!(self.is_reconfiguring());
@@ -506,17 +507,19 @@ public(package) fun end_reconfig(
         .extract();
     assert!(self.has_committee(next_epoch));
 
-    // If the mpc_public_key is empty, then this is the initial reconfig where
-    // DKG is run and we need to set the produced pubkey.
-    if (self.mpc_public_key.is_empty()) {
-        self.mpc_public_key = mpc_public_key;
-    } else {
+    // Initial reconfig (DKG) sets the per-protocol keys; subsequent reconfigs
+    // (resharing) keep them constant and require a committee handoff cert.
+    if (!self.mpc_public_keys.is_empty()) {
         assert!(committee_handoff_cert.is_some());
     };
-
-    // On subsequent reconfigs where key resharing is performing instead of
-    // DKG, we need to ensure that the pubkey remains constant
-    assert!(self.mpc_public_key == mpc_public_key);
+    let keys = protocol_keys.keys();
+    keys.do_ref!(|pid| {
+        let key = protocol_keys.get(pid);
+        if (!self.mpc_public_keys.contains(pid)) {
+            self.mpc_public_keys.insert(*pid, *key);
+        };
+        assert!(self.mpc_public_keys.get(pid) == key);
+    });
 
     self.epoch = next_epoch;
     (next_epoch, committee_handoff_cert)
@@ -550,8 +553,8 @@ public fun set_pending_reconfig_for_testing(self: &mut CommitteeSet, committee: 
 }
 
 #[test_only]
-public fun set_mpc_public_key_for_testing(self: &mut CommitteeSet, mpc_public_key: vector<u8>) {
-    self.mpc_public_key = mpc_public_key;
+public fun set_mpc_public_keys_for_testing(self: &mut CommitteeSet, keys: VecMap<u8, vector<u8>>) {
+    self.mpc_public_keys = keys;
 }
 
 // ======== Test-only Functions ========

--- a/packages/hashi/sources/core/reconfig.move
+++ b/packages/hashi/sources/core/reconfig.move
@@ -5,6 +5,7 @@
 module hashi::reconfig;
 
 use hashi::{committee::CommitteeSignature, hashi::Hashi};
+use sui::vec_map::VecMap;
 
 const ENotReconfiguring: u64 = 0;
 const EInitialReconfig: u64 = 1;
@@ -13,8 +14,8 @@ const EInitialReconfig: u64 = 1;
 public struct ReconfigCompletionMessage has copy, drop, store {
     /// The epoch of the new committee.
     epoch: u64,
-    /// The MPC committee's threshold public key.
-    mpc_public_key: vector<u8>,
+    /// Per-protocol MPC threshold public keys.
+    protocol_keys: VecMap<u8, vector<u8>>,
 }
 
 public struct CommitteeTransitionRequest has copy, drop, store {
@@ -44,8 +45,8 @@ entry fun start_reconfig(
 
 entry fun end_reconfig(
     self: &mut Hashi,
-    mpc_public_key: vector<u8>,
-    mpc_cert: CommitteeSignature,
+    protocol_keys: VecMap<u8, vector<u8>>,
+    cert: CommitteeSignature,
     ctx: &TxContext,
 ) {
     self.versioning().assert_version_enabled();
@@ -53,14 +54,12 @@ entry fun end_reconfig(
     let from_epoch = self.committee_set().epoch();
     let next_epoch = self.committee_set().pending_epoch_change().destroy_some();
     let next_committee = self.committee_set().get_committee(next_epoch);
-    let message = ReconfigCompletionMessage { epoch: next_epoch, mpc_public_key };
-    self.verify_with_committee(next_committee, message, mpc_cert);
-    let is_initial_reconfig = self.committee_set().mpc_public_key().is_empty();
+    let message = ReconfigCompletionMessage { epoch: next_epoch, protocol_keys };
+    self.verify_with_committee(next_committee, message, cert);
+    let is_initial_reconfig = self.committee_set().mpc_public_keys().is_empty();
 
     self.reset_num_consumed_presigs();
-    let (epoch, committee_handoff_cert) = self
-        .committee_set_mut()
-        .end_reconfig(mpc_public_key, ctx);
+    let (epoch, committee_handoff_cert) = self.committee_set_mut().end_reconfig(protocol_keys, ctx);
     if (is_initial_reconfig) {
         committee_handoff_cert.destroy_none();
     } else {
@@ -72,7 +71,7 @@ entry fun end_reconfig(
                 committee_handoff_cert.destroy_some(),
             );
     };
-    sui::event::emit(EndReconfigEvent { from_epoch, epoch, mpc_public_key });
+    sui::event::emit(EndReconfigEvent { from_epoch, epoch, protocol_keys });
 }
 
 entry fun submit_committee_handoff(
@@ -82,7 +81,7 @@ entry fun submit_committee_handoff(
 ) {
     self.versioning().assert_version_enabled();
     assert!(self.committee_set().is_reconfiguring(), ENotReconfiguring);
-    assert!(!self.committee_set().mpc_public_key().is_empty(), EInitialReconfig);
+    assert!(!self.committee_set().mpc_public_keys().is_empty(), EInitialReconfig);
     let next_epoch = self.committee_set().pending_epoch_change().destroy_some();
     let next_committee = self.committee_set().get_committee(next_epoch);
     let new_committee = *next_committee;
@@ -98,8 +97,8 @@ public struct StartReconfigEvent has copy, drop {
 public struct EndReconfigEvent has copy, drop {
     from_epoch: u64,
     epoch: u64,
-    /// The MPC committee's threshold public key.
-    mpc_public_key: vector<u8>,
+    /// Per-protocol MPC threshold public keys.
+    protocol_keys: VecMap<u8, vector<u8>>,
 }
 
 #[test_only]
@@ -135,6 +134,13 @@ fun cert_message<T: copy + drop + store>(epoch: u64, message: &T): vector<u8> {
     bytes
 }
 
+#[test_only]
+fun protocol_keys_for_testing(key: vector<u8>): VecMap<u8, vector<u8>> {
+    let mut keys = sui::vec_map::empty();
+    keys.insert(0u8, key);
+    keys
+}
+
 #[test]
 fun test_end_reconfig_stores_committee_handoff() {
     use hashi::test_utils;
@@ -146,9 +152,13 @@ fun test_end_reconfig_stores_committee_handoff() {
     let next_committee = pending_committee_for_testing(next_epoch);
     hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
 
-    let mpc_public_key = vector[1, 2, 3];
-    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
-    let mpc_message = ReconfigCompletionMessage { epoch: next_epoch, mpc_public_key };
+    hashi
+        .committee_set_mut()
+        .set_mpc_public_keys_for_testing(protocol_keys_for_testing(vector[1, 2, 3]));
+    let mpc_message = ReconfigCompletionMessage {
+        epoch: next_epoch,
+        protocol_keys: protocol_keys_for_testing(vector[1, 2, 3]),
+    };
     let mpc_cert = test_utils::sign_certificate(
         next_epoch,
         &cert_message(next_epoch, &mpc_message),
@@ -161,7 +171,7 @@ fun test_end_reconfig_stores_committee_handoff() {
     );
 
     submit_committee_handoff(&mut hashi, committee_handoff_cert, ctx);
-    end_reconfig(&mut hashi, mpc_public_key, mpc_cert, ctx);
+    end_reconfig(&mut hashi, protocol_keys_for_testing(vector[1, 2, 3]), mpc_cert, ctx);
 
     assert!(hashi.committee_set().epoch() == next_epoch);
     assert!(hashi.committee_set().has_committee_handoff_for_testing(0));
@@ -180,16 +190,18 @@ fun test_end_reconfig_requires_committee_handoff_after_initial_reconfig() {
     let next_committee = pending_committee_for_testing(next_epoch);
     hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
 
-    let mpc_public_key = vector[1];
-    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
-    let mpc_message = ReconfigCompletionMessage { epoch: next_epoch, mpc_public_key };
+    hashi.committee_set_mut().set_mpc_public_keys_for_testing(protocol_keys_for_testing(vector[1]));
+    let mpc_message = ReconfigCompletionMessage {
+        epoch: next_epoch,
+        protocol_keys: protocol_keys_for_testing(vector[1]),
+    };
     let mpc_cert = test_utils::sign_certificate(
         next_epoch,
         &cert_message(next_epoch, &mpc_message),
         3,
     );
 
-    end_reconfig(&mut hashi, mpc_public_key, mpc_cert, ctx);
+    end_reconfig(&mut hashi, protocol_keys_for_testing(vector[1]), mpc_cert, ctx);
     std::unit_test::destroy(hashi);
 }
 
@@ -227,9 +239,11 @@ fun test_submit_committee_handoff_rejects_handoff_signed_by_wrong_committee() {
     let next_committee = pending_committee_for_testing(next_epoch);
     hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
 
-    let mpc_public_key = vector[1];
-    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
-    let mpc_message = ReconfigCompletionMessage { epoch: next_epoch, mpc_public_key };
+    hashi.committee_set_mut().set_mpc_public_keys_for_testing(protocol_keys_for_testing(vector[1]));
+    let mpc_message = ReconfigCompletionMessage {
+        epoch: next_epoch,
+        protocol_keys: protocol_keys_for_testing(vector[1]),
+    };
     let mpc_cert = test_utils::sign_certificate(
         next_epoch,
         &cert_message(next_epoch, &mpc_message),
@@ -242,6 +256,6 @@ fun test_submit_committee_handoff_rejects_handoff_signed_by_wrong_committee() {
     );
 
     submit_committee_handoff(&mut hashi, committee_handoff_cert, ctx);
-    end_reconfig(&mut hashi, mpc_public_key, mpc_cert, ctx);
+    end_reconfig(&mut hashi, protocol_keys_for_testing(vector[1]), mpc_cert, ctx);
     std::unit_test::destroy(hashi);
 }

--- a/packages/hashi/sources/core/tob.move
+++ b/packages/hashi/sources/core/tob.move
@@ -12,30 +12,31 @@ const EWrongEpoch: u64 = 0;
 const ETooEarlyToDestroy: u64 = 1;
 
 public enum ProtocolType has copy, drop, store {
-    Dkg,
-    KeyRotation,
-    NonceGeneration,
+    Dkg { protocol_id: u8 },
+    KeyRotation { protocol_id: u8 },
+    NonceGeneration { protocol_id: u8 },
 }
 
-public fun protocol_type_dkg(): ProtocolType {
-    ProtocolType::Dkg
+public fun protocol_type_dkg(protocol_id: u8): ProtocolType {
+    ProtocolType::Dkg { protocol_id }
 }
 
-public fun protocol_type_key_rotation(): ProtocolType {
-    ProtocolType::KeyRotation
+public fun protocol_type_key_rotation(protocol_id: u8): ProtocolType {
+    ProtocolType::KeyRotation { protocol_id }
 }
 
-public fun protocol_type_nonce_generation(): ProtocolType {
-    ProtocolType::NonceGeneration
+public fun protocol_type_nonce_generation(protocol_id: u8): ProtocolType {
+    ProtocolType::NonceGeneration { protocol_id }
 }
 
 public struct TobKey has copy, drop, store {
+    protocol_id: u8,
     epoch: u64,
     batch_index: Option<u32>,
 }
 
-public fun tob_key(epoch: u64, batch_index: Option<u32>): TobKey {
-    TobKey { epoch, batch_index }
+public fun tob_key(protocol_id: u8, epoch: u64, batch_index: Option<u32>): TobKey {
+    TobKey { protocol_id, epoch, batch_index }
 }
 
 public fun epoch(self: &TobKey): u64 {

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -15,7 +15,7 @@ use hashi::{
     versioning::{Self, Versioning}
 };
 use std::string::String;
-use sui::{bag::{Self, Bag}, dynamic_field as df};
+use sui::{bag::{Self, Bag}, dynamic_field as df, vec_map::{Self, VecMap}};
 
 #[error]
 const ESystemPaused: vector<u8> = b"System is currently paused";
@@ -33,11 +33,10 @@ public struct Hashi has key {
     versioning: Versioning,
     treasury: Treasury,
     proposals: Proposals,
-    /// TOB certificates by (epoch, batch_index) -> EpochCertsV1
+    /// TOB certificates by (protocol_id, epoch, batch_index) -> EpochCertsV1
     tob: Bag,
-    /// Number of presignatures consumed in the current epoch.
-    /// Used by recovering nodes to derive `(batch_index, index_in_batch)`.
-    num_consumed_presigs: u64,
+    /// Per-protocol presignature counters for the current epoch.
+    num_consumed_presigs: VecMap<u8, u64>,
 }
 
 #[allow(unused_function)]
@@ -55,7 +54,7 @@ fun init(ctx: &mut TxContext) {
         treasury: hashi::treasury::create(ctx),
         proposals: proposals::create(ctx),
         tob: bag::new(ctx),
-        num_consumed_presigs: 0,
+        num_consumed_presigs: vec_map::empty(),
     };
 
     df::add(&mut hashi.id, bitcoin_state::key(), bitcoin_state::new(ctx));
@@ -225,18 +224,28 @@ public(package) fun epoch_certs(
     self.tob.borrow_mut(key)
 }
 
-public(package) fun num_consumed_presigs(self: &Hashi): u64 {
-    self.num_consumed_presigs
+public(package) fun num_consumed_presigs(self: &Hashi, protocol_id: u8): u64 {
+    if (self.num_consumed_presigs.contains(&protocol_id)) {
+        *self.num_consumed_presigs.get(&protocol_id)
+    } else {
+        0
+    }
 }
 
-public(package) fun allocate_presigs(self: &mut Hashi, count: u64): u64 {
-    let start = self.num_consumed_presigs;
-    self.num_consumed_presigs = self.num_consumed_presigs + count;
-    start
+public(package) fun allocate_presigs(self: &mut Hashi, protocol_id: u8, count: u64): u64 {
+    if (self.num_consumed_presigs.contains(&protocol_id)) {
+        let current = self.num_consumed_presigs.get_mut(&protocol_id);
+        let start = *current;
+        *current = start + count;
+        start
+    } else {
+        self.num_consumed_presigs.insert(protocol_id, count);
+        0
+    }
 }
 
 public(package) fun reset_num_consumed_presigs(self: &mut Hashi) {
-    self.num_consumed_presigs = 0;
+    self.num_consumed_presigs = vec_map::empty();
 }
 
 // ======== Test-only Functions ========
@@ -260,7 +269,7 @@ public fun create_for_testing(
         treasury,
         proposals,
         tob,
-        num_consumed_presigs: 0,
+        num_consumed_presigs: vec_map::empty(),
     };
     df::add(&mut hashi.id, bitcoin_state::key(), bitcoin_state::new(ctx));
     hashi


### PR DESCRIPTION
## Motivation

Hashi currently hardcodes a single MPC signing protocol (threshold Schnorr for Bitcoin). To bridge additional chains we'll need to support multiple signing protocols (ECDSA for Ethereum, EdDSA for Solana, etc.), each running independent DKG, maintaining its own threshold key, and managing its own presignature pool.

This PR generalizes the on-chain and off-chain infrastructure so that multiple MPC protocol instances can coexist. Each instance is identified by a `protocol_id: u8` and gets its own key storage, presig counter, and TOB cert bucket. The core protocol (committee consensus, governance, reconfig) remains protocol-agnostic — it coordinates all instances without needing to know what signing scheme each one uses.

No new protocols are introduced here. The system still runs Schnorr-only (protocol 0) for Bitcoin. The goal is to lay the foundation so that adding a second protocol later is a matter of wiring a new `protocol_id` through the chain-specific endpoints, not restructuring the core.

## Changes

**Move on-chain:**
- `CommitteeSet.mpc_public_keys`: single `vector<u8>` → `VecMap<u8, vector<u8>>` (one key per protocol)
- `Hashi.num_consumed_presigs`: single `u64` → `VecMap<u8, u64>` (independent presig pools per protocol)
- `TobKey` and `ProtocolType`: gain `protocol_id` field for per-protocol cert submission
- `end_reconfig`: accepts `VecMap<u8, vector<u8>>` of protocol keys (all-or-nothing coordination)
- `withdraw.move`: declares `PROTOCOL_SCHNORR = 0` locally for presig allocation

**Rust off-chain:**
- `hashi-types` and `onchain::types`: updated to use `BTreeMap<u8, _>` working types
- `sui_tx_executor`: PTB builder constructs `VecMap` via `vec_map::empty/insert`
- `protocol_id` threaded through TOB channel, cert fetching, metrics, and reconfig

## Test plan

- [x] 100/100 Move tests pass
- [x] All Rust crates compile clean (`hashi`, `hashi-types`, `e2e-tests`, `internal-tools`, `hashi-guardian`, `hashi-screener`, `hashi-monitor`)
- [ ] E2E test on localnet (DKG + deposit + withdrawal flow with protocol_id=0)