### PR TITLE
[guardian][onchain] 2-of-2 (mpc, guardian) taproot deposits + make guardian required

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -351,42 +351,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_bitcoin_withdrawal_e2e_flow() -> Result<()> {
-        run_bitcoin_withdrawal_e2e(false).await
-    }
-
-    #[tokio::test]
-    async fn test_bitcoin_withdrawal_with_guardian_e2e_flow() -> Result<()> {
-        run_bitcoin_withdrawal_e2e(true).await
-    }
-
-    async fn run_bitcoin_withdrawal_e2e(with_guardian: bool) -> Result<()> {
         init_test_logging();
-        let label = if with_guardian {
-            " (with guardian)"
-        } else {
-            ""
-        };
-        info!("=== Starting Bitcoin Withdrawal E2E Test{label} ===");
+        info!("=== Starting Bitcoin Withdrawal E2E Test ===");
 
-        let mut builder = TestNetworksBuilder::new().with_nodes(4);
-        if with_guardian {
-            builder = builder.with_guardian();
-        }
+        let builder = TestNetworksBuilder::new().with_nodes(4);
         let mut networks = setup_test_networks(builder).await?;
 
-        if with_guardian {
-            for node in networks.hashi_network.nodes() {
-                assert!(node.hashi().config.guardian_endpoint().is_some());
-                assert!(node.hashi().guardian_client().is_some());
-                // Harness waits for limiter bootstrap before returning.
-                assert!(node.hashi().local_limiter().is_some());
-            }
-            let harness = networks
-                .guardian_harness
-                .as_ref()
-                .expect("harness present when .with_guardian() is set");
-            assert!(harness.enclave().is_fully_initialized());
+        for node in networks.hashi_network.nodes() {
+            assert!(node.hashi().config.guardian_endpoint().is_some());
+            assert!(node.hashi().guardian_client().is_some());
+            // Harness waits for limiter bootstrap before returning.
+            assert!(node.hashi().local_limiter().is_some());
         }
+        let harness = networks
+            .guardian_harness
+            .as_ref()
+            .expect("harness present after 2-of-2 cutover");
+        assert!(harness.enclave().is_fully_initialized());
 
         let deposit_amount_sats = 100_000u64;
         let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_amount_sats).await?;
@@ -463,40 +444,38 @@ mod tests {
         )
         .await?;
 
-        if with_guardian {
-            let guardian_state = networks
-                .guardian_harness
-                .as_ref()
-                .expect("harness present when .with_guardian() is set")
-                .enclave()
-                .state
-                .limiter_state()
-                .await
-                .expect("guardian limiter state present after a successful withdrawal");
-            assert_eq!(guardian_state.next_seq, 1);
-            let local_state = hashi
-                .local_limiter()
-                .expect("local limiter present after bootstrap")
-                .snapshot();
-            // `last_updated_at` can drift a few seconds — watcher uses the
-            // event-carrying checkpoint, guardian the leader's signing one.
-            assert_eq!(local_state.next_seq, guardian_state.next_seq);
-            assert_eq!(
-                local_state.num_tokens_available,
-                guardian_state.num_tokens_available,
-            );
-            let drift = local_state
-                .last_updated_at
-                .checked_sub(guardian_state.last_updated_at);
-            assert!(
-                matches!(drift, Some(0..=60)),
-                "local last_updated_at ({}) must be 0–60s after guardian's ({})",
-                local_state.last_updated_at,
-                guardian_state.last_updated_at,
-            );
-        }
+        let guardian_state = networks
+            .guardian_harness
+            .as_ref()
+            .expect("harness present after 2-of-2 cutover")
+            .enclave()
+            .state
+            .limiter_state()
+            .await
+            .expect("guardian limiter state present after a successful withdrawal");
+        assert_eq!(guardian_state.next_seq, 1);
+        let local_state = hashi
+            .local_limiter()
+            .expect("local limiter present after bootstrap")
+            .snapshot();
+        // `last_updated_at` can drift a few seconds — watcher uses the
+        // event-carrying checkpoint, guardian the leader's signing one.
+        assert_eq!(local_state.next_seq, guardian_state.next_seq);
+        assert_eq!(
+            local_state.num_tokens_available,
+            guardian_state.num_tokens_available,
+        );
+        let drift = local_state
+            .last_updated_at
+            .checked_sub(guardian_state.last_updated_at);
+        assert!(
+            matches!(drift, Some(0..=60)),
+            "local last_updated_at ({}) must be 0–60s after guardian's ({})",
+            local_state.last_updated_at,
+            guardian_state.last_updated_at,
+        );
 
-        info!("=== Bitcoin Withdrawal E2E Test{label} Passed ===");
+        info!("=== Bitcoin Withdrawal E2E Test Passed ===");
         Ok(())
     }
 

--- a/crates/e2e-tests/src/guardian_harness.rs
+++ b/crates/e2e-tests/src/guardian_harness.rs
@@ -104,6 +104,14 @@ impl GuardianHarness {
     pub fn enclave(&self) -> &Arc<Enclave> {
         &self.enclave
     }
+
+    /// Generate (or return the already-generated) enclave BTC pubkey
+    /// without running provisioner-init. Used by e2e setup to publish
+    /// the pubkey on-chain before hashi DKG completes.
+    pub fn ensure_btc_pubkey(&self) -> Result<BitcoinPubkey> {
+        hashi_guardian::test_utils::set_or_get_enclave_btc_pubkey(&self.enclave)
+            .map_err(|e| anyhow::anyhow!("set_or_get_enclave_btc_pubkey: {e:?}"))
+    }
 }
 
 impl Drop for GuardianHarness {

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -135,12 +135,16 @@ impl TestNetworksBuilder {
             hashi_builder: HashiNetworkBuilder::new(),
             bitcoin_builder: BitcoinNodeBuilder::new(),
             onchain_config_overrides,
-            with_guardian: false,
+            // Guardian is now load-bearing for every deposit and withdrawal,
+            // so e2e tests always spin one up. The opt-in flag is preserved
+            // as a no-op for callers that explicitly request it.
+            with_guardian: true,
         }
     }
 
