### PR TITLE
[guardian][onchain] entry fn to publish BTC pubkey after init

### DIFF
--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -541,6 +541,37 @@ pub struct PublishOpts {
     pub yes: bool,
 }
 
+/// Options for the `set-guardian-btc-public-key` subcommand.
+///
+/// Publishes the guardian's enclave BTC pubkey on the already-published
+/// Hashi object. Signed by the original deployer keypair.
+#[derive(Args)]
+pub struct SetGuardianBtcPublicKeyOpts {
+    /// Sui RPC endpoint URL
+    #[clap(long, env = "SUI_RPC_URL")]
+    pub sui_rpc_url: String,
+
+    /// Path to the deployer keypair (same one that signed `hashi publish`)
+    #[clap(long, short = 'k', env = "HASHI_KEYPAIR")]
+    pub keypair: std::path::PathBuf,
+
+    /// Hashi package ID (output of `hashi publish`)
+    #[clap(long, env = "HASHI_PACKAGE_ID")]
+    pub package_id: String,
+
+    /// Hashi shared-object ID (output of `hashi publish`)
+    #[clap(long, env = "HASHI_OBJECT_ID")]
+    pub hashi_object_id: String,
+
+    /// Guardian BTC pubkey, x-only hex-encoded (32 bytes)
+    #[clap(long)]
+    pub btc_public_key: String,
+
+    /// Enable verbose output
+    #[clap(long, short)]
+    pub verbose: bool,
+}
+
 /// Options for the `register` subcommand.
 ///
 /// Unlike other CLI commands this uses a validator config file (the same one
@@ -978,6 +1009,50 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
     std::fs::write(out_path, &json)?;
     print_success(&format!("Wrote {out_path}"));
 
+    Ok(())
+}
+
+/// Run the `set-guardian-btc-public-key` command — set the BTC pubkey on
+/// an already-published Hashi object. Signs with the deployer keypair.
+pub async fn run_set_guardian_btc_public_key(
+    opts: SetGuardianBtcPublicKeyOpts,
+) -> anyhow::Result<()> {
+    use sui_sdk_types::Address;
+
+    crate::init_crypto_provider();
+    init_tracing(opts.verbose);
+
+    let btc_pubkey_hex = opts
+        .btc_public_key
+        .strip_prefix("0x")
+        .unwrap_or(&opts.btc_public_key);
+    let btc_pubkey = hex::decode(btc_pubkey_hex).context("invalid hex for --btc-public-key")?;
+
+    let package_id: Address = opts.package_id.parse().context("invalid --package-id")?;
+    let hashi_object_id: Address = opts
+        .hashi_object_id
+        .parse()
+        .context("invalid --hashi-object-id")?;
+
+    let signer = crate::config::load_ed25519_private_key_from_path(&opts.keypair)?;
+    print_info(&format!(
+        "Sender address: {}",
+        signer.public_key().derive_address()
+    ));
+    print_info(&format!("Hashi object:   {hashi_object_id}"));
+    print_info(&format!("Package:        {package_id}"));
+
+    let mut client = sui_rpc::Client::new(&opts.sui_rpc_url)?;
+    crate::publish::set_guardian_btc_public_key(
+        &mut client,
+        &signer,
+        package_id,
+        hashi_object_id,
+        btc_pubkey,
+    )
+    .await?;
+
+    print_success("Guardian BTC pubkey published on-chain");
     Ok(())
 }
 

--- a/crates/hashi/src/main.rs
+++ b/crates/hashi/src/main.rs
@@ -76,6 +76,12 @@ enum Commands {
         register_opts: hashi::cli::RegisterOpts,
     },
 
+    /// Publish the guardian's enclave BTC pubkey on an already-published Hashi
+    SetGuardianBtcPublicKey {
+        #[clap(flatten)]
+        opts: hashi::cli::SetGuardianBtcPublicKeyOpts,
+    },
+
     /// Deposit BTC into the Hashi bridge
     Deposit {
         #[clap(flatten)]
@@ -132,6 +138,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Publish { publish_opts } => hashi::cli::run_publish(publish_opts).await,
         Commands::Register { register_opts } => hashi::cli::run_register(register_opts).await,
+        Commands::SetGuardianBtcPublicKey { opts } => {
+            hashi::cli::run_set_guardian_btc_public_key(opts).await
+        }
         Commands::Deposit { cli_opts, action } => {
             hashi::cli::run(cli_opts, hashi::cli::CliCommand::Deposit { action }).await
         }

--- a/crates/hashi/src/publish.rs
+++ b/crates/hashi/src/publish.rs
@@ -279,3 +279,63 @@ pub async fn publish_and_init(
         hashi_object_id,
     })
 }
