### PR TITLE
[onchain] Bound scrape page size + raise gRPC decode limit to 32 MiB

### DIFF
--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -120,10 +120,15 @@ impl HashiClient {
         // Dropping the service immediately aborts the background watcher task, so the
         // OnchainState will have the initial scraped state but won't receive live updates.
         // This is fine for CLI commands for now.
-        let (onchain_state, _service) =
-            OnchainState::new(&config.sui_rpc_url, hashi_ids, None, None, None)
-                .await
-                .context("Failed to initialize on-chain state")?;
+        let (onchain_state, _service) = OnchainState::new(
+            &config.sui_rpc_url,
+            hashi_ids,
+            None,
+            Some(crate::config::DEFAULT_GRPC_MAX_DECODING_MESSAGE_SIZE),
+            None,
+        )
+        .await
+        .context("Failed to initialize on-chain state")?;
 
         // Try to create executor if keypair is available
         let executor = match config.load_keypair()? {

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -12,6 +12,9 @@ use crate::constants::SUI_MAINNET_CHAIN_ID;
 
 const DEFAULT_WITHDRAWAL_SIGNING_CONCURRENCY: usize = 25;
 const DEFAULT_MPC_SIGNING_CHUNK_SIZE: usize = 64;
+/// Tonic's 4 MiB default is too small to scrape a large on-chain state or
+/// receive large MPC round messages.
+pub(crate) const DEFAULT_GRPC_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 
 /// Load an Ed25519 private key from a file path or inline PEM string.
 ///
@@ -145,8 +148,9 @@ pub struct Config {
 
     /// Maximum gRPC decoding message size in bytes.
     ///
-    /// Defaults to 16 MiB if not specified. Tonic's built-in default is 4 MiB,
-    /// which is too small for large MPC round messages.
+    /// Defaults to 32 MiB if not specified. Tonic's built-in default is 4 MiB,
+    /// which is too small to scrape a large on-chain state or receive large MPC
+    /// round messages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grpc_max_decoding_message_size: Option<usize>,
 
@@ -395,7 +399,7 @@ impl Config {
 
     pub fn grpc_max_decoding_message_size(&self) -> usize {
         self.grpc_max_decoding_message_size
-            .unwrap_or(16 * 1024 * 1024)
+            .unwrap_or(DEFAULT_GRPC_MAX_DECODING_MESSAGE_SIZE)
     }
 
     pub fn max_concurrent_leader_job_tasks(&self) -> usize {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -42,6 +42,10 @@ use hashi_types::move_types;
 
 const BROADCAST_CHANNEL_CAPACITY: usize = 100;
 
+/// Bounded so a huge queue isn't returned as one oversized page that overflows
+/// the gRPC decode limit; the SDK still pages through every entry.
+const SCRAPE_PAGE_SIZE: u32 = 1000;
+
 pub mod types;
 mod watcher;
 
@@ -121,7 +125,12 @@ impl OnchainState {
         grpc_max_decoding_message_size: Option<usize>,
         metrics: Option<Arc<crate::metrics::Metrics>>,
     ) -> Result<(Self, Service)> {
-        let client = Client::new(sui_rpc_url)?;
+        let mut client = Client::new(sui_rpc_url)?;
+        // The scrape client reads the full on-chain state (the largest
+        // responses), so it needs the decode limit too — not just `committees`.
+        if let Some(limit) = grpc_max_decoding_message_size {
+            client = client.with_max_decoding_message_size(limit);
+        }
 
         let (mut state, checkpoint) = State::scrape(client.clone(), ids).await?;
         if let Some(tls_private_key) = &tls_private_key {
@@ -170,6 +179,10 @@ impl OnchainState {
 
     pub fn subscribe(&self) -> broadcast::Receiver<Notification> {
         self.0.sender.subscribe()
+    }
+
+    pub(crate) fn grpc_max_decoding_message_size(&self) -> Option<usize> {
+        self.0.grpc_max_decoding_message_size
     }
 
     fn notify(&self, notification: Notification) {
@@ -580,7 +593,7 @@ impl OnchainState {
             .list_dynamic_fields(
                 ListDynamicFieldsRequest::default()
                     .with_parent(tob_id)
-                    .with_page_size(u32::MAX)
+                    .with_page_size(SCRAPE_PAGE_SIZE)
                     .with_read_mask(FieldMask::from_paths([
                         DynamicField::path_builder().name().finish(),
                         DynamicField::path_builder().value().finish(),
@@ -626,7 +639,7 @@ impl OnchainState {
             .list_dynamic_fields(
                 ListDynamicFieldsRequest::default()
                     .with_parent(epoch_certs.certs.id)
-                    .with_page_size(u32::MAX)
+                    .with_page_size(SCRAPE_PAGE_SIZE)
                     .with_read_mask(FieldMask::from_paths([
                         DynamicField::path_builder().name().finish(),
                         DynamicField::path_builder().value().finish(),
@@ -689,7 +702,7 @@ async fn scrape_package_versions(
 ) -> Result<BTreeMap<u64, Address>> {
     let package_versions: BTreeMap<u64, Address> = client
         .list_package_versions(
-            ListPackageVersionsRequest::new(&package_id).with_page_size(u32::MAX),
+            ListPackageVersionsRequest::new(&package_id).with_page_size(SCRAPE_PAGE_SIZE),
         )
         .and_then(|package_version| async move {
             let storage_id = package_version
@@ -861,7 +874,7 @@ async fn scrape_treasury(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(treasury.objects.id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder().value().finish(),
@@ -933,7 +946,7 @@ async fn scrape_all_member_info(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(member_info_id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder().value().finish(),
@@ -1039,7 +1052,7 @@ async fn scrape_committees(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(committees_id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder().value().finish(),
@@ -1231,7 +1244,7 @@ async fn scrape_deposit_requests(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(deposit_queue_id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder()
@@ -1287,7 +1300,7 @@ async fn scrape_withdrawal_requests(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(requests_id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder()
@@ -1319,7 +1332,7 @@ async fn scrape_withdrawal_txns(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(withdrawal_txns_id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder()
@@ -1392,7 +1405,7 @@ async fn scrape_utxo_records(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(utxo_records_id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder().value().finish(),
@@ -1419,7 +1432,7 @@ async fn scrape_spent_utxos(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(spent_utxos_id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder().value().finish(),
@@ -1474,7 +1487,7 @@ async fn scrape_proposal_bag(
         .list_dynamic_fields(
             ListDynamicFieldsRequest::default()
                 .with_parent(bag.id)
-                .with_page_size(u32::MAX)
+                .with_page_size(SCRAPE_PAGE_SIZE)
                 .with_read_mask(FieldMask::from_paths([
                     DynamicField::path_builder().name().finish(),
                     DynamicField::path_builder().child_object().object_type(),

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -73,6 +73,11 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
                 continue;
             }
         };
+        // Same decode limit as the bootstrap scrape — this client does the
+        // reconnect rescrape, which reads the full (large) on-chain state.
+        if let Some(limit) = state.grpc_max_decoding_message_size() {
+            client = client.with_max_decoding_message_size(limit);
+        }
 
         let mut subscription = match client
             .subscription_client()


### PR DESCRIPTION
Defensive hardening for scraping a large on-chain state. `scrape_hashi` reads the full deposit/withdrawal queues and committee data; at sufficient scale a single response can overflow the scrape client's gRPC decode limit (`unexpected end of input`) or just be needlessly large.

- Bound the `list_*` page size to 1000 — the SDK still pages through every entry.
- Apply the decode limit to the scrape clients (they read the largest responses but used tonic's 4 MiB default) and raise that default to 32 MiB.
