### PR TITLE
[limiter] reconcile the local mirror's silent token drift

### DIFF
--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -129,6 +129,18 @@ impl LocalLimiter {
     pub fn reconcile_to(&self, state: LimiterState) {
         *self.state.write().unwrap() = state;
     }
+
+    /// Snap to the guardian's `state`, but only at a matching `next_seq` so a
+    /// racing `apply_consume` is never clobbered. Returns whether it reconciled.
+    pub fn reconcile_token_drift(&self, state: LimiterState) -> bool {
+        let mut guard = self.state.write().unwrap();
+        if guard.next_seq == state.next_seq && *guard != state {
+            *guard = state;
+            true
+        } else {
+            false
+        }
+    }
 }
 
 fn project_capacity(config: &LimiterConfig, state: &LimiterState, timestamp_secs: u64) -> u64 {
@@ -380,5 +392,27 @@ mod tests {
             assert!(!tracker.observe(30, 28));
         }
         assert!(tracker.observe(30, 28));
+    }
+
+    #[test]
+    fn reconcile_token_drift_only_at_matching_seq() {
+        let guardian = LimiterState {
+            num_tokens_available: 925_600,
+            last_updated_at: 838,
+            next_seq: 7,
+        };
+        // Same seq, diverged bucket → snaps.
+        let drifted = make_limiter(231_160, 839, 7);
+        assert!(drifted.reconcile_token_drift(guardian));
+        assert_eq!(drifted.snapshot(), guardian);
+        // Already in sync → no-op.
+        assert!(!drifted.reconcile_token_drift(guardian));
+        // Mirror raced ahead by seq → never clobbered.
+        let ahead = make_limiter(0, 900, 8);
+        assert!(!ahead.reconcile_token_drift(guardian));
+        assert_eq!(ahead.snapshot().next_seq, 8);
+        // Behind by seq (in-flight lag) → left to the stall/eager paths.
+        let behind = make_limiter(0, 900, 6);
+        assert!(!behind.reconcile_token_drift(guardian));
     }
 }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -901,6 +901,15 @@ impl Hashi {
         state: hashi_types::guardian::LimiterState,
     ) {
         limiter.reconcile_to(state);
+        self.record_limiter_reconcile(limiter, state);
+    }
+
+    /// Bump the reconcile counter and refresh the exported limiter gauges.
+    fn record_limiter_reconcile(
+        &self,
+        limiter: &guardian_limiter::LocalLimiter,
+        state: hashi_types::guardian::LimiterState,
+    ) {
         self.metrics.guardian_limiter_reconciled_total.inc();
         self.metrics.record_limiter_state(&state, limiter.config());
     }
@@ -922,6 +931,14 @@ impl Hashi {
                 "Local guardian limiter stalled away from the guardian; reconciled to authoritative state",
             );
             self.apply_limiter_reconcile(&limiter, state);
+        } else if limiter.reconcile_token_drift(state) {
+            // Equal seq, drifted bucket: the mirror debits at sign-time, the
+            // guardian at finalize-time — invisible to the seq-only tracker above.
+            self.record_limiter_reconcile(&limiter, state);
+            tracing::debug!(
+                seq = state.next_seq,
+                "Local guardian limiter token-drifted from the guardian; reconciled",
+            );
         }
     }
 


### PR DESCRIPTION
As of now, we are reconciling the local limiter with the guardian, in case their `next_seq` is off. 
We are now making the check more exhaustive and also reconciling if the available limits are off.