### PR TITLE
[Guardian] Persist encrypted KP shares to S3 for recovery

### DIFF
--- a/crates/hashi-guardian/README.md
+++ b/crates/hashi-guardian/README.md
@@ -11,6 +11,7 @@ Canonical key layout:
 - `withdraw/{yyyy}/{mm}/{dd}/{hh}/success-{seq:020}-{session_id}-wid{wid}.json`
 - `withdraw/{yyyy}/{mm}/{dd}/{hh}/failure-{session_id}-wid{wid}-{rand8}.json`
 - `ceremony/{sharing_seq:020}-{session_id}.json`
+- `shares/{sharing_seq:020}-{session_id}.json`
 - `committee-update/{new_epoch:020}-{session_id}.json`
 - `committee-update/failure-{proposed_epoch:020}-{session_id}-{rand8}.json`
 
@@ -29,7 +30,8 @@ Where:
 - `init` logs are per-session and deterministic by semantic message kind.
 - `heartbeat` logs are hour-partitioned and strictly ordered per session.
 - `withdraw` logs are hour-partitioned. Successes are seq-sorted within a bucket so the KP rotating in the next enclave can recover limiter state by reading the lexicographically last success key.
-- `ceremony` logs are flat (not date-partitioned). Each entry is a `CeremonyLogMessage` — `NewKey { instance }` written by `setup_new_key` (genesis, `sharing_seq=0`) or `Rotate { old_instance, new_instance }` written by `rotate_kps` (each rotation, `sharing_seq=prev+1`). A rotation records the `old_instance` it consumed so the chain is auditable from the log alone (each entry's `old_instance` should match the prior entry's instance). KPs read the lexicographically last entry to learn the current authoritative instance (commitments + N + T). The log does not carry the encrypted shares; KPs fetch their ciphertexts from the `setup_new_key` / `rotate_kps` response or from `get_guardian_info`, decrypt them, and verify the result against the instance's per-share commitments.
+- `ceremony` logs are flat (not date-partitioned). Each entry is a `CeremonyLogMessage` — `NewKey { instance }` written by `setup_new_key` (genesis, `sharing_seq=0`) or `Rotate { old_instance, new_instance }` written by `rotate_kps` (each rotation, `sharing_seq=prev+1`). A rotation records the `old_instance` it consumed so the chain is auditable from the log alone (each entry's `old_instance` should match the prior entry's instance). KPs read the lexicographically last entry to learn the current authoritative instance (commitments + N + T). The log does not carry the encrypted shares (those live in `shares/`); it does commit the recipient roster (per-share fingerprints) so a KP can check the full recipient set against the immutable record.
+- `shares` logs are flat and carry the ceremony's encrypted shares (the ciphertexts `ceremony/` omits), keyed by the same `sharing_seq` so each pairs with its `ceremony/` instance. Written by `setup_new_key` (`sharing_seq=0`) and each `rotate_kps`. Persisted purely for recovery liveness — a KP who lost their share point-reads `shares/{sharing_seq:020}-{session_id}.json`, verifies its enclave signature, and checks the decrypted share against the instance's commitments. Integrity is the signature, not S3 immutability, so these get only a short object lock (a fetch-window guarantee) and stay readable until purged.
 - `committee-update` logs are flat (not date-partitioned). Successes are epoch-sorted; failures lead with `failure-` so all successes sort first — the lex-last non-`failure-` key is the latest successfully-applied epoch.
 
 ## Why this layout

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -4,6 +4,7 @@
 use crate::Enclave;
 use hashi_types::guardian::crypto::combine_shares;
 use hashi_types::guardian::crypto::decrypt_verify_shares;
+use hashi_types::guardian::crypto::recipient_roster;
 use hashi_types::guardian::crypto::split_and_encrypt_for_kps;
 use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::GuardianError::InvalidInputs;
