### PR TITLE
[cli] batch withdrawal requests via --count

### DIFF
--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -23,7 +23,8 @@ pub async fn run(action: WithdrawCommands, config: &CliConfig, tx_opts: &TxOptio
         WithdrawCommands::Request {
             amount,
             btc_address,
-        } => request(config, tx_opts, amount, &btc_address).await,
+            count,
+        } => request(config, tx_opts, amount, &btc_address, count).await,
         WithdrawCommands::Cancel { request_id } => cancel(config, tx_opts, &request_id).await,
         WithdrawCommands::Status { request_id } => status(config, &request_id).await,
         WithdrawCommands::List {
@@ -45,8 +46,10 @@ async fn request(
     _tx_opts: &TxOptions,
     amount: u64,
     btc_address: &str,
+    count: usize,
 ) -> Result<()> {
     config.validate()?;
+    anyhow::ensure!(count >= 1, "--count must be at least 1");
 
     let hashi_ids = crate::config::HashiIds {
         package_id: config.package_id(),
@@ -68,19 +71,49 @@ async fn request(
         .context("Withdrawal address does not match the configured Bitcoin network")?;
     let destination_bytes = witness_program_from_address(&btc_addr)?;
 
-    print_info(&format!("Withdrawal amount: {} sats", amount));
-    print_info(&format!("BTC destination: {}", btc_address));
-
     let client = sui_rpc::Client::new(&config.sui_rpc_url)?;
     let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids);
 
-    print_info("Submitting withdrawal request on Sui...");
+    if count == 1 {
+        print_info(&format!("Withdrawal amount: {} sats", amount));
+        print_info(&format!("BTC destination: {}", btc_address));
+        print_info("Submitting withdrawal request on Sui...");
 
-    let request_id = executor
-        .execute_create_withdrawal_request(amount, destination_bytes)
-        .await?;
+        let request_id = executor
+            .execute_create_withdrawal_request(amount, destination_bytes)
+            .await?;
 
-    print_success(&format!("Withdrawal request created: {}", request_id));
+        print_success(&format!("Withdrawal request created: {}", request_id));
+        return Ok(());
+    }
+
+    // ~3 PTB commands per request (split + call) vs the 1024 command cap.
+    const CHUNK_SIZE: usize = 250;
+
+    print_info(&format!(
+        "Submitting {} withdrawal requests of {} sats to {} ({} per PTB)...",
+        count, amount, btc_address, CHUNK_SIZE
+    ));
+
+    let total_chunks = count.div_ceil(CHUNK_SIZE);
+    let mut chunk_idx = 0usize;
+    let mut submitted = 0usize;
+    let mut remaining = count;
+    while remaining > 0 {
+        chunk_idx += 1;
+        let this_batch = remaining.min(CHUNK_SIZE);
+        print_info(&format!(
+            "Batch {}/{} ({} requests)...",
+            chunk_idx, total_chunks, this_batch
+        ));
+        let ids = executor
+            .execute_create_withdrawal_requests_batch(amount, destination_bytes.clone(), this_batch)
+            .await?;
+        submitted += ids.len();
+        remaining -= this_batch;
+    }
+
+    print_success(&format!("Created {} withdrawal requests", submitted));
 
     Ok(())
 }

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -432,6 +432,10 @@ pub enum WithdrawCommands {
         /// Bitcoin address to receive the withdrawal
         #[clap(long)]
         btc_address: String,
+
+        /// Submit this many identical requests, batched into PTBs
+        #[clap(long, default_value_t = 1)]
+        count: usize,
     },
 
     /// Cancel a pending withdrawal request

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -848,6 +848,102 @@ impl SuiTxExecutor {
         anyhow::bail!("WithdrawalRequestedEvent not found in transaction events")
     }
 
+    /// Batched analogue of [`Self::execute_create_withdrawal_request`]: packs
+    /// `count` identical requests into a single PTB.
+    #[tracing::instrument(level = "info", skip_all, fields(count = count))]
+    pub async fn execute_create_withdrawal_requests_batch(
+        &mut self,
+        withdrawal_amount_sats: u64,
+        destination_bytes: Vec<u8>,
+        count: usize,
+    ) -> anyhow::Result<Vec<Address>> {
+        anyhow::ensure!(count > 0, "count must be greater than zero");
+        let total_sats = withdrawal_amount_sats as u128 * count as u128;
+        anyhow::ensure!(
+            total_sats <= u64::MAX as u128,
+            "withdrawal batch total overflows u64"
+        );
+        let total_sats = total_sats as u64;
+
+        let mut builder = TransactionBuilder::new();
+
+        let hashi_arg = builder.object(
+            ObjectInput::new(self.hashi_ids.hashi_object_id)
+                .as_shared()
+                .with_mutable(true),
+        );
+        let clock_arg = builder.object(
+            ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+                .as_shared()
+                .with_mutable(false),
+        );
+
+        let btc_type = StructTag::new(
+            self.hashi_ids.package_id,
+            Identifier::from_static("btc"),
+            Identifier::from_static("BTC"),
+            vec![],
+        );
+
+        // One balance-withdraw reservation for the whole batch (Sui caps these
+        // at 10 per tx), split into a Balance<BTC> per request.
+        let reserved = builder.intent(BalanceIntent::new(btc_type.clone(), total_sats));
+        let amount_arg = builder.pure(&withdrawal_amount_sats);
+        let destination_arg = builder.pure(&destination_bytes);
+
+        for i in 0..count {
+            // Last request takes the remainder, leaving no zero balance behind.
+            let btc_arg = if i + 1 < count {
+                builder.move_call(
+                    Function::new(
+                        Address::TWO,
+                        Identifier::from_static("balance"),
+                        Identifier::from_static("split"),
+                    )
+                    .with_type_args(vec![btc_type.clone().into()]),
+                    vec![reserved, amount_arg],
+                )
+            } else {
+                reserved
+            };
+
+            builder.move_call(
+                Function::new(
+                    self.hashi_ids.package_id,
+                    Identifier::from_static("withdraw"),
+                    Identifier::from_static("request_withdrawal"),
+                ),
+                vec![hashi_arg, clock_arg, btc_arg, destination_arg],
+            );
+        }
+
+        let response = self.execute(builder).await?;
+
+        if !response.transaction().effects().status().success() {
+            anyhow::bail!(
+                "Batch withdrawal request transaction failed: {:?}",
+                response.transaction().effects().status()
+            );
+        }
+
+        let mut request_ids = Vec::with_capacity(count);
+        for event in response.transaction().events().events() {
+            if event.contents().name().contains("WithdrawalRequestedEvent") {
+                let event_data = WithdrawalRequestedEvent::from_bcs(event.contents().value())?;
+                request_ids.push(event_data.request_id);
+            }
+        }
+
+        anyhow::ensure!(
+            request_ids.len() == count,
+            "Expected {} WithdrawalRequestedEvents but found {}",
+            count,
+            request_ids.len(),
+        );
+
+        Ok(request_ids)
+    }
+
     #[tracing::instrument(level = "info", skip_all)]
     pub async fn execute_start_reconfig(&mut self) -> anyhow::Result<()> {
         let mut builder = TransactionBuilder::new();


### PR DESCRIPTION
- No batched withdraw existed (deposits already batch via `deposit request`), so bulk withdrawals went one-tx-each.
- Add `--count N` to `withdraw request`: packs N requests into PTBs (250/PTB) via one balance-withdraw reservation split per request (Sui caps reservations at 10/tx). `--count 1` (default) unchanged.

Tested on devnet: `--count 300` → 2 PTBs, ~100/s.