### PR TITLE
[Guardian] Hide raw guardian info response fields

### DIFF
--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -51,8 +51,10 @@ encrypted share is addressed only to its labeled KP cert, finds the share labele
 for this KP's cert fingerprint, decrypts via the yubikey (`gpg --decrypt`), and
 verifies the decrypted share against its commitment.
 
-Both commands verify the guardian's signed info and Nitro attestation against
-the configured PCR0 before trusting the session signing key.
+The operator `run` command verifies live `/info` signed info and Nitro
+attestation against the configured PCR0 before trusting the session signing key.
+The KP `verify` command anchors trust to the S3 `init/` attestation log before
+verifying the ceremony and share logs under that attested session key.
 
 Only the share's **ciphertext** is written to disk (a temp file, deleted on
 drop); the decrypted scalar lives only in memory.

--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -51,8 +51,8 @@ encrypted share is addressed only to its labeled KP cert, finds the share labele
 for this KP's cert fingerprint, decrypts via the yubikey (`gpg --decrypt`), and
 verifies the decrypted share against its commitment.
 
-PCR attestation verification is not configured here yet; the underlying
-attestation check is pending the attestation PR and is currently a no-op.
+Both commands verify the guardian's signed info and Nitro attestation against
+the configured PCR0 before trusting the session signing key.
 
 Only the share's **ciphertext** is written to disk (a temp file, deleted on
 drop); the decrypted scalar lives only in memory.

--- a/crates/hashi-guardian-init/src/ceremony.rs
+++ b/crates/hashi-guardian-init/src/ceremony.rs
@@ -63,8 +63,8 @@ pub struct CeremonyCommonConfig {
     /// at index `i` (0-based) is assigned share id `i + 1`.
     pub kp_pgp_cert_paths: Vec<PathBuf>,
     /// Expected enclave-image measurement: PCR0 as hex, pinned against every
-    /// session's attestation. Required (a value is needed even in non-Nitro dev,
-    /// where verification is a no-op).
+    /// session's attestation. Required even in non-Nitro dev, where the
+    /// attestation verifier is stubbed.
     pub expected_pcr0: BuildPcrs,
 }
 

--- a/crates/hashi-guardian-init/src/ceremony.rs
+++ b/crates/hashi-guardian-init/src/ceremony.rs
@@ -38,7 +38,6 @@ use hashi_types::guardian::Share;
 use hashi_types::guardian::SharesLogMessage;
 use hashi_types::guardian::proto_conversions::operator_init_request_to_pb;
 use hashi_types::guardian::proto_conversions::setup_new_key_request_to_pb;
-use hashi_types::guardian::session_id_from_signing_pubkey;
 use hashi_types::pgp::PgpPublicCert;
 use hashi_types::pgp::cert_owns_key_handle;
 use hashi_types::pgp::decrypt_with_gpg;
