### PR TITLE
[kyoto-hardening][btc-monitor] Resume Kyoto near the tip on restart

### DIFF
--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -36,6 +36,12 @@ const KYOTO_RESTART_DELAY_BASE: Duration = Duration::from_secs(5);
 /// Random additional delay to spread reconnects across pods.
 const KYOTO_MAX_RESTART_DELAY_JITTER: Duration = Duration::from_secs(30);
 
+/// How far below the last known tip to re-anchor Kyoto when rebuilding after a
+/// restart. Must stay well above `bitcoin_confirmation_threshold` and any
+/// plausible reorg so deposits still awaiting confirmation are re-scanned;
+/// 2016 blocks (one difficulty period) clears both comfortably.
+const KYOTO_RESTART_CHECKPOINT_DEPTH: u32 = 2016;
+
 /// How many Bitcoin blocks a deposit observation can go without being
 /// refreshed before it's dropped from the confirmation-metrics cache.
 const STALE_OBSERVATION_BLOCKS: u32 = 10;
@@ -45,6 +51,18 @@ fn next_restart_delay() -> Duration {
         rand::thread_rng().gen_range(0..=KYOTO_MAX_RESTART_DELAY_JITTER.as_millis() as u64),
     );
     KYOTO_RESTART_DELAY_BASE + jitter
