### PR TITLE
Lower EnableVersion/DisableVersion/Upgrade proposal quorum to 2/3

### DIFF
--- a/packages/hashi/sources/core/proposal/types/disable_version.move
+++ b/packages/hashi/sources/core/proposal/types/disable_version.move
@@ -7,7 +7,7 @@ use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
-const THRESHOLD_BPS: u64 = 10000;
+const THRESHOLD_BPS: u64 = 6667;
 
 public struct DisableVersion has copy, drop, store {
     version: u64,

--- a/packages/hashi/sources/core/proposal/types/enable_version.move
+++ b/packages/hashi/sources/core/proposal/types/enable_version.move
@@ -7,7 +7,7 @@ use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
-const THRESHOLD_BPS: u64 = 10000;
+const THRESHOLD_BPS: u64 = 6667;
 
 public struct EnableVersion has copy, drop, store {
     version: u64,

--- a/packages/hashi/sources/core/proposal/types/upgrade.move
+++ b/packages/hashi/sources/core/proposal/types/upgrade.move
@@ -19,7 +19,7 @@ use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, package::{UpgradeTicket, UpgradeReceipt}, vec_map::VecMap};
 
-const THRESHOLD_BPS: u64 = 10000;
+const THRESHOLD_BPS: u64 = 6667;
 
 public struct Upgrade has copy, drop, store {
     digest: vector<u8>,


### PR DESCRIPTION
## What

Lowers the governance quorum for three proposal types from **unanimous (10000 bps)** to **2/3 (6667 bps)**:

- `EnableVersion`
- `DisableVersion`
- `Upgrade`

Single-line `THRESHOLD_BPS` constant change in each of the three `proposal/types/*.move` modules.

## Why

The [Node Operator Runbook](design/docs/node-operator-runbook.mdx) §7.1/§7.2 documents **all** governance actions as requiring **2/3 of committee weight**, with `EmergencyPause` (5% pause / 2/3 unpause) as the only exception. The code already matched this for `UpdateConfig`, `UpdateGuardian`, `AbortReconfig`, and the `EmergencyPause` unpause path — these three were the outliers still requiring unanimity. This aligns the code with the documented thresholds.

## Security note for reviewers

`Upgrade` is the most powerful governance action — it can replace the entire package, including BTC custody logic. Unanimity meant no subset of validators (even a colluding/compromised 2/3 supermajority) could push a malicious or buggy upgrade without *every* member agreeing. After this change, a 2/3 supermajority suffices. `EnableVersion`/`DisableVersion` are lower-stakes (they toggle already-published versions). Please weigh whether 2/3 is the intended threshold for `Upgrade` specifically, or whether the runbook should instead be corrected to keep it unanimous.

## Testing

- `sui move test` — all 112 package tests pass. No test relied on the unanimous threshold (the version-proposal tests use single-member committees; the multi-voter quorum tests already exercise the 6667 rounding behavior).
- No Rust changes: the threshold is enforced entirely on-chain; the Rust CLI only calls `propose`.