### PR TITLE
[leader] retry peer signing RPCs on transport errors; recycle peer connections

### DIFF
--- a/crates/hashi/src/grpc/mod.rs
+++ b/crates/hashi/src/grpc/mod.rs
@@ -124,6 +124,14 @@ impl HttpService {
 
         let server_handle = Arc::new(
             sui_http::Builder::new()
+                // Recycle peer connections via a graceful max-age drain: a
+                // long-lived multiplexed HTTP/2 connection accumulates state that
+                // trips a connection-level GoAway(PROTOCOL_ERROR) under sustained
+                // load, failing every in-flight request to that peer at once.
+                .config(
+                    sui_http::Config::default()
+                        .max_connection_age(std::time::Duration::from_secs(120)),
+                )
                 .tls_config(tls_config)
                 .serve(self.inner.config.listen_address(), router)
                 .unwrap(),

--- a/crates/hashi/src/leader/guardian.rs
+++ b/crates/hashi/src/leader/guardian.rs
@@ -231,24 +231,16 @@ impl LeaderService {
         let validator_address = member.validator_address();
         trace!("Requesting guardian withdrawal signature");
 
-        let mut rpc_client = inner
-            .onchain_state()
-            .bridge_service_client(&validator_address)
-            .or_else(|| {
-                error!(
-                    "Cannot find client for validator address: {:?}",
-                    validator_address
-                );
-                None
-            })?;
-
-        let response = rpc_client
-            .sign_guardian_withdrawal_request(proto_request.clone())
-            .await
-            .inspect_err(|e| {
-                error!("Failed to get guardian withdrawal signature from {validator_address}: {e}");
-            })
-            .ok()?;
+        let response = Self::call_peer_with_retry(
+            inner,
+            validator_address,
+            "guardian withdrawal signature",
+            move |mut client| {
+                let request = proto_request.clone();
+                async move { client.sign_guardian_withdrawal_request(request).await }
+            },
+        )
+        .await?;
 
         response
             .into_inner()

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use retry::RetryPolicy;
 use crate::Hashi;
 use crate::config::ForceRunAsLeader;
 use crate::deposits::DepositError;
+use crate::grpc::BoxedChannel;
 use crate::leader::retry::GlobalRetryTracker;
 use crate::leader::retry::RetryTracker;
 use crate::onchain::types::DepositRequest;
@@ -22,8 +23,10 @@ use fastcrypto::bls12381::min_pk::BLS12381Signature;
 use fastcrypto::traits::ToFromBytes;
 use futures::future::OptionFuture;
 use hashi_types::committee::MemberSignature;
+use hashi_types::proto::bridge_service_client::BridgeServiceClient;
 use std::collections::HashSet;
 use std::collections::VecDeque;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_futures::service::Service;
@@ -34,6 +37,7 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::trace;
+use tracing::warn;
 use x509_parser::nom::AsBytes;
 
 const NUM_CONSECUTIVE_LEADER_CHECKPOINTS: u64 = 100;
@@ -42,6 +46,23 @@ const LEADER_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 /// Result of a withdrawal broadcast task: `Some(spent_utxo_ids)` when the
 /// withdrawal was confirmed on Sui, `None` when it was not yet ready.
 type WithdrawalBroadcastResult = anyhow::Result<Option<Vec<crate::onchain::types::UtxoId>>>;
+
+/// Whether a failed peer RPC is worth retrying. Under sustained load a peer's
+/// HTTP/2 server tears the whole multiplexed connection down — `GoAway`
+/// (surfaced as `Internal`), broken pipe (`Unknown`), or the usual
+/// `Unavailable` — failing every in-flight request to that peer at once. The
+/// peer signing RPCs are idempotent, so retrying these transport-class codes is
+/// safe and lets the request land on a fresh connection.
+fn is_retriable_transport(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Unavailable
+            | tonic::Code::Unknown
+            | tonic::Code::Internal
+            | tonic::Code::Cancelled
+            | tonic::Code::DeadlineExceeded
+    )
+}
 
 pub(crate) struct LeaderService {
     inner: Arc<Hashi>,
@@ -97,6 +118,45 @@ impl LeaderService {
             guardian_committee_reconcile_task: None,
             last_guardian_reconcile_epoch: None,
         }
+    }
+
+    /// Invoke a peer's bridge-service signing RPC, retrying on transient
+    /// transport failures. `call` is handed a freshly-fetched client each
+    /// attempt so the retry reconnects (tonic reconnects lazily) rather than
+    /// reusing the connection the peer just tore down. Returns `None` once
+    /// attempts are exhausted or on a non-transport error.
+    async fn call_peer_with_retry<Resp, F, Fut>(
+        inner: &Arc<Hashi>,
+        validator: Address,
+        what: &str,
+        mut call: F,
+    ) -> Option<tonic::Response<Resp>>
+    where
+        F: FnMut(BridgeServiceClient<BoxedChannel>) -> Fut,
+        Fut: Future<Output = Result<tonic::Response<Resp>, tonic::Status>>,
+    {
+        const MAX_ATTEMPTS: u32 = 3;
+        for attempt in 1..=MAX_ATTEMPTS {
+            let Some(client) = inner.onchain_state().bridge_service_client(&validator) else {
+                error!("Cannot find bridge-service client for validator: {validator:?}");
+                return None;
+            };
+            match call(client).await {
+                Ok(response) => return Some(response),
+                Err(status) if attempt < MAX_ATTEMPTS && is_retriable_transport(&status) => {
+                    warn!(
+                        "Failed to get {what} from {validator} (attempt {attempt}/{MAX_ATTEMPTS}): \
+                         {status}; retrying on a fresh connection"
+                    );
+                    tokio::time::sleep(Duration::from_millis(50 * u64::from(attempt))).await;
+                }
+                Err(status) => {
+                    error!("Failed to get {what} from {validator}: {status}");
+                    return None;
+                }
+            }
+        }
+        None
     }
 
     /// Start the leader service and return a `Service` for lifecycle management.
@@ -310,4 +370,42 @@ fn parse_member_signature(
             .as_bytes(),
     )?;
     Ok(MemberSignature::new(epoch, address, signature))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_retriable_transport;
+    use tonic::Code;
+    use tonic::Status;
+
+    #[test]
+    fn classifies_transport_errors_as_retriable() {
+        // A peer tearing the connection down surfaces as these codes: GoAway ->
+        // Internal, broken pipe -> Unknown, plus the usual transient codes.
+        for code in [
+            Code::Unavailable,
+            Code::Unknown,
+            Code::Internal,
+            Code::Cancelled,
+            Code::DeadlineExceeded,
+        ] {
+            assert!(
+                is_retriable_transport(&Status::new(code, "boom")),
+                "{code:?} should be retried"
+            );
+        }
+        // Genuine application rejections from the peer must not be retried.
+        for code in [
+            Code::InvalidArgument,
+            Code::FailedPrecondition,
+            Code::PermissionDenied,
+            Code::NotFound,
+            Code::AlreadyExists,
+        ] {
+            assert!(
+                !is_retriable_transport(&Status::new(code, "nope")),
+                "{code:?} should not be retried"
+            );
+        }
+    }
 }

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -314,27 +314,16 @@ impl LeaderService {
         let validator_address = member.validator_address();
         trace!("Requesting withdrawal request approval signature");
 
-        let mut rpc_client = inner
-            .onchain_state()
-            .bridge_service_client(&validator_address)
-            .or_else(|| {
-                error!(
-                    "Cannot find client for validator address: {:?}",
-                    validator_address
-                );
-                None
-            })?;
-
-        let response = rpc_client
-            .sign_withdrawal_request_approval(proto_request.clone())
-            .await
-            .inspect_err(|e| {
-                error!(
-                    "Failed to get withdrawal request approval signature from {}: {e}",
-                    validator_address
-                );
-            })
-            .ok()?;
+        let response = Self::call_peer_with_retry(
+            inner,
+            validator_address,
+            "withdrawal request approval signature",
+            move |mut client| {
+                let request = proto_request.clone();
+                async move { client.sign_withdrawal_request_approval(request).await }
+            },
+        )
+        .await?;
 
         trace!(
             "Retrieved withdrawal request approval signature from {}",
@@ -739,27 +728,16 @@ impl LeaderService {
         let validator_address = member.validator_address();
         trace!("Requesting withdrawal tx commitment signature");
 
-        let mut rpc_client = inner
-            .onchain_state()
-            .bridge_service_client(&validator_address)
-            .or_else(|| {
-                error!(
-                    "Cannot find client for validator address: {:?}",
-                    validator_address
-                );
-                None
-            })?;
-
-        let response = rpc_client
-            .sign_withdrawal_tx_construction(proto_request.clone())
-            .await
-            .inspect_err(|e| {
-                error!(
-                    "Failed to get withdrawal approval signature from {}: {e}",
-                    validator_address
-                );
-            })
-            .ok()?;
+        let response = Self::call_peer_with_retry(
+            inner,
+            validator_address,
+            "withdrawal tx commitment signature",
+            move |mut client| {
+                let request = proto_request.clone();
+                async move { client.sign_withdrawal_tx_construction(request).await }
+            },
+        )
+        .await?;
 
         trace!(
             "Retrieved withdrawal approval signature from {}",

--- a/crates/hashi/src/leader/withdrawal_transactions.rs
+++ b/crates/hashi/src/leader/withdrawal_transactions.rs
@@ -445,27 +445,16 @@ impl LeaderService {
         let validator_address = member.validator_address();
         trace!("Requesting withdrawal tx signing signature");
 
-        let mut rpc_client = inner
-            .onchain_state()
-            .bridge_service_client(&validator_address)
-            .or_else(|| {
-                error!(
-                    "Cannot find client for validator address: {:?}",
-                    validator_address
-                );
-                None
-            })?;
-
-        let response = rpc_client
-            .sign_withdrawal_tx_signing(proto_request.clone())
-            .await
-            .inspect_err(|e| {
-                error!(
-                    "Failed to get withdrawal tx signing signature from {}: {e}",
-                    validator_address
-                );
-            })
-            .ok()?;
+        let response = Self::call_peer_with_retry(
+            inner,
+            validator_address,
+            "withdrawal tx signing signature",
+            move |mut client| {
+                let request = proto_request.clone();
+                async move { client.sign_withdrawal_tx_signing(request).await }
+            },
+        )
+        .await?;
 
         trace!(
             "Retrieved withdrawal tx signing signature from {}",
@@ -804,29 +793,19 @@ impl LeaderService {
         let validator_address = member.validator_address();
         trace!("Requesting withdrawal confirmation signature");
 
-        let mut rpc_client = inner
-            .onchain_state()
-            .bridge_service_client(&validator_address)
-            .or_else(|| {
-                error!(
-                    "Cannot find client for validator address: {:?}",
-                    validator_address
-                );
-                None
-            })?;
-
-        let response = rpc_client
-            .sign_withdrawal_confirmation(SignWithdrawalConfirmationRequest {
-                withdrawal_txn_id: withdrawal_txn_id.as_bytes().to_vec().into(),
-            })
-            .await
-            .inspect_err(|e| {
-                error!(
-                    "Failed to get withdrawal confirmation signature from {}: {e}",
-                    validator_address
-                );
-            })
-            .ok()?;
+        let proto_request = SignWithdrawalConfirmationRequest {
+            withdrawal_txn_id: withdrawal_txn_id.as_bytes().to_vec().into(),
+        };
+        let response = Self::call_peer_with_retry(
+            inner,
+            validator_address,
+            "withdrawal confirmation signature",
+            move |mut client| {
+                let request = proto_request.clone();
+                async move { client.sign_withdrawal_confirmation(request).await }
+            },
+        )
+        .await?;
 
         trace!(
             "Retrieved withdrawal confirmation signature from {}",


### PR DESCRIPTION
## Fixes

- **Retry peer signing RPCs on transport errors.** A shared `call_peer_with_retry` helper re-fetches the peer client (tonic reconnects lazily) and retries the idempotent peer signing RPCs up to 3× on transport-class status codes (`GoAway` → `Internal`, broken pipe → `Unknown`, plus `Unavailable` / `Cancelled` / `DeadlineExceeded`). A single connection teardown no longer fails the whole quorum round. Applied to the withdrawal-path peer calls: approval, tx-commitment, tx-signing, confirmation, guardian co-sign.
- **Recycle peer connections.** The sui_http peer server now sets a graceful `max_connection_age(120s)`, so a long-lived multiplexed connection can't accumulate the state that trips the `PROTOCOL_ERROR` (in-flight requests drain, new streams reconnect).

The two compose: the max-age drain bounds connection lifetime, and the retry covers the brief reconnect window.