### PR TITLE
[btc-monitor] Never rotate the trusted peer connection on a timer

### DIFF
--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -231,6 +231,7 @@ impl Monitor {
             // If all peers disconnect, the node exits with NoReachablePeers
             // and the supervision loop rebuilds it.
             .whitelist_only()
+            .maximum_connection_time(Duration::MAX)
             .chain_state(kyoto::ChainState::Checkpoint(checkpoint));
 
         if let Some(data_dir) = &config.data_dir {


### PR DESCRIPTION
Kyoto's default `max_connection_time` ends every peer connection after 2h, and with `whitelist_only` each rotation consumes a whitelist entry.

This causes each node's kyoto process to die with `NoReachablePeers` every ~4h and cause a full resync.

This PR removes this connection time limit altogether.