+
+/// Call `hashi::set_guardian_btc_public_key` on a published Hashi object.
+///
+/// Used by the deploy workflow when the BTC pubkey isn't available at
+/// publish time (fresh guardian needs `provisioner_init` first). Gated
+/// on-chain to the original deployer.
+pub async fn set_guardian_btc_public_key(
+    client: &mut Client,
+    signer: &Ed25519PrivateKey,
+    package_id: Address,
+    hashi_object_id: Address,
+    btc_public_key: Vec<u8>,
+) -> Result<()> {
+    anyhow::ensure!(
+        btc_public_key.len() == 32,
+        "guardian BTC public key must be 32 bytes (x-only), got {}",
+        btc_public_key.len(),
+    );
+
+    let sender = signer.public_key().derive_address();
+    let mut builder = TransactionBuilder::new();
+    builder.set_sender(sender);
+
+    let hashi_arg = builder.object(
+        ObjectInput::new(hashi_object_id)
+            .as_shared()
+            .with_mutable(true),
+    );
+    let btc_pk_arg = builder.pure(&btc_public_key);
+
+    builder.move_call(
+        Function::new(
+            package_id,
+            Identifier::from_static("hashi"),
+            Identifier::from_static("set_guardian_btc_public_key"),
+        ),
+        vec![hashi_arg, btc_pk_arg],
+    );
+
+    let transaction = builder.build(client).await?;
+    let signature = signer.sign_transaction(&transaction)?;
+
+    let response = client
+        .execute_transaction_and_wait_for_checkpoint(
+            ExecuteTransactionRequest::new(transaction.into())
+                .with_signatures(vec![signature.into()])
+                .with_read_mask(FieldMask::from_str("*")),
+            std::time::Duration::from_secs(30),
+        )
+        .await?
+        .into_inner();
+
+    anyhow::ensure!(
+        response.transaction().effects().status().success(),
+        "set_guardian_btc_public_key transaction failed: {:?}",
+        response.transaction().effects().status(),
+    );
+
+    Ok(())
+}

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -27,6 +27,8 @@ const EBadGuardianBtcPublicKeyLength: vector<u8> = b"Guardian BTC public key mus
 #[error(code = 4)]
 const EGuardianBtcPublicKeyImmutable: vector<u8> =
     b"Guardian BTC public key cannot be changed once set";
+#[error(code = 5)]
+const EDeployerAlreadySet: vector<u8> = b"Deployer already set";
 
 const PAUSED_KEY: vector<u8> = b"paused";
 const GUARDIAN_URL_KEY: vector<u8> = b"guardian_url";
@@ -34,6 +36,7 @@ const GUARDIAN_PUBLIC_KEY_KEY: vector<u8> = b"guardian_public_key";
 const GUARDIAN_PUBLIC_KEY_LEN: u64 = 32;
 const GUARDIAN_BTC_PUBLIC_KEY_KEY: vector<u8> = b"guardian_btc_public_key";
 const GUARDIAN_BTC_PUBLIC_KEY_LEN: u64 = 32;
+const DEPLOYER_KEY: vector<u8> = b"deployer";
 const EMERGENCY_PAUSE_THRESHOLD_BPS_KEY: vector<u8> = b"governance_emergency_pause_threshold_bps";
 const EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY: vector<u8> =
     b"governance_emergency_unpause_threshold_bps";
@@ -125,6 +128,17 @@ public(package) fun set_guardian_btc_public_key(self: &mut Config, btc_public_ke
         existing.destroy_none();
     };
     self.upsert(GUARDIAN_BTC_PUBLIC_KEY_KEY, config_value::new_bytes(btc_public_key));
