### PR TITLE
Add `proposal create emergency-pause` CLI command

### DIFF
--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -63,6 +63,11 @@ pub enum CreateProposalParams {
         public_key: Vec<u8>,
         metadata: Vec<(String, String)>,
     },
+    EmergencyPause {
+        /// `true` proposes a pause; `false` proposes an unpause.
+        pause: bool,
+        metadata: Vec<(String, String)>,
+    },
 }
 
 /// Live on-chain proposal detail fields not cached by `OnchainState`.
@@ -674,6 +679,24 @@ pub fn build_create_proposal_transaction(
                     validator_address_arg,
                     url_arg,
                     public_key_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
+            );
+        }
+        CreateProposalParams::EmergencyPause { pause, metadata } => {
+            let pause_arg = builder.pure(&pause);
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    hashi_ids.package_id,
+                    Identifier::from_static("emergency_pause"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    pause_arg,
                     metadata_arg,
                     clock_arg,
                 ],

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -670,6 +670,41 @@ pub async fn create_update_guardian_proposal(
     Ok(())
 }
 
+/// Create an emergency pause (or, with `pause == false`, unpause) proposal.
+///
+/// Pausing uses a deliberately low quorum (default 5%) so a small fraction of
+/// committee weight can halt the protocol quickly; unpausing requires the
+/// normal 2/3 supermajority. Both paths target `emergency_pause::propose`.
+pub async fn create_emergency_pause_proposal(
+    config: &CliConfig,
+    pause: bool,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let action = if pause { "Pause" } else { "Unpause" };
+    let title = format!("Creating Emergency {action} Proposal:");
+    print_detail(&format!("\n{}", title.as_str().bold()));
+    print_detail(&format!("  Action: {action}"));
+    print_metadata(&metadata);
+
+    prompt_continue(
+        &format!("create this emergency {} proposal", action.to_lowercase()),
+        tx_opts,
+    )
+    .await?;
+
+    let mut client = HashiClient::new(config).await?;
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::EmergencyPause {
+        pause,
+        metadata,
+    })?;
+
+    print_info("Transaction: emergency_pause::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
 // ============ Helper Functions ============
 
 fn print_proposal_detailed(

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -670,20 +670,20 @@ pub async fn create_update_guardian_proposal(
     Ok(())
 }
 
-/// Create an emergency pause (or, with `pause == false`, unpause) proposal.
+/// Create an emergency pause (or, with `unpause == true`, unpause) proposal.
 ///
 /// Pausing uses a deliberately low quorum (default 5%) so a small fraction of
 /// committee weight can halt the protocol quickly; unpausing requires the
 /// normal 2/3 supermajority. Both paths target `emergency_pause::propose`.
 pub async fn create_emergency_pause_proposal(
     config: &CliConfig,
-    pause: bool,
+    unpause: bool,
     metadata: Vec<(String, String)>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
-    let action = if pause { "Pause" } else { "Unpause" };
+    let action = if unpause { "Unpause" } else { "Pause" };
     let title = format!("Creating Emergency {action} Proposal:");
-    print_detail(&format!("\n{}", title.as_str().bold()));
+    print_detail(&format!("\n{}", title.bold()));
     print_detail(&format!("  Action: {action}"));
     print_metadata(&metadata);
 
@@ -695,7 +695,7 @@ pub async fn create_emergency_pause_proposal(
 
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::EmergencyPause {
-        pause,
+        pause: !unpause,
         metadata,
     })?;
 

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -913,7 +913,7 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                 CreateProposalCommands::EmergencyPause { unpause, metadata } => {
                     commands::proposal::create_emergency_pause_proposal(
                         &config,
-                        !unpause,
+                        unpause,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -274,6 +274,20 @@ pub enum CreateProposalCommands {
         #[clap(flatten)]
         metadata: MetadataArgs,
     },
+
+    /// Propose pausing the protocol (or unpausing it with `--unpause`).
+    ///
+    /// Pausing uses a deliberately low quorum (default 5% of committee
+    /// weight) so the committee can halt deposits/withdrawals fast in an
+    /// emergency; unpausing requires the normal 2/3 supermajority.
+    EmergencyPause {
+        /// Propose unpausing instead of pausing.
+        #[clap(long)]
+        unpause: bool,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
 }
 
 /// Shared metadata arguments for proposal creation
@@ -891,6 +905,15 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                         &config,
                         &url,
                         &public_key,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::EmergencyPause { unpause, metadata } => {
+                    commands::proposal::create_emergency_pause_proposal(
+                        &config,
+                        !unpause,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -571,6 +571,7 @@ hashi proposal create enable-version <version> [-m key=value]
 hashi proposal create disable-version <version> [-m key=value]
 hashi proposal create abort-reconfig [--epoch <N>] [-m key=value]
 hashi proposal create update-guardian [--url <url>] [--public-key <hex>] [-m key=value]
+hashi proposal create emergency-pause [--unpause] [-m key=value]
 ```
 
 Config values are type-prefixed: `u64:30000`, `bool:true`.
@@ -649,7 +650,7 @@ Builds, publishes, and initializes the Hashi Move package (including its onchain
 | **UpdateGuardian** | 2/3 | Change guardian endpoint and key | `--url`, `--public-key` |
 | **EmergencyPause** | 5% to pause, 2/3 to unpause | Quickly pause or resume the protocol in an emergency | n/a |
 
-> EmergencyPause uses a deliberately low threshold so a small fraction of committee weight can halt the protocol fast; resuming requires the normal 2/3. It is not part of the standard `proposal create` CLI.
+> EmergencyPause uses a deliberately low threshold so a small fraction of committee weight can halt the protocol fast; resuming requires the normal 2/3. Create it with `hashi proposal create emergency-pause` (add `--unpause` to propose resuming).
 
 **Configurable protocol parameters:**
 


### PR DESCRIPTION
## What

Adds `hashi proposal create emergency-pause [--unpause]`, wired to the on-chain `emergency_pause::propose(pause)`. Default proposes a **pause**; `--unpause` proposes an **unpause**.

```
hashi proposal create emergency-pause              # propose pause   (5% quorum)
hashi proposal create emergency-pause --unpause    # propose unpause (2/3 quorum)
```

## Why

`emergency_pause` was the **only** on-chain governance proposal type with no CLI `create` path. The CLI already handled EmergencyPause for `vote` / `remove-vote` / `view` / `list` / `execute` (the type is wired into every dispatch in `client.rs`), but a committee member could not *initiate* one. That left the deliberately-low **5% emergency-pause threshold unreachable from the CLI** — the only way to set `paused` was `update-config paused bool:true` at the normal **2/3** threshold, which defeats the purpose of a fast halt.

This was surfaced during a CLI coverage audit of the validator/protocol-management surface; emergency-pause-create was the single gap.

## Changes

- `cli/mod.rs` — `CreateProposalCommands::EmergencyPause { unpause, metadata }` + dispatch (`pause = !unpause`).
- `cli/client.rs` — `CreateProposalParams::EmergencyPause` + `build_create_proposal_transaction` arm calling `emergency_pause::propose`.
- `cli/commands/proposal.rs` — `create_emergency_pause_proposal` handler (mirrors the other `create_*` handlers).

No Move changes — the on-chain function already existed.

## Testing

Verified end-to-end on a 4-validator localnet:

- **Pause:** proposal shows `Threshold: 500 bps (5.00%)`, reaches quorum on the proposer's single vote; after `execute`, a `withdraw request` aborts with `ESystemPaused = System is currently paused`.
- **Unpause:** proposal shows `Threshold: 6667 bps (66.67%)`, requires 3 of 4 validators; after `vote --execute`, withdrawals succeed again.
- Regression pass over the existing `proposal` create types (`--dry-run`), `vote`/`remove-vote`/`execute`, committee/config queries, and a full deposit->balance->withdraw flow — all green.