### PR TITLE
[guardian] Record enclave PCR0 → commit provenance from CI

### DIFF
--- a/.github/workflows/guardian-enclave.yml
+++ b/.github/workflows/guardian-enclave.yml
@@ -4,12 +4,35 @@ on:
   workflow_dispatch:
     inputs:
       bucket_name:
-        description: 'S3 bucket name for the build'
+        description: 'S3 bucket baked into the build'
         required: true
-        default: 'guardian-test-bucket'
+        default: 'mysten-hashi-guardian-dev'
+      aws_region:
+        description: 'AWS region baked into the build'
+        required: true
+        default: 'us-west-2'
+      ceremony_mode:
+        description: 'Build the ceremony EIF (its own PCR0) instead of the withdraw EIF'
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - 'crates/hashi-guardian/**'
+      - 'crates/hashi-types/**'
+      - 'docker/hashi-guardian/**'
+      - 'Cargo.lock'
 
 permissions:
   contents: read
+
+# run.sh embeds all three into the initramfs, so each one changes PCR0 and a
+# recorded measurement is only meaningful alongside them. Pushes use the devnet
+# args; dispatch with another env's bucket to record that env's PCR0.
+env:
+  EIF_BUCKET: ${{ inputs.bucket_name || 'mysten-hashi-guardian-dev' }}
+  EIF_REGION: ${{ inputs.aws_region || 'us-west-2' }}
+  EIF_CEREMONY_MODE: ${{ inputs.ceremony_mode && 'true' || '' }}
 
 jobs:
   build:
@@ -24,10 +47,9 @@ jobs:
 
       - name: Build enclave EIF
         working-directory: docker/hashi-guardian
-        env:
-          BUCKET_NAME: ${{ inputs.bucket_name || 'guardian-test-bucket' }}
-          GIT_REVISION: ${{ github.sha }}
-        run: make BUCKET_NAME=$BUCKET_NAME GIT_REVISION=$GIT_REVISION
+        run: |
+          make BUCKET_NAME="$EIF_BUCKET" AWS_REGION="$EIF_REGION" \
+            CEREMONY_MODE="$EIF_CEREMONY_MODE" GIT_REVISION="${{ github.sha }}"
 
       - name: Print PCRs
         working-directory: docker/hashi-guardian
@@ -42,6 +64,10 @@ jobs:
   verify:
     needs: build
     runs-on: ubuntu-latest
+    outputs:
+      pcr0: ${{ steps.extract.outputs.pcr0 }}
+      pcr1: ${{ steps.extract.outputs.pcr1 }}
+      pcr2: ${{ steps.extract.outputs.pcr2 }}
     steps:
       - name: Download ubuntu-latest PCRs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
@@ -55,40 +81,101 @@ jobs:
           name: nitro-pcrs-ubuntu-22.04
           path: pcrs-22
 
-      - name: Compare PCRs
-        id: compare
+      - name: Fail if PCRs differ across runners
         run: |
-          LATEST=$(cat pcrs-latest/nitro.pcrs)
-          OLDER=$(cat pcrs-22/nitro.pcrs)
-          if diff pcrs-latest/nitro.pcrs pcrs-22/nitro.pcrs > /dev/null; then
-            echo "match=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "match=false" >> "$GITHUB_OUTPUT"
+          if ! diff pcrs-latest/nitro.pcrs pcrs-22/nitro.pcrs > /dev/null; then
+            echo "PCRs differ across platforms!"
+            diff pcrs-latest/nitro.pcrs pcrs-22/nitro.pcrs
+            exit 1
           fi
-          # Extract individual PCR values
-          PCR0=$(awk '/PCR0/ {print $1}' pcrs-latest/nitro.pcrs)
-          PCR1=$(awk '/PCR1/ {print $1}' pcrs-latest/nitro.pcrs)
-          PCR2=$(awk '/PCR2/ {print $1}' pcrs-latest/nitro.pcrs)
-          echo "pcr0=$PCR0" >> "$GITHUB_OUTPUT"
-          echo "pcr1=$PCR1" >> "$GITHUB_OUTPUT"
-          echo "pcr2=$PCR2" >> "$GITHUB_OUTPUT"
 
-      - name: Print results
+      - name: Extract PCRs
+        id: extract
         run: |
