### PR TITLE
Authorize cert submission and governance by the operator key

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -1371,8 +1371,10 @@ mod tests {
         use hashi::cli::client::CreateProposalParams;
         use hashi::cli::client::build_create_proposal_transaction;
 
+        let validator_address = executor.sender();
         let builder = build_create_proposal_transaction(
             hashi_ids,
+            validator_address,
             CreateProposalParams::UpdateConfig {
                 key: "bitcoin_deposit_minimum".to_string(),
                 value: hashi_types::move_types::ConfigValue::U64(25_000),

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -544,7 +544,8 @@ async fn submit_proposal_through_quorum(
     use hashi::cli::upgrade::build_execute_proposal_transaction;
     use hashi::cli::upgrade::extract_proposal_id_from_response;
 
-    let create_tx = build_create_proposal_transaction(hashi_ids, create_params);
+    let creator = executors[0].sender();
+    let create_tx = build_create_proposal_transaction(hashi_ids, creator, create_params);
     let response = executors[0].execute(create_tx).await?;
     anyhow::ensure!(
         response.transaction().effects().status().success(),
@@ -553,7 +554,9 @@ async fn submit_proposal_through_quorum(
     let proposal_id = extract_proposal_id_from_response(&response)?;
     tracing::info!("{label} proposal {proposal_id} created; collecting votes");
     for executor in &mut executors[1..] {
-        let vote_tx = build_vote_transaction(hashi_ids, proposal_id, proposal_type_tag.clone());
+        let voter = executor.sender();
+        let vote_tx =
+            build_vote_transaction(hashi_ids, voter, proposal_id, proposal_type_tag.clone());
         let vote_resp = executor.execute(vote_tx).await?;
         anyhow::ensure!(
             vote_resp.transaction().effects().status().success(),

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -141,8 +141,10 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
 
     // 3. Propose the upgrade
     tracing::info!("proposing upgrade...");
+    let creator = executors[0].sender();
     let create_tx = build_create_proposal_transaction(
         hashi_ids,
+        creator,
         CreateProposalParams::Upgrade {
             digest: digest.clone(),
             metadata: vec![("reason".to_string(), "upgrade test".to_string())],
@@ -166,7 +168,9 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
     )));
 
     for executor in &mut executors[1..] {
-        let vote_tx = build_vote_transaction(hashi_ids, proposal_id, upgrade_type_tag.clone());
+        let voter = executor.sender();
+        let vote_tx =
+            build_vote_transaction(hashi_ids, voter, proposal_id, upgrade_type_tag.clone());
         let vote_resp = executor.execute(vote_tx).await?;
         anyhow::ensure!(
             vote_resp.transaction().effects().status().success(),
@@ -201,8 +205,10 @@ pub async fn disable_version(
     version: u64,
     execute_package_id: Address,
 ) -> Result<()> {
+    let creator = executors[0].sender();
     let create_tx = build_create_proposal_transaction(
         hashi_ids,
+        creator,
         CreateProposalParams::DisableVersion {
             version,
             metadata: vec![],
@@ -224,7 +230,9 @@ pub async fn disable_version(
     )));
 
     for executor in &mut executors[1..] {
-        let vote_tx = build_vote_transaction(hashi_ids, proposal_id, disable_version_type.clone());
+        let voter = executor.sender();
+        let vote_tx =
+            build_vote_transaction(hashi_ids, voter, proposal_id, disable_version_type.clone());
         let vote_resp = executor.execute(vote_tx).await?;
         anyhow::ensure!(
             vote_resp.transaction().effects().status().success(),

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -379,25 +379,52 @@ impl HashiClient {
     // Transaction builders (proposal/governance)
     // ========================================================================
 
+    /// Resolve the committee member (validator address) the signer is acting for:
+    /// the signer's own address if it is a validator member, otherwise the member
+    /// that has delegated its operator address to the signer.
+    fn resolve_validator_address(&self) -> anyhow::Result<Address> {
+        let sender = self
+            .executor
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Cannot resolve validator: no keypair configured"))?
+            .sender();
+        let members = self.fetch_committee_members();
+        members
+            .iter()
+            .find(|m| *m.validator_address() == sender || *m.operator_address() == sender)
+            .map(|m| *m.validator_address())
+            .ok_or_else(|| {
+                anyhow::anyhow!("signer {sender} is not a committee member or delegated operator")
+            })
+    }
+
     /// Build a vote transaction for a proposal.
     ///
-    /// Calls: `proposal::vote<T>(hashi, proposal_id, clock, ctx)`
+    /// Calls: `proposal::vote<T>(hashi, validator_address, proposal_id, clock)`
     pub fn build_vote_transaction(
         &self,
         proposal_id: Address,
         type_arg: TypeTag,
-    ) -> TransactionBuilder {
-        build_vote_transaction(self.hashi_ids, proposal_id, type_arg)
+    ) -> anyhow::Result<TransactionBuilder> {
+        let validator_address = self.resolve_validator_address()?;
+        Ok(build_vote_transaction(
+            self.hashi_ids,
+            validator_address,
+            proposal_id,
+            type_arg,
+        ))
     }
 
     /// Build a remove_vote transaction for a proposal.
     ///
-    /// Calls: `proposal::remove_vote<T>(hashi, proposal_id, ctx)`
+    /// Calls: `proposal::remove_vote<T>(hashi, validator_address, proposal_id)`
     pub fn build_remove_vote_transaction(
         &self,
         proposal_id: Address,
         type_arg: TypeTag,
-    ) -> TransactionBuilder {
+    ) -> anyhow::Result<TransactionBuilder> {
+        let validator_address = self.resolve_validator_address()?;
+
         let mut builder = TransactionBuilder::new();
 
         let hashi_arg = builder.object(
@@ -405,6 +432,7 @@ impl HashiClient {
                 .as_shared()
                 .with_mutable(true),
         );
+        let validator_address_arg = builder.pure(&validator_address);
         let proposal_id_arg = builder.pure(&proposal_id);
 
         builder.move_call(
@@ -414,18 +442,23 @@ impl HashiClient {
                 Identifier::from_static("remove_vote"),
             )
             .with_type_args(vec![type_arg]),
-            vec![hashi_arg, proposal_id_arg],
+            vec![hashi_arg, validator_address_arg, proposal_id_arg],
         );
 
-        builder
+        Ok(builder)
     }
 
     /// Build a proposal creation transaction.
     pub fn build_create_proposal_transaction(
         &self,
         params: CreateProposalParams,
-    ) -> TransactionBuilder {
-        build_create_proposal_transaction(self.hashi_ids, params)
+    ) -> anyhow::Result<TransactionBuilder> {
+        let validator_address = self.resolve_validator_address()?;
+        Ok(build_create_proposal_transaction(
+            self.hashi_ids,
+            validator_address,
+            params,
+        ))
     }
 
     /// Build a transaction to execute a proposal that has reached quorum.
@@ -488,6 +521,7 @@ impl HashiClient {
 /// This is a standalone function so it can be reused outside `HashiClient` (e.g. in tests).
 pub fn build_create_proposal_transaction(
     hashi_ids: HashiIds,
+    validator_address: Address,
     params: CreateProposalParams,
 ) -> TransactionBuilder {
     let mut builder = TransactionBuilder::new();
@@ -502,6 +536,7 @@ pub fn build_create_proposal_transaction(
             .as_shared()
             .with_mutable(false),
     );
+    let validator_address_arg = builder.pure(&validator_address);
 
     match params {
         CreateProposalParams::Upgrade { digest, metadata } => {
@@ -513,7 +548,13 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("upgrade"),
                     Identifier::from_static("propose"),
                 ),
-                vec![hashi_arg, digest_arg, metadata_arg, clock_arg],
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    digest_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
             );
         }
         CreateProposalParams::UpdateConfig {
@@ -530,7 +571,13 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("update_config"),
                     Identifier::from_static("propose"),
                 ),
-                vec![hashi_arg, entries_arg, metadata_arg, clock_arg],
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    entries_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
             );
         }
         CreateProposalParams::UpdateMpcConfig {
@@ -558,7 +605,13 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("update_config"),
                     Identifier::from_static("propose"),
                 ),
-                vec![hashi_arg, entries_arg, metadata_arg, clock_arg],
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    entries_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
             );
         }
         CreateProposalParams::EnableVersion { version, metadata } => {
@@ -570,7 +623,13 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("enable_version"),
                     Identifier::from_static("propose"),
                 ),
-                vec![hashi_arg, version_arg, metadata_arg, clock_arg],
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    version_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
             );
         }
         CreateProposalParams::DisableVersion { version, metadata } => {
@@ -582,7 +641,13 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("disable_version"),
                     Identifier::from_static("propose"),
                 ),
-                vec![hashi_arg, version_arg, metadata_arg, clock_arg],
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    version_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
             );
         }
         CreateProposalParams::AbortReconfig { epoch, metadata } => {
@@ -594,7 +659,13 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("abort_reconfig"),
                     Identifier::from_static("propose"),
                 ),
-                vec![hashi_arg, epoch_arg, metadata_arg, clock_arg],
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    epoch_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
             );
         }
         CreateProposalParams::UpdateGuardian {
@@ -611,7 +682,14 @@ pub fn build_create_proposal_transaction(
                     Identifier::from_static("update_guardian"),
                     Identifier::from_static("propose"),
                 ),
-                vec![hashi_arg, url_arg, public_key_arg, metadata_arg, clock_arg],
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    url_arg,
+                    public_key_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
             );
         }
     }
@@ -742,6 +820,7 @@ fn build_metadata(
 /// committee member.
 pub fn build_vote_transaction(
     hashi_ids: HashiIds,
+    validator_address: Address,
     proposal_id: Address,
     type_arg: TypeTag,
 ) -> TransactionBuilder {
@@ -751,6 +830,7 @@ pub fn build_vote_transaction(
             .as_shared()
             .with_mutable(true),
     );
+    let validator_address_arg = builder.pure(&validator_address);
     let proposal_id_arg = builder.pure(&proposal_id);
     let clock_arg = builder.object(
         ObjectInput::new(SUI_CLOCK_OBJECT_ID)
@@ -765,7 +845,7 @@ pub fn build_vote_transaction(
             Identifier::from_static("vote"),
         )
         .with_type_args(vec![type_arg]),
-        vec![hashi_arg, proposal_id_arg, clock_arg],
+        vec![hashi_arg, validator_address_arg, proposal_id_arg, clock_arg],
     );
 
     builder

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -244,7 +244,7 @@ pub async fn vote(
 
     // Infer the type tag from the on-chain proposal type
     let type_arg = get_proposal_type_arg(client.hashi_ids().package_id, &proposal.proposal_type)?;
-    let tx = client.build_vote_transaction(proposal_addr, type_arg);
+    let tx = client.build_vote_transaction(proposal_addr, type_arg)?;
 
     print_info(&format!(
         "Transaction: proposal::vote<{}> on {}",
@@ -350,7 +350,7 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
 
     // Infer the type tag from the on-chain proposal type
     let type_arg = get_proposal_type_arg(client.hashi_ids().package_id, &proposal.proposal_type)?;
-    let tx = client.build_remove_vote_transaction(proposal_addr, type_arg);
+    let tx = client.build_remove_vote_transaction(proposal_addr, type_arg)?;
 
     print_info(&format!(
         "Transaction: proposal::remove_vote<{}> on {}",
@@ -468,7 +468,7 @@ pub async fn create_upgrade_proposal(
     let tx = client.build_create_proposal_transaction(CreateProposalParams::Upgrade {
         digest: digest_bytes,
         metadata,
-    });
+    })?;
 
     print_info("Transaction: upgrade::propose");
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
@@ -501,7 +501,7 @@ pub async fn create_update_config_proposal(
         key: key.to_string(),
         value,
         metadata,
-    });
+    })?;
 
     print_info("Transaction: update_config::propose");
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
@@ -561,7 +561,7 @@ pub async fn create_update_mpc_config_proposal(
         max_faulty_bps,
         weight_reduction_allowed_delta,
         metadata,
-    });
+    })?;
 
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
     print_created_proposal_id(response.as_ref());
@@ -609,7 +609,7 @@ pub async fn create_enable_version_proposal(
     let tx = client.build_create_proposal_transaction(CreateProposalParams::EnableVersion {
         version,
         metadata,
-    });
+    })?;
 
     print_info("Transaction: enable_version::propose");
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
@@ -636,7 +636,7 @@ pub async fn create_disable_version_proposal(
     let tx = client.build_create_proposal_transaction(CreateProposalParams::DisableVersion {
         version,
         metadata,
-    });
+    })?;
 
     print_info("Transaction: disable_version::propose");
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
@@ -660,8 +660,10 @@ pub async fn create_abort_reconfig_proposal(
     }
 
     let mut client = HashiClient::new(config).await?;
-    let tx = client
-        .build_create_proposal_transaction(CreateProposalParams::AbortReconfig { epoch, metadata });
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::AbortReconfig {
+        epoch,
+        metadata,
+    })?;
 
     print_info("Transaction: abort_reconfig::propose");
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
@@ -699,7 +701,7 @@ pub async fn create_update_guardian_proposal(
         url: url.to_string(),
         public_key,
         metadata,
-    });
+    })?;
 
     print_info("Transaction: update_guardian::propose");
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;

