### PR TITLE
[DO NOT MERGE] [devnet] hashi-server wire-compatible with deployed guardian (597301e7)

### DIFF
--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -3,6 +3,7 @@
 
 use crate::Hashi;
 use crate::btc_monitor::monitor::DepositConfirmError;
+use crate::leader::RetryPolicy;
 use crate::onchain::types::DepositConfirmationMessage;
 use crate::onchain::types::DepositRequest;
 use anyhow::Context;
@@ -49,16 +50,17 @@ impl Hashi {
     pub async fn validate_and_sign_deposit_confirmation(
         &self,
         deposit_request: &DepositRequest,
-    ) -> anyhow::Result<MemberSignature> {
+    ) -> Result<MemberSignature, UnapprovedDepositError> {
         self.validate_deposit_request(deposit_request).await?;
         self.sign_deposit_confirmation(deposit_request)
+            .map_err(UnapprovedDepositError::SignDepositFailed)
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(deposit_id = %deposit_request.id))]
     pub async fn validate_deposit_request(
         &self,
         deposit_request: &DepositRequest,
-    ) -> Result<(), DepositError> {
+    ) -> Result<(), UnapprovedDepositError> {
         self.validate_deposit_request_on_sui(deposit_request)?;
         self.validate_deposit_request_on_bitcoin(deposit_request)
             .await?;
@@ -69,7 +71,10 @@ impl Hashi {
     /// Run AML/Sanctions checks for the deposit request.
     /// If no screener client is configured, checks are skipped.
     #[tracing::instrument(level = "debug", skip_all, fields(deposit_id = %deposit_request.id))]
-    async fn screen_deposit(&self, deposit_request: &DepositRequest) -> Result<(), DepositError> {
+    async fn screen_deposit(
+        &self,
+        deposit_request: &DepositRequest,
+    ) -> Result<(), UnapprovedDepositError> {
         let Some(screener) = self.screener_client() else {
             tracing::debug!("AML checks skipped: no screener configured");
             return Ok(());
@@ -91,10 +96,10 @@ impl Hashi {
                 &sui_chain_id,
             )
             .await
-            .map_err(|e| DepositError::AmlServiceError(anyhow!(e)))?;
+            .map_err(|e| UnapprovedDepositError::AmlServiceError(anyhow!(e)))?;
 
         if !approved {
-            return Err(DepositError::AmlRejected(anyhow!(
+            return Err(UnapprovedDepositError::AmlRejected(anyhow!(
                 "AML checks failed for source tx {source_tx_hash}, destination {destination_address}, bitcoin chain {bitcoin_chain_id}, sui chain {sui_chain_id}"
             )));
         }
@@ -107,12 +112,12 @@ impl Hashi {
     fn validate_deposit_request_on_sui(
         &self,
         deposit_request: &DepositRequest,
-    ) -> Result<(), DepositError> {
+    ) -> Result<(), UnapprovedDepositError> {
         let state = self.onchain_state().state();
         let deposit_queue = &state.hashi().deposit_queue;
         match deposit_queue.requests().get(&deposit_request.id) {
             None => {
-                return Err(DepositError::InvalidOnchainRequest(anyhow!(
+                return Err(UnapprovedDepositError::InvalidOnchainRequest(anyhow!(
                     "Deposit request not found on Sui"
                 )));
             }
@@ -126,7 +131,7 @@ impl Hashi {
                     && onchain_request.sui_tx_digest == deposit_request.sui_tx_digest
                     && onchain_request.utxo == deposit_request.utxo;
                 if !core_matches {
-                    return Err(DepositError::InvalidOnchainRequest(anyhow!(
+                    return Err(UnapprovedDepositError::InvalidOnchainRequest(anyhow!(
                         "Deposit request fields do not match on-chain state"
                     )));
                 }
@@ -139,7 +144,7 @@ impl Hashi {
                 if let Some(cert) = &onchain_request.approval_cert
                     && cert.epoch == current_epoch
                 {
-                    return Err(DepositError::AlreadyApprovedThisEpoch);
+                    return Err(UnapprovedDepositError::AlreadyApprovedThisEpoch);
                 }
             }
         }
@@ -152,7 +157,7 @@ impl Hashi {
                 .spent_utxos()
                 .contains_key(&deposit_request.utxo.id)
         {
-            return Err(DepositError::DuplicateOrSpentOnSui(anyhow!(
+            return Err(UnapprovedDepositError::DuplicateOrSpentOnSui(anyhow!(
                 "UTXO {:?} is already active or spent",
                 deposit_request.utxo.id
             )));
@@ -174,7 +179,7 @@ impl Hashi {
     async fn validate_deposit_request_on_bitcoin(
         &self,
         deposit_request: &DepositRequest,
-    ) -> Result<(), DepositError> {
+    ) -> Result<(), UnapprovedDepositError> {
         let outpoint = bitcoin::OutPoint {
             txid: deposit_request.utxo.id.txid.into(),
             vout: deposit_request.utxo.id.vout,
@@ -189,12 +194,14 @@ impl Hashi {
             .map_err(|e| match e {
                 DepositConfirmError::UtxoSpent { .. } => {
                     self.metrics.deposits_rejected_utxo_spent.inc();
-                    DepositError::BitcoinUtxoSpent(anyhow!(e))
+                    UnapprovedDepositError::BitcoinUtxoSpent(anyhow!(e))
                 }
-                DepositConfirmError::Other(err) => DepositError::BitcoinConfirmFailed(err),
+                DepositConfirmError::Other(err) => {
+                    UnapprovedDepositError::BitcoinConfirmFailed(err)
+                }
             })?;
         if txout.value.to_sat() != deposit_request.utxo.amount {
-            return Err(DepositError::DepositDataMismatch(anyhow!(
+            return Err(UnapprovedDepositError::DepositDataMismatch(anyhow!(
                 "Bitcoin deposit amount mismatch: got {}, onchain is {}",
                 deposit_request.utxo.amount,
                 txout.value.to_sat(),
@@ -210,21 +217,21 @@ impl Hashi {
         &self,
         script_pubkey: &ScriptBuf,
         deposit_request: &DepositRequest,
-    ) -> Result<(), DepositError> {
+    ) -> Result<(), UnapprovedDepositError> {
         let deposit_address =
             bitcoin::Address::from_script(script_pubkey, self.config.bitcoin_network()).map_err(
                 |e| {
-                    DepositError::DepositDataMismatch(anyhow!(
+                    UnapprovedDepositError::DepositDataMismatch(anyhow!(
                         "Failed to extract address from script_pubkey: {e}"
                     ))
                 },
             )?;
         let expected_address = self
             .get_deposit_address(deposit_request.utxo.derivation_path.as_ref())
-            .map_err(DepositError::DepositDataMismatch)?;
+            .map_err(UnapprovedDepositError::DepositDataMismatch)?;
 
         if deposit_address != expected_address {
-            return Err(DepositError::DepositDataMismatch(anyhow!(
+            return Err(UnapprovedDepositError::DepositDataMismatch(anyhow!(
                 "Expected address {expected_address}, got address {deposit_address}",
             )));
         }
@@ -363,21 +370,18 @@ impl Hashi {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum DepositErrorKind {
+pub(crate) enum UnapprovedDepositErrorKind {
     RetryOnNextBlock,
     NeverRetry,
 }
 
 #[derive(Debug, Error)]
-pub enum DepositError {
+pub enum UnapprovedDepositError {
     #[error("Failed to confirm Bitcoin deposit: {0}")]
     BitcoinConfirmFailed(#[source] anyhow::Error),
 
     #[error("Screener service error: {0}")]
     AmlServiceError(#[source] anyhow::Error),
-
-    #[error("Not ready: {0}")]
-    NotReady(#[source] anyhow::Error),
 
     #[error("Invalid on-chain deposit request: {0}")]
     InvalidOnchainRequest(#[source] anyhow::Error),
@@ -406,8 +410,8 @@ pub enum DepositError {
     #[error("Failed to approve deposit on Sui: {0}")]
     ApproveDepositFailed(#[source] anyhow::Error),
 
-    #[error("Failed to confirm deposit on Sui: {0}")]
-    ConfirmDepositFailed(#[source] anyhow::Error),
+    #[error("Failed to sign deposit confirmation: {0}")]
+    SignDepositFailed(#[source] anyhow::Error),
 
     #[error("Deposit has already been approved by the current committee")]
     AlreadyApprovedThisEpoch,
@@ -416,24 +420,69 @@ pub enum DepositError {
     TimedOut(std::time::Duration),
 }
 
-impl DepositError {
-    pub(crate) fn kind(&self) -> DepositErrorKind {
+impl UnapprovedDepositError {
+    pub(crate) fn kind(&self) -> UnapprovedDepositErrorKind {
         match self {
             Self::BitcoinConfirmFailed(_)
             | Self::AmlServiceError(_)
-            | Self::NotReady(_)
             | Self::FailedQuorum { .. }
             | Self::CertificateBuildFailed(_)
             | Self::ExecutorInitFailed(_)
             | Self::ApproveDepositFailed(_)
-            | Self::ConfirmDepositFailed(_)
+            | Self::SignDepositFailed(_)
             | Self::AlreadyApprovedThisEpoch
-            | Self::TimedOut(_) => DepositErrorKind::RetryOnNextBlock,
+            | Self::TimedOut(_) => UnapprovedDepositErrorKind::RetryOnNextBlock,
             Self::InvalidOnchainRequest(_)
             | Self::DuplicateOrSpentOnSui(_)
             | Self::BitcoinUtxoSpent(_)
             | Self::DepositDataMismatch(_)
-            | Self::AmlRejected(_) => DepositErrorKind::NeverRetry,
+            | Self::AmlRejected(_) => UnapprovedDepositErrorKind::NeverRetry,
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum ApprovedDepositErrorKind {
+    ExecutorInitFailed,
+    ConfirmDepositFailed,
+    TimedOut,
+}
+
+#[derive(Debug, Error)]
+pub enum ApprovedDepositError {
+    #[error("Failed to create Sui transaction executor: {0}")]
+    ExecutorInitFailed(#[source] anyhow::Error),
+
+    #[error("Failed to confirm deposit on Sui: {0}")]
+    ConfirmDepositFailed(#[source] anyhow::Error),
+
+    #[error("Deposit processing timed out after {0:?}")]
+    TimedOut(std::time::Duration),
+}
+
+impl ApprovedDepositError {
+    pub(crate) fn kind(&self) -> ApprovedDepositErrorKind {
+        match self {
+            Self::ExecutorInitFailed(_) => ApprovedDepositErrorKind::ExecutorInitFailed,
+            Self::ConfirmDepositFailed(_) => ApprovedDepositErrorKind::ConfirmDepositFailed,
+            Self::TimedOut(_) => ApprovedDepositErrorKind::TimedOut,
+        }
+    }
+}
+
+// This backoff only applies after an eligible approved deposit confirmation
+// actually fails. Deposits whose time-delay has not elapsed are skipped before
+// entering retry tracking.
+impl RetryPolicy for ApprovedDepositErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        5 * 60 * 1000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        30 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
     }
 }

--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -5,8 +5,9 @@ use super::LEADER_TASK_TIMEOUT;
 use super::LeaderService;
 use super::parse_member_signature;
 use crate::Hashi;
-use crate::deposits::DepositError;
-use crate::deposits::DepositErrorKind;
+use crate::deposits::ApprovedDepositError;
+use crate::deposits::UnapprovedDepositError;
+use crate::deposits::UnapprovedDepositErrorKind;
 use crate::onchain::types::DepositConfirmationMessage;
 use crate::onchain::types::DepositRequest;
 use crate::sui_tx_executor::SuiTxExecutor;
@@ -17,24 +18,22 @@ use hashi_types::committee::certificate_threshold;
 use hashi_types::proto::SignDepositConfirmationRequest;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Duration;
 use sui_sdk_types::Address;
 use tokio::task::JoinSet;
-use tokio_util::task::AbortOnDropHandle;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::trace;
 use tracing::warn;
 
-#[derive(Clone, Copy, Debug)]
-enum DepositPhase {
-    Approve,
-    Confirm,
-}
-
 impl LeaderService {
-    pub(super) fn reload_pending_deposit_requests(&mut self) {
+    pub(super) fn process_deposits_on_bitcoin_block(&mut self, block_height: u32) {
+        debug!("New Bitcoin block {block_height}: processing deposit requests");
+        self.reload_pending_unapproved_deposit_requests();
+        self.process_unapproved_deposit_requests();
+    }
+
+    fn reload_pending_unapproved_deposit_requests(&mut self) {
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
         deposit_requests.sort_by_key(|r| r.timestamp_ms);
         let deposit_ids: HashSet<Address> =
@@ -47,31 +46,33 @@ impl LeaderService {
             .metrics
             .never_retry_deposit_ids
             .set(self.never_retry_deposit_ids.len() as i64);
-        self.pending_deposit_requests = deposit_requests
+
+        let current_epoch = self.inner.onchain_state().epoch();
+        self.pending_unapproved_deposit_requests = deposit_requests
             .into_iter()
             .filter(|request| !self.never_retry_deposit_ids.contains(&request.id))
+            .filter(|request| {
+                request
+                    .approval_cert
+                    .as_ref()
+                    .is_none_or(|cert| cert.epoch != current_epoch)
+            })
             .collect();
         debug!(
-            pending_deposits = self.pending_deposit_requests.len(),
+            pending_unapproved_deposits = self.pending_unapproved_deposit_requests.len(),
             never_retry_deposits = self.never_retry_deposit_ids.len(),
-            "Reloaded pending deposit worklist"
+            "Reloaded pending unapproved deposit worklist"
         );
     }
 
-    pub(super) fn process_deposit_requests(&mut self) {
-        if self.inner.onchain_state().state().hashi().config.paused() || self.is_reconfiguring() {
-            self.deposit_tasks.abort_all();
-            self.pending_deposit_requests.clear();
-            self.inflight_deposits.clear();
+    fn process_unapproved_deposit_requests(&mut self) {
+        if self.check_halt_deposit_processing() {
             return;
         }
 
         let max_concurrent = self.inner.config.max_concurrent_leader_job_tasks();
-        let now_ms = self.inner.onchain_state().latest_checkpoint_timestamp_ms();
-        let delay_ms = self.inner.onchain_state().bitcoin_deposit_time_delay_ms();
-        let current_epoch = self.inner.onchain_state().epoch();
-        for deposit_request in &self.pending_deposit_requests {
-            if self.deposit_tasks.len() >= max_concurrent {
+        for deposit_request in self.pending_unapproved_deposit_requests.clone() {
+            if self.unapproved_deposit_tasks.len() >= max_concurrent {
                 break;
             }
             let deposit_id = deposit_request.id;
@@ -79,56 +80,98 @@ impl LeaderService {
                 continue;
             }
 
-            // Decide whether to approve or confirm based on the on-chain
-            // approval state.
-            //
-            // - No cert, or a cert from a rotated-out committee: approve.
-            //   The on-chain `approve_deposit` rejects re-approval by the
-            //   same committee but accepts a fresh cert from the current
-            //   one, which is what re-approval after rotation needs.
-            // - Cert from the current committee, delay still open: skip
-            //   here entirely so we don't burn a task slot on work that
-            //   would just bail; the next checkpoint will re-evaluate.
-            // - Cert from the current committee, delay elapsed: confirm.
-            let phase = if let Some(cert) = &deposit_request.approval_cert
-                && cert.epoch == current_epoch
-            {
-                let approved_ms = deposit_request
-                    .approval_timestamp_ms
-                    .expect("approval_cert is set, so approval_timestamp_ms must be set");
-                if approved_ms.saturating_add(delay_ms) > now_ms {
-                    trace!(
-                        deposit_id = %deposit_id,
-                        approved_ms,
-                        delay_ms,
-                        now_ms,
-                        "Skipping deposit confirmation: time-delay has not elapsed",
-                    );
-                    continue;
-                }
-                DepositPhase::Confirm
-            } else {
-                DepositPhase::Approve
-            };
-
             let inner = self.inner.clone();
-            let deposit_request = deposit_request.clone();
 
             self.inflight_deposits.insert(deposit_id);
-            self.deposit_tasks.spawn(async move {
-                let task = async {
-                    match phase {
-                        DepositPhase::Approve => {
-                            Self::process_unapproved_deposit(inner, deposit_request).await
-                        }
-                        DepositPhase::Confirm => {
-                            Self::process_approved_deposit(inner, deposit_request).await
-                        }
-                    }
-                };
+            let task = async move {
+                let task = Self::process_unapproved_deposit(inner, deposit_request);
                 let result = match tokio::time::timeout(LEADER_TASK_TIMEOUT, task).await {
                     Ok(result) => result,
-                    Err(_) => Err(DepositError::TimedOut(LEADER_TASK_TIMEOUT)),
+                    Err(_) => Err(UnapprovedDepositError::TimedOut(LEADER_TASK_TIMEOUT)),
+                };
+
+                (deposit_id, result)
+            };
+            self.unapproved_deposit_tasks.spawn(task);
+        }
+    }
+
+    pub(super) fn process_approved_deposit_requests(&mut self) {
+        if self.check_halt_deposit_processing() {
+            return;
+        }
+
+        let max_concurrent = self.inner.config.max_concurrent_leader_job_tasks();
+        let now_ms = self.inner.onchain_state().latest_checkpoint_timestamp_ms();
+        let delay_ms = self.inner.onchain_state().bitcoin_deposit_time_delay_ms();
+        let current_epoch = self.inner.onchain_state().epoch();
+
+        let mut deposit_requests = self.inner.onchain_state().deposit_requests();
+        deposit_requests.sort_by_key(|r| r.timestamp_ms);
+        let approved_deposit_requests: Vec<_> = deposit_requests
+            .into_iter()
+            .filter(|request| !self.never_retry_deposit_ids.contains(&request.id))
+            .filter(|request| {
+                request
+                    .approval_cert
+                    .as_ref()
+                    .is_some_and(|cert| cert.epoch == current_epoch)
+            })
+            .collect();
+
+        let approved_deposit_ids: Vec<Address> = approved_deposit_requests
+            .iter()
+            .map(|request| request.id)
+            .collect();
+        self.approved_deposit_retry_tracker
+            .prune(&approved_deposit_ids);
+        self.inner
+            .metrics
+            .leader_items_in_backoff
+            .with_label_values(&["approved_deposit_confirmation"])
+            .set(self.approved_deposit_retry_tracker.in_backoff_count(now_ms) as i64);
+
+        for deposit_request in approved_deposit_requests {
+            let deposit_id = deposit_request.id;
+            if self.inflight_deposits.contains(&deposit_id) {
+                continue;
+            }
+            if self
+                .approved_deposit_retry_tracker
+                .should_skip(&deposit_id, now_ms)
+            {
+                continue;
+            }
+
+            let Some(approved_ms) = deposit_request.approval_timestamp_ms else {
+                warn!(
+                    deposit_id = %deposit_id,
+                    "Skipping deposit confirmation: approval timestamp is missing",
+                );
+                continue;
+            };
+            if approved_ms.saturating_add(delay_ms) > now_ms {
+                trace!(
+                    deposit_id = %deposit_id,
+                    approved_ms,
+                    delay_ms,
+                    now_ms,
+                    "Skipping deposit confirmation: time-delay has not elapsed",
+                );
+                continue;
+            }
+
+            if self.approved_deposit_tasks.len() >= max_concurrent {
+                break;
+            }
+
+            let inner = self.inner.clone();
+            self.inflight_deposits.insert(deposit_id);
+            self.approved_deposit_tasks.spawn(async move {
+                let task = Self::process_approved_deposit(inner, deposit_request);
+                let result = match tokio::time::timeout(LEADER_TASK_TIMEOUT, task).await {
+                    Ok(result) => result,
+                    Err(_) => Err(ApprovedDepositError::TimedOut(LEADER_TASK_TIMEOUT)),
                 };
 
                 (deposit_id, result)
@@ -136,48 +179,24 @@ impl LeaderService {
         }
     }
 
-    pub(super) fn schedule_delayed_deposit_processing(&mut self) {
-        let delay =
-            Duration::from_millis(self.inner.onchain_state().bitcoin_deposit_time_delay_ms());
-        self.delayed_deposit_processing_task =
-            Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
-                tokio::time::sleep(delay).await;
-                Ok(())
-            })));
-    }
-
-    pub(super) fn handle_delayed_deposit_processing(
+    pub(super) fn handle_completed_unapproved_deposit_task(
         &mut self,
-        result: Result<anyhow::Result<()>, tokio::task::JoinError>,
-        checkpoint_height: u64,
-    ) {
-        self.delayed_deposit_processing_task = None;
-        Self::log_task_result("delayed_deposit_processing", result);
-
-        if self.is_current_leader(checkpoint_height) {
-            debug!("Processing deposit requests after Bitcoin deposit time-delay");
-            self.process_deposit_requests();
-        }
-    }
-
-    pub(super) fn handle_completed_deposit_task(
-        &mut self,
-        result: Result<(Address, Result<(), DepositError>), tokio::task::JoinError>,
+        result: Result<(Address, Result<(), UnapprovedDepositError>), tokio::task::JoinError>,
     ) {
         match result {
             Ok((deposit_id, result)) => {
                 self.inflight_deposits.remove(&deposit_id);
-                self.pending_deposit_requests
+                self.pending_unapproved_deposit_requests
                     .retain(|request| request.id != deposit_id);
                 match result {
                     Ok(()) => {
                         info!(deposit_id = %deposit_id, "Deposit processed successfully");
                     }
                     Err(err) => match err.kind() {
-                        DepositErrorKind::RetryOnNextBlock => {
-                            warn!(deposit_id = %deposit_id, "Deferring deposit until next block: {err:#}");
+                        UnapprovedDepositErrorKind::RetryOnNextBlock => {
+                            warn!(deposit_id = %deposit_id, "Deferring deposit retry: {err:#}");
                         }
-                        DepositErrorKind::NeverRetry => {
+                        UnapprovedDepositErrorKind::NeverRetry => {
                             self.never_retry_deposit_ids.insert(deposit_id);
                             self.inner
                                 .metrics
@@ -187,16 +206,65 @@ impl LeaderService {
                         }
                     },
                 }
+                self.process_unapproved_deposit_requests();
             }
             Err(err) if err.is_panic() => error!("deposit task panicked: {err}"),
             Err(err) => error!("deposit task failed to join: {err}"),
         }
     }
 
+    pub(super) fn handle_completed_approved_deposit_task(
+        &mut self,
+        result: Result<(Address, Result<(), ApprovedDepositError>), tokio::task::JoinError>,
+    ) {
+        match result {
+            Ok((deposit_id, result)) => {
+                self.inflight_deposits.remove(&deposit_id);
+                match result {
+                    Ok(()) => {
+                        self.approved_deposit_retry_tracker.clear(&deposit_id);
+                        info!(deposit_id = %deposit_id, "Deposit processed successfully");
+                    }
+                    Err(err) => {
+                        let kind = err.kind();
+                        self.inner
+                            .metrics
+                            .leader_retries_total
+                            .with_label_values(&[
+                                "approved_deposit_confirmation",
+                                &format!("{kind:?}"),
+                            ])
+                            .inc();
+                        self.approved_deposit_retry_tracker.record_failure(
+                            kind,
+                            deposit_id,
+                            self.inner.onchain_state().latest_checkpoint_timestamp_ms(),
+                        );
+                    }
+                }
+            }
+            Err(err) if err.is_panic() => error!("deposit task panicked: {err}"),
+            Err(err) => error!("deposit task failed to join: {err}"),
+        }
+    }
+
+    fn check_halt_deposit_processing(&mut self) -> bool {
+        if !(self.inner.onchain_state().state().hashi().config.paused() || self.is_reconfiguring())
+        {
+            return false;
+        }
+
+        self.unapproved_deposit_tasks.abort_all();
+        self.approved_deposit_tasks.abort_all();
+        self.pending_unapproved_deposit_requests.clear();
+        self.inflight_deposits.clear();
+        true
+    }
+
     async fn process_unapproved_deposit(
         inner: Arc<Hashi>,
         deposit_request: DepositRequest,
-    ) -> Result<(), DepositError> {
+    ) -> Result<(), UnapprovedDepositError> {
         info!("Approving deposit request");
 
         // Validate deposit_request before asking for signatures
@@ -247,7 +315,7 @@ impl LeaderService {
         }
 
         if aggregator.weight() < required_weight {
-            return Err(DepositError::FailedQuorum {
+            return Err(UnapprovedDepositError::FailedQuorum {
                 weight: aggregator.weight(),
                 required_weight,
             });
@@ -255,11 +323,11 @@ impl LeaderService {
 
         let signed_message = match aggregator.finish() {
             Ok(signed_message) => signed_message,
-            Err(err) => return Err(DepositError::CertificateBuildFailed(err.into())),
+            Err(err) => return Err(UnapprovedDepositError::CertificateBuildFailed(err.into())),
         };
         let mut executor = match SuiTxExecutor::from_hashi(inner.clone()) {
             Ok(executor) => executor,
-            Err(err) => return Err(DepositError::ExecutorInitFailed(err)),
+            Err(err) => return Err(UnapprovedDepositError::ExecutorInitFailed(err)),
         };
         executor
             .execute_approve_deposit(&deposit_request, signed_message)
@@ -280,23 +348,23 @@ impl LeaderService {
                     .with_label_values(&["approve_deposit", "failure"])
                     .inc();
             })
-            .map_err(DepositError::ApproveDepositFailed)?;
+            .map_err(UnapprovedDepositError::ApproveDepositFailed)?;
         Ok(())
     }
 
     /// Submit `confirm_deposit` for a deposit that has already been
     /// approved on-chain and whose time-delay window has elapsed. The
-    /// caller (`process_deposit_requests`) checks the delay before
+    /// caller (`process_approved_deposit_requests`) checks the delay before
     /// scheduling the task.
     async fn process_approved_deposit(
         inner: Arc<Hashi>,
         deposit_request: DepositRequest,
-    ) -> Result<(), DepositError> {
+    ) -> Result<(), ApprovedDepositError> {
         info!("Confirming approved deposit request");
 
         let mut executor = match SuiTxExecutor::from_hashi(inner.clone()) {
             Ok(executor) => executor,
-            Err(err) => return Err(DepositError::ExecutorInitFailed(err)),
+            Err(err) => return Err(ApprovedDepositError::ExecutorInitFailed(err)),
         };
         executor
             .execute_confirm_deposit(deposit_request.id)
@@ -318,7 +386,7 @@ impl LeaderService {
                     .with_label_values(&["confirm_deposit", "failure"])
                     .inc();
             })
-            .map_err(DepositError::ConfirmDepositFailed)?;
+            .map_err(ApprovedDepositError::ConfirmDepositFailed)?;
         Ok(())
     }
 

--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -208,7 +208,7 @@ impl LeaderService {
                 }
                 self.process_unapproved_deposit_requests();
             }
-            Err(err) if err.is_panic() => error!("deposit task panicked: {err}"),
+            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
             Err(err) => error!("deposit task failed to join: {err}"),
         }
     }
@@ -243,7 +243,7 @@ impl LeaderService {
                     }
                 }
             }
-            Err(err) if err.is_panic() => error!("deposit task panicked: {err}"),
+            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
             Err(err) => error!("deposit task failed to join: {err}"),
         }
     }

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -17,8 +17,10 @@ use crate::deposits::UnapprovedDepositError;
 use crate::grpc::BoxedChannel;
 use crate::leader::retry::GlobalRetryTracker;
 use crate::leader::retry::RetryTracker;
+use crate::leader::withdrawal_transactions::WithdrawalBroadcastResult;
 use crate::onchain::types::DepositRequest;
 use crate::withdrawals::WithdrawalApprovalErrorKind;
+use crate::withdrawals::WithdrawalBroadcastErrorKind;
 use crate::withdrawals::WithdrawalCommitmentErrorKind;
 
 use fastcrypto::bls12381::min_pk::BLS12381Signature;
@@ -45,49 +47,69 @@ use x509_parser::nom::AsBytes;
 const NUM_CONSECUTIVE_LEADER_CHECKPOINTS: u64 = 100;
 const LEADER_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Result of a withdrawal broadcast task: `Some(spent_utxo_ids)` when the
-/// withdrawal was confirmed on Sui, `None` when it was not yet ready.
-type WithdrawalBroadcastResult = anyhow::Result<Option<Vec<crate::onchain::types::UtxoId>>>;
-
-/// Whether a failed peer RPC is worth retrying. Under sustained load a peer's
-/// HTTP/2 server tears the whole multiplexed connection down — `GoAway`
-/// (surfaced as `Internal`), broken pipe (`Unknown`), or the usual
-/// `Unavailable` — failing every in-flight request to that peer at once. The
-/// peer signing RPCs are idempotent, so retrying these transport-class codes is
-/// safe and lets the request land on a fresh connection.
-fn is_retriable_transport(status: &tonic::Status) -> bool {
-    matches!(
-        status.code(),
-        tonic::Code::Unavailable
-            | tonic::Code::Unknown
-            | tonic::Code::Internal
-            | tonic::Code::Cancelled
-            | tonic::Code::DeadlineExceeded
-    )
-}
-
 pub(crate) struct LeaderService {
+    // Shared application state and external service clients used by leader jobs.
     inner: Arc<Hashi>,
+
+    // Background tasks currently approving Bitcoin deposits.
     unapproved_deposit_tasks: JoinSet<(Address, Result<(), UnapprovedDepositError>)>,
+    // Background tasks currently confirming approved Bitcoin deposits.
     approved_deposit_tasks: JoinSet<(Address, Result<(), ApprovedDepositError>)>,
+    // Deposit requests loaded from Bitcoin/on-chain state and waiting for approval processing.
     pending_unapproved_deposit_requests: Vec<DepositRequest>,
+    // Deposit IDs that should not be retried by this leader process.
     never_retry_deposit_ids: HashSet<Address>,
+    // Deposit IDs currently running in either deposit task pool.
     inflight_deposits: HashSet<Address>,
-    withdrawal_approval_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
-    withdrawal_commitment_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
-    withdrawal_signing_tasks: JoinSet<(Address, anyhow::Result<()>)>,
-    inflight_withdrawal_signings: HashSet<Address>,
-    withdrawal_broadcast_tasks: JoinSet<(Address, WithdrawalBroadcastResult)>,
-    inflight_withdrawal_broadcasts: HashSet<Address>,
-    stuck_withdrawal_warned: HashSet<Address>,
-    approved_deposit_retry_tracker: RetryTracker<ApprovedDepositErrorKind>,
-    withdrawal_approval_retry_tracker: RetryTracker<WithdrawalApprovalErrorKind>,
-    withdrawal_commitment_retry_tracker: GlobalRetryTracker<WithdrawalCommitmentErrorKind>,
+    // Singleton task that deletes expired or spent deposit-related on-chain state.
     deposit_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+
+    // Singleton task that batches withdrawal request approval work.
+    withdrawal_approval_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    // Per-withdrawal retry state for collecting withdrawal approval signatures.
+    withdrawal_approval_retry_tracker: RetryTracker<WithdrawalApprovalErrorKind>,
+    // Singleton task that commits approved withdrawal requests into withdrawal txns.
+    withdrawal_commitment_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    // Global retry state for committing approved withdrawal requests into withdrawal txns.
+    withdrawal_commitment_retry_tracker: GlobalRetryTracker<WithdrawalCommitmentErrorKind>,
+
+    // Background tasks currently signing unsigned withdrawal transactions.
+    withdrawal_signing_tasks: JoinSet<(Address, anyhow::Result<()>)>,
+    // Withdrawal transaction IDs currently running in the signing task pool.
+    inflight_withdrawal_signings: HashSet<Address>,
+
+    // Normal checkpoint-triggered signed-withdrawal broadcast/status tasks.
+    withdrawal_broadcast_tasks: JoinSet<(Address, WithdrawalBroadcastResult)>,
+    // Withdrawal transaction IDs currently running in the normal broadcast task pool.
+    inflight_withdrawal_broadcasts: HashSet<Address>,
+    // Signed withdrawals parked until Bitcoin advances because they are in the
+    // mempool or confirmed below threshold.
+    withdrawals_waiting_for_btc_block: HashSet<Address>,
+    // Parked withdrawals made eligible again by a new Bitcoin block.
+    pending_btc_block_withdrawal_checks: HashSet<Address>,
+    // Separate task pool for Bitcoin-block-triggered status checks so normal
+    // checkpoint-triggered checks cannot starve them or be starved by them.
+    withdrawal_btc_block_check_tasks: JoinSet<(Address, WithdrawalBroadcastResult)>,
+    // Withdrawal IDs currently running in the Bitcoin-block-triggered task pool.
+    inflight_withdrawal_btc_block_checks: HashSet<Address>,
+    // Withdrawal IDs that have already emitted the stuck-withdrawal warning.
+    stuck_withdrawal_warned: HashSet<Address>,
+    // Per-deposit retry state for approved deposit confirmations.
+    approved_deposit_retry_tracker: RetryTracker<ApprovedDepositErrorKind>,
+    // Per-withdrawal retry state for signed withdrawal broadcast/status errors.
+    withdrawal_broadcast_retry_tracker: RetryTracker<WithdrawalBroadcastErrorKind>,
+
+    // Singleton task that deletes stale governance proposals.
     proposal_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+
+    // UTXO cleanup requests discovered after withdrawals are confirmed on Sui.
     pending_utxo_cleanups: VecDeque<garbage_collection::PendingUtxoCleanup>,
+    // Singleton task that cleans up spent withdrawal input UTXOs on-chain.
     utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    // Forces a fresh scan for UTXO cleanup work after cleanup state changes.
     utxo_cleanup_scan_needed: bool,
+
+    // Singleton task that reconciles the guardian committee with the on-chain committee.
     guardian_committee_reconcile_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     // Last hashi epoch we triggered a guardian-committee reconcile for, so
     // we only kick a new task when the chain advances (not every checkpoint).
@@ -100,6 +122,7 @@ impl LeaderService {
         Self {
             inner: hashi,
             withdrawal_approval_retry_tracker: RetryTracker::new(),
+            withdrawal_broadcast_retry_tracker: RetryTracker::new(),
             withdrawal_commitment_retry_tracker: GlobalRetryTracker::new(),
             unapproved_deposit_tasks: JoinSet::new(),
             approved_deposit_tasks: JoinSet::new(),
@@ -112,6 +135,10 @@ impl LeaderService {
             inflight_withdrawal_signings: HashSet::new(),
             withdrawal_broadcast_tasks: JoinSet::new(),
             inflight_withdrawal_broadcasts: HashSet::new(),
+            withdrawals_waiting_for_btc_block: HashSet::new(),
+            pending_btc_block_withdrawal_checks: HashSet::new(),
+            withdrawal_btc_block_check_tasks: JoinSet::new(),
+            inflight_withdrawal_btc_block_checks: HashSet::new(),
             stuck_withdrawal_warned: HashSet::new(),
             approved_deposit_retry_tracker: RetryTracker::new(),
             deposit_gc_task: None,
@@ -225,6 +252,8 @@ impl LeaderService {
                     let block_height = *btc_block_rx.borrow_and_update();
                     let checkpoint_height = checkpoint_rx.borrow().height;
 
+                    self.schedule_withdrawal_checks_for_btc_block();
+
                     if self.is_current_leader(checkpoint_height) {
                         self.process_deposits_on_bitcoin_block(block_height);
                     }
@@ -246,6 +275,9 @@ impl LeaderService {
                 }
                 Some(result) = self.withdrawal_broadcast_tasks.join_next() => {
                     self.handle_completed_withdrawal_broadcast_task(result);
+                }
+                Some(result) = self.withdrawal_btc_block_check_tasks.join_next() => {
+                    self.handle_completed_withdrawal_btc_block_check_task(result);
                 }
                 Some(result) = OptionFuture::from(self.withdrawal_approval_task.as_mut()) => {
                     self.withdrawal_approval_task = None;
@@ -360,6 +392,23 @@ fn parse_member_signature(
             .as_bytes(),
     )?;
     Ok(MemberSignature::new(epoch, address, signature))
+}
+
+/// Whether a failed peer RPC is worth retrying. Under sustained load a peer's
+/// HTTP/2 server tears the whole multiplexed connection down — `GoAway`
+/// (surfaced as `Internal`), broken pipe (`Unknown`), or the usual
+/// `Unavailable` — failing every in-flight request to that peer at once. The
+/// peer signing RPCs are idempotent, so retrying these transport-class codes is
+/// safe and lets the request land on a fresh connection.
+fn is_retriable_transport(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Unavailable
+            | tonic::Code::Unknown
+            | tonic::Code::Internal
+            | tonic::Code::Cancelled
+            | tonic::Code::DeadlineExceeded
+    )
 }
 
 #[cfg(test)]

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -11,7 +11,9 @@ pub(crate) use retry::RetryPolicy;
 
 use crate::Hashi;
 use crate::config::ForceRunAsLeader;
-use crate::deposits::DepositError;
+use crate::deposits::ApprovedDepositError;
+use crate::deposits::ApprovedDepositErrorKind;
+use crate::deposits::UnapprovedDepositError;
 use crate::grpc::BoxedChannel;
 use crate::leader::retry::GlobalRetryTracker;
 use crate::leader::retry::RetryTracker;
@@ -66,13 +68,11 @@ fn is_retriable_transport(status: &tonic::Status) -> bool {
 
 pub(crate) struct LeaderService {
     inner: Arc<Hashi>,
-    withdrawal_approval_retry_tracker: RetryTracker<WithdrawalApprovalErrorKind>,
-    withdrawal_commitment_retry_tracker: GlobalRetryTracker<WithdrawalCommitmentErrorKind>,
-    deposit_tasks: JoinSet<(Address, Result<(), DepositError>)>,
-    pending_deposit_requests: Vec<DepositRequest>,
+    unapproved_deposit_tasks: JoinSet<(Address, Result<(), UnapprovedDepositError>)>,
+    approved_deposit_tasks: JoinSet<(Address, Result<(), ApprovedDepositError>)>,
+    pending_unapproved_deposit_requests: Vec<DepositRequest>,
     never_retry_deposit_ids: HashSet<Address>,
     inflight_deposits: HashSet<Address>,
-    delayed_deposit_processing_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     withdrawal_approval_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     withdrawal_commitment_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     withdrawal_signing_tasks: JoinSet<(Address, anyhow::Result<()>)>,
@@ -80,6 +80,9 @@ pub(crate) struct LeaderService {
     withdrawal_broadcast_tasks: JoinSet<(Address, WithdrawalBroadcastResult)>,
     inflight_withdrawal_broadcasts: HashSet<Address>,
     stuck_withdrawal_warned: HashSet<Address>,
+    approved_deposit_retry_tracker: RetryTracker<ApprovedDepositErrorKind>,
+    withdrawal_approval_retry_tracker: RetryTracker<WithdrawalApprovalErrorKind>,
+    withdrawal_commitment_retry_tracker: GlobalRetryTracker<WithdrawalCommitmentErrorKind>,
     deposit_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     proposal_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     pending_utxo_cleanups: VecDeque<garbage_collection::PendingUtxoCleanup>,
@@ -98,11 +101,11 @@ impl LeaderService {
             inner: hashi,
             withdrawal_approval_retry_tracker: RetryTracker::new(),
             withdrawal_commitment_retry_tracker: GlobalRetryTracker::new(),
-            deposit_tasks: JoinSet::new(),
-            pending_deposit_requests: Vec::new(),
+            unapproved_deposit_tasks: JoinSet::new(),
+            approved_deposit_tasks: JoinSet::new(),
+            pending_unapproved_deposit_requests: Vec::new(),
             never_retry_deposit_ids: HashSet::new(),
             inflight_deposits: HashSet::new(),
-            delayed_deposit_processing_task: None,
             withdrawal_approval_task: None,
             withdrawal_commitment_task: None,
             withdrawal_signing_tasks: JoinSet::new(),
@@ -110,6 +113,7 @@ impl LeaderService {
             withdrawal_broadcast_tasks: JoinSet::new(),
             inflight_withdrawal_broadcasts: HashSet::new(),
             stuck_withdrawal_warned: HashSet::new(),
+            approved_deposit_retry_tracker: RetryTracker::new(),
             deposit_gc_task: None,
             proposal_gc_task: None,
             pending_utxo_cleanups: VecDeque::new(),
@@ -207,44 +211,34 @@ impl LeaderService {
                     self.process_approved_withdrawal_requests(checkpoint_timestamp_ms);
                     self.process_unsigned_withdrawal_txns();
                     self.process_signed_withdrawal_txns();
+                    self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
                     self.check_delete_proposals(checkpoint_timestamp_ms);
                     self.check_cleanup_spent_utxos();
-
-                    if !self.pending_deposit_requests.is_empty() {
-                        self.process_deposit_requests();
-                    }
+                    self.process_approved_deposit_requests();
                 }
                 wait_result = btc_block_rx.changed() => {
                     if let Err(e) = wait_result {
                         error!("Error waiting for Bitcoin block height change: {e}");
                         break;
                     }
+
                     let block_height = *btc_block_rx.borrow_and_update();
-                    let (checkpoint_height, checkpoint_timestamp_ms) = {
-                        let checkpoint_info = checkpoint_rx.borrow();
-                        (checkpoint_info.height, checkpoint_info.timestamp_ms)
-                    };
+                    let checkpoint_height = checkpoint_rx.borrow().height;
 
-                    // We want to unconditionally reload deposits, even if we aren't the leader to
-                    // avoid only the leader being able to reload the moment a block is seen.
-                    self.reload_pending_deposit_requests();
-                    // Approved deposits may only become confirmable after the configured
-                    // Bitcoin deposit time-delay elapses, without another Bitcoin block.
-                    self.schedule_delayed_deposit_processing();
-
-                    if !self.is_current_leader(checkpoint_height) {
-                        continue;
+                    if self.is_current_leader(checkpoint_height) {
+                        self.process_deposits_on_bitcoin_block(block_height);
                     }
-
-                    debug!("New Bitcoin block {block_height}: processing deposit requests");
-
-                    self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
-                    self.process_deposit_requests();
                 }
-                Some(result) = self.deposit_tasks.join_next() => {
-                    self.handle_completed_deposit_task(result);
-                    while let Some(result) = self.deposit_tasks.try_join_next() {
-                        self.handle_completed_deposit_task(result);
+                Some(result) = self.unapproved_deposit_tasks.join_next() => {
+                    self.handle_completed_unapproved_deposit_task(result);
+                    while let Some(result) = self.unapproved_deposit_tasks.try_join_next() {
+                        self.handle_completed_unapproved_deposit_task(result);
+                    }
+                }
+                Some(result) = self.approved_deposit_tasks.join_next() => {
+                    self.handle_completed_approved_deposit_task(result);
+                    while let Some(result) = self.approved_deposit_tasks.try_join_next() {
+                        self.handle_completed_approved_deposit_task(result);
                     }
                 }
                 Some(result) = self.withdrawal_signing_tasks.join_next() => {
@@ -260,10 +254,6 @@ impl LeaderService {
                 Some(result) = OptionFuture::from(self.withdrawal_commitment_task.as_mut()) => {
                     self.withdrawal_commitment_task = None;
                     Self::log_task_result("withdrawal_commitment", result);
-                }
-                Some(result) = OptionFuture::from(self.delayed_deposit_processing_task.as_mut()) => {
-                    let checkpoint_height = checkpoint_rx.borrow().height;
-                    self.handle_delayed_deposit_processing(result, checkpoint_height);
                 }
                 Some(result) = OptionFuture::from(self.deposit_gc_task.as_mut()) => {
                     self.deposit_gc_task = None;

--- a/crates/hashi/src/leader/withdrawal_transactions.rs
+++ b/crates/hashi/src/leader/withdrawal_transactions.rs
@@ -3,7 +3,6 @@
 
 use super::LEADER_TASK_TIMEOUT;
 use super::LeaderService;
-use super::WithdrawalBroadcastResult;
 use super::parse_member_signature;
 use crate::Hashi;
 use crate::btc_monitor::monitor::TxStatus;
@@ -11,6 +10,8 @@ use crate::leader::garbage_collection::PendingUtxoCleanup;
 use crate::onchain::types::UtxoId;
 use crate::onchain::types::WithdrawalTransaction;
 use crate::sui_tx_executor::SuiTxExecutor;
+use crate::withdrawals::WithdrawalBroadcastError;
+use crate::withdrawals::WithdrawalBroadcastErrorKind;
 use crate::withdrawals::WithdrawalTxSigning;
 use fastcrypto::groups::secp256k1::schnorr::SchnorrSignature;
 use fastcrypto::serde_helpers::ToFromByteArray;
@@ -33,11 +34,20 @@ use tracing::info;
 use tracing::trace;
 use tracing::warn;
 
+pub(super) enum WithdrawalBroadcastOutcome {
+    ConfirmedOnSui { utxo_ids: Vec<UtxoId> },
+    WaitForNextBitcoinBlock,
+}
+
+pub(super) type WithdrawalBroadcastResult =
+    Result<WithdrawalBroadcastOutcome, WithdrawalBroadcastError>;
+
 impl LeaderService {
     // ========================================================================
     // Step 3: MPC sign withdrawal transactions and store signatures on-chain
     // ========================================================================
 
+    /// Starts bounded background tasks for unsigned withdrawal transactions that need MPC signing.
     pub(super) fn process_unsigned_withdrawal_txns(&mut self) {
         debug!("Entering process_unsigned_withdrawal_txns");
         if self.is_reconfiguring() {
@@ -92,6 +102,7 @@ impl LeaderService {
         }
     }
 
+    /// Removes completed signing tasks from the inflight set and logs their result.
     pub(super) fn handle_completed_withdrawal_signing_task(
         &mut self,
         result: Result<(Address, anyhow::Result<()>), tokio::task::JoinError>,
@@ -101,11 +112,13 @@ impl LeaderService {
                 self.inflight_withdrawal_signings.remove(&withdrawal_id);
                 Ok(inner)
             }
+            Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
             Err(e) => Err(e),
         };
         Self::log_task_result("withdrawal_signing", mapped);
     }
 
+    /// Collects MPC and guardian signatures for one unsigned withdrawal and stores them on-chain.
     #[tracing::instrument(level = "info", skip_all, fields(withdrawal_txn_id = %txn.id))]
     async fn process_unsigned_withdrawal_txn(
         inner: Arc<Hashi>,
@@ -318,6 +331,7 @@ impl LeaderService {
         Ok(())
     }
 
+    /// Requests withdrawal transaction signatures from committee members until one complete set succeeds.
     async fn collect_withdrawal_tx_signatures(
         inner: &Arc<Hashi>,
         withdrawal_txn_id: &Address,
@@ -359,6 +373,7 @@ impl LeaderService {
         }
     }
 
+    /// Opens a streaming signing RPC to one committee member and validates one signature per input.
     #[tracing::instrument(level = "debug", skip_all, fields(validator = %member.validator_address()))]
     async fn request_withdrawal_tx_signature(
         inner: &Arc<Hashi>,
@@ -436,6 +451,7 @@ impl LeaderService {
         })
     }
 
+    /// Requests a committee member's BLS signature over the on-chain withdrawal signing message.
     #[tracing::instrument(level = "debug", skip_all, fields(validator = %member.validator_address()))]
     async fn request_withdrawal_tx_signing_signature(
         inner: &Arc<Hashi>,
@@ -475,6 +491,7 @@ impl LeaderService {
             .ok()
     }
 
+    /// Submits the signed withdrawal transaction witnesses and committee certificate to Sui.
     async fn submit_sign_withdrawal(
         inner: &Arc<Hashi>,
         withdrawal_id: &Address,
@@ -501,6 +518,8 @@ impl LeaderService {
     // Step 4-5: Broadcast signed tx and confirm on-chain
     // ========================================================================
 
+    /// Runs per-checkpoint signed-withdrawal work: normal status checks plus
+    /// draining BTC-block-triggered retry checks.
     pub(super) fn process_signed_withdrawal_txns(&mut self) {
         debug!("Entering process_signed_withdrawal_txns");
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
@@ -510,13 +529,24 @@ impl LeaderService {
         let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
         self.inflight_withdrawal_broadcasts
             .retain(|id| pending_ids.contains(id));
+        self.withdrawals_waiting_for_btc_block
+            .retain(|id| pending_ids.contains(id));
+        self.pending_btc_block_withdrawal_checks
+            .retain(|id| pending_ids.contains(id));
+        self.withdrawal_broadcast_retry_tracker.prune(&pending_ids);
 
         let max_concurrent = self.inner.config.max_concurrent_leader_job_tasks();
+        let checkpoint_timestamp_ms = self.inner.onchain_state().latest_checkpoint_timestamp_ms();
         for txn in withdrawal_txns {
             if self.withdrawal_broadcast_tasks.len() >= max_concurrent {
                 break;
             }
-            if self.inflight_withdrawal_broadcasts.contains(&txn.id) {
+            if self.withdrawals_waiting_for_btc_block.contains(&txn.id)
+                || self.is_withdrawal_broadcast_queued_or_inflight(&txn.id)
+                || self
+                    .withdrawal_broadcast_retry_tracker
+                    .should_skip(&txn.id, checkpoint_timestamp_ms)
+            {
                 continue;
             }
 
@@ -533,8 +563,78 @@ impl LeaderService {
 
                 let result = match result {
                     Ok(result) => result,
-                    Err(_) => Err(anyhow::anyhow!(
-                        "withdrawal broadcast for {txn_id} timed out after {LEADER_TASK_TIMEOUT:?}"
+                    Err(_) => Err(WithdrawalBroadcastError::new(
+                        WithdrawalBroadcastErrorKind::TaskFailed,
+                        anyhow::anyhow!(
+                            "withdrawal broadcast for {txn_id} timed out after {LEADER_TASK_TIMEOUT:?}"
+                        ),
+                    )),
+                };
+
+                (txn_id, result)
+            });
+        }
+
+        self.process_pending_btc_block_withdrawal_checks();
+    }
+
+    /// Moves withdrawals that were parked until Bitcoin advanced into the active BTC-block check queue.
+    pub(super) fn schedule_withdrawal_checks_for_btc_block(&mut self) {
+        let waiting = std::mem::take(&mut self.withdrawals_waiting_for_btc_block);
+        let eligible: Vec<_> = waiting
+            .into_iter()
+            .filter(|withdrawal_id| !self.is_withdrawal_broadcast_queued_or_inflight(withdrawal_id))
+            .collect();
+        self.pending_btc_block_withdrawal_checks.extend(eligible);
+    }
+
+    /// Drains the BTC-block-triggered withdrawal check queue into its separate bounded task pool.
+    fn process_pending_btc_block_withdrawal_checks(&mut self) {
+        let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
+        withdrawal_txns.retain(|p| p.signatures.is_some());
+        withdrawal_txns.sort_by_key(|p| p.timestamp_ms);
+
+        let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
+        self.inflight_withdrawal_btc_block_checks
+            .retain(|id| pending_ids.contains(id));
+        self.pending_btc_block_withdrawal_checks
+            .retain(|id| pending_ids.contains(id));
+        self.withdrawal_broadcast_retry_tracker.prune(&pending_ids);
+
+        let max_concurrent = self.inner.config.max_concurrent_leader_job_tasks();
+        let checkpoint_timestamp_ms = self.inner.onchain_state().latest_checkpoint_timestamp_ms();
+        for txn in withdrawal_txns {
+            if self.withdrawal_btc_block_check_tasks.len() >= max_concurrent {
+                break;
+            }
+            if !self.pending_btc_block_withdrawal_checks.contains(&txn.id)
+                || self.is_withdrawal_broadcast_inflight(&txn.id)
+                || self
+                    .withdrawal_broadcast_retry_tracker
+                    .should_skip(&txn.id, checkpoint_timestamp_ms)
+            {
+                continue;
+            }
+
+            self.pending_btc_block_withdrawal_checks.remove(&txn.id);
+            let txn_id = txn.id;
+            let inner = self.inner.clone();
+
+            self.inflight_withdrawal_btc_block_checks.insert(txn_id);
+            self.withdrawal_btc_block_check_tasks.spawn(async move {
+                let result = tokio::time::timeout(
+                    LEADER_TASK_TIMEOUT,
+                    Self::handle_signed_withdrawal(inner, txn),
+                )
+                .await;
+
+                let result = match result {
+                    Ok(result) => result,
+                    Err(_) => Err(WithdrawalBroadcastError::new(
+                        WithdrawalBroadcastErrorKind::TaskFailed,
+                        anyhow::anyhow!(
+                            "withdrawal broadcast for {txn_id} timed out after {LEADER_TASK_TIMEOUT:?}"
+                        ),
                     )),
                 };
 
@@ -543,6 +643,7 @@ impl LeaderService {
         }
     }
 
+    /// Handles completion of a normal checkpoint-triggered signed-withdrawal status task.
     pub(super) fn handle_completed_withdrawal_broadcast_task(
         &mut self,
         result: Result<(Address, WithdrawalBroadcastResult), tokio::task::JoinError>,
@@ -550,23 +651,80 @@ impl LeaderService {
         let mapped = match result {
             Ok((withdrawal_id, inner)) => {
                 self.inflight_withdrawal_broadcasts.remove(&withdrawal_id);
-                if let Ok(Some(utxo_ids)) = &inner {
-                    self.pending_utxo_cleanups.push_back(PendingUtxoCleanup {
-                        utxo_ids: utxo_ids.clone(),
-                    });
-                }
-                Ok(inner.map(|_| ()))
+                Ok(self.handle_withdrawal_broadcast_result(withdrawal_id, inner))
             }
+            Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
             Err(e) => Err(e),
         };
         Self::log_task_result("withdrawal_broadcast", mapped);
     }
 
-    /// Check BTC tx status, broadcast/re-broadcast if needed, confirm when
+    /// Handles completion of a BTC-block-triggered signed-withdrawal status task.
+    pub(super) fn handle_completed_withdrawal_btc_block_check_task(
+        &mut self,
+        result: Result<(Address, WithdrawalBroadcastResult), tokio::task::JoinError>,
+    ) {
+        let mapped = match result {
+            Ok((withdrawal_id, inner)) => {
+                self.inflight_withdrawal_btc_block_checks
+                    .remove(&withdrawal_id);
+                Ok(self.handle_withdrawal_broadcast_result(withdrawal_id, inner))
+            }
+            Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+            Err(e) => Err(e),
+        };
+        Self::log_task_result("withdrawal_btc_block_check", mapped);
+    }
+
+    /// Applies a signed-withdrawal task outcome to leader scheduler state.
+    fn handle_withdrawal_broadcast_result(
+        &mut self,
+        withdrawal_id: Address,
+        result: WithdrawalBroadcastResult,
+    ) -> anyhow::Result<()> {
+        match result {
+            Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui { utxo_ids }) => {
+                self.withdrawal_broadcast_retry_tracker
+                    .clear(&withdrawal_id);
+                self.pending_utxo_cleanups
+                    .push_back(PendingUtxoCleanup { utxo_ids });
+            }
+            Ok(WithdrawalBroadcastOutcome::WaitForNextBitcoinBlock) => {
+                self.withdrawal_broadcast_retry_tracker
+                    .clear(&withdrawal_id);
+                self.withdrawals_waiting_for_btc_block.insert(withdrawal_id);
+            }
+            Err(err) => {
+                self.withdrawal_broadcast_retry_tracker.record_failure(
+                    err.kind(),
+                    withdrawal_id,
+                    self.inner.onchain_state().latest_checkpoint_timestamp_ms(),
+                );
+                return Err(err.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns whether a signed withdrawal is queued or running in any broadcast/status path.
+    fn is_withdrawal_broadcast_queued_or_inflight(&self, withdrawal_id: &Address) -> bool {
+        self.pending_btc_block_withdrawal_checks
+            .contains(withdrawal_id)
+            || self.is_withdrawal_broadcast_inflight(withdrawal_id)
+    }
+
+    /// Returns whether a signed withdrawal is running in any broadcast/status task pool.
+    fn is_withdrawal_broadcast_inflight(&self, withdrawal_id: &Address) -> bool {
+        self.inflight_withdrawal_broadcasts.contains(withdrawal_id)
+            || self
+                .inflight_withdrawal_btc_block_checks
+                .contains(withdrawal_id)
+    }
+
+    /// Checks BTC tx status, broadcasts or re-broadcasts if needed, and confirms on Sui when
     /// enough BTC confirmations are reached.
     ///
-    /// Returns `Some(utxo_ids)` when the withdrawal was confirmed on Sui,
-    /// signalling that UTXO cleanup should be scheduled.
+    /// Returns the next scheduler action after the status check completes.
     #[tracing::instrument(level = "info", skip_all, fields(withdrawal_txn_id = %txn.id, bitcoin_txid))]
     async fn handle_signed_withdrawal(
         inner: Arc<Hashi>,
@@ -585,8 +743,15 @@ impl LeaderService {
                     "Withdrawal tx confirmed, proceeding to on-chain confirmation"
                 );
                 let utxo_ids: Vec<UtxoId> = txn.inputs.iter().map(|u| u.id).collect();
-                Self::confirm_withdrawal_on_sui(&inner, &txn).await?;
-                return Ok(Some(utxo_ids));
+                Self::confirm_withdrawal_on_sui(&inner, &txn)
+                    .await
+                    .map_err(|e| {
+                        WithdrawalBroadcastError::new(
+                            WithdrawalBroadcastErrorKind::SuiConfirmation,
+                            e,
+                        )
+                    })?;
+                return Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui { utxo_ids });
             }
             Ok(TxStatus::Confirmed { confirmations }) => {
                 debug!(
@@ -598,47 +763,47 @@ impl LeaderService {
                 debug!("Withdrawal tx in mempool, waiting for confirmations");
             }
             Ok(TxStatus::NotFound) => {
-                Self::rebuild_and_broadcast_withdrawal_btc_tx(&inner, &txn, txid).await;
+                Self::rebuild_and_broadcast_withdrawal_btc_tx(&inner, &txn, txid)
+                    .await
+                    .map_err(|e| {
+                        WithdrawalBroadcastError::new(WithdrawalBroadcastErrorKind::BitcoinRpc, e)
+                    })?;
             }
             Err(e) => {
-                anyhow::bail!(
-                    "failed to query transaction status for withdrawal transaction {}: {e}",
-                    txn.id
-                );
+                return Err(WithdrawalBroadcastError::new(
+                    WithdrawalBroadcastErrorKind::BitcoinRpc,
+                    anyhow::anyhow!(
+                        "failed to query transaction status for withdrawal transaction {}: {e}",
+                        txn.id
+                    ),
+                ));
             }
         }
-        Ok(None)
+        Ok(WithdrawalBroadcastOutcome::WaitForNextBitcoinBlock)
     }
 
-    /// Rebuild a fully signed Bitcoin transaction from on-chain WithdrawalTransaction
+    /// Rebuilds a fully signed Bitcoin transaction from on-chain WithdrawalTransaction
     /// data (stored witness signatures) and broadcast it to the Bitcoin network.
     #[tracing::instrument(level = "info", skip_all, fields(withdrawal_txn_id = %txn.id, bitcoin_txid = %txid))]
     async fn rebuild_and_broadcast_withdrawal_btc_tx(
         inner: &Arc<Hashi>,
         txn: &WithdrawalTransaction,
         txid: bitcoin::Txid,
-    ) {
+    ) -> anyhow::Result<()> {
         warn!("Withdrawal tx not found, re-broadcasting from on-chain signatures");
 
-        let tx = match Self::rebuild_signed_tx_from_onchain(inner, txn) {
-            Ok(tx) => tx,
-            Err(e) => {
-                error!("Failed to rebuild signed withdrawal tx: {e}");
-                return;
-            }
-        };
+        let tx = Self::rebuild_signed_tx_from_onchain(inner, txn)
+            .inspect_err(|e| error!("Failed to rebuild signed withdrawal tx: {e}"))?;
 
-        match inner.btc_monitor().broadcast_transaction(tx).await {
-            Ok(()) => {
-                info!("Re-broadcast withdrawal tx");
-            }
-            Err(e) => {
-                error!("Failed to re-broadcast withdrawal tx: {e}");
-            }
-        }
+        inner
+            .btc_monitor()
+            .broadcast_transaction(tx)
+            .await
+            .inspect(|()| info!("Re-broadcast withdrawal tx"))
+            .inspect_err(|e| error!("Failed to re-broadcast withdrawal tx: {e}"))
     }
 
-    /// Rebuild a fully signed Bitcoin transaction from on-chain
+    /// Rebuilds a fully signed Bitcoin transaction from on-chain
     /// `WithdrawalTransaction` data and broadcast-ready 2-of-2 witness.
     ///
     /// Witness layout per input (BIP342 multi_a, verified against
@@ -702,6 +867,7 @@ impl LeaderService {
         Ok(tx)
     }
 
+    /// Collects a confirmation certificate and submits the finalized withdrawal to Sui.
     #[tracing::instrument(level = "info", skip_all, fields(withdrawal_txn_id = %txn.id))]
     async fn confirm_withdrawal_on_sui(
         inner: &Arc<Hashi>,
@@ -736,6 +902,7 @@ impl LeaderService {
         Ok(())
     }
 
+    /// Collects enough committee signatures to certify that a withdrawal can be confirmed.
     #[tracing::instrument(level = "debug", skip_all, fields(withdrawal_txn_id = %withdrawal_txn_id))]
     async fn collect_withdrawal_confirmation_signature(
         inner: &Arc<Hashi>,
@@ -784,6 +951,7 @@ impl LeaderService {
         Ok(aggregator.finish()?.into_parts().0)
     }
 
+    /// Requests one committee member's BLS signature over a withdrawal confirmation message.
     #[tracing::instrument(level = "debug", skip_all, fields(validator = %member.validator_address()))]
     async fn request_withdrawal_confirmation_signature(
         inner: &Arc<Hashi>,
@@ -826,6 +994,7 @@ impl LeaderService {
             .ok()
     }
 
+    /// Submits the withdrawal confirmation certificate to Sui.
     async fn submit_confirm_withdrawal(
         inner: &Arc<Hashi>,
         withdrawal_txn_id: &Address,
@@ -845,6 +1014,7 @@ impl LeaderService {
 }
 
 impl WithdrawalTxSigning {
+    /// Converts the withdrawal signing message into the bridge-service protobuf request type.
     fn to_proto(&self) -> SignWithdrawalTxSigningRequest {
         SignWithdrawalTxSigningRequest {
             withdrawal_id: self.withdrawal_id.as_bytes().to_vec().into(),

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -1277,6 +1277,45 @@ impl WithdrawalCommitmentError {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum WithdrawalBroadcastErrorKind {
+    BitcoinRpc,
+    SuiConfirmation,
+    TaskFailed,
+}
+
+impl RetryPolicy for WithdrawalBroadcastErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        30 * 1000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        10 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("{kind:?}: {source}")]
+pub struct WithdrawalBroadcastError {
+    kind: WithdrawalBroadcastErrorKind,
+    #[source]
+    source: anyhow::Error,
+}
+
+impl WithdrawalBroadcastError {
+    pub fn new(kind: WithdrawalBroadcastErrorKind, source: anyhow::Error) -> Self {
+        Self { kind, source }
+    }
+
+    pub fn kind(&self) -> WithdrawalBroadcastErrorKind {
+        self.kind
+    }
+}
+
 pub fn witness_program_from_address(address: &BitcoinAddress) -> anyhow::Result<Vec<u8>> {
     let script = address.script_pubkey();
     let bytes = script.as_bytes();


### PR DESCRIPTION
Temporary devnet-only branch to unbreak withdrawals while the guardian stays on its deployed image. **Do not merge.**

The devnet guardian runs image `597301e7` (pre-#650, pre-#652). The soft redeploy to `eb2666cf9` broke hashi↔guardian wire compat on **two** protos:
- **#650** — `GetGuardianInfoResponse` field renumbering (limiter fields ↔ `encrypted_shares`)
- **#652** — `InputUTXO` field 3 `string address` → `bytes derivation_path`

Rather than hand-revert #652 (entangled with the #655 taproot/UTXO rewrite — security-critical signing code), this branch is the last commit before any break (`f70c798cd`, #651) with the two independent leader fixes cherry-picked on top:
- **#653** — Split deposit approval and confirmation processing
- **#656** — Prevent signed withdrawal status checks from starving rebroadcasts

Net: wire-compatible with the running guardian by construction; keeps the deposit-split + rebroadcast fixes; drops only #654 (partial-sig perf) and the #652/#655 UTXO hardening. The real fix is redeploying the guardian on the new proto with a PVC-persisted enclave key.