### PR TITLE
[leader] cap withdrawal approvals per PTB to fit Sui's tx size limit

### DIFF
--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -12,6 +12,20 @@ use crate::constants::SUI_MAINNET_CHAIN_ID;
 
 const DEFAULT_WITHDRAWAL_SIGNING_CONCURRENCY: usize = 25;
 
+/// Default cap on the number of withdrawal requests the leader approves in a
+/// single `approve_request` PTB. A larger backlog drains over successive
+/// checkpoints, oldest first, rather than overflowing one transaction.
+const DEFAULT_WITHDRAWAL_APPROVAL_BATCH_SIZE: usize = 200;
+
+/// Hard upper bound on the per-PTB approval count.
+///
+/// Each approval contributes two PTB commands (one
+/// `committee::new_committee_signature`, one `withdraw::approve_request`) plus
+/// several pure arguments, so this keeps a batch well under Sui's
+/// 1024-command-per-PTB ceiling and far under the 4 MiB transaction message
+/// limit.
+const MAX_WITHDRAWAL_APPROVALS_PER_PTB: usize = 400;
+
 /// Load an Ed25519 private key from a file path or inline PEM string.
 ///
 /// Supported formats:
@@ -168,6 +182,15 @@ pub struct Config {
     /// Defaults to 70 (the algorithm's hard upper bound).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_max_batch_size: Option<usize>,
+
+    /// Maximum number of withdrawal requests the leader approves in a single
+    /// `approve_request` PTB. Bounds the transaction size so a large approval
+    /// backlog cannot overflow Sui's 4 MiB transaction message limit; the
+    /// remaining backlog drains over successive checkpoints, oldest first.
+    ///
+    /// Defaults to 200 and is clamped to 400 (the per-PTB hard ceiling).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub withdrawal_approval_max_batch_size: Option<usize>,
 
     /// Max number of withdrawal-tx inputs whose MPC signatures the signer
     /// will collect in parallel within a single `sign_withdrawal_transaction`
@@ -378,6 +401,12 @@ impl Config {
             .min(crate::utxo_pool::CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)
     }
 
+    pub fn withdrawal_approval_max_batch_size(&self) -> usize {
+        self.withdrawal_approval_max_batch_size
+            .unwrap_or(DEFAULT_WITHDRAWAL_APPROVAL_BATCH_SIZE)
+            .clamp(1, MAX_WITHDRAWAL_APPROVALS_PER_PTB)
+    }
+
     pub fn withdrawal_signing_concurrency(&self) -> usize {
         self.withdrawal_signing_concurrency
             .unwrap_or(DEFAULT_WITHDRAWAL_SIGNING_CONCURRENCY)
@@ -528,5 +557,35 @@ mod tests {
             config.withdrawal_max_batch_size(),
             crate::utxo_pool::CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
         );
+    }
+
+    #[test]
+    fn test_withdrawal_approval_max_batch_size_defaults() {
+        let config = Config::default();
+        assert_eq!(
+            config.withdrawal_approval_max_batch_size(),
+            DEFAULT_WITHDRAWAL_APPROVAL_BATCH_SIZE
+        );
+    }
+
+    #[test]
+    fn test_withdrawal_approval_max_batch_size_clamps_to_ceiling() {
+        let config = Config {
+            withdrawal_approval_max_batch_size: Some(30_000),
+            ..Config::default()
+        };
+        assert_eq!(
+            config.withdrawal_approval_max_batch_size(),
+            MAX_WITHDRAWAL_APPROVALS_PER_PTB
+        );
+    }
+
+    #[test]
+    fn test_withdrawal_approval_max_batch_size_clamps_to_at_least_one() {
+        let config = Config {
+            withdrawal_approval_max_batch_size: Some(0),
+            ..Config::default()
+        };
+        assert_eq!(config.withdrawal_approval_max_batch_size(), 1);
     }
 }

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -61,7 +61,7 @@ impl LeaderService {
         self.withdrawal_approval_retry_tracker
             .prune(&unapproved_ids);
 
-        let to_process: Vec<_> = unapproved
+        let mut to_process: Vec<_> = unapproved
             .into_iter()
             .filter(|r| {
                 !self
@@ -81,6 +81,24 @@ impl LeaderService {
 
         if to_process.is_empty() {
             return;
+        }
+
+        // Cap how many requests we approve this checkpoint. Each approval adds
+        // two commands and several pure arguments to the `approve_request`
+        // PTB, so approving a large backlog (tens of thousands of requests) in
+        // one transaction overflows Sui's 4 MiB transaction message limit and
+        // its 1024-command-per-PTB ceiling, and the whole batch is rejected.
+        // The excess stays queued and is approved oldest first over later
+        // checkpoints.
+        let max_batch = self.inner.config.withdrawal_approval_max_batch_size();
+        if to_process.len() > max_batch {
+            info!(
+                eligible = to_process.len(),
+                max_batch,
+                "Withdrawal approval backlog exceeds per-PTB cap; \
+                 approving the oldest {max_batch} this checkpoint"
+            );
+            to_process.truncate(max_batch);
         }
 
         let inner = self.inner.clone();


### PR DESCRIPTION
Previously the leader collected every `requested` withdrawal and packed all of them into a single `approve_request` PTB. With a large backlog (~30k requests on devnet) that transaction grew to ~11.9 MB, exceeding Sui's 4 MiB message limit, so simulation rejected it. The retry path only shrinks the batch when a request was canceled, so an oversized-PTB failure aborted with "Could not identify failed request" and the backlog never drained.

With this commit the leader caps the number of requests it approves per checkpoint. Each approval emits two PTB commands plus several pure args, so a cap keeps the transaction well under Sui's 4 MiB message limit and its 1024-command-per-PTB ceiling. The excess stays queued and is approved oldest first over later checkpoints.

The cap is the new `withdrawal_approval_max_batch_size` config option, defaulting to 200 and clamped to a hard ceiling of 400. Also add getter tests for the default and clamp behavior.