### PR TITLE
[limiter] clear guardian_limiter_drifted on reconcile

### DIFF
--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -901,6 +901,8 @@ impl Hashi {
         state: hashi_types::guardian::LimiterState,
     ) {
         limiter.reconcile_to(state);
+        // Back in lockstep with the guardian; clear the sticky drift flag.
+        self.metrics.guardian_limiter_drifted.set(0);
         self.record_limiter_reconcile(limiter, state);
     }
 


### PR DESCRIPTION
`guardian_limiter_drifted` used to be a sticky metric, but since we now have a reconcile loop, we can use it to show the current state.