### PR TITLE
Round up batched withdrawal miner fee splits

### DIFF
--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -309,9 +309,12 @@ public(package) fun new_withdrawal_txn(
         EOutputCountMismatch,
     );
 
-    // Miner fee is split evenly across all withdrawal requests. Any remainder
-    // (at most request_count - 1 sats) is a rounding bonus to the miner.
-    let per_user_miner_fee = miner_fee / request_count;
+    // Miner fee is split evenly across all withdrawal requests, rounded up so
+    // the bridge does not subsidize any division remainder.
+    let mut per_user_miner_fee = miner_fee / request_count;
+    if (miner_fee % request_count > 0) {
+        per_user_miner_fee = per_user_miner_fee + 1;
+    };
     assert!(per_user_miner_fee <= max_network_fee, EMinerFeeExceedsMax);
 
     // Each withdrawal output must match the expected amount after deducting

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -551,14 +551,21 @@ fun test_miner_fee_batched_with_remainder() {
     let mut config = config::create();
     hashi::btc_config::init_defaults(&mut config);
 
-    // 3 requests, miner_fee=1001 -> per_user=333, remainder=2 goes to miner
     let btc_amount = 40_000u64;
+    let request_count = 3u64;
     let miner_fee = 1_001u64;
-    let per_user = miner_fee / 3; // 333
+    let mut per_user = miner_fee / request_count;
+    if (miner_fee % request_count > 0) {
+        per_user = per_user + 1;
+    };
     let user_output = btc_amount - per_user;
-    let total_user_outputs = user_output * 3;
+    let total_user_outputs = user_output * request_count;
     let input_amount = total_user_outputs + miner_fee + 10_000; // 10k change
     let change = input_amount - total_user_outputs - miner_fee;
+
+    assert!(per_user == 334);
+    assert!(user_output == 39_666);
+    assert!(change == 10_000);
 
     let id1 = setup_request(&mut queue, &clock, btc_amount, ctx);
     let id2 = setup_request(&mut queue, &clock, btc_amount, ctx);


### PR DESCRIPTION
## Summary

Fixes rounding up the per-request miner fee deduction for batched withdrawals.

Previously, `new_withdrawal_txn` used floor division when validating each withdrawal output:

```move
miner_fee / request_count
```

For a 1001 sat miner fee split across 3 requests, this charged each user 333 sats, so users only covered 999 sats total. The remaining 2 sats were implicitly absorbed by the bridge-controlled value.

This PR changes the Move-side validation to round up the per-request fee whenever the miner fee is not evenly divisible by the request count. This matches the conservative off-chain construction behavior and ensures users cover the fee remainder instead of the bridge subsidizing it.

## Changes
- Round up `per_user_miner_fee` in `withdrawal_queue::new_withdrawal_txn`.
- Update the batched-with-remainder withdrawal queue test to use the ceil fee split.

Note: This is a conservative fix: it prevents protocol value from covering fee remainders, but it can overcharge users by up to `request_count - 1` sats per batch. An alternative is to keep the base floor split and assign the remainder deterministically to one request, for example the last request pays `floor(miner_fee / request_count) + remainder`. That would make the total user-paid fee exactly match the miner fee. Feedback welcome on which policy is preferred.