### PR TITLE
[Guardian] Pin attestations with PCR allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,6 @@ dependencies = [
  "e2e-tests",
  "hashi-guardian",
  "hashi-types",
- "hex",
  "jsonrpc",
  "serde",
  "serde_yaml",

--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -52,9 +52,10 @@ for this KP's cert fingerprint, decrypts via the yubikey (`gpg --decrypt`), and
 verifies the decrypted share against its commitment.
 
 The operator `run` command verifies live `/info` signed info and Nitro
-attestation against the configured PCR0 before trusting the session signing key.
-The KP `verify` command anchors trust to the S3 `init/` attestation log before
-verifying the ceremony and share logs under that attested session key.
+attestation against the configured current build before trusting the session
+signing key. The KP `verify` command anchors trust to the S3 `init/`
+attestation log before verifying the ceremony and share logs under that
+attested session key.
 
 Only the share's **ciphertext** is written to disk (a temp file, deleted on
 drop); the decrypted scalar lives only in memory.
@@ -114,11 +115,11 @@ cargo run -p hashi-guardian-init -- provision --config provision.sample.yaml
 See [`provision.sample.yaml`](provision.sample.yaml) for a complete
 `ProvisionConfig` example: this KP's cert path, the full KP cert roster,
 expected `sharing_seq` and `n`/`t`, the guardian S3 config, limiter config, the
-MPC committee verifying key `G` (`hashi_btc_master_pubkey_hex`), the expected
-enclave-image measurement (`expected_pcr0`) pinned against each session's
-attestation, the relay endpoint the share is submitted to, and an optional
-`gpg_homedir` for a yubikey-backed gpg agent that does not use gpg's default
-homedir.
+MPC committee verifying key `G` (`hashi_btc_master_pubkey_hex`), the PCR
+allowlist (`current_build` plus optional `prev_builds`) pinned against each
+session's attestation, the relay endpoint the share is submitted to, and an
+optional `gpg_homedir` for a yubikey-backed gpg agent that does not use gpg's
+default homedir.
 `hashi_committee_genesis` is needed only at genesis; omit it once a
 `committee-update/` log exists.
 
@@ -133,5 +134,7 @@ cargo run -p hashi-guardian-init -- tools generate-master-key
 ```
 
 `dev-bootstrap` is a centralized dev shortcut for driving a guardian through
-bootstrap. `fetch-info` prints deployed guardian public keys. `generate-master-key`
-creates the BTC master keypair used by the dev bootstrap flow.
+bootstrap. `fetch-info` prints deployed guardian public keys for the legacy
+bootstrap path; it verifies the GuardianInfo signature but does not verify Nitro
+attestation or PCRs. `generate-master-key` creates the BTC master keypair used
+by the dev bootstrap flow.

--- a/crates/hashi-guardian-init/ceremony-run.sample.yaml
+++ b/crates/hashi-guardian-init/ceremony-run.sample.yaml
@@ -32,7 +32,15 @@ kp_pgp_cert_paths:
   - /path/to/kp4.asc
   - /path/to/kp5.asc
 
-# Expected enclave-image measurement: PCR0 (hex) from the reproducible build of
-# the guardian revision being provisioned. Pinned against the session's
-# attestation. Required (unused in non-Nitro dev, where verification is a no-op).
-expected_pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+# Expected enclave build: git revision + PCR0 (hex). The live guardian must
+# report this revision, and its attestation PCR0 must match it.
+current_build:
+  git_revision: "0000000000000000000000000000000000000000"
+  pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+# Older still-trusted builds accepted only for historical S3 logs during an
+# upgrade window. Omit or leave empty outside an upgrade.
+prev_builds: []
+# prev_builds:
+#   - git_revision: "1111111111111111111111111111111111111111"
+#     pcr0: "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"

--- a/crates/hashi-guardian-init/ceremony-verify.sample.yaml
+++ b/crates/hashi-guardian-init/ceremony-verify.sample.yaml
@@ -30,10 +30,18 @@ kp_pgp_cert_paths:
 # genesis setup, or N+1 for a rotation from prior sequence N.
 sharing_seq: 0
 
-# Expected enclave-image measurement: PCR0 (hex) from the reproducible build of
-# the guardian revision being verified. Pinned against the session's attestation.
-# Required (unused in non-Nitro dev, where verification is a no-op).
-expected_pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+# Expected enclave build: git revision + PCR0 (hex). The live guardian must
+# report this revision, and its attestation PCR0 must match it.
+current_build:
+  git_revision: "0000000000000000000000000000000000000000"
+  pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+# Older still-trusted builds accepted only for historical S3 logs during an
+# upgrade window. Omit or leave empty outside an upgrade.
+prev_builds: []
+# prev_builds:
+#   - git_revision: "1111111111111111111111111111111111111111"
+#     pcr0: "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
 
 # S3 config for the guardian's log bucket (object-lock enabled). Read to
 # discover the latest ceremony session, fetch its attestation, ceremony/ audit

--- a/crates/hashi-guardian-init/provision.sample.yaml
+++ b/crates/hashi-guardian-init/provision.sample.yaml
@@ -66,7 +66,15 @@ limiter_config:
 # guardian's own BTC key.
 hashi_btc_master_pubkey_hex: "0000000000000000000000000000000000000000000000000000000000000001"
 
-# Expected enclave-image measurement: PCR0 (hex) from the reproducible build of
-# the guardian revision being provisioned. Pinned against the session's
-# attestation. Required (unused in non-Nitro dev, where verification is a no-op).
-expected_pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+# Expected enclave build: git revision + PCR0 (hex). The live guardian must
+# report this revision, and its attestation PCR0 must match it.
+current_build:
+  git_revision: "0000000000000000000000000000000000000000"
+  pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+# Older still-trusted builds accepted only for historical S3 logs during an
+# upgrade window. Omit or leave empty outside an upgrade.
+prev_builds: []
+# prev_builds:
+#   - git_revision: "1111111111111111111111111111111111111111"
+#     pcr0: "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"

--- a/crates/hashi-guardian-init/src/ceremony.rs
+++ b/crates/hashi-guardian-init/src/ceremony.rs
@@ -19,6 +19,8 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use anyhow::ensure;
+use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::GuardianSigned;
@@ -100,7 +102,7 @@ pub async fn run(cfg: CeremonyRunConfig) -> Result<()> {
         bucket = cfg.common.guardian_s3.bucket_name(),
         region = cfg.common.guardian_s3.region(),
         endpoint = %cfg.guardian_endpoint,
-        expected_pcr0 = hex::encode(cfg.common.expected_pcr0.pcr0()),
+        current_pcr0 = hex::encode(cfg.common.pcr_allowlist.current_build().pcr0()),
         "running guardian key ceremony",
     );
 
@@ -166,8 +168,9 @@ pub async fn run(cfg: CeremonyRunConfig) -> Result<()> {
         .into_inner();
     let info_resp = GetGuardianInfoResponse::try_from(info_pb)
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
+    let allowlist = cfg.common.pcr_allowlist();
     let verified = info_resp
-        .verify(&cfg.common.expected_pcr0)
+        .verify(allowlist.current_build())
         .map_err(|e| anyhow!("verify GuardianInfo attestation/signature: {e:?}"))?;
     let signing_pub_key = verified.signing_pub_key;
     let session_id = verified.session_id;
@@ -181,13 +184,16 @@ pub async fn run(cfg: CeremonyRunConfig) -> Result<()> {
     info!(
         phase = "attestation pin",
         session_id = %session_id,
-        "connecting to guardian log bucket + verifying attestation against expected PCR0",
+        "connecting to guardian log bucket + verifying attestation against current build",
     );
-    let mut reader = GuardianReader::new(&cfg.common.guardian_s3, cfg.common.expected_pcr0.clone())
+    let mut reader = GuardianReader::new(&cfg.common.guardian_s3, allowlist)
         .await
         .context("connect to guardian log bucket")?;
-    let attested_signing_pub_key = reader.verified_pubkey(&session_id).await?;
-    anyhow::ensure!(
+    let verified_session = reader
+        .get_session_info(&session_id, BuildPolicy::Current)
+        .await?;
+    let attested_signing_pub_key = verified_session.signing_pubkey;
+    ensure!(
         attested_signing_pub_key == signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
@@ -305,8 +311,8 @@ pub async fn run(cfg: CeremonyRunConfig) -> Result<()> {
 ///
 /// Trust is anchored entirely to the guardian's S3 attestation log (unlike
 /// `run`, which talks to the live guardian over gRPC): the `GuardianReader`
-/// resolves the session's attested signing pubkey once (cached), and both the
-/// `ceremony/` audit entry and `shares/` recovery entry are verified under it.
+/// resolves the session's attested signing pubkey through the reader cache, and
+/// both the `ceremony/` audit entry and `shares/` recovery entry are verified under it.
 /// Each step is logged.
 ///
 /// Security: the ciphertext is piped into `gpg --decrypt` over stdin and the
@@ -359,11 +365,11 @@ pub async fn verify(cfg: CeremonyVerifyConfig) -> Result<()> {
         phase = "s3 connect",
         bucket = cfg.common.guardian_s3.bucket_name(),
         region = cfg.common.guardian_s3.region(),
-        expected_pcr0 = hex::encode(cfg.common.expected_pcr0.pcr0()),
+        current_pcr0 = hex::encode(cfg.common.pcr_allowlist.current_build().pcr0()),
         "connecting to guardian log bucket",
     );
     let sharing_seq = cfg.sharing_seq;
-    let mut reader = GuardianReader::new(&cfg.common.guardian_s3, cfg.common.expected_pcr0.clone())
+    let mut reader = GuardianReader::new(&cfg.common.guardian_s3, cfg.common.pcr_allowlist())
         .await
         .context("connect to guardian log bucket")?;
     info!(phase = "s3 connect", "connected to guardian log bucket");

--- a/crates/hashi-guardian-init/src/config.rs
+++ b/crates/hashi-guardian-init/src/config.rs
@@ -42,18 +42,10 @@ pub struct ProvisionConfig {
 
 impl ProvisionConfig {
     pub fn load_yaml(path: &Path) -> anyhow::Result<Self> {
-        let bytes = std::fs::read(path).with_context(|| {
-            format!(
-                "failed to read provisioner-init config at {}",
-                path.display()
-            )
-        })?;
-        serde_yaml::from_slice(&bytes).with_context(|| {
-            format!(
-                "failed to parse provisioner-init yaml at {}",
-                path.display()
-            )
-        })
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("failed to read provision config at {}", path.display()))?;
+        serde_yaml::from_slice(&bytes)
+            .with_context(|| format!("failed to parse provision yaml at {}", path.display()))
     }
 
     /// The MPC committee verifying key `G`, decoded from `hashi_btc_master_pubkey_hex`.

--- a/crates/hashi-guardian-init/src/dev_bootstrap.rs
+++ b/crates/hashi-guardian-init/src/dev_bootstrap.rs
@@ -254,8 +254,9 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
         .into_inner();
     let post_resp = GetGuardianInfoResponse::try_from(post_resp_pb)
         .map_err(|e| anyhow!("decode post-ProvisionerInit GetGuardianInfoResponse: {e:?}"))?;
-    // Same trust boundary as the initial `/info` read above: signature only
-    // until dev bootstrap accepts PCR config and can call `verify`.
+    // Same trust boundary as the initial `/info` read above: this skips
+    // attestation/PCR checks until dev bootstrap accepts PCR config and can
+    // call `verify`.
     let post_session_id = post_resp
         .verify_signed_info_without_attestation()
         .map_err(|e| anyhow!("verify post-ProvisionerInit GuardianInfo signature: {e:?}"))?

--- a/crates/hashi-guardian-init/src/fetch_info.rs
+++ b/crates/hashi-guardian-init/src/fetch_info.rs
@@ -7,6 +7,11 @@
 //! to stdout. Used by the deploy workflow to feed `hashi publish
 //! --guardian-public-key` / `--guardian-btc-public-key` so the keys get
 //! recorded on chain.