+}
+
+public(package) fun deployer(self: &Config): Option<address> {
+    self.try_get(DEPLOYER_KEY).map!(|v| v.as_address())
+}
+
+/// Pinned at publish time to the address that called `finish_publish`.
+/// One-time set; subsequent calls abort.
+public(package) fun set_deployer(self: &mut Config, deployer: address) {
+    assert!(self.deployer().is_none(), EDeployerAlreadySet);
+    self.upsert(DEPLOYER_KEY, config_value::new_address(deployer));
 }
 
 public(package) fun emergency_pause_threshold_bps(self: &Config): u64 {

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -24,6 +24,8 @@ const EReconfiguring: vector<u8> = b"System is currently reconfiguring";
 const ENoCommittee: vector<u8> = b"No committee exists for the current epoch";
 #[error]
 const EWrongUpgradeCap: vector<u8> = b"Upgrade cap does not belong to this package";
+#[error]
+const ENotDeployer: vector<u8> = b"Caller is not the original deployer";
 
 public struct Hashi has key {
     id: UID,
@@ -117,6 +119,7 @@ entry fun finish_publish(
     assert!(upgrade_cap.package() == this_package_id, EWrongUpgradeCap);
 
     self.config_mut().set_upgrade_cap(upgrade_cap);
+    self.config_mut().set_deployer(ctx.sender());
     hashi::btc_config::set_bitcoin_chain_id(self.config_mut(), bitcoin_chain_id);
 
     if (guardian_url.is_some() && guardian_public_key.is_some()) {
@@ -158,6 +161,21 @@ entry fun finish_publish(
     let (treasury_cap, metadata_cap) = hashi::btc::create(coin_registry, ctx);
     self.treasury.register_treasury_cap(treasury_cap);
     self.treasury.register_metadata_cap(metadata_cap);
+}
+
+/// Set the guardian BTC pubkey after `finish_publish` (used when the
+/// key isn't available at publish time). Gated to the deployer because
+/// the underlying setter rejects rotation — front-running with a wrong
+/// key would brick deposits.
+entry fun set_guardian_btc_public_key(
+    self: &mut Hashi,
+    btc_public_key: vector<u8>,
+    ctx: &TxContext,
+) {
+    self.config.assert_version_enabled();
+    let deployer = self.config().deployer().destroy_or!(abort ENotDeployer);
+    assert!(ctx.sender() == deployer, ENotDeployer);
+    self.config_mut().set_guardian_btc_public_key(btc_public_key);
 }
 
 public(package) fun id(self: &Hashi): &UID {

--- a/packages/hashi/tests/config_tests.move
+++ b/packages/hashi/tests/config_tests.move
@@ -148,6 +148,30 @@ fun test_set_guardian_btc_public_key_rejects_rotation() {
 }
 
 #[test]
+fun test_set_deployer_stores_address() {
+    let ctx = &mut test_utils::new_tx_context(@0x100, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+
+    assert!(config::deployer(hashi.config()).is_none());
+
+    config::set_deployer(hashi.config_mut(), @0xDE);
+    assert!(config::deployer(hashi.config()).destroy_some() == @0xDE);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test, expected_failure(abort_code = ::hashi::config::EDeployerAlreadySet)]
+fun test_set_deployer_rejects_overwrite() {
+    let ctx = &mut test_utils::new_tx_context(@0x100, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+
+    config::set_deployer(hashi.config_mut(), @0xDE);
+    config::set_deployer(hashi.config_mut(), @0xDE);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
 fun test_bitcoin_withdrawal_minimum_updates() {
     let ctx = &mut test_utils::new_tx_context(@0x100, 0);
     let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);

--- a/packages/hashi/tests/hashi_tests.move
+++ b/packages/hashi/tests/hashi_tests.move
@@ -1,21 +1,78 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/*
 #[test_only]
 module hashi::hashi_tests;
-// uncomment this line to import the module
-// use hashi::hashi;
 
-const ENotImplemented: u64 = 0;
+use hashi::{config, hashi as hashi_mod, test_utils};
+
+const DEPLOYER: address = @0xDE;
+const OTHER: address = @0xBAD;
+
+const VOTER1: address = @0x1;
+const VOTER2: address = @0x2;
+const VOTER3: address = @0x3;
 
 #[test]
-fun test_hashi() {
-    // pass
+fun test_set_guardian_btc_public_key_stores_value() {
+    let ctx = &mut test_utils::new_tx_context(DEPLOYER, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+    config::set_deployer(hashi.config_mut(), DEPLOYER);
+
+    let btc_pk = vector::tabulate!(32, |i| (i as u8));
+    hashi_mod::set_guardian_btc_public_key(&mut hashi, btc_pk, ctx);
+
+    assert!(config::guardian_btc_public_key(hashi.config()).destroy_some() == btc_pk);
+
+    std::unit_test::destroy(hashi);
 }
 
-#[test, expected_failure(abort_code = ::hashi::hashi_tests::ENotImplemented)]
-fun test_hashi_fail() {
-    abort ENotImplemented
+#[test]
+fun test_set_guardian_btc_public_key_is_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(DEPLOYER, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+    config::set_deployer(hashi.config_mut(), DEPLOYER);
+
+    let btc_pk = vector::tabulate!(32, |i| (i as u8));
+    hashi_mod::set_guardian_btc_public_key(&mut hashi, btc_pk, ctx);
+    hashi_mod::set_guardian_btc_public_key(&mut hashi, btc_pk, ctx);
+
+    std::unit_test::destroy(hashi);
 }
-*/
+
+#[test, expected_failure(abort_code = ::hashi::hashi::ENotDeployer)]
+fun test_set_guardian_btc_public_key_rejects_wrong_sender() {
+    let ctx = &mut test_utils::new_tx_context(OTHER, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+    config::set_deployer(hashi.config_mut(), DEPLOYER);
+
+    let btc_pk = vector::tabulate!(32, |i| (i as u8));
+    hashi_mod::set_guardian_btc_public_key(&mut hashi, btc_pk, ctx);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test, expected_failure(abort_code = ::hashi::hashi::ENotDeployer)]
+fun test_set_guardian_btc_public_key_rejects_unset_deployer() {
+    let ctx = &mut test_utils::new_tx_context(DEPLOYER, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+
+    let btc_pk = vector::tabulate!(32, |i| (i as u8));
+    hashi_mod::set_guardian_btc_public_key(&mut hashi, btc_pk, ctx);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test, expected_failure(abort_code = ::hashi::config::EGuardianBtcPublicKeyImmutable)]
+fun test_set_guardian_btc_public_key_rejects_rotation() {
+    let ctx = &mut test_utils::new_tx_context(DEPLOYER, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
+    config::set_deployer(hashi.config_mut(), DEPLOYER);
+
+    let first = vector::tabulate!(32, |i| (i as u8));
+    let second = vector::tabulate!(32, |i| ((i + 1) as u8));
+    hashi_mod::set_guardian_btc_public_key(&mut hashi, first, ctx);
+    hashi_mod::set_guardian_btc_public_key(&mut hashi, second, ctx);
+
+    std::unit_test::destroy(hashi);
+}


### PR DESCRIPTION
Stacked on #603. Adds the deploy-time hook for landing the guardian BTC pubkey on chain when it isn't available at publish time.

- `hashi::set_guardian_btc_public_key` entry fn — gated to the address that called `finish_publish` (pinned in `Config` as a new `deployer` field). The underlying `public(package)` setter rejects rotation, so this stops adversarial front-runs from bricking deposits with a wrong key.
- `hashi set-guardian-btc-public-key` CLI subcommand — `--keypair`, `--package-id`, `--hashi-object-id`, `--btc-public-key`. Builds the PTB and executes it.
- Move + Rust tests covering the deployer pin, the wrong-sender path, rotation rejection, and idempotency.

The deploy workflow (sui-operations #8057) will fetch the BTC pubkey from the guardian after `provisioner_init` and pipe it through this CLI.

## Test plan
- [x] `sui move test --path packages/hashi --build-env testnet` — 113 passing
- [x] `cargo nextest run -p hashi --lib` — 359 passing
- [x] `make fmt && make clippy`
- [ ] Devnet: deploy via sui-operations#8057, verify `Config.guardian_btc_public_key` is populated after the post-init step