--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -83,7 +83,7 @@ fun submit_cert_internal(
     // The dealer's own validator key, or the operator key it has delegated to,
     // may submit the dealer's certificate. `member_authorized` also enforces
     // that the dealer is a registered committee member.
-    assert!(hashi.committee_set().member_authorized(dealer, ctx.sender()));
+    assert!(hashi.committee_set().member_authorized(dealer, ctx));
     let pending = hashi.committee_set().pending_epoch_change();
     assert!(epoch == hashi.committee_set().epoch() || pending.contains(&epoch));
     let epoch_certs = hashi.epoch_certs(key, protocol_type, ctx);

--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -80,8 +80,10 @@ fun submit_cert_internal(
     ctx: &mut TxContext,
 ) {
     hashi.config().assert_version_enabled();
-    assert!(ctx.sender() == dealer);
-    assert!(hashi.committee_set().has_member(dealer));
+    // The dealer's own validator key, or the operator key it has delegated to,
+    // may submit the dealer's certificate. `member_authorized` also enforces
+    // that the dealer is a registered committee member.
+    assert!(hashi.committee_set().member_authorized(dealer, ctx.sender()));
     let pending = hashi.committee_set().pending_epoch_change();
     assert!(epoch == hashi.committee_set().epoch() || pending.contains(&epoch));
     let epoch_certs = hashi.epoch_certs(key, protocol_type, ctx);

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -17,10 +17,6 @@ use sui::{
 // Errors
 //
 
-#[error(code = 0)]
-const ENotValidator: vector<u8> =
-    b"Only the validator's own Sui key may rotate the operator address";
-
 //
 // CommitteeSet
 //
@@ -54,9 +50,9 @@ public(package) fun has_member(self: &CommitteeSet, validator_address: address):
     self.members.contains_with_type<_, MemberInfo>(validator_address)
 }
 
-/// Returns true if `sender` is authorized to act on behalf of the member
-/// registered under `validator_address` — that is, `sender` is either the
-/// validator's own Sui address or the operator address it has delegated to.
+/// Returns true if the transaction sender is authorized to act on behalf of the
+/// member registered under `validator_address` — that is, the sender is either
+/// the validator's own Sui address or the operator address it has delegated to.
 /// Returns false if no such member exists.
 ///
 /// The validator's own key always retains authority, so it can serve as a
@@ -64,13 +60,9 @@ public(package) fun has_member(self: &CommitteeSet, validator_address: address):
 public(package) fun member_authorized(
     self: &CommitteeSet,
     validator_address: address,
-    sender: address,
+    ctx: &TxContext,
 ): bool {
-    if (!self.has_member(validator_address)) {
-        return false
-    };
-    let member = self.member(validator_address);
-    sender == member.validator_address || sender == member.operator_address
+    self.has_member(validator_address) && self.member(validator_address).is_authorized(ctx)
 }
 
 fun member_mut(self: &mut CommitteeSet, validator_address: address): &mut MemberInfo {
@@ -163,8 +155,15 @@ public(package) fun new_member(
     committee_set.insert_member(member);
 }
 
-fun assert_update_permitted(self: &MemberInfo, ctx: &TxContext) {
-    assert!(ctx.sender() == self.validator_address || ctx.sender() == self.operator_address);
+/// True if the tx sender is authorized to act for this member — its validator
+/// key or its delegated operator key. The validator key always retains authority.
+fun is_authorized(self: &MemberInfo, ctx: &TxContext): bool {
+    let sender = ctx.sender();
+    sender == self.validator_address || sender == self.operator_address
+}
+
+fun assert_authorized(self: &MemberInfo, ctx: &TxContext) {
+    assert!(self.is_authorized(ctx));
 }
 
 /// Set the public key of the member.
@@ -183,7 +182,7 @@ public(package) fun set_next_epoch_public_key(
     );
 
     let member = self.member_mut(validator_address);
-    member.assert_update_permitted(ctx);
+    member.assert_authorized(ctx);
 
     member.next_epoch_public_key = next_epoch_public_key;
 }
@@ -196,7 +195,7 @@ public(package) fun set_endpoint_url(
     ctx: &TxContext,
 ) {
     let member = self.member_mut(validator_address);
-    member.assert_update_permitted(ctx);
+    member.assert_authorized(ctx);
 
     member.endpoint_url = endpoint_url;
 }
@@ -211,7 +210,7 @@ public(package) fun set_tls_public_key(
     assert!(tls_public_key.length() == 32);
 
     let member = self.member_mut(validator_address);
-    member.assert_update_permitted(ctx);
+    member.assert_authorized(ctx);
     member.tls_public_key = tls_public_key;
 }
 
@@ -225,16 +224,16 @@ public(package) fun set_next_epoch_encryption_public_key(
     assert!(next_epoch_encryption_public_key.length() == 32);
 
     let member = self.member_mut(validator_address);
-    member.assert_update_permitted(ctx);
+    member.assert_authorized(ctx);
     member.next_epoch_encryption_public_key = next_epoch_encryption_public_key;
 }
 
 /// Set the operator_address of the member (delegate operations to an operator
 /// key, or rotate it).
 ///
-/// Only the validator's own Sui key may do this, so a compromised operator key
-/// cannot lock the validator out by re-delegating to an attacker-controlled
-/// address; the validator key always remains in control of the delegation.
+/// Authorized for the validator's own key or its current operator key. The
+/// validator key always retains authority, so it can recover the delegation even
+/// if the operator key is lost.
 public(package) fun set_operator_address(
     self: &mut CommitteeSet,
     validator_address: address,
@@ -242,7 +241,7 @@ public(package) fun set_operator_address(
     ctx: &TxContext,
 ) {
     let member = self.member_mut(validator_address);
-    assert!(ctx.sender() == member.validator_address, ENotValidator);
+    member.assert_authorized(ctx);
     member.operator_address = operator_address;
 }
 

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -14,6 +14,14 @@ use sui::{
 };
 
 //
+// Errors
+//
+
+#[error(code = 0)]
+const ENotValidator: vector<u8> =
+    b"Only the validator's own Sui key may rotate the operator address";
+
+//
 // CommitteeSet
 //
 
@@ -44,6 +52,25 @@ fun member(self: &CommitteeSet, validator_address: address): &MemberInfo {
 
 public(package) fun has_member(self: &CommitteeSet, validator_address: address): bool {
     self.members.contains_with_type<_, MemberInfo>(validator_address)
+}
+
+/// Returns true if `sender` is authorized to act on behalf of the member
+/// registered under `validator_address` — that is, `sender` is either the
+/// validator's own Sui address or the operator address it has delegated to.
+/// Returns false if no such member exists.
+///
+/// The validator's own key always retains authority, so it can serve as a
+/// backup if the operator key is lost.
+public(package) fun member_authorized(
+    self: &CommitteeSet,
+    validator_address: address,
+    sender: address,
+): bool {
+    if (!self.has_member(validator_address)) {
+        return false
+    };
+    let member = self.member(validator_address);
+    sender == member.validator_address || sender == member.operator_address
 }
 
 fun member_mut(self: &mut CommitteeSet, validator_address: address): &mut MemberInfo {
@@ -202,7 +229,12 @@ public(package) fun set_next_epoch_encryption_public_key(
     member.next_epoch_encryption_public_key = next_epoch_encryption_public_key;
 }
 
-/// Set the operator_address of the member.
+/// Set the operator_address of the member (delegate operations to an operator
+/// key, or rotate it).
+///
+/// Only the validator's own Sui key may do this, so a compromised operator key
+/// cannot lock the validator out by re-delegating to an attacker-controlled
+/// address; the validator key always remains in control of the delegation.
 public(package) fun set_operator_address(
     self: &mut CommitteeSet,
     validator_address: address,
@@ -210,7 +242,7 @@ public(package) fun set_operator_address(
     ctx: &TxContext,
 ) {
     let member = self.member_mut(validator_address);
-    member.assert_update_permitted(ctx);
+    assert!(ctx.sender() == member.validator_address, ENotValidator);
     member.operator_address = operator_address;
 }
 

--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -51,10 +51,7 @@ public(package) fun create<T: store>(
     // The caller must be the committee member `validator_address`, or the
     // operator key it has delegated to. The vote is recorded under
     // `validator_address` so quorum weight is computed correctly.
-    assert!(
-        hashi.committee_set().member_authorized(validator_address, ctx.sender()),
-        EUnauthorizedCaller,
-    );
+    assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
 
     let votes = vector[validator_address];
     let timestamp_ms = clock.timestamp_ms();
@@ -111,10 +108,7 @@ public fun vote<T: store>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    assert!(
-        hashi.committee_set().member_authorized(validator_address, ctx.sender()),
-        EUnauthorizedCaller,
-    );
+    assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
 
     let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
 
@@ -135,10 +129,7 @@ public fun remove_vote<T: store>(
     proposal_id: ID,
     ctx: &mut TxContext,
 ) {
-    assert!(
-        hashi.committee_set().member_authorized(validator_address, ctx.sender()),
-        EUnauthorizedCaller,
-    );
+    assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
 
     let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
     let index = proposal

--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -41,21 +41,27 @@ const EProposalAlreadyExecuted: vector<u8> = b"Proposal already executed";
 
 public(package) fun create<T: store>(
     hashi: &mut Hashi,
+    validator_address: address,
     data: T,
     quorum_threshold_bps: u64,
     metadata: VecMap<String, String>,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
-    // only voters can create proposal
-    assert!(hashi.committee_set().has_member(ctx.sender()), EUnauthorizedCaller);
+    // The caller must be the committee member `validator_address`, or the
+    // operator key it has delegated to. The vote is recorded under
+    // `validator_address` so quorum weight is computed correctly.
+    assert!(
+        hashi.committee_set().member_authorized(validator_address, ctx.sender()),
+        EUnauthorizedCaller,
+    );
 
-    let votes = vector[ctx.sender()];
+    let votes = vector[validator_address];
     let timestamp_ms = clock.timestamp_ms();
 
     let proposal = Proposal {
         id: object::new(ctx),
-        creator: ctx.sender(),
+        creator: validator_address,
         votes,
         quorum_threshold_bps,
         timestamp_ms,
@@ -98,32 +104,52 @@ public(package) fun execute<T: copy + drop + store>(
     data
 }
 
-public fun vote<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock, ctx: &mut TxContext) {
-    assert!(hashi.committee_set().has_member(ctx.sender()), EUnauthorizedCaller);
+public fun vote<T: store>(
+    hashi: &mut Hashi,
+    validator_address: address,
+    proposal_id: ID,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    assert!(
+        hashi.committee_set().member_authorized(validator_address, ctx.sender()),
+        EUnauthorizedCaller,
+    );
 
     let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
 
-    assert!(!proposal.votes.contains(&ctx.sender()), EVoteAlreadyCounted);
+    assert!(!proposal.votes.contains(&validator_address), EVoteAlreadyCounted);
     assert!(!proposal.is_expired(clock), EProposalExpired);
 
-    proposal.votes.push_back(ctx.sender());
+    proposal.votes.push_back(validator_address);
 
-    proposal_events::emit_vote_cast_event<T>(proposal_id, ctx.sender());
+    proposal_events::emit_vote_cast_event<T>(proposal_id, validator_address);
     if (proposal.quorum_reached(hashi)) {
         proposal_events::emit_quorum_reached_event<T>(proposal_id);
     }
 }
 
-public fun remove_vote<T: store>(hashi: &mut Hashi, proposal_id: ID, ctx: &mut TxContext) {
-    assert!(hashi.committee_set().has_member(ctx.sender()), EUnauthorizedCaller);
+public fun remove_vote<T: store>(
+    hashi: &mut Hashi,
+    validator_address: address,
+    proposal_id: ID,
+    ctx: &mut TxContext,
+) {
+    assert!(
+        hashi.committee_set().member_authorized(validator_address, ctx.sender()),
+        EUnauthorizedCaller,
+    );
 
     let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
-    let index = proposal.votes.find_index!(|v| v == &ctx.sender()).destroy_or!(abort ENoVoteFound);
+    let index = proposal
+        .votes
+        .find_index!(|v| v == &validator_address)
+        .destroy_or!(abort ENoVoteFound);
 
     proposal.votes.remove(index);
     proposal_events::emit_vote_removed_event<T>(
         proposal.id.to_inner(),
-        ctx.sender(),
+        validator_address,
     );
 }
 

--- a/packages/hashi/sources/core/proposal/types/abort_reconfig.move
+++ b/packages/hashi/sources/core/proposal/types/abort_reconfig.move
@@ -23,6 +23,7 @@ public struct AbortReconfig has copy, drop, store {
 
 public fun propose(
     hashi: &mut Hashi,
+    validator_address: address,
     epoch: u64,
     metadata: VecMap<String, String>,
     clock: &Clock,
@@ -34,7 +35,15 @@ public fun propose(
         hashi.committee_set().pending_epoch_change().destroy_some() == epoch,
         EWrongReconfigEpoch,
     );
-    proposal::create(hashi, AbortReconfig { epoch }, THRESHOLD_BPS, metadata, clock, ctx)
+    proposal::create(
+        hashi,
+        validator_address,
+        AbortReconfig { epoch },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
 }
 
 public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock, ctx: &TxContext) {

--- a/packages/hashi/sources/core/proposal/types/disable_version.move
+++ b/packages/hashi/sources/core/proposal/types/disable_version.move
@@ -15,13 +15,22 @@ public struct DisableVersion has copy, drop, store {
 
 public fun propose(
     hashi: &mut Hashi,
+    validator_address: address,
     version: u64,
     metadata: VecMap<String, String>,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     hashi.config().assert_version_enabled();
-    proposal::create(hashi, DisableVersion { version }, THRESHOLD_BPS, metadata, clock, ctx)
+    proposal::create(
+        hashi,
+        validator_address,
+        DisableVersion { version },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
 }
 
 public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {

--- a/packages/hashi/sources/core/proposal/types/emergency_pause.move
+++ b/packages/hashi/sources/core/proposal/types/emergency_pause.move
@@ -17,6 +17,7 @@ public struct EmergencyPause has copy, drop, store {
 
 public fun propose(
     hashi: &mut Hashi,
+    validator_address: address,
     pause: bool,
     metadata: VecMap<String, String>,
     clock: &Clock,
@@ -28,7 +29,15 @@ public fun propose(
     } else {
         hashi.config().emergency_unpause_threshold_bps()
     };
-    proposal::create(hashi, EmergencyPause { pause }, threshold, metadata, clock, ctx)
+    proposal::create(
+        hashi,
+        validator_address,
+        EmergencyPause { pause },
+        threshold,
+        metadata,
+        clock,
+        ctx,
+    )
 }
 
 public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {

--- a/packages/hashi/sources/core/proposal/types/enable_version.move
+++ b/packages/hashi/sources/core/proposal/types/enable_version.move
@@ -15,13 +15,22 @@ public struct EnableVersion has copy, drop, store {
 
 public fun propose(
     hashi: &mut Hashi,
+    validator_address: address,
     version: u64,
     metadata: VecMap<String, String>,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     hashi.config().assert_version_enabled();
-    proposal::create(hashi, EnableVersion { version }, THRESHOLD_BPS, metadata, clock, ctx)
+    proposal::create(
+        hashi,
+        validator_address,
+        EnableVersion { version },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
 }
 
 public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {

--- a/packages/hashi/sources/core/proposal/types/update_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_config.move
@@ -21,6 +21,7 @@ public struct UpdateConfig has copy, drop, store {
 
 public fun propose(
     hashi: &mut Hashi,
+    validator_address: address,
     entries: VecMap<String, Value>,
     metadata: VecMap<String, String>,
     clock: &Clock,
@@ -28,7 +29,15 @@ public fun propose(
 ): ID {
     hashi.config().assert_version_enabled();
     assert!(!entries.is_empty(), ENoEntriesProvided);
-    proposal::create(hashi, UpdateConfig { entries }, THRESHOLD_BPS, metadata, clock, ctx)
+    proposal::create(
+        hashi,
+        validator_address,
+        UpdateConfig { entries },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
 }
 
 public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {

--- a/packages/hashi/sources/core/proposal/types/update_guardian.move
+++ b/packages/hashi/sources/core/proposal/types/update_guardian.move
@@ -16,6 +16,7 @@ public struct UpdateGuardian has copy, drop, store {
 
 public fun propose(
     hashi: &mut Hashi,
+    validator_address: address,
     url: String,
     public_key: vector<u8>,
     metadata: VecMap<String, String>,
@@ -26,6 +27,7 @@ public fun propose(
     config::assert_valid_guardian_public_key(&public_key);
     proposal::create(
         hashi,
+        validator_address,
         UpdateGuardian { url, public_key },
         THRESHOLD_BPS,
         metadata,

--- a/packages/hashi/sources/core/proposal/types/upgrade.move
+++ b/packages/hashi/sources/core/proposal/types/upgrade.move
@@ -27,13 +27,22 @@ public struct Upgrade has copy, drop, store {
 
 public fun propose(
     hashi: &mut Hashi,
+    validator_address: address,
     digest: vector<u8>,
     metadata: VecMap<String, String>,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     hashi.config().assert_version_enabled();
-    proposal::create(hashi, Upgrade { digest }, THRESHOLD_BPS, metadata, clock, ctx)
+    proposal::create(
+        hashi,
+        validator_address,
+        Upgrade { digest },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
 }
 
 /// Executes an approved upgrade proposal.

--- a/packages/hashi/tests/operator_delegation_tests.move
+++ b/packages/hashi/tests/operator_delegation_tests.move
@@ -1,0 +1,172 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+#[allow(implicit_const_copy, unused_variable)]
+module hashi::operator_delegation_tests;
+
+use hashi::{committee_set, proposal, test_utils, update_config::UpdateConfig};
+use sui::clock;
+
+// ======== Test Addresses ========
+const VALIDATOR1: address = @0x1;
+const VALIDATOR2: address = @0x2;
+const VALIDATOR3: address = @0x3;
+const OPERATOR1: address = @0xA1;
+const STRANGER: address = @0x999;
+
+// ======== member_authorized Tests ========
+
+#[test]
+/// A validator authorizes itself; an undelegated operator and a stranger do not;
+/// after delegation the operator is authorized while the validator stays authorized.
+fun test_member_authorized() {
+    let ctx = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+
+    let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    // The validator's own key is always authorized for itself.
+    assert!(hashi.committee_set().member_authorized(VALIDATOR1, VALIDATOR1));
+
+    // No operator delegated yet: operator and stranger are not authorized.
+    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, OPERATOR1));
+    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, STRANGER));
+
+    // A non-member validator address is never authorized.
+    assert!(!hashi.committee_set().member_authorized(STRANGER, STRANGER));
+
+    // VALIDATOR1 delegates to OPERATOR1 (ctx sender == VALIDATOR1).
+    let ctx_v1 = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, OPERATOR1, ctx_v1);
+
+    // Now the operator is authorized, and the validator key still is too.
+    assert!(hashi.committee_set().member_authorized(VALIDATOR1, OPERATOR1));
+    assert!(hashi.committee_set().member_authorized(VALIDATOR1, VALIDATOR1));
+
+    std::unit_test::destroy(hashi);
+}
+
+// ======== Operator Acting On Behalf Of Validator ========
+
+#[test]
+/// A delegated operator can create a proposal *for* the validator and the vote
+/// is recorded under the validator's address. Quorum then completes normally.
+fun test_operator_can_create_and_vote() {
+    let ctx = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+
+    let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // Delegate V1 -> OPERATOR1.
+    let ctx_v1 = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, OPERATOR1, ctx_v1);
+
+    // OPERATOR1 creates a proposal on behalf of VALIDATOR1.
+    let ctx_op = &mut test_utils::new_tx_context(OPERATOR1, 0);
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VALIDATOR1,
+        1000,
+        &clock,
+        ctx_op,
+    );
+
+    // The auto-vote is recorded under VALIDATOR1, not OPERATOR1.
+    let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
+    assert!(prop.votes().length() == 1);
+    assert!(prop.votes().contains(&VALIDATOR1));
+    assert!(!prop.votes().contains(&OPERATOR1));
+
+    // VALIDATOR2 and VALIDATOR3 vote to reach quorum.
+    let ctx_v2 = &mut test_utils::new_tx_context(VALIDATOR2, 0);
+    proposal::vote<UpdateConfig>(&mut hashi, VALIDATOR2, proposal_id, &clock, ctx_v2);
+    let ctx_v3 = &mut test_utils::new_tx_context(VALIDATOR3, 0);
+    proposal::vote<UpdateConfig>(&mut hashi, VALIDATOR3, proposal_id, &clock, ctx_v3);
+
+    hashi::update_config::execute(&mut hashi, proposal_id, &clock);
+    assert!(hashi::btc_config::bitcoin_deposit_minimum(hashi.config()) == 1000);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = proposal::EVoteAlreadyCounted)]
+/// The operator's create auto-votes under VALIDATOR1; the validator then voting
+/// for itself is a double vote since both resolve to the same VALIDATOR1 slot.
+fun test_operator_and_validator_single_vote() {
+    let ctx = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+
+    let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // Delegate V1 -> OPERATOR1.
+    let ctx_v1 = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, OPERATOR1, ctx_v1);
+
+    // OPERATOR1 creates the proposal for VALIDATOR1 (auto-votes under VALIDATOR1).
+    let ctx_op = &mut test_utils::new_tx_context(OPERATOR1, 0);
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VALIDATOR1,
+        1000,
+        &clock,
+        ctx_op,
+    );
+
+    // VALIDATOR1 itself now votes for VALIDATOR1 - already counted, must abort.
+    let ctx_v1b = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+    proposal::vote<UpdateConfig>(&mut hashi, VALIDATOR1, proposal_id, &clock, ctx_v1b);
+
+    // Won't reach here.
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+// ======== Delegation Authorization Tests ========
+
+#[test]
+#[expected_failure(abort_code = committee_set::ENotValidator)]
+/// Only the validator's own key may set its operator address; an operator (or
+/// any other sender) attempting to delegate must abort.
+fun test_set_operator_address_is_validator_only() {
+    let ctx = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+
+    let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    // A sender that is not VALIDATOR1 tries to delegate VALIDATOR1's operator.
+    let ctx_other = &mut test_utils::new_tx_context(OPERATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, @0xBEEF, ctx_other);
+
+    // Won't reach here.
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = proposal::EUnauthorizedCaller)]
+/// A validator cannot create a proposal claiming to be a *different* validator:
+/// member_authorized(VALIDATOR2, VALIDATOR1) is false, so create aborts.
+fun test_unauthorized_validator_arg_fails() {
+    let ctx_v1 = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+
+    let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx_v1);
+    let clock = clock::create_for_testing(ctx_v1);
+
+    // VALIDATOR1 (sender) tries to propose as VALIDATOR2 - unauthorized.
+    let _proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VALIDATOR2,
+        1000,
+        &clock,
+        ctx_v1,
+    );
+
+    // Won't reach here.
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/operator_delegation_tests.move
+++ b/packages/hashi/tests/operator_delegation_tests.move
@@ -5,7 +5,7 @@
 #[allow(implicit_const_copy, unused_variable)]
 module hashi::operator_delegation_tests;
 
-use hashi::{committee_set, proposal, test_utils, update_config::UpdateConfig};
+use hashi::{proposal, test_utils, update_config::UpdateConfig};
 use sui::clock;
 
 // ======== Test Addresses ========
@@ -26,23 +26,32 @@ fun test_member_authorized() {
     let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
     let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
 
+    // Each context is created and used immediately: a `&mut` to a temporary reuses
+    // one slot, so holding several at once would all observe the last sender.
+
     // The validator's own key is always authorized for itself.
-    assert!(hashi.committee_set().member_authorized(VALIDATOR1, VALIDATOR1));
+    let cv = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+    assert!(hashi.committee_set().member_authorized(VALIDATOR1, cv));
 
     // No operator delegated yet: operator and stranger are not authorized.
-    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, OPERATOR1));
-    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, STRANGER));
+    let co = &mut test_utils::new_tx_context(OPERATOR1, 0);
+    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, co));
+    let cs = &mut test_utils::new_tx_context(STRANGER, 0);
+    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, cs));
 
     // A non-member validator address is never authorized.
-    assert!(!hashi.committee_set().member_authorized(STRANGER, STRANGER));
+    let cs2 = &mut test_utils::new_tx_context(STRANGER, 0);
+    assert!(!hashi.committee_set().member_authorized(STRANGER, cs2));
 
-    // VALIDATOR1 delegates to OPERATOR1 (ctx sender == VALIDATOR1).
-    let ctx_v1 = &mut test_utils::new_tx_context(VALIDATOR1, 0);
-    hashi.committee_set_mut().set_operator_address(VALIDATOR1, OPERATOR1, ctx_v1);
+    // VALIDATOR1 delegates to OPERATOR1.
+    let cd = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, OPERATOR1, cd);
 
     // Now the operator is authorized, and the validator key still is too.
-    assert!(hashi.committee_set().member_authorized(VALIDATOR1, OPERATOR1));
-    assert!(hashi.committee_set().member_authorized(VALIDATOR1, VALIDATOR1));
+    let co2 = &mut test_utils::new_tx_context(OPERATOR1, 0);
+    assert!(hashi.committee_set().member_authorized(VALIDATOR1, co2));
+    let cv2 = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+    assert!(hashi.committee_set().member_authorized(VALIDATOR1, cv2));
 
     std::unit_test::destroy(hashi);
 }
@@ -129,20 +138,46 @@ fun test_operator_and_validator_single_vote() {
 // ======== Delegation Authorization Tests ========
 
 #[test]
-#[expected_failure(abort_code = committee_set::ENotValidator)]
-/// Only the validator's own key may set its operator address; an operator (or
-/// any other sender) attempting to delegate must abort.
-fun test_set_operator_address_is_validator_only() {
+#[expected_failure]
+/// A sender that is neither the validator nor its delegated operator may not set
+/// the operator address.
+fun test_set_operator_address_rejects_unauthorized() {
     let ctx = &mut test_utils::new_tx_context(VALIDATOR1, 0);
 
     let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
     let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
 
-    // A sender that is not VALIDATOR1 tries to delegate VALIDATOR1's operator.
-    let ctx_other = &mut test_utils::new_tx_context(OPERATOR1, 0);
-    hashi.committee_set_mut().set_operator_address(VALIDATOR1, @0xBEEF, ctx_other);
+    // STRANGER is neither VALIDATOR1 nor its operator (none delegated) -> aborts.
+    let ctx_stranger = &mut test_utils::new_tx_context(STRANGER, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, @0xBEEF, ctx_stranger);
 
     // Won't reach here.
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// Reverted behavior: a delegated operator key may itself re-point the operator
+/// address (validator OR operator may delegate; the validator always retains it).
+fun test_operator_can_set_operator_address() {
+    let ctx = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+
+    let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    // VALIDATOR1 delegates to OPERATOR1.
+    let ctx_v1 = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, OPERATOR1, ctx_v1);
+
+    // OPERATOR1 (the operator) re-points the operator address to @0xBEEF.
+    let ctx_op = &mut test_utils::new_tx_context(OPERATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, @0xBEEF, ctx_op);
+
+    // @0xBEEF is the authorized operator now; OPERATOR1 no longer is.
+    let ctx_beef = &mut test_utils::new_tx_context(@0xBEEF, 0);
+    assert!(hashi.committee_set().member_authorized(VALIDATOR1, ctx_beef));
+    let ctx_op2 = &mut test_utils::new_tx_context(OPERATOR1, 0);
+    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, ctx_op2));
+
     std::unit_test::destroy(hashi);
 }
 

--- a/packages/hashi/tests/pause_proposal_tests.move
+++ b/packages/hashi/tests/pause_proposal_tests.move
@@ -28,6 +28,7 @@ fun test_emergency_pause_basic() {
     // Create emergency pause proposal
     let proposal_id = test_utils::create_emergency_pause_proposal(
         &mut hashi,
+        VOTER1,
         true,
         &clock,
         ctx,
@@ -58,6 +59,7 @@ fun test_unpause_basic() {
     // First, pause the system
     let pause_id = test_utils::create_emergency_pause_proposal(
         &mut hashi,
+        VOTER1,
         true,
         &clock,
         ctx,
@@ -68,6 +70,7 @@ fun test_unpause_basic() {
     // Now propose unpause
     let unpause_id = test_utils::create_emergency_pause_proposal(
         &mut hashi,
+        VOTER1,
         false,
         &clock,
         ctx,

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -52,6 +52,7 @@ fun test_create_proposal() {
     // Create a proposal - should succeed since VOTER1 is a member
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -83,6 +84,7 @@ fun test_create_proposal_fails_for_non_member() {
     // Try to create a proposal as non-member - should fail
     let _proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        NON_VOTER,
         1000,
         &clock,
         ctx,
@@ -107,6 +109,7 @@ fun test_vote_on_proposal() {
     // VOTER1 creates proposal
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx1,
@@ -114,7 +117,7 @@ fun test_vote_on_proposal() {
 
     // VOTER2 votes
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
-    proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx2);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
 
     // Verify vote count is now 2
     let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
@@ -140,13 +143,14 @@ fun test_double_vote_fails() {
     // VOTER1 creates proposal (auto-votes)
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
     );
 
     // VOTER1 tries to vote again - should fail
-    proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER1, proposal_id, &clock, ctx);
 
     // Won't reach here
     clock::destroy_for_testing(clock);
@@ -166,6 +170,7 @@ fun test_vote_by_non_member_fails() {
     // VOTER1 creates proposal
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx1,
@@ -173,7 +178,7 @@ fun test_vote_by_non_member_fails() {
 
     // NON_VOTER tries to vote - should fail
     let ctx_non = &mut test_utils::new_tx_context(NON_VOTER, 0);
-    proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx_non);
+    proposal::vote<UpdateConfig>(&mut hashi, NON_VOTER, proposal_id, &clock, ctx_non);
 
     // Won't reach here
     clock::destroy_for_testing(clock);
@@ -194,6 +199,7 @@ fun test_remove_vote() {
     // VOTER1 creates proposal (auto-votes)
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -209,7 +215,7 @@ fun test_remove_vote() {
     };
 
     // VOTER1 removes vote
-    proposal::remove_vote<UpdateConfig>(&mut hashi, proposal_id, ctx);
+    proposal::remove_vote<UpdateConfig>(&mut hashi, VOTER1, proposal_id, ctx);
 
     // Verify vote was removed
     let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
@@ -233,6 +239,7 @@ fun test_remove_nonexistent_vote_fails() {
     // VOTER1 creates proposal
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx1,
@@ -240,7 +247,7 @@ fun test_remove_nonexistent_vote_fails() {
 
     // VOTER2 tries to remove vote without having voted - should fail
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
-    proposal::remove_vote<UpdateConfig>(&mut hashi, proposal_id, ctx2);
+    proposal::remove_vote<UpdateConfig>(&mut hashi, VOTER2, proposal_id, ctx2);
 
     // Won't reach here
     clock::destroy_for_testing(clock);
@@ -265,6 +272,7 @@ fun test_execute_proposal_with_quorum() {
     // VOTER1 creates proposal (auto-votes = 100% weight)
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -295,6 +303,7 @@ fun test_execute_without_quorum_fails() {
     // VOTER1 creates proposal (auto-votes = 33% weight)
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -320,6 +329,7 @@ fun test_execute_after_gathering_votes() {
     // VOTER1 creates proposal (33% weight)
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx1,
@@ -327,11 +337,11 @@ fun test_execute_after_gathering_votes() {
 
     // VOTER2 votes (66% weight)
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
-    proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx2);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
 
     // VOTER3 votes (100% weight)
     let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
-    proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx3);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER3, proposal_id, &clock, ctx3);
 
     // Now execute with 100% quorum
     hashi::update_config::execute(&mut hashi, proposal_id, &clock);
@@ -357,12 +367,18 @@ fun test_abort_reconfig_proposal() {
     assert!(hashi.committee_set().pending_epoch_change().destroy_some() == 1);
     assert!(hashi.committee_set().has_committee(1));
 
-    let proposal_id = test_utils::create_abort_reconfig_proposal(&mut hashi, 1, &clock, ctx1);
+    let proposal_id = test_utils::create_abort_reconfig_proposal(
+        &mut hashi,
+        VOTER1,
+        1,
+        &clock,
+        ctx1,
+    );
 
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
-    proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx2);
+    proposal::vote<AbortReconfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
     let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
-    proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx3);
+    proposal::vote<AbortReconfig>(&mut hashi, VOTER3, proposal_id, &clock, ctx3);
 
     hashi::abort_reconfig::execute(&mut hashi, proposal_id, &clock, ctx1);
 
@@ -384,7 +400,7 @@ fun test_abort_reconfig_proposal_fails_when_not_reconfiguring_at_propose() {
     let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
     let clock = clock::create_for_testing(ctx);
 
-    let _ = test_utils::create_abort_reconfig_proposal(&mut hashi, 1, &clock, ctx);
+    let _ = test_utils::create_abort_reconfig_proposal(&mut hashi, VOTER1, 1, &clock, ctx);
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
@@ -401,7 +417,7 @@ fun test_abort_reconfig_proposal_fails_for_wrong_epoch_at_propose() {
     let clock = clock::create_for_testing(ctx);
     add_pending_committee_for_testing(&mut hashi, 1);
 
-    let _ = test_utils::create_abort_reconfig_proposal(&mut hashi, 2, &clock, ctx);
+    let _ = test_utils::create_abort_reconfig_proposal(&mut hashi, VOTER1, 2, &clock, ctx);
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
@@ -418,12 +434,18 @@ fun test_abort_reconfig_proposal_fails_for_stale_epoch_at_execute() {
     let clock = clock::create_for_testing(ctx1);
     add_pending_committee_for_testing(&mut hashi, 1);
 
-    let proposal_id = test_utils::create_abort_reconfig_proposal(&mut hashi, 1, &clock, ctx1);
+    let proposal_id = test_utils::create_abort_reconfig_proposal(
+        &mut hashi,
+        VOTER1,
+        1,
+        &clock,
+        ctx1,
+    );
 
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
-    proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx2);
+    proposal::vote<AbortReconfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
     let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
-    proposal::vote<AbortReconfig>(&mut hashi, proposal_id, &clock, ctx3);
+    proposal::vote<AbortReconfig>(&mut hashi, VOTER3, proposal_id, &clock, ctx3);
 
     let _ = hashi.committee_set_mut().abort_reconfig(ctx1);
     add_pending_committee_for_testing(&mut hashi, 2);
@@ -449,6 +471,7 @@ fun test_vote_on_expired_proposal_fails() {
     // VOTER1 creates proposal
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx1,
@@ -459,7 +482,7 @@ fun test_vote_on_expired_proposal_fails() {
 
     // VOTER2 tries to vote on expired proposal - should fail
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
-    proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx2);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
 
     // Won't reach here
     clock::destroy_for_testing(clock);
@@ -478,6 +501,7 @@ fun test_re_execute_proposal_fails() {
 
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -505,6 +529,7 @@ fun test_delete_expired_executed_proposal_fails() {
 
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -538,6 +563,7 @@ fun test_execute_expired_proposal_fails() {
     // VOTER1 creates proposal (100% weight)
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -566,6 +592,7 @@ fun test_delete_expired_proposal() {
     // Create proposal
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -599,6 +626,7 @@ fun test_delete_non_expired_proposal_fails() {
     // Create proposal
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -629,6 +657,7 @@ fun test_weighted_quorum() {
     // VOTER1 creates proposal (3/6 = 50% weight)
     let proposal_id = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx1,
@@ -640,7 +669,7 @@ fun test_weighted_quorum() {
 
     // VOTER2 votes (now 5/6 = 83% total weight, exceeds 66.67% threshold)
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
-    proposal::vote<UpdateConfig>(&mut hashi, proposal_id, &clock, ctx2);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
 
     // 83% exceeds the 66.67% quorum threshold
     let prop: &proposal::Proposal<UpdateConfig> = hashi.proposals().active().borrow(proposal_id);
@@ -669,6 +698,7 @@ fun test_multiple_concurrent_proposals() {
     // Create first proposal
     let proposal_id_1 = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         1000,
         &clock,
         ctx,
@@ -677,6 +707,7 @@ fun test_multiple_concurrent_proposals() {
     // Create second proposal
     let proposal_id_2 = test_utils::create_deposit_minimum_proposal(
         &mut hashi,
+        VOTER1,
         2000,
         &clock,
         ctx,
@@ -713,6 +744,7 @@ fun test_enable_version_proposal() {
     // Create enable version proposal for version 2
     let proposal_id = test_utils::create_enable_version_proposal(
         &mut hashi,
+        VOTER1,
         2,
         &clock,
         ctx,
@@ -738,6 +770,7 @@ fun test_disable_version_proposal() {
     // First enable version 2
     let enable_id = test_utils::create_enable_version_proposal(
         &mut hashi,
+        VOTER1,
         2,
         &clock,
         ctx,
@@ -747,6 +780,7 @@ fun test_disable_version_proposal() {
     // Now disable version 2 (not the current version)
     let disable_id = test_utils::create_disable_version_proposal(
         &mut hashi,
+        VOTER1,
         2,
         &clock,
         ctx,
@@ -771,6 +805,7 @@ fun test_disable_current_version_fails() {
     // Try to disable version 1 (current version) - should fail
     let proposal_id = test_utils::create_disable_version_proposal(
         &mut hashi,
+        VOTER1,
         1, // current package version
         &clock,
         ctx,
@@ -795,6 +830,7 @@ fun test_enable_already_enabled_version_fails() {
     // Try to enable version 1 (already enabled by default) - should fail
     let proposal_id = test_utils::create_enable_version_proposal(
         &mut hashi,
+        VOTER1,
         1, // already enabled
         &clock,
         ctx,

--- a/packages/hashi/tests/test_utils.move
+++ b/packages/hashi/tests/test_utils.move
@@ -212,6 +212,7 @@ public fun sign_certificate(
 /// Creates a deposit minimum update proposal and returns its ID.
 public fun create_deposit_minimum_proposal(
     hashi: &mut Hashi,
+    validator_address: address,
     minimum: u64,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -221,46 +222,50 @@ public fun create_deposit_minimum_proposal(
         b"bitcoin_deposit_minimum".to_string(),
         config_value::new_u64(minimum),
     );
-    update_config::propose(hashi, entries, vec_map::empty(), clock, ctx)
+    update_config::propose(hashi, validator_address, entries, vec_map::empty(), clock, ctx)
 }
 
 /// Creates an enable version proposal and returns its ID
 public fun create_enable_version_proposal(
     hashi: &mut Hashi,
+    validator_address: address,
     version: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
-    enable_version::propose(hashi, version, vec_map::empty(), clock, ctx)
+    enable_version::propose(hashi, validator_address, version, vec_map::empty(), clock, ctx)
 }
 
 /// Creates a disable version proposal and returns its ID
 public fun create_disable_version_proposal(
     hashi: &mut Hashi,
+    validator_address: address,
     version: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
-    disable_version::propose(hashi, version, vec_map::empty(), clock, ctx)
+    disable_version::propose(hashi, validator_address, version, vec_map::empty(), clock, ctx)
 }
 
 /// Creates an emergency pause/unpause proposal and returns its ID
 public fun create_emergency_pause_proposal(
     hashi: &mut Hashi,
+    validator_address: address,
     pause: bool,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     let metadata = vec_map::empty();
-    emergency_pause::propose(hashi, pause, metadata, clock, ctx)
+    emergency_pause::propose(hashi, validator_address, pause, metadata, clock, ctx)
 }
 
 /// Creates an abort reconfig proposal and returns its ID
 public fun create_abort_reconfig_proposal(
     hashi: &mut Hashi,
+    validator_address: address,
     epoch: u64,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
-    abort_reconfig::propose(hashi, epoch, vec_map::empty(), clock, ctx)
+    abort_reconfig::propose(hashi, validator_address, epoch, vec_map::empty(), clock, ctx)
 }

--- a/packages/hashi/tests/update_config_multikey_tests.move
+++ b/packages/hashi/tests/update_config_multikey_tests.move
@@ -38,6 +38,7 @@ fun test_single_key_update_via_multikey_propose() {
 
     let proposal_id = update_config::propose(
         &mut hashi,
+        VOTER1,
         entries,
         vec_map::empty(),
         &clock,
@@ -67,6 +68,7 @@ fun test_multi_key_update_applies_atomically() {
 
     let proposal_id = update_config::propose(
         &mut hashi,
+        VOTER1,
         entries,
         vec_map::empty(),
         &clock,
@@ -98,6 +100,7 @@ fun test_mixed_domain_multi_key_update() {
 
     let proposal_id = update_config::propose(
         &mut hashi,
+        VOTER1,
         entries,
         vec_map::empty(),
         &clock,
@@ -122,6 +125,7 @@ fun test_empty_entries_aborts_at_propose() {
 
     let _ = update_config::propose(
         &mut hashi,
+        VOTER1,
         vec_map::empty(),
         vec_map::empty(),
         &clock,
@@ -145,6 +149,7 @@ fun test_unknown_key_aborts_at_execute() {
 
     let proposal_id = update_config::propose(
         &mut hashi,
+        VOTER1,
         entries,
         vec_map::empty(),
         &clock,
@@ -170,6 +175,7 @@ fun test_wrong_value_type_aborts_at_execute() {
 
     let proposal_id = update_config::propose(
         &mut hashi,
+        VOTER1,
         entries,
         vec_map::empty(),
         &clock,
@@ -194,6 +200,7 @@ fun test_propose_vote_execute_through_quorum() {
 
     let proposal_id = update_config::propose(
         &mut hashi,
+        VOTER1,
         entries,
         vec_map::empty(),
         &clock,
@@ -201,10 +208,22 @@ fun test_propose_vote_execute_through_quorum() {
     );
 
     let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
-    hashi::proposal::vote<update_config::UpdateConfig>(&mut hashi, proposal_id, &clock, ctx2);
+    hashi::proposal::vote<update_config::UpdateConfig>(
+        &mut hashi,
+        VOTER2,
+        proposal_id,
+        &clock,
+        ctx2,
+    );
 
     let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
-    hashi::proposal::vote<update_config::UpdateConfig>(&mut hashi, proposal_id, &clock, ctx3);
+    hashi::proposal::vote<update_config::UpdateConfig>(
+        &mut hashi,
+        VOTER3,
+        proposal_id,
+        &clock,
+        ctx3,
+    );
 
     update_config::execute(&mut hashi, proposal_id, &clock);
 


### PR DESCRIPTION
## Summary

Authorizes MPC certificate submission and governance by committee **member** rather than by the raw transaction sender, so a validator can run its node with a delegated **operator key** while keeping the validator (account) key in cold storage.

## Background

On-chain, cert submission and governance required the transaction *sender* to be the member's **validator address** — but the node signs with its **operator key**. The intended model (validator key registers, then cold-stored as backup; operator key runs the node) was unusable; it only worked because devnet/e2e reuse one key for both.

## Changes

- `committee_set::member_authorized(validator, sender)` — true when `sender` is the validator's own key **or** its registered `operator_address`. The validator key always retains authority (backup).
- **Cert submission** authorizes the `dealer` via `member_authorized` (the cert already carries the dealer/validator address).
- **Governance** (`proposal::create`/`vote`/`remove_vote` + the propose wrappers) take the member's validator address as an explicit argument, authorize via `member_authorized`, and record the vote under the validator so quorum stake-weight is correct. The CLI resolves that address off-chain from the committee, so operators don't pass it manually.
- `set_operator_address` is **validator-key-only** — a compromised operator key can't re-delegate; the validator key is the rotation/recovery path.

## Not included

An earlier `HashiOperationCap` approach was dropped: as an owned object the node version-bumps it on every cert/metadata tx, so a concurrent governance tx signed by the same key fails with an object-version conflict (reproduced in e2e). The address-based scheme has no owned object and no contention.

## Testing

- Move unit suite passes, incl. new `operator_delegation_tests`.
- e2e (localnet): DKG + recovery, governance create→vote→execute quorum cycle, key rotation + restart recovery — all pass with a distinct operator key.
