### PR TITLE
Make guardian init S3 credentials optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,6 +2976,8 @@ name = "hashi-guardian-init"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aws-config",
+ "aws-credential-types",
  "bcs",
  "bitcoin",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 tempfile = "3.23.0"
 jiff = "0.2"
 tar = "0.4"
+aws-config = "1.1.7"
+aws-credential-types = "1"
+aws-sdk-s3 = "1.12.0"
 
 # fastcrypto — pinned to the `nitro-attestation` branch tip (our prior base +
 # the AWS Nitro attestation module). The merged main tip can't be used yet: it

--- a/crates/hashi-guardian-init/Cargo.toml
+++ b/crates/hashi-guardian-init/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
+aws-config.workspace = true
+aws-credential-types.workspace = true
 bcs.workspace = true
 bitcoin.workspace = true
 clap.workspace = true

--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -22,6 +22,11 @@ the key ceremony and provisioning flow is then driven through these commands.
 All production commands read the same unified config file; see
 [`guardian-init.sample.yaml`](guardian-init.sample.yaml).
 
+The guardian init production config may omit `guardian_s3.access_key` and
+`guardian_s3.secret_key`; when both are omitted, the production commands use the
+AWS SDK default credential chain. The `tools dev-bootstrap` shortcut is
+unchanged and still reads AWS credentials from its required env vars.
+
 ## operator ceremony
 
 The production guardian key ceremony — genesis setup, run once by the operator.

--- a/crates/hashi-guardian-init/guardian-init.sample.yaml
+++ b/crates/hashi-guardian-init/guardian-init.sample.yaml
@@ -17,6 +17,15 @@ relay_endpoint: "http://localhost:50051"
 # required by key-provisioner commands.
 kp_pgp_cert_path: /path/to/kp3.asc
 
+# S3 config for the guardian's log bucket. Must have object-lock enabled.
+# If access_key and secret_key are omitted, guardian-init uses the default AWS
+# credential chain.
+guardian_s3:
+  bucket: "hashi-guardian-logs"
+  region: "us-east-1"
+  access_key:
+  secret_key:
+
 hashi:
   # Sui RPC URL used to fetch Hashi on-chain state.
   sui_rpc: "https://fullnode.devnet.sui.io:443"
@@ -29,14 +38,6 @@ kp_roster:
   # Secret-sharing parameters. `num_shares` MUST equal `kp_pgp_cert_paths.len()`.
   num_shares: 5
   threshold: 3
-
-  # S3 config for the guardian's log bucket. Must have object-lock enabled.
-  guardian_s3:
-    access_key: "AKIA..."
-    secret_key: "..."
-    bucket_info:
-      bucket: "hashi-guardian-logs"
-      region: "us-east-1"
 
   # Paths to every KP's armored OpenPGP public cert from the expected ceremony roster.
   kp_pgp_cert_paths:

--- a/crates/hashi-guardian-init/src/config.rs
+++ b/crates/hashi-guardian-init/src/config.rs
@@ -5,12 +5,46 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Context;
+use aws_credential_types::provider::ProvideCredentials;
 use hashi::config::HashiIds;
 use hashi::onchain::OnchainState;
 use hashi_types::guardian::LimiterConfig;
+use hashi_types::guardian::S3BucketInfo;
+use hashi_types::guardian::S3Config;
 use serde::Deserialize;
 
 use crate::kp_roster::KpRosterConfig;