+}
+
+/// Height to re-anchor Kyoto at on restart: `depth` below the tip, or `None` to
+/// reuse the start checkpoint when there's no tip yet or the tip is within
+/// `depth` of the start. Pure so the policy is testable without bitcoind.
+fn resume_anchor_height(
+    tip: Option<HashCheckpoint>,
+    start_checkpoint: HashCheckpoint,
+    depth: u32,
+) -> Option<u32> {
+    let resume_height = tip?.height.saturating_sub(depth);
+    (resume_height > start_checkpoint.height).then_some(resume_height)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -284,6 +302,50 @@ impl Monitor {
         HashCheckpoint::from_genesis(network)
     }
 
+    /// Checkpoint to anchor to when rebuilding the node after a restart. Once
+    /// we've synced we know the tip, so we re-anchor
+    /// [`KYOTO_RESTART_CHECKPOINT_DEPTH`] blocks below it instead of
+    /// re-downloading from `start_checkpoint`. Falls back to `start_checkpoint`
+    /// before the first sync, near the start, or on RPC failure.
+    async fn resume_checkpoint(&self) -> HashCheckpoint {
+        let Some(resume_height) = resume_anchor_height(
+            self.tip,
+            self.start_checkpoint,
+            KYOTO_RESTART_CHECKPOINT_DEPTH,
+        ) else {
+            return self.start_checkpoint;
+        };
+        match btc_rpc_call(&self.bitcoind_rpc, move |rpc| {
+            rpc.get_block_hash(resume_height as u64)
+        })
+        .await
+        {
+            Ok(raw) => match raw.into_model() {
+                Ok(model) => {
+                    info!(
+                        "Re-anchoring Kyoto at height {resume_height} ({}) on restart",
+                        model.0
+                    );
+                    HashCheckpoint::new(resume_height, model.0)
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to parse getblockhash({resume_height}) on restart: {e}; \
+                         anchoring at start height instead"
+                    );
+                    self.start_checkpoint
+                }
+            },
+            Err(e) => {
+                warn!(
+                    "Failed to fetch resume block hash at height {resume_height}: {e}; \
+                     anchoring at start height instead"
+                );
+                self.start_checkpoint
+            }
+        }
+    }
+
     /// Run a BTC monitor with the given configuration.
     /// Returns the client for interacting with the monitor and a Service for lifecycle management.
     pub fn run(config: MonitorConfig, metrics: Arc<Metrics>) -> Result<(MonitorClient, Service)> {
@@ -395,8 +457,8 @@ impl Monitor {
 
             tokio::time::sleep(next_restart_delay()).await;
 
-            let (new_node, new_client) =
-                Self::build_kyoto_node(&self.config, self.start_checkpoint);
+            let resume_checkpoint = self.resume_checkpoint().await;
+            let (new_node, new_client) = Self::build_kyoto_node(&self.config, resume_checkpoint);
             current_node = new_node;
             current_client = new_client;
             self.requester = current_client.requester.clone();
@@ -1422,6 +1484,29 @@ mod tests {
             Monitor::resolve_start_checkpoint(&rpc, &between_segwit_and_taproot).await,
             HashCheckpoint::segwit_activation(),
         );
+    }
+
+    #[test]
+    fn resume_anchor_height_policy() {
+        let depth = KYOTO_RESTART_CHECKPOINT_DEPTH;
+        let start = HashCheckpoint::new(297_756, block_hash(7));
+
+        // Before the first sync there's no tip: reuse the start checkpoint.
+        assert_eq!(resume_anchor_height(None, start, depth), None);
+
+        // A tip well above the start anchors `depth` blocks below it.
+        let tip = HashCheckpoint::new(307_819, block_hash(8));
+        assert_eq!(
+            resume_anchor_height(Some(tip), start, depth),
+            Some(307_819 - depth),
+        );
+
+        // A tip within — or exactly one depth above — the start has nothing
+        // deeper to anchor at, so reuse the start checkpoint.
+        let near = HashCheckpoint::new(start.height + 100, block_hash(9));
+        assert_eq!(resume_anchor_height(Some(near), start, depth), None);
+        let exact = HashCheckpoint::new(start.height + depth, block_hash(10));
+        assert_eq!(resume_anchor_height(Some(exact), start, depth), None);
     }
 
     #[test]

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -192,6 +192,7 @@ pub struct Monitor {
     client_tx: tokio::sync::mpsc::Sender<MonitorMessage>,
     requester: kyoto::Requester,
     tip: Option<HashCheckpoint>,
+    start_checkpoint: HashCheckpoint,
     block_height_tx: tokio::sync::watch::Sender<u32>,
     pending_deposits: Vec<PendingDeposit>,
     pending_deposit_workers: JoinSet<()>,
@@ -213,17 +214,10 @@ where
 }
 
 impl Monitor {
-    fn build_kyoto_node(config: &MonitorConfig) -> (kyoto::Node, kyoto::Client) {
-        let checkpoint = match config.network {
-            bitcoin::Network::Bitcoin if config.start_height > 709_631 => {
-                kyoto::HashCheckpoint::taproot_activation()
-            }
-            bitcoin::Network::Bitcoin if config.start_height > 481_823 => {
-                kyoto::HashCheckpoint::segwit_activation()
-            }
-            network => kyoto::HashCheckpoint::from_genesis(network),
-        };
-
+    fn build_kyoto_node(
+        config: &MonitorConfig,
+        checkpoint: HashCheckpoint,
+    ) -> (kyoto::Node, kyoto::Client) {
         let mut builder = kyoto::Builder::new(config.network)
             .add_peers(config.trusted_peers.iter().cloned())
             // Only connect to the configured trusted peers. Prevents Kyoto from
@@ -238,6 +232,56 @@ impl Monitor {
         }
 
         builder.build()
+    }
+
+    /// Kyoto re-syncs from its checkpoint on every build, so anchoring at genesis
+    /// replays the whole chain. Anchor non-mainnet at `start_height`; mainnet
+    /// keeps the soft-fork activation anchors.
+    async fn resolve_start_checkpoint(
+        bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
+        config: &MonitorConfig,
+    ) -> HashCheckpoint {
+        match config.network {
+            bitcoin::Network::Bitcoin if config.start_height > 709_631 => {
+                HashCheckpoint::taproot_activation()
+            }
+            bitcoin::Network::Bitcoin if config.start_height > 481_823 => {
+                HashCheckpoint::segwit_activation()
+            }
+            network => Self::checkpoint_at_height(bitcoind_rpc, config.start_height, network).await,
+        }
+    }
+
+    async fn checkpoint_at_height(
+        bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
+        height: u32,
+        network: bitcoin::Network,
+    ) -> HashCheckpoint {
+        const MAX_ATTEMPTS: u32 = 5;
+        const RETRY_DELAY: Duration = Duration::from_secs(2);
+
+        for attempt in 1..=MAX_ATTEMPTS {
+            match btc_rpc_call(bitcoind_rpc, move |rpc| rpc.get_block_hash(height as u64)).await {
+                Ok(raw) => match raw.into_model() {
+                    Ok(model) => {
+                        info!("Anchoring Kyoto at start height {height} ({})", model.0);
+                        return HashCheckpoint::new(height, model.0);
+                    }
+                    Err(e) => error!("Failed to parse getblockhash({height}) response: {e}"),
+                },
+                Err(e) => warn!(
+                    "Failed to fetch block hash at start height {height} \
+                     (attempt {attempt}/{MAX_ATTEMPTS}): {e}"
+                ),
+            }
+            tokio::time::sleep(RETRY_DELAY).await;
+        }
+
+        warn!(
+            "Could not resolve a checkpoint at start height {height}; falling back to genesis. \
+             Kyoto will sync the entire chain from genesis."
+        );
+        HashCheckpoint::from_genesis(network)
     }
 
     /// Run a BTC monitor with the given configuration.
@@ -256,8 +300,8 @@ impl Monitor {
             async move {
                 let bitcoind_rpc = Arc::new(bitcoind_rpc);
 
-                // Build initial Kyoto node.
-                let (kyoto_node, kyoto_client) = Self::build_kyoto_node(&config);
+                let start_checkpoint = Self::resolve_start_checkpoint(&bitcoind_rpc, &config).await;
+                let (kyoto_node, kyoto_client) = Self::build_kyoto_node(&config, start_checkpoint);
 
                 let mut monitor = Monitor {
                     config,
@@ -266,6 +310,7 @@ impl Monitor {
                     requester: kyoto_client.requester.clone(),
                     client_tx,
                     tip: None,
+                    start_checkpoint,
                     block_height_tx,
                     pending_deposits: vec![],
                     pending_deposit_workers: JoinSet::new(),
@@ -350,7 +395,8 @@ impl Monitor {
 
             tokio::time::sleep(next_restart_delay()).await;
 
-            let (new_node, new_client) = Self::build_kyoto_node(&self.config);
+            let (new_node, new_client) =
+                Self::build_kyoto_node(&self.config, self.start_checkpoint);
             current_node = new_node;
             current_client = new_client;
             self.requester = current_client.requester.clone();
@@ -1324,7 +1370,10 @@ mod tests {
         cache.put_tx_block(txid, block_info);
         let (client_tx, _client_rx) = tokio::sync::mpsc::channel(10);
         let mut result_rxs = Vec::new();
-        let (_, kyoto_client) = Monitor::build_kyoto_node(&MonitorConfig::default());
+        let (_, kyoto_client) = Monitor::build_kyoto_node(
+            &MonitorConfig::default(),
+            HashCheckpoint::from_genesis(bitcoin::Network::Bitcoin),
+        );
 
         for vout in [0, 1] {
             let (pending_deposit, result_rx) =
@@ -1345,6 +1394,34 @@ mod tests {
         }
 
         assert_eq!(cache_requests(&metrics, "tx_block", "hit"), 2);
+    }
+
+    #[tokio::test]
+    async fn resolve_start_checkpoint_uses_mainnet_activation_anchors() {
+        // Mainnet uses hard-coded anchors, so the RPC is never called here.
+        let rpc = Arc::new(corepc_client::client_sync::v29::Client::new(
+            "http://127.0.0.1:1",
+        ));
+
+        let above_taproot = MonitorConfig {
+            network: bitcoin::Network::Bitcoin,
+            start_height: 800_000,
+            ..MonitorConfig::default()
+        };
+        assert_eq!(
+            Monitor::resolve_start_checkpoint(&rpc, &above_taproot).await,
+            HashCheckpoint::taproot_activation(),
+        );
+
+        let between_segwit_and_taproot = MonitorConfig {
+            network: bitcoin::Network::Bitcoin,
+            start_height: 500_000,
+            ..MonitorConfig::default()
+        };
+        assert_eq!(
+            Monitor::resolve_start_checkpoint(&rpc, &between_segwit_and_taproot).await,
+            HashCheckpoint::segwit_activation(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stacked on #669. Even anchored at `start_height`, every supervision restart re-downloads everything since deployment. Once we've synced we know the tip, so on rebuild we re-anchor `KYOTO_RESTART_CHECKPOINT_DEPTH` (2016) blocks below it instead — a restart now resyncs ~2k blocks (seconds) rather than every block since `start_height`.

2016 is far above `bitcoin_confirmation_threshold` (6 on devnet) and any plausible reorg, so deposits still awaiting confirmation are always re-scanned; deeper deposits are already final. Falls back to the start checkpoint before the first sync, when the tip is within one depth of the start, or if the hash can't be fetched.

Second of three btc-monitor efficiency PRs.

## Changes

- `resume_checkpoint`: on rebuild, anchor 2016 blocks below the last known tip (hash from bitcoind), falling back to the start checkpoint.
- `resume_anchor_height`: pure helper for the depth-below-tip policy, unit-tested.
