### PR TITLE
add metrics_push module: push prometheus metrics to sui-proxy via mTLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,11 +2906,13 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rcgen",
+ "reqwest",
  "rust-embed",
  "rustls 0.23.37",
  "serde",
  "serde_derive",
  "serde_json",
+ "snap",
  "sui-crypto",
  "sui-futures",
  "sui-http",
@@ -5757,6 +5759,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,9 @@ bin-version = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be
 prometheus-closure-metric = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
 sui-futures = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
 
+# Metrics push
+snap = "1"
+
 [profile.dev.package.blst]
 opt-level = 2
 [profile.dev.package.fastcrypto]

--- a/crates/hashi/Cargo.toml
+++ b/crates/hashi/Cargo.toml
@@ -66,6 +66,11 @@ fjall.workspace = true
 # DKG dependencies
 fastcrypto.workspace = true
 fastcrypto-tbls.workspace = true
+
+# Metrics push dependencies
+snap.workspace = true
+reqwest.workspace = true
+
 async-trait.workspace = true
 thiserror.workspace = true
 hex.workspace = true

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -198,6 +198,28 @@ pub struct Config {
     /// complaint recovery flow. Must not be set on mainnet or testnet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test_corrupt_shares_for: Option<Address>,
+
+    /// Configure pushing Prometheus metrics out to a sui-proxy instance. When
+    /// unset, the push task is not started and the only metrics surface is the
+    /// local scrape endpoint at `metrics_http_address`.
+    ///
+    /// The push uses the same `tls_private_key` already registered on chain in
+    /// `MemberInfo.tls_public_key`, so no additional credential setup is
+    /// required for operators that have already completed hashi committee
+    /// registration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics_push: Option<MetricsPushConfig>,
+}
+
+#[derive(Clone, Debug, serde_derive::Deserialize, serde_derive::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct MetricsPushConfig {
+    /// sui-proxy `/publish/metrics` URL (e.g. `https://metrics-proxy.testnet.example.com/publish/metrics`).
+    pub push_url: String,
+
+    /// How often to push. Defaults to 60s if unset (matches sui-node default).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_interval_seconds: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, serde_derive::Deserialize, serde_derive::Serialize)]

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -25,6 +25,7 @@ pub mod grpc;
 pub mod guardian_limiter;
 pub mod leader;
 pub mod metrics;
+pub mod metrics_push;
 pub mod mpc;
 pub mod onchain;
 pub mod publish;

--- a/crates/hashi/src/main.rs
+++ b/crates/hashi/src/main.rs
@@ -188,6 +188,21 @@ async fn run_server(config_path: Option<std::path::PathBuf>) -> anyhow::Result<(
         prometheus::default_registry().clone(),
     );
 
+    // If configured, start pushing metrics to a sui-proxy instance. Operators
+    // who haven't set `metrics_push` get only the local scrape endpoint, which
+    // is the current pre-launch behavior.
+    if let Some(push_cfg) = config.metrics_push.clone() {
+        match hashi::metrics_push::start(
+            push_cfg,
+            config.tls_private_key().map_err(|e| {
+                anyhow::anyhow!("metrics_push set but tls_private_key not loadable: {e}")
+            })?,
+        ) {
+            Ok(()) => tracing::info!("hashi metrics push task started"),
+            Err(e) => tracing::error!("failed to start metrics push task: {e:#}"),
+        }
+    }
+
     let server_version = ServerVersion::new(env!("CARGO_BIN_NAME"), VERSION);
 
     let hashi = Hashi::new(server_version, config_path, config)?;

--- a/crates/hashi/src/metrics_push.rs
+++ b/crates/hashi/src/metrics_push.rs
@@ -9,7 +9,9 @@ use anyhow::Context;
 use ed25519_dalek::pkcs8::EncodePrivateKey;
 use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
 use prometheus::Encoder;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 /// SNI/DNS name in the client cert; sui-proxy's TLS verifier checks this.
 /// Mirrors `sui_tls::SUI_VALIDATOR_SERVER_NAME` — inlined to avoid a sui-tls dep.

