### PR TITLE
[limiter] stop reconcile from clobbering the local mirror's refill

### DIFF
--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -130,16 +130,23 @@ impl LocalLimiter {
         *self.state.write().unwrap() = state;
     }
 
-    /// Snap to the guardian's `state`, but only at a matching `next_seq` so a
-    /// racing `apply_consume` is never clobbered. Returns whether it reconciled.
+    /// Snap the mirror to the guardian's `state` on genuine drift, only at a matching
+    /// `next_seq` (so a racing `apply_consume` isn't clobbered). A pure refill-timing
+    /// difference — same bucket line, different snapshot instant — isn't drift (equal
+    /// projected capacity at a common time); clobbering it would stall the refill.
     pub fn reconcile_token_drift(&self, state: LimiterState) -> bool {
         let mut guard = self.state.write().unwrap();
-        if guard.next_seq == state.next_seq && *guard != state {
-            *guard = state;
-            true
-        } else {
-            false
+        if guard.next_seq != state.next_seq {
+            return false;
         }
+        let common = guard.last_updated_at.max(state.last_updated_at);
+        if project_capacity(&self.config, &guard, common)
+            == project_capacity(&self.config, &state, common)
+        {
+            return false;
+        }
+        *guard = state;
+        true
     }
 }
 
@@ -429,8 +436,36 @@ mod tests {
         let ahead = make_limiter(0, 900, 8);
         assert!(!ahead.reconcile_token_drift(guardian));
         assert_eq!(ahead.snapshot().next_seq, 8);
-        // Behind by seq (in-flight lag) → left to the stall/eager paths.
+        // Behind by seq (in-flight lag) → left to the stall-gated tick.
         let behind = make_limiter(0, 900, 6);
         assert!(!behind.reconcile_token_drift(guardian));
+    }
+
+    #[test]
+    fn reconcile_token_drift_ignores_refill_timing_on_the_same_line() {
+        // Same refill line, snapshotted 100s apart (rate 1_000/s): not drift —
+        // clobbering it resets the refill baseline each cycle and wedges forever.
+        let guardian = LimiterState {
+            num_tokens_available: 500_000,
+            last_updated_at: 1_000,
+            next_seq: 7,
+        };
+        let mirror = make_limiter(600_000, 1_100, 7); // 500_000 + 100 * 1_000
+        assert!(!mirror.reconcile_token_drift(guardian));
+        assert_eq!(mirror.snapshot().num_tokens_available, 600_000);
+        assert_eq!(mirror.snapshot().last_updated_at, 1_100);
+    }
+
+    #[test]
+    fn reconcile_token_drift_still_snaps_genuine_divergence() {
+        // Different refill lines at the same seq = real drift → still snaps.
+        let guardian = LimiterState {
+            num_tokens_available: 925_600,
+            last_updated_at: 838,
+            next_seq: 7,
+        };
+        let mirror = make_limiter(600_000, 1_100, 7);
+        assert!(mirror.reconcile_token_drift(guardian));
+        assert_eq!(mirror.snapshot(), guardian);
     }
 }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -944,20 +944,21 @@ impl Hashi {
         }
     }
 
-    /// Forward-only reconcile triggered by a watcher rescrape (which likely
-    /// dropped an event); skips the stall detector. Guardian seq is monotonic.
-    async fn reconcile_guardian_limiter_eager(&self) {
+    /// Reconcile on a watcher rescrape. A rescrape can't tell a dropped signed event
+    /// (real drift) from an in-flight withdrawal (consumed by the guardian, event
+    /// pending), so forward-snapping `next_seq` would double-count the in-flight ones
+    /// (the snap counts them, then their `WithdrawalSignedEvent` counts them again).
+    /// So only re-align the bucket at a matching seq; seq drift is left to the stall tick.
+    async fn reconcile_guardian_limiter_on_rescrape(&self) {
         let Some((limiter, state)) = self.guardian_limiter_and_state().await else {
             return;
         };
-        let local_seq = limiter.next_seq();
-        if state.next_seq > local_seq {
-            tracing::warn!(
-                local_seq,
-                guardian_seq = state.next_seq,
-                "Local guardian limiter behind guardian after watcher rescrape; reconciled to authoritative state",
+        if limiter.reconcile_token_drift(state) {
+            self.record_limiter_reconcile(&limiter, state);
+            tracing::debug!(
+                seq = state.next_seq,
+                "Local guardian limiter bucket reconciled after watcher rescrape",
             );
-            self.apply_limiter_reconcile(&limiter, state);
         }
     }
 
@@ -984,8 +985,8 @@ impl Hashi {
             .await;
             tracing::info!("Guardian bootstrap complete");
 
-            // Safety net for the event-driven fast path: periodic tick catches
-            // slow drifts (stall-gated); rescrape notify catches them eagerly.
+            // Safety net for the event path: the periodic tick catches slow seq drift
+            // (stall-gated) + bucket drift; a rescrape notify re-aligns the bucket.
             let reconcile_notify = self.onchain_state().limiter_reconcile_notify();
             // Pinned + re-armed so a notify can't be lost to `select!` cancellation.
             let rescraped = reconcile_notify.notified();
@@ -1001,7 +1002,7 @@ impl Hashi {
                     _ = &mut rescraped => {
                         // Re-arm first so a rescrape during the reconcile isn't lost.
                         rescraped.set(reconcile_notify.notified());
-                        self.reconcile_guardian_limiter_eager().await;
+                        self.reconcile_guardian_limiter_on_rescrape().await;
                     }
                 }
             }


### PR DESCRIPTION
The local limiter mirror's reconcile could clobber a healthy mirror two ways:

- `reconcile_token_drift` snapped to the guardian snapshot even when the only difference was refill *timing* (the same bucket line read a moment apart), resetting the refill baseline every cycle so capacity never climbed — Zhou's "never refills." It now snaps only on genuine divergence (equal projected capacity at a common time isn't drift).
- The rescrape reconcile blindly forward-snapped `next_seq`, which double-counts in-flight withdrawals: the snap counts them, then their signed event counts them again (it bypasses the `apply_consume` idempotency gate). It now only re-aligns the bucket; real seq drift is left to the stall-gated tick.

The stall tracker is unchanged. One trade-off: a genuinely dropped signed event recovers on the next stall tick (~5 min) instead of an immediate snap that could double-count.