+//!
+//! TODO: Remove this bootstrap helper once deploy no longer records guardian
+//! keys by querying a live guardian. This command verifies the returned
+//! GuardianInfo signature, but it does not verify the guardian's Nitro
+//! attestation or PCRs.
 
 use anyhow::Context;
 use anyhow::Result;

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -22,11 +22,12 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
-use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::KPEncryptedShare;
 use hashi_types::guardian::KPEncryptedShares;
 use hashi_types::guardian::KPFingerprint;
+use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::SecretSharingParams;
@@ -45,7 +46,7 @@ use zeroize::Zeroize;
 use zeroize::Zeroizing;
 
 /// Common KP-roster config: the sharing params, the guardian's S3 log bucket,
-/// the full KP cert roster, and the expected enclave measurement. Shared (via
+/// the full KP cert roster, and the PCR allowlist. Shared (via
 /// `#[serde(flatten)]`) by `ceremony run`, `ceremony verify`, and `provision` —
 /// every command that needs to discover and verify a ceremony against an
 /// expected KP set.
@@ -62,10 +63,8 @@ pub struct KpRosterConfig {
     /// the read-only commands (`ceremony verify`, `provision`), shares are
     /// matched by fingerprint so order is irrelevant.
     pub kp_pgp_cert_paths: Vec<PathBuf>,
-    /// Expected enclave-image measurement: PCR0 as hex, pinned against every
-    /// session's attestation. Required (a value is needed even in non-Nitro dev,
-    /// where verification is a no-op).
-    pub expected_pcr0: BuildPcrs,
+    #[serde(flatten)]
+    pub pcr_allowlist: PcrAllowlist,
 }
 
 impl KpRosterConfig {
@@ -81,6 +80,11 @@ impl KpRosterConfig {
         );
 
         Ok(())
+    }
+
+    /// The PCR allowlist decoded from `current_build` + `prev_builds`.
+    pub fn pcr_allowlist(&self) -> PcrAllowlist {
+        self.pcr_allowlist.clone()
     }
 }
 