-          echo "## Guardian Enclave PCR Measurements" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| PCR | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| PCR0 | \`${{ steps.compare.outputs.pcr0 }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| PCR1 | \`${{ steps.compare.outputs.pcr1 }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| PCR2 | \`${{ steps.compare.outputs.pcr2 }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Cross-platform check**: ${{ steps.compare.outputs.match == 'true' && 'Reproducible' || 'MISMATCH' }} (ubuntu-latest vs ubuntu-22.04)" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Bucket**: \`${{ inputs.bucket_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          f=pcrs-latest/nitro.pcrs
+          pcr0=$(jq -r '.PCR0 // empty' "$f" 2>/dev/null || true)
+          pcr1=$(jq -r '.PCR1 // empty' "$f" 2>/dev/null || true)
+          pcr2=$(jq -r '.PCR2 // empty' "$f" 2>/dev/null || true)
+          # Fallback for a non-JSON pcrs file: PCRs are 96-hex (SHA-384), in order.
+          if [ -z "$pcr0" ]; then
+            mapfile -t P < <(grep -oiE '[a-f0-9]{96}' "$f")
+            pcr0=${P[0]:-}; pcr1=${P[1]:-}; pcr2=${P[2]:-}
+          fi
+          # An empty measurement must not reach the provenance record: a blank
+          # row there is worse than a failed build, because deployments pin it.
+          for v in "$pcr0" "$pcr1" "$pcr2"; do
+            case "$v" in
+              [a-fA-F0-9]*) [ "${#v}" -eq 96 ] || { echo "not a SHA-384 PCR: $v" >&2; exit 1; } ;;
+              *) echo "could not extract PCRs from $f:" >&2; cat "$f" >&2; exit 1 ;;
+            esac
+          done
+          echo "pcr0=$pcr0" >> "$GITHUB_OUTPUT"
+          echo "pcr1=$pcr1" >> "$GITHUB_OUTPUT"
+          echo "pcr2=$pcr2" >> "$GITHUB_OUTPUT"
 
-      - name: Fail if PCRs differ
-        if: steps.compare.outputs.match != 'true'
+      - name: Summary
         run: |
-          echo "PCRs differ across platforms!"
-          diff pcrs-latest/nitro.pcrs pcrs-22/nitro.pcrs
+          {
+            echo "## Guardian Enclave PCR Measurements"
+            echo ""
+            echo "| PCR | Value |"
+            echo "|-----|-------|"
+            echo "| PCR0 | \`${{ steps.extract.outputs.pcr0 }}\` |"
+            echo "| PCR1 | \`${{ steps.extract.outputs.pcr1 }}\` |"
+            echo "| PCR2 | \`${{ steps.extract.outputs.pcr2 }}\` |"
+            echo ""
+            echo "Reproducible across ubuntu-latest + ubuntu-22.04. Bucket \`$EIF_BUCKET\` / region \`$EIF_REGION\`, mode \`${EIF_CEREMONY_MODE:-withdraw}\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Append PCR0 -> commit to MystenLabs/hashi-guardian-revision-history so a
+  # running enclave's attested PCR0 traces back to this source. Dispatch records
+  # too: an env whose bucket differs from devnet's has a different PCR0, and
+  # pinning it is the whole point.
+  record-provenance:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Append PCR0 -> commit to the revision-history repo
+        env:
+          GH_TOKEN: ${{ secrets.HASHI_GUARDIAN_REVISION_HISTORY_TOKEN }}
+          PCR0: ${{ needs.verify.outputs.pcr0 }}
+          PCR1: ${{ needs.verify.outputs.pcr1 }}
+          PCR2: ${{ needs.verify.outputs.pcr2 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "HASHI_GUARDIAN_REVISION_HISTORY_TOKEN not set; skipping provenance record." >&2
+            exit 0
+          fi
+          # Not shallow: the push below rebases onto concurrent appends.
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/MystenLabs/hashi-guardian-revision-history.git" rev-history
+          cd rev-history
+          commit="${{ github.sha }}"
+          if [ -n "$EIF_CEREMONY_MODE" ]; then mode=ceremony; else mode=withdraw; fi
+          # Field-exact, so a bucket name containing regex metacharacters cannot
+          # match the wrong row. The build args are part of the key: they change
+          # PCR0, so the same commit legitimately has one row per (bucket, region,
+          # mode).
+          if awk -F'\t' -v c="$commit" -v b="$EIF_BUCKET" -v r="$EIF_REGION" -v m="$mode" \
+               '$2==c && $6==b && $7==r && $8==m {found=1} END {exit !found}' \
+               pcr-history.tsv 2>/dev/null; then
+            echo "Already recorded for ($commit, $EIF_BUCKET, $EIF_REGION, $mode)."
+            exit 0
+          fi
+          printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$commit" "$PCR0" "$PCR1" "$PCR2" \
+            "$EIF_BUCKET" "$EIF_REGION" "$mode" >> pcr-history.tsv
+          git config user.name "hashi-guardian-ci"
+          git config user.email "hashi-guardian-ci@users.noreply.github.com"
+          git add pcr-history.tsv
+          git commit -m "Record PCR0 for hashi@${commit:0:8} ($EIF_BUCKET/$EIF_REGION/$mode)"
+          # Concurrent enclave builds race on this push; the file is append-only.
+          for _ in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            git pull --rebase
+          done
+          echo "could not push the provenance record" >&2
           exit 1


### PR DESCRIPTION
## Summary

Records each enclave build's PCR0 against the commit it came from, in [`hashi-guardian-revision-history`](https://github.com/MystenLabs/hashi-guardian-revision-history), so a running enclave's attested measurement can be traced back to source and reproduced. Deployments need this to pin what they verify against: reading PCR0 off the host you are about to verify is circular.

`run.sh` bakes the bucket, region and boot mode into the initramfs, so each of those changes PCR0. A measurement is only meaningful alongside them, and they are part of the record's key.

## Changes

- Build on pushes to main that touch the enclave, not just manual dispatch.
- Add `aws_region` and `ceremony_mode` inputs; pushes use the devnet build args, and dispatch can record another env's or the ceremony EIF's PCR0.
- Append `(timestamp, commit, PCR0-2, bucket, region, mode)` to `pcr-history.tsv`, deduped on exact field match and retried against concurrent appends.
- Fail the build if a PCR doesn't extract as a SHA-384 — a blank row is worse than a failed build when deployments pin it.
- Fail on cross-runner PCR mismatch directly rather than through a `match` output.
