### PR TITLE
Surface signing-in-progress withdrawal state (metrics + CLI)

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -343,6 +343,14 @@ impl SigningBatch {
             .count()
     }
 
+    /// Number of inputs whose MPC signature is complete.
+    pub fn signed_count(&self) -> usize {
+        self.signatures
+            .iter()
+            .filter(|s| matches!(s, MpcSig::Signed(_)))
+            .count()
+    }
+
     /// Indices of inputs still awaiting an MPC signature (the resume set).
     pub fn unsigned_indices(&self) -> Vec<u64> {
         self.signatures

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -299,12 +299,16 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
     {
         let txid_bytes: [u8; 32] = pw.id.into();
         let txid = bitcoin::Txid::from_byte_array(txid_bytes);
-        // TODO(tuning): surface incremental progress (signed_count/num_inputs)
-        // as a distinct "Signing (X/N)" state for the multi-checkpoint window.
         let is_signed = pw.is_fully_signed();
+        let signed_inputs = pw.signing.signed_count();
+        let num_inputs = pw.signing.num_inputs();
         let step = if is_signed { 4 } else { 3 };
+        // Distinguish the multi-checkpoint signing window: an in-progress txn
+        // shows "Signing (X/N)" rather than a flat "Committed".
         let status_label = if is_signed {
             "Signed".green()
+        } else if signed_inputs > 0 {
+            format!("Signing ({signed_inputs}/{num_inputs})").cyan()
         } else {
             "Committed".cyan()
         };

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -966,15 +966,23 @@ impl Metrics {
             .requests()
             .values()
             .partition::<Vec<_>, _>(|r| r.status.is_requested());
-        // TODO(tuning): with incremental signing a withdrawal is now "signing"
-        // (some inputs done, not finalized) for a multi-checkpoint window. Split
-        // `pending` into pending/signing (via `w.signing.signed_count`) for
-        // operator visibility before rollout.
-        let (signed, pending): (Vec<_>, Vec<_>) = hashi
-            .withdrawal_queue
-            .withdrawal_txns()
-            .values()
-            .partition(|w| w.is_fully_signed());
+        // Three on-chain withdrawal-txn states, distinguished for operator
+        // visibility now that signing spans a multi-checkpoint window:
+        //   signed  = fully signed (2-of-2 witness assembled), broadcast-ready
+        //   signing = some inputs MPC-signed but not yet finalized (in progress)
+        //   pending = committed on-chain but no inputs signed yet
+        let mut signed = Vec::new();
+        let mut signing = Vec::new();
+        let mut pending = Vec::new();
+        for w in hashi.withdrawal_queue.withdrawal_txns().values() {
+            if w.is_fully_signed() {
+                signed.push(w);
+            } else if w.signing.signed_count() > 0 {
+                signing.push(w);
+            } else {
+                pending.push(w);
+            }
+        }
         self.withdrawal_queue_size
             .with_label_values(&["requested"])
             .set(requested.len() as i64);
@@ -994,6 +1002,18 @@ impl Metrics {
             .with_label_values(&["pending", "BTC"])
             .set(
                 pending
+                    .iter()
+                    .flat_map(|w| &w.withdrawal_outputs)
+                    .map(|o| o.amount)
+                    .sum::<u64>() as i64,
+            );
+        self.withdrawal_queue_size
+            .with_label_values(&["signing"])
+            .set(signing.len() as i64);
+        self.withdrawal_queue_value
+            .with_label_values(&["signing", "BTC"])
+            .set(
+                signing
                     .iter()
                     .flat_map(|w| &w.withdrawal_outputs)
                     .map(|o| o.amount)


### PR DESCRIPTION
## Summary

Follow-up to #667: operator visibility for the new **signing-in-progress** state.

With incremental signing, a withdrawal transaction now spends a multi-checkpoint window partially signed (some inputs MPC-signed, not yet finalized). Metrics and the CLI previously knew only two states — pending vs fully signed — so an in-flight large withdrawal looked indistinguishable from one that hadn't started.

## Changes
- `SigningBatch::signed_count()` added to the BCS mirror (`hashi-types`).
- **Metrics** (`hashi_withdrawal_queue_{size,value}`): on-chain txns are split three ways — `pending` (committed, 0 inputs signed), `signing` (signed_count > 0, not finalized), `signed` (fully signed). Adds a new `signing` label value (additive — existing series are unchanged).
- **CLI** (`withdraw status`): in-progress txns show `Signing (X/N)` instead of a flat `Committed`.

Observability only — no change to signing behavior.

> Stacked on #667 — review/merge that first.
