### PR TITLE
[guardian] trust the guardian over TLS + onchain BTC key

### DIFF
--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -730,6 +730,14 @@ impl GetGuardianInfoResponse {
             encrypted_shares: self.encrypted_shares.clone(),
         })
     }
+
+    /// Extract the guardian's self-reported `GuardianInfo` WITHOUT verifying the
+    /// signature or attestation. The node uses this after authenticating the
+    /// guardian over TLS; withdrawals are gated by the on-chain BTC key, and the
+    /// ed25519 signing key is verified only by KPs/monitors on the S3 audit logs.
+    pub fn into_info_unchecked(self) -> GuardianInfo {
+        self.signed_info.into_data_unchecked()
+    }
 }
 
 // ---------------------------------

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -98,3 +98,12 @@ impl<T: Serialize + SigningIntent> GuardianSigned<T> {
         Ok(self.data)
     }
 }
+
+impl<T> GuardianSigned<T> {
+    /// Move out the payload WITHOUT verifying the signature. The node uses this
+    /// on guardian responses it has already authenticated over TLS; the ed25519
+    /// signing key is verified only by KPs/monitors on the S3 audit logs.
+    pub fn into_data_unchecked(self) -> T {
+        self.data
+    }
+}

--- a/crates/hashi/src/leader/guardian.rs
+++ b/crates/hashi/src/leader/guardian.rs
@@ -102,9 +102,6 @@ impl LeaderService {
             anyhow::anyhow!("Guardian rejected withdrawal: {}", status.message())
         })?;
 
-        let pubkey = inner
-            .guardian_signing_pubkey()
-            .expect("guardian signing pubkey set during bootstrap");
         let signed_response: GuardianSigned<StandardWithdrawalResponse> = response_pb
             .try_into()
             .inspect_err(|_| {
@@ -115,18 +112,10 @@ impl LeaderService {
                 );
             })
             .map_err(|e| anyhow::anyhow!("Failed to parse guardian withdrawal response: {e}"))?;