+
+#[derive(Deserialize)]
+pub struct Config {
+    pub hashi: HashiOnchainConfig,
+    pub guardian_s3: GuardianInitS3Config,
+    pub kp_roster: KpRosterConfig,
+    pub limiter_config: LimiterConfig,
+    /// Relay endpoint the KP's encrypted share is submitted to.
+    pub relay_endpoint: String,
+    /// gRPC endpoint of the guardian.
+    pub guardian_endpoint: String,
+    /// Path to this KP's armored OpenPGP public cert. Required by
+    /// key-provisioner commands.
+    pub kp_pgp_cert_path: Option<PathBuf>,
+}
+
+impl Config {
+    pub fn load_yaml(path: &Path) -> anyhow::Result<Self> {
+        let bytes = std::fs::read(path).with_context(|| {
+            format!("failed to read guardian init config at {}", path.display())
+        })?;
+        serde_yaml::from_slice(&bytes)
+            .with_context(|| format!("failed to parse guardian init yaml at {}", path.display()))
+    }
+
+    pub fn require_kp_pgp_cert_path(&self, command: &str) -> anyhow::Result<&Path> {
+        self.kp_pgp_cert_path.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("{command} requires kp_pgp_cert_path in guardian init config")
+        })
+    }
+}
 
 #[derive(Clone)]
 pub struct HashiOnchainConfig {
@@ -55,31 +89,54 @@ impl HashiOnchainConfig {
 }
 
 #[derive(Deserialize)]
-pub struct Config {
-    pub hashi: HashiOnchainConfig,
-    pub kp_roster: KpRosterConfig,
-    pub limiter_config: LimiterConfig,
-    /// Relay endpoint the KP's encrypted share is submitted to.
-    pub relay_endpoint: String,
-    /// gRPC endpoint of the guardian.
-    pub guardian_endpoint: String,
-    /// Path to this KP's armored OpenPGP public cert. Required by
-    /// key-provisioner commands.
-    pub kp_pgp_cert_path: Option<PathBuf>,
+pub struct GuardianInitS3Config {
+    pub bucket: String,
+    pub region: String,
+    pub access_key: Option<String>,
+    pub secret_key: Option<String>,
 }
 
-impl Config {
-    pub fn load_yaml(path: &Path) -> anyhow::Result<Self> {
-        let bytes = std::fs::read(path).with_context(|| {
-            format!("failed to read guardian init config at {}", path.display())
-        })?;
-        serde_yaml::from_slice(&bytes)
-            .with_context(|| format!("failed to parse guardian init yaml at {}", path.display()))
-    }
+impl GuardianInitS3Config {
+    pub async fn resolve(&self) -> anyhow::Result<S3Config> {
+        let access_key = self
+            .access_key
+            .as_deref()
+            .filter(|value| !value.trim().is_empty());
+        let secret_key = self
+            .secret_key
+            .as_deref()
+            .filter(|value| !value.trim().is_empty());
 
-    pub fn require_kp_pgp_cert_path(&self, command: &str) -> anyhow::Result<&Path> {
-        self.kp_pgp_cert_path.as_deref().ok_or_else(|| {
-            anyhow::anyhow!("{command} requires kp_pgp_cert_path in guardian init config")
+        let (access_key, secret_key) = match (access_key, secret_key) {
+            (Some(access_key), Some(secret_key)) => {
+                (access_key.to_string(), secret_key.to_string())
+            }
+            (None, None) => {
+                let provider =
+                    aws_config::default_provider::credentials::DefaultCredentialsChain::builder()
+                        .build()
+                        .await;
+                let creds = provider
+                    .provide_credentials()
+                    .await
+                    .context("failed to resolve AWS credentials from the default provider chain")?;
+                (
+                    creds.access_key_id().to_string(),
+                    creds.secret_access_key().to_string(),
+                )
+            }
+            _ => anyhow::bail!(
+                "guardian_s3 access_key and secret_key must either both be set or both be omitted"
+            ),
+        };
+
+        Ok(S3Config {
+            access_key,
+            secret_key,
+            bucket_info: S3BucketInfo {
+                bucket: self.bucket.clone(),
+                region: self.region.clone(),
+            },
         })
     }
 }

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -28,11 +28,12 @@ use crate::kp_roster::ensure_cert_in_roster;
 /// written to disk by this flow.
 pub async fn run(cfg: Config) -> Result<()> {
     cfg.kp_roster.validate()?;
+    let guardian_s3 = cfg.guardian_s3.resolve().await?;
 
     info!(
         phase = "setup",
-        bucket = cfg.kp_roster.guardian_s3.bucket_name(),
-        region = cfg.kp_roster.guardian_s3.region(),
+        bucket = guardian_s3.bucket_name(),
+        region = guardian_s3.region(),
         num_shares = cfg.kp_roster.num_shares,
         threshold = cfg.kp_roster.threshold,
         sui_rpc = %cfg.hashi.sui_rpc,
@@ -74,12 +75,12 @@ pub async fn run(cfg: Config) -> Result<()> {
     //    (attestation-verified once via the reader's session-key cache).
     info!(
         phase = "s3 connect",
-        bucket = cfg.kp_roster.guardian_s3.bucket_name(),
-        region = cfg.kp_roster.guardian_s3.region(),
+        bucket = guardian_s3.bucket_name(),
+        region = guardian_s3.region(),
         current_pcr0 = hex::encode(cfg.kp_roster.pcr_allowlist.current_build().pcr0()),
         "connecting to guardian log bucket",
     );
-    let mut reader = GuardianReader::new(&cfg.kp_roster.guardian_s3, cfg.kp_roster.pcr_allowlist())
+    let mut reader = GuardianReader::new(&guardian_s3, cfg.kp_roster.pcr_allowlist())
         .await
         .context("connect to guardian log bucket")?;
     info!(phase = "s3 connect", "connected to guardian log bucket");

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -58,11 +58,12 @@ use crate::limiter_recovery;
 
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
+    let guardian_s3 = cfg.guardian_s3.resolve().await?;
 
     info!(
         phase = "setup",
-        bucket = cfg.kp_roster.guardian_s3.bucket_name(),
-        region = cfg.kp_roster.guardian_s3.region(),
+        bucket = guardian_s3.bucket_name(),
+        region = guardian_s3.region(),
         num_shares = cfg.kp_roster.num_shares,
         threshold = cfg.kp_roster.threshold,
         relay_endpoint = %cfg.relay_endpoint,
@@ -74,15 +75,15 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     // reads that session first.
     info!(
         phase = "s3 connect",
-        bucket = cfg.kp_roster.guardian_s3.bucket_name(),
-        region = cfg.kp_roster.guardian_s3.region(),
+        bucket = guardian_s3.bucket_name(),
+        region = guardian_s3.region(),
         current_git_revision = %cfg.kp_roster.pcr_allowlist.current_build().git_revision(),
         current_pcr0 = hex::encode(cfg.kp_roster.pcr_allowlist.current_build().pcr0()),
         prev_build_count = cfg.kp_roster.pcr_allowlist.prev_builds().len(),
         "connecting to guardian log bucket",
     );
     let allowlist = cfg.kp_roster.pcr_allowlist();
-    let mut reader = GuardianReader::new(&cfg.kp_roster.guardian_s3, allowlist.clone())
+    let mut reader = GuardianReader::new(&guardian_s3, allowlist.clone())
         .await
         .context("connect to guardian log bucket")?;
     info!(phase = "s3 connect", "connected to guardian log bucket");
@@ -186,9 +187,9 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         enclave_git_revision
     );
     anyhow::ensure!(
-        cfg.kp_roster.guardian_s3.bucket_info == enclave_bucket_info,
+        guardian_s3.bucket_info == enclave_bucket_info,
         "Guardian bucket info mismatch: expected {:?}, got {:?}",
-        cfg.kp_roster.guardian_s3.bucket_info,
+        guardian_s3.bucket_info,
         enclave_bucket_info
     );
     anyhow::ensure!(

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -27,7 +27,6 @@ use hashi_types::guardian::KPEncryptedShare;
 use hashi_types::guardian::KPEncryptedShares;
 use hashi_types::guardian::KPFingerprint;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::SecretSharingParams;
 use hashi_types::guardian::SetupNewKeyResponse;
@@ -44,17 +43,15 @@ use tracing::info;
 use zeroize::Zeroize;
 use zeroize::Zeroizing;
 
-/// Common KP-roster config: the sharing params, the guardian's S3 log bucket,
-/// the full KP cert roster, and the PCR allowlist. Shared by every command that
-/// needs to discover and verify a ceremony against an expected KP set.
+/// Common KP-roster config: the sharing params, the full KP cert roster, and the
+/// PCR allowlist. Shared by every command that needs to discover and verify a
+/// ceremony against an expected KP set.
 #[derive(Deserialize)]
 pub struct KpRosterConfig {
     /// Total number of shares. Must equal `kp_pgp_cert_paths.len()`.
     pub num_shares: usize,
     /// Reconstruction threshold. Must satisfy `2 <= threshold <= num_shares`.
     pub threshold: usize,
-    /// S3 config for the guardian's log bucket (object-lock enabled).
-    pub guardian_s3: S3Config,
     /// Paths to each KP's armored OpenPGP public cert. Order matters for
     /// `operator ceremony` (the cert at index `i` is assigned share id `i + 1`); for
     /// the read-only commands (`key-provisioner ceremony`, `key-provisioner provision`), shares are

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -40,13 +40,15 @@ use crate::kp_roster::VerifiedCeremonyState;
 /// See the module docs for the full step-by-step flow. Each step is logged via
 /// `tracing` so the operator can follow exactly what is happening.
 pub async fn run(cfg: Config) -> Result<()> {
+    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+
     info!(
         phase = "setup",
         num_shares = cfg.kp_roster.num_shares,
         threshold = cfg.kp_roster.threshold,
         cert_count = cfg.kp_roster.kp_pgp_cert_paths.len(),
-        bucket = cfg.kp_roster.guardian_s3.bucket_name(),
-        region = cfg.kp_roster.guardian_s3.region(),
+        bucket = guardian_s3.bucket_name(),
+        region = guardian_s3.region(),
         endpoint = %cfg.guardian_endpoint,
         sui_rpc = %cfg.hashi.sui_rpc,
         package_id = %cfg.hashi.hashi_ids.package_id,
@@ -92,14 +94,13 @@ pub async fn run(cfg: Config) -> Result<()> {
     // 4. operator_init (ceremony mode: S3 config only, no WithdrawModeConfig).
     info!(
         phase = "operator_init",
-        bucket = cfg.kp_roster.guardian_s3.bucket_name(),
-        region = cfg.kp_roster.guardian_s3.region(),
+        bucket = guardian_s3.bucket_name(),
+        region = guardian_s3.region(),
         "calling OperatorInit (ceremony mode: S3 config only)",
     );
-    let oi_req = operator_init_request_to_pb(OperatorInitRequest::new_ceremony_mode(
-        cfg.kp_roster.guardian_s3.clone(),
-    ))
-    .map_err(|e| anyhow!("encode OperatorInitRequest: {e:?}"))?;
+    let oi_req =
+        operator_init_request_to_pb(OperatorInitRequest::new_ceremony_mode(guardian_s3.clone()))
+            .map_err(|e| anyhow!("encode OperatorInitRequest: {e:?}"))?;
     client
         .operator_init(oi_req)
         .await
@@ -138,7 +139,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         session_id = %session_id,
         "connecting to guardian log bucket + verifying attestation against current build",
     );
-    let mut reader = GuardianReader::new(&cfg.kp_roster.guardian_s3, allowlist)
+    let mut reader = GuardianReader::new(&guardian_s3, allowlist)
         .await
         .context("connect to guardian log bucket")?;
     let verified_session = reader

--- a/crates/hashi-guardian/Cargo.toml
+++ b/crates/hashi-guardian/Cargo.toml
@@ -23,9 +23,9 @@ nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", rev 
 hpke.workspace = true
 
 # AWS dependencies
-aws-config = "1.1.7"
-aws-sdk-s3 = "1.12.0"
-aws-credential-types = "1"
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
+aws-credential-types.workspace = true
 
 aws-smithy-mocks = { version = "0.1", optional = true }
 


### PR DESCRIPTION
Move guardian S3 config to the top-level init config and support resolving omitted credentials through the AWS default credential chain.