@@ -177,13 +176,9 @@ pub async fn run(cfg: CeremonyRunConfig) -> Result<()> {
         .context("OperatorInit RPC failed")?;
     info!("operator_init complete; guardian S3 logger installed");
 
-    // 5. get_guardian_info → verify the enclave's self-signature on its info →
-    //    pin the session id. This binds `signing_pub_key` (and thus the session)
-    //    before we trust the SetupNewKey response we'll verify against it below.
-    //
-    //    NOTE: this authenticates only the guardian's *internal* consistency;
-    //    the enclave's hardware attestation is pinned just below, when the reader
-    //    verifies the session's attestation against `expected_pcr0`.
+    // 5. get_guardian_info → verify attestation/PCRs and signed info → pin the
+    //    session id. This binds `signing_pub_key` (and thus the session) before
+    //    we trust the SetupNewKey response we'll verify against it below.
     info!("calling GetGuardianInfo");
     let info_pb = client
         .get_guardian_info(pb::GetGuardianInfoRequest {})
@@ -192,13 +187,12 @@ pub async fn run(cfg: CeremonyRunConfig) -> Result<()> {
         .into_inner();
     let info_resp = GetGuardianInfoResponse::try_from(info_pb)
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
-    let signing_pub_key = info_resp.signing_pub_key;
-    let session_id = session_id_from_signing_pubkey(&signing_pub_key);
-    info_resp
-        .signed_info
-        .verify(&signing_pub_key)
-        .map_err(|e| anyhow!("verify GuardianInfo signature (session={session_id}): {e:?}"))?;
-    info!(session_id = %session_id, "guardian info signature verified; session pinned");
+    let verified = info_resp
+        .verify(&cfg.common.expected_pcr0)
+        .map_err(|e| anyhow!("verify GuardianInfo attestation/signature: {e:?}"))?;
+    let signing_pub_key = verified.signing_pub_key;
+    let session_id = verified.session_id;
+    info!(session_id = %session_id, "guardian info attestation verified; session pinned");
 
     let mut reader = GuardianReader::new(&cfg.common.guardian_s3, cfg.common.expected_pcr0.clone())
         .await

--- a/crates/hashi-guardian-init/src/dev_bootstrap.rs
+++ b/crates/hashi-guardian-init/src/dev_bootstrap.rs
@@ -254,8 +254,9 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
         .into_inner();
     let post_resp = GetGuardianInfoResponse::try_from(post_resp_pb)
         .map_err(|e| anyhow!("decode post-ProvisionerInit GetGuardianInfoResponse: {e:?}"))?;
+    // Same trust boundary as the initial `/info` read above: signature only
+    // until dev bootstrap accepts PCR config and can call `verify`.
     let post_session_id = post_resp
-        // TODO: Reuse dev bootstrap PCR config here and use `verify` for attestation/PCR checks.
         .verify_signed_info_without_attestation()
         .map_err(|e| anyhow!("verify post-ProvisionerInit GuardianInfo signature: {e:?}"))?
         .session_id;

--- a/crates/hashi-guardian-init/src/dev_bootstrap.rs
+++ b/crates/hashi-guardian-init/src/dev_bootstrap.rs
@@ -185,7 +185,7 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
     //
     // TODO: also authenticate `signing_pub_key` against the AWS Nitro
     // attestation once the guardian runs in an enclave. Today
-    // `hashi_types::guardian::verify_enclave_attestation` is a no-op, so a
+    // `hashi_types::guardian::NitroAttestation::verify` is a no-op, so a
     // malicious operator with their own signing key can pass all the
     // checks below (sign their own GuardianInfo, echo the bucket and
     // commitments we just submitted, return their own encryption key) and

--- a/crates/hashi-guardian-init/src/dev_bootstrap.rs
+++ b/crates/hashi-guardian-init/src/dev_bootstrap.rs
@@ -183,17 +183,11 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
     // hostile endpoint could trick us into encrypting shares to a key it
     // controls.
     //
-    // TODO: also authenticate `signing_pub_key` against the AWS Nitro
-    // attestation once the guardian runs in an enclave. Today
-    // `hashi_types::guardian::NitroAttestation::verify` is a no-op, so a
-    // malicious operator with their own signing key can pass all the
-    // checks below (sign their own GuardianInfo, echo the bucket and
-    // commitments we just submitted, return their own encryption key) and
-    // capture `t` encrypted shares. The current deployment runs the
-    // guardian in a k8s cluster — the attestation gate lands when we move
-    // to Nitro.
+    // TODO: Thread PCR config into dev bootstrap and use `verify` here. Until
+    // then this call site skips attestation/PCR checks, so a malicious operator
+    // with their own signing key could sign matching GuardianInfo and return an
+    // encryption key it controls.
     let verified = resp
-        // TODO: Thread PCR config into dev bootstrap and use `verify` for attestation/PCR checks.
         .verify_signed_info_without_attestation()
         .map_err(|e| anyhow!("verify GuardianInfo signature: {e:?}"))?;
     let session_id = verified.session_id;

--- a/crates/hashi-guardian-init/src/dev_bootstrap.rs
+++ b/crates/hashi-guardian-init/src/dev_bootstrap.rs
@@ -34,7 +34,6 @@ use hashi_types::guardian::crypto::commit_share;
 use hashi_types::guardian::crypto::split_secret;
 use hashi_types::guardian::proto_conversions::provisioner_init_request_to_pb;
 use hashi_types::guardian::proto_conversions::withdraw_mode_config_to_pb;
-use hashi_types::guardian::session_id_from_signing_pubkey;
 use hashi_types::proto as pb;
 use hashi_types::proto::guardian_service_client::GuardianServiceClient;
 use hpke::Deserializable;
@@ -178,7 +177,6 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
         .into_inner();
     let resp = GetGuardianInfoResponse::try_from(info_pb)
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
-    let session_id = session_id_from_signing_pubkey(&resp.signing_pub_key);
 
     // Verify the enclave's own signature on the info — without this the
     // `encryption_pubkey` below would be unauthenticated and a buggy or
@@ -194,10 +192,11 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
     // capture `t` encrypted shares. The current deployment runs the
     // guardian in a k8s cluster — the attestation gate lands when we move
     // to Nitro.
-    let info = resp
-        .signed_info
-        .verify(&resp.signing_pub_key)
-        .map_err(|e| anyhow!("verify GuardianInfo signature (session={session_id}): {e:?}"))?;
+    let verified = resp
+        .verify_signed_info_without_attestation()
+        .map_err(|e| anyhow!("verify GuardianInfo signature: {e:?}"))?;
+    let session_id = verified.session_id;
+    let info = verified.info;
 
     // Match against what we just sent in OperatorInit. Catches a stale or
     // wrong enclave echoing back a different config than the one we set up.
@@ -260,7 +259,10 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
         .into_inner();
     let post_resp = GetGuardianInfoResponse::try_from(post_resp_pb)
         .map_err(|e| anyhow!("decode post-ProvisionerInit GetGuardianInfoResponse: {e:?}"))?;
-    let post_session_id = session_id_from_signing_pubkey(&post_resp.signing_pub_key);
+    let post_session_id = post_resp
+        .verify_signed_info_without_attestation()
+        .map_err(|e| anyhow!("verify post-ProvisionerInit GuardianInfo signature: {e:?}"))?
+        .session_id;
     anyhow::ensure!(
         post_session_id == session_id,
         "guardian session changed mid-bootstrap: started {session_id}, now {post_session_id} \

--- a/crates/hashi-guardian-init/src/dev_bootstrap.rs
+++ b/crates/hashi-guardian-init/src/dev_bootstrap.rs
@@ -193,6 +193,7 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
     // guardian in a k8s cluster — the attestation gate lands when we move
     // to Nitro.
     let verified = resp
+        // TODO: Thread PCR config into dev bootstrap and use `verify` for attestation/PCR checks.
         .verify_signed_info_without_attestation()
         .map_err(|e| anyhow!("verify GuardianInfo signature: {e:?}"))?;
     let session_id = verified.session_id;
@@ -260,6 +261,7 @@ pub async fn run(args: Args, onchain_state: &OnchainState) -> Result<()> {
     let post_resp = GetGuardianInfoResponse::try_from(post_resp_pb)
         .map_err(|e| anyhow!("decode post-ProvisionerInit GetGuardianInfoResponse: {e:?}"))?;
     let post_session_id = post_resp
+        // TODO: Reuse dev bootstrap PCR config here and use `verify` for attestation/PCR checks.
         .verify_signed_info_without_attestation()
         .map_err(|e| anyhow!("verify post-ProvisionerInit GuardianInfo signature: {e:?}"))?
         .session_id;

--- a/crates/hashi-guardian-init/src/fetch_info.rs
+++ b/crates/hashi-guardian-init/src/fetch_info.rs
@@ -48,6 +48,7 @@ pub async fn run(args: Args) -> Result<()> {
     let verified = GetGuardianInfoResponse::try_from(resp)
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
     let verified = verified
+        // TODO: Accept PCR config here and use `verify` for attestation/PCR checks.
         .verify_signed_info_without_attestation()
         .map_err(|e| anyhow!("verify GuardianInfo signature: {e:?}"))?;
     match args.field {

--- a/crates/hashi-guardian-init/src/fetch_info.rs
+++ b/crates/hashi-guardian-init/src/fetch_info.rs
@@ -45,14 +45,17 @@ pub async fn run(args: Args) -> Result<()> {
         .await
         .context("GetGuardianInfo RPC failed")?
         .into_inner();
-    let info = GetGuardianInfoResponse::try_from(resp)
+    let verified = GetGuardianInfoResponse::try_from(resp)
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
+    let verified = verified
+        .verify_signed_info_without_attestation()
+        .map_err(|e| anyhow!("verify GuardianInfo signature: {e:?}"))?;
     match args.field {
         Field::SigningPubKey => {
-            println!("{}", hex::encode(info.signing_pub_key.as_bytes()));
+            println!("{}", hex::encode(verified.signing_pub_key.as_bytes()));
         }
         Field::EnclaveBtcPubkey => {
-            let btc_pk = info.signed_info.data.enclave_btc_pubkey.ok_or_else(|| {
+            let btc_pk = verified.info.enclave_btc_pubkey.ok_or_else(|| {
                 anyhow!(
                     "guardian /info did not return enclave_btc_pubkey; \
                      provisioner_init may not have completed"

--- a/crates/hashi-guardian-init/src/provisioner.rs
+++ b/crates/hashi-guardian-init/src/provisioner.rs
@@ -11,7 +11,6 @@ use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::ProvisionerInitRequest;
 use hashi_types::guardian::WithdrawModeState;
-use hashi_types::guardian::session_id_from_signing_pubkey;
 use hashi_types::proto as pb;
 use hpke::Deserializable;
 use rand::thread_rng;
@@ -230,11 +229,12 @@ async fn prechecks(
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
     // Attestation-anchored, signature-verified GuardianInfo in one call.
-    let info = resp
+    let verified = resp
         .verify(build_pcrs)
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    let info = verified.info;
 
-    let actual_session_id = session_id_from_signing_pubkey(&resp.signing_pub_key);
+    let actual_session_id = verified.session_id;
     anyhow::ensure!(
         actual_session_id == expected_session_id,
         "relay endpoint session mismatch: expected {}, got {}",

--- a/crates/hashi-guardian/src/attestation.rs
+++ b/crates/hashi-guardian/src/attestation.rs
@@ -5,9 +5,9 @@
 //! Module hardware; the `non-enclave-dev` feature and `cfg(test)` route to a
 //! mock document instead.
 
-use hashi_types::guardian::Attestation;
 use hashi_types::guardian::GuardianPubKey;
 use hashi_types::guardian::GuardianResult;
+use hashi_types::guardian::NitroAttestation;
 
 #[cfg(not(any(test, feature = "non-enclave-dev")))]
 use hashi_types::guardian::GuardianError;
@@ -26,7 +26,7 @@ use tracing::info;
 
 /// Returns an attestation document committed to the enclave's signing public key.
 #[cfg(not(any(test, feature = "non-enclave-dev")))]
-pub fn get_attestation(signing_pk: &GuardianPubKey) -> GuardianResult<Attestation> {
+pub fn get_attestation(signing_pk: &GuardianPubKey) -> GuardianResult<NitroAttestation> {
     let signing_pk_bytes = signing_pk.to_bytes();
 
     info!("Initializing NSM driver.");
@@ -45,7 +45,7 @@ pub fn get_attestation(signing_pk: &GuardianPubKey) -> GuardianResult<Attestatio
         NsmResponse::Attestation { document } => {
             driver::nsm_exit(fd);
             info!("Attestation document generated ({} bytes).", document.len());
-            Ok(document)
+            Ok(NitroAttestation::new(document))
         }
         _ => {
             driver::nsm_exit(fd);
@@ -58,6 +58,8 @@ pub fn get_attestation(signing_pk: &GuardianPubKey) -> GuardianResult<Attestatio
 }
 
 #[cfg(any(test, feature = "non-enclave-dev"))]
-pub fn get_attestation(_: &GuardianPubKey) -> GuardianResult<Attestation> {
-    Ok(b"mock_attestation_document_hex".to_vec())
+pub fn get_attestation(_: &GuardianPubKey) -> GuardianResult<NitroAttestation> {
+    Ok(NitroAttestation::new(
+        b"mock_attestation_document_hex".to_vec(),
+    ))
 }

--- a/crates/hashi-guardian/src/info.rs
+++ b/crates/hashi-guardian/src/info.rs
@@ -15,7 +15,7 @@ pub async fn get_guardian_info(enclave: Arc<Enclave>) -> GuardianResult<GetGuard
 
     let signing_pub_key = enclave.signing_pubkey();
     let attestation = get_attestation(&signing_pub_key)?;
-    Ok(GetGuardianInfoResponse::from_raw_parts(
+    Ok(GetGuardianInfoResponse::new(
         attestation,
         signing_pub_key,
         enclave.sign(enclave.info().await),

--- a/crates/hashi-guardian/src/info.rs
+++ b/crates/hashi-guardian/src/info.rs
@@ -15,10 +15,10 @@ pub async fn get_guardian_info(enclave: Arc<Enclave>) -> GuardianResult<GetGuard
 
     let signing_pub_key = enclave.signing_pubkey();
     let attestation = get_attestation(&signing_pub_key)?;
-    Ok(GetGuardianInfoResponse {
+    Ok(GetGuardianInfoResponse::from_raw_parts(
         attestation,
         signing_pub_key,
-        signed_info: enclave.sign(enclave.info().await),
-        encrypted_shares: enclave.latest_encrypted_shares(),
-    })
+        enclave.sign(enclave.info().await),
+        enclave.latest_encrypted_shares(),
+    ))
 }

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -18,7 +18,6 @@ use aws_sdk_s3::types::ObjectLockEnabled;
 use aws_sdk_s3::types::ObjectLockMode;
 use aws_sdk_s3::Client as S3Client;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
-use hashi_types::guardian::verify_enclave_attestation;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::GuardianError::S3Error;
 use hashi_types::guardian::GuardianPubKey;
@@ -551,7 +550,7 @@ impl GuardianS3Client {
                 _ => None,
             })
             .ok_or_else(|| S3Error(format!("expected OIAttestationUnsigned at key {}", key)))?;
-        verify_enclave_attestation(&attestation, &signing_public_key, build_pcrs)?;
+        attestation.verify(&signing_public_key, build_pcrs)?;
         Ok(signing_public_key)
     }
 }

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::GuardianPubKey;
+use super::GuardianResult;
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
+use super::errors::GuardianError::InvalidInputs;
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
+use super::time_utils::now_timestamp_ms;
+
+/// Raw AWS Nitro attestation document bytes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NitroAttestation(Vec<u8>);
+
+impl NitroAttestation {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    /// Verify this Nitro attestation document (COSE signature + AWS cert chain
+    /// to the Nitro root + freshness), that it commits to `signing_pubkey`, and
+    /// that its PCR0 matches `build_pcrs`.
+    pub fn verify(
+        &self,
+        signing_pubkey: &GuardianPubKey,
+        build_pcrs: &BuildPcrs,
+    ) -> GuardianResult<()> {
+        #[cfg(any(test, feature = "non-enclave-dev"))]
+        {
+            let _ = (signing_pubkey, build_pcrs);
+            Ok(())
+        }
+        #[cfg(not(any(test, feature = "non-enclave-dev")))]
+        {
+            use fastcrypto::nitro_attestation::parse_nitro_attestation;
+            use fastcrypto::nitro_attestation::verify_nitro_attestation;
+
+            // Bools: (is_upgraded_parsing, include_all_nonzero_pcrs,
+            // always_include_required_pcrs). The last keeps PCR0 in `pcr_map` even if
+            // zero, so the pin below can't be bypassed by a missing entry.
+            let (signature, signed_message, doc) =
+                parse_nitro_attestation(&self.0, true, true, true)
+                    .map_err(|e| InvalidInputs(format!("attestation parse failed: {e}")))?;
+            verify_nitro_attestation(&signature, &signed_message, &doc, now_timestamp_ms())
+                .map_err(|e| InvalidInputs(format!("attestation verification failed: {e}")))?;
+
+            let attested = doc
+                .public_key
+                .ok_or_else(|| InvalidInputs("attestation has no public_key".into()))?;
+            if attested != signing_pubkey.to_bytes() {
+                return Err(InvalidInputs(
+                    "attestation public_key does not match the session signing pubkey".into(),
+                ));
+            }
+
+            // Pin PCR0 (the whole EIF image hash).
+            if doc.pcr_map.get(&0).map(Vec::as_slice) != Some(build_pcrs.pcr0()) {
+                return Err(InvalidInputs(
+                    "attestation PCR0 does not match the expected enclave image".into(),
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Known-good Nitro measurement an attestation is pinned to. Construction
+/// mandates PCR0 - the hash of the whole enclave image (EIF), which uniquely
+/// identifies the build - so a pinning policy can never omit it.
+///
+/// We record only PCR0: in a StageX (reproducible, single-binary) build it is
+/// the only measurement that carries signal - the others (kernel, bootloader,
+/// IAM role) are constant or irrelevant for our pinning.
+///
+/// TODO: holds only a single PCR0, so it can't accept the two valid measurements
+/// that briefly coexist during a software upgrade (old + new image), nor pin
+/// additional PCRs. A `commit -> PCRs` allowlist keyed on `untrusted_git_revision`
+/// is the follow-up.
+#[derive(Debug, Clone)]
+pub struct BuildPcrs {
+    pcr0: Vec<u8>,
+}
+
+impl BuildPcrs {
+    pub fn new(pcr0: Vec<u8>) -> Self {
+        Self { pcr0 }
+    }
+
+    pub fn pcr0(&self) -> &[u8] {
+        &self.pcr0
+    }
+}
+
+/// Deserialize from a hex string (optional `0x` prefix) - the form config files
+/// pin PCR0 in.
+impl<'de> Deserialize<'de> for BuildPcrs {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let hex_str = String::deserialize(deserializer)?;
+        let pcr0 =
+            hex::decode(hex_str.trim_start_matches("0x")).map_err(serde::de::Error::custom)?;
+        Ok(Self { pcr0 })
+    }
+}

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -150,6 +150,7 @@ mod tests {
     use crate::guardian::InitLogMessage;
     use crate::guardian::KPEncryptedShares;
     use crate::guardian::LimiterState;
+    use crate::guardian::NitroAttestation;
     use crate::guardian::StandardWithdrawalRequest;
     use crate::guardian::StandardWithdrawalRequestWire;
     use crate::guardian::StandardWithdrawalResponse;
@@ -170,7 +171,7 @@ mod tests {
         let mut log = LogRecord::new(
             session_id.clone(),
             LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
-                attestation: vec![1, 2, 3],
+                attestation: NitroAttestation::new(vec![1, 2, 3]),
                 signing_public_key: signing_key.verification_key(),
             })),
             &signing_key,

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -12,13 +12,13 @@ use super::S3_DIR_INIT;
 use super::S3_DIR_SHARES;
 use super::S3_DIR_WITHDRAW;
 use crate::committee::CommitteeSignature;
-use crate::guardian::Attestation;
 use crate::guardian::GuardianError;
 use crate::guardian::GuardianInfo;
 use crate::guardian::GuardianPubKey;
 use crate::guardian::KPEncryptedShares;
 use crate::guardian::KPFingerprint;
 use crate::guardian::LimiterState;
+use crate::guardian::NitroAttestation;
 use crate::guardian::SecretSharingInstance;
 use crate::guardian::ShareID;
 use crate::guardian::StandardWithdrawalRequestWire;
@@ -101,7 +101,7 @@ impl CeremonyLogMessage {
 pub enum InitLogMessage {
     /// Attestation and signing public key posted in /operator_init
     OIAttestationUnsigned {
-        attestation: Attestation,
+        attestation: NitroAttestation,
         signing_public_key: GuardianPubKey,
     },
     /// Signed GuardianInfo logged in /operator_init (secret-sharing instance,

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -813,6 +813,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn get_guardian_info_verify_signed_info_passes_for_valid_signature() {
+        let resp = GetGuardianInfoResponse::mock_for_testing();
+        let verified = resp.verify_signed_info_without_attestation().unwrap();
+
+        assert_eq!(verified.signing_pub_key, resp.signing_pub_key);
+        assert_eq!(
+            verified.session_id,
+            session_id_from_signing_pubkey(&resp.signing_pub_key)
+        );
+        assert_eq!(verified.info, resp.signed_info.data);
+        assert_eq!(verified.encrypted_shares, resp.encrypted_shares);
+    }
+
+    #[test]
+    fn get_guardian_info_verify_signed_info_fails_when_pubkey_did_not_sign() {
+        let mut resp = GetGuardianInfoResponse::mock_for_testing();
+        let wrong_signing_key = GuardianSignKeyPair::new(rand::thread_rng());
+        resp.signing_pub_key = wrong_signing_key.verification_key();
+
+        assert!(matches!(
+            resp.verify_signed_info_without_attestation().unwrap_err(),
+            InvalidInputs(_)
+        ));
+    }
+
+    #[test]
+    fn get_guardian_info_verify_signed_info_fails_when_signature_tampered() {
+        let mut resp = GetGuardianInfoResponse::mock_for_testing();
+        let mut sig_bytes: [u8; 64] = resp.signed_info.signature.to_bytes();
+        sig_bytes[0] ^= 0xff;
+        resp.signed_info.signature = GuardianSignature::from(sig_bytes);
+
+        assert!(matches!(
+            resp.verify_signed_info_without_attestation().unwrap_err(),
+            InvalidInputs(_)
+        ));
+    }
+
+    #[test]
     fn rotate_kps_state_new_rejects_wrong_cert_count() {
         let mut certs = test_utils::mock_pgp_certs(5);
         certs.pop();

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -676,7 +676,7 @@ impl GuardianInfo {
 }
 
 impl GetGuardianInfoResponse {
-    pub fn from_raw_parts(
+    pub fn new(
         attestation: Attestation,
         signing_pub_key: GuardianPubKey,
         signed_info: GuardianSigned<GuardianInfo>,

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod attestation;
 pub mod crypto;
 pub mod errors;
 pub mod log;
@@ -12,6 +13,8 @@ pub mod time_utils;
 pub mod limiter;
 pub mod s3_utils;
 
+pub use attestation::BuildPcrs;
+pub use attestation::NitroAttestation;
 pub use limiter::LimiterConfig;
 pub use limiter::LimiterState;
 pub use limiter::RateLimiter;
@@ -91,7 +94,7 @@ pub struct OperatorInitRequest {
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetGuardianInfoResponse {
     /// AWS Nitro attestation
-    attestation: Attestation,
+    attestation: NitroAttestation,
     /// Signing pub key of the guardian
     signing_pub_key: GuardianPubKey,
     /// Signed guardian info
@@ -272,8 +275,6 @@ pub struct RotateKpsResponse {
 /// 32-byte UID of the on-chain `WithdrawalTransaction` Sui object.
 /// Used to correlate events across Sui, hashi nodes, and the guardian.
 pub type WithdrawalID = sui_sdk_types::Address;
-
-pub type Attestation = Vec<u8>;
 
 /// Guardian session identifier — a short prefix of the hex-encoded signing
 /// pubkey (see [`session_id_from_signing_pubkey`]). Tags per-session S3 objects.
@@ -677,7 +678,7 @@ impl GuardianInfo {
 
 impl GetGuardianInfoResponse {
     pub fn new(
-        attestation: Attestation,
+        attestation: NitroAttestation,
         signing_pub_key: GuardianPubKey,
         signed_info: GuardianSigned<GuardianInfo>,
         encrypted_shares: KPEncryptedShares,
@@ -694,11 +695,11 @@ impl GetGuardianInfoResponse {
     /// the attestation anchors `signing_pub_key`, and `signed_info` must be
     /// signed by it.
     pub fn verify(&self, build_pcrs: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
-        verify_enclave_attestation(&self.attestation, &self.signing_pub_key, build_pcrs)?;
+        self.attestation.verify(&self.signing_pub_key, build_pcrs)?;
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
         Ok(VerifiedGuardianInfo {
             info,
-            signing_pub_key: self.signing_pub_key.clone(),
+            signing_pub_key: self.signing_pub_key,
             session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
             encrypted_shares: self.encrypted_shares.clone(),
         })
@@ -712,98 +713,10 @@ impl GetGuardianInfoResponse {
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
         Ok(VerifiedGuardianInfo {
             info,
-            signing_pub_key: self.signing_pub_key.clone(),
+            signing_pub_key: self.signing_pub_key,
             session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
             encrypted_shares: self.encrypted_shares.clone(),
         })
-    }
-}
-
-/// Known-good Nitro measurement an attestation is pinned to. Construction
-/// mandates PCR0 — the hash of the whole enclave image (EIF), which uniquely
-/// identifies the build — so a pinning policy can never omit it.
-///
-/// We record only PCR0: in a StageX (reproducible, single-binary) build it is
-/// the only measurement that carries signal — the others (kernel, bootloader,
-/// IAM role) are constant or irrelevant for our pinning.
-///
-/// TODO: holds only a single PCR0, so it can't accept the two valid measurements
-/// that briefly coexist during a software upgrade (old + new image), nor pin
-/// additional PCRs. A `commit -> PCRs` allowlist keyed on `untrusted_git_revision`
-/// is the follow-up.
-#[derive(Debug, Clone)]
-pub struct BuildPcrs {
-    pcr0: Vec<u8>,
-}
-
-impl BuildPcrs {
-    pub fn new(pcr0: Vec<u8>) -> Self {
-        Self { pcr0 }
-    }
-
-    pub fn pcr0(&self) -> &[u8] {
-        &self.pcr0
-    }
-}
-
-/// Deserialize from a hex string (optional `0x` prefix) — the form config files
-/// pin PCR0 in.
-impl<'de> Deserialize<'de> for BuildPcrs {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let hex_str = String::deserialize(deserializer)?;
-        let pcr0 =
-            hex::decode(hex_str.trim_start_matches("0x")).map_err(serde::de::Error::custom)?;
-        Ok(Self { pcr0 })
-    }
-}
-
-/// Verify a Nitro attestation document (COSE signature + AWS cert chain to the
-/// Nitro root + freshness) and that it commits to `signing_pubkey` — the enclave
-/// binds its signing key as the document's `public_key`.
-///
-/// In non-enclave dev/test builds the enclave emits a mock document, so this is a
-/// no-op, mirroring [`crate`]'s `get_attestation` `non-enclave-dev` stub. Real
-/// verification runs only in enclave (prod) builds.
-pub fn verify_enclave_attestation(
-    attestation: &[u8],
-    signing_pubkey: &GuardianPubKey,
-    build_pcrs: &BuildPcrs,
-) -> GuardianResult<()> {
-    #[cfg(any(test, feature = "non-enclave-dev"))]
-    {
-        let _ = (attestation, signing_pubkey, build_pcrs);
-        Ok(())
-    }
-    #[cfg(not(any(test, feature = "non-enclave-dev")))]
-    {
-        use fastcrypto::nitro_attestation::parse_nitro_attestation;
-        use fastcrypto::nitro_attestation::verify_nitro_attestation;
-
-        // Bools: (is_upgraded_parsing, include_all_nonzero_pcrs,
-        // always_include_required_pcrs). The last keeps PCR0 in `pcr_map` even if
-        // zero, so the pin below can't be bypassed by a missing entry.
-        let (signature, signed_message, doc) =
-            parse_nitro_attestation(attestation, true, true, true)
-                .map_err(|e| InvalidInputs(format!("attestation parse failed: {e}")))?;
-        verify_nitro_attestation(&signature, &signed_message, &doc, now_timestamp_ms())
-            .map_err(|e| InvalidInputs(format!("attestation verification failed: {e}")))?;
-
-        let attested = doc
-            .public_key
-            .ok_or_else(|| InvalidInputs("attestation has no public_key".into()))?;
-        if attested != signing_pubkey.to_bytes() {
-            return Err(InvalidInputs(
-                "attestation public_key does not match the session signing pubkey".into(),
-            ));
-        }
-
-        // Pin PCR0 (the whole EIF image hash).
-        if doc.pcr_map.get(&0).map(Vec::as_slice) != Some(build_pcrs.pcr0()) {
-            return Err(InvalidInputs(
-                "attestation PCR0 does not match the expected enclave image".into(),
-            ));
-        }
-        Ok(())
     }
 }
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -696,13 +696,7 @@ impl GetGuardianInfoResponse {
     /// signed by it.
     pub fn verify(&self, build_pcrs: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
         self.attestation.verify(&self.signing_pub_key, build_pcrs)?;
-        let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
-        Ok(VerifiedGuardianInfo {
-            info,
-            signing_pub_key: self.signing_pub_key,
-            session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
-            encrypted_shares: self.encrypted_shares.clone(),
-        })
+        self.verify_signed_info_without_attestation()
     }
 
     /// Verify only the signed `GuardianInfo` payload.
@@ -824,6 +818,19 @@ mod tests {
         );
         assert_eq!(verified.info, resp.signed_info.data);
         assert_eq!(verified.encrypted_shares, resp.encrypted_shares);
+    }
+
+    #[test]
+    fn get_guardian_info_verify_uses_signed_info_verification() {
+        let mut resp = GetGuardianInfoResponse::mock_for_testing();
+        let mut sig_bytes: [u8; 64] = resp.signed_info.signature.to_bytes();
+        sig_bytes[0] ^= 0xff;
+        resp.signed_info.signature = GuardianSignature::from(sig_bytes);
+
+        assert!(matches!(
+            resp.verify(&BuildPcrs::new(vec![0])).unwrap_err(),
+            InvalidInputs(_)
+        ));
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -696,7 +696,12 @@ impl GetGuardianInfoResponse {
     pub fn verify(&self, build_pcrs: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
         verify_enclave_attestation(&self.attestation, &self.signing_pub_key, build_pcrs)?;
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
-        Ok(self.verified_info(info))
+        Ok(VerifiedGuardianInfo {
+            info,
+            signing_pub_key: self.signing_pub_key.clone(),
+            session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
+            encrypted_shares: self.encrypted_shares.clone(),
+        })
     }
 
     /// Verify only the signed `GuardianInfo` payload.
@@ -705,16 +710,12 @@ impl GetGuardianInfoResponse {
     /// PCRs. Prefer [`Self::verify`] whenever the caller has PCR config.
     pub fn verify_signed_info_without_attestation(&self) -> GuardianResult<VerifiedGuardianInfo> {
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
-        Ok(self.verified_info(info))
-    }
-
-    fn verified_info(&self, info: GuardianInfo) -> VerifiedGuardianInfo {
-        VerifiedGuardianInfo {
+        Ok(VerifiedGuardianInfo {
             info,
             signing_pub_key: self.signing_pub_key.clone(),
             session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
             encrypted_shares: self.encrypted_shares.clone(),
-        }
+        })
     }
 }
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -91,13 +91,21 @@ pub struct OperatorInitRequest {
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetGuardianInfoResponse {
     /// AWS Nitro attestation
-    pub attestation: Attestation,
+    attestation: Attestation,
     /// Signing pub key of the guardian
-    pub signing_pub_key: GuardianPubKey,
+    signing_pub_key: GuardianPubKey,
     /// Signed guardian info
-    pub signed_info: GuardianSigned<GuardianInfo>,
+    signed_info: GuardianSigned<GuardianInfo>,
     /// Encrypted shares from the ceremony (empty in non-ceremony mode); KPs
     /// fetch their share here and verify it against the instance commitments.
+    encrypted_shares: KPEncryptedShares,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct VerifiedGuardianInfo {
+    pub info: GuardianInfo,
+    pub signing_pub_key: GuardianPubKey,
+    pub session_id: SessionID,
     pub encrypted_shares: KPEncryptedShares,
 }
 
@@ -668,13 +676,45 @@ impl GuardianInfo {
 }
 
 impl GetGuardianInfoResponse {
-    /// Verify the response end to end and return the trusted `GuardianInfo`: the
-    /// attestation anchors `signing_pub_key`, and `signed_info` must be signed by
-    /// it. Self-contained so any caller (KP init, hashi nodes) can turn an
-    /// untrusted response into a trusted `GuardianInfo` in one call.
-    pub fn verify(&self, build_pcrs: &BuildPcrs) -> GuardianResult<GuardianInfo> {
+    pub fn from_raw_parts(
+        attestation: Attestation,
+        signing_pub_key: GuardianPubKey,
+        signed_info: GuardianSigned<GuardianInfo>,
+        encrypted_shares: KPEncryptedShares,
+    ) -> Self {
+        Self {
+            attestation,
+            signing_pub_key,
+            signed_info,
+            encrypted_shares,
+        }
+    }
+
+    /// Verify the response end to end and return the trusted guardian payload:
+    /// the attestation anchors `signing_pub_key`, and `signed_info` must be
+    /// signed by it.
+    pub fn verify(&self, build_pcrs: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
         verify_enclave_attestation(&self.attestation, &self.signing_pub_key, build_pcrs)?;
-        self.signed_info.clone().verify(&self.signing_pub_key)
+        let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
+        Ok(self.verified_info(info))
+    }
+
+    /// Verify only the signed `GuardianInfo` payload.
+    ///
+    /// This does not authenticate the enclave image, the Nitro attestation, or
+    /// PCRs. Prefer [`Self::verify`] whenever the caller has PCR config.
+    pub fn verify_signed_info_without_attestation(&self) -> GuardianResult<VerifiedGuardianInfo> {
+        let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
+        Ok(self.verified_info(info))
+    }
+
+    fn verified_info(&self, info: GuardianInfo) -> VerifiedGuardianInfo {
+        VerifiedGuardianInfo {
+            info,
+            signing_pub_key: self.signing_pub_key.clone(),
+            session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
+            encrypted_shares: self.encrypted_shares.clone(),
+        }
     }
 }
 

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -328,7 +328,7 @@ impl TryFrom<pb::GetGuardianInfoResponse> for GetGuardianInfoResponse {
             .collect::<GuardianResult<Vec<_>>>()?;
         let encrypted_shares = KPEncryptedShares::new(encrypted_shares)?;
 
-        Ok(GetGuardianInfoResponse::from_raw_parts(
+        Ok(GetGuardianInfoResponse::new(
             attestation.to_vec(),
             signing_pub_key,
             signed_info,

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -23,6 +23,7 @@ use super::KPEncryptedShare;
 use super::KPEncryptedShares;
 use super::LimiterConfig;
 use super::LimiterState;
+use super::NitroAttestation;
 use super::OperatorInitRequest;
 use super::ProvisionerInitRequest;
 use super::RotateKpsRequest;
@@ -329,7 +330,7 @@ impl TryFrom<pb::GetGuardianInfoResponse> for GetGuardianInfoResponse {
         let encrypted_shares = KPEncryptedShares::new(encrypted_shares)?;
 
         Ok(GetGuardianInfoResponse::new(
-            attestation.to_vec(),
+            NitroAttestation::new(attestation.to_vec()),
             signing_pub_key,
             signed_info,
             encrypted_shares,
@@ -506,7 +507,7 @@ pub fn rotate_kps_request_to_pb(r: RotateKpsRequest) -> pb::RotateKpsRequest {
 
 pub fn get_guardian_info_response_to_pb(r: GetGuardianInfoResponse) -> pb::GetGuardianInfoResponse {
     pb::GetGuardianInfoResponse {
-        attestation: Some(r.attestation.into()),
+        attestation: Some(r.attestation.into_bytes().into()),
         signing_pub_key: Some(r.signing_pub_key.to_bytes().to_vec().into()),
         signed_info: Some(signed_guardian_info_to_pb(r.signed_info)),
         encrypted_shares: r

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -328,12 +328,12 @@ impl TryFrom<pb::GetGuardianInfoResponse> for GetGuardianInfoResponse {
             .collect::<GuardianResult<Vec<_>>>()?;
         let encrypted_shares = KPEncryptedShares::new(encrypted_shares)?;
 
-        Ok(GetGuardianInfoResponse {
-            attestation: attestation.to_vec(),
+        Ok(GetGuardianInfoResponse::from_raw_parts(
+            attestation.to_vec(),
             signing_pub_key,
             signed_info,
             encrypted_shares,
-        })
+        ))
     }
 }
 

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -93,12 +93,12 @@ impl GetGuardianInfoResponse {
             mpc_master_g: None,
         };
 
-        GetGuardianInfoResponse {
-            attestation: "abcd".as_bytes().to_vec(),
+        GetGuardianInfoResponse::from_raw_parts(
+            "abcd".as_bytes().to_vec(),
             signing_pub_key,
-            signed_info: GuardianSigned::new(info, &signing_key, 1234),
-            encrypted_shares: dummy_encrypted_shares(),
-        }
+            GuardianSigned::new(info, &signing_key, 1234),
+            dummy_encrypted_shares(),
+        )
     }
 }
 

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -93,7 +93,7 @@ impl GetGuardianInfoResponse {
             mpc_master_g: None,
         };
 
-        GetGuardianInfoResponse::from_raw_parts(
+        GetGuardianInfoResponse::new(
             "abcd".as_bytes().to_vec(),
             signing_pub_key,
             GuardianSigned::new(info, &signing_key, 1234),

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -13,6 +13,7 @@ use super::KPEncryptedShare;
 use super::KPEncryptedShares;
 use super::LimiterConfig;
 use super::LimiterState;
+use super::NitroAttestation;
 use super::OperatorInitRequest;
 use super::ProvisionerInitRequest;
 use super::RotateKpsResponse;
@@ -94,7 +95,7 @@ impl GetGuardianInfoResponse {
         };
 
         GetGuardianInfoResponse::new(
-            "abcd".as_bytes().to_vec(),
+            NitroAttestation::new("abcd".as_bytes().to_vec()),
             signing_pub_key,
             GuardianSigned::new(info, &signing_key, 1234),
             dummy_encrypted_shares(),

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -822,9 +822,13 @@ impl Hashi {
         }
     }
 
-    /// The one trusted entry point for guardian `/info`: fetch, verify the
-    /// signature, pin the signing pubkey to on-chain, and return the *verified*
+    /// The guarded entry point for guardian `/info`: fetch, verify the signed
+    /// payload, pin the signing pubkey to on-chain, and return that verified
     /// `GuardianInfo`. Callers must read guardian state only through this.
+    ///
+    /// TODO: Thread PCR config into Hashi nodes and use `verify` here so this
+    /// also authenticates the Nitro attestation/PCRs.
+    ///
     /// Records the matching bootstrap-outcome metric on each failure.
     async fn fetch_verified_guardian_info(
         &self,
@@ -841,7 +845,6 @@ impl Hashi {
                 );
                 anyhow::anyhow!("parse GetGuardianInfoResponse: {e:?}")
             })?;
-        // TODO: Thread PCR config into Hashi nodes and use `verify` for attestation/PCR checks.
         let verified = resp.verify_signed_info_without_attestation().map_err(|e| {
             self.metrics.record_guardian_bootstrap_outcome(
                 metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -841,6 +841,7 @@ impl Hashi {
                 );
                 anyhow::anyhow!("parse GetGuardianInfoResponse: {e:?}")
             })?;
+        // TODO: Thread PCR config into Hashi nodes and use `verify` for attestation/PCR checks.
         let verified = resp.verify_signed_info_without_attestation().map_err(|e| {
             self.metrics.record_guardian_bootstrap_outcome(
                 metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -1060,29 +1060,6 @@ fn assert_test_only_config(sui_chain_id: &str, bitcoin_chain_id: &str, field_nam
     );
 }
 
-/// Verify the signature on the guardian's `/info` envelope under its
-/// own `signing_pub_key`. Caller is responsible for verifying that the
-/// pubkey itself matches on-chain first; this is the second leg of the
-/// trust chain (signed_info → enclave that holds the on-chain pubkey).
-#[cfg(test)]
-fn verify_guardian_signed_info(
-    signed_info: hashi_types::guardian::GuardianSigned<hashi_types::guardian::GuardianInfo>,
-    signing_pub_key: &hashi_types::guardian::GuardianPubKey,
-    metrics: &metrics::Metrics,
-) -> anyhow::Result<hashi_types::guardian::GuardianInfo> {
-    signed_info.verify(signing_pub_key).map_err(|e| {
-        metrics.record_guardian_bootstrap_outcome(
-            metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID,
-        );
-        tracing::error!(
-            error = ?e,
-            "FATAL: guardian /info signed_info signature invalid under its own \
-             signing_pub_key; refusing to seed or reconcile local limiter",
-        );
-        anyhow::anyhow!("guardian signed_info signature invalid")
-    })
-}
-
 /// `expected = None` skips the check (pre-feature chains).
 fn verify_signing_pub_key_matches(
     signing_pub_key: &hashi_types::guardian::GuardianPubKey,
@@ -1411,33 +1388,9 @@ mod test {
             .get()
     }
 
-    fn signature_invalid_count(metrics: &crate::metrics::Metrics) -> u64 {
-        metrics
-            .guardian_bootstrap_outcomes_total
-            .with_label_values(&[crate::metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID])
-            .get()
-    }
-
     fn random_signing_pubkey() -> hashi_types::guardian::GuardianPubKey {
         let signing_key = hashi_types::guardian::GuardianSignKeyPair::new(rand::thread_rng());
         signing_key.verification_key()
-    }
-
-    fn signed_guardian_info_for_test() -> (
-        hashi_types::guardian::GuardianSigned<hashi_types::guardian::GuardianInfo>,
-        hashi_types::guardian::GuardianPubKey,
-    ) {
-        let resp = hashi_types::guardian::GetGuardianInfoResponse::mock_for_testing();
-        let info = resp
-            .verify_signed_info_without_attestation()
-            .expect("mock /info must verify")
-            .info;
-        let signing_key = hashi_types::guardian::GuardianSignKeyPair::from([2u8; 32]);
-        let signing_pub_key = signing_key.verification_key();
-        (
-            hashi_types::guardian::GuardianSigned::new(info, &signing_key, 1234),
-            signing_pub_key,
-        )
     }
 
     #[test]
@@ -1475,42 +1428,6 @@ mod test {
             &metrics
         ));
         assert_eq!(key_mismatch_count(&metrics), 1);
-    }
-
-    #[test]
-    fn verify_guardian_signed_info_passes_for_valid_signature() {
-        let (signed_info, signing_pub_key) = signed_guardian_info_for_test();
-        let metrics = fresh_metrics();
-        assert!(
-            crate::verify_guardian_signed_info(signed_info, &signing_pub_key, &metrics,).is_ok()
-        );
-        assert_eq!(signature_invalid_count(&metrics), 0);
-    }
-
-    #[test]
-    fn verify_guardian_signed_info_fails_when_pubkey_did_not_sign() {
-        // Mock signs with key A, exposes pub_key_A. Verify under pub_key_B
-        // (random) — must fail and bump the metric.
-        let (signed_info, _) = signed_guardian_info_for_test();
-        let wrong_pubkey = random_signing_pubkey();
-        let metrics = fresh_metrics();
-        assert!(crate::verify_guardian_signed_info(signed_info, &wrong_pubkey, &metrics,).is_err());
-        assert_eq!(signature_invalid_count(&metrics), 1);
-    }
-
-    #[test]
-    fn verify_guardian_signed_info_fails_when_signature_tampered() {
-        let (mut signed_info, signing_pub_key) = signed_guardian_info_for_test();
-        // Flip a byte of the signature so verification under the original
-        // pubkey now fails.
-        let mut sig_bytes: [u8; 64] = signed_info.signature.to_bytes();
-        sig_bytes[0] ^= 0xff;
-        signed_info.signature = hashi_types::guardian::GuardianSignature::from(sig_bytes);
-        let metrics = fresh_metrics();
-        assert!(
-            crate::verify_guardian_signed_info(signed_info, &signing_pub_key, &metrics,).is_err()
-        );
-        assert_eq!(signature_invalid_count(&metrics), 1);
     }
 
     // --- guardian /info BTC pubkey verification ---

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -822,11 +822,10 @@ impl Hashi {
         }
     }
 
-    /// The one trusted entry point for guardian `/info`: fetch, pin the signing
-    /// pubkey to on-chain, verify the signature, and return the *verified*
-    /// `GuardianInfo`. Callers must read guardian state only through this —
-    /// never `resp.signed_info.data` directly. Records the matching
-    /// bootstrap-outcome metric on each failure.
+    /// The one trusted entry point for guardian `/info`: fetch, verify the
+    /// signature, pin the signing pubkey to on-chain, and return the *verified*
+    /// `GuardianInfo`. Callers must read guardian state only through this.
+    /// Records the matching bootstrap-outcome metric on each failure.
     async fn fetch_verified_guardian_info(
         &self,
     ) -> anyhow::Result<hashi_types::guardian::GuardianInfo> {
@@ -842,13 +841,23 @@ impl Hashi {
                 );
                 anyhow::anyhow!("parse GetGuardianInfoResponse: {e:?}")
             })?;
-        let signing_pub_key = resp.signing_pub_key;
+        let verified = resp.verify_signed_info_without_attestation().map_err(|e| {
+            self.metrics.record_guardian_bootstrap_outcome(
+                metrics::GUARDIAN_BOOTSTRAP_OUTCOME_SIGNATURE_INVALID,
+            );
+            tracing::error!(
+                error = ?e,
+                "FATAL: guardian /info signature invalid under its own \
+                 signing_pub_key; refusing to seed or reconcile local limiter",
+            );
+            anyhow::anyhow!("guardian signed_info signature invalid")
+        })?;
+        let signing_pub_key = verified.signing_pub_key;
         if !self.verify_guardian_signing_pubkey(&signing_pub_key) {
             anyhow::bail!("guardian signing pubkey does not match on-chain");
         }
-        let info = verify_guardian_signed_info(resp.signed_info, &signing_pub_key, &self.metrics)?;
         let _ = self.guardian_signing_pubkey.set(Some(signing_pub_key));
-        Ok(info)
+        Ok(verified.info)
     }
 
     /// Fetch the guardian's authoritative `LimiterState` and the live local
@@ -1055,6 +1064,7 @@ fn assert_test_only_config(sui_chain_id: &str, bitcoin_chain_id: &str, field_nam
 /// own `signing_pub_key`. Caller is responsible for verifying that the
 /// pubkey itself matches on-chain first; this is the second leg of the
 /// trust chain (signed_info → enclave that holds the on-chain pubkey).
+#[cfg(test)]
 fn verify_guardian_signed_info(
     signed_info: hashi_types::guardian::GuardianSigned<hashi_types::guardian::GuardianInfo>,
     signing_pub_key: &hashi_types::guardian::GuardianPubKey,
@@ -1413,6 +1423,23 @@ mod test {
         signing_key.verification_key()
     }
 
+    fn signed_guardian_info_for_test() -> (
+        hashi_types::guardian::GuardianSigned<hashi_types::guardian::GuardianInfo>,
+        hashi_types::guardian::GuardianPubKey,
+    ) {
+        let resp = hashi_types::guardian::GetGuardianInfoResponse::mock_for_testing();
+        let info = resp
+            .verify_signed_info_without_attestation()
+            .expect("mock /info must verify")
+            .info;
+        let signing_key = hashi_types::guardian::GuardianSignKeyPair::from([2u8; 32]);
+        let signing_pub_key = signing_key.verification_key();
+        (
+            hashi_types::guardian::GuardianSigned::new(info, &signing_key, 1234),
+            signing_pub_key,
+        )
+    }
+
     #[test]
     fn verify_signing_pub_key_matches_passes_when_equal() {
         let pubkey = random_signing_pubkey();
@@ -1452,11 +1479,10 @@ mod test {
 
     #[test]
     fn verify_guardian_signed_info_passes_for_valid_signature() {
-        let resp = hashi_types::guardian::GetGuardianInfoResponse::mock_for_testing();
+        let (signed_info, signing_pub_key) = signed_guardian_info_for_test();
         let metrics = fresh_metrics();
         assert!(
-            crate::verify_guardian_signed_info(resp.signed_info, &resp.signing_pub_key, &metrics,)
-                .is_ok()
+            crate::verify_guardian_signed_info(signed_info, &signing_pub_key, &metrics,).is_ok()
         );
         assert_eq!(signature_invalid_count(&metrics), 0);
     }
@@ -1465,27 +1491,24 @@ mod test {
     fn verify_guardian_signed_info_fails_when_pubkey_did_not_sign() {
         // Mock signs with key A, exposes pub_key_A. Verify under pub_key_B
         // (random) — must fail and bump the metric.
-        let resp = hashi_types::guardian::GetGuardianInfoResponse::mock_for_testing();
+        let (signed_info, _) = signed_guardian_info_for_test();
         let wrong_pubkey = random_signing_pubkey();
         let metrics = fresh_metrics();
-        assert!(
-            crate::verify_guardian_signed_info(resp.signed_info, &wrong_pubkey, &metrics,).is_err()
-        );
+        assert!(crate::verify_guardian_signed_info(signed_info, &wrong_pubkey, &metrics,).is_err());
         assert_eq!(signature_invalid_count(&metrics), 1);
     }
 
     #[test]
     fn verify_guardian_signed_info_fails_when_signature_tampered() {
-        let mut resp = hashi_types::guardian::GetGuardianInfoResponse::mock_for_testing();
+        let (mut signed_info, signing_pub_key) = signed_guardian_info_for_test();
         // Flip a byte of the signature so verification under the original
         // pubkey now fails.
-        let mut sig_bytes: [u8; 64] = resp.signed_info.signature.to_bytes();
+        let mut sig_bytes: [u8; 64] = signed_info.signature.to_bytes();
         sig_bytes[0] ^= 0xff;
-        resp.signed_info.signature = hashi_types::guardian::GuardianSignature::from(sig_bytes);
+        signed_info.signature = hashi_types::guardian::GuardianSignature::from(sig_bytes);
         let metrics = fresh_metrics();
         assert!(
-            crate::verify_guardian_signed_info(resp.signed_info, &resp.signing_pub_key, &metrics,)
-                .is_err()
+            crate::verify_guardian_signed_info(signed_info, &signing_pub_key, &metrics,).is_err()
         );
         assert_eq!(signature_invalid_count(&metrics), 1);
     }


### PR DESCRIPTION
## Summary
- Make raw `GetGuardianInfoResponse` fields private and return verified data through `VerifiedGuardianInfo`.
- Add `NitroAttestation` to own raw Nitro document bytes and its PCR-backed verification; move `BuildPcrs` into the new guardian attestation module.
- Route callers through full `verify` when PCR config is available, or the explicit `verify_signed_info_without_attestation` path with TODOs where attestation/PCR checks still need to be threaded in.
- Update proto, log, and test construction to use `GetGuardianInfoResponse::new` and the new attestation wrapper.

## Test plan
- `make fmt`
- `cargo check -p hashi-types -p hashi-guardian -p hashi-guardian-init -p hashi`
- `cargo test -p hashi-types get_guardian_info_response_round_trip`
- `cargo test -p hashi verify_signing_pub_key_matches`
