### PR TITLE
Strip Docker release binary symbols

### DIFF
--- a/docker/hashi-guardian-k8s/Containerfile
+++ b/docker/hashi-guardian-k8s/Containerfile
@@ -34,7 +34,7 @@ RUN mkdir -p crates/hashi-guardian/src \
 ENV TARGET=x86_64-unknown-linux-musl
 ENV OPENSSL_STATIC=true
 ENV CARGO_INCREMENTAL=0
-ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64"
+ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64 -C strip=symbols"
 
 RUN cargo fetch
 RUN --network=none cargo build --release --frozen --target "$TARGET" -p hashi-guardian --features non-enclave-dev --bin hashi-guardian

--- a/docker/hashi-guardian/Containerfile
+++ b/docker/hashi-guardian/Containerfile
@@ -60,7 +60,7 @@ COPY Cargo.lock /Cargo.lock
 WORKDIR /
 ENV OPENSSL_STATIC=true
 ENV TARGET=x86_64-unknown-linux-musl
-ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64"
+ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64 -C strip=symbols"
 RUN cargo build --locked --no-default-features --release --target "$TARGET" -p hashi-guardian
 
 WORKDIR /build_cpio

--- a/docker/hashi-screener/Containerfile
+++ b/docker/hashi-screener/Containerfile
@@ -29,7 +29,7 @@ RUN mkdir -p crates/hashi-screener/src \
 ENV TARGET=x86_64-unknown-linux-musl
 ENV OPENSSL_STATIC=true
 ENV CARGO_INCREMENTAL=0
-ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64"
+ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64 -C strip=symbols"
 
 RUN cargo fetch
 RUN --network=none cargo build --release --frozen --target "$TARGET" --bin hashi-screener

--- a/docker/hashi/Containerfile
+++ b/docker/hashi/Containerfile
@@ -28,7 +28,7 @@ ENV TARGET=x86_64-unknown-linux-musl
 ENV OPENSSL_STATIC=true
 ENV CARGO_INCREMENTAL=0
 ENV SOURCE_DATE_EPOCH=0
-ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64"
+ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64 -C strip=symbols"
 
 RUN cargo fetch
 RUN --network=none cargo build --release --frozen --target "$TARGET" --bin hashi


### PR DESCRIPTION
Strip symbols from Docker release binaries to avoid deterministic build failures caused by non-loadable ELF symbol metadata ordering.
