### PR TITLE
[guardian] verify the mock attestation in dev builds

### DIFF
--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -253,7 +253,8 @@ impl TestNetworksBuilder {
         let guardian_btc_pubkey = guardian_harness.ensure_btc_pubkey()?;
         let guardian_config = hashi::publish::GuardianConfig {
             url: guardian_harness.endpoint().to_string(),
-            // Non-Nitro dev: attestation is a no-op, so an all-zero build is fine.
+            // Non-Nitro dev: no real enclave to attest, so leave the build
+            // unpinned (empty git revision) — the node verifies signature-only.
             git_revision: String::new(),
             pcr0: vec![0u8; 48],
             btc_public_key: guardian_btc_pubkey.serialize().to_vec(),

--- a/crates/hashi-guardian/src/attestation.rs
+++ b/crates/hashi-guardian/src/attestation.rs
@@ -58,8 +58,9 @@ pub fn get_attestation(signing_pk: &GuardianPubKey) -> GuardianResult<NitroAttes
 }
 
 #[cfg(any(test, feature = "non-enclave-dev"))]
-pub fn get_attestation(_: &GuardianPubKey) -> GuardianResult<NitroAttestation> {
-    Ok(NitroAttestation::new(
-        b"mock_attestation_document_hex".to_vec(),
-    ))
+pub fn get_attestation(signing_pk: &GuardianPubKey) -> GuardianResult<NitroAttestation> {
+    // No NSM off-enclave to produce a real document, so emit a mock binding the
+    // signing key + an all-zero PCR0. A `non-enclave-dev` `verify` checks that
+    // binding (`verify_mock_attestation`) in place of the COSE signature.
+    Ok(NitroAttestation::mock(signing_pk, &[0u8; 48]))
 }

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -28,22 +28,43 @@ impl NitroAttestation {
         self.0
     }
 
-    /// Verify this Nitro attestation document (COSE signature + AWS cert chain to the
-    /// Nitro root + freshness), that it commits to `signing_pubkey`, and that its
-    /// PCR0 matches `build_pcrs`.
+    /// Off-enclave (dev/test) stand-in for a real Nitro document. There is no
+    /// NSM to produce one, so encode just the fields `verify` checks — the
+    /// signing key it commits to and the build's PCR0. Used by the guardian's
+    /// `non-enclave-dev` attestation path; never produced on a real enclave.
+    pub fn mock(signing_pubkey: &GuardianPubKey, pcr0: &[u8]) -> Self {
+        let doc = MockAttestationDoc {
+            public_key: signing_pubkey.to_bytes(),
+            pcr0: pcr0.to_vec(),
+        };
+        Self(bcs::to_bytes(&doc).expect("serialize mock attestation document"))
+    }
+
+    /// Verify this Nitro attestation document (COSE signature + AWS cert chain
+    /// to the Nitro root + freshness), that it commits to `signing_pubkey`, and
+    /// that its PCR0 matches `build_pcrs`.
     ///
-    /// In non-enclave dev/test builds the enclave emits a mock document, so the
-    /// attestation check is a no-op, mirroring `get_attestation` `non-enclave-dev`
-    /// stub behavior. Real verification runs only in enclave builds.
+    /// Off-enclave there is no NSM: the `non-enclave-dev` build checks the mock
+    /// document's key + PCR0 binding (`verify_mock_attestation`); `cfg(test)` is a
+    /// no-op. Real COSE/cert-chain verification runs only in enclave builds.
     pub fn verify(
         &self,
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,
     ) -> GuardianResult<()> {
-        #[cfg(any(test, feature = "non-enclave-dev"))]
+        #[cfg(test)]
         {
+            // Unit tests build placeholder documents; the strict off-enclave
+            // path is covered by `verify_mock_attestation`'s own tests.
             let _ = (signing_pubkey, build_pcrs);
             Ok(())
+        }
+        #[cfg(all(feature = "non-enclave-dev", not(test)))]
+        {
+            // No NSM off-enclave, so the COSE signature / cert chain can't be
+            // checked — but the guardian still emits a mock document binding its
+            // signing key + PCR0 (`NitroAttestation::mock`), so verify those.
+            verify_mock_attestation(&self.0, signing_pubkey, build_pcrs)
         }
         #[cfg(not(any(test, feature = "non-enclave-dev")))]
         {
@@ -86,6 +107,38 @@ pub struct VerifiedSessionInfo {
     pub signing_pubkey: GuardianPubKey,
     pub info: GuardianInfo,
     pub build_pcrs: BuildPcrs,
+}
+
+/// Payload of a [`NitroAttestation::mock`] document — the subset of a real
+/// Nitro document the off-enclave `verify` path can still check.
+#[derive(Serialize, Deserialize)]
+struct MockAttestationDoc {
+    public_key: [u8; 32],
+    pcr0: Vec<u8>,
+}
+
+/// Off-enclave counterpart to the real `verify`: skips the COSE signature / cert
+/// chain (no NSM to produce them) but still checks the signing-key binding and
+/// PCR0, so dev/e2e exercises the same policy a real node enforces.
+#[cfg(any(test, feature = "non-enclave-dev"))]
+fn verify_mock_attestation(
+    bytes: &[u8],
+    signing_pubkey: &GuardianPubKey,
+    build_pcrs: &BuildPcrs,
+) -> GuardianResult<()> {
+    let doc: MockAttestationDoc = bcs::from_bytes(bytes)
+        .map_err(|e| InvalidInputs(format!("mock attestation parse failed: {e}")))?;
+    if doc.public_key != signing_pubkey.to_bytes() {
+        return Err(InvalidInputs(
+            "mock attestation public_key does not match the session signing pubkey".into(),
+        ));
+    }
+    if doc.pcr0.as_slice() != build_pcrs.pcr0() {
+        return Err(InvalidInputs(
+            "mock attestation PCR0 does not match the expected enclave image".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// One enclave build: its git revision and known-good Nitro measurement. A build is
@@ -225,5 +278,55 @@ impl<'de> Deserialize<'de> for PcrAllowlist {
 
         let wire = PcrAllowlistWire::deserialize(deserializer)?;
         PcrAllowlist::new(wire.current_build, wire.prev_builds).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::GuardianSignKeyPair;
+    use super::*;
+
+    fn keypair() -> GuardianSignKeyPair {
+        GuardianSignKeyPair::new(rand::thread_rng())
+    }
+
+    #[test]
+    fn mock_attestation_accepts_matching_build_and_key() {
+        let pubkey = keypair().verification_key();
+        let att = NitroAttestation::mock(&pubkey, &[7u8; 48]);
+        verify_mock_attestation(
+            &att.into_bytes(),
+            &pubkey,
+            &BuildPcrs::new("test-build", vec![7u8; 48]),
+        )
+        .expect("matching mock attestation should verify");
+    }
+
+    #[test]
+    fn mock_attestation_rejects_pcr0_mismatch() {
+        let pubkey = keypair().verification_key();
+        let att = NitroAttestation::mock(&pubkey, &[7u8; 48]);
+        assert!(
+            verify_mock_attestation(
+                &att.into_bytes(),
+                &pubkey,
+                &BuildPcrs::new("test-build", vec![8u8; 48])
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn mock_attestation_rejects_pubkey_mismatch() {
+        let att = NitroAttestation::mock(&keypair().verification_key(), &[7u8; 48]);
+        let other = keypair().verification_key();
+        assert!(
+            verify_mock_attestation(
+                &att.into_bytes(),
+                &other,
+                &BuildPcrs::new("test-build", vec![7u8; 48])
+            )
+            .is_err()
+        );
     }
 }


### PR DESCRIPTION
Off-enclave (`non-enclave-dev`) the guardian's attestation was a placeholder string and #675's `verify` a no-op, so the PCR0 / signing-key binding was never exercised in dev.

- `NitroAttestation::mock(signing_key, pcr0)` encodes the fields `verify` checks; the off-enclave guardian emits it instead of the placeholder.
- The `non-enclave-dev` `verify` arm checks that binding (`verify_mock_attestation`) rather than returning `Ok`; `cfg(test)` stays a no-op so existing tests are undisturbed.

Stacked on #691; touches #675's attestation module, so flagging for Deepak.

Now stacked on #675, a dev deploy pins an empty git revision, so the node verifies signature-only and only reaches this when a real build is pinned. It's a thin completeness check on top of #675's git-revision match — fine to fold into #675 or drop if you'd prefer.
