### PR TITLE
Restore on-chain value validation for MPC config params

### DIFF
--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -169,7 +169,7 @@ impl MpcManager {
         )?;
         let total_weight = nodes.total_weight();
         let nonce_generation_protocol =
-            NonceGenerationProtocol::from_onchain(committee.mpc_nonce_generation_protocol());
+            NonceGenerationProtocol::from_onchain(committee.mpc_nonce_generation_protocol())?;
         let mpc_config = MpcConfig::new(
             epoch,
             nodes,

--- a/crates/hashi/src/mpc/types.rs
+++ b/crates/hashi/src/mpc/types.rs
@@ -48,21 +48,13 @@ pub enum NonceGenerationProtocol {
 }
 
 impl NonceGenerationProtocol {
-    // TODO(IOP-302): Remove the "other" branch once the on-chain value validation for MPC config params
-    // is restored (removed in PR #506).
-    pub fn from_onchain(value: u16) -> Self {
+    pub fn from_onchain(value: u16) -> MpcResult<Self> {
         match value {
-            0 => Self::Vanilla,
-            1 => Self::Avid,
-            other => {
-                let default = Self::default();
-                tracing::warn!(
-                    value = other,
-                    ?default,
-                    "unknown mpc_nonce_generation_protocol; using default"
-                );
-                default
-            }
+            0 => Ok(Self::Vanilla),
+            1 => Ok(Self::Avid),
+            other => Err(MpcError::InvalidConfig(format!(
+                "unknown mpc_nonce_generation_protocol: {other}"
+            ))),
         }
     }
 }
@@ -810,21 +802,15 @@ mod tests {
     #[test]
     fn test_nonce_generation_protocol_from_onchain() {
         assert_eq!(
-            NonceGenerationProtocol::from_onchain(0),
+            NonceGenerationProtocol::from_onchain(0).unwrap(),
             NonceGenerationProtocol::Vanilla
         );
         assert_eq!(
-            NonceGenerationProtocol::from_onchain(1),
+            NonceGenerationProtocol::from_onchain(1).unwrap(),
             NonceGenerationProtocol::Avid
         );
-        assert_eq!(
-            NonceGenerationProtocol::from_onchain(2),
-            NonceGenerationProtocol::default()
-        );
-        assert_eq!(
-            NonceGenerationProtocol::from_onchain(u16::MAX),
-            NonceGenerationProtocol::default()
-        );
+        assert!(NonceGenerationProtocol::from_onchain(2).is_err());
+        assert!(NonceGenerationProtocol::from_onchain(u16::MAX).is_err());
         assert_eq!(
             NonceGenerationProtocol::default(),
             NonceGenerationProtocol::Vanilla

--- a/packages/hashi/sources/core/mpc_config.move
+++ b/packages/hashi/sources/core/mpc_config.move
@@ -13,10 +13,28 @@ const DEFAULT_MAX_FAULTY_IN_BASIS_POINTS: u64 = 3333;
 
 const VANILLA_NONCE_GENERATION_PROTOCOL: u64 = 0;
 
+const MAX_BPS: u64 = 10000;
+
 const KEY_THRESHOLD_IN_BASIS_POINTS: vector<u8> = b"mpc_threshold_in_basis_points";
 const KEY_MAX_FAULTY_IN_BASIS_POINTS: vector<u8> = b"mpc_max_faulty_in_basis_points";
 const KEY_WEIGHT_REDUCTION_ALLOWED_DELTA: vector<u8> = b"mpc_weight_reduction_allowed_delta";
 const KEY_NONCE_GENERATION_PROTOCOL: vector<u8> = b"mpc_nonce_generation_protocol";
+
+#[allow(implicit_const_copy)]
+public(package) fun is_valid_value(key: &std::string::String, value: &config_value::Value): bool {
+    let k = key.as_bytes();
+    if (k == &KEY_THRESHOLD_IN_BASIS_POINTS) {
+        value.is_u64() && (*value).as_u64() > 0 && (*value).as_u64() <= MAX_BPS
+    } else if (k == &KEY_WEIGHT_REDUCTION_ALLOWED_DELTA) {
+        value.is_u64() && (*value).as_u64() <= MAX_BPS
+    } else if (k == &KEY_MAX_FAULTY_IN_BASIS_POINTS) {
+        value.is_u64() && (*value).as_u64() <= MAX_BPS
+    } else if (k == &KEY_NONCE_GENERATION_PROTOCOL) {
+        value.is_u64() && (*value).as_u64() <= 1
+    } else {
+        true
+    }
+}
 
 public(package) fun threshold_in_basis_points(config: &Config): u64 {
     config
@@ -44,18 +62,6 @@ public(package) fun nonce_generation_protocol(config: &Config): u64 {
         .try_get(KEY_NONCE_GENERATION_PROTOCOL)
         .map!(|v| v.as_u64())
         .destroy_or!(VANILLA_NONCE_GENERATION_PROTOCOL)
-}
-
-public(package) fun set_threshold_in_basis_points(config: &mut Config, value: u64) {
-    config.upsert(KEY_THRESHOLD_IN_BASIS_POINTS, config_value::new_u64(value));
-}
-
-public(package) fun set_max_faulty_in_basis_points(config: &mut Config, value: u64) {
-    config.upsert(KEY_MAX_FAULTY_IN_BASIS_POINTS, config_value::new_u64(value));
-}
-
-public(package) fun set_weight_reduction_allowed_delta(config: &mut Config, value: u64) {
-    config.upsert(KEY_WEIGHT_REDUCTION_ALLOWED_DELTA, config_value::new_u64(value));
 }
 
 public(package) fun init_defaults(config: &mut Config) {

--- a/packages/hashi/sources/core/proposal/types/update_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_config.move
@@ -3,7 +3,7 @@
 
 module hashi::update_config;
 
-use hashi::{config_value::Value, hashi::Hashi, proposal};
+use hashi::{config_value::Value, hashi::Hashi, mpc_config, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
@@ -44,7 +44,11 @@ public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
     let UpdateConfig { entries } = proposal::execute(hashi, proposal_id, clock);
     let (keys, values) = entries.into_keys_values();
     keys.zip_do!(values, |key, value| {
-        assert!(hashi.config().is_valid_config_update(&key, &value), EInvalidConfigEntry);
+        assert!(
+            hashi.config().is_valid_config_update(&key, &value)
+                && mpc_config::is_valid_value(&key, &value),
+            EInvalidConfigEntry,
+        );
         hashi.config_mut().upsert(*key.as_bytes(), value);
     });
 }

--- a/packages/hashi/tests/update_config_multikey_tests.move
+++ b/packages/hashi/tests/update_config_multikey_tests.move
@@ -268,3 +268,136 @@ fun test_propose_vote_execute_through_quorum() {
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
 }
+
+const MAX_BPS: u64 = 10000;
+
+fun reject_single(key: std::string::String, value: config_value::Value) {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(key, value);
+    let proposal_id = update_config::propose(
+        &mut hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    update_config::execute(&mut hashi, proposal_id, &clock);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_reject_threshold_zero() {
+    reject_single(mpc_threshold_key(), config_value::new_u64(0));
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_reject_threshold_above_max() {
+    reject_single(mpc_threshold_key(), config_value::new_u64(MAX_BPS + 1));
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_reject_max_faulty_above_max() {
+    reject_single(mpc_max_faulty_key(), config_value::new_u64(MAX_BPS + 1));
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_reject_allowed_delta_above_max() {
+    reject_single(mpc_allowed_delta_key(), config_value::new_u64(MAX_BPS + 1));
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_reject_nonce_protocol_above_one() {
+    reject_single(mpc_nonce_generation_protocol_key(), config_value::new_u64(2));
+}
+
+#[test]
+fun test_accept_max_faulty_zero() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(0));
+    let proposal_id = update_config::propose(
+        &mut hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    update_config::execute(&mut hashi, proposal_id, &clock);
+
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 0);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_accept_upper_boundary_values() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_threshold_key(), config_value::new_u64(MAX_BPS));
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(MAX_BPS));
+    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(MAX_BPS));
+    let proposal_id = update_config::propose(
+        &mut hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    update_config::execute(&mut hashi, proposal_id, &clock);
+
+    assert!(mpc_config::threshold_in_basis_points(hashi.config()) == MAX_BPS);
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == MAX_BPS);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.config()) == MAX_BPS);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_batch_with_out_of_range_entry_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_threshold_key(), config_value::new_u64(5200));
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(MAX_BPS + 1));
+    let proposal_id = update_config::propose(
+        &mut hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    update_config::execute(&mut hashi, proposal_id, &clock);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}


### PR DESCRIPTION
It had been removed in #506.

#368 #531 