-    /// Spin up an in-process guardian, wire its endpoint into every
-    /// hashi node, and finalize it once DKG completes.
+    /// Kept for explicit call-sites that opt in to the guardian. After the
+    /// 2-of-2 deposit cutover this is always on, but the method still
+    /// exists so callers don't have to be updated in lockstep.
     pub fn with_guardian(mut self) -> Self {
         self.with_guardian = true;
         self
@@ -253,26 +257,44 @@ impl TestNetworksBuilder {
             .await?;
         Self::cp_packages(dir.as_ref())?;
 
+        // Guardian must be reachable + have its BTC key generated BEFORE
+        // publish, so the on-chain config can pin the right BTC pubkey.
+        // Provisioner-init (which needs the hashi DKG output) runs later
+        // via `finalize_guardian_harness`.
+        anyhow::ensure!(
+            self.with_guardian,
+            "TestNetworksBuilder requires `with_guardian` after the 2-of-2 cutover",
+        );
+        let guardian_harness =
+            guardian_harness::GuardianHarness::start(bitcoin::Network::Regtest).await?;
+        let guardian_btc_pubkey = guardian_harness.ensure_btc_pubkey()?;
+        let guardian_config = hashi::publish::GuardianConfig {
+            url: guardian_harness.endpoint().to_string(),
+            public_key: guardian_harness
+                .enclave()
+                .signing_pubkey()
+                .as_bytes()
+                .to_vec(),
+            btc_public_key: guardian_btc_pubkey.serialize().to_vec(),
+        };
+        tracing::info!(
+            endpoint = %guardian_harness.endpoint(),
+            "guardian harness started (operator-init)"
+        );
+
+        let mut hashi_builder = self.hashi_builder;
+        hashi_builder =
+            hashi_builder.with_guardian_endpoint(guardian_harness.endpoint().to_string());
+
         let hashi_ids = publish(
             dir.as_ref(),
             &mut sui_network.client,
             sui_network.user_keys.first().unwrap(),
+            &guardian_config,
         )
         .await?;
 
-        let mut hashi_builder = self.hashi_builder;
-        let guardian_harness = if self.with_guardian {
-            let harness =
-                guardian_harness::GuardianHarness::start(bitcoin::Network::Regtest).await?;
-            hashi_builder = hashi_builder.with_guardian_endpoint(harness.endpoint().to_string());
-            tracing::info!(
-                endpoint = %harness.endpoint(),
-                "guardian harness started (operator-init)"
-            );
-            Some(harness)
-        } else {
-            None
-        };
+        let guardian_harness = Some(guardian_harness);
 
         let hashi_network = hashi_builder
             .build(

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -117,7 +117,6 @@ pub struct TestNetworksBuilder {
     /// On-chain config overrides applied after DKG completes, before `build()`
     /// returns. Each entry is run through the full propose/vote/execute flow.
     onchain_config_overrides: Vec<(String, hashi_types::move_types::ConfigValue)>,
-    with_guardian: bool,
 }
 
 impl TestNetworksBuilder {
@@ -135,19 +134,7 @@ impl TestNetworksBuilder {
             hashi_builder: HashiNetworkBuilder::new(),
             bitcoin_builder: BitcoinNodeBuilder::new(),
             onchain_config_overrides,
-            // Guardian is now load-bearing for every deposit and withdrawal,
-            // so e2e tests always spin one up. The opt-in flag is preserved
-            // as a no-op for callers that explicitly request it.
-            with_guardian: true,
         }
-    }
-
-    /// Kept for explicit call-sites that opt in to the guardian. After the
-    /// 2-of-2 deposit cutover this is always on, but the method still
-    /// exists so callers don't have to be updated in lockstep.
-    pub fn with_guardian(mut self) -> Self {
-        self.with_guardian = true;
-        self
     }
 
     pub fn with_nodes(mut self, num_nodes: usize) -> Self {
@@ -261,10 +248,6 @@ impl TestNetworksBuilder {
         // publish, so the on-chain config can pin the right BTC pubkey.
         // Provisioner-init (which needs the hashi DKG output) runs later
         // via `finalize_guardian_harness`.
-        anyhow::ensure!(
-            self.with_guardian,
-            "TestNetworksBuilder requires `with_guardian` after the 2-of-2 cutover",
-        );
         let guardian_harness =
             guardian_harness::GuardianHarness::start(bitcoin::Network::Regtest).await?;
         let guardian_btc_pubkey = guardian_harness.ensure_btc_pubkey()?;

--- a/crates/e2e-tests/src/main.rs
+++ b/crates/e2e-tests/src/main.rs
@@ -734,10 +734,22 @@ async fn cmd_deposit(amount: u64, recipient: Option<&str>, data_dir: &Path) -> R
         anyhow::bail!("MPC public key not available on-chain. Has the committee completed DKG?");
     }
 
-    // Derive deposit address
+    let guardian_btc_pubkey = onchain_state
+        .state()
+        .hashi()
+        .config
+        .guardian_btc_public_key()
+        .map(<[u8]>::to_vec)
+        .context(
+            "Guardian BTC pubkey not available on-chain. \
+             Did finish_publish run with --guardian-btc-public-key?",
+        )?;
+
+    // Derive deposit address (2-of-2 taproot)
     let btc_network = bitcoin::Network::Regtest;
     let deposit_address = hashi::cli::commands::deposit::cli_derive_deposit_address(
         &mpc_pubkey,
+        &guardian_btc_pubkey,
         Some(&recipient_addr),
         btc_network,
     )?;

--- a/crates/e2e-tests/src/publish.rs
+++ b/crates/e2e-tests/src/publish.rs
@@ -13,6 +13,7 @@ pub async fn publish(
     dir: &Path,
     client: &mut Client,
     private_key: &Ed25519PrivateKey,
+    guardian: &hashi::publish::GuardianConfig,
 ) -> Result<HashiIds> {
     let params = hashi::publish::BuildParams {
         sui_binary: sui_binary(),
@@ -27,7 +28,7 @@ pub async fn publish(
         private_key,
         compiled,
         bitcoin_chain_id,
-        None,
+        guardian,
         &hashi::publish::BitcoinConfigOverrides::default(),
     )
     .await

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -250,15 +250,15 @@ pub struct FullyInitializedArgs {
     pub limiter_state: LimiterState,
 }
 
-/// Drive an operator-initialized enclave to fully-initialized state without
-/// running the share-encryption round-trip. Generates a fresh BTC keypair.
-pub fn finalize_enclave(
-    enclave: &Arc<Enclave>,
-    committee: HashiCommittee,
-    master_pubkey: BitcoinPubkey,
-    withdrawal_config: WithdrawalConfig,
-    limiter_state: LimiterState,
-) -> GuardianResult<()> {
+/// Generate and set a fresh BTC keypair on an operator-init'd enclave.
+/// Returns the x-only pubkey so callers can publish it on-chain before
+/// the rest of provisioner-init has run (i.e. before DKG completes and
+/// `finalize_enclave` can be called). Idempotent: returns the existing
+/// pubkey if the keypair has already been set.
+pub fn set_or_get_enclave_btc_pubkey(enclave: &Arc<Enclave>) -> GuardianResult<BitcoinPubkey> {
+    if let Ok(pk) = enclave.config.enclave_btc_pubkey() {
+        return Ok(pk);
+    }
     let secp = Secp256k1::new();
     let mut sk_bytes = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut sk_bytes);
@@ -266,7 +266,26 @@ pub fn finalize_enclave(
         &secp,
         &SecretKey::from_slice(&sk_bytes).expect("random bytes form a valid secp256k1 key"),
     );
+    let pk = enclave_btc_keypair.x_only_public_key().0;
     enclave.config.set_btc_keypair(enclave_btc_keypair)?;
+    Ok(pk)
+}
+
+/// Drive an operator-initialized enclave to fully-initialized state
+/// without running the share-encryption round-trip. The BTC keypair may
+/// have been generated up front via [`set_or_get_enclave_btc_pubkey`]
+/// (so the on-chain `guardian_btc_public_key` was set at publish time);
+/// if not, a fresh one is generated here.
+pub fn finalize_enclave(
+    enclave: &Arc<Enclave>,
+    committee: HashiCommittee,
+    master_pubkey: BitcoinPubkey,
+    withdrawal_config: WithdrawalConfig,
+    limiter_state: LimiterState,
+) -> GuardianResult<()> {
+    // Ensure the BTC keypair is set (idempotent — no-op if a caller
+    // already generated it before publish).
+    let _ = set_or_get_enclave_btc_pubkey(enclave)?;
     enclave.config.set_hashi_btc_pk(master_pubkey)?;
     enclave.config.set_withdrawal_config(withdrawal_config)?;
 

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -349,6 +349,17 @@ impl HashiClient {
         self.onchain_state.mpc_public_key()
     }
 
+    /// Fetch the guardian's x-only BTC pubkey from on-chain config.
+    /// Returns `None` on pre-feature chains where the field is unset.
+    pub fn fetch_guardian_btc_public_key(&self) -> Option<Vec<u8>> {
+        self.onchain_state
+            .state()
+            .hashi()
+            .config
+            .guardian_btc_public_key()
+            .map(<[u8]>::to_vec)
+    }
+
     /// Fetch pending deposit requests
     pub fn fetch_deposit_requests(&self) -> Vec<crate::onchain::types::DepositRequest> {
         self.onchain_state.deposit_requests()

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -58,42 +58,32 @@ pub async fn run(action: DepositCommands, config: &CliConfig, tx_opts: &TxOption
     }
 }
 
-/// Parse raw on-chain MPC public key bytes and derive the deposit address.
+/// Parse raw on-chain MPC public key bytes and derive the 2-of-2 deposit address.
 pub fn cli_derive_deposit_address(
     mpc_pubkey_bytes: &[u8],
+    guardian_btc_pubkey_bytes: &[u8],
     recipient: Option<&sui_sdk_types::Address>,
     btc_network: bitcoin::Network,
 ) -> Result<bitcoin::Address> {
     use fastcrypto::groups::secp256k1::ProjectivePoint;
     use fastcrypto::serde_helpers::ToFromByteArray;
 
-    let mpc_key = match mpc_pubkey_bytes.len() {
-        33 => <ProjectivePoint as ToFromByteArray<33>>::from_byte_array(
-            mpc_pubkey_bytes
-                .try_into()
-                .context("MPC key must be 33 bytes")?,
-        )
-        .context("Failed to parse MPC key as ProjectivePoint")?,
-        32 => {
-            if recipient.is_some() {
-                anyhow::bail!(
-                    "Key derivation requires the full 33-byte compressed MPC key, \
-                     but only 32-byte x-only key is available"
-                );
-            }
-            let xonly = XOnlyPublicKey::from_slice(mpc_pubkey_bytes)
-                .context("Failed to parse 32-byte MPC key")?;
-            return Ok(
-                hashi_types::guardian::bitcoin_utils::single_key_taproot_script_path_address(
-                    &xonly,
-                    btc_network,
-                ),
-            );
-        }
-        n => anyhow::bail!("Unexpected MPC public key length: {} bytes", n),
-    };
+    anyhow::ensure!(
+        mpc_pubkey_bytes.len() == 33,
+        "MPC key must be 33 bytes (compressed), got {}",
+        mpc_pubkey_bytes.len(),
+    );
+    let mpc_key = <ProjectivePoint as ToFromByteArray<33>>::from_byte_array(
+        mpc_pubkey_bytes
+            .try_into()
+            .context("MPC key must be 33 bytes")?,
+    )
+    .context("Failed to parse MPC key as ProjectivePoint")?;
 
-    crate::deposits::derive_deposit_address(&mpc_key, recipient, btc_network)
+    let guardian_btc_pubkey = XOnlyPublicKey::from_slice(guardian_btc_pubkey_bytes)
+        .context("Guardian BTC pubkey must be 32 bytes (x-only)")?;
+
+    crate::deposits::derive_deposit_address(&mpc_key, &guardian_btc_pubkey, recipient, btc_network)
 }
 
 async fn generate_address(config: &CliConfig, recipient: &str) -> Result<()> {
@@ -103,6 +93,9 @@ async fn generate_address(config: &CliConfig, recipient: &str) -> Result<()> {
     if mpc_pubkey.is_empty() {
         anyhow::bail!("MPC public key not available on-chain. Has the committee completed DKG?");
     }
+    let guardian_btc_pubkey = client.fetch_guardian_btc_public_key().context(
+        "Guardian BTC pubkey is not yet on-chain. Did finish_publish run with --guardian-btc-public-key?",
+    )?;
 
     let is_change = recipient.is_empty();
     let recipient_addr = if is_change {
@@ -119,7 +112,12 @@ async fn generate_address(config: &CliConfig, recipient: &str) -> Result<()> {
         config.bitcoin.as_ref().and_then(|b| b.network.as_deref()),
     )?;
 
-    let address = cli_derive_deposit_address(&mpc_pubkey, recipient_addr.as_ref(), btc_network)?;
+    let address = cli_derive_deposit_address(
+        &mpc_pubkey,
+        &guardian_btc_pubkey,
+        recipient_addr.as_ref(),
+        btc_network,
+    )?;
 
     let title = if is_change {
         "Deposit Address (Change Address)"
@@ -238,13 +236,20 @@ async fn request_all(
                 "MPC public key not available on-chain. Has the committee completed DKG?"
             );
         }
+        let guardian_btc_pubkey = client.fetch_guardian_btc_public_key().context(
+            "Guardian BTC pubkey is not yet on-chain. Did finish_publish run with --guardian-btc-public-key?",
+        )?;
 
         let btc_network = crate::btc_monitor::config::parse_btc_network(
             config.bitcoin.as_ref().and_then(|b| b.network.as_deref()),
         )?;
 
-        let deposit_address =
-            cli_derive_deposit_address(&mpc_pubkey, derivation_path.as_ref(), btc_network)?;
+        let deposit_address = cli_derive_deposit_address(
+            &mpc_pubkey,
+            &guardian_btc_pubkey,
+            derivation_path.as_ref(),
+            btc_network,
+        )?;
 
         // Look up the transaction and find all matching outputs
         let raw_tx = btc_rpc

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -509,18 +509,19 @@ pub struct PublishOpts {
     #[clap(long)]
     pub bitcoin_chain_id: String,
 
-    /// Guardian gRPC endpoint URL (optional)
+    /// Guardian gRPC endpoint URL. Required — every deposit address is a
+    /// 2-of-2 (mpc, guardian) taproot leaf.
     #[clap(long)]
-    pub guardian_url: Option<String>,
+    pub guardian_url: String,
 
-    /// Guardian signing public key, hex-encoded (optional, requires --guardian-url)
+    /// Guardian Ed25519 signing pubkey, hex-encoded (32 bytes).
     #[clap(long)]
-    pub guardian_public_key: Option<String>,
+    pub guardian_public_key: String,
 
     /// Guardian BTC pubkey, x-only hex-encoded (32 bytes). Published
     /// on-chain for 2-of-2 deposit address derivation.
     #[clap(long)]
-    pub guardian_btc_public_key: Option<String>,
+    pub guardian_btc_public_key: String,
 
     /// Override `bitcoin_confirmation_threshold` on-chain at publish time.
     /// Falls back to the Move package's `init_defaults` (currently 6) when omitted.
@@ -912,50 +913,33 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
     // Connect to RPC
     let mut client = sui_rpc::Client::new(&opts.sui_rpc_url)?;
 
-    // Build optional guardian config
-    let guardian_btc_public_key = match opts.guardian_btc_public_key {
-        Some(hex_str) => {
-            let bytes = hex::decode(hex_str.strip_prefix("0x").unwrap_or(&hex_str))
-                .context("Invalid hex for --guardian-btc-public-key")?;
-            // from_slice requires exactly 32 bytes and a valid curve point.
-            hashi_types::guardian::BitcoinPubkey::from_slice(&bytes)
-                .context("--guardian-btc-public-key must be a 32-byte x-only Bitcoin pubkey")?;
-            Some(bytes)
-        }
-        None => None,
-    };
-    let guardian = match (opts.guardian_url, opts.guardian_public_key) {
-        (Some(url), Some(pk_hex)) => {
-            let public_key = hex::decode(pk_hex.strip_prefix("0x").unwrap_or(&pk_hex))
-                .context("Invalid hex for --guardian-public-key")?;
-            anyhow::ensure!(
-                public_key.len() == 32,
-                "--guardian-public-key must be 32 bytes (Ed25519), got {} bytes",
-                public_key.len(),
-            );
-            // The guardian is configured all-or-nothing on-chain: the BTC key is
-            // required alongside the URL/signing key, else `finish_publish` would
-            // silently skip the whole guardian config.
-            anyhow::ensure!(
-                guardian_btc_public_key.is_some(),
-                "--guardian-btc-public-key is required with --guardian-url and --guardian-public-key"
-            );
-            Some(crate::publish::GuardianConfig {
-                url,
-                public_key,
-                btc_public_key: guardian_btc_public_key,
-            })
-        }
-        (None, None) => {
-            anyhow::ensure!(
-                guardian_btc_public_key.is_none(),
-                "--guardian-btc-public-key requires --guardian-url and --guardian-public-key"
-            );
-            None
-        }
-        _ => anyhow::bail!(
-            "--guardian-url and --guardian-public-key must both be provided or both omitted"
-        ),
+    // Guardian is required — all three flags must be present.
+    let public_key = hex::decode(
+        opts.guardian_public_key
+            .strip_prefix("0x")
+            .unwrap_or(&opts.guardian_public_key),
+    )
+    .context("Invalid hex for --guardian-public-key")?;
+    anyhow::ensure!(
+        public_key.len() == 32,
+        "--guardian-public-key must be 32 bytes (Ed25519), got {} bytes",
+        public_key.len(),
+    );
+    let btc_public_key = hex::decode(
+        opts.guardian_btc_public_key
+            .strip_prefix("0x")
+            .unwrap_or(&opts.guardian_btc_public_key),
+    )
+    .context("Invalid hex for --guardian-btc-public-key")?;
+    anyhow::ensure!(
+        btc_public_key.len() == 32,
+        "--guardian-btc-public-key must be 32 bytes (x-only), got {} bytes",
+        btc_public_key.len(),
+    );
+    let guardian = crate::publish::GuardianConfig {
+        url: opts.guardian_url,
+        public_key,
+        btc_public_key,
     };
 
     let bitcoin_overrides = crate::publish::BitcoinConfigOverrides {
@@ -970,7 +954,7 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
         &signer,
         compiled,
         &opts.bitcoin_chain_id,
-        guardian.as_ref(),
+        &guardian,
         &bitcoin_overrides,
     )
     .await?;

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -23,16 +23,9 @@ fn path_bytes_or_zero(derivation_path: Option<&sui_sdk_types::Address>) -> [u8; 
     derivation_path.map(|p| p.into_inner()).unwrap_or([0u8; 32])
 }
 
-/// Derive a deposit address as the 2-of-2 taproot script-path output
 /// `tr(NUMS, multi_a(2, guardian_btc_pubkey, derive(mpc_pubkey, path)))`.
-///
-/// `mpc_key` is the 33-byte compressed MPC committee pubkey (subject to
-/// BIP32-style derivation by `path`). `guardian_btc_pubkey` is the
-/// x-only enclave key (32 bytes), used as-is — the guardian holds a
-/// single Bitcoin key shared across every deposit.
-///
-/// `path = None` means "change address": no derivation on the MPC key,
-/// same 2-of-2 leaf using the master MPC key directly.
+/// `path = None` (change address) maps to a zero-byte path so deposit
+/// and withdrawal sides agree on the leaf key without a special case.
 pub fn derive_deposit_address(
     mpc_key: &ProjectivePoint,
     guardian_btc_pubkey: &XOnlyPublicKey,
@@ -46,15 +39,10 @@ pub fn derive_deposit_address(
             .context("Failed to parse x-only MPC key")?
     };
 
-    // The 2-of-2 helper internally derives the hashi pubkey from the
-    // `[u8; 32]` path. Use a zero path for the "no derivation" case so
-    // the change address is stable for an undeposited master key.
-    let path_bytes = derivation_path.map(|p| p.into_inner()).unwrap_or([0u8; 32]);
-
     Ok(bitcoin_utils::two_of_two_taproot_script_path_address(
         guardian_btc_pubkey,
         &mpc_master_xonly,
-        &path_bytes,
+        &path_bytes_or_zero(derivation_path),
         btc_network,
     ))
 }
@@ -263,9 +251,9 @@ impl Hashi {
         ))
     }
 
-    /// 2-of-2 taproot leaf artifacts for spending a deposit UTXO whose
-    /// hashi child key was derived along `derivation_path`. Used by the
-    /// withdrawal sighash construction and the rebroadcast witness.
+    /// 2-of-2 taproot leaf artifacts (script, control block, leaf hash)
+    /// for a deposit UTXO. Used by the withdrawal sighash and the
+    /// rebroadcast witness builder.
     pub(crate) fn deposit_spend_artifacts(
         &self,
         hashi_pubkey: &XOnlyPublicKey,
@@ -276,72 +264,40 @@ impl Hashi {
         bitcoin::taproot::TapLeafHash,
     )> {
         let guardian_pubkey = self.require_guardian_btc_pubkey()?;
-        let path_bytes = path_bytes_or_zero(derivation_path);
         Ok(
             bitcoin_utils::two_of_two_taproot_script_path_spend_artifacts(
                 &guardian_pubkey,
                 hashi_pubkey,
-                &path_bytes,
+                &path_bytes_or_zero(derivation_path),
             ),
         )
     }
 
-    /// Hashi committee's child pubkey for `derivation_path`. Returned as
-    /// the x-only key — used to verify the MPC's per-input Schnorr sig
-    /// against the leaf, even though the script binds both this and the
-    /// guardian's pubkey.
+    /// Hashi committee's child pubkey at `derivation_path`. `None` maps
+    /// to a zero-byte path (change outputs).
     pub(crate) fn deposit_pubkey(
         &self,
-        hashi_pubkey: &XOnlyPublicKey,
         derivation_path: Option<&sui_sdk_types::Address>,
     ) -> anyhow::Result<XOnlyPublicKey> {
-        if let Some(path) = derivation_path {
-            // Prefer the local signing manager (available after DKG preparation).
-            // Fall back to the on-chain key, which is guaranteed present once the
-            // initial committee has formed and `end_reconfig` has been processed.
-            let verifying_key = self
-                .signing_verifying_key()
-                .map(Ok)
-                .unwrap_or_else(|| self.onchain_verifying_key_g())
-                .context("MPC public key not available yet")?;
-            let derived = fastcrypto_tbls::threshold_schnorr::key_derivation::derive_verifying_key(
-                &verifying_key,
-                &path.into_inner(),
-            );
-            let pubkey = XOnlyPublicKey::from_slice(&derived.to_byte_array())
-                .context("valid 32-byte x-only key")?;
-            Ok(pubkey)
-        } else {
-            // `None` path is the bridge's "change output" leaf — we use a
-            // zero-byte derivation path so deposit and withdrawal sides
-            // agree on the key without a special `Option::None` script.
-            let verifying_key = self
-                .signing_verifying_key()
-                .map(Ok)
-                .unwrap_or_else(|| self.onchain_verifying_key_g())
-                .context("MPC public key not available yet")?;
-            let derived = fastcrypto_tbls::threshold_schnorr::key_derivation::derive_verifying_key(
-                &verifying_key,
-                &[0u8; 32],
-            );
-            let pubkey = XOnlyPublicKey::from_slice(&derived.to_byte_array())
-                .context("valid 32-byte x-only key")?;
-            let _ = hashi_pubkey;
-            Ok(pubkey)
-        }
+        // Prefer the local signing manager (available after DKG preparation).
+        // Fall back to the on-chain key, which is guaranteed present once the
+        // initial committee has formed and `end_reconfig` has been processed.
+        let verifying_key = self
+            .signing_verifying_key()
+            .map(Ok)
+            .unwrap_or_else(|| self.onchain_verifying_key_g())
+            .context("MPC public key not available yet")?;
+        let derived = fastcrypto_tbls::threshold_schnorr::key_derivation::derive_verifying_key(
+            &verifying_key,
+            &path_bytes_or_zero(derivation_path),
+        );
+        XOnlyPublicKey::from_slice(&derived.to_byte_array()).context("valid 32-byte x-only key")
     }
 
-    /// Read the guardian BTC pubkey pinned during `try_seed_guardian_state`.
-    /// Errors when the guardian-required cutover is live but the cache
-    /// hasn't been populated yet — callers should treat that as "not
-    /// ready", not as a permanent failure.
     fn require_guardian_btc_pubkey(&self) -> anyhow::Result<XOnlyPublicKey> {
-        self.guardian_btc_pubkey().copied().ok_or_else(|| {
-            anyhow!(
-                "Guardian BTC pubkey not yet available; \
-                 try_seed_guardian_state has not pinned it"
-            )
-        })
+        self.guardian_btc_pubkey()
+            .copied()
+            .ok_or_else(|| anyhow!("Guardian BTC pubkey not yet pinned"))
     }
 
     pub fn get_hashi_pubkey(&self) -> anyhow::Result<XOnlyPublicKey> {

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -19,28 +19,44 @@ use hashi_types::guardian::bitcoin_utils;
 use hashi_types::proto::MemberSignature;
 use thiserror::Error;
 
-/// Derive a deposit address from a compressed MPC public key (33-byte ProjectivePoint),
-/// an optional derivation path, and the target Bitcoin network.
+fn path_bytes_or_zero(derivation_path: Option<&sui_sdk_types::Address>) -> [u8; 32] {
+    derivation_path.map(|p| p.into_inner()).unwrap_or([0u8; 32])
+}
+
+/// Derive a deposit address as the 2-of-2 taproot script-path output
+/// `tr(NUMS, multi_a(2, guardian_btc_pubkey, derive(mpc_pubkey, path)))`.
+///
+/// `mpc_key` is the 33-byte compressed MPC committee pubkey (subject to
+/// BIP32-style derivation by `path`). `guardian_btc_pubkey` is the
+/// x-only enclave key (32 bytes), used as-is — the guardian holds a
+/// single Bitcoin key shared across every deposit.
+///
+/// `path = None` means "change address": no derivation on the MPC key,
+/// same 2-of-2 leaf using the master MPC key directly.
 pub fn derive_deposit_address(
     mpc_key: &ProjectivePoint,
+    guardian_btc_pubkey: &XOnlyPublicKey,
     derivation_path: Option<&sui_sdk_types::Address>,
     btc_network: bitcoin::Network,
 ) -> anyhow::Result<bitcoin::Address> {
-    let xonly = if let Some(path) = derivation_path {
-        let derived = fastcrypto_tbls::threshold_schnorr::key_derivation::derive_verifying_key(
-            mpc_key,
-            &path.into_inner(),
-        );
-        XOnlyPublicKey::from_slice(&derived.to_byte_array()).context("valid 32-byte x-only key")?
-    } else {
+    let mpc_master_xonly = {
         let schnorr_pk = SchnorrPublicKey::try_from(mpc_key)
             .context("Failed to convert MPC key to schnorr key")?;
         XOnlyPublicKey::from_slice(&schnorr_pk.to_byte_array())
-            .context("Failed to parse x-only key")?
+            .context("Failed to parse x-only MPC key")?
     };
 
-    Ok(bitcoin_utils::single_key_taproot_script_path_address(
-        &xonly,
+    // The 2-of-2 helper internally derives the hashi pubkey from the
+    // `[u8; 32]` path. Use a zero path for the "no derivation" case so
+    // the change address is stable for an undeposited master key.
+    let path_bytes = derivation_path
+        .map(|p| p.into_inner())
+        .unwrap_or([0u8; 32]);
+
+    Ok(bitcoin_utils::two_of_two_taproot_script_path_address(
+        guardian_btc_pubkey,
+        &mpc_master_xonly,
+        &path_bytes,
         btc_network,
     ))
 }
@@ -239,10 +255,41 @@ impl Hashi {
         hashi_pubkey: &XOnlyPublicKey,
         derivation_path: Option<&sui_sdk_types::Address>,
     ) -> anyhow::Result<bitcoin::Address> {
-        let pubkey = self.deposit_pubkey(hashi_pubkey, derivation_path)?;
-        Ok(self.bitcoin_address_from_pubkey(&pubkey))
+        let guardian_pubkey = self.require_guardian_btc_pubkey()?;
+        let path_bytes = path_bytes_or_zero(derivation_path);
+        Ok(bitcoin_utils::two_of_two_taproot_script_path_address(
+            &guardian_pubkey,
+            hashi_pubkey,
+            &path_bytes,
+            self.config.bitcoin_network(),
+        ))
     }
 
+    /// 2-of-2 taproot leaf artifacts for spending a deposit UTXO whose
+    /// hashi child key was derived along `derivation_path`. Used by the
+    /// withdrawal sighash construction and the rebroadcast witness.
+    pub(crate) fn deposit_spend_artifacts(
+        &self,
+        hashi_pubkey: &XOnlyPublicKey,
+        derivation_path: Option<&sui_sdk_types::Address>,
+    ) -> anyhow::Result<(
+        bitcoin::ScriptBuf,
+        bitcoin::taproot::ControlBlock,
+        bitcoin::taproot::TapLeafHash,
+    )> {
+        let guardian_pubkey = self.require_guardian_btc_pubkey()?;
+        let path_bytes = path_bytes_or_zero(derivation_path);
+        Ok(bitcoin_utils::two_of_two_taproot_script_path_spend_artifacts(
+            &guardian_pubkey,
+            hashi_pubkey,
+            &path_bytes,
+        ))
+    }
+
+    /// Hashi committee's child pubkey for `derivation_path`. Returned as
+    /// the x-only key — used to verify the MPC's per-input Schnorr sig
+    /// against the leaf, even though the script binds both this and the
+    /// guardian's pubkey.
     pub(crate) fn deposit_pubkey(
         &self,
         hashi_pubkey: &XOnlyPublicKey,
@@ -265,12 +312,36 @@ impl Hashi {
                 .context("valid 32-byte x-only key")?;
             Ok(pubkey)
         } else {
-            Ok(*hashi_pubkey)
+            // `None` path is the bridge's "change output" leaf — we use a
+            // zero-byte derivation path so deposit and withdrawal sides
+            // agree on the key without a special `Option::None` script.
+            let verifying_key = self
+                .signing_verifying_key()
+                .map(Ok)
+                .unwrap_or_else(|| self.onchain_verifying_key_g())
+                .context("MPC public key not available yet")?;
+            let derived = fastcrypto_tbls::threshold_schnorr::key_derivation::derive_verifying_key(
+                &verifying_key,
+                &[0u8; 32],
+            );
+            let pubkey = XOnlyPublicKey::from_slice(&derived.to_byte_array())
+                .context("valid 32-byte x-only key")?;
+            let _ = hashi_pubkey;
+            Ok(pubkey)
         }
     }
 
-    pub(crate) fn bitcoin_address_from_pubkey(&self, pubkey: &XOnlyPublicKey) -> bitcoin::Address {
-        bitcoin_utils::single_key_taproot_script_path_address(pubkey, self.config.bitcoin_network())
+    /// Read the guardian BTC pubkey pinned during `try_seed_guardian_state`.
+    /// Errors when the guardian-required cutover is live but the cache
+    /// hasn't been populated yet — callers should treat that as "not
+    /// ready", not as a permanent failure.
+    fn require_guardian_btc_pubkey(&self) -> anyhow::Result<XOnlyPublicKey> {
+        self.guardian_btc_pubkey().copied().ok_or_else(|| {
+            anyhow!(
+                "Guardian BTC pubkey not yet available; \
+                 try_seed_guardian_state has not pinned it"
+            )
+        })
     }
 
     pub fn get_hashi_pubkey(&self) -> anyhow::Result<XOnlyPublicKey> {

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -49,9 +49,7 @@ pub fn derive_deposit_address(
     // The 2-of-2 helper internally derives the hashi pubkey from the
     // `[u8; 32]` path. Use a zero path for the "no derivation" case so
     // the change address is stable for an undeposited master key.
-    let path_bytes = derivation_path
-        .map(|p| p.into_inner())
-        .unwrap_or([0u8; 32]);
+    let path_bytes = derivation_path.map(|p| p.into_inner()).unwrap_or([0u8; 32]);
 
     Ok(bitcoin_utils::two_of_two_taproot_script_path_address(
         guardian_btc_pubkey,
@@ -279,11 +277,13 @@ impl Hashi {
     )> {
         let guardian_pubkey = self.require_guardian_btc_pubkey()?;
         let path_bytes = path_bytes_or_zero(derivation_path);
-        Ok(bitcoin_utils::two_of_two_taproot_script_path_spend_artifacts(
-            &guardian_pubkey,
-            hashi_pubkey,
-            &path_bytes,
-        ))
+        Ok(
+            bitcoin_utils::two_of_two_taproot_script_path_spend_artifacts(
+                &guardian_pubkey,
+                hashi_pubkey,
+                &path_bytes,
+            ),
+        )
     }
 
     /// Hashi committee's child pubkey for `derivation_path`. Returned as

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -19,7 +19,7 @@ use hashi_types::guardian::bitcoin_utils;
 use hashi_types::proto::MemberSignature;
 use thiserror::Error;
 
-fn path_bytes_or_zero(derivation_path: Option<&sui_sdk_types::Address>) -> [u8; 32] {
+pub(crate) fn path_bytes_or_zero(derivation_path: Option<&sui_sdk_types::Address>) -> [u8; 32] {
     derivation_path.map(|p| p.into_inner()).unwrap_or([0u8; 32])
 }
 

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -39,7 +39,6 @@ use hashi_types::guardian::CommitteeTransition;
 use hashi_types::guardian::GuardianSigned;
 use hashi_types::guardian::StandardWithdrawalRequest;
 use hashi_types::guardian::StandardWithdrawalResponse;
-use hashi_types::guardian::bitcoin_utils;
 use hashi_types::guardian::proto_conversions::signed_committee_transition_to_pb;
 use hashi_types::guardian::proto_conversions::signed_standard_withdrawal_request_to_pb;
 use hashi_types::proto::SignCommitteeTransitionRequest;
@@ -1697,7 +1696,15 @@ impl LeaderService {
         }
     }
 
-    /// Rebuild a fully signed Bitcoin transaction from on-chain WithdrawalTransaction
+    /// Rebuild a fully signed Bitcoin transaction from on-chain
+    /// `WithdrawalTransaction` data and broadcast-ready 2-of-2 witness.
+    ///
+    /// Witness layout per input (BIP342 multi_a, verified against
+    /// rust-miniscript's `Terminal::MultiA` satisfier):
+    ///
+    /// ```text
+    /// [hashi_sig, guardian_sig, leaf_script, control_block]
+    /// ```
     fn rebuild_signed_tx_from_onchain(
         inner: &Arc<Hashi>,
         txn: &WithdrawalTransaction,
@@ -1705,15 +1712,24 @@ impl LeaderService {
         let raw_sigs = txn
             .signatures
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("No signatures on withdrawal transaction"))?;
+            .ok_or_else(|| anyhow::anyhow!("No MPC signatures on withdrawal transaction"))?;
+        let raw_guardian_sigs = txn.guardian_signatures.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("No guardian signatures on withdrawal transaction")
+        })?;
 
         let mut tx = inner.build_unsigned_withdrawal_tx(&txn.inputs, &txn.all_outputs())?;
 
         anyhow::ensure!(
             raw_sigs.len() == tx.input.len(),
-            "Signature count mismatch: tx has {} inputs, on-chain has {} signatures",
+            "MPC signature count mismatch: tx has {} inputs, on-chain has {} signatures",
             tx.input.len(),
             raw_sigs.len()
+        );
+        anyhow::ensure!(
+            raw_guardian_sigs.len() == tx.input.len(),
+            "Guardian signature count mismatch: tx has {} inputs, on-chain has {} signatures",
+            tx.input.len(),
+            raw_guardian_sigs.len()
         );
         anyhow::ensure!(
             tx.input.len() == txn.inputs.len(),
@@ -1723,14 +1739,19 @@ impl LeaderService {
         );
 
         let hashi_pubkey = inner.get_hashi_pubkey()?;
-        for ((input, txn_input), sig_bytes) in
-            tx.input.iter_mut().zip(txn.inputs.iter()).zip(raw_sigs)
+        for (((input, txn_input), hashi_sig_bytes), guardian_sig_bytes) in tx
+            .input
+            .iter_mut()
+            .zip(txn.inputs.iter())
+            .zip(raw_sigs)
+            .zip(raw_guardian_sigs)
         {
-            let pubkey = inner.deposit_pubkey(&hashi_pubkey, txn_input.derivation_path.as_ref())?;
             let (script, control_block, _) =
-                bitcoin_utils::single_key_taproot_script_path_spend_artifacts(&pubkey);
+                inner.deposit_spend_artifacts(&hashi_pubkey, txn_input.derivation_path.as_ref())?;
             let mut witness = bitcoin::Witness::new();
-            witness.push(sig_bytes);
+            // multi_a satisfier order: hashi_sig (bottom) then guardian_sig (top).
+            witness.push(hashi_sig_bytes);
+            witness.push(guardian_sig_bytes);
             witness.push(script.to_bytes());
             witness.push(control_block.serialize());
             input.witness = witness;

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1466,26 +1466,39 @@ impl LeaderService {
         // 3. Post-MPC: forward to guardian for the enclave signature. Reuses
         // the `timestamp_secs` from the pre-MPC validate so the BLS-signed
         // certificate covers a consistent `(timestamp, seq, amount)` triple.
-        if let (Some(guardian), Some(seq)) = (inner.guardian_client(), expected_limiter_seq) {
-            Self::finalize_withdrawal_through_guardian(
-                &inner,
-                &txn,
-                &members,
-                guardian,
-                timestamp_secs,
-                seq,
-            )
-            .await?;
-            inner.record_guardian_finalized(seq, txn.id);
-        }
+        // The per-input enclave signatures are stored on-chain alongside the
+        // MPC sigs to satisfy the 2-of-2 deposit witness.
+        let guardian_signatures: Vec<Vec<u8>> =
+            match (inner.guardian_client(), expected_limiter_seq) {
+                (Some(guardian), Some(seq)) => {
+                    let sigs = Self::finalize_withdrawal_through_guardian(
+                        &inner,
+                        &txn,
+                        &members,
+                        guardian,
+                        timestamp_secs,
+                        seq,
+                    )
+                    .await?;
+                    inner.record_guardian_finalized(seq, txn.id);
+                    sigs
+                }
+                _ => {
+                    anyhow::bail!(
+                        "Guardian endpoint or seq missing — refusing to sign \
+                         a 2-of-2 withdrawal without the guardian half of the \
+                         witness"
+                    );
+                }
+            };
 
-        // 4. Build the WithdrawalTxSigning and get BLS certificate via fan-out
+        // 4. Build the WithdrawalTxSigning (binds BOTH sig arrays) and get
+        // the BLS certificate via fan-out.
         let signed_message = WithdrawalTxSigning {
             withdrawal_id: txn.id,
             request_ids: txn.request_ids.clone(),
             signatures: witness_signatures.clone(),
-            // Carried empty until the 2-of-2 cutover populates it.
-            guardian_signatures: vec![],
+            guardian_signatures: guardian_signatures.clone(),
         };
 
         let committee = inner
@@ -1532,6 +1545,7 @@ impl LeaderService {
             &txn.id,
             &txn.request_ids.clone(),
             &witness_signatures,
+            &guardian_signatures,
             signed.committee_signature(),
         )
         .await
@@ -2169,13 +2183,20 @@ impl LeaderService {
         withdrawal_id: &Address,
         request_ids: &[Address],
         signatures: &[Vec<u8>],
+        guardian_signatures: &[Vec<u8>],
         cert: &CommitteeSignature,
     ) -> anyhow::Result<u64> {
         info!("Submitting sign_withdrawal for {:?}", withdrawal_id);
 
         let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
         executor
-            .execute_sign_withdrawal(withdrawal_id, request_ids, signatures, &[], cert)
+            .execute_sign_withdrawal(
+                withdrawal_id,
+                request_ids,
+                signatures,
+                guardian_signatures,
+                cert,
+            )
             .await
     }
 
@@ -2200,6 +2221,8 @@ impl LeaderService {
     // Guardian: post-MPC enclave-signature RPC
     // ========================================================================
 
+    /// Returns the per-input guardian Schnorr signatures (64 bytes each)
+    /// for inclusion in the on-chain `sign_withdrawal` PTB.
     #[tracing::instrument(level = "info", skip_all, fields(withdrawal_txn_id = %txn.id, seq))]
     async fn finalize_withdrawal_through_guardian(
         inner: &Arc<Hashi>,
@@ -2208,7 +2231,7 @@ impl LeaderService {
         guardian: &crate::grpc::guardian_client::GuardianClient,
         timestamp_secs: u64,
         seq: u64,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<Vec<u8>>> {
         let signed_request =
             Self::collect_guardian_withdrawal_signatures(inner, txn, members, timestamp_secs, seq)
                 .await?;
@@ -2259,7 +2282,7 @@ impl LeaderService {
                 );
             })
             .map_err(|e| anyhow::anyhow!("Failed to parse guardian withdrawal response: {e}"))?;
-        signed_response
+        let response = signed_response
             .verify(pubkey)
             .inspect_err(|_| {
                 Self::record_guardian_rpc_outcome(
@@ -2272,13 +2295,34 @@ impl LeaderService {
                 anyhow::anyhow!("Guardian response signature verification failed: {e:?}")
             })?;
 
+        anyhow::ensure!(
+            response.enclave_signatures.len() == txn.inputs.len(),
+            "Guardian returned {} enclave_signatures but tx has {} inputs",
+            response.enclave_signatures.len(),
+            txn.inputs.len(),
+        );
+        let guardian_signatures: Vec<Vec<u8>> = response
+            .enclave_signatures
+            .iter()
+            .enumerate()
+            .map(|(i, sig)| {
+                let bytes = sig.to_vec();
+                anyhow::ensure!(
+                    bytes.len() == 64,
+                    "Guardian enclave_signatures[{i}] is {} bytes, expected 64",
+                    bytes.len(),
+                );
+                Ok(bytes)
+            })
+            .collect::<anyhow::Result<_>>()?;
+
         Self::record_guardian_rpc_outcome(
             inner,
             crate::metrics::GUARDIAN_RPC_OUTCOME_OK,
             rpc_elapsed,
         );
         info!(seq, "Guardian approved withdrawal");
-        Ok(())
+        Ok(guardian_signatures)
     }
 
     fn record_guardian_rpc_outcome(inner: &Arc<Hashi>, outcome: &str, elapsed_secs: f64) {

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -1727,9 +1727,10 @@ impl LeaderService {
             .signatures
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("No MPC signatures on withdrawal transaction"))?;
-        let raw_guardian_sigs = txn.guardian_signatures.as_ref().ok_or_else(|| {
-            anyhow::anyhow!("No guardian signatures on withdrawal transaction")
-        })?;
+        let raw_guardian_sigs = txn
+            .guardian_signatures
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("No guardian signatures on withdrawal transaction"))?;
 
         let mut tx = inner.build_unsigned_withdrawal_tx(&txn.inputs, &txn.all_outputs())?;
 

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -664,11 +664,8 @@ impl Hashi {
         .or_else(|| self.config.guardian_endpoint().map(|s| s.to_string()))
         .ok_or_else(|| {
             anyhow!(
-                "Guardian is required: no `guardian_url` on-chain and no \
-                 `guardian_endpoint` in local config / env override. Bridge \
-                 deposit addresses are 2-of-2 (mpc, guardian) and every \
-                 withdrawal needs the guardian's signature, so hashi-server \
-                 refuses to start without one."
+                "Guardian is required: set `guardian_url` on-chain or \
+                 `guardian_endpoint` in local config / env override"
             )
         })?;
 

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -661,34 +661,27 @@ impl Hashi {
             let state = self.onchain_state().state();
             state.hashi().config.guardian_url().map(|s| s.to_string())
         }
-        .or_else(|| self.config.guardian_endpoint().map(|s| s.to_string()));
+        .or_else(|| self.config.guardian_endpoint().map(|s| s.to_string()))
+        .ok_or_else(|| {
+            anyhow!(
+                "Guardian is required: no `guardian_url` on-chain and no \
+                 `guardian_endpoint` in local config / env override. Bridge \
+                 deposit addresses are 2-of-2 (mpc, guardian) and every \
+                 withdrawal needs the guardian's signature, so hashi-server \
+                 refuses to start without one."
+            )
+        })?;
 
-        let guardian = if let Some(endpoint) = guardian_endpoint.as_deref() {
-            match grpc::guardian_client::GuardianClient::new(endpoint) {
-                Ok(client) => {
-                    let client = client.with_metrics(self.metrics.clone());
-                    tracing::info!("Guardian client configured for {}", client.endpoint());
-                    Some(client)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to configure guardian client for {}: {}",
-                        endpoint,
-                        e
-                    );
-                    None
-                }
-            }
-        } else {
-            tracing::info!("No guardian endpoint configured; guardian integration disabled");
-            None
-        };
+        let guardian = grpc::guardian_client::GuardianClient::new(&guardian_endpoint)
+            .map_err(|e| {
+                anyhow!("Failed to configure guardian client for {guardian_endpoint}: {e}")
+            })?
+            .with_metrics(self.metrics.clone());
+        tracing::info!("Guardian client configured for {}", guardian.endpoint());
 
-        self.metrics
-            .guardian_enabled
-            .set(if guardian.is_some() { 1 } else { 0 });
+        self.metrics.guardian_enabled.set(1);
         self.guardian_client
-            .set(guardian)
+            .set(Some(guardian))
             .map_err(|_| anyhow!("Guardian client already initialized"))?;
 
         // Verify the local bitcoin_chain_id matches the on-chain value.

--- a/crates/hashi/src/publish.rs
+++ b/crates/hashi/src/publish.rs
@@ -101,11 +101,14 @@ stderr: {}",
     })
 }
 
-/// Optional guardian configuration for post-publish initialization.
+/// Guardian configuration for post-publish initialization. Required —
+/// every deposit address is a 2-of-2 (mpc, guardian) taproot leaf, so a
+/// guardian-less deploy can't produce spendable deposits.
 pub struct GuardianConfig {
     pub url: String,
     pub public_key: Vec<u8>,
-    pub btc_public_key: Option<Vec<u8>>,
+    /// X-only BTC pubkey of the enclave (32 bytes).
+    pub btc_public_key: Vec<u8>,
 }
 
 /// Optional Bitcoin config overrides applied during `finish_publish`. Any
@@ -131,7 +134,7 @@ pub async fn publish_and_init(
     signer: &Ed25519PrivateKey,
     publish: sui_sdk_types::Publish,
     bitcoin_chain_id: &str,
-    guardian: Option<&GuardianConfig>,
+    guardian: &GuardianConfig,
     bitcoin_overrides: &BitcoinConfigOverrides,
 ) -> Result<HashiIds> {
     let sender = signer.public_key().derive_address();
@@ -222,10 +225,9 @@ pub async fn publish_and_init(
     );
     let upgrade_cap_arg = builder.object(ObjectInput::new(upgrade_cap_id).as_owned());
     let bitcoin_chain_id_arg = builder.pure(&bitcoin_chain_id_addr);
-    let guardian_url_arg = builder.pure(&guardian.map(|g| g.url.as_str()));
-    let guardian_public_key_arg = builder.pure(&guardian.map(|g| g.public_key.as_slice()));
-    let guardian_btc_public_key_arg =
-        builder.pure(&guardian.and_then(|g| g.btc_public_key.as_deref()));
+    let guardian_url_arg = builder.pure(&guardian.url.as_str());
+    let guardian_public_key_arg = builder.pure(&guardian.public_key.as_slice());
+    let guardian_btc_public_key_arg = builder.pure(&guardian.btc_public_key.as_slice());
     let confirmation_threshold_arg = builder.pure(&bitcoin_overrides.confirmation_threshold);
     let deposit_time_delay_ms_arg = builder.pure(&bitcoin_overrides.deposit_time_delay_ms);
     let coin_registry_arg = builder.object(

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -136,6 +136,12 @@ pub struct WithdrawalTxCommitment {
 
 /// The data that validators BLS-sign over to store witness signatures on-chain.
 /// This is the step 3 certificate.
+///
+/// MUST bind both signature arrays. The on-chain `sign_withdrawal` entry
+/// then writes them together; without the binding a malicious leader
+/// could pair a valid MPC sig set with a garbage guardian sig set and
+/// the on-chain check would still pass, leaving an unbroadcastable
+/// transaction.
 #[derive(Clone, Debug, serde_derive::Serialize)]
 pub struct WithdrawalTxSigning {
     pub withdrawal_id: Address,
@@ -507,8 +513,15 @@ impl Hashi {
 
         anyhow::ensure!(
             message.signatures.len() == txn.inputs.len(),
-            "Signature count ({}) does not match input count ({}) for WithdrawalTransaction {}",
+            "MPC signature count ({}) does not match input count ({}) for WithdrawalTransaction {}",
             message.signatures.len(),
+            txn.inputs.len(),
+            message.withdrawal_id
+        );
+        anyhow::ensure!(
+            message.guardian_signatures.len() == txn.inputs.len(),
+            "Guardian signature count ({}) does not match input count ({}) for WithdrawalTransaction {}",
+            message.guardian_signatures.len(),
             txn.inputs.len(),
             message.withdrawal_id
         );
@@ -516,30 +529,52 @@ impl Hashi {
         let tx = self.build_unsigned_withdrawal_tx(&txn.inputs, &txn.all_outputs())?;
         let signing_messages = self.withdrawal_signing_messages(&tx, &txn.inputs)?;
         let hashi_pubkey = self.get_hashi_pubkey()?;
+        let guardian_btc_pubkey = self
+            .guardian_btc_pubkey()
+            .copied()
+            .ok_or_else(|| anyhow!("Guardian BTC pubkey not yet pinned; cannot validate withdrawal"))?;
+        let guardian_schnorr_pk = SchnorrPublicKey::from_byte_array(&guardian_btc_pubkey.serialize())
+            .map_err(|e| anyhow!("Failed to convert guardian BTC pubkey: {e}"))?;
 
-        for (i, (sig_bytes, sighash)) in message
+        for (i, ((mpc_sig_bytes, guardian_sig_bytes), sighash)) in message
             .signatures
             .iter()
+            .zip(message.guardian_signatures.iter())
             .zip(signing_messages.iter())
             .enumerate()
         {
-            let arr: &[u8; 64] = sig_bytes.as_slice().try_into().map_err(|_| {
+            // MPC: verify against the derived hashi child key.
+            let mpc_arr: &[u8; 64] = mpc_sig_bytes.as_slice().try_into().map_err(|_| {
                 anyhow!(
-                    "Signature {i} is not 64 bytes for WithdrawalTransaction {}",
+                    "MPC signature {i} is not 64 bytes for WithdrawalTransaction {}",
                     message.withdrawal_id
                 )
             })?;
-            let sig = SchnorrSignature::from_byte_array(arr)
-                .map_err(|e| anyhow!("Invalid Schnorr signature at input {i}: {e}"))?;
-
+            let mpc_sig = SchnorrSignature::from_byte_array(mpc_arr)
+                .map_err(|e| anyhow!("Invalid MPC Schnorr signature at input {i}: {e}"))?;
             let input_pubkey =
                 self.deposit_pubkey(&hashi_pubkey, txn.inputs[i].derivation_path.as_ref())?;
-            let schnorr_pk = SchnorrPublicKey::from_byte_array(&input_pubkey.serialize())
-                .map_err(|e| anyhow!("Failed to convert pubkey for input {i}: {e}"))?;
+            let mpc_schnorr_pk = SchnorrPublicKey::from_byte_array(&input_pubkey.serialize())
+                .map_err(|e| anyhow!("Failed to convert mpc pubkey for input {i}: {e}"))?;
+            mpc_schnorr_pk
+                .verify(sighash, &mpc_sig)
+                .map_err(|e| anyhow!("MPC signature verification failed for input {i}: {e}"))?;
 
-            schnorr_pk
-                .verify(sighash, &sig)
-                .map_err(|e| anyhow!("Signature verification failed for input {i}: {e}"))?;
+            // Guardian: verify against the on-chain enclave BTC pubkey.
+            // Same sighash — both sigs commit to the same multi_a leaf.
+            let guardian_arr: &[u8; 64] =
+                guardian_sig_bytes.as_slice().try_into().map_err(|_| {
+                    anyhow!(
+                        "Guardian signature {i} is not 64 bytes for WithdrawalTransaction {}",
+                        message.withdrawal_id
+                    )
+                })?;
+            let guardian_sig = SchnorrSignature::from_byte_array(guardian_arr).map_err(|e| {
+                anyhow!("Invalid guardian Schnorr signature at input {i}: {e}")
+            })?;
+            guardian_schnorr_pk
+                .verify(sighash, &guardian_sig)
+                .map_err(|e| anyhow!("Guardian signature verification failed for input {i}: {e}"))?;
         }
 
         self.sign_message_proto(message)

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -766,10 +766,15 @@ impl Hashi {
         let mut signatures_by_input = Vec::with_capacity(signing_messages.len());
         for (input_index, message) in signing_messages.iter().enumerate() {
             let request_id = withdrawal_input_signing_request_id(&txn.id, input_index as u32);
+            // Change UTXOs (`derivation_path = None`) ride the `[0; 32]`
+            // path everywhere else (leaf script, `deposit_pubkey`). MPC
+            // must too — passing `None` signs for master `G`, not the
+            // `derive(G, [0; 32])` child the 2-of-2 leaf binds.
             let derivation_address = txn
                 .inputs
                 .get(input_index)
-                .and_then(|input| input.derivation_path.as_ref().map(|path| path.into_inner()));
+                .map(|input| crate::deposits::path_bytes_or_zero(input.derivation_path.as_ref()))
+                .expect("input_index iterated from signing_messages.len() == txn.inputs.len()");
             let sign_start = std::time::Instant::now();
             let global_presig_index = txn.presig_start_index + input_index as u64;
             let sign_result = signing_manager
@@ -779,7 +784,7 @@ impl Hashi {
                     message,
                     global_presig_index,
                     &beacon,
-                    derivation_address.as_ref(),
+                    Some(&derivation_address),
                     WITHDRAWAL_SIGNING_TIMEOUT,
                     &self.metrics,
                 )

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -529,12 +529,12 @@ impl Hashi {
         let tx = self.build_unsigned_withdrawal_tx(&txn.inputs, &txn.all_outputs())?;
         let signing_messages = self.withdrawal_signing_messages(&tx, &txn.inputs)?;
         let hashi_pubkey = self.get_hashi_pubkey()?;
-        let guardian_btc_pubkey = self
-            .guardian_btc_pubkey()
-            .copied()
-            .ok_or_else(|| anyhow!("Guardian BTC pubkey not yet pinned; cannot validate withdrawal"))?;
-        let guardian_schnorr_pk = SchnorrPublicKey::from_byte_array(&guardian_btc_pubkey.serialize())
-            .map_err(|e| anyhow!("Failed to convert guardian BTC pubkey: {e}"))?;
+        let guardian_btc_pubkey = self.guardian_btc_pubkey().copied().ok_or_else(|| {
+            anyhow!("Guardian BTC pubkey not yet pinned; cannot validate withdrawal")
+        })?;
+        let guardian_schnorr_pk =
+            SchnorrPublicKey::from_byte_array(&guardian_btc_pubkey.serialize())
+                .map_err(|e| anyhow!("Failed to convert guardian BTC pubkey: {e}"))?;
 
         for (i, ((mpc_sig_bytes, guardian_sig_bytes), sighash)) in message
             .signatures
@@ -569,12 +569,13 @@ impl Hashi {
                         message.withdrawal_id
                     )
                 })?;
-            let guardian_sig = SchnorrSignature::from_byte_array(guardian_arr).map_err(|e| {
-                anyhow!("Invalid guardian Schnorr signature at input {i}: {e}")
-            })?;
+            let guardian_sig = SchnorrSignature::from_byte_array(guardian_arr)
+                .map_err(|e| anyhow!("Invalid guardian Schnorr signature at input {i}: {e}"))?;
             guardian_schnorr_pk
                 .verify(sighash, &guardian_sig)
-                .map_err(|e| anyhow!("Guardian signature verification failed for input {i}: {e}"))?;
+                .map_err(|e| {
+                    anyhow!("Guardian signature verification failed for input {i}: {e}")
+                })?;
         }
 
         self.sign_message_proto(message)

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -805,10 +805,10 @@ impl Hashi {
         let spend_inputs = inputs
             .iter()
             .map(|input| {
-                let pubkey = self.deposit_pubkey(&hashi_pubkey, input.derivation_path.as_ref())?;
-                let address = self.bitcoin_address_from_pubkey(&pubkey);
+                let address =
+                    self.get_deposit_address(&hashi_pubkey, input.derivation_path.as_ref())?;
                 let (_, _, leaf_hash) =
-                    bitcoin_utils::single_key_taproot_script_path_spend_artifacts(&pubkey);
+                    self.deposit_spend_artifacts(&hashi_pubkey, input.derivation_path.as_ref())?;
                 Ok((
                     TxOut {
                         value: Amount::from_sat(input.amount),
@@ -1430,10 +1430,10 @@ pub fn build_guardian_withdrawal_request(
         .inputs
         .iter()
         .map(|utxo| {
-            let pubkey = hashi.deposit_pubkey(&hashi_pubkey, utxo.derivation_path.as_ref())?;
             let (_, _, leaf_hash) =
-                bitcoin_utils::single_key_taproot_script_path_spend_artifacts(&pubkey);
-            let address = hashi.bitcoin_address_from_pubkey(&pubkey);
+                hashi.deposit_spend_artifacts(&hashi_pubkey, utxo.derivation_path.as_ref())?;
+            let address =
+                hashi.get_deposit_address(&hashi_pubkey, utxo.derivation_path.as_ref())?;
 
             let outpoint = bitcoin::OutPoint {
                 txid: utxo.id.txid.into(),

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -135,13 +135,9 @@ pub struct WithdrawalTxCommitment {
 }
 
 /// The data that validators BLS-sign over to store witness signatures on-chain.
-/// This is the step 3 certificate.
-///
-/// MUST bind both signature arrays. The on-chain `sign_withdrawal` entry
-/// then writes them together; without the binding a malicious leader
-/// could pair a valid MPC sig set with a garbage guardian sig set and
-/// the on-chain check would still pass, leaving an unbroadcastable
-/// transaction.
+/// This is the step 3 certificate. The cert binds both signature arrays
+/// — otherwise a malicious leader could pair valid MPC sigs with garbage
+/// guardian sigs and the on-chain check would still pass.
 #[derive(Clone, Debug, serde_derive::Serialize)]
 pub struct WithdrawalTxSigning {
     pub withdrawal_id: Address,
@@ -528,7 +524,6 @@ impl Hashi {
 
         let tx = self.build_unsigned_withdrawal_tx(&txn.inputs, &txn.all_outputs())?;
         let signing_messages = self.withdrawal_signing_messages(&tx, &txn.inputs)?;
-        let hashi_pubkey = self.get_hashi_pubkey()?;
         let guardian_btc_pubkey = self.guardian_btc_pubkey().copied().ok_or_else(|| {
             anyhow!("Guardian BTC pubkey not yet pinned; cannot validate withdrawal")
         })?;
@@ -552,8 +547,7 @@ impl Hashi {
             })?;
             let mpc_sig = SchnorrSignature::from_byte_array(mpc_arr)
                 .map_err(|e| anyhow!("Invalid MPC Schnorr signature at input {i}: {e}"))?;
-            let input_pubkey =
-                self.deposit_pubkey(&hashi_pubkey, txn.inputs[i].derivation_path.as_ref())?;
+            let input_pubkey = self.deposit_pubkey(txn.inputs[i].derivation_path.as_ref())?;
             let mpc_schnorr_pk = SchnorrPublicKey::from_byte_array(&input_pubkey.serialize())
                 .map_err(|e| anyhow!("Failed to convert mpc pubkey for input {i}: {e}"))?;
             mpc_schnorr_pk

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -47,11 +47,9 @@ public struct WithdrawalCommitmentMessage has copy, drop, store {
 
 // MESSAGE STEP 3
 //
-// The BLS-certed message MUST bind both signature arrays. If only the
-// MPC sigs were covered, a malicious leader could pair a valid MPC sig
-// set with a garbage guardian sig set and still pass the cert check at
-// the on-chain `sign_withdrawal` call, leaving an unbroadcastable
-// transaction on chain.
+// The cert binds both signature arrays — otherwise a malicious leader
+// could pair valid MPC sigs with garbage guardian sigs and the cert
+// would still pass.
 public struct WithdrawalSignedMessage has copy, drop, store {
     withdrawal_id: address,
     request_ids: vector<address>,

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -98,13 +98,18 @@ public(package) fun assert_not_reconfiguring(self: &Hashi) {
 
 // Function that needs to be called immediately after publishing to finalize
 // some input parameters, register BTC and the package's UpgradeCap.
+//
+// The guardian URL, signing key, and BTC key are all required: the
+// guardian is a load-bearing component of every deposit address (2-of-2
+// taproot leaf) and every withdrawal signature, so a deploy without
+// them would produce a non-functional bridge.
 entry fun finish_publish(
     self: &mut Hashi,
     upgrade_cap: sui::package::UpgradeCap,
     bitcoin_chain_id: address,
-    guardian_url: Option<String>,
-    guardian_public_key: Option<vector<u8>>,
-    guardian_btc_public_key: Option<vector<u8>>,
+    guardian_url: String,
+    guardian_public_key: vector<u8>,
+    guardian_btc_public_key: vector<u8>,
     bitcoin_confirmation_threshold: Option<u64>,
     bitcoin_deposit_time_delay_ms: Option<u64>,
     coin_registry: &mut sui::coin_registry::CoinRegistry,
@@ -119,24 +124,8 @@ entry fun finish_publish(
     self.config_mut().set_upgrade_cap(upgrade_cap);
     hashi::btc_config::set_bitcoin_chain_id(self.config_mut(), bitcoin_chain_id);
 
-    // Guardian config is all-or-nothing: URL, signing key, and BTC key must be
-    // set together. A partial config (e.g. URL/key without the BTC key) would
-    // derive 2-of-2 deposit addresses that can never be spent.
-    if (
-        guardian_url.is_some() && guardian_public_key.is_some() && guardian_btc_public_key.is_some()
-    ) {
-        self
-            .config_mut()
-            .set_guardian(
-                guardian_url.destroy_some(),
-                guardian_public_key.destroy_some(),
-            );
-        self.config_mut().set_guardian_btc_public_key(guardian_btc_public_key.destroy_some());
-    } else {
-        guardian_url.destroy_none();
-        guardian_public_key.destroy_none();
-        guardian_btc_public_key.destroy_none();
-    };
+    self.config_mut().set_guardian(guardian_url, guardian_public_key);
+    self.config_mut().set_guardian_btc_public_key(guardian_btc_public_key);
 
     if (bitcoin_confirmation_threshold.is_some()) {
         hashi::btc_config::set_bitcoin_confirmation_threshold(


### PR DESCRIPTION
Cuts the bridge over to 2-of-2 deposit addresses and makes the guardian required end-to-end. The mechanical `guardian_signatures` field plumbing is split into #620 (below); this PR is the load-bearing crypto + policy.

## Review guide (by commit)
- **require guardian config in finish_publish** — drop the `Option<>` guardian args.
- **derive deposit addresses as 2-of-2** — `tr(NUMS, multi_a(2, guardian_btc_pubkey, derive(mpc, path)))`.
- **build 2-of-2 witness** — `[hashi_sig, guardian_sig, leaf_script, control_block]` per input (multi_a satisfier order).
- **capture guardian sigs + post both arrays** — leader gets per-input enclave sigs from the guardian; every follower Schnorr-verifies both arrays against the same sighash before BLS-signing, and the cert binds both (a malicious leader can't pair good MPC sigs with garbage guardian sigs).
- **make guardian required** — `Hashi::start` requires an endpoint; publish/CLI flags required; e2e always spins up a guardian.
- **MPC-sign change-UTXO at the zero path** — change outputs sign `derive(G,[0;32])` to match the 2-of-2 change leaf.

## Notes
- **Start-time enforcement**: `Hashi::start` fails fast only if the guardian *endpoint* is missing/unreachable. The BTC-pubkey match against on-chain runs in the non-fatal, retrying background bootstrap (`verify_and_pin_guardian_btc_pubkey`), not at start. (Corrects the earlier draft wording.)
- **Breaking on-chain change**: `WithdrawalTransaction` / events / messages gain `guardian_signatures` → upgrade-incompatible; needs a fresh publish + devnet wipe. All deposit addresses change (single-key → 2-of-2), so pre-existing UTXOs are stranded — fresh deploy only.
- Stacked on #620 (plumbing); the raw-`G` derivation fix is #609 above. #604 alone is red on the withdrawal e2e until #609.

## Test plan
- [x] `sui move test --build-env testnet`
- [x] `cargo nextest` with #609 on top (rotation + withdrawal e2e green; epoch-boundary `#[ignore]`d pending guardian wid-idempotency)
- [x] `make fmt && make clippy`