### PR TITLE
[leader] reload the deposit worklist when the time-delay timer fires

### DIFF
--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -154,6 +154,8 @@ impl LeaderService {
         self.delayed_deposit_processing_task = None;
         Self::log_task_result("delayed_deposit_processing", result);
 
+        self.reload_pending_deposit_requests();
+
         if self.is_current_leader(checkpoint_height) {
             debug!("Processing deposit requests after Bitcoin deposit time-delay");
             self.process_deposit_requests();


### PR DESCRIPTION
Follow-up to #630. The delayed pass re-runs `process_deposit_requests` without reloading the worklist, but a successful Approve drops the deposit from it — so a deposit approved between sparse Bitcoin blocks is gone when the timer fires, and its Confirm stalls until the next block. Reload before processing (for all nodes, like the block arm), restoring the reload from the closed #535.