### PR TITLE
Add --serialize-unsigned-transaction to the hashi CLI

### DIFF
--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -18,7 +18,6 @@ use crate::sui_tx_executor::SuiTxExecutor;
 use anyhow::Context;
 use anyhow::Result;
 use hashi_types::move_types::ConfigValue;
-use sui_rpc::proto::sui::rpc::v2::ExecuteTransactionResponse;
 use sui_sdk_types::Address;
 use sui_sdk_types::Identifier;
 use sui_sdk_types::StructTag;
@@ -154,41 +153,29 @@ impl HashiClient {
         self.executor.is_some()
     }
 
-    /// Execute a transaction built with `TransactionBuilder`.
+    /// Finalize `builder` according to `tx_opts`: serialize it unsigned,
+    /// dry-run it, or sign and submit it.
     ///
-    /// Returns an error if no keypair is configured.
-    pub async fn execute(
-        &mut self,
+    /// A keypair is required only for [`TxMode::Execute`](crate::sui_tx_executor::TxMode);
+    /// the serialize and dry-run paths build with just the sender address
+    /// (explicit `--sender`, or the keypair's address when one is configured).
+    pub async fn finalize_tx(
+        &self,
         builder: TransactionBuilder,
-    ) -> Result<ExecuteTransactionResponse> {
-        let executor = self
-            .executor
-            .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("Cannot execute transactions: no keypair configured"))?;
-
-        executor.execute(builder).await
-    }
-
-    /// Simulate a transaction (dry-run) without executing it.
-    ///
-    /// Returns the estimated gas budget on success.
-    /// This performs the same steps as execute but stops before signing/submitting.
-    pub async fn simulate(&mut self, mut builder: TransactionBuilder) -> Result<SimulationResult> {
-        let executor = self.executor.as_ref().ok_or_else(|| {
-            anyhow::anyhow!("Cannot simulate transactions: no keypair configured")
-        })?;
-
-        let sender = executor.sender();
-        builder.set_sender(sender);
-
-        // Build the transaction - this internally does a dry-run for gas estimation
-        let transaction = builder.build(&mut self.onchain_state.client()).await?;
-
-        Ok(SimulationResult {
-            sender,
-            gas_budget: transaction.gas_payment.budget,
-            gas_price: transaction.gas_payment.price,
-        })
+        tx_opts: &crate::cli::TxOptions,
+    ) -> Result<crate::sui_tx_executor::TxOutcome> {
+        let signer = self.executor.as_ref().map(|e| e.signer());
+        let mut client = self.onchain_state.client();
+        crate::sui_tx_executor::finalize(
+            &mut client,
+            signer,
+            builder,
+            tx_opts.sender,
+            &tx_opts.gas_overrides(),
+            tx_opts.mode(),
+            std::time::Duration::from_secs(10),
+        )
+        .await
     }
 
     // ========================================================================

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -140,12 +140,14 @@ async fn generate_address(config: &CliConfig, recipient: &str) -> Result<()> {
 
 async fn request(
     config: &CliConfig,
-    _tx_opts: &TxOptions,
+    tx_opts: &TxOptions,
     txid: &str,
     vout: u32,
     amount: u64,
     recipient: Option<&str>,
 ) -> Result<()> {
+    use crate::sui_tx_executor::TxMode;
+
     config.validate()?;
 
     let hashi_ids = crate::config::HashiIds {
@@ -153,49 +155,91 @@ async fn request(
         hashi_object_id: config.hashi_object_id(),
     };
 
-    let signer = config
-        .load_keypair()?
-        .context("Keypair required for deposit request. Set keypair_path in config.")?;
+    // A keypair is optional: serialize/dry-run only need the sender address.
+    let signer = config.load_keypair()?;
+    if tx_opts.mode() == TxMode::Execute && signer.is_none() {
+        anyhow::bail!(
+            "Keypair required to submit a deposit request (set keypair_path in config), \
+             or use --serialize-unsigned-transaction to emit an unsigned transaction."
+        );
+    }
 
+    // Sender: explicit --sender (e.g. a multisig), else the keypair's address.
+    let sender = tx_opts
+        .sender
+        .or_else(|| signer.as_ref().map(|s| s.public_key().derive_address()));
+
+    // hBTC recipient defaults to the sender when not given explicitly.
     let derivation_path = match recipient {
         Some(r) => Some(
             r.parse::<sui_sdk_types::Address>()
                 .context("Invalid recipient Sui address")?,
         ),
         None => {
-            let addr = signer.public_key().derive_address();
-            print_info(&format!(
-                "No --recipient specified, defaulting to signer address {}",
-                addr
-            ));
+            let addr = sender.context(
+                "No --recipient given and no sender to default to; pass --recipient, \
+                 --sender, or configure a keypair",
+            )?;
+            print_info(&format!("No --recipient specified, defaulting to {addr}"));
             Some(addr)
         }
     };
 
-    let client = sui_rpc::Client::new(&config.sui_rpc_url)?;
-    let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids);
-
     let parsed_txid: bitcoin::Txid = txid.parse().context("Invalid txid")?;
     let txid_address = sui_sdk_types::Address::new(parsed_txid.to_byte_array());
 
-    print_info("Submitting deposit request on Sui...");
+    let builder = crate::sui_tx_executor::build_create_deposit_request(
+        hashi_ids,
+        txid_address,
+        vout,
+        amount,
+        derivation_path,
+    );
 
-    let request_id = executor
-        .execute_create_deposit_request(txid_address, vout, amount, derivation_path)
-        .await?;
+    match tx_opts.mode() {
+        TxMode::SerializeUnsigned => print_info("Building unsigned deposit request..."),
+        TxMode::DryRun => print_info("Simulating deposit request (dry-run)..."),
+        TxMode::Execute => print_info("Submitting deposit request on Sui..."),
+    }
 
-    print_success(&format!("Deposit request created: {}", request_id));
+    let mut client = sui_rpc::Client::new(&config.sui_rpc_url)?;
+    let outcome = crate::sui_tx_executor::finalize(
+        &mut client,
+        signer.as_ref(),
+        builder,
+        sender,
+        &tx_opts.gas_overrides(),
+        tx_opts.mode(),
+        std::time::Duration::from_secs(10),
+    )
+    .await?;
+
+    if let Some(response) = crate::cli::print_tx_outcome(outcome) {
+        let request_id = crate::sui_tx_executor::deposit_request_id_from_response(&response)?;
+        print_success(&format!("Deposit request created: {request_id}"));
+    }
 
     Ok(())
 }
 
 async fn request_all(
     config: &CliConfig,
-    _tx_opts: &TxOptions,
+    tx_opts: &TxOptions,
     txid: &str,
     outputs: Option<&str>,
     recipient: Option<&str>,
 ) -> Result<()> {
+    // This batches outputs into one transaction per ~333 deposits, so it can't
+    // emit a single unsigned/dry-run transaction. Direct the user to the
+    // per-output command for those modes.
+    if tx_opts.mode() != crate::sui_tx_executor::TxMode::Execute {
+        anyhow::bail!(
+            "`deposit request` builds one transaction per batch of outputs and cannot emit a \
+             single unsigned or dry-run transaction. Use `deposit request-single` per output \
+             with --serialize-unsigned-transaction or --dry-run."
+        );
+    }
+
     config.validate()?;
 
     let hashi_ids = crate::config::HashiIds {

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -14,9 +14,9 @@ use tabled::Tabled;
 use crate::cli::TxOptions;
 use crate::cli::client::CreateProposalParams;
 use crate::cli::client::HashiClient;
-use crate::cli::client::SimulationResult;
 use crate::cli::client::get_proposal_type_arg;
 use crate::cli::config::CliConfig;
+use crate::cli::print_detail;
 use crate::cli::print_info;
 use crate::cli::print_warning;
 use crate::cli::types::Proposal;
@@ -25,69 +25,44 @@ use crate::cli::types::display;
 /// Print metadata if present
 fn print_metadata(metadata: &[(String, String)]) {
     if !metadata.is_empty() {
-        println!("  {}", "Metadata:".bold());
+        print_detail(&format!("  {}", "Metadata:".bold()));
         for (key, value) in metadata {
-            println!("    {}: {}", key.dimmed(), value);
+            print_detail(&format!("    {}: {}", key.dimmed(), value));
         }
     }
 }
 
-/// Print simulation (dry-run) results
-fn print_simulation_result(result: &SimulationResult) {
-    println!("\n{}", "🔍 Dry-run Results:".bold());
-    println!("  {} {}", "Sender:".dimmed(), result.sender.to_hex().cyan());
-    println!(
-        "  {} {} MIST",
-        "Gas Budget:".dimmed(),
-        result.gas_budget.to_string().cyan()
-    );
-    println!(
-        "  {} {} MIST/unit",
-        "Gas Price:".dimmed(),
-        result.gas_price.to_string().cyan()
-    );
-    let max_cost_sui = (result.gas_budget as f64) / 1_000_000_000.0;
-    println!(
-        "  {} {:.6} SUI",
-        "Max Cost:".dimmed(),
-        format!("{:.6}", max_cost_sui).yellow()
-    );
-    println!(
-        "\n  {} Transaction was simulated successfully. Use without --dry-run to execute.",
-        "✓".green()
-    );
-}
-
-/// Execute or simulate a transaction based on tx_opts.
+/// Finalize a transaction according to `tx_opts`: serialize it unsigned,
+/// dry-run it, or sign and submit it.
 ///
 /// Returns `Some(response)` when a real transaction was executed, and `None`
-/// on dry-run or when no keypair is configured.
+/// for dry-run, serialize-unsigned, or when execution is requested but no
+/// keypair is configured.
 async fn execute_or_simulate(
     client: &mut HashiClient,
     tx: sui_transaction_builder::TransactionBuilder,
     tx_opts: &TxOptions,
 ) -> Result<Option<ExecuteTransactionResponse>> {
-    if !client.can_execute() {
-        print_warning("Transaction execution requires keypair configuration (--keypair).");
+    use crate::sui_tx_executor::TxMode;
+
+    // Only the execute path needs a keypair; serialize/dry-run build with just
+    // the sender address.
+    if tx_opts.mode() == TxMode::Execute && !client.can_execute() {
+        print_warning(
+            "Transaction execution requires a keypair (--keypair). Use \
+             --serialize-unsigned-transaction to emit an unsigned transaction, or --dry-run.",
+        );
         return Ok(None);
     }
 
-    if tx_opts.dry_run {
-        print_info("Simulating transaction (dry-run)...");
-        let result = client.simulate(tx).await?;
-        print_simulation_result(&result);
-        return Ok(None);
+    match tx_opts.mode() {
+        TxMode::SerializeUnsigned => print_info("Building unsigned transaction..."),
+        TxMode::DryRun => print_info("Simulating transaction (dry-run)..."),
+        TxMode::Execute => print_info("Executing transaction..."),
     }
 
-    print_info("Executing transaction...");
-    let response = client.execute(tx).await?;
-    let digest = response.transaction().digest();
-    println!(
-        "\n{} Transaction submitted: {}",
-        "✓".green(),
-        digest.to_string().cyan()
-    );
-    Ok(Some(response))
+    let outcome = client.finalize_tx(tx, tx_opts).await?;
+    Ok(crate::cli::print_tx_outcome(outcome).map(|response| *response))
 }
 
 /// Print the newly-created proposal's ID after a `create_*_proposal` call,
@@ -233,12 +208,10 @@ pub async fn vote(
 
     let proposal_type_str = display::format_proposal_type(&proposal.proposal_type);
 
-    println!("\n{}", "Proposal Details:".bold());
-    println!("  Type: {}", proposal_type_str.cyan());
+    print_detail(&format!("\n{}", "Proposal Details:".bold()));
+    print_detail(&format!("  Type: {}", proposal_type_str.cyan()));
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("vote on this proposal").await?;
-    }
+    prompt_continue("vote on this proposal", tx_opts).await?;
 
     print_info("Building vote transaction...");
 
@@ -339,12 +312,10 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
 
     let proposal_type_str = display::format_proposal_type(&proposal.proposal_type);
 
-    println!("\n{}", "Proposal Details:".bold());
-    println!("  Type: {}", proposal_type_str.cyan());
+    print_detail(&format!("\n{}", "Proposal Details:".bold()));
+    print_detail(&format!("  Type: {}", proposal_type_str.cyan()));
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("remove your vote from this proposal").await?;
-    }
+    prompt_continue("remove your vote from this proposal", tx_opts).await?;
 
     print_info("Building remove_vote transaction...");
 
@@ -385,13 +356,11 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
         );
     }
 
-    println!("\n{}", "Execute Proposal:".bold());
-    println!("  Type: {}", proposal_type_str.cyan());
-    println!("  ID:   {}", proposal_id);
+    print_detail(&format!("\n{}", "Execute Proposal:".bold()));
+    print_detail(&format!("  Type: {}", proposal_type_str.cyan()));
+    print_detail(&format!("  ID:   {}", proposal_id));
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("execute this proposal").await?;
-    }
+    prompt_continue("execute this proposal", tx_opts).await?;
 
     let tx = client.build_execute_proposal_transaction(proposal_addr, proposal_type)?;
 
@@ -457,13 +426,11 @@ pub async fn create_upgrade_proposal(
         (Some(_), Some(_)) => unreachable!("clap enforces mutual exclusion"),
     };
 
-    println!("\n{}", "Creating Upgrade Proposal:".bold());
-    println!("  Digest: 0x{}", hex::encode(&digest_bytes));
+    print_detail(&format!("\n{}", "Creating Upgrade Proposal:".bold()));
+    print_detail(&format!("  Digest: 0x{}", hex::encode(&digest_bytes)));
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("create this upgrade proposal").await?;
-    }
+    prompt_continue("create this upgrade proposal", tx_opts).await?;
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::Upgrade {
         digest: digest_bytes,
@@ -487,14 +454,12 @@ pub async fn create_update_config_proposal(
     let value = parse_config_value(value_str)
         .context("Invalid value format. Use type:value, e.g. u64:1000 or bool:true")?;
 
-    println!("\n{}", "Creating Update Config Proposal:".bold());
-    println!("  Key:   {}", key);
-    println!("  Value: {}", value_str);
+    print_detail(&format!("\n{}", "Creating Update Config Proposal:".bold()));
+    print_detail(&format!("  Key:   {}", key));
+    print_detail(&format!("  Value: {}", value_str));
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("create this config update proposal").await?;
-    }
+    prompt_continue("create this config update proposal", tx_opts).await?;
 
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateConfig {
@@ -551,9 +516,7 @@ pub async fn create_update_mpc_config_proposal(
         );
     }
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("create this MPC config update proposal").await?;
-    }
+    prompt_continue("create this MPC config update proposal", tx_opts).await?;
 
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateMpcConfig {
@@ -597,13 +560,11 @@ pub async fn create_enable_version_proposal(
     metadata: Vec<(String, String)>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
-    println!("\n{}", "Creating Enable Version Proposal:".bold());
-    println!("  Version: {}", version);
+    print_detail(&format!("\n{}", "Creating Enable Version Proposal:".bold()));
+    print_detail(&format!("  Version: {}", version));
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("create this enable version proposal").await?;
-    }
+    prompt_continue("create this enable version proposal", tx_opts).await?;
 
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::EnableVersion {
@@ -624,13 +585,14 @@ pub async fn create_disable_version_proposal(
     metadata: Vec<(String, String)>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
-    println!("\n{}", "Creating Disable Version Proposal:".bold());
-    println!("  Version: {}", version);
+    print_detail(&format!(
+        "\n{}",
+        "Creating Disable Version Proposal:".bold()
+    ));
+    print_detail(&format!("  Version: {}", version));
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("create this disable version proposal").await?;
-    }
+    prompt_continue("create this disable version proposal", tx_opts).await?;
 
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::DisableVersion {
@@ -651,13 +613,11 @@ pub async fn create_abort_reconfig_proposal(
     metadata: Vec<(String, String)>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
-    println!("\n{}", "Creating Abort Reconfig Proposal:".bold());
+    print_detail(&format!("\n{}", "Creating Abort Reconfig Proposal:".bold()));
     print_info(&format!("Target epoch: {epoch}"));
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("create this abort reconfig proposal").await?;
-    }
+    prompt_continue("create this abort reconfig proposal", tx_opts).await?;
 
     let mut client = HashiClient::new(config).await?;
     let tx = client
@@ -685,14 +645,15 @@ pub async fn create_update_guardian_proposal(
         public_key.len(),
     );
 
-    println!("\n{}", "Creating Update Guardian Proposal:".bold());
-    println!("  URL:        {}", url);
-    println!("  Public Key: 0x{}", hex::encode(&public_key));
+    print_detail(&format!(
+        "\n{}",
+        "Creating Update Guardian Proposal:".bold()
+    ));
+    print_detail(&format!("  URL:        {}", url));
+    print_detail(&format!("  Public Key: 0x{}", hex::encode(&public_key)));
     print_metadata(&metadata);
 
-    if !tx_opts.skip_confirm {
-        prompt_continue("create this update guardian proposal").await?;
-    }
+    prompt_continue("create this update guardian proposal", tx_opts).await?;
 
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateGuardian {
@@ -798,12 +759,19 @@ fn print_proposal_detailed(
     println!("{}", "━".repeat(60).dimmed());
 }
 
-/// Pause for user acknowledgement. Press enter to proceed, Ctrl+C to cancel.
-async fn prompt_continue(action: &str) -> Result<()> {
+/// Pause for user acknowledgement before an actual execution. No-op when the
+/// user passed `-y/--yes`, or in dry-run / serialize-unsigned mode — those
+/// change no on-chain state, and serialize mode must keep stdout clean.
+async fn prompt_continue(action: &str, tx_opts: &TxOptions) -> Result<()> {
+    use crate::sui_tx_executor::TxMode;
     use tokio::io::AsyncBufReadExt;
     use tokio::io::BufReader;
 
-    println!(
+    if tx_opts.skip_confirm || tx_opts.mode() != TxMode::Execute {
+        return Ok(());
+    }
+
+    eprintln!(
         "\n{}",
         format!("Press enter to {action}, or Ctrl+C to cancel...").yellow()
     );

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -45,11 +45,13 @@ pub async fn run(action: WithdrawCommands, config: &CliConfig, tx_opts: &TxOptio
 
 async fn request(
     config: &CliConfig,
-    _tx_opts: &TxOptions,
+    tx_opts: &TxOptions,
     amount: u64,
     btc_address: &str,
     count: usize,
 ) -> Result<()> {
+    use crate::sui_tx_executor::TxMode;
+
     config.validate()?;
     anyhow::ensure!(count >= 1, "--count must be at least 1");
 
@@ -58,9 +60,20 @@ async fn request(
         hashi_object_id: config.hashi_object_id(),
     };
 
-    let signer = config
-        .load_keypair()?
-        .context("Keypair required for withdrawal request. Set keypair_path in config.")?;
+    // A keypair is optional: serialize/dry-run only need the sender address.
+    let signer = config.load_keypair()?;
+    if tx_opts.mode() == TxMode::Execute && signer.is_none() {
+        anyhow::bail!(
+            "Keypair required to submit a withdrawal request (set keypair_path in config), \
+             or use --serialize-unsigned-transaction to emit an unsigned transaction."
+        );
+    }
+
+    // Sender: explicit --sender (e.g. a multisig), else the keypair's address.
+    // The BTC balance is drawn from this sender during the build.
+    let sender = tx_opts
+        .sender
+        .or_else(|| signer.as_ref().map(|s| s.public_key().derive_address()));
 
     // Parse the BTC destination address and verify it matches the configured network
     let btc_network = crate::btc_monitor::config::parse_btc_network(
@@ -73,28 +86,63 @@ async fn request(
         .context("Withdrawal address does not match the configured Bitcoin network")?;
     let destination_bytes = witness_program_from_address(&btc_addr)?;
 
-    let client = sui_rpc::Client::new(&config.sui_rpc_url)?;
-    let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids);
+    let mut client = sui_rpc::Client::new(&config.sui_rpc_url)?;
 
+    // A single request supports all tx modes (execute / dry-run /
+    // serialize-unsigned) via the builder + finalize path.
     if count == 1 {
-        print_info(&format!("Withdrawal amount: {} sats", amount));
-        print_info(&format!("BTC destination: {}", btc_address));
-        print_info("Submitting withdrawal request on Sui...");
+        print_info(&format!("Withdrawal amount: {amount} sats"));
+        print_info(&format!("BTC destination: {btc_address}"));
 
-        let request_id = executor
-            .execute_create_withdrawal_request(amount, destination_bytes)
-            .await?;
+        let builder = crate::sui_tx_executor::build_create_withdrawal_request(
+            hashi_ids,
+            amount,
+            destination_bytes,
+        );
 
-        print_success(&format!("Withdrawal request created: {}", request_id));
+        match tx_opts.mode() {
+            TxMode::SerializeUnsigned => print_info("Building unsigned withdrawal request..."),
+            TxMode::DryRun => print_info("Simulating withdrawal request (dry-run)..."),
+            TxMode::Execute => print_info("Submitting withdrawal request on Sui..."),
+        }
+
+        let outcome = crate::sui_tx_executor::finalize(
+            &mut client,
+            signer.as_ref(),
+            builder,
+            sender,
+            &tx_opts.gas_overrides(),
+            tx_opts.mode(),
+            std::time::Duration::from_secs(10),
+        )
+        .await?;
+
+        if let Some(response) = crate::cli::print_tx_outcome(outcome) {
+            let request_id =
+                crate::sui_tx_executor::withdrawal_request_id_from_response(&response)?;
+            print_success(&format!("Withdrawal request created: {request_id}"));
+        }
         return Ok(());
     }
+
+    // `--count > 1` bulk-submits many requests across PTBs and only makes sense
+    // for direct execution: there is no batch builder to emit or simulate, so
+    // --serialize-unsigned-transaction / --dry-run apply to a single request.
+    anyhow::ensure!(
+        tx_opts.mode() == TxMode::Execute,
+        "--count > 1 only supports execute mode; --serialize-unsigned-transaction \
+         and --dry-run apply to a single withdrawal request"
+    );
+
+    // Execute mode guarantees a signer (rejected above otherwise).
+    let signer = signer.expect("execute mode requires a signer");
+    let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids);
 
     // ~3 PTB commands per request (split + call) vs the 1024 command cap.
     const CHUNK_SIZE: usize = 250;
 
     print_info(&format!(
-        "Submitting {} withdrawal requests of {} sats to {} ({} per PTB)...",
-        count, amount, btc_address, CHUNK_SIZE
+        "Submitting {count} withdrawal requests of {amount} sats to {btc_address} ({CHUNK_SIZE} per PTB)...",
     ));
 
     let total_chunks = count.div_ceil(CHUNK_SIZE);
@@ -105,8 +153,7 @@ async fn request(
         chunk_idx += 1;
         let this_batch = remaining.min(CHUNK_SIZE);
         print_info(&format!(
-            "Batch {}/{} ({} requests)...",
-            chunk_idx, total_chunks, this_batch
+            "Batch {chunk_idx}/{total_chunks} ({this_batch} requests)...",
         ));
         let ids = executor
             .execute_create_withdrawal_requests_batch(amount, destination_bytes.clone(), this_batch)
@@ -115,33 +162,65 @@ async fn request(
         remaining -= this_batch;
     }
 
-    print_success(&format!("Created {} withdrawal requests", submitted));
+    print_success(&format!("Created {submitted} withdrawal requests"));
 
     Ok(())
 }
 
-async fn cancel(config: &CliConfig, _tx_opts: &TxOptions, request_id: &str) -> Result<()> {
+async fn cancel(config: &CliConfig, tx_opts: &TxOptions, request_id: &str) -> Result<()> {
+    use crate::sui_tx_executor::TxMode;
+
     config.validate()?;
 
     let req_addr = request_id
         .parse::<sui_sdk_types::Address>()
         .context("Invalid request ID")?;
 
-    let signer = config
-        .load_keypair()?
-        .context("Keypair required to cancel withdrawal.")?;
-
     let hashi_ids = crate::config::HashiIds {
         package_id: config.package_id(),
         hashi_object_id: config.hashi_object_id(),
     };
 
-    let client = sui_rpc::Client::new(&config.sui_rpc_url)?;
-    let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids);
+    let signer = config.load_keypair()?;
+    if tx_opts.mode() == TxMode::Execute && signer.is_none() {
+        anyhow::bail!(
+            "Keypair required to cancel a withdrawal, or use \
+             --serialize-unsigned-transaction to emit an unsigned transaction."
+        );
+    }
 
-    print_info("Cancelling withdrawal...");
-    executor.execute_cancel_withdrawal(&req_addr).await?;
-    print_success("Withdrawal cancelled.");
+    // The refunded Balance<BTC> is sent to `sender`, which must equal the
+    // transaction sender. Required up front so the PTB can address the refund.
+    let sender = tx_opts
+        .sender
+        .or_else(|| signer.as_ref().map(|s| s.public_key().derive_address()))
+        .context(
+            "No sender available: pass --sender (the refund recipient) or configure a keypair",
+        )?;
+
+    let builder = crate::sui_tx_executor::build_cancel_withdrawal(hashi_ids, &req_addr, sender);
+
+    match tx_opts.mode() {
+        TxMode::SerializeUnsigned => print_info("Building unsigned withdrawal cancellation..."),
+        TxMode::DryRun => print_info("Simulating withdrawal cancellation (dry-run)..."),
+        TxMode::Execute => print_info("Cancelling withdrawal..."),
+    }
+
+    let mut client = sui_rpc::Client::new(&config.sui_rpc_url)?;
+    let outcome = crate::sui_tx_executor::finalize(
+        &mut client,
+        signer.as_ref(),
+        builder,
+        Some(sender),
+        &tx_opts.gas_overrides(),
+        tx_opts.mode(),
+        std::time::Duration::from_secs(10),
+    )
+    .await?;
+
+    if crate::cli::print_tx_outcome(outcome).is_some() {
+        print_success("Withdrawal cancelled.");
+    }
 
     Ok(())
 }

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -90,6 +90,30 @@ pub struct CliGlobalOpts {
     /// Simulate the transaction without executing (dry-run)
     #[clap(long)]
     pub dry_run: bool,
+
+    /// Build the transaction and print it as base64 (BCS `TransactionData`)
+    /// instead of signing/executing. The unsigned transaction is the only thing
+    /// written to stdout, ready for `sui keytool sign` + `sui client
+    /// execute-signed-tx` (e.g. multisig). No keypair required; pair with
+    /// --sender to set the signing address.
+    #[clap(long, conflicts_with = "dry_run")]
+    pub serialize_unsigned_transaction: bool,
+
+    /// Sender address to build the transaction for (e.g. a multisig address).
+    /// Defaults to the configured keypair's address; required when serializing
+    /// or dry-running without a keypair.
+    #[clap(long)]
+    pub sender: Option<String>,
+
+    /// Pin the gas coin (object id) used to pay for the transaction. Only the
+    /// id is needed. Defaults to fullnode gas selection, or `gas_coin` from the
+    /// config file.
+    #[clap(long)]
+    pub gas: Option<String>,
+
+    /// Gas price override in MIST per unit. Defaults to the reference gas price.
+    #[clap(long)]
+    pub gas_price: Option<u64>,
 }
 
 #[derive(Subcommand)]
@@ -469,9 +493,41 @@ pub struct TxOptions {
     pub skip_confirm: bool,
     /// If true, simulate the transaction without executing
     pub dry_run: bool,
+    /// If true, build and print the unsigned transaction as base64 instead of
+    /// signing/executing it.
+    pub serialize_unsigned: bool,
+    /// Explicit sender address (e.g. a multisig). `None` => derive from the
+    /// configured keypair.
+    pub sender: Option<sui_sdk_types::Address>,
+    /// Pin a specific gas coin object id (`None` => fullnode gas selection).
+    pub gas_object: Option<sui_sdk_types::Address>,
+    /// Gas price override in MIST/unit (`None` => reference price).
+    pub gas_price: Option<u64>,
 }
 
 impl TxOptions {
+    /// The finalization mode implied by the flags. `--serialize-unsigned-transaction`
+    /// wins over `--dry-run` (they are also mutually exclusive at the clap layer).
+    pub fn mode(&self) -> crate::sui_tx_executor::TxMode {
+        use crate::sui_tx_executor::TxMode;
+        if self.serialize_unsigned {
+            TxMode::SerializeUnsigned
+        } else if self.dry_run {
+            TxMode::DryRun
+        } else {
+            TxMode::Execute
+        }
+    }
+
+    /// The manual gas overrides implied by the flags.
+    pub fn gas_overrides(&self) -> crate::sui_tx_executor::GasOverrides {
+        crate::sui_tx_executor::GasOverrides {
+            gas_object: self.gas_object,
+            gas_budget: self.gas_budget,
+            gas_price: self.gas_price,
+        }
+    }
+
     /// Get gas budget, using the provided estimate if not explicitly set
     pub fn gas_budget_or(&self, estimate: u64) -> u64 {
         self.gas_budget.unwrap_or(estimate)
@@ -483,6 +539,65 @@ impl TxOptions {
             // Add 20% safety margin to estimates
             estimate.saturating_mul(120).saturating_div(100)
         })
+    }
+}
+
+#[cfg(test)]
+mod tx_options_tests {
+    use super::TxOptions;
+    use crate::sui_tx_executor::TxMode;
+
+    fn base() -> TxOptions {
+        TxOptions {
+            gas_budget: None,
+            skip_confirm: false,
+            dry_run: false,
+            serialize_unsigned: false,
+            sender: None,
+            gas_object: None,
+            gas_price: None,
+        }
+    }
+
+    #[test]
+    fn mode_defaults_to_execute() {
+        assert_eq!(base().mode(), TxMode::Execute);
+    }
+
+    #[test]
+    fn dry_run_maps_to_dry_run() {
+        let opts = TxOptions {
+            dry_run: true,
+            ..base()
+        };
+        assert_eq!(opts.mode(), TxMode::DryRun);
+    }
+
+    #[test]
+    fn serialize_unsigned_wins_over_dry_run() {
+        // The flags are mutually exclusive at the clap layer, but if both were
+        // set, serialize-unsigned must take precedence (we never execute).
+        let opts = TxOptions {
+            serialize_unsigned: true,
+            dry_run: true,
+            ..base()
+        };
+        assert_eq!(opts.mode(), TxMode::SerializeUnsigned);
+    }
+
+    #[test]
+    fn gas_overrides_pass_through() {
+        let gas = sui_sdk_types::Address::from_static("0x2");
+        let opts = TxOptions {
+            gas_object: Some(gas),
+            gas_budget: Some(123),
+            gas_price: Some(7),
+            ..base()
+        };
+        let overrides = opts.gas_overrides();
+        assert_eq!(overrides.gas_object, Some(gas));
+        assert_eq!(overrides.gas_budget, Some(123));
+        assert_eq!(overrides.gas_price, Some(7));
     }
 }
 
@@ -578,10 +693,12 @@ pub struct RegisterOpts {
     #[clap(long)]
     pub operator_address: Option<String>,
 
-    /// Print the unsigned transaction as base64 instead of executing it.
-    /// Useful for signing with a hardware wallet. No private key is required.
-    #[clap(long)]
-    pub print_only: bool,
+    /// Build the transaction and print it as base64 (BCS `TransactionData`)
+    /// instead of executing it — for offline / multisig signing via
+    /// `sui keytool sign`. No private key required. (`--print-only` is a
+    /// deprecated alias.)
+    #[clap(long = "serialize-unsigned-transaction", alias = "print-only")]
+    pub serialize_unsigned: bool,
 
     /// Enable verbose output
     #[clap(long, short)]
@@ -641,11 +758,33 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
         btc_overrides,
     )?;
 
+    let sender = opts
+        .sender
+        .as_deref()
+        .map(str::parse::<sui_sdk_types::Address>)
+        .transpose()
+        .context("Invalid --sender address")?;
+    let gas_object = opts
+        .gas
+        .as_deref()
+        .map(str::parse::<sui_sdk_types::Address>)
+        .transpose()
+        .context("Invalid --gas object id")?
+        .or(config.gas_coin);
+
     let tx_opts = TxOptions {
         gas_budget: opts.gas_budget,
         skip_confirm: opts.yes,
         dry_run: opts.dry_run,
+        serialize_unsigned: opts.serialize_unsigned_transaction,
+        sender,
+        gas_object,
+        gas_price: opts.gas_price,
     };
+
+    // In serialize-unsigned mode, keep stdout clean (base64 only) by sending
+    // all human-readable notes to stderr.
+    set_notes_to_stderr(tx_opts.serialize_unsigned);
 
     match command {
         CliCommand::Proposal { action } => match action {
@@ -883,19 +1022,102 @@ fn init_tracing(verbose: bool) {
         .init();
 }
 
+/// When set, human-readable notes/summaries are written to stderr instead of
+/// stdout. This is enabled in `--serialize-unsigned-transaction` mode so that
+/// stdout carries only the base64 unsigned transaction (safe to pipe into
+/// `sui keytool sign`).
+static NOTES_TO_STDERR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Route human-readable notes/summaries to stderr (keeping stdout clean for
+/// machine-readable output). Call once when entering a serialize-unsigned flow.
+pub fn set_notes_to_stderr(enabled: bool) {
+    NOTES_TO_STDERR.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn notes_to_stderr() -> bool {
+    NOTES_TO_STDERR.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Print a human-readable note/summary line. Goes to stderr in serialize mode
+/// (so stdout stays clean for the base64 transaction), stdout otherwise.
+pub fn print_detail(msg: &str) {
+    if notes_to_stderr() {
+        eprintln!("{msg}");
+    } else {
+        println!("{msg}");
+    }
+}
+
 /// Print a success message
 pub fn print_success(msg: &str) {
-    println!("{} {}", "✓".green().bold(), msg);
+    print_detail(&format!("{} {}", "✓".green().bold(), msg));
 }
 
 /// Print an info message
 pub fn print_info(msg: &str) {
-    println!("{} {}", "ℹ".blue().bold(), msg);
+    print_detail(&format!("{} {}", "ℹ".blue().bold(), msg));
 }
 
 /// Print a warning message
 pub fn print_warning(msg: &str) {
-    println!("{} {}", "⚠".yellow().bold(), msg);
+    print_detail(&format!("{} {}", "⚠".yellow().bold(), msg));
+}
+
+/// Render the result of a finalized transaction and return the execution
+/// response when one was produced (execute mode only). The serialized unsigned
+/// transaction is the only thing written to stdout; everything else is a note.
+pub fn print_tx_outcome(
+    outcome: crate::sui_tx_executor::TxOutcome,
+) -> Option<Box<sui_rpc::proto::sui::rpc::v2::ExecuteTransactionResponse>> {
+    use crate::sui_tx_executor::TxOutcome;
+    match outcome {
+        TxOutcome::Serialized(tx_base64) => {
+            println!("{tx_base64}");
+            None
+        }
+        TxOutcome::Simulated {
+            sender,
+            gas_budget,
+            gas_price,
+        } => {
+            print_detail(&format!("\n{}", "🔍 Dry-run Results:".bold()));
+            print_detail(&format!(
+                "  {} {}",
+                "Sender:".dimmed(),
+                sender.to_hex().cyan()
+            ));
+            print_detail(&format!(
+                "  {} {} MIST",
+                "Gas Budget:".dimmed(),
+                gas_budget.to_string().cyan()
+            ));
+            print_detail(&format!(
+                "  {} {} MIST/unit",
+                "Gas Price:".dimmed(),
+                gas_price.to_string().cyan()
+            ));
+            let max_cost_sui = (gas_budget as f64) / 1_000_000_000.0;
+            print_detail(&format!(
+                "  {} {:.6} SUI",
+                "Max Cost:".dimmed(),
+                format!("{max_cost_sui:.6}").yellow()
+            ));
+            print_detail(&format!(
+                "\n  {} Transaction simulated successfully (not executed).",
+                "✓".green()
+            ));
+            None
+        }
+        TxOutcome::Executed(response) => {
+            let digest = response.transaction().digest();
+            print_detail(&format!(
+                "\n{} Transaction submitted: {}",
+                "✓".green(),
+                digest.to_string().cyan()
+            ));
+            Some(response)
+        }
+    }
 }
 
 /// Print an in-progress status line (no newline) that can be overwritten.
@@ -1016,6 +1238,9 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
 
     init_tracing(opts.verbose);
 
+    // In serialize mode keep stdout clean (base64 only); notes go to stderr.
+    set_notes_to_stderr(opts.serialize_unsigned);
+
     // Load the validator config
     let config = crate::config::Config::load(&opts.config)?;
 
@@ -1037,7 +1262,7 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
     print_info(&format!("Validator address: {validator_address}"));
     print_info(&format!("Sui RPC: {sui_rpc_url}"));
 
-    if opts.print_only {
+    if opts.serialize_unsigned {
         // Build the transaction and print as base64 without executing.
         // No private key is required for this path.
         let mut client = sui_rpc::Client::new(&sui_rpc_url)?;

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -201,6 +201,7 @@ use sui_sdk_types::StructTag;
 use sui_sdk_types::Transaction;
 use sui_sdk_types::TypeTag;
 use sui_sdk_types::bcs::FromBcs;
+use sui_sdk_types::bcs::ToBcs;
 use sui_transaction_builder::Function;
 use sui_transaction_builder::ObjectInput;
 use sui_transaction_builder::TransactionBuilder;
@@ -227,6 +228,121 @@ const MOVE_STDLIB_ADDRESS: Address = Address::from_static("0x1");
 pub const SUI_CLOCK_OBJECT_ID: Address = Address::from_static("0x6");
 const SUI_SYSTEM_STATE_OBJECT_ID: Address = Address::from_static("0x5");
 const SUI_RANDOM_OBJECT_ID: Address = Address::from_static("0x8");
+
+/// How a built transaction should be finalized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TxMode {
+    /// Sign with the local key and submit, waiting for the checkpoint.
+    Execute,
+    /// Build and dry-run only; report the gas estimate without submitting.
+    DryRun,
+    /// Build but do not sign: emit the unsigned transaction as base64-encoded
+    /// BCS `TransactionData`, ready for offline / multisig signing via
+    /// `sui keytool sign` + `sui client execute-signed-tx`.
+    SerializeUnsigned,
+}
+
+/// Optional manual overrides for the gas payment. Any field left `None` is
+/// resolved by the fullnode during the build/dry-run.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GasOverrides {
+    /// Pin a specific gas coin by object id. Only the id is needed — the online
+    /// build resolves the version/digest server-side.
+    pub gas_object: Option<Address>,
+    /// Fixed gas budget in MIST. When `None`, the dry-run computes it.
+    pub gas_budget: Option<u64>,
+    /// Fixed gas price in MIST/unit. When `None`, the reference price is used.
+    pub gas_price: Option<u64>,
+}
+
+impl GasOverrides {
+    fn apply(&self, builder: &mut TransactionBuilder) {
+        if let Some(gas_object) = self.gas_object {
+            builder.add_gas_objects([ObjectInput::new(gas_object)]);
+        }
+        if let Some(budget) = self.gas_budget {
+            builder.set_gas_budget(budget);
+        }
+        if let Some(price) = self.gas_price {
+            builder.set_gas_price(price);
+        }
+    }
+}
+
+/// The result of [`finalize`], depending on the [`TxMode`].
+pub enum TxOutcome {
+    /// `Execute`: the transaction was signed and submitted.
+    Executed(Box<ExecuteTransactionResponse>),
+    /// `DryRun`: the transaction was built and simulated but not submitted.
+    Simulated {
+        sender: Address,
+        gas_budget: u64,
+        gas_price: u64,
+    },
+    /// `SerializeUnsigned`: base64-encoded BCS `TransactionData` for external signing.
+    Serialized(String),
+}
+
+/// Set the sender and gas overrides on `builder`, then finish it according to
+/// `mode`: serialize it unsigned, dry-run it, or sign and submit it.
+///
+/// The sender is taken from `sender` if provided, otherwise derived from
+/// `signer`; if neither is available this errors. `signer` is only *required*
+/// for [`TxMode::Execute`] — the serialize and dry-run paths need only the
+/// sender address (no private key), which is what lets us produce an unsigned
+/// transaction for a multisig sender.
+pub async fn finalize(
+    client: &mut Client,
+    signer: Option<&Ed25519PrivateKey>,
+    mut builder: TransactionBuilder,
+    sender: Option<Address>,
+    gas: &GasOverrides,
+    mode: TxMode,
+    timeout: Duration,
+) -> anyhow::Result<TxOutcome> {
+    let sender = sender
+        .or_else(|| signer.map(|s| s.public_key().derive_address()))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no sender available: pass --sender <address> \
+                 (required when no keypair is configured)"
+            )
+        })?;
+    builder.set_sender(sender);
+    gas.apply(&mut builder);
+
+    match mode {
+        TxMode::SerializeUnsigned => {
+            let transaction = builder.build(client).await?;
+            Ok(TxOutcome::Serialized(transaction.to_bcs_base64()?))
+        }
+        TxMode::DryRun => {
+            let transaction = builder.build(client).await?;
+            Ok(TxOutcome::Simulated {
+                sender,
+                gas_budget: transaction.gas_payment.budget,
+                gas_price: transaction.gas_payment.price,
+            })
+        }
+        TxMode::Execute => {
+            let signer = signer.ok_or_else(|| {
+                anyhow::anyhow!("cannot execute transaction: no keypair configured")
+            })?;
+            let transaction = builder.build(client).await?;
+            let signature = signer.sign_transaction(&transaction)?;
+            let response = client
+                .execute_transaction_and_wait_for_checkpoint(
+                    ExecuteTransactionRequest::new(transaction.into())
+                        .with_signatures(vec![signature.into()])
+                        .with_read_mask(FieldMask::from_str("*")),
+                    timeout,
+                )
+                .await?
+                .into_inner();
+            Ok(TxOutcome::Executed(Box::new(response)))
+        }
+    }
+}
 
 /// A reusable executor for submitting Sui transactions.
 ///
@@ -288,6 +404,12 @@ impl SuiTxExecutor {
         self.signer.public_key().derive_address()
     }
 
+    /// Borrow the signer (e.g. so a shared finalizer can sign on this
+    /// executor's behalf).
+    pub fn signer(&self) -> &Ed25519PrivateKey {
+        &self.signer
+    }
+
     // ========================================================================
     // Generic execution methods
     // ========================================================================
@@ -306,32 +428,29 @@ impl SuiTxExecutor {
     )]
     pub async fn execute(
         &mut self,
-        mut builder: TransactionBuilder,
+        builder: TransactionBuilder,
     ) -> anyhow::Result<ExecuteTransactionResponse> {
-        let sender = self.signer.public_key().derive_address();
+        let outcome = finalize(
+            &mut self.client,
+            Some(&self.signer),
+            builder,
+            None,
+            &GasOverrides::default(),
+            TxMode::Execute,
+            self.timeout,
+        )
+        .await?;
 
-        builder.set_sender(sender);
-
-        let transaction = builder.build(&mut self.client).await?;
-        let signature = self.signer.sign_transaction(&transaction)?;
-
-        let response = self
-            .client
-            .execute_transaction_and_wait_for_checkpoint(
-                ExecuteTransactionRequest::new(transaction.into())
-                    .with_signatures(vec![signature.into()])
-                    .with_read_mask(FieldMask::from_str("*")),
-                self.timeout,
-            )
-            .await?
-            .into_inner();
+        let TxOutcome::Executed(response) = outcome else {
+            unreachable!("TxMode::Execute always yields TxOutcome::Executed");
+        };
 
         tracing::Span::current().record(
             "sui_digest",
             tracing::field::display(response.transaction().digest()),
         );
 
-        Ok(response)
+        Ok(*response)
     }
 
     // ========================================================================
@@ -503,54 +622,8 @@ impl SuiTxExecutor {
         amount_sats: u64,
         derivation_path: Option<Address>,
     ) -> anyhow::Result<Address> {
-        let mut builder = TransactionBuilder::new();
-
-        let hashi_arg = builder.object(
-            ObjectInput::new(self.hashi_ids.hashi_object_id)
-                .as_shared()
-                .with_mutable(true),
-        );
-        let clock_arg = builder.object(
-            ObjectInput::new(SUI_CLOCK_OBJECT_ID)
-                .as_shared()
-                .with_mutable(false),
-        );
-
-        // Pure inputs
-        let txid_arg = builder.pure(&txid);
-        let vout_arg = builder.pure(&vout);
-        let amount_arg = builder.pure(&amount_sats);
-        let derivation_path_arg = builder.pure(&derivation_path);
-
-        // 1. Create UtxoId: utxo::utxo_id(txid, vout)
-        let utxo_id_arg = builder.move_call(
-            Function::new(
-                self.hashi_ids.package_id,
-                Identifier::from_static("utxo"),
-                Identifier::from_static("utxo_id"),
-            ),
-            vec![txid_arg, vout_arg],
-        );
-
-        // 2. Create Utxo: utxo::utxo(utxo_id, amount, derivation_path)
-        let utxo_arg = builder.move_call(
-            Function::new(
-                self.hashi_ids.package_id,
-                Identifier::from_static("utxo"),
-                Identifier::from_static("utxo"),
-            ),
-            vec![utxo_id_arg, amount_arg, derivation_path_arg],
-        );
-
-        // 3. Call deposit(hashi, utxo, clock)
-        builder.move_call(
-            Function::new(
-                self.hashi_ids.package_id,
-                Identifier::from_static("deposit"),
-                Identifier::from_static("deposit"),
-            ),
-            vec![hashi_arg, utxo_arg, clock_arg],
-        );
+        let builder =
+            build_create_deposit_request(self.hashi_ids, txid, vout, amount_sats, derivation_path);
 
         let response = self.execute(builder).await?;
 
@@ -561,18 +634,7 @@ impl SuiTxExecutor {
             );
         }
 
-        // Parse events to extract the deposit request ID
-        let events = response.transaction().events();
-        for event in events.events() {
-            let event_type = event.contents().name();
-
-            if event_type.contains("DepositRequestedEvent") {
-                let event_data = DepositRequestedEvent::from_bcs(event.contents().value())?;
-                return Ok(event_data.request_id);
-            }
-        }
-
-        anyhow::bail!("DepositRequestedEvent not found in transaction events")
+        deposit_request_id_from_response(&response)
     }
 
     /// Execute a batch deposit request transaction.
@@ -788,40 +850,10 @@ impl SuiTxExecutor {
         withdrawal_amount_sats: u64,
         destination_bytes: Vec<u8>,
     ) -> anyhow::Result<Address> {
-        let mut builder = TransactionBuilder::new();
-
-        // Shared objects
-        let hashi_arg = builder.object(
-            ObjectInput::new(self.hashi_ids.hashi_object_id)
-                .as_shared()
-                .with_mutable(true),
-        );
-        let clock_arg = builder.object(
-            ObjectInput::new(SUI_CLOCK_OBJECT_ID)
-                .as_shared()
-                .with_mutable(false),
-        );
-
-        // BTC balance via Balance intent.
-        let btc_type = StructTag::new(
-            self.hashi_ids.package_id,
-            Identifier::from_static("btc"),
-            Identifier::from_static("BTC"),
-            vec![],
-        );
-        let btc_arg = builder.intent(BalanceIntent::new(btc_type, withdrawal_amount_sats));
-
-        // Pure inputs
-        let destination_arg = builder.pure(&destination_bytes);
-
-        // Call withdraw::request_withdrawal(hashi, clock, btc, bitcoin_address)
-        builder.move_call(
-            Function::new(
-                self.hashi_ids.package_id,
-                Identifier::from_static("withdraw"),
-                Identifier::from_static("request_withdrawal"),
-            ),
-            vec![hashi_arg, clock_arg, btc_arg, destination_arg],
+        let builder = build_create_withdrawal_request(
+            self.hashi_ids,
+            withdrawal_amount_sats,
+            destination_bytes,
         );
 
         let response = self.execute(builder).await?;
@@ -833,19 +865,9 @@ impl SuiTxExecutor {
             );
         }
 
-        // Parse events to extract the withdrawal request ID
-        for event in response.transaction().events().events() {
-            if event.contents().name().contains("WithdrawalRequestedEvent") {
-                let event_data = WithdrawalRequestedEvent::from_bcs(event.contents().value())?;
-                tracing::Span::current().record(
-                    "request_id",
-                    tracing::field::display(&event_data.request_id),
-                );
-                return Ok(event_data.request_id);
-            }
-        }
-
-        anyhow::bail!("WithdrawalRequestedEvent not found in transaction events")
+        let request_id = withdrawal_request_id_from_response(&response)?;
+        tracing::Span::current().record("request_id", tracing::field::display(&request_id));
+        Ok(request_id)
     }
 
     /// Batched analogue of [`Self::execute_create_withdrawal_request`]: packs
@@ -1398,47 +1420,7 @@ impl SuiTxExecutor {
         &mut self,
         withdrawal_id: &Address,
     ) -> anyhow::Result<()> {
-        let mut builder = TransactionBuilder::new();
-
-        let hashi_arg = builder.object(
-            ObjectInput::new(self.hashi_ids.hashi_object_id)
-                .as_shared()
-                .with_mutable(true),
-        );
-        let request_id_arg = builder.pure(withdrawal_id);
-        let clock_arg = builder.object(
-            ObjectInput::new(SUI_CLOCK_OBJECT_ID)
-                .as_shared()
-                .with_mutable(false),
-        );
-
-        let refunded_balance = builder.move_call(
-            Function::new(
-                self.hashi_ids.package_id,
-                Identifier::from_static("withdraw"),
-                Identifier::from_static("cancel_withdrawal"),
-            ),
-            vec![hashi_arg, request_id_arg, clock_arg],
-        );
-
-        // Send the refunded Balance<BTC> back to the sender's address balance.
-        let btc_type = StructTag::new(
-            self.hashi_ids.package_id,
-            Identifier::from_static("btc"),
-            Identifier::from_static("BTC"),
-            vec![],
-        );
-        let sender = self.signer.public_key().derive_address();
-        let sender_arg = builder.pure(&sender);
-        builder.move_call(
-            Function::new(
-                Address::TWO,
-                Identifier::from_static("balance"),
-                Identifier::from_static("send_funds"),
-            )
-            .with_type_args(vec![btc_type.into()]),
-            vec![refunded_balance, sender_arg],
-        );
+        let builder = build_cancel_withdrawal(self.hashi_ids, withdrawal_id, self.sender());
 
         let response = self.execute(builder).await?;
         if !response.transaction().effects().status().success() {
@@ -1559,6 +1541,188 @@ impl SuiTxExecutor {
         }
         Ok(())
     }
+}
+
+/// Build the PTB for a single deposit request. Pure (no signer / no network),
+/// so it can be signed/executed by [`SuiTxExecutor::execute`] or serialized
+/// unsigned via [`finalize`].
+pub fn build_create_deposit_request(
+    hashi_ids: HashiIds,
+    txid: Address,
+    vout: u32,
+    amount_sats: u64,
+    derivation_path: Option<Address>,
+) -> TransactionBuilder {
+    let mut builder = TransactionBuilder::new();
+
+    let hashi_arg = builder.object(
+        ObjectInput::new(hashi_ids.hashi_object_id)
+            .as_shared()
+            .with_mutable(true),
+    );
+    let clock_arg = builder.object(
+        ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .as_shared()
+            .with_mutable(false),
+    );
+
+    let txid_arg = builder.pure(&txid);
+    let vout_arg = builder.pure(&vout);
+    let amount_arg = builder.pure(&amount_sats);
+    let derivation_path_arg = builder.pure(&derivation_path);
+
+    // utxo::utxo_id(txid, vout)
+    let utxo_id_arg = builder.move_call(
+        Function::new(
+            hashi_ids.package_id,
+            Identifier::from_static("utxo"),
+            Identifier::from_static("utxo_id"),
+        ),
+        vec![txid_arg, vout_arg],
+    );
+
+    // utxo::utxo(utxo_id, amount, derivation_path)
+    let utxo_arg = builder.move_call(
+        Function::new(
+            hashi_ids.package_id,
+            Identifier::from_static("utxo"),
+            Identifier::from_static("utxo"),
+        ),
+        vec![utxo_id_arg, amount_arg, derivation_path_arg],
+    );
+
+    // deposit::deposit(hashi, utxo, clock)
+    builder.move_call(
+        Function::new(
+            hashi_ids.package_id,
+            Identifier::from_static("deposit"),
+            Identifier::from_static("deposit"),
+        ),
+        vec![hashi_arg, utxo_arg, clock_arg],
+    );
+
+    builder
+}
+
+/// Extract the deposit request id from a successful deposit transaction.
+pub fn deposit_request_id_from_response(
+    response: &ExecuteTransactionResponse,
+) -> anyhow::Result<Address> {
+    for event in response.transaction().events().events() {
+        if event.contents().name().contains("DepositRequestedEvent") {
+            let event_data = DepositRequestedEvent::from_bcs(event.contents().value())?;
+            return Ok(event_data.request_id);
+        }
+    }
+    anyhow::bail!("DepositRequestedEvent not found in transaction events")
+}
+
+/// Build the PTB for a withdrawal request. The `Balance<BTC>` is drawn from the
+/// transaction sender via a balance intent, resolved at build time.
+pub fn build_create_withdrawal_request(
+    hashi_ids: HashiIds,
+    withdrawal_amount_sats: u64,
+    destination_bytes: Vec<u8>,
+) -> TransactionBuilder {
+    let mut builder = TransactionBuilder::new();
+
+    let hashi_arg = builder.object(
+        ObjectInput::new(hashi_ids.hashi_object_id)
+            .as_shared()
+            .with_mutable(true),
+    );
+    let clock_arg = builder.object(
+        ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .as_shared()
+            .with_mutable(false),
+    );
+
+    let btc_type = StructTag::new(
+        hashi_ids.package_id,
+        Identifier::from_static("btc"),
+        Identifier::from_static("BTC"),
+        vec![],
+    );
+    let btc_arg = builder.intent(BalanceIntent::new(btc_type, withdrawal_amount_sats));
+
+    let destination_arg = builder.pure(&destination_bytes);
+
+    // withdraw::request_withdrawal(hashi, clock, btc, bitcoin_address)
+    builder.move_call(
+        Function::new(
+            hashi_ids.package_id,
+            Identifier::from_static("withdraw"),
+            Identifier::from_static("request_withdrawal"),
+        ),
+        vec![hashi_arg, clock_arg, btc_arg, destination_arg],
+    );
+
+    builder
+}
+
+/// Extract the withdrawal request id from a successful withdrawal transaction.
+pub fn withdrawal_request_id_from_response(
+    response: &ExecuteTransactionResponse,
+) -> anyhow::Result<Address> {
+    for event in response.transaction().events().events() {
+        if event.contents().name().contains("WithdrawalRequestedEvent") {
+            let event_data = WithdrawalRequestedEvent::from_bcs(event.contents().value())?;
+            return Ok(event_data.request_id);
+        }
+    }
+    anyhow::bail!("WithdrawalRequestedEvent not found in transaction events")
+}
+
+/// Build the PTB for cancelling a withdrawal. The refunded `Balance<BTC>` is
+/// sent to `sender`'s address balance, so `sender` must be the same address the
+/// transaction is finalized for.
+pub fn build_cancel_withdrawal(
+    hashi_ids: HashiIds,
+    withdrawal_id: &Address,
+    sender: Address,
+) -> TransactionBuilder {
+    let mut builder = TransactionBuilder::new();
+
+    let hashi_arg = builder.object(
+        ObjectInput::new(hashi_ids.hashi_object_id)
+            .as_shared()
+            .with_mutable(true),
+    );
+    let request_id_arg = builder.pure(withdrawal_id);
+    let clock_arg = builder.object(
+        ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .as_shared()
+            .with_mutable(false),
+    );
+
+    let refunded_balance = builder.move_call(
+        Function::new(
+            hashi_ids.package_id,
+            Identifier::from_static("withdraw"),
+            Identifier::from_static("cancel_withdrawal"),
+        ),
+        vec![hashi_arg, request_id_arg, clock_arg],
+    );
+
+    // Send the refunded Balance<BTC> back to the sender's address balance.
+    let btc_type = StructTag::new(
+        hashi_ids.package_id,
+        Identifier::from_static("btc"),
+        Identifier::from_static("BTC"),
+        vec![],
+    );
+    let sender_arg = builder.pure(&sender);
+    builder.move_call(
+        Function::new(
+            Address::TWO,
+            Identifier::from_static("balance"),
+            Identifier::from_static("send_funds"),
+        )
+        .with_type_args(vec![btc_type.into()]),
+        vec![refunded_balance, sender_arg],
+    );
+
+    builder
 }
 
 /// Build a transaction to register and/or update validator metadata.


### PR DESCRIPTION
Generalizes unsigned-transaction generation (previously only on `register --print-only`) into a uniform mode for every transaction-producing command, matching the Sui CLI so the output plugs directly into `sui keytool sign` + `sui client execute-signed-tx` (e.g. multisig).

- New global flags: `--serialize-unsigned-transaction`, `--sender`, `--gas`, `--gas-price` (and `--gas-budget` is now actually wired into the builder).
- Single shared `finalize()` in `sui_tx_executor`: build per mode (serialize-unsigned / dry-run / sign+submit); sender resolved from `--sender` or the keypair; serialize/dry-run need no keypair. The validator executor's `execute()` delegates to it.
- Governance (proposal vote/create/execute), deposit, withdraw, and register all route through it. Deposit/withdraw executor methods are split into pure `build_*` helpers + `execute_*` wrappers, so the e2e API is unchanged.
- `register --print-only` kept as a deprecated alias of `--serialize-unsigned-transaction`.
- In serialize mode, diagnostics go to stderr so stdout carries only the base64 transaction (safe to pipe).
- Batched `deposit request` rejects serialize/dry-run (it spans multiple txs); use `deposit request-single`.

Interop: `to_bcs_base64()` emits the bare BCS `TransactionData` (no intent prefix, standard base64) — byte-identical to what `sui client --serialize-unsigned-transaction` emits, so the external signer applies the intent.
