### PR TITLE
[guardian] provisioner: derive from the on-chain MPC G, not the guardian key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,6 +2991,7 @@ name = "hashi-monitor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs",
  "bitcoin",
  "clap",
  "corepc-client",

--- a/crates/hashi-monitor/Cargo.toml
+++ b/crates/hashi-monitor/Cargo.toml
@@ -12,6 +12,7 @@ clap.workspace = true
 hashi-types = { path = "../hashi-types" }
 # guardian imported for s3 logger
 hashi-guardian = { path = "../hashi-guardian" }
+bcs.workspace = true
 hex.workspace = true
 hpke.workspace = true
 k256.workspace = true

--- a/crates/hashi-monitor/src/provisioner/config.rs
+++ b/crates/hashi-monitor/src/provisioner/config.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
-use hashi_types::guardian::BitcoinPubkey;
 use hashi_types::guardian::GuardianInfo;
+use hashi_types::guardian::HashiMasterG;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::S3BucketInfo;
 use hashi_types::guardian::S3Config;
@@ -77,8 +77,9 @@ pub struct ProvisionerConfig {
     pub hashi_committee: CommitteeRepr,
     // Limiter config
     pub limiter_config: LimiterConfig,
-    // Hashi BTC pubkey
-    pub hashi_btc_master_pubkey: BitcoinPubkey,
+    /// MPC committee `G` (on-chain `CommitteeSet.mpc_public_key`) as hex of `bcs(G)`;
+    /// the derivation master (NOT the guardian's own key). Must match operator init.
+    pub hashi_btc_master_pubkey_hex: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -125,6 +126,19 @@ impl ProvisionerConfig {
             share_commitments,
         })
     }
+
+    /// The MPC committee verifying key `G`, decoded from `hashi_btc_master_pubkey_hex`.
+    pub fn mpc_master_g(&self) -> anyhow::Result<HashiMasterG> {
+        decode_master_g_hex(&self.hashi_btc_master_pubkey_hex)
+    }
+}
+
+/// Decode the MPC committee verifying key `G` from hex of its `bcs(G)` encoding
+/// (the same `bcs(G)` `Hashi::onchain_verifying_key_g` reads from chain).
+fn decode_master_g_hex(hex_str: &str) -> anyhow::Result<HashiMasterG> {
+    let bytes = hex::decode(hex_str.trim_start_matches("0x"))
+        .context("hashi_btc_master_pubkey_hex is not valid hex")?;
+    bcs::from_bytes(&bytes).context("decode MPC verifying key G from bcs(G)")
 }
 
 impl ShareCommitmentInput {
@@ -154,5 +168,19 @@ impl ShareInput {
             id: ShareID::from(id),
             value: scalar,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_master_g_hex_accepts_bcs_g_and_rejects_garbage() {
+        // hex of a real on-chain CommitteeSet.mpc_public_key (bcs(G), devnet).
+        let g_hex = "a6adc1f72da0e65df2dfb17820fe6dc26d42a84f5738a8b7cb1fa745626f818c00";
+        decode_master_g_hex(g_hex).expect("valid bcs(G) decodes");
+        assert!(decode_master_g_hex("nothex").is_err());
+        assert!(decode_master_g_hex("0011").is_err());
     }
 }

--- a/crates/hashi-monitor/src/provisioner/mod.rs
+++ b/crates/hashi-monitor/src/provisioner/mod.rs
@@ -11,7 +11,6 @@ use hashi_types::guardian::EncPubKey;
 use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::GuardianEncryptedShare;
 use hashi_types::guardian::GuardianInfo;
-use hashi_types::guardian::HashiMasterG;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::ProvisionerInitRequest;
 use hashi_types::guardian::WithdrawModeState;
@@ -61,16 +60,11 @@ pub async fn run(cfg: ProvisionerConfig) -> anyhow::Result<()> {
         }
     };
 
-    // Recompute the init state the operator should have booted the enclave with;
-    // its digest is the state_hash we bind as the share's AAD.
+    // Recompute the init state the operator booted the enclave with; its digest is
+    // the state_hash we bind as the share's AAD. `master_g` is the MPC committee `G`
+    // (see config doc), NOT the guardian's own BTC key.
+    let master_g = cfg.mpc_master_g()?;
     let committee = cfg.hashi_committee.try_into()?;
-    // Config holds the master pubkey as a 32-byte x-only key; reconstruct the
-    // even-y `G` so derivations match the BIP-340 even-y convention.
-    // TODO: extend the YAML to carry the y-parity bit (or the full 33-byte
-    // compressed pubkey) so this also handles odd-y MPC outputs.
-    let master_g =
-        HashiMasterG::with_even_y_from_x_be_bytes(&cfg.hashi_btc_master_pubkey.serialize())
-            .map_err(|e| anyhow::anyhow!("convert master pubkey to G: {e:?}"))?;
     let expected_state =
         WithdrawModeState::new(committee, cfg.limiter_config, limiter_state, master_g)
             .map_err(|e| anyhow::anyhow!(e))?;


### PR DESCRIPTION
Same bug as #637 (now merged), the other guardian-init path.

The hashi-monitor provisioner recomputes the enclave's init state to match its `state_hash`, and was building `master_g` from the guardian's own BTC key (even-y x-only) instead of the MPC committee `G` — so it disagrees with hashi exactly as #637 describes.

The provisioner has no chain access, so it now takes `G` from config: `hashi_btc_master_pubkey_hex` (hex of `bcs(G)`, = on-chain `mpc_public_key`). Not deployed today (no hashi-monitor stack), so nothing in sui-operations needs to change yet.
