### PR TITLE
[leader] set an explicit gas budget for the approve_request PTB

### DIFF
--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1188,6 +1188,19 @@ impl SuiTxExecutor {
             );
         }
 
+        // approve_request verifies a committee BLS cert per request, so a large
+        // batch can exceed the auto-estimated budget (the simulation fails with
+        // INSUFFICIENT_GAS). Set an explicit budget that scales with the batch;
+        // gas is a ceiling (only actual usage is charged) and this stays far
+        // below the protocol max.
+        const GAS_BUDGET_PER_REQUEST_MIST: u64 = 100_000_000; // 0.1 SUI
+        const GAS_BUDGET_BASE_MIST: u64 = 200_000_000; // 0.2 SUI
+        builder.set_gas_budget(
+            (approvals.len() as u64)
+                .saturating_mul(GAS_BUDGET_PER_REQUEST_MIST)
+                .saturating_add(GAS_BUDGET_BASE_MIST),
+        );
+
         let response = self.execute(builder).await?;
         if !response.transaction().effects().status().success() {
             anyhow::bail!(


### PR DESCRIPTION
## Problem

With a large approved-withdrawal backlog, the leader's `approve_request` PTB batches ~400 approvals into one transaction — each verifying a committee BLS certificate. At that size the node's auto-estimated gas budget is too low: the transaction simulation fails with `INSUFFICIENT_GAS` (observed at command 567 of a 400-request batch), so approvals never land and the queue stalls at the `approved` stage.

This surfaced on devnet only **after** the transport-resilience fix (#642) let the approval quorum complete — before that, the leader never got far enough to submit, so the gas shortfall was masked. Node gas balances are healthy (~30M SUI each), so this is a per-tx **budget** issue, not funding.

## Fix

Set an explicit gas budget on the approval PTB that scales with the batch (0.1 SUI/request + 0.2 SUI base), bypassing the SDK's auto-estimate. The SDK only auto-estimates when no budget is set (`TransactionBuilder::build()` runs a server-side simulate with no explicit budget); setting one makes the simulation use it. Gas is a ceiling — only actual usage is charged — and a 400-request batch's ~40 SUI budget stays far below the devnet protocol max (50,000 SUI).

## Follow-up

If the commitment / other batch PTBs hit the same wall at scale, they'll want the same treatment.

## Testing

`make clippy` clean; `cargo nextest run -p hashi` → 377 passed. Pending a devnet deploy to confirm the backlog drains.
