### PR TITLE
[Guardian] Simplify bitcoin_utils: validation chokepoint, dead code, shared sighash helper

### DIFF
--- a/crates/hashi-types/src/guardian/bitcoin_utils/mod.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/mod.rs
@@ -20,5 +20,5 @@ pub static BTC_LIB: LazyLock<Secp256k1<All>> = LazyLock::new(Secp256k1::new);
 
 /// A Hashi key-derivation path: the 32-byte Sui address of the deposit
 /// recipient. Converted to fastcrypto's raw `[u8; 32]` form only at the
-/// `derive_verifying_key` boundary (see `taproot::derive_hashi_child_pubkey`).
+/// `derive_verifying_key` boundary in `taproot`.
 pub type DerivationPath = sui_sdk_types::Address;

--- a/crates/hashi-types/src/guardian/bitcoin_utils/taproot.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/taproot.rs
@@ -9,6 +9,9 @@ use super::DerivationPath;
 use crate::guardian::BitcoinAddress;
 use crate::guardian::BitcoinPubkey;
 use crate::guardian::HashiMasterG;
+use bitcoin::hashes::Hash;
+use bitcoin::sighash::Prevouts;
+use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::ControlBlock;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::taproot::TapLeafHash;
@@ -122,6 +125,31 @@ pub fn two_of_two_taproot_script_path_spend_artifacts(
     let leaf_hash = TapLeafHash::from_script(&tap_script, LeafVersion::TapScript);
 
     (tap_script, control_block, leaf_hash)
+}
+
+/// Per-input taproot script-spend sighashes for an unsigned tx. `prevouts` and
+/// `leaf_hashes` run parallel to `tx.input`. Builds one `SighashCache` and reuses
+/// it across inputs, since the whole-tx components are input-independent.
+pub fn taproot_script_spend_sighashes(
+    tx: &Transaction,
+    prevouts: &[TxOut],
+    leaf_hashes: &[TapLeafHash],
+) -> Vec<[u8; 32]> {
+    let prevouts = Prevouts::All(prevouts);
+    let mut sighasher = SighashCache::new(tx);
+    (0..tx.input.len())
+        .map(|index| {
+            let sighash = sighasher
+                .taproot_script_spend_signature_hash(
+                    index,
+                    &prevouts,
+                    leaf_hashes[index],
+                    TapSighashType::Default,
+                )
+                .expect("taproot script-spend sighash failed");
+            *sighash.as_byte_array()
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/hashi-types/src/guardian/bitcoin_utils/taproot.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/taproot.rs
@@ -24,12 +24,6 @@ use std::str::FromStr;
 /// 1. Derive a child hashi pubkey from the derivation path
 /// 2. Create a 2-of-2 tapscript with the enclave key and derived hashi key
 /// 3. Place the tapscript as the sole leaf with a NUMS internal key
-///
-/// `hashi_master_g` is the raw MPC verifying key — the same `G` point that
-/// `fastcrypto_tbls::threshold_schnorr::key_derivation::derive_verifying_key`
-/// consumes inside MPC signing. Passing the x-only projection here would
-/// silently force an even-y parent and produce a derived child that doesn't
-/// match the MPC signature for ~half of all vks.
 pub fn compute_taproot_descriptor(
     enclave_pubkey: &BitcoinPubkey,
     hashi_master_g: &HashiMasterG,
@@ -52,10 +46,14 @@ pub fn compute_taproot_descriptor(
     }
 }
 
-/// Derive the hashi child pubkey at `derivation_path` from the raw MPC
-/// verifying key `G` point. The result is the same x-only key that the MPC
-/// signing protocol produces signatures against, so the leaf script will
-/// agree with the on-chain signed witness.
+/// Derives the hashi child pubkey at `derivation_path` from `hashi_master_g`.
+///
+/// `hashi_master_g` must be the raw MPC verifying key with y-parity preserved:
+/// `derive_verifying_key` consumes the full `G`, so the x-only/even-y projection
+/// would derive a different child for ~half of all vks and break the 2-of-2 leaf
+/// script. The returned x-only key is exactly what the MPC protocol signs
+/// against. This is the module's canonical statement of the raw-`G` requirement;
+/// other sites point here rather than restating it.
 pub fn derive_hashi_child_pubkey(
     hashi_master_g: &HashiMasterG,
     hashi_derivation_path: &DerivationPath,

--- a/crates/hashi-types/src/guardian/bitcoin_utils/taproot.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/taproot.rs
@@ -132,7 +132,7 @@ mod bitcoin_tests {
     use crate::guardian::BitcoinKeypair;
     use crate::guardian::bitcoin_utils::BTC_LIB;
     use crate::guardian::bitcoin_utils::InputUTXO;
-    use crate::guardian::bitcoin_utils::OutputUTXO;
+    use crate::guardian::bitcoin_utils::OutputUTXOWire;
     use crate::guardian::bitcoin_utils::TxUTXOs;
     use crate::guardian::bitcoin_utils::construct_tx;
     use crate::guardian::bitcoin_utils::sign_btc_tx;
@@ -284,17 +284,16 @@ mod bitcoin_tests {
             vec![input_utxo.clone()],
             vec![
                 // 100 sats sent externally; the rest (minus fee) returns as change.
-                OutputUTXO::new_external(
+                OutputUTXOWire::external(
                     dest_address.as_unchecked().clone(),
                     Amount::from_sat(100),
-                    Regtest,
-                )
-                .unwrap(),
-                OutputUTXO::new_internal(
+                ),
+                OutputUTXOWire::internal(
                     DerivationPath::ZERO,
                     input_amount - Amount::from_sat(1000),
                 ),
             ],
+            Regtest,
         )
         .unwrap();
 

--- a/crates/hashi-types/src/guardian/bitcoin_utils/taproot.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/taproot.rs
@@ -21,20 +21,27 @@ use fastcrypto_tbls::threshold_schnorr::key_derivation::derive_verifying_key;
 use miniscript::Descriptor;
 use miniscript::descriptor::Tr;
 use std::str::FromStr;
+use std::sync::LazyLock;
+
+/// Fixed nothing-up-my-sleeve (NUMS) point used as the taproot internal key. Copied from BIP-341.
+static NUMS_INTERNAL_KEY: LazyLock<BitcoinPubkey> = LazyLock::new(|| {
+    BitcoinPubkey::from_str("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0")
+        .expect("valid nums key")
+});
 
 /// Creates a taproot descriptor for the given enclave and hashi keys with a 2-of-2 multi_a script.
 /// Taproot addresses are constructed as follows:
 /// 1. Derive a child hashi pubkey from the derivation path
 /// 2. Create a 2-of-2 tapscript with the enclave key and derived hashi key
 /// 3. Place the tapscript as the sole leaf with a NUMS internal key
-pub fn compute_taproot_descriptor(
+fn compute_taproot_descriptor(
     enclave_pubkey: &BitcoinPubkey,
     hashi_master_g: &HashiMasterG,
     hashi_derivation_path: &DerivationPath,
 ) -> Tr<BitcoinPubkey> {
     let derived_hashi_pubkey = derive_hashi_child_pubkey(hashi_master_g, hashi_derivation_path);
 
-    let internal = nums_internal_key();
+    let internal = *NUMS_INTERNAL_KEY;
 
     // Taproot descriptor with one leaf: 2-of-2 checksigadd-style multisig
     // Descriptor docs: https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
@@ -54,10 +61,8 @@ pub fn compute_taproot_descriptor(
 /// `hashi_master_g` must be the raw MPC verifying key with y-parity preserved:
 /// `derive_verifying_key` consumes the full `G`, so the x-only/even-y projection
 /// would derive a different child for ~half of all vks and break the 2-of-2 leaf
-/// script. The returned x-only key is exactly what the MPC protocol signs
-/// against. This is the module's canonical statement of the raw-`G` requirement;
-/// other sites point here rather than restating it.
-pub fn derive_hashi_child_pubkey(
+/// script. The returned x-only key is exactly what the MPC protocol signs against.
+fn derive_hashi_child_pubkey(
     hashi_master_g: &HashiMasterG,
     hashi_derivation_path: &DerivationPath,
 ) -> BitcoinPubkey {
@@ -65,14 +70,8 @@ pub fn derive_hashi_child_pubkey(
     BitcoinPubkey::from_slice(&derived.to_byte_array()).expect("derived schnorr key is x-only")
 }
 
-// Use a fixed nothing-up-my-sleeve (NUMS) point as the internal key. Copied from BIP-341.
-pub fn nums_internal_key() -> BitcoinPubkey {
-    BitcoinPubkey::from_str("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0")
-        .expect("valid nums key")
-}
-
-/// Computes both the address and leaf script for a given derivation path and network.
-pub(super) fn compute_taproot_artifacts(
+/// scriptPubKey and tap leaf hash for the 2-of-2 output at `derivation_path`.
+pub(super) fn taproot_script_pubkey_and_leaf_hash(
     enclave_pubkey: &BitcoinPubkey,
     hashi_master_g: &HashiMasterG,
     hashi_derivation_path: &DerivationPath,
@@ -90,7 +89,7 @@ pub(super) fn compute_taproot_artifacts(
 }
 
 /// Deposit address for `tr(NUMS, multi_a(2, enclave, derived_hashi))`.
-pub fn two_of_two_taproot_script_path_address(
+pub fn taproot_address(
     enclave_pubkey: &BitcoinPubkey,
     hashi_master_g: &HashiMasterG,
     hashi_derivation_path: &DerivationPath,
@@ -101,7 +100,7 @@ pub fn two_of_two_taproot_script_path_address(
 }
 
 /// Spend artifacts for `tr(NUMS, multi_a(2, enclave, derived_hashi))`.
-pub fn two_of_two_taproot_script_path_spend_artifacts(
+pub fn taproot_witness_artifacts(
     enclave_pubkey: &BitcoinPubkey,
     hashi_master_g: &HashiMasterG,
     hashi_derivation_path: &DerivationPath,
@@ -224,17 +223,14 @@ mod bitcoin_tests {
         network: Network,
     ) -> (BitcoinAddress, ControlBlock, ScriptBuf) {
         let hashi_master_g = hashi_master_g_from_xonly(hashi_master_pubkey);
-        let addr = two_of_two_taproot_script_path_address(
+        let addr = taproot_address(
             enclave_pubkey,
             &hashi_master_g,
             hashi_derivation_path,
             network,
         );
-        let (tap_script, control_block, _) = two_of_two_taproot_script_path_spend_artifacts(
-            enclave_pubkey,
-            &hashi_master_g,
-            hashi_derivation_path,
-        );
+        let (tap_script, control_block, _) =
+            taproot_witness_artifacts(enclave_pubkey, &hashi_master_g, hashi_derivation_path);
         (addr, control_block, tap_script)
     }
 
@@ -392,11 +388,8 @@ mod bitcoin_tests {
         );
 
         // The production 2-of-2 leaf must embed the MPC-signed child.
-        let (leaf_script, _, _) = two_of_two_taproot_script_path_spend_artifacts(
-            &enclave_pubkey,
-            &raw_g,
-            &DerivationPath::from(path),
-        );
+        let (leaf_script, _, _) =
+            taproot_witness_artifacts(&enclave_pubkey, &raw_g, &DerivationPath::from(path));
         let script = leaf_script.as_bytes();
         assert!(
             script.windows(32).any(|w| w == mpc_child.as_slice()),
@@ -507,8 +500,7 @@ mod bitcoin_tests {
                 c.label,
             );
 
-            let addr_regtest =
-                two_of_two_taproot_script_path_address(&enclave_pk, &master_g, &c.path, Regtest);
+            let addr_regtest = taproot_address(&enclave_pk, &master_g, &c.path, Regtest);
             assert_eq!(
                 addr_regtest.to_string(),
                 c.expected_addr_regtest,
@@ -516,12 +508,7 @@ mod bitcoin_tests {
                 c.label,
             );
 
-            let addr_signet = two_of_two_taproot_script_path_address(
-                &enclave_pk,
-                &master_g,
-                &c.path,
-                Network::Signet,
-            );
+            let addr_signet = taproot_address(&enclave_pk, &master_g, &c.path, Network::Signet);
             assert_eq!(
                 addr_signet.to_string(),
                 c.expected_addr_signet,
@@ -530,7 +517,7 @@ mod bitcoin_tests {
             );
 
             let (script, _control_block, leaf_hash) =
-                two_of_two_taproot_script_path_spend_artifacts(&enclave_pk, &master_g, &c.path);
+                taproot_witness_artifacts(&enclave_pk, &master_g, &c.path);
             assert_eq!(script.as_bytes().len(), 70, "leaf script must be 70 bytes");
             assert_eq!(
                 script.as_bytes().as_hex().to_string(),
@@ -590,16 +577,14 @@ mod bitcoin_tests {
         let derived = derive_hashi_child_pubkey(&master_g, &path);
         assert_eq!(derived.serialize().as_hex().to_string(), EXPECTED_DERIVED);
 
-        let addr_regtest =
-            two_of_two_taproot_script_path_address(&enclave_pk, &master_g, &path, Regtest);
+        let addr_regtest = taproot_address(&enclave_pk, &master_g, &path, Regtest);
         assert_eq!(addr_regtest.to_string(), EXPECTED_ADDR_REGTEST);
 
-        let addr_signet =
-            two_of_two_taproot_script_path_address(&enclave_pk, &master_g, &path, Network::Signet);
+        let addr_signet = taproot_address(&enclave_pk, &master_g, &path, Network::Signet);
         assert_eq!(addr_signet.to_string(), EXPECTED_ADDR_SIGNET);
 
         let (script, _control_block, leaf_hash) =
-            two_of_two_taproot_script_path_spend_artifacts(&enclave_pk, &master_g, &path);
+            taproot_witness_artifacts(&enclave_pk, &master_g, &path);
         assert_eq!(script.as_bytes().len(), 70);
         assert_eq!(script.as_bytes().as_hex().to_string(), EXPECTED_LEAF_SCRIPT);
         assert_eq!(leaf_hash.to_string(), EXPECTED_TAP_LEAF_HASH);

--- a/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
@@ -46,9 +46,10 @@ pub struct InputUTXO {
     pub derivation_path: DerivationPath,
 }
 
-/// Output UTXOs belonging to users
+/// Output UTXO belonging to a user. Internal to `TxUTXOs`: the checked address
+/// is only ever produced by `TxUTXOs::new` after network validation.
 #[derive(Serialize, Debug, Clone, PartialEq)]
-pub struct ExternalOutputUTXO {
+struct ExternalOutputUTXO {
     /// Bitcoin address to withdraw to
     address: BitcoinAddress<NetworkChecked>,
     /// Amount in satoshis
@@ -72,11 +73,12 @@ pub struct InternalOutputUTXO {
     pub amount: Amount,
 }
 
-/// Withdrawal destination and amount.
+/// Withdrawal destination and amount. Internal to `TxUTXOs`; callers build the
+/// `OutputUTXOWire` form and let `TxUTXOs::new` validate and convert.
 /// External amounts count towards rate limits whereas internal amounts don't.
 /// Internal address is derived inside the enclave to ensure that it is actually internal.
 #[derive(Serialize, Debug, Clone, PartialEq)]
-pub enum OutputUTXO {
+enum OutputUTXO {
     External(ExternalOutputUTXO),
     Internal(InternalOutputUTXO),
 }
@@ -178,19 +180,15 @@ impl InternalOutputUTXO {
     }
 }
 
-impl ExternalOutputUTXO {
-    /// Constructs a new `ExternalOutputUTXO` and validates the address for the network.
-    pub fn new(
-        address: BitcoinAddress<NetworkUnchecked>,
-        amount: Amount,
-        network: Network,
-    ) -> GuardianResult<Self> {
-        let address = validate_address_for_network(&address, network)?;
-        Ok(Self { address, amount })
+impl OutputUTXOWire {
+    /// External payout to a user-provided (unchecked) address.
+    pub fn external(address: BitcoinAddress<NetworkUnchecked>, amount: Amount) -> Self {
+        OutputUTXOWire::External(ExternalOutputUTXOWire { address, amount })
     }
 
-    pub fn from_wire(input: ExternalOutputUTXOWire, network: Network) -> GuardianResult<Self> {
-        Self::new(input.address, input.amount, network)
+    /// Internal change output, derived inside the enclave from `derivation_path`.
+    pub fn internal(derivation_path: DerivationPath, amount: Amount) -> Self {
+        OutputUTXOWire::Internal(InternalOutputUTXO::new(derivation_path, amount))
     }
 }
 
@@ -198,36 +196,8 @@ impl ExternalOutputUTXO {
 ///
 /// Outputs can be **external** (to a user-provided address) or **internal** (change, derived inside enclave).
 impl OutputUTXO {
-    /// Constructs a new `OutputUTXO::External` variant.
-    pub fn new_external(
-        address: BitcoinAddress<NetworkUnchecked>,
-        amount: Amount,
-        network: Network,
-    ) -> GuardianResult<Self> {
-        Ok(OutputUTXO::External(ExternalOutputUTXO::new(
-            address, amount, network,
-        )?))
-    }
-
-    /// Constructs a new `OutputUTXO::Internal` variant.
-    pub fn new_internal(derivation_path: DerivationPath, amount: Amount) -> Self {
-        OutputUTXO::Internal(InternalOutputUTXO {
-            derivation_path,
-            amount,
-        })
-    }
-
-    pub fn from_wire(output: OutputUTXOWire, network: Network) -> GuardianResult<Self> {
-        Ok(match output {
-            OutputUTXOWire::External(external) => {
-                OutputUTXO::External(ExternalOutputUTXO::from_wire(external, network)?)
-            }
-            OutputUTXOWire::Internal(internal) => OutputUTXO::Internal(internal),
-        })
-    }
-
     /// Returns the output amount in satoshis.
-    pub fn amount(&self) -> Amount {
+    fn amount(&self) -> Amount {
         match self {
             OutputUTXO::External(ExternalOutputUTXO { amount, .. }) => *amount,
             OutputUTXO::Internal(InternalOutputUTXO { amount, .. }) => *amount,
@@ -240,7 +210,7 @@ impl OutputUTXO {
     /// Internal outputs derive their child key from this raw G — using only
     /// the x-only/even-y projection would silently produce a different child
     /// key for half of all MPC vks, breaking the 2-of-2 leaf script.
-    pub fn to_txout(&self, enclave_pubkey: &BitcoinPubkey, hashi_master_g: &HashiMasterG) -> TxOut {
+    fn to_txout(&self, enclave_pubkey: &BitcoinPubkey, hashi_master_g: &HashiMasterG) -> TxOut {
         match self {
             OutputUTXO::External(ExternalOutputUTXO { address, amount }) => TxOut {
                 value: *amount,
@@ -262,8 +232,15 @@ impl OutputUTXO {
 }
 
 impl TxUTXOs {
-    /// Constructs a new `TxUTXOs` and validates all invariants.
-    pub fn new(inputs: Vec<InputUTXO>, outputs: Vec<OutputUTXO>) -> GuardianResult<Self> {
+    /// Constructs a `TxUTXOs`, validating every invariant in one place: external
+    /// output addresses must be valid for `network`, amounts must be non-zero,
+    /// inputs must be unique, and fees must be positive. The single gate for both
+    /// locally-built and wire-parsed UTXO sets.
+    pub fn new(
+        inputs: Vec<InputUTXO>,
+        outputs: Vec<OutputUTXOWire>,
+        network: Network,
+    ) -> GuardianResult<Self> {
         if inputs.is_empty() {
             return Err(InvalidInputs("input utxos must not be empty".into()));
         }
@@ -271,10 +248,22 @@ impl TxUTXOs {
             return Err(InvalidInputs("output utxos must not be empty".into()));
         }
 
+        // Validate each external address against the network, turning untrusted
+        // unchecked addresses into checked ones. Internal outputs carry no address.
+        let mut checked = Vec::with_capacity(outputs.len());
+        for output in outputs {
+            checked.push(match output {
+                OutputUTXOWire::External(ext) => OutputUTXO::External(ExternalOutputUTXO {
+                    address: validate_address_for_network(&ext.address, network)?,
+                    amount: ext.amount,
+                }),
+                OutputUTXOWire::Internal(int) => OutputUTXO::Internal(int),
+            });
+        }
+        let outputs = checked;
+
         // Reject zero amounts on both sides: a 0-value input is meaningless and a
-        // 0-value output is invalid on Bitcoin. This is the single gate every UTXO
-        // set passes through (locally built or parsed from the wire), so per-UTXO
-        // constructors don't repeat it.
+        // 0-value output is invalid on Bitcoin.
         for utxo in &inputs {
             if utxo.amount == Amount::ZERO {
                 return Err(InvalidInputs("input amount must be > 0".into()));

--- a/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
@@ -41,11 +41,12 @@ use std::collections::HashSet;
 /// (Hashi+Guardian)-owned input UTXO
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct InputUTXO {
-    outpoint: OutPoint,
-    amount: Amount,
-    derivation_path: DerivationPath,
+    pub outpoint: OutPoint,
+    pub amount: Amount,
+    pub derivation_path: DerivationPath,
 }
 
+/// Output UTXOs belonging to users
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct ExternalOutputUTXO {
     /// Bitcoin address to withdraw to
@@ -54,12 +55,21 @@ pub struct ExternalOutputUTXO {
     amount: Amount,
 }
 
+/// Copy of bitcoin_utils::ExternalOutputUTXO with unchecked address
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalOutputUTXOWire {
+    /// Bitcoin address to withdraw to
+    pub address: BitcoinAddress<NetworkUnchecked>,
+    /// Amount in satoshis
+    pub amount: Amount,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct InternalOutputUTXO {
     /// The derivation path
-    derivation_path: DerivationPath,
+    pub derivation_path: DerivationPath,
     /// Amount in satoshis
-    amount: Amount,
+    pub amount: Amount,
 }
 
 /// Withdrawal destination and amount.
@@ -71,6 +81,13 @@ pub enum OutputUTXO {
     Internal(InternalOutputUTXO),
 }
 
+/// Copy of bitcoin_utils::OutputUTXO with unchecked address
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OutputUTXOWire {
+    External(ExternalOutputUTXOWire),
+    Internal(InternalOutputUTXO),
+}
+
 /// All the UTXOs associated with a withdrawal transaction
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct TxUTXOs {
@@ -78,6 +95,15 @@ pub struct TxUTXOs {
     inputs: Vec<InputUTXO>,
     /// Outputs: either external or internal
     outputs: Vec<OutputUTXO>,
+}
+
+/// Copy of bitcoin_utils::TxUTXOs with unchecked output addresses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxUTXOsWire {
+    /// Inputs: internal
+    pub inputs: Vec<InputUTXO>,
+    /// Outputs: either external or internal
+    pub outputs: Vec<OutputUTXOWire>,
 }
 
 // ---------------------------------
@@ -108,18 +134,6 @@ impl InputUTXO {
             amount,
             derivation_path,
         }
-    }
-
-    pub fn outpoint(&self) -> OutPoint {
-        self.outpoint
-    }
-
-    pub fn amount(&self) -> Amount {
-        self.amount
-    }
-
-    pub fn derivation_path(&self) -> DerivationPath {
-        self.derivation_path
     }
 
     /// Returns a `TxIn` for this UTXO with placeholder witness data.
@@ -162,13 +176,6 @@ impl InternalOutputUTXO {
             amount,
         }
     }
-
-    pub fn derivation_path(&self) -> DerivationPath {
-        self.derivation_path
-    }
-    pub fn amount(&self) -> Amount {
-        self.amount
-    }
 }
 
 impl ExternalOutputUTXO {
@@ -186,6 +193,7 @@ impl ExternalOutputUTXO {
         Self::new(input.address, input.amount, network)
     }
 }
+
 /// Represents an output destination for a withdrawal.
 ///
 /// Outputs can be **external** (to a user-provided address) or **internal** (change, derived inside enclave).
@@ -297,16 +305,6 @@ impl TxUTXOs {
         Ok(tx_info)
     }
 
-    /// Returns a reference to the inputs.
-    pub fn get_inputs(&self) -> &[InputUTXO] {
-        &self.inputs
-    }
-
-    /// Returns a reference to the outputs.
-    pub fn get_outputs(&self) -> &[OutputUTXO] {
-        &self.outputs
-    }
-
     /// Constructs all outputs (both external and internal).
     ///
     /// For `External` outputs, uses the user-provided address. For `Internal` outputs,
@@ -322,30 +320,9 @@ impl TxUTXOs {
             .collect()
     }
 
-    pub fn external_outs(&self) -> Vec<&ExternalOutputUTXO> {
-        self.outputs
-            .iter()
-            .filter_map(|utxo| match utxo {
-                OutputUTXO::External(x) => Some(x),
-                OutputUTXO::Internal(_) => None,
-            })
-            .collect::<Vec<_>>()
-    }
-
-    pub fn external_out_amount(&self) -> Amount {
-        self.outputs
-            .iter()
-            .filter_map(|utxo| match utxo {
-                OutputUTXO::External(x) => Some(x.amount),
-                OutputUTXO::Internal(_) => None,
-            })
-            .sum()
-    }
-
     /// BTC that leaves the pool when this txn broadcasts: `inputs - change`,
-    /// equivalent to `external_out_amount + miner_fee`. The amount that
-    /// consumes the rate-limiter (miner fee leaves the pool too; change
-    /// flows back).
+    /// equivalent to `external outputs + miner_fee`. The amount that consumes
+    /// the rate-limiter (miner fee leaves the pool too; change flows back).
     pub fn gross_outflow_amount(&self) -> Amount {
         let inputs: Amount = self.inputs.iter().map(|i| i.amount).sum();
         let internal: Amount = self
@@ -461,15 +438,6 @@ pub fn construct_tx(inputs: Vec<TxIn>, outputs: Vec<TxOut>) -> Transaction {
 //    Serialize / Deserialize
 // ---------------------------------
 
-/// Copy of bitcoin_utils::ExternalOutputUTXO with unchecked address
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
-pub struct ExternalOutputUTXOWire {
-    /// Bitcoin address to withdraw to
-    pub address: BitcoinAddress<NetworkUnchecked>,
-    /// Amount in satoshis
-    pub amount: Amount,
-}
-
 impl From<ExternalOutputUTXO> for ExternalOutputUTXOWire {
     fn from(o: ExternalOutputUTXO) -> Self {
         Self {
@@ -479,13 +447,6 @@ impl From<ExternalOutputUTXO> for ExternalOutputUTXOWire {
     }
 }
 
-/// Copy of bitcoin_utils::OutputUTXO with unchecked address
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum OutputUTXOWire {
-    External(ExternalOutputUTXOWire),
-    Internal(InternalOutputUTXO),
-}
-
 impl From<OutputUTXO> for OutputUTXOWire {
     fn from(o: OutputUTXO) -> Self {
         match o {
@@ -493,17 +454,6 @@ impl From<OutputUTXO> for OutputUTXOWire {
             OutputUTXO::Internal(o) => OutputUTXOWire::Internal(o),
         }
     }
-}
-
-/// Copy of bitcoin_utils::TxUTXOs with unchecked output addresses. Inputs carry
-/// no checked address, so the domain `InputUTXO` is reused directly (same as
-/// `OutputUTXOWire::Internal`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TxUTXOsWire {
-    /// Inputs: internal
-    pub inputs: Vec<InputUTXO>,
-    /// Outputs: either external or internal
-    pub outputs: Vec<OutputUTXOWire>,
 }
 
 impl From<TxUTXOs> for TxUTXOsWire {

--- a/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
@@ -12,6 +12,7 @@
 use super::BTC_LIB;
 use super::DerivationPath;
 use super::taproot::compute_taproot_artifacts;
+use super::taproot::taproot_script_spend_sighashes;
 use crate::guardian::BitcoinAddress;
 use crate::guardian::BitcoinKeypair;
 use crate::guardian::BitcoinPubkey;
@@ -22,10 +23,7 @@ use crate::guardian::HashiMasterG;
 use bitcoin::absolute::LockTime;
 use bitcoin::address::NetworkChecked;
 use bitcoin::address::NetworkUnchecked;
-use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::Message;
-use bitcoin::sighash::Prevouts;
-use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::Signature;
 use bitcoin::taproot::TapLeafHash;
 use bitcoin::transaction::Version;
@@ -349,29 +347,13 @@ impl TxUTXOs {
             .iter()
             .map(|input| input.prevout_and_leaf_hash(enclave_pubkey, hashi_master_g))
             .collect();
-        let prevouts: Vec<TxOut> = artifacts
-            .iter()
-            .map(|(prevout, _)| prevout.clone())
-            .collect();
+        let prevouts: Vec<TxOut> = artifacts.iter().map(|(p, _)| p.clone()).collect();
+        let leaf_hashes: Vec<TapLeafHash> = artifacts.iter().map(|(_, h)| *h).collect();
 
-        // One cache, reused across inputs: the whole-tx sighash components are
-        // input-independent, so building it once avoids rehashing.
-        let mut sighasher = SighashCache::new(&tx);
-        let messages = artifacts
-            .iter()
-            .enumerate()
-            .map(|(index, (_, leaf_hash))| {
-                let sighash = sighasher
-                    .taproot_script_spend_signature_hash(
-                        index,
-                        &Prevouts::All(&prevouts),
-                        *leaf_hash,
-                        TapSighashType::Default,
-                    )
-                    .expect("sighash failed unexpectedly");
-                Message::from_digest(*sighash.as_byte_array())
-            })
-            .collect::<Vec<Message>>();
+        let messages = taproot_script_spend_sighashes(&tx, &prevouts, &leaf_hashes)
+            .into_iter()
+            .map(Message::from_digest)
+            .collect();
         (messages, tx.compute_txid())
     }
 

--- a/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
@@ -56,7 +56,7 @@ struct ExternalOutputUTXO {
     amount: Amount,
 }
 
-/// Copy of bitcoin_utils::ExternalOutputUTXO with unchecked address
+/// Copy of ExternalOutputUTXO with unchecked address
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExternalOutputUTXOWire {
     /// Bitcoin address to withdraw to
@@ -83,7 +83,7 @@ enum OutputUTXO {
     Internal(InternalOutputUTXO),
 }
 
-/// Copy of bitcoin_utils::OutputUTXO with unchecked address
+/// Copy of OutputUTXO with unchecked address
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum OutputUTXOWire {
     External(ExternalOutputUTXOWire),
@@ -99,7 +99,7 @@ pub struct TxUTXOs {
     outputs: Vec<OutputUTXO>,
 }
 
-/// Copy of bitcoin_utils::TxUTXOs with unchecked output addresses.
+/// Copy of TxUTXOs with unchecked output addresses.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TxUTXOsWire {
     /// Inputs: internal
@@ -204,12 +204,8 @@ impl OutputUTXO {
         }
     }
 
-    /// Constructs a `TxOut` for this output.
-    ///
-    /// `hashi_master_g` is the raw MPC verifying key (with y-parity preserved).
-    /// Internal outputs derive their child key from this raw G — using only
-    /// the x-only/even-y projection would silently produce a different child
-    /// key for half of all MPC vks, breaking the 2-of-2 leaf script.
+    /// Builds the `TxOut`: external uses the checked address, internal derives
+    /// its taproot script via `taproot::derive_hashi_child_pubkey`.
     fn to_txout(&self, enclave_pubkey: &BitcoinPubkey, hashi_master_g: &HashiMasterG) -> TxOut {
         match self {
             OutputUTXO::External(ExternalOutputUTXO { address, amount }) => TxOut {
@@ -358,11 +354,13 @@ impl TxUTXOs {
             .map(|(prevout, _)| prevout.clone())
             .collect();
 
+        // One cache, reused across inputs: the whole-tx sighash components are
+        // input-independent, so building it once avoids rehashing.
+        let mut sighasher = SighashCache::new(&tx);
         let messages = artifacts
             .iter()
             .enumerate()
             .map(|(index, (_, leaf_hash))| {
-                let mut sighasher = SighashCache::new(tx.clone());
                 let sighash = sighasher
                     .taproot_script_spend_signature_hash(
                         index,

--- a/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
@@ -4,8 +4,12 @@
 //! UTXO and transaction types for guardian withdrawals.
 //!
 //! Two classes of types exist here:
-//! - Types with checked addresses that implement Serialize but not Deserialize
-//! - Wire types with unchecked addresses that implement both Serialize and Deserialize
+//! - Domain types with checked addresses that implement Serialize but not Deserialize
+//! - `*Wire` types with unchecked addresses that implement both Serialize and Deserialize
+//!
+//! Untrusted input arrives as the `*Wire` form; `TxUTXOs::new` is the single gate
+//! that validates it (address-network, amounts, duplicates, fees) and converts it
+//! into the checked domain types.
 //!
 //! Internal-output addresses are derived via `super::taproot`.
 
@@ -220,7 +224,7 @@ impl OutputUTXO {
     }
 
     /// Builds the `TxOut`: external uses the checked address, internal derives
-    /// its taproot script via `taproot::derive_hashi_child_pubkey`.
+    /// its taproot script via `super::taproot`.
     fn to_txout(&self, enclave_pubkey: &BitcoinPubkey, hashi_master_g: &HashiMasterG) -> TxOut {
         match self {
             OutputUTXO::External(ExternalOutputUTXO { address, amount }) => TxOut {
@@ -378,11 +382,11 @@ impl TxUTXOs {
     }
 
     fn assert_positive_fees(&self) -> GuardianResult<()> {
-        let input_sum = self.inputs.iter().map(|utxo| utxo.amount).sum::<Amount>();
-        let output_sum = self.outputs.iter().map(|utxo| utxo.amount()).sum();
+        let input_sum: Amount = self.inputs.iter().map(|utxo| utxo.amount).sum();
+        let output_sum: Amount = self.outputs.iter().map(|utxo| utxo.amount()).sum();
         if input_sum <= output_sum {
             return Err(InvalidInputs(format!(
-                "fees must be positive: input_sum={} output_sum={}",
+                "fees must be greater than zero: input_sum={} output_sum={}",
                 input_sum, output_sum
             )));
         }

--- a/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
@@ -169,6 +169,20 @@ impl InputUTXO {
     }
 }
 
+impl From<&crate::move_types::Utxo> for InputUTXO {
+    /// A `None` derivation path (change) maps to the all-zeros path.
+    fn from(u: &crate::move_types::Utxo) -> Self {
+        InputUTXO::new(
+            OutPoint {
+                txid: u.id.txid.into(),
+                vout: u.id.vout,
+            },
+            Amount::from_sat(u.amount),
+            u.derivation_path.unwrap_or(DerivationPath::ZERO),
+        )
+    }
+}
+
 impl InternalOutputUTXO {
     pub fn new(derivation_path: DerivationPath, amount: Amount) -> Self {
         Self {

--- a/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
+++ b/crates/hashi-types/src/guardian/bitcoin_utils/utxo.rs
@@ -11,7 +11,7 @@
 
 use super::BTC_LIB;
 use super::DerivationPath;
-use super::taproot::compute_taproot_artifacts;
+use super::taproot::taproot_script_pubkey_and_leaf_hash;
 use super::taproot::taproot_script_spend_sighashes;
 use crate::guardian::BitcoinAddress;
 use crate::guardian::BitcoinKeypair;
@@ -157,8 +157,11 @@ impl InputUTXO {
         enclave_pubkey: &BitcoinPubkey,
         hashi_master_g: &HashiMasterG,
     ) -> (TxOut, TapLeafHash) {
-        let (script_pubkey, leaf_hash) =
-            compute_taproot_artifacts(enclave_pubkey, hashi_master_g, &self.derivation_path);
+        let (script_pubkey, leaf_hash) = taproot_script_pubkey_and_leaf_hash(
+            enclave_pubkey,
+            hashi_master_g,
+            &self.derivation_path,
+        );
         (
             TxOut {
                 value: self.amount,
@@ -228,8 +231,11 @@ impl OutputUTXO {
                 derivation_path,
                 amount,
             }) => {
-                let scripts =
-                    compute_taproot_artifacts(enclave_pubkey, hashi_master_g, derivation_path);
+                let scripts = taproot_script_pubkey_and_leaf_hash(
+                    enclave_pubkey,
+                    hashi_master_g,
+                    derivation_path,
+                );
                 TxOut {
                     value: *amount,
                     script_pubkey: scripts.0,

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -25,7 +25,6 @@ pub use time_utils::now_timestamp_ms;
 pub use time_utils::now_timestamp_secs;
 pub use time_utils::unix_millis_to_seconds;
 
-use self::bitcoin_utils::OutputUTXO;
 use self::bitcoin_utils::TxUTXOs;
 use self::bitcoin_utils::TxUTXOsWire;
 use self::errors::GuardianError::*;
@@ -664,20 +663,9 @@ impl AddressValidation<StandardWithdrawalRequestWire> for StandardWithdrawalRequ
         value: StandardWithdrawalRequestWire,
         network: Network,
     ) -> GuardianResult<Self> {
-        let utxos = value.utxos;
-        // Inputs carry no checked address, so they're already the domain type;
-        // only outputs need address validation. `TxUTXOs::new` validates amounts.
-        let inputs = utxos.inputs;
-
-        let outputs = utxos
-            .outputs
-            .into_iter()
-            .map(|utxo| OutputUTXO::from_wire(utxo, network))
-            .collect::<Result<Vec<_>, _>>()?;
-
         Ok(Self {
             wid: value.wid,
-            utxos: TxUTXOs::new(inputs, outputs)?,
+            utxos: TxUTXOs::new(value.utxos.inputs, value.utxos.outputs, network)?,
             timestamp_secs: value.timestamp_secs,
             seq: value.seq,
         })

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -1046,11 +1046,11 @@ fn tx_utxos_wire_to_pb(utxos: TxUTXOsWire) -> pb::TxUtxos {
 fn input_utxo_to_pb(input: InputUTXO) -> pb::InputUtxo {
     pb::InputUtxo {
         outpoint: Some(pb::UtxoId {
-            txid: Some(input.outpoint().txid.as_byte_array().to_vec().into()),
-            vout: Some(input.outpoint().vout),
+            txid: Some(input.outpoint.txid.as_byte_array().to_vec().into()),
+            vout: Some(input.outpoint.vout),
         }),
-        amount: Some(input.amount().to_sat()),
-        derivation_path: Some(input.derivation_path().into_inner().to_vec().into()),
+        amount: Some(input.amount.to_sat()),
+        derivation_path: Some(input.derivation_path.into_inner().to_vec().into()),
     }
 }
 
@@ -1064,8 +1064,8 @@ fn output_utxo_wire_to_pb(output: OutputUTXOWire) -> pb::OutputUtxo {
         }
         OutputUTXOWire::Internal(int) => {
             pb::output_utxo::Output::Internal(pb::InternalOutputUtxo {
-                derivation_path: Some(int.derivation_path().into_inner().to_vec().into()),
-                amount: Some(int.amount().to_sat()),
+                derivation_path: Some(int.derivation_path.into_inner().to_vec().into()),
+                amount: Some(int.amount.to_sat()),
             })
         }
     };

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -31,7 +31,7 @@ pub use crate::pgp::test_utils::mock_pgp_certs_armored;
 
 use super::bitcoin_utils::BTC_LIB;
 use super::bitcoin_utils::InputUTXO;
-use super::bitcoin_utils::OutputUTXO;
+use super::bitcoin_utils::OutputUTXOWire;
 use super::bitcoin_utils::TxUTXOs;
 use super::bitcoin_utils::sign_btc_tx;
 use crate::committee::Bls12381PrivateKey;
@@ -273,13 +273,10 @@ impl StandardWithdrawalRequest {
 
         let input = InputUTXO::new(outpoint, Amount::from_sat(10_000), [7u8; 32].into());
 
-        let output_external =
-            OutputUTXO::new_external(addr_unchecked, Amount::from_sat(9_000), network)
-                .expect("valid external output");
+        let output_external = OutputUTXOWire::external(addr_unchecked, Amount::from_sat(9_000));
+        let output_internal = OutputUTXOWire::internal([42u8; 32].into(), Amount::from_sat(500));
 
-        let output_internal = OutputUTXO::new_internal([42u8; 32].into(), Amount::from_sat(500));
-
-        let utxos = TxUTXOs::new(vec![input], vec![output_external, output_internal])
+        let utxos = TxUTXOs::new(vec![input], vec![output_external, output_internal], network)
             .expect("valid TxUTXOs");
 
         StandardWithdrawalRequest::new(wid, utxos, 1_000_000, 0)

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -36,7 +36,7 @@ pub fn derive_deposit_address(
     derivation_path: Option<&sui_sdk_types::Address>,
     btc_network: bitcoin::Network,
 ) -> anyhow::Result<bitcoin::Address> {
-    Ok(bitcoin_utils::two_of_two_taproot_script_path_address(
+    Ok(bitcoin_utils::taproot_address(
         guardian_btc_pubkey,
         mpc_key,
         &derivation_path
@@ -240,7 +240,7 @@ impl Hashi {
     ) -> anyhow::Result<bitcoin::Address> {
         let mpc_g = self.mpc_master_g()?;
         let guardian_pubkey = self.require_guardian_btc_pubkey()?;
-        Ok(bitcoin_utils::two_of_two_taproot_script_path_address(
+        Ok(bitcoin_utils::taproot_address(
             &guardian_pubkey,
             &mpc_g,
             &derivation_path
@@ -263,15 +263,13 @@ impl Hashi {
     )> {
         let mpc_g = self.mpc_master_g()?;
         let guardian_pubkey = self.require_guardian_btc_pubkey()?;
-        Ok(
-            bitcoin_utils::two_of_two_taproot_script_path_spend_artifacts(
-                &guardian_pubkey,
-                &mpc_g,
-                &derivation_path
-                    .copied()
-                    .unwrap_or(sui_sdk_types::Address::ZERO),
-            ),
-        )
+        Ok(bitcoin_utils::taproot_witness_artifacts(
+            &guardian_pubkey,
+            &mpc_g,
+            &derivation_path
+                .copied()
+                .unwrap_or(sui_sdk_types::Address::ZERO),
+        ))
     }
 
     /// Raw MPC verifying key (`G`) with y-parity preserved. Prefers the

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -9,10 +9,6 @@ use bitcoin::TxOut;
 use bitcoin::Weight;
 use bitcoin::blockdata::script::witness_program::WitnessProgram;
 use bitcoin::blockdata::script::witness_version::WitnessVersion;
-use bitcoin::hashes::Hash;
-use bitcoin::sighash::Prevouts;
-use bitcoin::sighash::SighashCache;
-use bitcoin::sighash::TapSighashType;
 use bitcoin::taproot::TapLeafHash;
 use fastcrypto::groups::secp256k1::schnorr::SchnorrPublicKey;
 use fastcrypto::groups::secp256k1::schnorr::SchnorrSignature;
@@ -904,22 +900,11 @@ impl Hashi {
             .map(|(_, leaf_hash)| *leaf_hash)
             .collect::<Vec<TapLeafHash>>();
 
-        (0..inputs.len())
-            .map(|input_index| {
-                let mut sighasher = SighashCache::new(unsigned_tx);
-                let sighash = sighasher
-                    .taproot_script_spend_signature_hash(
-                        input_index,
-                        &Prevouts::All(&prevouts),
-                        leaf_hashes[input_index],
-                        TapSighashType::Default,
-                    )
-                    .map_err(|e| {
-                        anyhow!("Failed to construct taproot script spend sighash: {e}")
-                    })?;
-                Ok(*sighash.as_byte_array())
-            })
-            .collect()
+        Ok(bitcoin_utils::taproot_script_spend_sighashes(
+            unsigned_tx,
+            &prevouts,
+            &leaf_hashes,
+        ))
     }
 
     // --- UTXO selection and tx crafting ---

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -1494,7 +1494,7 @@ pub fn build_guardian_withdrawal_request(
     seq: u64,
 ) -> anyhow::Result<hashi_types::guardian::StandardWithdrawalRequest> {
     use hashi_types::guardian::bitcoin_utils::InputUTXO;
-    use hashi_types::guardian::bitcoin_utils::OutputUTXO;
+    use hashi_types::guardian::bitcoin_utils::OutputUTXOWire;
     use hashi_types::guardian::bitcoin_utils::TxUTXOs;
 
     let network = hashi.config.bitcoin_network();
@@ -1525,14 +1525,12 @@ pub fn build_guardian_withdrawal_request(
                 let script_pubkey = script_pubkey_from_raw_address(&output.bitcoin_address)?;
                 let address = BitcoinAddress::from_script(&script_pubkey, network)
                     .map_err(|e| anyhow!("Cannot derive address from output script: {e}"))?;
-                OutputUTXO::new_external(
+                Ok(OutputUTXOWire::external(
                     address.into_unchecked(),
                     Amount::from_sat(output.amount),
-                    network,
-                )
-                .map_err(|e| anyhow!("Failed to build guardian external OutputUTXO: {e}"))
+                ))
             } else {
-                Ok(OutputUTXO::new_internal(
+                Ok(OutputUTXOWire::internal(
                     sui_sdk_types::Address::ZERO,
                     Amount::from_sat(output.amount),
                 ))
@@ -1540,7 +1538,7 @@ pub fn build_guardian_withdrawal_request(
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    let utxos = TxUTXOs::new(inputs, outputs)
+    let utxos = TxUTXOs::new(inputs, outputs, network)
         .map_err(|e| anyhow!("Failed to build guardian TxUTXOs: {e}"))?;
 
     // The on-chain `WithdrawalTransaction` UID doubles as the guardian-side `wid`.

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -919,15 +919,7 @@ impl Hashi {
     ) -> anyhow::Result<bitcoin::Transaction> {
         let inputs: Vec<bitcoin::TxIn> = selected_utxos
             .iter()
-            .map(|utxo| bitcoin::TxIn {
-                previous_output: bitcoin::OutPoint {
-                    txid: utxo.id.txid.into(),
-                    vout: utxo.id.vout,
-                },
-                script_sig: bitcoin::ScriptBuf::default(),
-                sequence: bitcoin::Sequence::ENABLE_RBF_NO_LOCKTIME,
-                witness: bitcoin::Witness::default(),
-            })
+            .map(|utxo| bitcoin_utils::InputUTXO::from(utxo).txin())
             .collect();
 
         let tx_outputs: Vec<bitcoin::TxOut> = outputs
@@ -1484,20 +1476,7 @@ pub fn build_guardian_withdrawal_request(
 
     let network = hashi.config.bitcoin_network();
 
-    let inputs: Vec<_> = txn
-        .inputs
-        .iter()
-        .map(|utxo| {
-            let outpoint = bitcoin::OutPoint {
-                txid: utxo.id.txid.into(),
-                vout: utxo.id.vout,
-            };
-            // `None` (change) maps to the all-zeros path, matching `path_bytes_or_zero`.
-            let derivation_path = utxo.derivation_path.unwrap_or(Address::ZERO);
-
-            InputUTXO::new(outpoint, Amount::from_sat(utxo.amount), derivation_path)
-        })
-        .collect();
+    let inputs: Vec<_> = txn.inputs.iter().map(InputUTXO::from).collect();
 
     // First N outputs are external payouts; any trailing output is internal change.
     let all_outputs = txn.all_outputs();


### PR DESCRIPTION
Incremental cleanup of `bitcoin_utils` (`utxo.rs` / `taproot.rs`) plus the leader-side signing path. No behavior change — verified against the existing taproot signing tests (2-of-2 round-trip + cross-language vectors).

### Commits (each self-contained)

1. **Slim `utxo.rs`** — make `InputUTXO`/`InternalOutputUTXO` fields `pub` and drop the trivial getters (the validation invariant lives in `TxUTXOs`, which only ever hands out `&[..]`); remove four dead `TxUTXOs` methods (`external_outs`, `external_out_amount`, `get_inputs`, `get_outputs`); trim unused derives on `ExternalOutputUTXOWire`.

2. **Consolidate validation into `TxUTXOs::new`** — address-network validation moves in alongside the existing amount/dup/fee checks, so `new` is the single gate for both locally-built and wire-parsed UTXO sets. `ExternalOutputUTXO`/`OutputUTXO` become module-private (callers only ever build the wire form). Per-output validating constructors removed; `validate_addr` collapses to one call.

3. **Reuse `SighashCache` + dedup rationale** — build the cache once and reuse it across inputs instead of cloning the tx per input (the cache memoizes the whole-tx sighash components — see `bitcoin-0.32.8/src/crypto/sighash.rs`); consolidate the "raw `G`, not x-only" derivation rationale to one canonical doc on `taproot::derive_hashi_child_pubkey`.

4. **Extract shared taproot sighash helper** — both signing paths (`TxUTXOs::signing_messages_and_txid` and the leader's `withdrawal_signing_messages`) duplicated the per-input script-spend sighash loop. Extract `taproot::taproot_script_spend_sighashes`; both delegate. This also fixes the leader-side per-input `SighashCache` rebuild (same O(n²) rehash the guardian side fixed in commit 3).

### Deliberately *not* done
Routing the leader's `build_unsigned_withdrawal_tx` through `TxUTXOs` (the larger "unify the libs" idea). The two paths legitimately differ in source-of-truth for the change script — the leader/validator reads recorded on-chain bytes (robust to key skew), the guardian re-derives (it's constructing what to sign). Merging would couple the validator's txid recompute to live key derivation. Tracking an **equivalence test** (assert both produce identical txids) instead of a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)