### PR TITLE
[guardian] remove dead x-only MPC pubkey helpers

### DIFF
--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -347,9 +347,9 @@ async fn finalize_guardian_harness(networks: &mut TestNetworks) -> Result<()> {
         .current_committee()
         .ok_or_else(|| anyhow::anyhow!("no current committee after DKG"))?;
     // Pass the raw `G` (with y-parity) so the guardian's child-key
-    // derivation matches the MPC's signing path. Sending only the x-only
-    // projection (`get_onchain_mpc_pubkey`) would force an even-y parent
-    // and silently disagree with MPC sigs for half of all DKG outputs.
+    // derivation matches the MPC's signing path. Using only the x-only
+    // projection would force an even-y parent and silently disagree with
+    // MPC sigs for half of all DKG outputs.
     let master_pubkey = hashi.onchain_verifying_key_g()?;
 
     let withdrawal_config = default_test_withdrawal_config(&committee);

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -11,7 +11,6 @@ use bitcoin::ScriptBuf;
 
 use bitcoin::secp256k1::XOnlyPublicKey;
 use fastcrypto::groups::secp256k1::ProjectivePoint;
-use fastcrypto::groups::secp256k1::schnorr::SchnorrPublicKey;
 use fastcrypto::serde_helpers::ToFromByteArray;
 use fastcrypto::traits::ToFromBytes;
 use fastcrypto_tbls::threshold_schnorr::G;
@@ -305,31 +304,6 @@ impl Hashi {
         self.guardian_btc_pubkey()
             .copied()
             .ok_or_else(|| anyhow!("Guardian BTC pubkey not yet pinned"))
-    }
-
-    pub fn get_hashi_pubkey(&self) -> anyhow::Result<XOnlyPublicKey> {
-        let g = self
-            .mpc_handle()
-            .context("MpcHandle not initialized")?
-            .public_key()
-            .context("MPC public key not available yet")?;
-        // Convert G (ProjectivePoint, 33 bytes compressed) to SchnorrPublicKey (32 bytes x-only)
-        let schnorr_pk = SchnorrPublicKey::try_from(&g)
-            .map_err(|e| anyhow!("invalid group element for schnorr key: {e}"))?;
-        Ok(XOnlyPublicKey::from_slice(&schnorr_pk.to_byte_array())?)
-    }
-
-    /// Read the MPC public key from on-chain state.
-    ///
-    /// Unlike `get_hashi_pubkey`, this does not depend on the node's local DKG
-    /// completion channel. The on-chain key is set during `end_reconfig` event
-    /// processing, so it is guaranteed to be present once the initial committee
-    /// has formed (i.e., after `HashiNetworkBuilder::build()` returns).
-    pub fn get_onchain_mpc_pubkey(&self) -> anyhow::Result<XOnlyPublicKey> {
-        let g = self.onchain_verifying_key_g()?;
-        let schnorr_pk = SchnorrPublicKey::try_from(&g)
-            .map_err(|e| anyhow!("invalid group element for schnorr key: {e}"))?;
-        Ok(XOnlyPublicKey::from_slice(&schnorr_pk.to_byte_array())?)
     }
 
     /// Deserialize the BCS-encoded MPC group element from on-chain state.


### PR DESCRIPTION
`get_hashi_pubkey` / `get_onchain_mpc_pubkey` return the x-only projection of the MPC master key. After the raw-`G` derivation fix (#609) they have no callers, and deriving a child from their output would reintroduce the odd-y "Invalid Schnorr signature" bug — a reviewer asked to drop them. Removes both and the now-unused `SchnorrPublicKey` import.

Stacked on the regression-fix PR.