### PR TITLE
Set up macbook neos for guardian key provisioning

### DIFF
--- a/key-provisioner/flake.lock
+++ b/key-provisioner/flake.lock
@@ -1,0 +1,49 @@
+{
+  "nodes": {
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772129556,
+        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "ref": "nix-darwin-25.11",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779662858,
+        "narHash": "sha256-6GVXkkCp1wkjk41mpJkh1JYCSswYjWku9OVMzVEHL9c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cae661c6ce67cd7e0fad012646fca4625fcbbef9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/key-provisioner/flake.lock
+++ b/key-provisioner/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786845137,
+        "narHash": "sha256-oQFip+v0luP8NIxJzmiW4Wu8bILsbFWom5l0zonl8hQ=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "4cff07de74b50e64bdd68cd4e722ab5b6b35ee48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788400875,
+        "narHash": "sha256-JIHQ6xNAN53cdo6zZ72LRcQ9lpvnABCnNE4hldJ5uZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5545adfad2e98de106a5544ca7067e03010410bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/key-provisioner/flake.nix
+++ b/key-provisioner/flake.nix
@@ -1,0 +1,78 @@
+{
+  description = "Hashi guardian key provisioner Mac configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nix-darwin, ... }:
+    {
+      darwinConfigurations.hashi-guardian-key-provisioner = nix-darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        modules = [
+          {
+            nix.enable = false; # For determinate nix
+            nix.settings = {
+              substituters = [
+                "https://nix-community.cachix.org/"
+              ];
+
+              trusted-public-keys = [
+                "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+              ];
+            };
+            nixpkgs.hostPlatform = "aarch64-darwin";
+            system.primaryUser = "admin";
+            system.stateVersion = 7;
+
+            system.defaults.NSGlobalDomain.NSAutomaticWindowAnimationsEnabled = false;
+            system.defaults.NSGlobalDomain.AppleInterfaceStyle = "Dark";
+
+            system.defaults.CustomUserPreferences = {
+              NSGlobalDomain.ApplePersistenceIgnoreState = true;
+              "com.apple.loginwindow" = {
+                LoginwindowLaunchesRelaunchApps = false;
+                TALLogoutSavesState = false;
+              };
+            };
+
+            system.defaults.WindowManager = {
+              StageManagerHideWidgets = true;
+              StandardHideWidgets = true;
+            };
+
+            system.defaults.dock = {
+              autohide = false;
+              orientation = "right";
+              persistent-apps = [
+                "/System/Applications/System Settings.app"
+                "/System/Applications/Utilities/Terminal.app"
+                "/System/Cryptexes/App/System/Applications/Safari.app"
+              ];
+              persistent-others = [ ];
+              show-recents = false;
+            };
+
+            system.defaults.finder = {
+              AppleShowAllExtensions = true;
+              AppleShowAllFiles = true;
+              FXRemoveOldTrashItems = true;
+              _FXShowPosixPathInTitle = true;
+              _FXSortFoldersFirst = true;
+            };
+
+            system.keyboard = {
+              enableKeyMapping = true;
+              remapCapsLockToEscape = true;
+            };
+          }
+        ];
+      };
+    };
+}

--- a/key-provisioner/flake.nix
+++ b/key-provisioner/flake.nix
@@ -15,63 +15,81 @@
     {
       darwinConfigurations.hashi-guardian-key-provisioner = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
+
         modules = [
-          {
-            nix.enable = false; # For determinate nix
-            nix.settings = {
-              substituters = [
-                "https://nix-community.cachix.org/"
+          (
+            { pkgs, ... }:
+            {
+              environment.systemPackages = [
+                pkgs.cargo
+                pkgs.cargo-nextest
+                pkgs.clippy
+                pkgs.neovim
+                pkgs.rust-analyzer
+                pkgs.rustc
+                pkgs.rustfmt
               ];
 
-              trusted-public-keys = [
-                "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-              ];
-            };
-            nixpkgs.hostPlatform = "aarch64-darwin";
-            system.primaryUser = "admin";
-            system.stateVersion = 7;
+              nix.enable = false; # For determinate nix
+              nix.settings = {
+                substituters = [
+                  "https://nix-community.cachix.org/"
+                ];
 
-            system.defaults.NSGlobalDomain.NSAutomaticWindowAnimationsEnabled = false;
-            system.defaults.NSGlobalDomain.AppleInterfaceStyle = "Dark";
-
-            system.defaults.CustomUserPreferences = {
-              NSGlobalDomain.ApplePersistenceIgnoreState = true;
-              "com.apple.loginwindow" = {
-                LoginwindowLaunchesRelaunchApps = false;
-                TALLogoutSavesState = false;
+                trusted-public-keys = [
+                  "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+                ];
               };
-            };
 
-            system.defaults.WindowManager = {
-              StageManagerHideWidgets = true;
-              StandardHideWidgets = true;
-            };
+              nixpkgs.hostPlatform = "aarch64-darwin";
 
-            system.defaults.dock = {
-              autohide = false;
-              orientation = "right";
-              persistent-apps = [
-                "/System/Applications/System Settings.app"
-                "/System/Applications/Utilities/Terminal.app"
-                "/System/Cryptexes/App/System/Applications/Safari.app"
-              ];
-              persistent-others = [ ];
-              show-recents = false;
-            };
+              system.primaryUser = "admin";
+              system.stateVersion = 7;
 
-            system.defaults.finder = {
-              AppleShowAllExtensions = true;
-              AppleShowAllFiles = true;
-              FXRemoveOldTrashItems = true;
-              _FXShowPosixPathInTitle = true;
-              _FXSortFoldersFirst = true;
-            };
+              system.defaults = {
+                CustomUserPreferences = {
+                  NSGlobalDomain.ApplePersistenceIgnoreState = true;
+                  "com.apple.loginwindow" = {
+                    LoginwindowLaunchesRelaunchApps = false;
+                    TALLogoutSavesState = false;
+                  };
+                };
 
-            system.keyboard = {
-              enableKeyMapping = true;
-              remapCapsLockToEscape = true;
-            };
-          }
+                NSGlobalDomain = {
+                  AppleInterfaceStyle = "Dark";
+                  NSAutomaticWindowAnimationsEnabled = false;
+                };
+
+                WindowManager = {
+                  StageManagerHideWidgets = true;
+                  StandardHideWidgets = true;
+                };
+
+                dock = {
+                  autohide = false;
+                  orientation = "right";
+                  persistent-apps = [
+                    "/System/Applications/Utilities/Terminal.app"
+                  ];
+                  persistent-others = [ ];
+                  show-recents = false;
+                };
+
+                finder = {
+                  AppleShowAllExtensions = true;
+                  AppleShowAllFiles = true;
+                  FXRemoveOldTrashItems = true;
+                  _FXShowPosixPathInTitle = true;
+                  _FXSortFoldersFirst = true;
+                };
+              };
+
+              system.keyboard = {
+                enableKeyMapping = true;
+                remapCapsLockToEscape = true;
+              };
+            }
+          )
         ];
       };
     };

--- a/key-provisioner/flake.nix
+++ b/key-provisioner/flake.nix
@@ -1,0 +1,94 @@
+{
+  description = "Hashi guardian key provisioner Mac configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nix-darwin, ... }:
+    {
+      darwinConfigurations.hashi-guardian-key-provisioner = nix-darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+
+        modules = [
+          (
+            { pkgs, ... }:
+            {
+              environment.systemPackages = [
+                pkgs._1password-gui
+                pkgs.awscli2
+                pkgs.cargo
+                pkgs.gnupg
+                pkgs.neovim
+                pkgs.openpgp-card-tools
+                pkgs.rustc
+                pkgs.yubikey-manager
+              ];
+
+              networking = {
+                hostName = "kp-mbn";
+                computerName = "kp-mbn";
+              };
+
+              nix.enable = false; # For determinate nix
+
+              nixpkgs.config.allowUnfree = true;
+              nixpkgs.hostPlatform = "aarch64-darwin";
+
+              system.primaryUser = "kp";
+              system.stateVersion = 7;
+
+              system.defaults = {
+                CustomUserPreferences = {
+                  NSGlobalDomain.ApplePersistenceIgnoreState = true;
+                  "com.apple.loginwindow" = {
+                    LoginwindowLaunchesRelaunchApps = false;
+                    TALLogoutSavesState = false;
+                  };
+                };
+
+                NSGlobalDomain.NSAutomaticWindowAnimationsEnabled = false;
+
+                WindowManager = {
+                  EnableStandardClickToShowDesktop = false;
+                  StageManagerHideWidgets = true;
+                  StandardHideWidgets = true;
+                };
+
+                dock = {
+                  autohide = false;
+                  orientation = "right";
+                  persistent-apps = [
+                    "/System/Applications/Utilities/Terminal.app"
+                  ];
+                  persistent-others = [ ];
+                  show-recents = false;
+                };
+
+                finder = {
+                  AppleShowAllExtensions = true;
+                  AppleShowAllFiles = true;
+                  FXRemoveOldTrashItems = true;
+                  NewWindowTarget = "Home";
+                  ShowPathbar = true;
+                  _FXShowPosixPathInTitle = true;
+                  _FXSortFoldersFirst = true;
+                };
+              };
+
+              system.keyboard = {
+                enableKeyMapping = true;
+                remapCapsLockToEscape = true;
+              };
+            }
+          )
+        ];
+      };
+    };
+}

--- a/key-provisioner/provision.md
+++ b/key-provisioner/provision.md
@@ -1,6 +1,104 @@
 # Key Provisioner Setup
 
+## Setting up 1Password
+
+TBD
+
 ## Setting up your MacBook Neo
+
+### Complete macOS Setup Assistant
+
+After turning on the MacBook for the first time, complete macOS Setup Assistant
+using the following settings:
+
+1. Select **English** as the language.
+2. Select your country or region.
+3. Set up the Mac as a new computer. Do not transfer information from another
+   Mac or backup.
+4. On the Accessibility screen, do not enable any accessibility features; select
+   **Not Now**.
+5. Connect to Wi-Fi.
+6. On the Data & Privacy screen, select **Continue**.
+7. Create the local account:
+   - Set **Full Name** to `Hashi Guardian Key Provisioner`.
+   - Set **Account Name** to `kp`.
+   - Generate a random password in 1Password and save it there. The password
+     must be at least 12 characters long and contain uppercase letters,
+     lowercase letters, numbers, and symbols.
+   - Leave **Allow this computer account password to be reset with your Apple
+     Account** unchecked.
+8. Do not sign in to an Apple Account. Select **Other Sign-In Options**, then
+   **Sign In Later in Settings**, and finally **Skip**.
+9. Agree to the terms and conditions.
+10. Select **Adult** as the age range.
+11. Do not enable Location Services. When prompted, select **Don't Use**.
+12. Select the time zone manually without enabling Location Services.
+13. Do not share analytics, crash data, or usage data with Apple.
+14. On the Screen Time screen, select **Set Up Later**.
+15. On the Apple Intelligence screen, select **Skip**.
+16. Disable **Enable Ask Siri**, then continue.
+17. Turn on FileVault.
+18. Save the FileVault recovery key in 1Password.
+19. Choose your preferred appearance.
+20. When asked about automatic macOS updates, select **Only Download
+    Automatically**.
+
+### Provision the MacBook Neo
+
+This procedure prepares the MacBook Neo to run Hashi key provisioner operations.
+It updates macOS, clones the Hashi repository, installs Determinate Nix, and
+applies the nix-darwin configuration that installs the required tooling.
+
+1. Open Terminal and install macOS updates:
+
+   ```sh
+   sudo softwareupdate --install --all --restart
+   ```
+
+   Enter the `kp` account password when prompted. Updates may take some time.
+   Wait for them to finish, including any required restarts, before continuing.
+   If the Mac restarts, sign back in and reopen Terminal for the next step.
+
+2. Install the Xcode Command Line Tools:
+
+   ```sh
+   xcode-select --install
+   ```
+
+   Find the installation pop-up window, select **Install**, and wait for the
+   installation to finish before continuing.
+
+3. Clone the Hashi repository into `~/hashi`:
+
+   ```sh
+   git clone https://github.com/MystenLabs/hashi.git ~/hashi
+   ```
+
+4. Enter the repository directory and run the setup script to install
+   Determinate Nix and apply the nix-darwin configuration:
+
+   ```sh
+   cd ~/hashi
+   ./key-provisioner/scripts/setup-mac.sh
+   ```
+
+   Enter the `kp` account password each time `sudo` prompts for it. If macOS
+   asks whether to allow Terminal to administer your computer, select **Allow**.
+   Setup may take some time.
+
+   When setup finishes, the script prints **Setup complete** and restarts the
+   Mac to apply the macOS settings.
+
+5. After the restart, sign back in. When prompted to unlock **Nix Store**, enter
+   the `kp` account password and check **Remember this password in my keychain**
+   before unlocking it.
+
+   Quit Terminal completely with **Command-Q**, then reopen it to load the new
+   shell environment. Do not continue in a Terminal session restored after the
+   restart; the installed tools may not be on its `PATH`.
+
+Congratulations, your MacBook Neo setup is complete! Continue below to set up
+your YubiKey.
 
 ## Setting up your YubiKey
 
@@ -15,15 +113,11 @@ public certificate is shared with the guardian operator.
 
 ### Provision the YubiKey
 
-Obtain a new [YubiKey 5 Series](https://www.yubico.com/products/yubikey-5-overview/)
-device and label it so its physical identity can be matched to its public
-certificate and storage record.
+Obtain a new [YubiKey 5 Series](https://www.yubico.com/products/yubikey-5-overview/) device and label it so its physical identity can
+be matched to its public certificate and storage record.
 
-Use a setup machine with a physical USB port. Install
-[`oct`](https://codeberg.org/openpgp-card/openpgp-card-tools),
-[`gpg`](https://gnupg.org/), and
-[`ykman`](https://docs.yubico.com/software/yubikey/tools/ykman/), then disconnect
-every YubiKey except the device being provisioned.
+Use a setup machine with a physical USB port. Install [`oct`](https://codeberg.org/openpgp-card/openpgp-card-tools), [`gpg`](https://gnupg.org/), and [`ykman`](https://docs.yubico.com/software/yubikey/tools/ykman/), then
+disconnect every YubiKey except the device being provisioned.
 
 From the repository root, run the interactive provisioning script:
 
@@ -54,9 +148,9 @@ kp_roster:
     - /secure/kp3.asc
 ```
 
-Each entry represents one KP, one guardian share, and one YubiKey-backed
-OpenPGP certificate. The KP's local `kp_pgp_cert_path` points to the same
-certificate for ceremony and provisioning commands.
+Each entry represents one KP, one guardian share, and one YubiKey-backed OpenPGP
+certificate. The KP's local `kp_pgp_cert_path` points to the same certificate
+for ceremony and provisioning commands.
 
 Store the YubiKey separately from the public certificate and guardian
 configuration. Losing the YubiKey prevents that KP from decrypting and

--- a/key-provisioner/scripts/repo-pull.sh
+++ b/key-provisioner/scripts/repo-pull.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Fetching latest main"
+git fetch origin main
+
+echo "Checking out main"
+git checkout main
+
+echo "Recent commits:"
+git log --oneline -5

--- a/key-provisioner/scripts/setup-mac.sh
+++ b/key-provisioner/scripts/setup-mac.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [ "${HASHI_TART_TEST:-}" = "1" ]; then
+    echo "Skipping software updates in Tart test VM"
+else
+    echo "Updating MacOS"
+    sudo softwareupdate --install --all --restart
+    echo "Installing Xcode Command Line Tools"
+    xcode-select --install
+fi
+
+echo "Installing Determinate Nix"
+curl --proto '=https' --tlsv1.2 -sSf -L \
+    -o /tmp/determinate-nix.pkg \
+    https://install.determinate.systems/determinate-pkg/stable/Universal
+sudo installer -pkg /tmp/determinate-nix.pkg -target /
+
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+
+echo "Applying nix-darwin config"
+sudo nix run nix-darwin/nix-darwin-25.11#darwin-rebuild -- switch \
+    --flake "$repo_root/key-provisioner#hashi-guardian-key-provisioner"
+
+if [ "${HASHI_TART_TEST:-}" = "1" ]; then
+    echo "Restarting Tart test VM to apply macOS settings"
+    sudo shutdown -r now
+fi

--- a/key-provisioner/scripts/setup-mac.sh
+++ b/key-provisioner/scripts/setup-mac.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [ -x /nix/var/nix/profiles/default/bin/nix ]; then
+    echo "Nix is already installed; skipping Determinate Nix installation"
+else
+    echo "Installing Determinate Nix"
+    curl --proto '=https' --tlsv1.2 -sSf -L \
+        -o /tmp/determinate-nix.pkg \
+        https://install.determinate.systems/determinate-pkg/stable/Universal
+    sudo installer -pkg /tmp/determinate-nix.pkg -target /
+fi
+
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+
+echo "Applying nix-darwin config..."
+sudo -H nix run --inputs-from "$repo_root/key-provisioner" nix-darwin#darwin-rebuild -- switch \
+    --flake "$repo_root/key-provisioner#hashi-guardian-key-provisioner"
+
+echo "Setup complete. Restarting to apply macOS settings..."
+sudo shutdown -r now

--- a/key-provisioner/scripts/update-mac.sh
+++ b/key-provisioner/scripts/update-mac.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+echo "Applying nix-darwin config"
+sudo darwin-rebuild switch --flake "$repo_root/key-provisioner#hashi-guardian-key-provisioner"
+
 if [ "${HASHI_TART_TEST:-}" = "1" ]; then
     echo "Skipping macOS software updates in Tart test VM"
 else
     echo "Installing all macOS software updates"
     sudo softwareupdate --install --all --restart
 fi
-
-echo "Applying nix-darwin config"
-sudo darwin-rebuild switch --flake "$repo_root/key-provisioner#hashi-guardian-key-provisioner"

--- a/key-provisioner/scripts/update-mac.sh
+++ b/key-provisioner/scripts/update-mac.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [ "${HASHI_TART_TEST:-}" = "1" ]; then
+    echo "Skipping macOS software updates in Tart test VM"
+else
+    echo "Installing all macOS software updates"
+    sudo softwareupdate --install --all --restart
+fi
+
+echo "Applying nix-darwin config"
+sudo darwin-rebuild switch --flake "$repo_root/key-provisioner#hashi-guardian-key-provisioner"

--- a/key-provisioner/scripts/update-mac.sh
+++ b/key-provisioner/scripts/update-mac.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+if [ "${HASHI_TART_TEST:-}" = "1" ]; then
+    echo "Skipping repository update in Tart test VM"
+else
+    echo "Updating to latest main..."
+    git checkout main
+    git pull --ff-only origin main
+
+    echo "Recent commits:"
+    git log --oneline -5
+fi
+
+echo "Applying nix-darwin config"
+sudo darwin-rebuild switch --flake "$repo_root/key-provisioner#hashi-guardian-key-provisioner"
+
+if [ "${HASHI_TART_TEST:-}" = "1" ]; then
+    echo "Skipping macOS software updates in Tart test VM"
+else
+    echo "Installing all macOS software updates"
+    sudo softwareupdate --install --all --restart
+fi

--- a/key-provisioner/test/run-test-setup-mac.command
+++ b/key-provisioner/test/run-test-setup-mac.command
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd ~/hashi
+HASHI_TART_TEST=1 ./key-provisioner/scripts/setup-mac.sh

--- a/key-provisioner/test/run-test-update-mac.command
+++ b/key-provisioner/test/run-test-update-mac.command
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd ~/hashi
+HASHI_TART_TEST=1 ./key-provisioner/scripts/update-mac.sh

--- a/key-provisioner/test/test-mac-vm.sh
+++ b/key-provisioner/test/test-mac-vm.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+vm_name="hashi-key-provisioner-test"
+image="ghcr.io/cirruslabs/macos-tahoe-base:latest"
+repo_root="$(pwd)"
+
+if [ "$(basename "$repo_root")" != "hashi" ]; then
+    echo "Run this script from the hashi repo root"
+    exit 1
+fi
+
+echo "Regenerating key-provisioner/flake.lock"
+nix flake lock --output-lock-file "$repo_root/key-provisioner/flake.lock" "path:$repo_root/key-provisioner"
+
+echo "Deleting any existing VM $vm_name"
+tart stop "$vm_name" || true
+tart delete "$vm_name" || true
+
+echo "Cloning $image to $vm_name"
+tart clone "$image" "$vm_name"
+
+echo "Setting VM memory to 16 GB"
+tart set "$vm_name" --memory 16384
+
+echo "Setting VM disk to 75 GB"
+tart set "$vm_name" --disk-size 75
+
+echo "Running VM $vm_name"
+tart run --dir=hashi:"$repo_root" "$vm_name" &
+
+echo "Waiting for VM $vm_name to start"
+until tart exec "$vm_name" true; do
+    sleep 1
+done
+
+echo "Copying hashi repo to ~/hashi"
+tart exec "$vm_name" rsync -a \
+    --exclude .git \
+    --exclude .jj \
+    --exclude target \
+    --exclude out \
+    "/Volumes/My Shared Files/hashi/" \
+    /Users/admin/hashi/
+
+echo "Default VM username: admin"
+echo "Default VM password: admin"
+
+boot_time="$(tart exec "$vm_name" sysctl -n kern.boottime)"
+
+echo "Running setup-mac.sh"
+tart exec "$vm_name" open /Users/admin/hashi/key-provisioner/test/run-test-setup-mac.command
+
+echo "Waiting for VM $vm_name to restart"
+until new_boot_time="$(timeout 2s tart exec "$vm_name" sysctl -n kern.boottime 2>/dev/null)" && [ "$new_boot_time" != "$boot_time" ]; do
+    sleep 1
+done
+
+echo "VM $vm_name restarted"
+
+echo "Running update-mac.sh"
+tart exec "$vm_name" open /Users/admin/hashi/key-provisioner/test/run-test-update-mac.command

--- a/key-provisioner/test/test-mac-vm.sh
+++ b/key-provisioner/test/test-mac-vm.sh
@@ -24,6 +24,9 @@ tart clone "$image" "$vm_name"
 echo "Setting VM memory to 16 GB"
 tart set "$vm_name" --memory 16384
 
+echo "Setting VM disk to 75 GB"
+tart set "$vm_name" --disk-size 75
+
 echo "Running VM $vm_name"
 tart run --dir=hashi:"$repo_root" "$vm_name" &
 

--- a/key-provisioner/test/test-mac-vm.sh
+++ b/key-provisioner/test/test-mac-vm.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+vm_name="hashi-key-provisioner-test"
+image="ghcr.io/cirruslabs/macos-tahoe-base:latest"
+repo_root="$(pwd)"
+
+if [ "$(basename "$repo_root")" != "hashi" ]; then
+    echo "Run this script from the hashi repo root"
+    exit 1
+fi
+
+echo "Regenerating key-provisioner/flake.lock"
+nix flake lock --output-lock-file "$repo_root/key-provisioner/flake.lock" "path:$repo_root/key-provisioner"
+
+echo "Deleting any existing VM $vm_name"
+tart stop "$vm_name" || true
+tart delete "$vm_name" || true
+
+echo "Cloning $image to $vm_name"
+tart clone "$image" "$vm_name"
+
+echo "Setting VM memory to 16 GB"
+tart set "$vm_name" --memory 16384
+
+echo "Running VM $vm_name"
+tart run --dir=hashi:"$repo_root" "$vm_name" &
+
+echo "Waiting for VM $vm_name to start"
+until tart exec "$vm_name" true; do
+    sleep 1
+done
+
+echo "Copying hashi repo to ~/hashi"
+tart exec "$vm_name" rsync -a \
+    --exclude .git \
+    --exclude .jj \
+    --exclude target \
+    --exclude out \
+    "/Volumes/My Shared Files/hashi/" \
+    /Users/admin/hashi/
+
+echo "Default VM username: admin"
+echo "Default VM password: admin"
+
+boot_time="$(tart exec "$vm_name" sysctl -n kern.boottime)"
+
+echo "Running setup-mac.sh"
+tart exec "$vm_name" open /Users/admin/hashi/key-provisioner/test/run-test-setup-mac.command
+
+echo "Waiting for VM $vm_name to restart"
+until new_boot_time="$(timeout 2s tart exec "$vm_name" sysctl -n kern.boottime 2>/dev/null)" && [ "$new_boot_time" != "$boot_time" ]; do
+    sleep 1
+done
+
+echo "VM $vm_name restarted"
+
+echo "Running update-mac.sh"
+tart exec "$vm_name" open /Users/admin/hashi/key-provisioner/test/run-test-update-mac.command


### PR DESCRIPTION
- Document initial MacBook Neo setup for guardian key provisioners.
- Add Nix-managed tooling and macOS configuration, with setup and update scripts.
- Add a Tart VM harness for testing the setup workflow.