-        let response = signed_response
-            .verify(pubkey)
-            .inspect_err(|_| {
-                Self::record_guardian_rpc_outcome(
-                    inner,
-                    crate::metrics::GUARDIAN_RPC_OUTCOME_SIGNATURE_ERROR,
-                    rpc_elapsed,
-                );
-            })
-            .map_err(|e| {
-                anyhow::anyhow!("Guardian response signature verification failed: {e:?}")
-            })?;
+        // Authenticated by TLS; the per-input BTC witness signatures below only
+        // spend the 2-of-2 if they verify against the on-chain guardian BTC key
+        // (enforced by Bitcoin), so the response itself isn't signature-checked.
+        let response = signed_response.into_data_unchecked();
 
         anyhow::ensure!(
             response.enclave_signatures.len() == txn.inputs.len(),
@@ -270,7 +259,7 @@ impl LeaderService {
         // Seed `guardian_epoch` once from `GetGuardianInfo`; subsequent
         // iterations reuse `current_committee_epoch` from `UpdateCommittee`
         // and skip the extra round-trip.
-        let info = inner.fetch_verified_guardian_info().await?;
+        let info = inner.fetch_guardian_info_data().await?;
         let Some(mut guardian_epoch) = info.current_committee_epoch else {
             // ProvisionerInit hasn't run yet; the bootstrap CLI seeds it.
             return Ok(());

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -62,7 +62,6 @@ pub struct Hashi {
     btc_monitor: OnceLock<crate::btc_monitor::monitor::MonitorClient>,
     screener_client: OnceLock<Option<grpc::screener_client::ScreenerClient>>,
     guardian_client: OnceLock<Option<grpc::guardian_client::GuardianClient>>,
-    guardian_signing_pubkey: OnceLock<Option<hashi_types::guardian::GuardianPubKey>>,
     guardian_btc_pubkey: OnceLock<Option<hashi_types::bitcoin::BitcoinPubkey>>,
     local_limiter: OnceLock<Arc<guardian_limiter::LocalLimiter>>,
     /// `(seq, wid)` of the last guardian-finalized withdrawal, for pacing.
@@ -94,7 +93,6 @@ impl Hashi {
             btc_monitor: OnceLock::new(),
             screener_client: OnceLock::new(),
             guardian_client: OnceLock::new(),
-            guardian_signing_pubkey: OnceLock::new(),
             guardian_btc_pubkey: OnceLock::new(),
             local_limiter: OnceLock::new(),
             guardian_last_finalized: RwLock::new(None),
@@ -125,7 +123,6 @@ impl Hashi {
             btc_monitor: OnceLock::new(),
             screener_client: OnceLock::new(),
             guardian_client: OnceLock::new(),
-            guardian_signing_pubkey: OnceLock::new(),
             guardian_btc_pubkey: OnceLock::new(),
             local_limiter: OnceLock::new(),
             guardian_last_finalized: RwLock::new(None),
@@ -240,12 +237,6 @@ impl Hashi {
 
     pub fn guardian_client(&self) -> Option<&grpc::guardian_client::GuardianClient> {
         self.guardian_client.get().and_then(|opt| opt.as_ref())
-    }
-
-    pub fn guardian_signing_pubkey(&self) -> Option<&hashi_types::guardian::GuardianPubKey> {
-        self.guardian_signing_pubkey
-            .get()
-            .and_then(|opt| opt.as_ref())
     }
 
     pub fn guardian_btc_pubkey(&self) -> Option<&hashi_types::bitcoin::BitcoinPubkey> {
@@ -764,7 +755,7 @@ impl Hashi {
 
     async fn try_seed_guardian_state(&self) -> bool {
         self.metrics.guardian_bootstrap_attempts_total.inc();
-        let Ok(info) = self.fetch_verified_guardian_info().await else {
+        let Ok(info) = self.fetch_guardian_info_data().await else {
             return false;
         };
         if !self.verify_and_pin_guardian_btc_pubkey(info.enclave_btc_pubkey) {
@@ -822,15 +813,12 @@ impl Hashi {
         }
     }
 
-    /// The guarded entry point for guardian `/info`: fetch, verify the signed
-    /// payload, pin the signing pubkey to on-chain, and return that verified
-    /// `GuardianInfo`. Callers must read guardian state only through this.
-    ///
-    /// TODO: Thread PCR config into Hashi nodes and use `verify` here so this
-    /// also authenticates the Nitro attestation/PCRs.
-    ///
-    /// Records the matching bootstrap-outcome metric on each failure.
-    async fn fetch_verified_guardian_info(
+    /// Fetch the guardian's `GuardianInfo` over the (TLS) channel and return it.
+    /// The guardian is authenticated by TLS and withdrawals are gated by the
+    /// on-chain BTC key, so the ed25519 signing key and Nitro attestation are
+    /// not checked here (the signing key is verified only by KPs/monitors on the
+    /// S3 audit logs). Records the matching bootstrap-outcome metric on failure.
+    async fn fetch_guardian_info_data(
         &self,
     ) -> anyhow::Result<hashi_types::guardian::GuardianInfo> {
         let Some(info_pb) = self.fetch_guardian_info().await else {
@@ -845,23 +833,7 @@ impl Hashi {
                 );
                 anyhow::anyhow!("parse GetGuardianInfoResponse: {e:?}")
             })?;
-        let verified = resp.verify_signed_info_without_attestation().map_err(|e| {
-            self.metrics.record_guardian_bootstrap_outcome(
-                metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID,
-            );
-            tracing::error!(
-                error = ?e,
-                "FATAL: guardian /info signature invalid under its own \
-                 signing_pub_key; refusing to seed or reconcile local limiter",
-            );
-            anyhow::anyhow!("guardian signed_info signature invalid")
-        })?;
-        let signing_pub_key = verified.signing_pub_key;
-        if !self.verify_guardian_signing_pubkey(&signing_pub_key) {
-            anyhow::bail!("guardian signing pubkey does not match on-chain");
-        }
-        let _ = self.guardian_signing_pubkey.set(Some(signing_pub_key));
-        Ok(verified.info)
+        Ok(resp.into_info_unchecked())
     }
 
     /// Fetch the guardian's authoritative `LimiterState` and the live local
@@ -873,7 +845,7 @@ impl Hashi {
         hashi_types::guardian::LimiterState,
     )> {
         let limiter = self.local_limiter()?;
-        let info = self.fetch_verified_guardian_info().await.ok()?;
+        let info = self.fetch_guardian_info_data().await.ok()?;
         if !self.verify_and_pin_guardian_btc_pubkey(info.enclave_btc_pubkey) {
             return None;
         }
@@ -881,18 +853,8 @@ impl Hashi {
         Some((limiter, state))
     }
 
-    /// Read on each call: a chain that didn't publish the key at hashi
-    /// startup may bind `guardian_public_key` later via governance.
-    fn verify_guardian_signing_pubkey(
-        &self,
-        signing_pub_key: &hashi_types::guardian::GuardianPubKey,
-    ) -> bool {
-        let expected = self.onchain_state().guardian_public_key();
-        verify_signing_pub_key_matches(signing_pub_key, expected.as_deref(), &self.metrics)
-    }
-
-    /// BTC-key analogue of [`Self::verify_guardian_signing_pubkey`]. Pins
-    /// the live key in `guardian_btc_pubkey` on first successful match.
+    /// Cross-check the live guardian's BTC pubkey against the on-chain pin and
+    /// cache it in `guardian_btc_pubkey` on first successful match.
     fn verify_and_pin_guardian_btc_pubkey(
         &self,
         live: Option<hashi_types::bitcoin::BitcoinPubkey>,
@@ -1064,31 +1026,11 @@ fn assert_test_only_config(sui_chain_id: &str, bitcoin_chain_id: &str, field_nam
     );
 }
 
-/// `expected = None` skips the check (pre-feature chains).
-fn verify_signing_pub_key_matches(
-    signing_pub_key: &hashi_types::guardian::GuardianPubKey,
-    expected: Option<&[u8]>,
-    metrics: &metrics::Metrics,
-) -> bool {
-    let Some(expected) = expected else {
-        return true;
-    };
-    if signing_pub_key.as_bytes().as_slice() == expected {
-        return true;
-    }
-    metrics.record_guardian_bootstrap_outcome(metrics::GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH);
-    tracing::error!(
-        on_chain = %hex::encode(expected),
-        from_info = %hex::encode(signing_pub_key.as_bytes()),
-        "FATAL: guardian /info signing_pub_key does not match on-chain \
-         guardian_public_key; refusing to seed or reconcile local limiter",
-    );
-    false
-}
-
-/// BTC-key analogue of [`verify_signing_pub_key_matches`]. Extra fatal
-/// case: when the on-chain key is `Some` but the live guardian doesn't
-/// return one — the deploy must have come from a guardian that did.
+/// Cross-check the live guardian's BTC pubkey against the on-chain pin.
+/// `expected = None` skips the check (the pin may be bound later via
+/// governance). Extra fatal case: when the on-chain key is `Some` but the live
+/// guardian doesn't return one — the deploy must have come from a guardian that
+/// did.
 fn verify_btc_pub_key_matches(
     live: Option<&hashi_types::bitcoin::BitcoinPubkey>,
     expected: Option<&[u8]>,
@@ -1383,55 +1325,6 @@ mod test {
     fn fresh_metrics() -> std::sync::Arc<crate::metrics::Metrics> {
         let registry = prometheus::Registry::new();
         std::sync::Arc::new(crate::metrics::Metrics::new(&registry))
-    }
-
-    fn key_mismatch_count(metrics: &crate::metrics::Metrics) -> u64 {
-        metrics
-            .guardian_bootstrap_outcomes_total
-            .with_label_values(&[crate::metrics::GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH])
-            .get()
-    }
-
-    fn random_signing_pubkey() -> hashi_types::guardian::GuardianPubKey {
-        let signing_key = hashi_types::guardian::GuardianSignKeyPair::new(rand::thread_rng());
-        signing_key.verification_key()
-    }
-
-    #[test]
-    fn verify_signing_pub_key_matches_passes_when_equal() {
-        let pubkey = random_signing_pubkey();
-        let expected = pubkey.as_bytes().to_vec();
-        let metrics = fresh_metrics();
-        assert!(crate::verify_signing_pub_key_matches(
-            &pubkey,
-            Some(&expected),
-            &metrics
-        ));
-        assert_eq!(key_mismatch_count(&metrics), 0);
-    }
-
-    #[test]
-    fn verify_signing_pub_key_matches_skips_when_expected_absent() {
-        let pubkey = random_signing_pubkey();
-        let metrics = fresh_metrics();
-        assert!(crate::verify_signing_pub_key_matches(
-            &pubkey, None, &metrics
-        ));
-        assert_eq!(key_mismatch_count(&metrics), 0);
-    }
-
-    #[test]
-    fn verify_signing_pub_key_matches_fails_on_mismatch() {
-        let live = random_signing_pubkey();
-        let mut wrong = live.as_bytes().to_vec();
-        wrong[0] ^= 0xff;
-        let metrics = fresh_metrics();
-        assert!(!crate::verify_signing_pub_key_matches(
-            &live,
-            Some(&wrong),
-            &metrics
-        ));
-        assert_eq!(key_mismatch_count(&metrics), 1);
     }
 
     // --- guardian /info BTC pubkey verification ---

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1105,8 +1105,6 @@ pub const GUARDIAN_BOOTSTRAP_OUTCOME_SUCCESS: &str = "success";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE: &str = "rpc_failure";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE: &str = "parse_failure";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET: &str = "no_limiter_yet";
-pub const GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH: &str = "key_mismatch";
-pub const GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID: &str = "signature_invalid";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_BTC_KEY_MISMATCH: &str = "btc_key_mismatch";
 pub const GUARDIAN_BOOTSTRAP_OUTCOME_BTC_KEY_MISSING_FROM_INFO: &str = "btc_key_missing_from_info";
 
@@ -1118,7 +1116,6 @@ pub const GUARDIAN_RPC_OUTCOME_SEQ_MISMATCH: &str = "seq_mismatch";
 pub const GUARDIAN_RPC_OUTCOME_RATE_LIMITED: &str = "rate_limited";
 pub const GUARDIAN_RPC_OUTCOME_UNAVAILABLE: &str = "unavailable";
 pub const GUARDIAN_RPC_OUTCOME_PARSE_ERROR: &str = "parse_error";
-pub const GUARDIAN_RPC_OUTCOME_SIGNATURE_ERROR: &str = "signature_error";
 
 fn limiter_outcome_label(
     result: &Result<(), crate::guardian_limiter::LocalLimiterError>,
@@ -1287,8 +1284,6 @@ mod tests {
             GUARDIAN_BOOTSTRAP_OUTCOME_RPC_FAILURE,
             GUARDIAN_BOOTSTRAP_OUTCOME_PARSE_FAILURE,
             GUARDIAN_BOOTSTRAP_OUTCOME_NO_LIMITER_YET,
-            GUARDIAN_BOOTSTRAP_OUTCOME_KEY_MISMATCH,
-            GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID,
             GUARDIAN_BOOTSTRAP_OUTCOME_BTC_KEY_MISMATCH,
             GUARDIAN_BOOTSTRAP_OUTCOME_BTC_KEY_MISSING_FROM_INFO,
         ] {
@@ -1305,7 +1300,6 @@ mod tests {
                 GUARDIAN_RPC_OUTCOME_RATE_LIMITED,
                 GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
                 GUARDIAN_RPC_OUTCOME_PARSE_ERROR,
-                GUARDIAN_RPC_OUTCOME_SIGNATURE_ERROR,
             ] {
                 metrics.record_guardian_rpc(method, outcome, 0.1);
             }

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -513,14 +513,6 @@ impl OnchainState {
             .map(str::to_string)
     }
 
-    pub fn guardian_public_key(&self) -> Option<Vec<u8>> {
-        self.state()
-            .hashi()
-            .config
-            .guardian_public_key()
-            .map(<[u8]>::to_vec)
-    }
-
     pub fn guardian_btc_public_key(&self) -> Option<Vec<u8>> {
         self.state()
             .hashi()

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -603,13 +603,6 @@ impl Config {
         }
     }
 
-    pub fn guardian_public_key(&self) -> Option<&[u8]> {
-        match self.config.get("guardian_public_key") {
-            Some(ConfigValue::Bytes(v)) => Some(v.as_slice()),
-            _ => None,
-        }
-    }
-
     pub fn guardian_btc_public_key(&self) -> Option<&[u8]> {
         match self.config.get("guardian_btc_public_key") {
             Some(ConfigValue::Bytes(v)) => Some(v.as_slice()),


### PR DESCRIPTION
## Summary

Node-side companion to #690. The node no longer verifies the guardian's ephemeral ed25519 signing key (which rotated on every reboot) or its Nitro attestation. It reaches the guardian over TLS and verifies withdrawals against the immutable on-chain BTC key — the only crypto material that can't be replicated. The ed25519 key is verified only by KPs/monitors on the S3 audit logs.

A spoofed endpoint costs liveness, not funds: outputs are fixed in the BLS-certed on-chain withdrawal, the local limiter is authoritatively advanced by on-chain `WithdrawalSignedEvent`s, and the BTC witness signatures only spend the 2-of-2 if they verify against the on-chain BTC key (enforced by Bitcoin).

Replaces the earlier "verify the guardian via attestation on the node" approach.

## Changes

- Drop the signing-key pin (`guardian_signing_pubkey`, `verify_guardian_signing_pubkey`) and the on-chain `guardian_public_key` getters.
- Read `GuardianInfo` and the withdrawal response without ed25519 verification (`into_info_unchecked` / `into_data_unchecked`); the BTC-key cross-check is unchanged.
- Drop the now-dead `key_mismatch` / `signature_invalid` / `signature_error` metric labels.