--- a/crates/hashi/src/metrics_push.rs
+++ b/crates/hashi/src/metrics_push.rs
@@ -1,0 +1,191 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Push hashi-server metrics to a sui-proxy `/publish/metrics` endpoint via
+//! the same mTLS protocol sui-node and sui-bridge use.
+
+use crate::config::MetricsPushConfig;
+use anyhow::Context;
+use ed25519_dalek::pkcs8::EncodePrivateKey;
+use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
+use prometheus::Encoder;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// SNI/DNS name in the client cert; sui-proxy's TLS verifier checks this.
+/// Mirrors `sui_tls::SUI_VALIDATOR_SERVER_NAME` — inlined to avoid a sui-tls dep.
+const PROXY_SERVER_NAME: &str = "sui";
+
+const DEFAULT_PUSH_INTERVAL: Duration = Duration::from_secs(60);
+const PUSH_TIMEOUT: Duration = Duration::from_secs(45);
+const CONSECUTIVE_FAILS_BEFORE_ERROR: u32 = 10;
+
+/// Spawn the metrics push task. Returns immediately; pushing happens in the
+/// background and surfaces failures via `tracing::warn!` / `tracing::error!`.
+pub fn start(
+    cfg: MetricsPushConfig,
+    tls_private_key: ed25519_dalek::SigningKey,
+) -> anyhow::Result<()> {
+    let interval = cfg
+        .push_interval_seconds
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_PUSH_INTERVAL);
+    let url = reqwest::Url::parse(&cfg.push_url)
+        .with_context(|| format!("invalid metrics_push.push_url '{}'", cfg.push_url))?;
+
+    let identity_pem = build_identity_pem(&tls_private_key)?;
+    let mut client = build_client(&identity_pem)?;
+    let user_agent = format!("hashi-server/{}", env!("CARGO_PKG_VERSION"));
+
+    tokio::spawn(async move {
+        tracing::info!(push_url =% url, interval =? interval, "started hashi metrics push task");
+
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        let mut consecutive_errors: u32 = 0;
+        loop {
+            ticker.tick().await;
+
+            match push_once(&client, &url, &user_agent).await {
+                Ok(()) => consecutive_errors = 0,
+                Err(e) => {
+                    consecutive_errors += 1;
+                    if consecutive_errors >= CONSECUTIVE_FAILS_BEFORE_ERROR {
+                        tracing::error!(
+                            consecutive_errors,
+                            "unable to push metrics: {e:#}; rebuilding client",
+                        );
+                    } else {
+                        tracing::warn!(
+                            consecutive_errors,
+                            "unable to push metrics: {e:#}; rebuilding client",
+                        );
+                    }
+                    // Match sui-metrics-push-client's behavior: rebuild the connection
+                    // on failure rather than rely on reqwest's pool to recover.
+                    match build_client(&identity_pem) {
+                        Ok(c) => client = c,
+                        Err(e) => {
+                            // Keep the previous client; we'll try to rebuild again on the next failure.
+                            tracing::error!("failed to rebuild metrics-push client: {e:#}");
+                        }
+                    }
+                }
+            }
+        }
+    });
+    Ok(())
+}
+
+/// Build the PEM that reqwest's `Identity::from_pem` expects: cert PEM
+/// concatenated with the PKCS#8 private-key PEM.
+fn build_identity_pem(tls_private_key: &ed25519_dalek::SigningKey) -> anyhow::Result<String> {
+    // PKCS#8 v1 DER of the Ed25519 seed; what `ring` (via rustls/rcgen) accepts.
+    let pkcs8 = tls_private_key
+        .to_pkcs8_der()
+        .context("PKCS#8-encode tls_private_key")?;
+
+    let private_key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(pkcs8.as_bytes().to_vec().into());
+    let keypair = rcgen::KeyPair::from_der_and_sign_algo(&private_key_der, &rcgen::PKCS_ED25519)
+        .context("rcgen Ed25519 PKCS#8 DER")?;
+
+    let cert = rcgen::CertificateParams::new(vec![PROXY_SERVER_NAME.to_owned()])
+        .context("rcgen CertificateParams construction")?
+        .self_signed(&keypair)
+        .context("rcgen self_signed")?;
+
+    let cert_pem = cert.pem();
+    let key_pem = tls_private_key
+        .to_pkcs8_pem(LineEnding::LF)
+        .context("PEM encoding of PKCS#8 key")?;
+    // `to_pkcs8_pem` returns Zeroizing<String>; deref into &str for format!.
+    Ok(format!("{cert_pem}\n{}", &*key_pem))
+}
+
+/// Build a reqwest client with the operator's mTLS identity loaded. sui-proxy
+/// verifies the client cert's public key against `MemberInfo.tls_public_key`
+/// for that validator on chain.
+fn build_client(identity_pem: &str) -> anyhow::Result<reqwest::Client> {
+    let identity = reqwest::tls::Identity::from_pem(identity_pem.as_bytes())
+        .context("reqwest Identity::from_pem")?;
+    reqwest::Client::builder()
+        .identity(identity)
+        .timeout(PUSH_TIMEOUT)
+        .build()
+        .context("reqwest client build")
+}
+
+async fn push_once(
+    client: &reqwest::Client,
+    url: &reqwest::Url,
+    user_agent: &str,
+) -> anyhow::Result<()> {
+    // Stamp every series with a single collection time.
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("clock before unix epoch")?
+        .as_millis() as i64;
+
+    let mut metric_families = prometheus::default_registry().gather();
+    for mf in metric_families.iter_mut() {
+        for m in mf.mut_metric() {
+            m.set_timestamp_ms(now_ms);
+        }
+    }
+
+    let mut buf = Vec::new();
+    let encoder = prometheus::ProtobufEncoder::new();
+    encoder
+        .encode(&metric_families, &mut buf)
+        .context("protobuf encoding")?;
+
+    // Snappy raw block (NOT frame). sui-proxy decodes via `snap::raw::Decoder`;
+    // frame format would arrive as "corrupt input" on the decoder side.
+    let compressed = snap::raw::Encoder::new()
+        .compress_vec(&buf)
+        .context("snappy raw compression")?;
+
+    let response = client
+        .post(url.clone())
+        // `prometheus::PROTOBUF_FORMAT` (the verbose vnd.google.protobuf string) — sui-proxy's
+        // middleware accepts only this exact value; sourcing from the proxy's crate keeps us in lockstep.
+        .header(reqwest::header::CONTENT_TYPE, prometheus::PROTOBUF_FORMAT)
+        .header(reqwest::header::CONTENT_ENCODING, "snappy")
+        .header(reqwest::header::CONTENT_LENGTH, compressed.len())
+        .header(reqwest::header::USER_AGENT, user_agent)
+        .header("X-Mysten-Proxy", user_agent)
+        .body(compressed)
+        .send()
+        .await
+        .context("HTTP send")?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("sui-proxy returned {status}: {body}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn build_identity_pem_produces_parseable_reqwest_identity() {
+        // If reqwest rejects the PEM bundle we generate, the production push task
+        // can never authenticate.
+        let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let pem = build_identity_pem(&key).expect("identity PEM construction");
+        reqwest::tls::Identity::from_pem(pem.as_bytes())
+            .expect("reqwest accepts the identity PEM we produce");
+    }
+
+    #[test]
+    fn build_client_succeeds_for_valid_identity() {
+        let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let pem = build_identity_pem(&key).expect("identity PEM");
+        let _client = build_client(&pem).expect("client build");
+    }
+}


