### PR TITLE
[kyoto-hardening][btc-monitor] Skip per-header work during Kyoto catch-up

### DIFF
--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -192,6 +192,9 @@ pub struct Monitor {
     client_tx: tokio::sync::mpsc::Sender<MonitorMessage>,
     requester: kyoto::Requester,
     tip: Option<HashCheckpoint>,
+    /// Set once Kyoto's initial filter sync completes; gates per-block side
+    /// effects so the catch-up replay doesn't run them per header.
+    synced: bool,
     block_height_tx: tokio::sync::watch::Sender<u32>,
     pending_deposits: Vec<PendingDeposit>,
     pending_deposit_workers: JoinSet<()>,
@@ -266,6 +269,7 @@ impl Monitor {
                     requester: kyoto_client.requester.clone(),
                     client_tx,
                     tip: None,
+                    synced: false,
                     block_height_tx,
                     pending_deposits: vec![],
                     pending_deposit_workers: JoinSet::new(),
@@ -343,6 +347,7 @@ impl Monitor {
                 }
             }
 
+            self.synced = false;
             self.metrics.kyoto_restarts.inc();
             self.metrics.kyoto_connected_peers.set(0);
             self.metrics.kyoto_synced.set(0);
@@ -477,11 +482,6 @@ impl Monitor {
     fn process_chain_update(&mut self, changes: kyoto::chain::BlockHeaderChanges) {
         match changes {
             kyoto::chain::BlockHeaderChanges::Connected(indexed_header) => {
-                info!(
-                    "New block header at height {} ({})",
-                    indexed_header.height,
-                    indexed_header.block_hash()
-                );
                 self.metrics.kyoto_blocks_received.inc();
                 self.metrics
                     .kyoto_best_height
@@ -490,8 +490,23 @@ impl Monitor {
                     indexed_header.height,
                     indexed_header.block_hash(),
                 ));
-                let _ = self.block_height_tx.send(indexed_header.height);
-                self.process_pending_deposits();
+                // Kyoto replays a Connected event per header during catch-up;
+                // gate side effects until synced to avoid a per-block storm.
+                if self.synced {
+                    info!(
+                        "New block header at height {} ({})",
+                        indexed_header.height,
+                        indexed_header.block_hash()
+                    );
+                    let _ = self.block_height_tx.send(indexed_header.height);
+                    self.process_pending_deposits();
+                } else {
+                    debug!(
+                        "Catching up: connected header at height {} ({})",
+                        indexed_header.height,
+                        indexed_header.block_hash()
+                    );
+                }
             }
             kyoto::chain::BlockHeaderChanges::Reorganized {
                 accepted,
@@ -534,6 +549,7 @@ impl Monitor {
             tip.hash,
             sync_update.recent_history.len()
         );
+        self.synced = true;
         self.metrics.kyoto_synced.set(1);
         self.metrics.kyoto_best_height.set(tip.height as i64);
         self.metrics.kyoto_sync_percent.set(100);


### PR DESCRIPTION
## Summary

During its initial sync Kyoto fires a `Connected` event for every header, and the handler ran deposit processing and logged on each one — so catch-up became a storm of hundreds of thousands of iterations that blew out the devnet log buffers.

Gate those per-block side effects on a `synced` flag so they only run once Kyoto has caught up.

## Changes

- Add a `synced` flag (set on `FiltersSynced`, cleared on restart).
- During catch-up only track the tip; gate the info log, block-height notification, and deposit processing behind `synced`.
