### PR TITLE
[guardian][onchain] verify guardian /info pubkey against on-chain config

### DIFF
--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -679,6 +679,11 @@ pub async fn create_update_guardian_proposal(
 ) -> Result<()> {
     let public_key = hex::decode(public_key_hex.strip_prefix("0x").unwrap_or(public_key_hex))
         .context("Invalid hex for public key")?;
+    anyhow::ensure!(
+        public_key.len() == 32,
+        "--public-key must be 32 bytes (Ed25519), got {} bytes",
+        public_key.len(),
+    );
 
     println!("\n{}", "Creating Update Guardian Proposal:".bold());
     println!("  URL:        {}", url);

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -912,6 +912,11 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
         (Some(url), Some(pk_hex)) => {
             let public_key = hex::decode(pk_hex.strip_prefix("0x").unwrap_or(&pk_hex))
                 .context("Invalid hex for --guardian-public-key")?;
+            anyhow::ensure!(
+                public_key.len() == 32,
+                "--guardian-public-key must be 32 bytes (Ed25519), got {} bytes",
+                public_key.len(),
+            );
             Some(crate::publish::GuardianConfig { url, public_key })
         }
         (None, None) => None,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -781,6 +781,9 @@ impl Hashi {
                 return false;
             }
         };
+        if !self.verify_guardian_signing_pubkey(&info.signing_pub_key) {
+            return false;
+        }
         let _ = self.guardian_signing_pubkey.set(Some(info.signing_pub_key));
         let (Some(state), Some(config)) = (info.limiter_state, info.limiter_config) else {
             self.metrics.record_guardian_bootstrap_outcome(
@@ -835,7 +838,9 @@ impl Hashi {
     }
 
     /// Fetch the guardian's authoritative `LimiterState` and the live local
-    /// limiter handle. `None` if the limiter isn't seeded or the RPC fails.
+    /// limiter handle. `None` if the limiter isn't seeded, the RPC fails, or
+    /// the guardian's signing key doesn't match the on-chain expected key
+    /// (treated as fatal: a stale or wrong guardian must not steer the limiter).
     async fn guardian_limiter_and_state(
         &self,
     ) -> Option<(
@@ -845,8 +850,31 @@ impl Hashi {
         let limiter = self.local_limiter()?;
         let info_pb = self.fetch_guardian_info().await?;
         let info = hashi_types::guardian::GetGuardianInfoResponse::try_from(info_pb).ok()?;
+        if !self.verify_guardian_signing_pubkey(&info.signing_pub_key) {
+            return None;
+        }
         let state = info.limiter_state?;
         Some((limiter, state))
+    }
+
+    /// Verify a fresh `GetGuardianInfo` `signing_pub_key` against the on-chain
+    /// `guardian_public_key`. Mismatch is fatal: log, bump
+    /// `bootstrap_outcomes{outcome="key_mismatch"}`, return false. On-chain
+    /// `None` (legacy chains without the key) skips the check. Re-reads on
+    /// each call so a corrective `UpdateGuardian` governance proposal heals
+    /// the node without a hashi-server restart.
+    fn verify_guardian_signing_pubkey(
+        &self,
+        signing_pub_key: &hashi_types::guardian::GuardianPubKey,
+    ) -> bool {
+        let expected = self
+            .onchain_state()
+            .state()
+            .hashi()
+            .config
+            .guardian_public_key()
+            .map(<[u8]>::to_vec);
+        verify_signing_pub_key_matches(signing_pub_key, expected.as_deref(), &self.metrics)
     }
 
     /// Snap the local limiter to the guardian's authoritative state.
@@ -982,6 +1010,30 @@ fn assert_test_only_config(sui_chain_id: &str, bitcoin_chain_id: &str, field_nam
             && bitcoin_chain_id == constants::BITCOIN_REGTEST_CHAIN_ID,
         "{field_name} is only allowed on regtest"
     );
+}
+
+/// Pure check separated from [`Hashi`] so it's unit-testable without an
+/// `OnchainState`. `expected = None` means the chain pre-dates the on-chain
+/// guardian pubkey and we skip the check (backwards-compat).
+fn verify_signing_pub_key_matches(
+    signing_pub_key: &hashi_types::guardian::GuardianPubKey,
+    expected: Option<&[u8]>,
+    metrics: &metrics::Metrics,
+) -> bool {
+    let Some(expected) = expected else {
+        return true;
+    };
+    if signing_pub_key.as_bytes().as_slice() == expected {
+        return true;
+    }
+    metrics.record_guardian_bootstrap_outcome(metrics::GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH);
+    tracing::error!(
+        on_chain = %hex::encode(expected),
+        from_info = %hex::encode(signing_pub_key.as_bytes()),
+        "FATAL: guardian /info signing_pub_key does not match on-chain \
+         guardian_public_key; refusing to seed or reconcile local limiter",
+    );
+    false
 }
 
 #[cfg(test)]
@@ -1238,5 +1290,66 @@ mod test {
         //             dbg!(resp);
         //             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         //         }
+    }
+
+    // --- guardian /info pubkey verification ---
+
+    fn fresh_metrics() -> std::sync::Arc<crate::metrics::Metrics> {
+        let registry = prometheus::Registry::new();
+        std::sync::Arc::new(crate::metrics::Metrics::new(&registry))
+    }
+
+    fn key_mismatch_count(metrics: &crate::metrics::Metrics) -> u64 {
+        metrics
+            .guardian_bootstrap_outcomes_total
+            .with_label_values(&[crate::metrics::GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH])
+            .get()
+    }
+
+    fn random_signing_pubkey() -> hashi_types::guardian::GuardianPubKey {
+        let signing_key = hashi_types::guardian::GuardianSignKeyPair::new(rand::thread_rng());
+        signing_key.verification_key()
+    }
+
+    #[test]
+    fn verify_signing_pub_key_matches_passes_when_equal() {
+        let pubkey = random_signing_pubkey();
+        let expected = pubkey.as_bytes().to_vec();
+        let metrics = fresh_metrics();
+        assert!(crate::verify_signing_pub_key_matches(
+            &pubkey,
+            Some(&expected),
+            &metrics
+        ));
+        assert_eq!(key_mismatch_count(&metrics), 0);
+    }
+
+    #[test]
+    fn verify_signing_pub_key_matches_skips_when_expected_absent() {
+        let pubkey = random_signing_pubkey();
+        let metrics = fresh_metrics();
+        // Pre-feature chains have no on-chain key — verification is a no-op.
+        assert!(crate::verify_signing_pub_key_matches(
+            &pubkey, None, &metrics
+        ));
+        assert_eq!(key_mismatch_count(&metrics), 0);
+    }
+
+    #[test]
+    fn verify_signing_pub_key_matches_fails_on_mismatch() {
+        let live = random_signing_pubkey();
+        let mut wrong = live.as_bytes().to_vec();
+        wrong[0] ^= 0xff;
+        let metrics = fresh_metrics();
+        assert!(!crate::verify_signing_pub_key_matches(
+            &live,
+            Some(&wrong),
+            &metrics
+        ));
+        assert_eq!(
+            key_mismatch_count(&metrics),
+            1,
+            "mismatch must bump the key_mismatch outcome counter"
+        );
     }
 }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -784,6 +784,9 @@ impl Hashi {
         if !self.verify_guardian_signing_pubkey(&info.signing_pub_key) {
             return false;
         }
+        if !verify_guardian_signed_info(info.signed_info, &info.signing_pub_key, &self.metrics) {
+            return false;
+        }
         let _ = self.guardian_signing_pubkey.set(Some(info.signing_pub_key));
         let (Some(state), Some(config)) = (info.limiter_state, info.limiter_config) else {
             self.metrics.record_guardian_bootstrap_outcome(
@@ -849,6 +852,9 @@ impl Hashi {
         let info_pb = self.fetch_guardian_info().await?;
         let info = hashi_types::guardian::GetGuardianInfoResponse::try_from(info_pb).ok()?;
         if !self.verify_guardian_signing_pubkey(&info.signing_pub_key) {
+            return None;
+        }
+        if !verify_guardian_signed_info(info.signed_info, &info.signing_pub_key, &self.metrics) {
             return None;
         }
         let state = info.limiter_state?;
@@ -998,6 +1004,29 @@ fn assert_test_only_config(sui_chain_id: &str, bitcoin_chain_id: &str, field_nam
             && bitcoin_chain_id == constants::BITCOIN_REGTEST_CHAIN_ID,
         "{field_name} is only allowed on regtest"
     );
+}
+
+/// Verify the signature on the guardian's `/info` envelope under its
+/// own `signing_pub_key`. Caller is responsible for verifying that the
+/// pubkey itself matches on-chain first; this is the second leg of the
+/// trust chain (signed_info → enclave that holds the on-chain pubkey).
+fn verify_guardian_signed_info(
+    signed_info: hashi_types::guardian::GuardianSigned<hashi_types::guardian::GuardianInfo>,
+    signing_pub_key: &hashi_types::guardian::GuardianPubKey,
+    metrics: &metrics::Metrics,
+) -> bool {
+    if let Err(e) = signed_info.verify(signing_pub_key) {
+        metrics.record_guardian_bootstrap_outcome(
+            metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID,
+        );
+        tracing::error!(
+            error = ?e,
+            "FATAL: guardian /info signed_info signature invalid under its own \
+             signing_pub_key; refusing to seed or reconcile local limiter",
+        );
+        return false;
+    }
+    true
 }
 
 /// `expected = None` skips the check (pre-feature chains).
@@ -1292,6 +1321,13 @@ mod test {
             .get()
     }
 
+    fn signature_invalid_count(metrics: &crate::metrics::Metrics) -> u64 {
+        metrics
+            .guardian_bootstrap_outcomes_total
+            .with_label_values(&[crate::metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID])
+            .get()
+    }
+
     fn random_signing_pubkey() -> hashi_types::guardian::GuardianPubKey {
         let signing_key = hashi_types::guardian::GuardianSignKeyPair::new(rand::thread_rng());
         signing_key.verification_key()
@@ -1332,5 +1368,49 @@ mod test {
             &metrics
         ));
         assert_eq!(key_mismatch_count(&metrics), 1);
+    }
+
+    #[test]
+    fn verify_guardian_signed_info_passes_for_valid_signature() {
+        let resp = hashi_types::guardian::GetGuardianInfoResponse::mock_for_testing();
+        let metrics = fresh_metrics();
+        assert!(crate::verify_guardian_signed_info(
+            resp.signed_info,
+            &resp.signing_pub_key,
+            &metrics,
+        ));
+        assert_eq!(signature_invalid_count(&metrics), 0);
+    }
+
+    #[test]
+    fn verify_guardian_signed_info_fails_when_pubkey_did_not_sign() {
+        // Mock signs with key A, exposes pub_key_A. Verify under pub_key_B
+        // (random) — must fail and bump the metric.
+        let resp = hashi_types::guardian::GetGuardianInfoResponse::mock_for_testing();
+        let wrong_pubkey = random_signing_pubkey();
+        let metrics = fresh_metrics();
+        assert!(!crate::verify_guardian_signed_info(
+            resp.signed_info,
+            &wrong_pubkey,
+            &metrics,
+        ));
+        assert_eq!(signature_invalid_count(&metrics), 1);
+    }
+
+    #[test]
+    fn verify_guardian_signed_info_fails_when_signature_tampered() {
+        let mut resp = hashi_types::guardian::GetGuardianInfoResponse::mock_for_testing();
+        // Flip a byte of the signature so verification under the original
+        // pubkey now fails.
+        let mut sig_bytes: [u8; 64] = resp.signed_info.signature.to_bytes();
+        sig_bytes[0] ^= 0xff;
+        resp.signed_info.signature = hashi_types::guardian::GuardianSignature::from(sig_bytes);
+        let metrics = fresh_metrics();
+        assert!(!crate::verify_guardian_signed_info(
+            resp.signed_info,
+            &resp.signing_pub_key,
+            &metrics,
+        ));
+        assert_eq!(signature_invalid_count(&metrics), 1);
     }
 }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -857,12 +857,8 @@ impl Hashi {
         Some((limiter, state))
     }
 
-    /// Verify a fresh `GetGuardianInfo` `signing_pub_key` against the on-chain
-    /// `guardian_public_key`. Mismatch is fatal: log, bump
-    /// `bootstrap_outcomes{outcome="key_mismatch"}`, return false. On-chain
-    /// `None` (legacy chains without the key) skips the check. Re-reads on
-    /// each call so a corrective `UpdateGuardian` governance proposal heals
-    /// the node without a hashi-server restart.
+    /// Re-reads the on-chain expected key on every call so a corrective
+    /// `UpdateGuardian` proposal heals the node without a restart.
     fn verify_guardian_signing_pubkey(
         &self,
         signing_pub_key: &hashi_types::guardian::GuardianPubKey,
@@ -1328,7 +1324,6 @@ mod test {
     fn verify_signing_pub_key_matches_skips_when_expected_absent() {
         let pubkey = random_signing_pubkey();
         let metrics = fresh_metrics();
-        // Pre-feature chains have no on-chain key — verification is a no-op.
         assert!(crate::verify_signing_pub_key_matches(
             &pubkey, None, &metrics
         ));
@@ -1346,10 +1341,6 @@ mod test {
             Some(&wrong),
             &metrics
         ));
-        assert_eq!(
-            key_mismatch_count(&metrics),
-            1,
-            "mismatch must bump the key_mismatch outcome counter"
-        );
+        assert_eq!(key_mismatch_count(&metrics), 1);
     }
 }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -838,9 +838,7 @@ impl Hashi {
     }
 
     /// Fetch the guardian's authoritative `LimiterState` and the live local
-    /// limiter handle. `None` if the limiter isn't seeded, the RPC fails, or
-    /// the guardian's signing key doesn't match the on-chain expected key
-    /// (treated as fatal: a stale or wrong guardian must not steer the limiter).
+    /// limiter handle. `None` if not seeded, the RPC fails, or pubkey mismatches.
     async fn guardian_limiter_and_state(
         &self,
     ) -> Option<(
@@ -857,8 +855,7 @@ impl Hashi {
         Some((limiter, state))
     }
 
-    /// Re-reads the on-chain expected key on every call so a corrective
-    /// `UpdateGuardian` proposal heals the node without a restart.
+    /// Re-read on each call so `UpdateGuardian` heals without a restart.
     fn verify_guardian_signing_pubkey(
         &self,
         signing_pub_key: &hashi_types::guardian::GuardianPubKey,
@@ -1008,9 +1005,7 @@ fn assert_test_only_config(sui_chain_id: &str, bitcoin_chain_id: &str, field_nam
     );
 }
 
-/// Pure check separated from [`Hashi`] so it's unit-testable without an
-/// `OnchainState`. `expected = None` means the chain pre-dates the on-chain
-/// guardian pubkey and we skip the check (backwards-compat).
+/// `expected = None` skips the check (pre-feature chains).
 fn verify_signing_pub_key_matches(
     signing_pub_key: &hashi_types::guardian::GuardianPubKey,
     expected: Option<&[u8]>,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -855,18 +855,13 @@ impl Hashi {
         Some((limiter, state))
     }
 
-    /// Re-read on each call so `UpdateGuardian` heals without a restart.
+    /// Read on each call: a chain that didn't publish the key at hashi
+    /// startup may bind `guardian_public_key` later via governance.
     fn verify_guardian_signing_pubkey(
         &self,
         signing_pub_key: &hashi_types::guardian::GuardianPubKey,
     ) -> bool {
-        let expected = self
-            .onchain_state()
-            .state()
-            .hashi()
-            .config
-            .guardian_public_key()
-            .map(<[u8]>::to_vec);
+        let expected = self.onchain_state().guardian_public_key();
         verify_signing_pub_key_matches(signing_pub_key, expected.as_deref(), &self.metrics)
     }
 

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1096,6 +1096,9 @@ pub const GUARDIAN_BOOTSTRAP_OUTCOME_SUCCESS: &str = "success";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE: &str = "rpc_failure";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE: &str = "parse_failure";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET: &str = "no_limiter_yet";
+/// `GetGuardianInfo.signing_pub_key` did not match the on-chain
+/// `guardian_public_key`. Refuse to seed the limiter; alert.
+pub const GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH: &str = "key_mismatch";
 
 pub const GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO: &str = "get_guardian_info";
 pub const GUARDIAN_RPC_METHOD_STANDARD_WITHDRAWAL: &str = "standard_withdrawal";
@@ -1274,6 +1277,7 @@ mod tests {
             GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE,
             GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE,
             GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET,
+            GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH,
         ] {
             metrics.record_guardian_bootstrap_outcome(outcome);
         }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1096,8 +1096,6 @@ pub const GUARDIAN_BOOTSTRAP_OUTCOME_SUCCESS: &str = "success";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE: &str = "rpc_failure";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE: &str = "parse_failure";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET: &str = "no_limiter_yet";
-/// `GetGuardianInfo.signing_pub_key` did not match the on-chain
-/// `guardian_public_key`. Refuse to seed the limiter; alert.
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH: &str = "key_mismatch";
 
 pub const GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO: &str = "get_guardian_info";

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1097,6 +1097,7 @@ pub const GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE: &str = "rpc_failure";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE: &str = "parse_failure";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET: &str = "no_limiter_yet";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH: &str = "key_mismatch";
+pub const GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID: &str = "signature_invalid";
 
 pub const GUARDIAN_RPC_METHOD_GET_GUARDIAN_INFO: &str = "get_guardian_info";
 pub const GUARDIAN_RPC_METHOD_STANDARD_WITHDRAWAL: &str = "standard_withdrawal";
@@ -1276,6 +1277,7 @@ mod tests {
             GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE,
             GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET,
             GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH,
+            GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID,
         ] {
             metrics.record_guardian_bootstrap_outcome(outcome);
         }

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -497,6 +497,22 @@ impl OnchainState {
         self.state().hashi().config.mpc_max_faulty_in_basis_points()
     }
 
+    pub fn guardian_url(&self) -> Option<String> {
+        self.state()
+            .hashi()
+            .config
+            .guardian_url()
+            .map(str::to_string)
+    }
+
+    pub fn guardian_public_key(&self) -> Option<Vec<u8>> {
+        self.state()
+            .hashi()
+            .config
+            .guardian_public_key()
+            .map(<[u8]>::to_vec)
+    }
+
     pub fn bridge_service_client(
         &self,
         validator: &Address,

--- a/crates/internal-tools/src/fetch_guardian_info.rs
+++ b/crates/internal-tools/src/fetch_guardian_info.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fetch a deployed guardian's signing public key.
+//!
+//! Calls `GuardianService/GetGuardianInfo` and prints the hex-encoded
+//! Ed25519 `signing_pub_key` to stdout. Used by the deploy workflow to feed
+//! `hashi publish --guardian-public-key` so the key gets recorded on chain.
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use clap::Parser;
+use hashi_types::guardian::GetGuardianInfoResponse;
+use hashi_types::proto as pb;
+use hashi_types::proto::guardian_service_client::GuardianServiceClient;
+
+#[derive(Parser)]
+pub struct Args {
+    /// gRPC endpoint of the deployed guardian (e.g. `http://localhost:3000`).
+    #[arg(long, env = "GUARDIAN_ENDPOINT")]
+    pub endpoint: String,
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    let mut client = GuardianServiceClient::connect(args.endpoint.clone())
+        .await
+        .with_context(|| format!("connect to guardian at {}", args.endpoint))?;
+    let resp = client
+        .get_guardian_info(pb::GetGuardianInfoRequest {})
+        .await
+        .context("GetGuardianInfo RPC failed")?
+        .into_inner();
+    let info = GetGuardianInfoResponse::try_from(resp)
+        .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
+    println!("{}", hex::encode(info.signing_pub_key.as_bytes()));
+    Ok(())
+}

--- a/crates/internal-tools/src/main.rs
+++ b/crates/internal-tools/src/main.rs
@@ -14,6 +14,7 @@ use hashi::onchain::OnchainState;
 
 mod bootstrap_guardian;
 mod dump_utxos;
+mod fetch_guardian_info;
 mod key_recovery;
 mod sweep_utxos;
 mod utxo_csv;
@@ -59,6 +60,10 @@ enum Commands {
         config: ConfigArgs,
         #[command(flatten)]
         args: bootstrap_guardian::Args,
+    },
+    FetchGuardianInfo {
+        #[command(flatten)]
+        args: fetch_guardian_info::Args,
     },
 }
 
@@ -114,5 +119,6 @@ async fn main() -> anyhow::Result<()> {
                     .context("failed to connect to Sui RPC")?;
             bootstrap_guardian::run(args, &onchain_state).await
         }
+        Commands::FetchGuardianInfo { args } => fetch_guardian_info::run(args).await,
     }
 }

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -20,10 +20,13 @@ const PACKAGE_VERSION: u64 = 1;
 const EVersionDisabled: vector<u8> = b"Version disabled";
 #[error(code = 1)]
 const EDisableCurrentVersion: vector<u8> = b"Cannot disable current version";
+#[error(code = 2)]
+const EBadGuardianPublicKeyLength: vector<u8> = b"Guardian public key must be 32 bytes";
 
 const PAUSED_KEY: vector<u8> = b"paused";
 const GUARDIAN_URL_KEY: vector<u8> = b"guardian_url";
 const GUARDIAN_PUBLIC_KEY_KEY: vector<u8> = b"guardian_public_key";
+const GUARDIAN_PUBLIC_KEY_LEN: u64 = 32;
 const EMERGENCY_PAUSE_THRESHOLD_BPS_KEY: vector<u8> = b"governance_emergency_pause_threshold_bps";
 const EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY: vector<u8> =
     b"governance_emergency_unpause_threshold_bps";
@@ -93,6 +96,7 @@ public(package) fun guardian_public_key(self: &Config): Option<vector<u8>> {
 }
 
 public(package) fun set_guardian(self: &mut Config, url: String, public_key: vector<u8>) {
+    assert!(public_key.length() == GUARDIAN_PUBLIC_KEY_LEN, EBadGuardianPublicKeyLength);
     self.upsert(GUARDIAN_URL_KEY, config_value::new_string(url));
     self.upsert(GUARDIAN_PUBLIC_KEY_KEY, config_value::new_bytes(public_key));
 }

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -96,9 +96,13 @@ public(package) fun guardian_public_key(self: &Config): Option<vector<u8>> {
 }
 
 public(package) fun set_guardian(self: &mut Config, url: String, public_key: vector<u8>) {
-    assert!(public_key.length() == GUARDIAN_PUBLIC_KEY_LEN, EBadGuardianPublicKeyLength);
+    assert_valid_guardian_public_key(&public_key);
     self.upsert(GUARDIAN_URL_KEY, config_value::new_string(url));
     self.upsert(GUARDIAN_PUBLIC_KEY_KEY, config_value::new_bytes(public_key));
+}
+
+public(package) fun assert_valid_guardian_public_key(public_key: &vector<u8>) {
+    assert!(public_key.length() == GUARDIAN_PUBLIC_KEY_LEN, EBadGuardianPublicKeyLength);
 }
 
 public(package) fun emergency_pause_threshold_bps(self: &Config): u64 {

--- a/packages/hashi/sources/core/proposal/types/update_guardian.move
+++ b/packages/hashi/sources/core/proposal/types/update_guardian.move
@@ -3,7 +3,7 @@
 
 module hashi::update_guardian;
 
-use hashi::{hashi::Hashi, proposal};
+use hashi::{config, hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
@@ -23,6 +23,7 @@ public fun propose(
     ctx: &mut TxContext,
 ): ID {
     hashi.config().assert_version_enabled();
+    config::assert_valid_guardian_public_key(&public_key);
     proposal::create(
         hashi,
         UpdateGuardian { url, public_key },

--- a/packages/hashi/tests/config_tests.move
+++ b/packages/hashi/tests/config_tests.move
@@ -4,7 +4,8 @@
 #[test_only]
 module hashi::config_tests;
 
-use hashi::{btc_config, test_utils};
+use hashi::{btc_config, config, test_utils};
+use std::string;
 
 const VOTER1: address = @0x1;
 const VOTER2: address = @0x2;
@@ -64,6 +65,34 @@ fun test_bitcoin_withdrawal_minimum_floors() {
     assert!(btc_config::bitcoin_withdrawal_minimum(hashi.config()) == 10_000);
 
     std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_set_guardian_stores_url_and_key() {
+    let ctx = &mut test_utils::new_tx_context(@0x100, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+
+    let url = string::utf8(b"http://guardian.example:3000");
+    let pk = vector::tabulate!(32, |i| (i as u8));
+    config::set_guardian(hashi.config_mut(), url, pk);
+
+    assert!(config::guardian_url(hashi.config()).borrow() == url);
+    let stored = config::guardian_public_key(hashi.config()).destroy_some();
+    assert!(stored.length() == 32);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test, expected_failure(abort_code = ::hashi::config::EBadGuardianPublicKeyLength)]
+fun test_set_guardian_rejects_wrong_length_key() {
+    let ctx = &mut test_utils::new_tx_context(@0x100, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+
+    let url = string::utf8(b"http://guardian.example:3000");
+    let bad_pk = vector::tabulate!(31, |i| (i as u8));
+    config::set_guardian(hashi.config_mut(), url, bad_pk);
+
+    abort // unreachable; assertion above must fire
 }
 
 #[test]

--- a/packages/hashi/tests/config_tests.move
+++ b/packages/hashi/tests/config_tests.move
@@ -92,7 +92,7 @@ fun test_set_guardian_rejects_wrong_length_key() {
     let bad_pk = vector::tabulate!(31, |i| (i as u8));
     config::set_guardian(hashi.config_mut(), url, bad_pk);
 
-    abort // unreachable; assertion above must fire
+    std::unit_test::destroy(hashi);
 }
 
 #[test]


### PR DESCRIPTION
builds on top of #549, which allows publishing the guardian configuration onchain.

## changes:

### hashi
- At hashi startup, compare the live guardian `signing_pub_key` against on-chain `guardian_public_key` on both the bootstrap and the periodic-reconcile paths in `Hashi::start`. 
- on mismatch, the retry loop keeps running so a corrective `UpdateGuardian` proposal heals the node without a restart.

### observability
- add new metric `guardian_bootstrap_outcomes_total{outcome="key_mismatch"}` to track failures

### publishing the config during deployments
- `set_guardian` asserts a 32-byte key on-chain and at the `hashi publish --guardian-public-key` flag boundary.
- `internal-tools fetch-guardian-info --endpoint <url>` prints the hex pubkey from a deployed guardian's `/info`
- MystenLabs/sui-operations#8055 uses this to pipe the `--guardian-public-key`