### PR DESCRIPTION
Hashi operators need a way to send Prometheus metrics to Mysten's Mimir. We reuse the sui-proxy mTLS protocol sui-node and sui-bridge already use, so a single proxy can ingest from all three node types. Operators don't provision new credentials — the existing `tls_private_key` (already on chain as `MemberInfo.tls_public_key`) is what sui-proxy's hashi resolver matches client certs against.

Wire format (matched to sui-proxy's middleware):
- POST to the configured `/publish/metrics` URL with mTLS client cert (self-signed x509 wrapping the operator's Ed25519 tls_private_key)
- Body: length-delimited Prometheus protobuf, snappy raw block compressed
- Content-Type sourced from `prometheus::PROTOBUF_FORMAT` directly so it can't drift from the proxy's decoder

Why inlined rather than depending on `sui-metrics-push-client`: that crate transitively pulls `sui-types` → `mysten-network` → old `multihash` requiring a yanked `core2 0.4.0`. Inlining the small push loop avoids churning hashi's pinned sui rev.

Config: a new optional `[metrics-push]` block (push_url + push_interval_seconds, default 60s). When unset, behavior is unchanged.

Retry: rebuild the reqwest client after each failure rather than relying on the connection pool, escalating warn → error after 10 consecutive failures.

Verified end-to-end against private-testnet sui-proxy with hashi pushing on a 60s interval — series visible in Mimir under
`{network="private-testnet", host="hashi-<validator-name>"}`.