### PR TITLE
[guardian] remove the onchain ed25519 pin

### DIFF
--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -253,11 +253,6 @@ impl TestNetworksBuilder {
         let guardian_btc_pubkey = guardian_harness.ensure_btc_pubkey()?;
         let guardian_config = hashi::publish::GuardianConfig {
             url: guardian_harness.endpoint().to_string(),
-            public_key: guardian_harness
-                .enclave()
-                .signing_pubkey()
-                .as_bytes()
-                .to_vec(),
             btc_public_key: guardian_btc_pubkey.serialize().to_vec(),
         };
         tracing::info!(

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -475,7 +475,6 @@ pub struct AbortReconfig {
 #[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct UpdateGuardian {
     pub url: String,
-    pub public_key: Vec<u8>,
 }
 
 /// Rust version of the Move sui::vec_map::VecMap type.

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -60,7 +60,6 @@ pub enum CreateProposalParams {
     },
     UpdateGuardian {
         url: String,
-        public_key: Vec<u8>,
         metadata: Vec<(String, String)>,
     },
     EmergencyPause {
@@ -660,13 +659,8 @@ pub fn build_create_proposal_transaction(
                 ],
             );
         }
-        CreateProposalParams::UpdateGuardian {
-            url,
-            public_key,
-            metadata,
-        } => {
+        CreateProposalParams::UpdateGuardian { url, metadata } => {
             let url_arg = builder.pure(&url);
-            let public_key_arg = builder.pure(&public_key);
             let metadata_arg = build_metadata(&mut builder, &metadata);
             builder.move_call(
                 Function::new(
@@ -678,7 +672,6 @@ pub fn build_create_proposal_transaction(
                     hashi_arg,
                     validator_address_arg,
                     url_arg,
-                    public_key_arg,
                     metadata_arg,
                     clock_arg,
                 ],

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -635,24 +635,14 @@ pub async fn create_abort_reconfig_proposal(
 pub async fn create_update_guardian_proposal(
     config: &CliConfig,
     url: &str,
-    public_key_hex: &str,
     metadata: Vec<(String, String)>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
-    let public_key = hex::decode(public_key_hex.strip_prefix("0x").unwrap_or(public_key_hex))
-        .context("Invalid hex for public key")?;
-    anyhow::ensure!(
-        public_key.len() == 32,
-        "--public-key must be 32 bytes (Ed25519), got {} bytes",
-        public_key.len(),
-    );
-
     print_detail(&format!(
         "\n{}",
         "Creating Update Guardian Proposal:".bold()
     ));
     print_detail(&format!("  URL:        {}", url));
-    print_detail(&format!("  Public Key: 0x{}", hex::encode(&public_key)));
     print_metadata(&metadata);
 
     prompt_continue("create this update guardian proposal", tx_opts).await?;
@@ -660,7 +650,6 @@ pub async fn create_update_guardian_proposal(
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateGuardian {
         url: url.to_string(),
-        public_key,
         metadata,
     })?;
 

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -261,15 +261,11 @@ pub enum CreateProposalCommands {
         metadata: MetadataArgs,
     },
 
-    /// Propose updating the guardian URL and public key
+    /// Propose updating the guardian URL
     UpdateGuardian {
         /// The guardian gRPC endpoint URL
         #[clap(long)]
         url: String,
-
-        /// The guardian's signing public key (hex encoded)
-        #[clap(long)]
-        public_key: String,
 
         #[clap(flatten)]
         metadata: MetadataArgs,
@@ -659,10 +655,6 @@ pub struct PublishOpts {
     #[clap(long)]
     pub guardian_url: String,
 
-    /// Guardian Ed25519 signing pubkey, hex-encoded (32 bytes).
-    #[clap(long)]
-    pub guardian_public_key: String,
-
     /// Guardian BTC pubkey, x-only hex-encoded (32 bytes). Published
     /// on-chain for 2-of-2 deposit address derivation.
     #[clap(long)]
@@ -896,15 +888,10 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                     )
                     .await?;
                 }
-                CreateProposalCommands::UpdateGuardian {
-                    url,
-                    public_key,
-                    metadata,
-                } => {
+                CreateProposalCommands::UpdateGuardian { url, metadata } => {
                     commands::proposal::create_update_guardian_proposal(
                         &config,
                         &url,
-                        &public_key,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )
@@ -1198,18 +1185,7 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
     // Connect to RPC
     let mut client = sui_rpc::Client::new(&opts.sui_rpc_url)?;
 
-    // Guardian is required — all three flags must be present.
-    let public_key = hex::decode(
-        opts.guardian_public_key
-            .strip_prefix("0x")
-            .unwrap_or(&opts.guardian_public_key),
-    )
-    .context("Invalid hex for --guardian-public-key")?;
-    anyhow::ensure!(
-        public_key.len() == 32,
-        "--guardian-public-key must be 32 bytes (Ed25519), got {} bytes",
-        public_key.len(),
-    );
+    // Guardian is required — both flags must be present.
     let btc_public_key = hex::decode(
         opts.guardian_btc_public_key
             .strip_prefix("0x")
@@ -1223,7 +1199,6 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
     );
     let guardian = crate::publish::GuardianConfig {
         url: opts.guardian_url,
-        public_key,
         btc_public_key,
     };
 

--- a/crates/hashi/src/publish.rs
+++ b/crates/hashi/src/publish.rs
@@ -106,7 +106,6 @@ stderr: {}",
 /// guardian-less deploy can't produce spendable deposits.
 pub struct GuardianConfig {
     pub url: String,
-    pub public_key: Vec<u8>,
     /// X-only BTC pubkey of the enclave (32 bytes).
     pub btc_public_key: Vec<u8>,
 }
@@ -226,7 +225,6 @@ pub async fn publish_and_init(
     let upgrade_cap_arg = builder.object(ObjectInput::new(upgrade_cap_id).as_owned());
     let bitcoin_chain_id_arg = builder.pure(&bitcoin_chain_id_addr);
     let guardian_url_arg = builder.pure(&guardian.url.as_str());
-    let guardian_public_key_arg = builder.pure(&guardian.public_key.as_slice());
     let guardian_btc_public_key_arg = builder.pure(&guardian.btc_public_key.as_slice());
     let confirmation_threshold_arg = builder.pure(&bitcoin_overrides.confirmation_threshold);
     let deposit_time_delay_ms_arg = builder.pure(&bitcoin_overrides.deposit_time_delay_ms);
@@ -247,7 +245,6 @@ pub async fn publish_and_init(
             upgrade_cap_arg,
             bitcoin_chain_id_arg,
             guardian_url_arg,
-            guardian_public_key_arg,
             guardian_btc_public_key_arg,
             confirmation_threshold_arg,
             deposit_time_delay_ms_arg,

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -20,8 +20,6 @@ const PACKAGE_VERSION: u64 = 1;
 const EVersionDisabled: vector<u8> = b"Version disabled";
 #[error(code = 1)]
 const EDisableCurrentVersion: vector<u8> = b"Cannot disable current version";
-#[error(code = 2)]
-const EBadGuardianPublicKeyLength: vector<u8> = b"Guardian public key must be 32 bytes";
 #[error(code = 3)]
 const EBadGuardianBtcPublicKeyLength: vector<u8> = b"Guardian BTC public key must be 32 bytes";
 #[error(code = 4)]
@@ -30,8 +28,6 @@ const EGuardianBtcPublicKeyImmutable: vector<u8> =
 
 const PAUSED_KEY: vector<u8> = b"paused";
 const GUARDIAN_URL_KEY: vector<u8> = b"guardian_url";
-const GUARDIAN_PUBLIC_KEY_KEY: vector<u8> = b"guardian_public_key";
-const GUARDIAN_PUBLIC_KEY_LEN: u64 = 32;
 const GUARDIAN_BTC_PUBLIC_KEY_KEY: vector<u8> = b"guardian_btc_public_key";
 const GUARDIAN_BTC_PUBLIC_KEY_LEN: u64 = 32;
 const EMERGENCY_PAUSE_THRESHOLD_BPS_KEY: vector<u8> = b"governance_emergency_pause_threshold_bps";
@@ -98,22 +94,14 @@ public(package) fun guardian_url(self: &Config): Option<String> {
     self.try_get(GUARDIAN_URL_KEY).map!(|v| v.as_string())
 }
 
-public(package) fun guardian_public_key(self: &Config): Option<vector<u8>> {
-    self.try_get(GUARDIAN_PUBLIC_KEY_KEY).map!(|v| v.as_bytes())
-}
-
 public(package) fun guardian_btc_public_key(self: &Config): Option<vector<u8>> {
     self.try_get(GUARDIAN_BTC_PUBLIC_KEY_KEY).map!(|v| v.as_bytes())
 }
 
-public(package) fun set_guardian(self: &mut Config, url: String, public_key: vector<u8>) {
-    assert_valid_guardian_public_key(&public_key);
+/// Set the guardian's URL. The ephemeral signing key is intentionally not pinned
+/// onchain; the node authenticates the guardian over TLS + the immutable BTC key.
+public(package) fun set_guardian_url(self: &mut Config, url: String) {
     self.upsert(GUARDIAN_URL_KEY, config_value::new_string(url));
-    self.upsert(GUARDIAN_PUBLIC_KEY_KEY, config_value::new_bytes(public_key));
-}
-
-public(package) fun assert_valid_guardian_public_key(public_key: &vector<u8>) {
-    assert!(public_key.length() == GUARDIAN_PUBLIC_KEY_LEN, EBadGuardianPublicKeyLength);
 }
 
 /// Pin the guardian's x-only BTC pubkey (32 bytes). Immutable once set —

--- a/packages/hashi/sources/core/proposal/types/update_guardian.move
+++ b/packages/hashi/sources/core/proposal/types/update_guardian.move
@@ -3,7 +3,7 @@
 
 module hashi::update_guardian;
 
-use hashi::{config, hashi::Hashi, proposal};
+use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
@@ -11,24 +11,21 @@ const THRESHOLD_BPS: u64 = 6667;
 
 public struct UpdateGuardian has copy, drop, store {
     url: String,
-    public_key: vector<u8>,
 }
 
 public fun propose(
     hashi: &mut Hashi,
     validator_address: address,
     url: String,
-    public_key: vector<u8>,
     metadata: VecMap<String, String>,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     hashi.config().assert_version_enabled();
-    config::assert_valid_guardian_public_key(&public_key);
     proposal::create(
         hashi,
         validator_address,
-        UpdateGuardian { url, public_key },
+        UpdateGuardian { url },
         THRESHOLD_BPS,
         metadata,
         clock,
@@ -37,6 +34,6 @@ public fun propose(
 }
 
 public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
-    let UpdateGuardian { url, public_key } = proposal::execute(hashi, proposal_id, clock);
-    hashi.config_mut().set_guardian(url, public_key);
+    let UpdateGuardian { url } = proposal::execute(hashi, proposal_id, clock);
+    hashi.config_mut().set_guardian_url(url);
 }

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -99,16 +99,15 @@ public(package) fun assert_not_reconfiguring(self: &Hashi) {
 // Function that needs to be called immediately after publishing to finalize
 // some input parameters, register BTC and the package's UpgradeCap.
 //
-// The guardian URL, signing key, and BTC key are all required: the
-// guardian is a load-bearing component of every deposit address (2-of-2
-// taproot leaf) and every withdrawal signature, so a deploy without
-// them would produce a non-functional bridge.
+// The guardian URL and BTC key are both required: the guardian is a
+// load-bearing component of every deposit address (2-of-2 taproot leaf)
+// and every withdrawal signature, so a deploy without them would produce
+// a non-functional bridge.
 entry fun finish_publish(
     self: &mut Hashi,
     upgrade_cap: sui::package::UpgradeCap,
     bitcoin_chain_id: address,
     guardian_url: String,
-    guardian_public_key: vector<u8>,
     guardian_btc_public_key: vector<u8>,
     bitcoin_confirmation_threshold: Option<u64>,
     bitcoin_deposit_time_delay_ms: Option<u64>,
@@ -124,7 +123,7 @@ entry fun finish_publish(
     self.config_mut().set_upgrade_cap(upgrade_cap);
     hashi::btc_config::set_bitcoin_chain_id(self.config_mut(), bitcoin_chain_id);
 
-    self.config_mut().set_guardian(guardian_url, guardian_public_key);
+    self.config_mut().set_guardian_url(guardian_url);
     self.config_mut().set_guardian_btc_public_key(guardian_btc_public_key);
 
     if (bitcoin_confirmation_threshold.is_some()) {

--- a/packages/hashi/tests/config_tests.move
+++ b/packages/hashi/tests/config_tests.move
@@ -68,29 +68,14 @@ fun test_bitcoin_withdrawal_minimum_floors() {
 }
 
 #[test]
-fun test_set_guardian_stores_url_and_key() {
+fun test_set_guardian_url_stores_url() {
     let ctx = &mut test_utils::new_tx_context(@0x100, 0);
     let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
 
     let url = string::utf8(b"http://guardian.example:3000");
-    let pk = vector::tabulate!(32, |i| (i as u8));
-    config::set_guardian(hashi.config_mut(), url, pk);
+    config::set_guardian_url(hashi.config_mut(), url);
 
     assert!(config::guardian_url(hashi.config()).borrow() == url);
-    let stored = config::guardian_public_key(hashi.config()).destroy_some();
-    assert!(stored.length() == 32);
-
-    std::unit_test::destroy(hashi);
-}
-
-#[test, expected_failure(abort_code = ::hashi::config::EBadGuardianPublicKeyLength)]
-fun test_set_guardian_rejects_wrong_length_key() {
-    let ctx = &mut test_utils::new_tx_context(@0x100, 0);
-    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx);
-
-    let url = string::utf8(b"http://guardian.example:3000");
-    let bad_pk = vector::tabulate!(31, |i| (i as u8));
-    config::set_guardian(hashi.config_mut(), url, bad_pk);
 
     std::unit_test::destroy(hashi);
 }


### PR DESCRIPTION
## Summary

The node used to pin the guardian's ephemeral ed25519 signing key on-chain (`guardian_public_key`). The guardian regenerates that key on every enclave reboot, so a reboot broke verification and stalled withdrawals.

Per design review, validators don't pin the guardian's signing key or its enclave build (PCR0) — the enclave is a KP/provisioner concern, and the only crypto material a validator needs to trust is the immutable BTC key. So drop `guardian_public_key` from on-chain config entirely: the guardian's on-chain identity is now its URL plus the immutable BTC key. The node reaches it over TLS and verifies withdrawals against the BTC key (node side: #691).

Replaces the earlier "pin the enclave build (PCR0) on-chain" approach.

## Changes

- `config.move`: drop `guardian_public_key`; `set_guardian` → `set_guardian_url`.
- `update_guardian` proposal + `finish_publish`: URL only.
- CLI / publish: drop `--guardian-public-key`.
