### PR TITLE
[onchain] Reconnect checkpoint watcher when the Sui stream stalls

### DIFF
--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -156,8 +156,10 @@ impl OnchainState {
         .pipe(Self);
 
         let watcher_state = state.clone();
+        // The watcher rebuilds its client on every reconnect, so hand it the URL.
+        let sui_rpc_url = sui_rpc_url.to_owned();
         let service = Service::new().spawn_aborting(async move {
-            watcher::watcher(client, watcher_state, metrics).await;
+            watcher::watcher(sui_rpc_url, watcher_state, metrics).await;
             Ok(())
         });
 

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -31,8 +31,14 @@ use crate::onchain::types::ProposalType;
 use crate::onchain::types::WithdrawalRequest;
 use crate::withdrawals::withdrawal_limiter_consumption_amount;
 
+/// Reconnect if the checkpoint stream goes silent this long. A half-open h2
+/// stream yields neither an item nor an error, so an unbounded read hangs — the
+/// SDK's keepalive only trips on a fully-dead connection, not a live one whose
+/// server silently stopped sending checkpoints.
+const CHECKPOINT_STREAM_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 #[tracing::instrument(name = "watcher", skip_all)]
-pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Arc<Metrics>>) {
+pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<Arc<Metrics>>) {
     let subscription_read_mask = FieldMask::from_paths([
         Checkpoint::path_builder().sequence_number(),
         Checkpoint::path_builder().summary().timestamp(),
@@ -54,6 +60,20 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
     let mut rescrape_state = false;
 
     loop {
+        // Reconnect with a fresh client each iteration. Re-subscribing on the
+        // same channel can reuse a wedged h2 connection — the one whose stream
+        // just stalled — and silently hang again; a new client forces a clean
+        // connection. Reconnects are rare, so the extra setup cost is fine.
+        let mut client = match Client::new(&sui_rpc_url) {
+            Ok(client) => client,
+            Err(e) => {
+                tracing::warn!("error creating Sui RPC client: {e}");
+                rescrape_state = true;
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
+            }
+        };
+
         let mut subscription = match client
             .subscription_client()
             .subscribe_checkpoints(
@@ -95,17 +115,17 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
                 }
             }
 
-            rescrape_state = false;
             // Rescrape gapped the event-driven limiter; trigger an eager reconcile.
             state.request_limiter_reconcile();
         }
 
-        while let Some(item) = subscription.next().await {
+        while let Ok(Some(item)) =
+            tokio::time::timeout(CHECKPOINT_STREAM_STALL_TIMEOUT, subscription.next()).await
+        {
             let checkpoint = match item {
                 Ok(checkpoint) => checkpoint,
                 Err(e) => {
                     tracing::warn!("error in checkpoint stream: {e}");
-                    rescrape_state = true;
                     break;
                 }
             };
@@ -160,6 +180,11 @@ pub async fn watcher(mut client: Client, state: OnchainState, metrics: Option<Ar
                 metrics.update_onchain_state(&state);
             }
         }
+
+        // The stream stalled, errored, or closed. Loop to rebuild the client,
+        // re-subscribe, and rescrape to recover any gap we missed.
+        tracing::warn!("checkpoint stream ended; reconnecting Sui client and rescraping");
+        rescrape_state = true;
     }
 }
 


### PR DESCRIPTION
This fixes an issue where the on-chain watcher's checkpoint subscription can hang forever on a half-open gRPC stream, freezing the node's view of on-chain state.

## Changes

- Wrap each checkpoint read in a 120s `timeout`; a stalled stream now exits the loop instead of hanging (the SDK client's h2 keepalive only catches fully-dead connections, not a live connection whose stream went silent).
- Re-subscribe and rescrape after the loop exits (stall, stream error, or close) to recover any gap, and rebuild the Sui client on each reconnect so a stalled h2 connection isn't reused.