@@ -117,12 +121,16 @@ impl VerifiedCeremonyState {
         expected_n: usize,
         expected_t: usize,
     ) -> Result<Self> {
+        // TODO: KP-begins discovery for rotations needs to read the latest
+        // historical ceremony with `BuildPolicy::AnyAllowlisted` to learn N.
+        // Keep this helper current-build-only for target verification, and add
+        // a separate discovery path there.
         let (session_id, instance, roster) = reader
-            .read_latest_ceremony()
+            .read_latest_ceremony(BuildPolicy::Current)
             .await?
             .ok_or_else(|| anyhow!("no ceremony logs found in guardian S3 bucket"))?;
         let encrypted_shares = reader
-            .read_shares(&session_id, instance.sharing_seq())
+            .read_shares(&session_id, instance.sharing_seq(), BuildPolicy::Current)
             .await?;
         Self::from_scraped(
             session_id,

--- a/crates/hashi-guardian-init/src/limiter_recovery.rs
+++ b/crates/hashi-guardian-init/src/limiter_recovery.rs
@@ -134,6 +134,7 @@ mod tests {
     use bitcoin::Network;
     use bitcoin::Txid;
     use bitcoin::hashes::Hash;
+    use hashi_types::guardian::BuildPcrs;
     use hashi_types::guardian::GuardianError;
     use hashi_types::guardian::GuardianSigned;
     use hashi_types::guardian::StandardWithdrawalRequest;
@@ -146,6 +147,10 @@ mod tests {
             last_updated_at: 100,
             next_seq,
         }
+    }
+
+    fn build_pcrs() -> BuildPcrs {
+        BuildPcrs::new("current", vec![0])
     }
 
     fn success_log(next_seq: u64) -> VerifiedLogRecord {
@@ -162,6 +167,7 @@ mod tests {
             session_id: "test-session".to_string(),
             timestamp_ms: 0,
             message: LogMessage::Withdrawal(Box::new(msg)),
+            build_pcrs: build_pcrs(),
         }
     }
 
@@ -177,6 +183,7 @@ mod tests {
             session_id: "test-session".to_string(),
             timestamp_ms: 0,
             message: LogMessage::Withdrawal(Box::new(msg)),
+            build_pcrs: build_pcrs(),
         }
     }
 

--- a/crates/hashi-guardian-init/src/provision.rs
+++ b/crates/hashi-guardian-init/src/provision.rs
@@ -32,6 +32,7 @@
 //!    relay's `single_provisioner_init` RPC (TODO).
 
 use anyhow::Context;
+use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::EncPubKey;
@@ -76,11 +77,13 @@ pub async fn run(cfg: ProvisionConfig) -> anyhow::Result<()> {
         phase = "s3 connect",
         bucket = cfg.common.guardian_s3.bucket_name(),
         region = cfg.common.guardian_s3.region(),
-        expected_pcr0 = hex::encode(cfg.common.expected_pcr0.pcr0()),
+        current_git_revision = %cfg.common.pcr_allowlist.current_build().git_revision(),
+        current_pcr0 = hex::encode(cfg.common.pcr_allowlist.current_build().pcr0()),
+        prev_build_count = cfg.common.pcr_allowlist.prev_builds().len(),
         "connecting to guardian log bucket",
     );
-    let build_pcrs = cfg.common.expected_pcr0.clone();
-    let mut reader = GuardianReader::new(&cfg.common.guardian_s3, build_pcrs.clone())
+    let allowlist = cfg.common.pcr_allowlist();
+    let mut reader = GuardianReader::new(&cfg.common.guardian_s3, allowlist.clone())
         .await
         .context("connect to guardian log bucket")?;
     info!(phase = "s3 connect", "connected to guardian log bucket");
@@ -133,7 +136,10 @@ pub async fn run(cfg: ProvisionConfig) -> anyhow::Result<()> {
         session_id = %session_id,
         "fetching + verifying new guardian's signed GuardianInfo from S3",
     );
-    let guardian_info = reader.get_info(&session_id).await?;
+    let verified_session = reader
+        .get_session_info(&session_id, BuildPolicy::Current)
+        .await?;
+    let guardian_info = verified_session.info;
     let (
         enclave_ss_instance,
         enclave_bucket_info,
@@ -160,8 +166,14 @@ pub async fn run(cfg: ProvisionConfig) -> anyhow::Result<()> {
         committee_epoch = enclave_current_committee_epoch,
         limiter_refill_rate = enclave_limiter_config.refill_rate,
         limiter_max_capacity = enclave_limiter_config.max_bucket_capacity,
-        untrusted_git_revision = %enclave_git_revision,
-        "guardian info fetched (git_revision is self-reported, untrusted — verified via PCR0 match); cross-checking against config",
+        verified_git_revision = %enclave_git_revision,
+        "guardian info verified against current build; cross-checking against config",
+    );
+    anyhow::ensure!(
+        enclave_git_revision == allowlist.current_build().git_revision(),
+        "Guardian git revision mismatch: expected {}, got {}",
+        allowlist.current_build().git_revision(),
+        enclave_git_revision
     );
     anyhow::ensure!(
         cfg.common.guardian_s3.bucket_info == enclave_bucket_info,
@@ -198,7 +210,7 @@ pub async fn run(cfg: ProvisionConfig) -> anyhow::Result<()> {
         "scraping authoritative ceremony/ log for the secret-sharing instance",
     );
     let (ceremony_session, scraped_instance, roster) = reader
-        .read_latest_ceremony()
+        .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     let sharing_seq = scraped_instance.sharing_seq();
@@ -280,7 +292,10 @@ pub async fn run(cfg: ProvisionConfig) -> anyhow::Result<()> {
         phase = "state hash",
         "recomputing state_hash from committee + limiter + master_g",
     );
-    let committee = match reader.read_latest_committee().await? {
+    let committee = match reader
+        .read_latest_committee(BuildPolicy::AnyAllowlisted)
+        .await?
+    {
         Some(scraped) => {
             info!(
                 phase = "state hash",
@@ -337,7 +352,9 @@ pub async fn run(cfg: ProvisionConfig) -> anyhow::Result<()> {
         sharing_seq,
         "reading + verifying this KP's encrypted share from shares/",
     );
-    let encrypted_shares = reader.read_shares(&ceremony_session, sharing_seq).await?;
+    let encrypted_shares = reader
+        .read_shares(&ceremony_session, sharing_seq, BuildPolicy::AnyAllowlisted)
+        .await?;
     let state = VerifiedCeremonyState::from_scraped(
         ceremony_session.clone(),
         scraped_instance.clone(),
@@ -454,7 +471,7 @@ pub async fn run(cfg: ProvisionConfig) -> anyhow::Result<()> {
         &session_id,
         guardian_info,
         encrypted_share,
-        &build_pcrs,
+        allowlist.current_build(),
     )
     .await?;
     Ok(())
@@ -473,7 +490,7 @@ async fn submit_provisioner_init_to_relay(
     expected_session_id: &str,
     expected_guardian_info: GuardianInfo,
     encrypted_share: GuardianEncryptedShare,
-    build_pcrs: &BuildPcrs,
+    current_build: &BuildPcrs,
 ) -> anyhow::Result<()> {
     info!(
         phase = "relay submit",
@@ -496,7 +513,7 @@ async fn submit_provisioner_init_to_relay(
         &mut client,
         expected_session_id,
         expected_guardian_info,
-        build_pcrs,
+        current_build,
     )
     .await
     .with_context(|| "relay endpoint pre-check failed")?;
@@ -513,7 +530,7 @@ async fn prechecks(
     client: &mut pb::guardian_service_client::GuardianServiceClient<tonic::transport::Channel>,
     expected_session_id: &str,
     expected_guardian_info: GuardianInfo,
-    build_pcrs: &BuildPcrs,
+    current_build: &BuildPcrs,
 ) -> anyhow::Result<()> {
     let resp_pb = client
         .get_guardian_info(pb::GetGuardianInfoRequest {})
@@ -523,7 +540,7 @@ async fn prechecks(
 
     let resp = GetGuardianInfoResponse::try_from(resp_pb)?;
 
-    let verified = resp.verify(build_pcrs)?;
+    let verified = resp.verify(current_build)?;
     let actual_session_id = verified.session_id;
     info!(
         phase = "relay submit",

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -4,6 +4,7 @@
 use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_credential_types::CredentialsBuilder;
 use aws_sdk_s3::error::DisplayErrorContext;
+use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::S3BucketInfo;
 use hashi_types::guardian::S3Config;
@@ -18,11 +19,12 @@ use aws_sdk_s3::types::ObjectLockEnabled;
 use aws_sdk_s3::types::ObjectLockMode;
 use aws_sdk_s3::Client as S3Client;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
-use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::GuardianError::S3Error;
 use hashi_types::guardian::GuardianPubKey;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::InitLogMessage;
+use hashi_types::guardian::PcrAllowlist;
+use hashi_types::guardian::VerifiedSessionInfo;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tracing::info;
@@ -519,28 +521,39 @@ impl GuardianS3Client {
         self.get_object_unsafe::<LogRecord>(key).await
     }
 
-    /// Fetch the session's attestation record, verify it against `build_pcrs`,
-    /// and return the trusted enclave signing pubkey. Verification binds the
-    /// logged `signing_public_key` to the attestation's `public_key`, so the
-    /// returned key is attestation-anchored. No caller needs the raw bytes.
-    ///
-    /// `pub(crate)` so the only verified-pubkey path off-crate is
-    /// [`GuardianReader::verified_pubkey`], which caches the result.
-    pub(crate) async fn get_verified_enclave_pubkey(
+    /// Note: Callers must set signing_pubkey to None only for unsigned messages.
+    async fn get_verified_log_record(
         &self,
-        session_id: &str,
-        build_pcrs: &BuildPcrs,
-    ) -> GuardianResult<GuardianPubKey> {
-        let key = InitLogMessage::attestation_object_key(session_id);
-        let record = self.get_log_record(&key).await?;
-        if record.session_id != session_id {
+        key: &str,
+        expected_session_id: &str,
+        signing_pubkey: Option<&GuardianPubKey>,
+    ) -> GuardianResult<LogMessage> {
+        let log = self.get_log_record(key).await?;
+        if log.session_id != expected_session_id {
             return Err(S3Error(format!("log session_id mismatch for key {}", key)));
         }
-        // The attestation record is unsigned — it's the bootstrap carrying the
-        // pubkey everything else is verified against — so verify it as unsigned.
-        let (attestation, signing_public_key) = record
-            .verify_unsigned()?
-            .message
+        let (_, _, message) = match signing_pubkey {
+            Some(pk) => log.verify(pk),
+            None => log.verify_unsigned(),
+        }?;
+        Ok(message)
+    }
+
+    /// Resolve a session's [`VerifiedSessionInfo`]: read the AWS-self-signed
+    /// attestation (anchoring the signing pubkey), then the signed `GuardianInfo`,
+    /// and pin the attestation's PCR0 against the `allowlist` entry named by the
+    /// info's reported build. No caller needs the raw attestation bytes.
+    pub(crate) async fn get_verified_session_info(
+        &self,
+        session_id: &str,
+        allowlist: &PcrAllowlist,
+    ) -> GuardianResult<VerifiedSessionInfo> {
+        // 1. Attestation (unsigned: authenticated by AWS, not the enclave key) →
+        //    the signing pubkey it commits to.
+        let att_key = InitLogMessage::attestation_object_key(session_id);
+        let (attestation, signing_pubkey) = self
+            .get_verified_log_record(&att_key, session_id, None)
+            .await?
             .into_init_log()
             .and_then(|x| match x {
                 InitLogMessage::OIAttestationUnsigned {
@@ -549,9 +562,30 @@ impl GuardianS3Client {
                 } => Some((attestation, signing_public_key)),
                 _ => None,
             })
-            .ok_or_else(|| S3Error(format!("expected OIAttestationUnsigned at key {}", key)))?;
-        attestation.verify(&signing_public_key, build_pcrs)?;
-        Ok(signing_public_key)
+            .ok_or_else(|| S3Error(format!("expected OIAttestationUnsigned at key {att_key}")))?;
+
+        // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
+        let info_key = InitLogMessage::guardian_info_object_key(session_id);
+        let info = self
+            .get_verified_log_record(&info_key, session_id, Some(&signing_pubkey))
+            .await?
+            .into_init_log()
+            .and_then(|x| match x {
+                InitLogMessage::OIGuardianInfo(info) => Some(*info),
+                _ => None,
+            })
+            .ok_or_else(|| S3Error(format!("expected OIGuardianInfo at key {info_key}")))?;
+
+        // 3. Anchor the pubkey and pin PCR0 to the allowlist entry for the
+        //    reported build.
+        let build_pcrs = allowlist.resolve(&info.untrusted_git_revision)?.clone();
+        attestation.verify(&signing_pubkey, &build_pcrs)?;
+
+        Ok(VerifiedSessionInfo {
+            signing_pubkey,
+            info,
+            build_pcrs,
+        })
     }
 }
 

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -5,10 +5,11 @@
 //!
 //! The guardian writes its logs via [`GuardianS3Client`]; off-enclave readers
 //! (the monitor auditor, KP/operator init tooling) replay them here through a
-//! [`GuardianReader`], which owns the S3 client and the trusted-key cache so a
-//! session's attestation is verified once across every read. Streams are
-//! hour-partitioned (`withdraw/`/`heartbeat/`); [`withdraw_cursor`]/[`heartbeat_cursor`]
-//! open a cursor that the caller advances/retreats and feeds to [`GuardianReader::read_dir`].
+//! [`GuardianReader`], which owns the S3 client and a per-session info cache
+//! that records the build PCRs verified for each session. Streams are
+//! hour-partitioned (`withdraw/`/`heartbeat/`);
+//! [`withdraw_cursor`]/[`heartbeat_cursor`] open a cursor that the caller
+//! advances/retreats and feeds to [`GuardianReader::read_dir`].
 
 use crate::s3_client::GuardianS3Client;
 use anyhow::Context;
@@ -18,17 +19,18 @@ use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GuardianInfo;
-use hashi_types::guardian::GuardianPubKey;
-use hashi_types::guardian::InitLogMessage;
+use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::KPEncryptedShares;
 use hashi_types::guardian::KPFingerprint;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogRecord;
+use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::SessionID;
 use hashi_types::guardian::SharesLogMessage;
 use hashi_types::guardian::VerifiedLogRecord;
+use hashi_types::guardian::VerifiedSessionInfo;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
 use hashi_types::guardian::S3_DIR_HEARTBEAT;
@@ -48,28 +50,45 @@ pub fn heartbeat_cursor(start: UnixSeconds) -> S3HourScopedDirectory {
     S3HourScopedDirectory::new(S3_DIR_HEARTBEAT, start)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BuildPolicy {
+    /// Accept only the configured current guardian build.
+    Current,
+    /// Accept either the configured current build or an explicitly allowlisted
+    /// previous build. This is for historical log reads, not live-session checks.
+    AnyAllowlisted,
+}
+
+impl BuildPolicy {
+    fn enforce(self, allowlist: &PcrAllowlist, build_pcrs: &BuildPcrs) -> GuardianResult<()> {
+        match self {
+            Self::Current => allowlist.require_current_build(build_pcrs),
+            Self::AnyAllowlisted => Ok(()),
+        }
+    }
+}
+
 /// Verified reader over the guardian's S3 logs. Owns the S3 client and a private
-/// session-key cache, so each session's (eventually expensive) attestation check
-/// happens at most once across every read. Thread a single `&mut GuardianReader`
-/// through a run.
+/// session cache. Thread a single `&mut GuardianReader` through a run so repeated
+/// reads can reuse session info and inspect the attested build.
 pub struct GuardianReader {
     s3: GuardianS3Client,
-    pubkey_cache: GuardianSessionKeyCache,
+    cache: GuardianSessionCache,
 }
 
 impl GuardianReader {
-    pub async fn new(config: &S3Config, build_pcrs: BuildPcrs) -> anyhow::Result<Self> {
+    pub async fn new(config: &S3Config, allowlist: PcrAllowlist) -> anyhow::Result<Self> {
         let s3 = GuardianS3Client::new_checked(config)
             .await
             .map_err(|e| anyhow::anyhow!(e))
             .context("failed to verify guardian S3 connectivity")?;
-        Ok(Self::from_s3_client(s3, build_pcrs))
+        Ok(Self::from_s3_client(s3, allowlist))
     }
 
-    pub fn from_s3_client(s3: GuardianS3Client, build_pcrs: BuildPcrs) -> Self {
+    pub fn from_s3_client(s3: GuardianS3Client, allowlist: PcrAllowlist) -> Self {
         Self {
             s3,
-            pubkey_cache: GuardianSessionKeyCache::new(build_pcrs),
+            cache: GuardianSessionCache::new(allowlist),
         }
     }
 
@@ -78,8 +97,25 @@ impl GuardianReader {
         &self.s3
     }
 
+    pub fn require_current_build(&self, build_pcrs: &BuildPcrs) -> GuardianResult<()> {
+        self.cache.allowlist.require_current_build(build_pcrs)
+    }
+
+    fn enforce_build_policy(
+        &self,
+        context: &str,
+        build_policy: BuildPolicy,
+        build_pcrs: &BuildPcrs,
+    ) -> anyhow::Result<()> {
+        build_policy
+            .enforce(&self.cache.allowlist, build_pcrs)
+            .map_err(|e| anyhow::anyhow!("{context} PCR check: {e:?}"))
+    }
+
     /// Read and verify every record in `dir`, resolving each writing session's
-    /// signing pubkey via the cache (loaded once per session).
+    /// signing pubkey via the cache. Batch readers can straddle upgrades, so
+    /// callers that need current-only semantics must inspect each returned
+    /// record's build PCRs with [`Self::require_current_build`].
     pub async fn read_dir(
         &mut self,
         dir: &S3HourScopedDirectory,
@@ -92,26 +128,35 @@ impl GuardianReader {
 
         let mut out = Vec::with_capacity(all_logs.len());
         for log in all_logs {
-            out.push(self.pubkey_cache.verify_record(&self.s3, log).await?);
+            out.push(self.cache.verify_record(&self.s3, log).await?);
         }
         Ok(out)
     }
 
-    /// Read and verify a session's signed `OIGuardianInfo` log (written at
-    /// operator-init). Implements check B of IOP-225.
-    pub async fn get_info(&mut self, session_id: &str) -> anyhow::Result<GuardianInfo> {
-        let key = InitLogMessage::guardian_info_object_key(session_id);
-        let record = self.s3.get_log_record(&key).await?;
-        self.pubkey_cache
-            .verify_record(&self.s3, record)
+    /// The session's verified guardian info. Served from the session cache, which
+    /// resolves the attestation + signed info on first touch and records the
+    /// verified build PCRs.
+    pub async fn get_session_info(
+        &mut self,
+        session_id: &str,
+        build_policy: BuildPolicy,
+    ) -> anyhow::Result<VerifiedSessionInfo> {
+        let session_info = self
+            .cache
+            .get_or_load_session_info(&self.s3, session_id)
             .await?
-            .message
-            .into_init_log()
-            .and_then(|x| match x {
-                InitLogMessage::OIGuardianInfo(info) => Some(*info),
-                _ => None,
-            })
-            .with_context(|| format!("expected OIGuardianInfo at {key}"))
+            .clone();
+        self.enforce_build_policy("session", build_policy, &session_info.build_pcrs)?;
+        Ok(session_info)
+    }
+
+    /// The session's verified `GuardianInfo`, discarding the verified build PCRs.
+    pub async fn get_info(
+        &mut self,
+        session_id: &str,
+        build_policy: BuildPolicy,
+    ) -> anyhow::Result<GuardianInfo> {
+        Ok(self.get_session_info(session_id, build_policy).await?.info)
     }
 
     /// The latest secret-sharing instance from `ceremony/` — the max-`sharing_seq`
@@ -120,18 +165,20 @@ impl GuardianReader {
     /// key exists.
     pub async fn read_latest_ceremony_instance(
         &mut self,
+        build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<SecretSharingInstance>> {
         Ok(self
-            .read_latest_ceremony()
+            .read_latest_ceremony(build_policy)
             .await?
             .map(|(_, instance, _)| instance))
     }
 
     /// Like [`Self::read_latest_ceremony_instance`], but also returns the writing
-    /// session id and recipient roster — needed to locate the matching `shares/`
-    /// object and to check the roster against the agreed KP set.
+    /// session id and recipient roster. The session id locates the matching
+    /// `shares/` object; the roster is checked against the agreed KP set.
     pub async fn read_latest_ceremony(
         &mut self,
+        build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<(SessionID, SecretSharingInstance, Vec<KPFingerprint>)>> {
         let keys = self
             .s3
@@ -140,7 +187,7 @@ impl GuardianReader {
         let Some(key) = pick_latest_key(keys, S3_DIR_CEREMONY) else {
             return Ok(None);
         };
-        Ok(Some(self.read_ceremony_record(&key).await?))
+        Ok(Some(self.read_ceremony_record(&key, build_policy).await?))
     }
 
     /// Read + verify the `ceremony/` record at `key`, returning its writing
@@ -148,25 +195,18 @@ impl GuardianReader {
     async fn read_ceremony_record(
         &mut self,
         key: &str,
+        build_policy: BuildPolicy,
     ) -> anyhow::Result<(SessionID, SecretSharingInstance, Vec<KPFingerprint>)> {
         let record = self.s3.get_log_record(key).await?;
-        let record = self.pubkey_cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         let session_id = record.session_id.clone();
+        let build_pcrs = record.build_pcrs.clone();
+        self.enforce_build_policy("ceremony log", build_policy, &build_pcrs)?;
         let LogMessage::Ceremony(msg) = record.message else {
             anyhow::bail!("expected a ceremony log at {key}");
         };
         let (instance, roster) = ceremony_instance_and_roster(*msg, key)?;
         Ok((session_id, instance, roster))
-    }
-
-    /// The session's attestation-verified signing pubkey, loaded once via the
-    /// cache (later reads of the same session reuse it). Lets callers anchor a
-    /// cross-check on the attested key without a second attestation pass.
-    pub async fn verified_pubkey(&mut self, session_id: &str) -> anyhow::Result<GuardianPubKey> {
-        Ok(*self
-            .pubkey_cache
-            .get_or_load_pubkey(&self.s3, session_id)
-            .await?)
     }
 
     /// Read + verify the encrypted shares at `shares/{seq}-{session}.json`. Point
@@ -181,6 +221,7 @@ impl GuardianReader {
         &mut self,
         session_id: &str,
         sharing_seq: u64,
+        build_policy: BuildPolicy,
     ) -> anyhow::Result<KPEncryptedShares> {
         let key = SharesLogMessage::object_key(session_id, sharing_seq);
         let record: LogRecord = self.s3.get_object_no_lock(&key).await?;
@@ -190,7 +231,9 @@ impl GuardianReader {
                 record.session_id
             );
         }
-        let record = self.pubkey_cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
+        let build_pcrs = record.build_pcrs.clone();
+        self.enforce_build_policy("shares log", build_policy, &build_pcrs)?;
         let LogMessage::Shares(msg) = record.message else {
             anyhow::bail!("expected a shares log at {key}");
         };
@@ -209,7 +252,10 @@ impl GuardianReader {
     /// signature-verified. `None` if no committee update has been logged (e.g. a
     /// fresh deployment whose committee still only exists in the operator's boot
     /// config).
-    pub async fn read_latest_committee(&mut self) -> anyhow::Result<Option<Committee>> {
+    pub async fn read_latest_committee(
+        &mut self,
+        build_policy: BuildPolicy,
+    ) -> anyhow::Result<Option<Committee>> {
         let keys = self
             .s3
             .list_all_keys_in_dir(&format!("{}/", S3_DIR_COMMITTEE_UPDATE))
@@ -218,7 +264,8 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.pubkey_cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
+        self.enforce_build_policy("committee-update log", build_policy, &record.build_pcrs)?;
         let LogMessage::CommitteeUpdate(msg) = record.message else {
             anyhow::bail!("expected a committee-update log at {key}");
         };
@@ -231,39 +278,36 @@ impl GuardianReader {
     }
 }
 
-/// Enclave signing pubkeys trusted after their attestation was verified once,
-/// keyed by session. Internal to [`GuardianReader`]; pins every session's
-/// attestation against `build_pcrs`.
-///
-/// TODO(check C): make `build_pcrs` a `commit -> BuildPcrs` map resolved
-/// per session from its `/info`-reported `untrusted_git_revision`, instead of a
-/// single flat set.
-struct GuardianSessionKeyCache {
-    keys: HashMap<SessionID, GuardianPubKey>,
-    build_pcrs: BuildPcrs,
+/// Per-session [`VerifiedSessionInfo`] cache, internal to [`GuardianReader`]. The first
+/// touch of a session resolves and verifies its info (attestation + signed
+/// info, PCR0 pinned against `allowlist`); later reads reuse it and expose the
+/// verified build PCRs to callers.
+struct GuardianSessionCache {
+    sessions: HashMap<SessionID, VerifiedSessionInfo>,
+    allowlist: PcrAllowlist,
 }
 
-impl GuardianSessionKeyCache {
-    fn new(build_pcrs: BuildPcrs) -> Self {
+impl GuardianSessionCache {
+    fn new(allowlist: PcrAllowlist) -> Self {
         Self {
-            keys: HashMap::new(),
-            build_pcrs,
+            sessions: HashMap::new(),
+            allowlist,
         }
     }
 
-    /// The session's signing pubkey, verifying and caching its attestation on first use.
-    async fn get_or_load_pubkey(
+    /// The session's verified info, resolving and caching it on first use.
+    async fn get_or_load_session_info(
         &mut self,
         s3: &GuardianS3Client,
         session_id: &str,
-    ) -> anyhow::Result<&GuardianPubKey> {
-        if !self.keys.contains_key(session_id) {
-            let pubkey = s3
-                .get_verified_enclave_pubkey(session_id, &self.build_pcrs)
+    ) -> anyhow::Result<&VerifiedSessionInfo> {
+        if !self.sessions.contains_key(session_id) {
+            let session_info = s3
+                .get_verified_session_info(session_id, &self.allowlist)
                 .await?;
-            self.keys.insert(session_id.to_string(), pubkey);
+            self.sessions.insert(session_id.to_string(), session_info);
         }
-        Ok(&self.keys[session_id])
+        Ok(&self.sessions[session_id])
     }
 
     /// Verify `record`'s signature under its session's trusted pubkey.
@@ -272,9 +316,19 @@ impl GuardianSessionKeyCache {
         s3: &GuardianS3Client,
         record: LogRecord,
     ) -> anyhow::Result<VerifiedLogRecord> {
-        let signing_pubkey = self.get_or_load_pubkey(s3, &record.session_id).await?;
+        let session_info = self
+            .get_or_load_session_info(s3, &record.session_id)
+            .await?;
         record
-            .verify(signing_pubkey)
+            .verify(&session_info.signing_pubkey)
+            .map(|(session_id, timestamp_ms, message)| {
+                VerifiedLogRecord::new(
+                    session_id,
+                    timestamp_ms,
+                    message,
+                    session_info.build_pcrs.clone(),
+                )
+            })
             .with_context(|| "failed to verify guardian enclave signature")
     }
 }

--- a/crates/hashi-monitor/Cargo.toml
+++ b/crates/hashi-monitor/Cargo.toml
@@ -12,7 +12,6 @@ clap.workspace = true
 hashi-types = { path = "../hashi-types" }
 # guardian imported for s3 logger
 hashi-guardian = { path = "../hashi-guardian" }
-hex.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 tokio.workspace = true

--- a/crates/hashi-monitor/audit.sample.yaml
+++ b/crates/hashi-monitor/audit.sample.yaml
@@ -11,9 +11,18 @@ next_event_delays:
 guardian:
   s3_bucket: "hashi-guardian-logs"
 
-# Expected guardian enclave-image measurement: PCR0 (hex), pinned against every
-# session's attestation the auditor reads.
-expected_pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+# Expected enclave build: git revision + PCR0 (hex). The live guardian must
+# report this revision, and its attestation PCR0 must match it.
+current_build:
+  git_revision: "0000000000000000000000000000000000000000"
+  pcr0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+# Older still-trusted builds accepted only for historical S3 logs during an
+# upgrade window. Omit or leave empty outside an upgrade.
+prev_builds: []
+# prev_builds:
+#   - git_revision: "1111111111111111111111111111111111111111"
+#     pcr0: "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
 
 sui:
   rpc_url: "https://fullnode.testnet.sui.io:443"

--- a/crates/hashi-monitor/src/config.rs
+++ b/crates/hashi-monitor/src/config.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::anyhow;
 use corepc_client::client_sync::Auth;
-use hashi_types::guardian::BuildPcrs;
+use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use serde::Deserialize;
 
@@ -24,9 +24,8 @@ pub struct Config {
     pub clock_skew: u64,
 
     pub guardian: S3Config,
-    /// Expected guardian enclave-image measurement: PCR0 as hex, pinned against
-    /// every session's attestation the auditor reads.
-    pub expected_pcr0: String,
+    #[serde(flatten)]
+    pub pcr_allowlist: PcrAllowlist,
     pub sui: SuiConfig,
     pub btc: BtcConfig,
 }
@@ -137,10 +136,8 @@ impl Config {
         self.next_event_delays.get_delay(source)
     }
 
-    /// The expected guardian enclave measurement, decoded from `expected_pcr0`.
-    pub fn build_pcrs(&self) -> anyhow::Result<BuildPcrs> {
-        let pcr0 = hex::decode(self.expected_pcr0.trim_start_matches("0x"))
-            .context("expected_pcr0 is not valid hex")?;
-        Ok(BuildPcrs::new(pcr0))
+    /// The PCR allowlist decoded from `current_build` + `prev_builds`.
+    pub fn pcr_allowlist(&self) -> PcrAllowlist {
+        self.pcr_allowlist.clone()
     }
 }

--- a/crates/hashi-monitor/src/rpc/btc.rs
+++ b/crates/hashi-monitor/src/rpc/btc.rs
@@ -117,7 +117,11 @@ mod tests {
             .expect("valid next event delays"),
             clock_skew: 10,
             guardian: hashi_types::guardian::S3Config::mock_for_testing(),
-            expected_pcr0: String::new(),
+            pcr_allowlist: hashi_types::guardian::PcrAllowlist::new(
+                hashi_types::guardian::BuildPcrs::new("", vec![]),
+                vec![],
+            )
+            .expect("valid PCR allowlist"),
             sui: SuiConfig {
                 rpc_url: "http://sui".to_string(),
             },

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -68,7 +68,7 @@ impl GuardianWithdrawalsPoller {
     // Note: Throws an error if there is a S3 connectivity issue
     pub async fn new(config: &Config, start: UnixSeconds) -> anyhow::Result<Self> {
         Ok(Self {
-            reader: GuardianReader::new(&config.guardian, config.build_pcrs()?).await?,
+            reader: GuardianReader::new(&config.guardian, config.pcr_allowlist()).await?,
             cursor: withdraw_cursor(start),
         })
     }
@@ -85,6 +85,10 @@ impl GuardianWithdrawalsPoller {
         }
 
         let verified_logs = self.reader.read_dir(&self.cursor).await?;
+        // Withdrawal polling may replay historical buckets during an upgrade, so
+        // this caller accepts any record whose session build verifies against the
+        // configured allowlist. Add a cursor/cutoff policy here if tailing must
+        // require the current build after the upgrade window.
         let withdrawal_events = verified_logs
             .into_iter()
             .map(VerifiedWithdrawal::try_from)

--- a/crates/hashi-monitor/src/state_machine.rs
+++ b/crates/hashi-monitor/src/state_machine.rs
@@ -382,7 +382,11 @@ mod tests {
             .expect("valid intra-event delays"),
             clock_skew: 10,
             guardian: S3Config::mock_for_testing(),
-            expected_pcr0: String::new(),
+            pcr_allowlist: hashi_types::guardian::PcrAllowlist::new(
+                hashi_types::guardian::BuildPcrs::new("", vec![]),
+                vec![],
+            )
+            .expect("valid PCR allowlist"),
             sui: SuiConfig {
                 rpc_url: "http://sui".to_string(),
             },

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -3,13 +3,17 @@
 
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::BTreeSet;
 
+use super::GuardianInfo;
 use super::GuardianPubKey;
 use super::GuardianResult;
-#[cfg(not(any(test, feature = "non-enclave-dev")))]
 use super::errors::GuardianError::InvalidInputs;
 #[cfg(not(any(test, feature = "non-enclave-dev")))]
 use super::time_utils::now_timestamp_ms;
+
+/// Git commit revision reported by the enclave build.
+pub type GitRevision = String;
 
 /// Raw AWS Nitro attestation document bytes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -24,9 +28,13 @@ impl NitroAttestation {
         self.0
     }
 
-    /// Verify this Nitro attestation document (COSE signature + AWS cert chain
-    /// to the Nitro root + freshness), that it commits to `signing_pubkey`, and
-    /// that its PCR0 matches `build_pcrs`.
+    /// Verify this Nitro attestation document (COSE signature + AWS cert chain to the
+    /// Nitro root + freshness), that it commits to `signing_pubkey`, and that its
+    /// PCR0 matches `build_pcrs`.
+    ///
+    /// In non-enclave dev/test builds the enclave emits a mock document, so the
+    /// attestation check is a no-op, mirroring `get_attestation` `non-enclave-dev`
+    /// stub behavior. Real verification runs only in enclave builds.
     pub fn verify(
         &self,
         signing_pubkey: &GuardianPubKey,
@@ -71,26 +79,38 @@ impl NitroAttestation {
     }
 }
 
-/// Known-good Nitro measurement an attestation is pinned to. Construction
-/// mandates PCR0 - the hash of the whole enclave image (EIF), which uniquely
-/// identifies the build - so a pinning policy can never omit it.
+/// A session's verified guardian info: the attestation-anchored signing pubkey,
+/// the signed `GuardianInfo`, and the build PCRs proven by attestation.
+#[derive(Debug, Clone)]
+pub struct VerifiedSessionInfo {
+    pub signing_pubkey: GuardianPubKey,
+    pub info: GuardianInfo,
+    pub build_pcrs: BuildPcrs,
+}
+
+/// One enclave build: its git revision and known-good Nitro measurement. A build is
+/// identified by its revision and pinned by PCR0 - the hash of the whole enclave
+/// image (EIF), which uniquely identifies the build.
 ///
 /// We record only PCR0: in a StageX (reproducible, single-binary) build it is
-/// the only measurement that carries signal - the others (kernel, bootloader,
-/// IAM role) are constant or irrelevant for our pinning.
-///
-/// TODO: holds only a single PCR0, so it can't accept the two valid measurements
-/// that briefly coexist during a software upgrade (old + new image), nor pin
-/// additional PCRs. A `commit -> PCRs` allowlist keyed on `untrusted_git_revision`
-/// is the follow-up.
-#[derive(Debug, Clone)]
+/// the only measurement that carries signal - the others (kernel, bootloader, IAM
+/// role) are constant or irrelevant for our pinning.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuildPcrs {
+    git_revision: GitRevision,
     pcr0: Vec<u8>,
 }
 
 impl BuildPcrs {
-    pub fn new(pcr0: Vec<u8>) -> Self {
-        Self { pcr0 }
+    pub fn new(git_revision: &str, pcr0: Vec<u8>) -> Self {
+        Self {
+            git_revision: git_revision.to_string(),
+            pcr0,
+        }
+    }
+
+    pub fn git_revision(&self) -> &str {
+        &self.git_revision
     }
 
     pub fn pcr0(&self) -> &[u8] {
@@ -98,13 +118,112 @@ impl BuildPcrs {
     }
 }
 
-/// Deserialize from a hex string (optional `0x` prefix) - the form config files
-/// pin PCR0 in.
+/// PCR pins for enclave builds that may appear in guardian attestations.
+/// Used by GuardianReader in s3_reader.rs.
+///
+/// `current_build` is the current/live build. `prev_builds` contains older
+/// builds that may still appear in persisted logs during an upgrade or replay.
+/// Verification matches the signature-verified `untrusted_git_revision` to one
+/// entry, then checks PCR0 against that entry. Callers use the resolved
+/// `BuildPcrs` to enforce the policy for their context.
+#[derive(Debug, Clone)]
+pub struct PcrAllowlist {
+    current_build: BuildPcrs,
+    prev_builds: Vec<BuildPcrs>,
+}
+
+impl PcrAllowlist {
+    pub fn new(
+        current_build: BuildPcrs,
+        prev_builds: impl IntoIterator<Item = BuildPcrs>,
+    ) -> GuardianResult<Self> {
+        let prev_builds = prev_builds.into_iter().collect::<Vec<_>>();
+        let mut seen = BTreeSet::new();
+        for build in std::iter::once(&current_build).chain(prev_builds.iter()) {
+            if !seen.insert(build.git_revision.clone()) {
+                return Err(InvalidInputs(format!(
+                    "duplicate PCR allowlist entry for build '{}'",
+                    build.git_revision
+                )));
+            }
+        }
+
+        Ok(Self {
+            current_build,
+            prev_builds,
+        })
+    }
+
+    pub fn current_build(&self) -> &BuildPcrs {
+        &self.current_build
+    }
+
+    pub fn prev_builds(&self) -> &[BuildPcrs] {
+        &self.prev_builds
+    }
+
+    /// The `BuildPcrs` whose revision is `git_revision`.
+    pub fn resolve(&self, git_revision: &str) -> GuardianResult<&BuildPcrs> {
+        if self.current_build.git_revision == git_revision {
+            return Ok(&self.current_build);
+        }
+        if let Some(prev_build) = self
+            .prev_builds
+            .iter()
+            .find(|build| build.git_revision == git_revision)
+        {
+            return Ok(prev_build);
+        }
+        Err(InvalidInputs(format!(
+            "enclave reports build '{git_revision}' not present in PCR allowlist"
+        )))
+    }
+
+    pub fn is_current_build(&self, build_pcrs: &BuildPcrs) -> bool {
+        self.current_build == *build_pcrs
+    }
+
+    pub fn require_current_build(&self, build_pcrs: &BuildPcrs) -> GuardianResult<()> {
+        if self.is_current_build(build_pcrs) {
+            Ok(())
+        } else {
+            Err(InvalidInputs(
+                "guardian attestation matched a non-current build, but current build is required"
+                    .into(),
+            ))
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for BuildPcrs {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let hex_str = String::deserialize(deserializer)?;
-        let pcr0 =
-            hex::decode(hex_str.trim_start_matches("0x")).map_err(serde::de::Error::custom)?;
-        Ok(Self { pcr0 })
+        #[derive(Deserialize)]
+        struct BuildPcrsWire {
+            git_revision: GitRevision,
+            pcr0: String,
+        }
+
+        let wire = BuildPcrsWire::deserialize(deserializer)?;
+        let pcr0 = hex::decode(wire.pcr0.trim_start_matches("0x")).map_err(|e| {
+            serde::de::Error::custom(format!(
+                "build '{}' pcr0 is not valid hex: {e}",
+                wire.git_revision
+            ))
+        })?;
+        Ok(BuildPcrs::new(&wire.git_revision, pcr0))
+    }
+}
+
+impl<'de> Deserialize<'de> for PcrAllowlist {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct PcrAllowlistWire {
+            current_build: BuildPcrs,
+            #[serde(default)]
+            prev_builds: Vec<BuildPcrs>,
+        }
+
+        let wire = PcrAllowlistWire::deserialize(deserializer)?;
+        PcrAllowlist::new(wire.current_build, wire.prev_builds).map_err(serde::de::Error::custom)
     }
 }

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -12,6 +12,7 @@ use super::S3_OBJECT_LOCK_DURATION_INIT;
 use super::S3_OBJECT_LOCK_DURATION_SHARES;
 use super::S3_OBJECT_LOCK_DURATION_WITHDRAW;
 use super::message::LogMessage;
+use crate::guardian::BuildPcrs;
 use crate::guardian::GuardianError::InvalidInputs;
 use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
@@ -35,12 +36,30 @@ pub struct LogRecord {
     pub signature: Option<GuardianSignature>,
 }
 
-/// A verified log record where message authenticity has been checked.
+/// A log record whose message signature and writing session's attestation/PCRs
+/// have both been verified.
 #[derive(Debug)]
 pub struct VerifiedLogRecord {
     pub session_id: SessionID,
     pub timestamp_ms: UnixMillis,
     pub message: LogMessage,
+    pub build_pcrs: BuildPcrs,
+}
+
+impl VerifiedLogRecord {
+    pub fn new(
+        session_id: SessionID,
+        timestamp_ms: UnixMillis,
+        message: LogMessage,
+        build_pcrs: BuildPcrs,
+    ) -> Self {
+        Self {
+            session_id,
+            timestamp_ms,
+            message,
+            build_pcrs,
+        }
+    }
 }
 
 impl LogRecord {
@@ -104,7 +123,10 @@ impl LogRecord {
         }
     }
 
-    pub fn verify(self, pub_key: &GuardianPubKey) -> GuardianResult<VerifiedLogRecord> {
+    pub fn verify(
+        self,
+        pub_key: &GuardianPubKey,
+    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         let session_id = self.session_id;
         let timestamp_ms = self.timestamp_ms;
         let message = self.message;
@@ -123,24 +145,16 @@ impl LogRecord {
             .verify(pub_key)?
         };
 
-        Ok(VerifiedLogRecord {
-            session_id,
-            timestamp_ms,
-            message,
-        })
+        Ok((session_id, timestamp_ms, message))
     }
 
-    pub fn verify_unsigned(self) -> GuardianResult<VerifiedLogRecord> {
+    pub fn verify_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         if !self.message.is_allowed_unsigned() {
             return Err(InvalidInputs(
                 "expected unsigned log record but message requires a signature".into(),
             ));
         }
-        Ok(VerifiedLogRecord {
-            session_id: self.session_id,
-            timestamp_ms: self.timestamp_ms,
-            message: self.message,
-        })
+        Ok((self.session_id, self.timestamp_ms, self.message))
     }
 }
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -14,7 +14,10 @@ pub mod limiter;
 pub mod s3_utils;
 
 pub use attestation::BuildPcrs;
+pub use attestation::GitRevision;
 pub use attestation::NitroAttestation;
+pub use attestation::PcrAllowlist;
+pub use attestation::VerifiedSessionInfo;
 pub use limiter::LimiterConfig;
 pub use limiter::LimiterState;
 pub use limiter::RateLimiter;
@@ -129,7 +132,7 @@ pub struct GuardianInfo {
     /// Git revision of the guardian build. Untrusted (enclave-self-reported);
     /// verified out-of-band by reproducibly building at this revision and matching
     /// PCRs against the session's attestation.
-    pub untrusted_git_revision: String,
+    pub untrusted_git_revision: GitRevision,
     /// Enclave BTC signing pubkey (x-only). Absent before `provisioner_init`.
     pub enclave_btc_pubkey: Option<BitcoinPubkey>,
     /// Current rate limiter state (if initialized).
@@ -647,7 +650,7 @@ impl GuardianInfo {
         S3BucketInfo,
         EncPubKeyBytes,
         [u8; 32],
-        String,
+        GitRevision,
         Option<BitcoinPubkey>,
         LimiterState,
         LimiterConfig,
@@ -692,11 +695,26 @@ impl GetGuardianInfoResponse {
     }
 
     /// Verify the response end to end and return the trusted guardian payload:
-    /// the attestation anchors `signing_pub_key`, and `signed_info` must be
-    /// signed by it.
-    pub fn verify(&self, build_pcrs: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
-        self.attestation.verify(&self.signing_pub_key, build_pcrs)?;
-        self.verify_signed_info_without_attestation()
+    /// the attestation anchors `signing_pub_key`, `signed_info` must be signed by
+    /// it, the signed git revision must match `expected_build`, and PCR0 must
+    /// match `expected_build`.
+    pub fn verify(&self, expected_build: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
+        let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
+        if info.untrusted_git_revision != expected_build.git_revision() {
+            return Err(InvalidInputs(format!(
+                "guardian info reports build '{}', expected current build '{}'",
+                info.untrusted_git_revision,
+                expected_build.git_revision()
+            )));
+        }
+        self.attestation
+            .verify(&self.signing_pub_key, expected_build)?;
+        Ok(VerifiedGuardianInfo {
+            info,
+            signing_pub_key: self.signing_pub_key,
+            session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
+            encrypted_shares: self.encrypted_shares.clone(),
+        })
     }
 
     /// Verify only the signed `GuardianInfo` payload.
@@ -828,7 +846,8 @@ mod tests {
         resp.signed_info.signature = GuardianSignature::from(sig_bytes);
 
         assert!(matches!(
-            resp.verify(&BuildPcrs::new(vec![0])).unwrap_err(),
+            resp.verify(&BuildPcrs::new("test-revision", vec![0]))
+                .unwrap_err(),
             InvalidInputs(_)
         ));
     }
@@ -886,6 +905,75 @@ mod tests {
         assert!(
             matches!(err, InvalidInputs(msg) if msg.contains("duplicate OpenPGP certificate fingerprint"))
         );
+    }
+
+    #[test]
+    fn pcr_allowlist_resolves_current_and_multiple_prev_builds() {
+        let allowlist = PcrAllowlist::new(
+            BuildPcrs::new("current", vec![0]),
+            vec![
+                BuildPcrs::new("prev-1", vec![1]),
+                BuildPcrs::new("prev-2", vec![2]),
+            ],
+        )
+        .unwrap();
+
+        let current_build = allowlist.resolve("current").unwrap();
+        assert_eq!(current_build.pcr0(), &[0]);
+        assert!(allowlist.is_current_build(current_build));
+        let prev_build = allowlist.resolve("prev-1").unwrap();
+        assert_eq!(prev_build.pcr0(), &[1]);
+        assert!(!allowlist.is_current_build(prev_build));
+        let prev2_build = allowlist.resolve("prev-2").unwrap();
+        assert_eq!(prev2_build.pcr0(), &[2]);
+    }
+
+    #[test]
+    fn pcr_allowlist_rejects_duplicate_build_revisions() {
+        let err = PcrAllowlist::new(
+            BuildPcrs::new("current", vec![0]),
+            vec![BuildPcrs::new("current", vec![1])],
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, InvalidInputs(msg) if msg.contains("duplicate PCR allowlist entry")));
+    }
+
+    #[test]
+    fn pcr_allowlist_deserializes_hex_wire_form() {
+        let allowlist: PcrAllowlist = serde_json::from_value(serde_json::json!({
+            "current_build": {
+                "git_revision": "current",
+                "pcr0": "0x00ff"
+            },
+            "prev_builds": [
+                {
+                    "git_revision": "prev",
+                    "pcr0": "01"
+                }
+            ]
+        }))
+        .unwrap();
+
+        let current_build = allowlist.resolve("current").unwrap();
+        assert_eq!(current_build.pcr0(), &[0x00, 0xff]);
+        let prev_build = allowlist.resolve("prev").unwrap();
+        assert_eq!(prev_build.pcr0(), &[0x01]);
+    }
+
+    #[test]
+    fn pcr_allowlist_requires_current_build() {
+        let allowlist = PcrAllowlist::new(
+            BuildPcrs::new("current", vec![0]),
+            vec![BuildPcrs::new("prev", vec![1])],
+        )
+        .unwrap();
+
+        let current_build = allowlist.resolve("current").unwrap();
+        allowlist.require_current_build(current_build).unwrap();
+
+        let prev_build = allowlist.resolve("prev").unwrap();
+        assert!(allowlist.require_current_build(prev_build).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace the single expected PCR with a PCR allowlist: `current_build` plus configured `prev_builds`, each represented as `BuildPcrs`.
- Add `BuildPolicy::{Current, AnyAllowlisted}` to single-object S3 reader APIs so live-session reads require the current build while historical reads can explicitly accept any allowlisted build.
- Thread resolved `BuildPcrs` into Nitro attestation verification so PCR0 is checked against the allowlist entry for the signed guardian revision.
- Carry verified PCR pins as `build_pcrs` on verified session/log records; batch log reads still expose per-record `build_pcrs` so callers can apply upgrade-boundary policy with local context.