@@ -86,7 +87,12 @@ async fn finalize_rotation(
         .log_ceremony(CeremonyLogMessage::Rotate {
             old_instance: old_instance.clone(),
             new_instance,
+            roster: recipient_roster(&encrypted_shares),
         })
+        .await?;
+
+    enclave
+        .log_shares(new_sharing_seq, encrypted_shares.clone())
         .await?;
 
     enclave.set_latest_encrypted_shares(encrypted_shares.clone())?;
@@ -213,6 +219,7 @@ mod tests {
         let CeremonyLogMessage::Rotate {
             old_instance,
             new_instance,
+            roster,
         } = *ceremony
         else {
             panic!("expected Rotate variant");
@@ -224,6 +231,26 @@ mod tests {
         assert_eq!(new_instance.sharing_seq(), 1);
         assert_eq!(new_instance.num_shares(), new_n);
         assert_eq!(new_instance.threshold(), new_t);
+        // Roster commits one recipient fingerprint per new share.
+        assert_eq!(roster.len(), new_n);
+
+        // The new shares are persisted to shares/ keyed by the new sharing_seq.
+        let shares_logs: Vec<_> = captured
+            .iter()
+            .filter(|(k, _)| k.starts_with("shares/"))
+            .collect();
+        assert_eq!(shares_logs.len(), 1, "expected one shares/ log");
+        let (shares_key, shares_body) = shares_logs[0];
+        assert!(
+            shares_key.starts_with("shares/00000000000000000001-"),
+            "expected sharing_seq=1, got key {shares_key}"
+        );
+        let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
+        let LogMessage::Shares(shares) = shares_record.message else {
+            panic!("expected Shares variant");
+        };
+        assert_eq!(shares.sharing_seq, 1);
+        assert_eq!(shares.encrypted_shares.len(), new_n);
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -82,7 +82,11 @@ async fn finalize_rotation(
 
     let new_sharing_seq = old_instance.sharing_seq() + 1;
     let new_instance = SecretSharingInstance::new(share_commitments, n, t, new_sharing_seq)?;
-    info!("Writing CeremonyLogMessage sharing_seq={new_sharing_seq} to ceremony/.");
+    info!("Persisting rotation sharing_seq={new_sharing_seq} to shares/ + ceremony/.");
+    enclave
+        .log_shares(new_sharing_seq, encrypted_shares.clone())
+        .await?;
+
     enclave
         .log_ceremony(CeremonyLogMessage::Rotate {
             old_instance: old_instance.clone(),
@@ -92,10 +96,8 @@ async fn finalize_rotation(
         .await?;
 
     enclave
-        .log_shares(new_sharing_seq, encrypted_shares.clone())
-        .await?;
-
-    enclave.set_latest_encrypted_shares(encrypted_shares.clone())?;
+        .set_latest_encrypted_shares(encrypted_shares.clone())
+        .expect("set_latest_encrypted_shares should work if ceremony_complete=false");
 
     info!("Rotation complete.");
     Ok(enclave.sign(RotateKpsResponse { encrypted_shares }))

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -58,6 +58,8 @@ pub async fn setup_new_key(
     let ss_instance = SecretSharingInstance::new(share_commitments.clone(), n, t, 0)
         .expect("(n, t) validated by SetupNewKeyRequest; commitments produced with matching count");
 
+    enclave.log_shares(0, encrypted_shares.clone()).await?;
+
     enclave
         .log_ceremony(CeremonyLogMessage::NewKey {
             instance: ss_instance,
@@ -65,9 +67,9 @@ pub async fn setup_new_key(
         })
         .await?;
 
-    enclave.log_shares(0, encrypted_shares.clone()).await?;
-
-    enclave.set_latest_encrypted_shares(encrypted_shares.clone())?;
+    enclave
+        .set_latest_encrypted_shares(encrypted_shares.clone())
+        .expect("set_latest_encrypted_shares should work if ceremony_complete=false");
 
     let response = enclave.sign(SetupNewKeyResponse {
         encrypted_shares,

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Enclave;
+use hashi_types::guardian::crypto::recipient_roster;
 use hashi_types::guardian::crypto::split_and_encrypt_for_kps;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::*;
@@ -60,8 +61,11 @@ pub async fn setup_new_key(
     enclave
         .log_ceremony(CeremonyLogMessage::NewKey {
             instance: ss_instance,
+            roster: recipient_roster(&encrypted_shares),
         })
         .await?;
+
+    enclave.log_shares(0, encrypted_shares.clone()).await?;
 
     enclave.set_latest_encrypted_shares(encrypted_shares.clone())?;
 
@@ -130,11 +134,35 @@ mod tests {
         let LogMessage::Ceremony(ceremony) = record.message else {
             panic!("expected Ceremony variant");
         };
-        let CeremonyLogMessage::NewKey { instance } = *ceremony else {
+        let CeremonyLogMessage::NewKey { instance, roster } = *ceremony else {
             panic!("expected NewKey variant");
         };
         assert_eq!(instance.sharing_seq(), 0);
         assert_eq!(instance.num_shares(), TEST_N);
         assert_eq!(instance.threshold(), TEST_T);
+        // The roster commits one recipient fingerprint per share.
+        assert_eq!(roster.len(), TEST_N);
+
+        // The encrypted shares are persisted to shares/ keyed by sharing_seq,
+        // and carry the ciphertexts the ceremony log omits.
+        let shares_logs: Vec<_> = captured
+            .iter()
+            .filter(|(k, _)| k.starts_with("shares/"))
+            .collect();
+        assert_eq!(shares_logs.len(), 1, "expected one shares/ log");
+        let (shares_key, shares_body) = shares_logs[0];
+        assert_eq!(
+            *shares_key,
+            format!("shares/{:020}-{}.json", 0, enclave.s3_session_id())
+        );
+        let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
+        let LogMessage::Shares(shares) = shares_record.message else {
+            panic!("expected Shares variant");
+        };
+        assert_eq!(shares.sharing_seq, 0);
+        assert_eq!(shares.encrypted_shares.len(), TEST_N);
+        assert!(std::str::from_utf8(shares_body)
+            .unwrap()
+            .contains("BEGIN PGP MESSAGE"));
     }
 }

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -58,6 +58,7 @@ pub async fn setup_new_key(
     let ss_instance = SecretSharingInstance::new(share_commitments.clone(), n, t, 0)
         .expect("(n, t) validated by SetupNewKeyRequest; commitments produced with matching count");
 
+    info!("Persisting setup sharing_seq=0 to shares/ + ceremony/.");
     enclave.log_shares(0, encrypted_shares.clone()).await?;
 
     enclave
@@ -77,6 +78,7 @@ pub async fn setup_new_key(
     });
 
     *ceremony_complete = true;
+    info!("Setup complete.");
     Ok(response)
 }
 

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -524,6 +524,20 @@ impl Enclave {
         self.write_log(LogMessage::Ceremony(Box::new(state))).await
     }
 
+    /// Persist the ceremony's encrypted shares to `shares/` for recovery. Keyed
+    /// by `sharing_seq` so it pairs with the matching `ceremony/` instance.
+    pub async fn log_shares(
+        &self,
+        sharing_seq: u64,
+        encrypted_shares: Vec<KPEncryptedShare>,
+    ) -> GuardianResult<()> {
+        self.write_log(LogMessage::Shares(Box::new(SharesLogMessage {
+            sharing_seq,
+            encrypted_shares,
+        })))
+        .await
+    }
+
     // ========================================================================
     // Scratchpad (Initialization-only data)
     // ========================================================================

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -503,7 +503,11 @@ impl GuardianS3Client {
         })
     }
 
-    /// Caller must ensure that the object has unexpired compliance-mode object lock. (TODO: Investigate what this means)
+    /// Reads an immutable-log object, asserting its Compliance lock metadata is
+    /// present but not that it is unexpired.
+    /// TODO: also reject when `retain_until <= now` — once the lock lapses the
+    /// version check below no longer detects tampering (see
+    /// `ensure_no_duplicates_or_deletions`).
     pub async fn get_log_record(&self, key: &str) -> GuardianResult<LogRecord> {
         let keys = self.ensure_no_duplicates_or_deletions(key).await?;
         if keys.len() != 1 || keys[0] != key {

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -466,6 +466,43 @@ impl GuardianS3Client {
         })
     }
 
+    /// Plain point read + deserialize, with no object-lock assertion and no
+    /// version/deletion check. For objects whose integrity comes from their own
+    /// signature rather than S3 immutability (e.g. `shares/`, which carry only a
+    /// short lock that is expected to expire). A tampered object fails the
+    /// caller's signature check; a purged one surfaces as a get error.
+    pub async fn get_object_no_lock<T: DeserializeOwned>(&self, key: &str) -> GuardianResult<T> {
+        let response = self
+            .client
+            .get_object()
+            .bucket(self.config.bucket_name())
+            .key(key)
+            .send()
+            .await
+            .map_err(|e| {
+                S3Error(format!(
+                    "Failed to get object {}: {}",
+                    key,
+                    DisplayErrorContext(&e)
+                ))
+            })?;
+
+        let bytes = response.body.collect().await.map_err(|e| {
+            S3Error(format!(
+                "Failed to read object body for key {}: {}",
+                key,
+                DisplayErrorContext(&e)
+            ))
+        })?;
+
+        serde_json::from_slice::<T>(&bytes.into_bytes()).map_err(|e| {
+            S3Error(format!(
+                "Failed to deserialize object {} into target type: {}",
+                key, e
+            ))
+        })
+    }
+
     /// Caller must ensure that the object has unexpired compliance-mode object lock. (TODO: Investigate what this means)
     pub async fn get_log_record(&self, key: &str) -> GuardianResult<LogRecord> {
         let keys = self.ensure_no_duplicates_or_deletions(key).await?;

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -153,13 +153,18 @@ impl GuardianReader {
     /// Read + verify the encrypted shares at `shares/{seq}-{session}.json`. Point
     /// read by exact key (recovery anchors on the ceremony instance's seq), so a
     /// purged older `shares/` object never blocks reading the current one.
+    ///
+    /// Uses the lock-agnostic read: shares carry only a short lock that is
+    /// expected to expire, and their integrity is the enclave signature checked
+    /// below — not S3 immutability — so the immutable-log lock assertion in
+    /// `get_log_record` doesn't apply.
     pub async fn read_shares(
         &mut self,
         session_id: &str,
         sharing_seq: u64,
     ) -> anyhow::Result<Vec<KPEncryptedShare>> {
         let key = format!("{}/{:020}-{}.json", S3_DIR_SHARES, sharing_seq, session_id);
-        let record = self.s3.get_log_record(&key).await?;
+        let record: LogRecord = self.s3.get_object_no_lock(&key).await?;
         let record = self.pubkey_cache.verify_record(&self.s3, record).await?;
         let LogMessage::Shares(msg) = record.message else {
             anyhow::bail!("expected a shares log at {key}");

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -19,6 +19,7 @@ use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianPubKey;
 use hashi_types::guardian::InitLogMessage;
+use hashi_types::guardian::KPEncryptedShare;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::S3Config;
@@ -28,6 +29,7 @@ use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
 use hashi_types::guardian::S3_DIR_HEARTBEAT;
+use hashi_types::guardian::S3_DIR_SHARES;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
 use hashi_types::move_types::Committee;
 use std::collections::HashMap;
@@ -117,6 +119,17 @@ impl GuardianReader {
     pub async fn read_latest_ceremony_instance(
         &mut self,
     ) -> anyhow::Result<Option<SecretSharingInstance>> {
+        Ok(self
+            .read_latest_ceremony()
+            .await?
+            .map(|(_, instance)| instance))
+    }
+
+    /// Like [`Self::read_latest_ceremony_instance`], but also returns the writing
+    /// session id — needed to locate the matching `shares/` object for recovery.
+    pub async fn read_latest_ceremony(
+        &mut self,
+    ) -> anyhow::Result<Option<(SessionID, SecretSharingInstance)>> {
         let keys = self
             .s3
             .list_all_keys_in_dir(&format!("{}/", S3_DIR_CEREMONY))
@@ -126,13 +139,32 @@ impl GuardianReader {
         };
         let record = self.s3.get_log_record(&key).await?;
         let record = self.pubkey_cache.verify_record(&self.s3, record).await?;
+        let session_id = record.session_id.clone();
         let LogMessage::Ceremony(msg) = record.message else {
             anyhow::bail!("expected a ceremony log at {key}");
         };
-        Ok(Some(match *msg {
-            CeremonyLogMessage::NewKey { instance } => instance,
+        let instance = match *msg {
+            CeremonyLogMessage::NewKey { instance, .. } => instance,
             CeremonyLogMessage::Rotate { new_instance, .. } => new_instance,
-        }))
+        };
+        Ok(Some((session_id, instance)))
+    }
+
+    /// Read + verify the encrypted shares at `shares/{seq}-{session}.json`. Point
+    /// read by exact key (recovery anchors on the ceremony instance's seq), so a
+    /// purged older `shares/` object never blocks reading the current one.
+    pub async fn read_shares(
+        &mut self,
+        session_id: &str,
+        sharing_seq: u64,
+    ) -> anyhow::Result<Vec<KPEncryptedShare>> {
+        let key = format!("{}/{:020}-{}.json", S3_DIR_SHARES, sharing_seq, session_id);
+        let record = self.s3.get_log_record(&key).await?;
+        let record = self.pubkey_cache.verify_record(&self.s3, record).await?;
+        let LogMessage::Shares(msg) = record.message else {
+            anyhow::bail!("expected a shares log at {key}");
+        };
+        Ok(msg.encrypted_shares)
     }
 
     /// The latest applied committee from `committee-update/` — the lex-last

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -165,10 +165,23 @@ impl GuardianReader {
     ) -> anyhow::Result<Vec<KPEncryptedShare>> {
         let key = format!("{}/{:020}-{}.json", S3_DIR_SHARES, sharing_seq, session_id);
         let record: LogRecord = self.s3.get_object_no_lock(&key).await?;
+        if record.session_id != session_id {
+            anyhow::bail!(
+                "session id mismatch at {key}: expected {session_id}, got {}",
+                record.session_id
+            );
+        }
         let record = self.pubkey_cache.verify_record(&self.s3, record).await?;
         let LogMessage::Shares(msg) = record.message else {
             anyhow::bail!("expected a shares log at {key}");
         };
+        if msg.sharing_seq != sharing_seq {
+            anyhow::bail!(
+                "sharing_seq mismatch: {} != {}",
+                msg.sharing_seq,
+                sharing_seq
+            );
+        }
         Ok(msg.encrypted_shares)
     }
 

--- a/crates/hashi-types/src/guardian/crypto.rs
+++ b/crates/hashi-types/src/guardian/crypto.rs
@@ -453,6 +453,17 @@ pub fn split_and_encrypt_for_kps<R: CryptoRng + RngCore>(
     (encrypted_shares, commitments)
 }
 
+/// Recipient PGP fingerprints ordered by share id — the roster committed into
+/// the `ceremony/` log so a KP can check the full recipient set.
+pub fn recipient_roster(shares: &[KPEncryptedShare]) -> Vec<String> {
+    let mut shares: Vec<&KPEncryptedShare> = shares.iter().collect();
+    shares.sort_by_key(|s| s.id);
+    shares
+        .iter()
+        .map(|s| s.recipient_fingerprint.clone())
+        .collect()
+}
+
 /// Encrypt a share for delivery to a key provisioner using OpenPGP ASCII armor.
 pub fn encrypt_share_for_provisioner(share: &Share, cert: &PgpPublicCert) -> KPEncryptedShare {
     KPEncryptedShare {

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -9,6 +9,7 @@ use super::S3_OBJECT_LOCK_DURATION_CEREMONY;
 use super::S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE;
 use super::S3_OBJECT_LOCK_DURATION_HEARTBEAT;
 use super::S3_OBJECT_LOCK_DURATION_INIT;
+use super::S3_OBJECT_LOCK_DURATION_SHARES;
 use super::S3_OBJECT_LOCK_DURATION_WITHDRAW;
 use super::message::LogMessage;
 use crate::guardian::GuardianError::InvalidInputs;
@@ -70,6 +71,7 @@ impl LogRecord {
             LogMessage::Heartbeat { .. } => S3_OBJECT_LOCK_DURATION_HEARTBEAT,
             LogMessage::Withdrawal(..) => S3_OBJECT_LOCK_DURATION_WITHDRAW,
             LogMessage::Ceremony(..) => S3_OBJECT_LOCK_DURATION_CEREMONY,
+            LogMessage::Shares(..) => S3_OBJECT_LOCK_DURATION_SHARES,
             LogMessage::CommitteeUpdate(..) => S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE,
         }
     }
@@ -198,6 +200,29 @@ mod tests {
             log.object_key(),
             "heartbeat/2023/11/14/22/session-b-00000000000000000042.json"
         );
+    }
+
+    #[test]
+    fn object_key_and_lock_for_shares() {
+        use crate::guardian::SharesLogMessage;
+
+        let session_id = "session-d".to_string();
+        let signing_key = GuardianSignKeyPair::from([10u8; 32]);
+        let mut log = LogRecord::new(
+            session_id,
+            LogMessage::Shares(Box::new(SharesLogMessage {
+                sharing_seq: 7,
+                encrypted_shares: vec![],
+            })),
+            &signing_key,
+        );
+        set_timestamp(&mut log, 1_700_000_000_000);
+
+        assert_eq!(
+            log.object_key(),
+            "shares/00000000000000000007-session-d.json"
+        );
+        assert_eq!(log.object_lock_duration(), S3_OBJECT_LOCK_DURATION_SHARES);
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -9,12 +9,14 @@ use super::S3_DIR_CEREMONY;
 use super::S3_DIR_COMMITTEE_UPDATE;
 use super::S3_DIR_HEARTBEAT;
 use super::S3_DIR_INIT;
+use super::S3_DIR_SHARES;
 use super::S3_DIR_WITHDRAW;
 use crate::committee::CommitteeSignature;
 use crate::guardian::Attestation;
 use crate::guardian::GuardianError;
 use crate::guardian::GuardianInfo;
 use crate::guardian::GuardianPubKey;
+use crate::guardian::KPEncryptedShare;
 use crate::guardian::LimiterState;
 use crate::guardian::SecretSharingInstance;
 use crate::guardian::ShareID;
@@ -36,21 +38,39 @@ pub enum LogMessage {
     Init(Box<InitLogMessage>),
     Withdrawal(Box<WithdrawalLogMessage>),
     Ceremony(Box<CeremonyLogMessage>),
+    Shares(Box<SharesLogMessage>),
     CommitteeUpdate(Box<CommitteeUpdateLogMessage>),
 }
 
+/// Encrypted KP shares persisted for recovery, written to `shares/` after each
+/// ceremony. Keyed by `sharing_seq` so it pairs with the matching `ceremony/`
+/// instance; carries the ciphertexts the `ceremony/` log deliberately omits.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SharesLogMessage {
+    pub sharing_seq: u64,
+    pub encrypted_shares: Vec<KPEncryptedShare>,
+}
+
 /// The authoritative share state, written to `ceremony/` after each ceremony.
-/// Carries only instances (commitments + n/t/seq); ciphertexts are delivered
-/// out-of-band and verified against the commitments. A rotation records the
-/// `old_instance` it consumed so the chain is auditable from the log alone.
+/// Carries the instance (commitments + n/t/seq) plus the recipient roster; the
+/// ciphertexts live in `shares/`. A rotation records the `old_instance` it
+/// consumed so the chain is auditable from the log alone.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum CeremonyLogMessage {
     /// Initial key setup (`setup_new_key`); `instance` has `sharing_seq` 0.
-    NewKey { instance: SecretSharingInstance },
+    NewKey {
+        instance: SecretSharingInstance,
+        /// Recipient fingerprints ordered by share id; lets a KP check the full
+        /// roster against the agreed set from the immutable log, not just the
+        /// operator-served shares.
+        roster: Vec<String>,
+    },
     /// Key rotation (`rotate_kps`) from `old_instance` to `new_instance`.
     Rotate {
         old_instance: SecretSharingInstance,
         new_instance: SecretSharingInstance,
+        /// Recipient fingerprints for `new_instance`; see [`Self::NewKey`].
+        roster: Vec<String>,
     },
 }
 
@@ -58,7 +78,7 @@ impl CeremonyLogMessage {
     /// The resulting instance's `sharing_seq` — used as the `ceremony/` object key.
     pub fn sharing_seq(&self) -> u64 {
         match self {
-            CeremonyLogMessage::NewKey { instance } => instance.sharing_seq(),
+            CeremonyLogMessage::NewKey { instance, .. } => instance.sharing_seq(),
             CeremonyLogMessage::Rotate { new_instance, .. } => new_instance.sharing_seq(),
         }
     }
@@ -241,6 +261,7 @@ impl LogMessage {
                     .to_string()
             }
             LogMessage::Ceremony(..) => format!("{}/", S3_DIR_CEREMONY),
+            LogMessage::Shares(..) => format!("{}/", S3_DIR_SHARES),
             LogMessage::CommitteeUpdate(..) => format!("{}/", S3_DIR_COMMITTEE_UPDATE),
         }
     }
@@ -252,6 +273,7 @@ impl LogMessage {
             LogMessage::Heartbeat { seq } => format!("{}-{:020}.json", prefix, seq),
             LogMessage::Withdrawal(withdrawal_message) => withdrawal_message.log_name(prefix),
             LogMessage::Ceremony(ss) => format!("{:020}-{}.json", ss.sharing_seq(), prefix),
+            LogMessage::Shares(s) => format!("{:020}-{}.json", s.sharing_seq, prefix),
             LogMessage::CommitteeUpdate(committee_message) => committee_message.log_name(prefix),
         }
     }

--- a/crates/hashi-types/src/guardian/log/mod.rs
+++ b/crates/hashi-types/src/guardian/log/mod.rs
@@ -22,12 +22,17 @@ use std::time::Duration;
 /// TODO: Uniform 7 days is a coarse placeholder. Revisit per-log-type
 /// against the SLO we actually want to defend — heartbeats could be shorter,
 /// ceremony/withdraws likely want years.
+const ONE_DAY: Duration = Duration::from_secs(24 * 60 * 60);
 const ONE_WEEK: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 pub const S3_OBJECT_LOCK_DURATION_INIT: Duration = ONE_WEEK;
 pub const S3_OBJECT_LOCK_DURATION_WITHDRAW: Duration = ONE_WEEK;
 pub const S3_OBJECT_LOCK_DURATION_HEARTBEAT: Duration = ONE_WEEK;
 pub const S3_OBJECT_LOCK_DURATION_CEREMONY: Duration = ONE_WEEK;
 pub const S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE: Duration = ONE_WEEK;
+/// Shares carry their own enclave signature, so the lock isn't for integrity —
+/// it only guarantees a window in which the operator can't purge them before KPs
+/// fetch. Short on purpose; they stay readable after expiry until deleted.
+pub const S3_OBJECT_LOCK_DURATION_SHARES: Duration = ONE_DAY;
 
 /// S3 sub-prefixes used for guardian log streams.
 /// See `crates/hashi-guardian/README.md` for canonical key layout.
@@ -35,4 +40,5 @@ pub const S3_DIR_INIT: &str = "init";
 pub const S3_DIR_WITHDRAW: &str = "withdraw";
 pub const S3_DIR_HEARTBEAT: &str = "heartbeat";
 pub const S3_DIR_CEREMONY: &str = "ceremony";
+pub const S3_DIR_SHARES: &str = "shares";
 pub const S3_DIR_COMMITTEE_UPDATE: &str = "committee-update";


### PR DESCRIPTION
Groundwork for the ceremony `run`/`verify` rework in #681: make the **enclave** persist each ceremony's encrypted shares, so a KP who loses their share can recover it — instead of the shares living only in the ephemeral `get_guardian_info` response.

## What
- **New `LogMessage::Shares` / `SharesLogMessage`** written to a `shares/{sharing_seq:020}-{session_id}.json` prefix, keyed by `sharing_seq` so each object pairs with its `ceremony/` instance. Short object lock — a fetch-window guarantee, *not* integrity (that's the enclave signature) — so shares stay readable until purged.
- **Enclave writes shares in both `setup_new_key` and `rotate_kps`**, so recovery is rotation-correct by construction (no genesis-only gap).
- **Roster committed into the attested `ceremony/` log** (`CeremonyLogMessage` now carries the per-share recipient fingerprints), so a KP can check the full recipient set against the immutable record rather than the operator-served shares. See the roster gap discussion on #681.
- **`GuardianReader`**: `read_latest_ceremony` (also returns the writing session id, needed to locate the share object) + `read_shares` point-read.

## Why this shape
Shares are enclave-authored state, so the enclave writes them (signature carries authenticity; the operator can't forge). Reusing the existing locked log path means **no second bucket, no lock-agnostic primitives, no operator-side upload** — which supersedes the artifact-bucket approach in #681. The short lock + separate prefix lets shares be purged without tripping the strict immutable-log reader that guards `ceremony/`.

## Scope / follow-ups
- KP-side recovery **tooling** (a `ceremony` command that reads + decrypts from `shares/`) is deferred; this PR lands the enclave write path + reader primitives.
- Real attestation verification (`verify_enclave_attestation` is a no-op) is tracked separately.

Draft until the above lands / #681 is reworked on top.