### PR TITLE
docs: TS SDK doc

### DIFF
--- a/design/docs/ts-sdk.mdx
+++ b/design/docs/ts-sdk.mdx
@@ -1,0 +1,254 @@
+---
+title: TypeScript SDK
+description: "TypeScript SDK for the Hashi protocol. Hashi is a decentralized Bitcoin collateralization primitive on Sui. Orchestrate native BTC directly from smart contracts—without centralized balance sheets."
+keywords: [ Hashi, TypeScript, SDK, hBTC, deposit, withdrawal, Sui, Bitcoin ]
+sidebar_label: TypeScript SDK
+---
+
+{/* AUTO-GENERATED from MystenLabs/hashi-ts-sdk README — do not edit by hand. */}
+{/* Refresh with: npm run fetch-sdk-readme (from design/). */}
+
+TypeScript SDK for the [Hashi](https://github.com/MystenLabs/hashi) protocol. Hashi is a decentralized Bitcoin collateralization primitive on Sui. Orchestrate native BTC directly from smart contracts—without centralized balance sheets.
+
+:::warning
+
+**Not production-ready.** This SDK is pre-1.0 and under active development. The API may change without notice and only Sui devnet is wired up. Do not use it in production environments yet.
+
+:::
+
+End-user actions only: **deposit**, **request withdrawal**, **cancel withdrawal**. Operator/committee/relayer calls are intentionally not part of this surface — those tools should import the generated bindings under `src/contracts/hashi/` directly.
+
+## Install
+
+```bash
+pnpm add @mysten-incubation/hashi @mysten/sui
+```
+
+`@mysten/sui` is a peer dependency.
+
+## Setup
+
+The SDK attaches to any Sui client via `$extend`. After extension, every Hashi method lives under `client.hashi.*`.
+
+```ts
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { hashi } from "@mysten-incubation/hashi";
+
+const client = new SuiGrpcClient({
+  network: "devnet",
+  baseUrl: "https://fullnode.devnet.sui.io:443",
+}).$extend(hashi({ network: "devnet" }));
+
+const signer = Ed25519Keypair.fromSecretKey(/* … */);
+```
+
+> **Network support.** Only Sui **devnet** is currently wired up (Bitcoin **signet** by default). Testnet and mainnet are not yet deployed; `hashi({ network: "testnet" })` will throw until those land. To target a custom or local deployment, pass `hashiObjectId`, `packageId`, and `bitcoinNetwork` explicitly.
+
+> **Optional client options.** `hashi({ ... })` also accepts `btcRpcUrl` — a Bitcoin Core JSON-RPC URL, required for the [`client.hashi.bitcoin.*`](#bitcoin-rpc-optional) lookups — and `graphqlUrl`, which overrides the Sui GraphQL endpoint used by [`transactionHistory`](#transaction-history) (defaults to `https://fullnode.{network}.sui.io:443/graphql`).
+
+## Quickstart: Deposit BTC → mint hBTC
+
+1. Derive the unique P2TR Bitcoin deposit address for your Sui address.
+2. Send BTC to that address from any wallet.
+3. Submit the funding `txid` + `vout` to Hashi for committee confirmation.
+
+The committee watches the Bitcoin chain, confirms the funding tx after `bitcoinConfirmationThreshold` blocks, and mints `hBTC` to the `recipient` address.
+
+```ts
+const recipient = signer.toSuiAddress();
+
+// 1. Get the deposit address.
+const btcAddress = await client.hashi.generateDepositAddress({
+  suiAddress: recipient,
+});
+
+// 2. Send BTC to `btcAddress` from any wallet, then collect the
+//    funding tx's display-order txid and the vout that paid the
+//    deposit address. (Display-order = the form mempool.space and
+//    `bitcoin-cli` show — the SDK reverses internally.)
+
+// 3. Record the deposit on Sui.
+const result = await client.hashi.deposit({
+  signer,
+  txid: "0x<64-hex display-order txid>",
+  utxos: [{ vout: 0, amountSats: 100_000n }],
+  recipient,
+});
+
+if (result.$kind !== "Transaction") {
+  throw new Error(`deposit failed: ${JSON.stringify(result.FailedTransaction)}`);
+}
+// `hBTC` lands in `recipient`'s balance once the committee confirms.
+```
+
+A single funding tx may pay the deposit address on multiple outputs — pass them all in `utxos` and they're batched into one atomic Sui PTB.
+
+## Quickstart: Request withdrawal (burn hBTC → receive BTC)
+
+Burns `amountSats` of `hBTC` from the signer's balance and enqueues a request for the committee to send BTC to `bitcoinAddress`. The address is decoded client-side as bech32 (P2WPKH) or bech32m (P2TR) and must match the client's configured Bitcoin network.
+
+```ts
+const result = await client.hashi.requestWithdrawal({
+  signer,
+  amountSats: 50_000n,
+  bitcoinAddress: "tb1q…", // P2WPKH on signet/testnet, or `tb1p…` for P2TR
+});
+
+if (result.$kind !== "Transaction") {
+  throw new Error(`request failed: ${JSON.stringify(result.FailedTransaction)}`);
+}
+
+// Pull the request id out of the WithdrawalRequestedEvent — needed if
+// you later want to cancel.
+const evt = result.Transaction.events?.find((e) =>
+  e.eventType.endsWith("::withdrawal_queue::WithdrawalRequestedEvent"),
+);
+const requestId = (evt as { json?: { request_id?: string } } | undefined)?.json?.request_id;
+```
+
+## Quickstart: Cancel a pending withdrawal
+
+Returns the locked `hBTC` to the signer. Only the original requester can cancel, only while the request is still `Requested` or `Approved` (not after committee commitment), and only after `withdrawalCancellationCooldownMs` has elapsed since the request. All three are enforced on-chain.
+
+```ts
+await client.hashi.cancelWithdrawal({ signer, requestId });
+```
+
+## Tracking a deposit or withdrawal
+
+`deposit` and `requestWithdrawal` resolve to a transaction execution result whose `Transaction.digest` identifies the submitted Sui tx. Pass that digest to the `view.*Status` readers for a one-shot check, or to the `waitFor*` helpers to poll until a terminal state.
+
+```ts
+const digest = result.Transaction?.digest;
+
+// One-shot status check — returns null if the digest has no Hashi event.
+const deposit = await client.hashi.view.depositStatus(digest);
+// deposit?.status: "pending" | "confirmed" | "expired" | "unknown"
+
+const withdrawal = await client.hashi.view.withdrawalStatus(digest);
+// withdrawal?.status: "Requested" | "Approved" | "Processing"
+//                     | "Signed" | "Confirmed" | "cancelled"
+```
+
+To block until the committee finishes, use the polling helpers. They resolve on a terminal state — deposits on `confirmed`/`expired`, withdrawals on `Confirmed`/`cancelled`:
+
+```ts
+const info = await client.hashi.waitForDeposit(digest, {
+  intervalMs: 15_000, // default
+  signal: AbortSignal.timeout(600_000), // optional cancellation
+});
+
+const wInfo = await client.hashi.waitForWithdrawal(digest);
+// wInfo.btcTxid is populated once the committee commits the Bitcoin tx.
+```
+
+## Checking hBTC balance
+
+```ts
+const { totalBalance, coinObjectCount } = await client.hashi.view.balance(signer.toSuiAddress());
+// totalBalance — hBTC in satoshis; coinObjectCount — number of coin objects held.
+```
+
+## Transaction history
+
+`view.transactionHistory` returns a unified, newest-first list of deposits and withdrawals for a Sui address. Each item is a discriminated union — switch on `kind`:
+
+```ts
+const history = await client.hashi.view.transactionHistory(signer.toSuiAddress());
+
+for (const item of history) {
+  if (item.kind === "deposit") {
+    console.log(item.btcTxid, item.amountSats, item.approved);
+  } else {
+    console.log(item.requestId, item.btcAmountSats, item.status);
+  }
+}
+```
+
+Confirmed requests come from the on-chain index; in-flight deposits are discovered via the Sui GraphQL endpoint (`graphqlUrl`). If GraphQL is unavailable the call still returns the confirmed set.
+
+## Detecting already-used UTXOs
+
+Before submitting a deposit, check whether its outputs were already recorded — re-submitting a consumed UTXO aborts on-chain.
+
+```ts
+const results = await client.hashi.view.findUsedUtxos([
+  { txid: "0x<64-hex display-order txid>", vout: 0 },
+]);
+// results[0]: { utxoId, inActivePool, inSpentPool, isUsed }
+```
+
+## Estimating fees
+
+```ts
+// Withdrawal: worst-case BTC network fee + on-chain minimum. Pass a sender
+// to also get a dry-run gas estimate.
+const fees = await client.hashi.view.withdrawalFees(signer.toSuiAddress());
+// { worstCaseNetworkFeeSats, withdrawalMinimumSats, gasEstimateMist }
+
+// Deposit: dry-run gas estimate only.
+const { gasEstimateMist } = await client.hashi.view.depositGasEstimate(signer.toSuiAddress());
+```
+
+Gas estimation is best-effort — a failed simulation yields `0n` rather than throwing.
+
+## Reading governance state
+
+Governance parameters — the pause flag, deposit/withdrawal minimums, confirmation threshold, and cancellation cooldown — are read through `client.hashi.view`, the same namespace as the balance, status, history, and fee readers above. Prefer `view.all()` when you need 2+ values — single round-trip, internally consistent snapshot.
+
+```ts
+const snap = await client.hashi.view.all();
+// { paused, bitcoinDepositMinimum, bitcoinWithdrawalMinimum,
+//   bitcoinConfirmationThreshold, withdrawalCancellationCooldownMs,
+//   worstCaseNetworkFee, ... }
+```
+
+## Errors
+
+Direct methods throw typed errors before signing whenever a precondition can be checked client-side. `instanceof` to distinguish:
+
+| Error                        | Thrown when                                                                |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `InvalidParamsError`         | `txid`/`recipient` not 0x-prefixed 32-byte hex, or `utxos` empty/duplicate |
+| `InvalidBitcoinAddressError` | `bitcoinAddress` fails bech32(m) decode or HRP mismatches the BTC network  |
+| `HashiPausedError`           | Governance has paused the operation (`deposit` or `withdraw`)              |
+| `AmountBelowMinimumError`    | A UTXO or withdrawal amount is below the on-chain minimum                  |
+| `HashiFetchError`            | The Hashi shared object can't be read or has an unexpected shape           |
+| `HashiConfigError`           | A governance config entry is missing or malformed                          |
+
+## Advanced: composable transactions
+
+The direct methods (`deposit`, `requestWithdrawal`, `cancelWithdrawal`) sign and execute in one call. For sponsored transactions, dry-runs, or bundling Hashi calls into a larger PTB, use the `tx.*` builders — they return an unsigned `Transaction` and leave signing to the caller.
+
+```ts
+const tx = client.hashi.tx.deposit({ txid, utxos, recipient });
+// …add more commands to `tx`, then sign and execute via your usual path.
+```
+
+Move-call thunks are also available under `client.hashi.call.*` for direct composition into hand-built PTBs.
+
+## Bitcoin RPC (optional)
+
+When the client is constructed with a `btcRpcUrl`, the `client.hashi.bitcoin.*` namespace reads the Bitcoin chain directly — useful for finding which output of a funding tx paid your deposit address, and for checking confirmations before submitting a deposit.
+
+```ts
+const client = new SuiGrpcClient({
+  network: "devnet",
+  baseUrl: "https://fullnode.devnet.sui.io:443",
+}).$extend(hashi({ network: "devnet", btcRpcUrl: "http://user:pass@127.0.0.1:8332" }));
+
+// Which output(s) of the funding tx paid the deposit address?
+const output = await client.hashi.bitcoin.lookupVout(btcTxid, btcAddress);
+const outputs = await client.hashi.bitcoin.lookupAllVouts(btcTxid, btcAddress);
+// each result: { vout, amountSats }
+
+// Confirmation count — 0 while the tx is still in the mempool.
+const confirmations = await client.hashi.bitcoin.confirmations(btcTxid);
+```
+
+Calling any `bitcoin.*` method without `btcRpcUrl` configured throws.
+
+## Bitcoin address derivation
+
+Each Sui address maps to a unique P2TR Bitcoin deposit address with two script-path leaves: an immediate 2-of-2 leaf `multi_a(2, guardian, derive(mpc_master, sui_address))`, and a delayed MPC-only recovery leaf `and_v(v:older(delay), pk(derive(mpc_master, sui_address)))`. The MPC child-key derivation replicates `fastcrypto_tbls::threshold_schnorr::key_derivation::derive_verifying_key`; the guardian's BTC key is read from the on-chain `guardian_btc_public_key` config, and `generateDepositAddress` throws `HashiConfigError` until the deployment publishes it. See the [Hashi address-scheme docs](https://mystenlabs.github.io/hashi/design/address-scheme.html) for the full design.

--- a/design/package.json
+++ b/design/package.json
@@ -12,8 +12,9 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "prebuild": "node scripts/generate-import-context.js",
-    "prestart": "node scripts/generate-import-context.js",
+    "fetch-sdk-readme": "node scripts/fetch-sdk-readme.js",
+    "prebuild": "node scripts/fetch-sdk-readme.js && node scripts/generate-import-context.js",
+    "prestart": "node scripts/fetch-sdk-readme.js && node scripts/generate-import-context.js",
     "postbuild": "node scripts/copy-markdown-files.js && node scripts/generate-llmstxt.js"
   },
   "dependencies": {

--- a/design/scripts/fetch-sdk-readme.js
+++ b/design/scripts/fetch-sdk-readme.js
@@ -1,0 +1,216 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Imports the README from MystenLabs/hashi-ts-sdk and formats it into a
+// Docusaurus page at docs/ts-sdk.mdx.
+//
+// Usage:
+//   node scripts/fetch-sdk-readme.js
+//
+// hashi-ts-sdk is a PRIVATE repo, so fetching needs a GitHub token. The token
+// is read from GITHUB_TOKEN / GH_TOKEN; if neither is set the script falls back
+// to the `gh` CLI (which uses your `gh auth login` credentials). When no
+// credentials are available — e.g. an external contributor or a docs CI that
+// can't see the private repo — the script logs a notice and leaves the existing
+// committed docs/ts-sdk.mdx in place, so builds never break. Because of that the
+// generated file IS committed; rerun this script (npm run fetch-sdk-readme) to
+// refresh it whenever the SDK README changes.
+//
+// Formatting applied to the raw README markdown:
+//   - drops the leading H1 (the title comes from front matter instead)
+//   - derives the page description from the first prose paragraph
+//   - converts GitHub alerts (`> [!WARNING]`) to Docusaurus admonitions
+//   - rewrites any relative links/images to absolute hashi-ts-sdk URLs
+//   - wraps everything in Docusaurus front matter + an AUTO-GENERATED banner
+// The source README must stay MDX-friendly (no bare `<` / `{` outside code
+// fences); fenced code blocks are passed through untouched.
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const REPO = "MystenLabs/hashi-ts-sdk";
+const BRANCH = "main";
+const REPO_BLOB = `https://github.com/${REPO}/blob/${BRANCH}`;
+const REPO_RAW = `https://raw.githubusercontent.com/${REPO}/${BRANCH}`;
+
+const SITE_ROOT = path.resolve(__dirname, ".."); // design/
+const OUT_FILE = path.join(SITE_ROOT, "docs/ts-sdk.mdx");
+
+const ALERT_ADMONITION = {
+  NOTE: "note",
+  TIP: "tip",
+  IMPORTANT: "info",
+  WARNING: "warning",
+  CAUTION: "danger",
+};
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+async function fetchReadme() {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (token) {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/readme`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github.raw",
+        "User-Agent": "hashi-docs-fetch-sdk-readme",
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`GitHub API responded ${res.status} ${res.statusText}`);
+    }
+    return await res.text();
+  }
+
+  // No token in the environment — fall back to the gh CLI.
+  return execSync(`gh api repos/${REPO}/readme -H "Accept: application/vnd.github.raw"`, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+}
+
+function hasCredentials() {
+  if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) return true;
+  try {
+    execSync("gh auth status", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+const stripMarkdown = (s) =>
+  s
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1") // links / images -> text
+    .replace(/[`*_>#]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+// Run `fn` over the prose, leaving fenced code blocks (odd-indexed parts) alone.
+function transformProse(body, fn) {
+  return body
+    .split(/(```[\s\S]*?```)/g)
+    .map((part, i) => (i % 2 === 1 ? part : fn(part)))
+    .join("");
+}
+
+function rewriteRelativeLinks(text) {
+  return text.replace(/(!?)\[([^\]]*)\]\(([^)]+)\)/g, (match, bang, label, url) => {
+    const u = url.trim();
+    // Leave absolute URLs, anchors, mailto, and protocol-relative links alone.
+    if (/^(https?:|mailto:|#|\/\/)/i.test(u)) return match;
+    const base = bang ? REPO_RAW : REPO_BLOB;
+    const clean = u.replace(/^\.\//, "").replace(/^\//, "");
+    return `${bang}[${label}](${base}/${clean})`;
+  });
+}
+
+// `> [!WARNING]` blocks -> `:::warning ... :::` admonitions.
+function convertAlerts(text) {
+  const lines = text.split("\n");
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*$/i.exec(lines[i]);
+    if (!m) {
+      out.push(lines[i]);
+      continue;
+    }
+    const admonition = ALERT_ADMONITION[m[1].toUpperCase()];
+    const content = [];
+    let j = i + 1;
+    for (; j < lines.length && /^>\s?/.test(lines[j]); j++) {
+      content.push(lines[j].replace(/^>\s?/, ""));
+    }
+    out.push("", `:::${admonition}`, "", ...content, "", ":::", "");
+    i = j - 1;
+  }
+  return out.join("\n");
+}
+
+function deriveDescription(body) {
+  for (const block of body.split(/\n\s*\n/)) {
+    const t = block.trim();
+    if (!t) continue;
+    if (/^!?\[!?\[/.test(t)) continue; // badge block
+    if (/^#{1,6}\s/.test(t)) continue; // heading
+    if (/^>/.test(t)) continue; // blockquote / alert
+    return stripMarkdown(t);
+  }
+  return "TypeScript SDK for the Hashi protocol.";
+}
+
+function format(readme) {
+  let body = readme.replace(/\r\n?/g, "\n");
+
+  // Drop the leading H1 — Docusaurus renders the title from front matter.
+  body = body.replace(/^\s*#\s+.*\n/, "");
+
+  const description = deriveDescription(body);
+
+  // Strip the leading badge block (consecutive shield/CI image-link lines).
+  // They're README furniture, and the CI badge points at the private repo's
+  // Actions endpoint, which 404s as a broken image for anonymous viewers.
+  body = body.replace(/^(?:\s*\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)\s*\n)+/, "");
+
+  body = transformProse(body, (prose) => convertAlerts(rewriteRelativeLinks(prose)));
+  body = body.replace(/\n{3,}/g, "\n\n").trim();
+
+  const frontMatter = [
+    "---",
+    "title: TypeScript SDK",
+    `description: ${JSON.stringify(description)}`,
+    "keywords: [ Hashi, TypeScript, SDK, hBTC, deposit, withdrawal, Sui, Bitcoin ]",
+    "sidebar_label: TypeScript SDK",
+    "---",
+  ].join("\n");
+
+  const banner =
+    `{/* AUTO-GENERATED from ${REPO} README — do not edit by hand. */}\n` +
+    `{/* Refresh with: npm run fetch-sdk-readme (from design/). */}`;
+
+  return `${frontMatter}\n\n${banner}\n\n${body}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (!hasCredentials()) {
+    if (fs.existsSync(OUT_FILE)) {
+      console.log(
+        "ℹ️  fetch-sdk-readme: no GitHub credentials; keeping committed docs/ts-sdk.mdx",
+      );
+      return;
+    }
+    console.warn(
+      "⚠️  fetch-sdk-readme: no GitHub credentials and no committed docs/ts-sdk.mdx to fall back on.",
+    );
+    return;
+  }
+
+  console.log(`📥 fetch-sdk-readme: importing ${REPO}@${BRANCH} README`);
+
+  try {
+    const readme = await fetchReadme();
+    fs.writeFileSync(OUT_FILE, format(readme), "utf8");
+    console.log(`✅ fetch-sdk-readme: wrote ${path.relative(SITE_ROOT, OUT_FILE)}`);
+  } catch (err) {
+    if (fs.existsSync(OUT_FILE)) {
+      console.warn(
+        `⚠️  fetch-sdk-readme: fetch failed (${err.message}); keeping committed docs/ts-sdk.mdx`,
+      );
+    } else {
+      console.warn(`⚠️  fetch-sdk-readme: fetch failed (${err.message}); no fallback file.`);
+    }
+  }
+}
+
+main();

--- a/design/scripts/generate-llmstxt.js
+++ b/design/scripts/generate-llmstxt.js
@@ -49,6 +49,14 @@ const SECTIONS = [
     label: "Flows",
     items: ["reconfiguration", "deposit", "withdraw"],
   },
+  {
+    label: "Operators",
+    items: ["node-operator-runbook", "node-backup"],
+  },
+  {
+    label: "SDKs",
+    items: ["ts-sdk"],
+  },
 ];
 
 function readDoc(slug) {

--- a/design/sidebars.js
+++ b/design/sidebars.js
@@ -8,7 +8,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Design',
-      collapsed: false,
+      collapsed: true,
       items: [
         'committee',
         'governance-actions',
@@ -25,7 +25,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Flows',
-      collapsed: false,
+      collapsed: true,
       items: [
         'reconfiguration',
         'deposit',
@@ -35,10 +35,18 @@ const sidebars = {
     {
       type: 'category',
       label: 'Operators',
-      collapsed: false,
+      collapsed: true,
       items: [
         'node-operator-runbook',
         'node-backup',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'SDKs',
+      collapsed: true,
+      items: [
+        'ts-sdk',
       ],
     },
   ],

--- a/design/src/shared/components/OpenInPlayMoveButton/index.tsx
+++ b/design/src/shared/components/OpenInPlayMoveButton/index.tsx
@@ -1,0 +1,111 @@
+/*
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+*/
+
+/**
+ * OpenInPlayMoveButton — shared button that opens the nearest code block in
+ * PlayMove (https://www.playmove.dev) in a new tab. Designed to sit inside a
+ * Docusaurus CodeBlock button bar, alongside Copy and OpenInAgentButton.
+ *
+ * PlayMove reads its initial editor contents from the URL hash, so we open
+ * `https://www.playmove.dev/#<encodeURIComponent(code)>`.
+ *
+ * The button only appears on Move code blocks: it walks the DOM upward from its
+ * own position to find a `pre code[class*='language-move']` element, and stays
+ * hidden otherwise. The wrapper span always renders so the ref is available on
+ * mount; we toggle its display once detection has run.
+ */
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
+import clsx from "clsx";
+import styles from "./styles.module.css";
+
+const PLAYMOVE_URL = "https://www.playmove.dev";
+
+/** Walk up from `start` to find the nearest code text in the code block. */
+function getNearestCodeText(start: HTMLElement | null): string {
+  let el: HTMLElement | null = start;
+  while (el) {
+    const code = el.querySelector?.(
+      "pre code, code, pre",
+    ) as HTMLElement | null;
+    if (code?.innerText) {
+      return code.innerText.replace(/\n$/, "");
+    }
+    el = el.parentElement;
+  }
+  return "";
+}
+
+export default function OpenInPlayMoveButton({
+  className,
+  ButtonComponent,
+}: {
+  className?: string;
+  /** Optional base button component from the site's theme (e.g. @theme/CodeBlock/Buttons/Button).
+   *  Falls back to a plain <button> when not provided. */
+  ButtonComponent?: React.ComponentType<
+    React.ButtonHTMLAttributes<HTMLButtonElement>
+  >;
+}): ReactNode {
+  const wrapperRef = useRef<HTMLSpanElement | null>(null);
+  const [isMove, setIsMove] = useState(false);
+
+  const Btn = ButtonComponent ?? "button";
+
+  // Detect whether the surrounding code block is Move. Docusaurus puts the
+  // `language-move` class on the <pre> (not the <code>), so match the <pre>.
+  useEffect(() => {
+    let el: HTMLElement | null = wrapperRef.current;
+    while (el) {
+      if (el.querySelector?.("pre[class*='language-move']")) {
+        setIsMove(true);
+        return;
+      }
+      el = el.parentElement;
+    }
+  }, []);
+
+  const handleClick = useCallback(() => {
+    const code = getNearestCodeText(wrapperRef.current);
+    if (!code) return;
+    window.open(
+      `${PLAYMOVE_URL}/#${encodeURIComponent(code)}`,
+      "_blank",
+      "noopener",
+    );
+  }, []);
+
+  return (
+    <span
+      ref={wrapperRef}
+      className={styles.wrapper}
+      style={{ display: isMove ? "inline-flex" : "none" }}
+    >
+      <Btn
+        type="button"
+        className={clsx(className, styles.triggerBtn, "clean-btn")}
+        aria-label="Open in Move Playground"
+        title="Open in Move Playground"
+        onClick={handleClick}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M8 5v14l11-7z" />
+        </svg>
+        <span className={styles.label}>Playground</span>
+      </Btn>
+    </span>
+  );
+}

--- a/design/src/shared/components/OpenInPlayMoveButton/styles.module.css
+++ b/design/src/shared/components/OpenInPlayMoveButton/styles.module.css
@@ -1,0 +1,21 @@
+/*
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+*/
+.wrapper {
+  display: inline-flex;
+}
+
+/* Trigger button: inherits code-block button styling from the theme.
+  These are minimal overrides for layout. */
+.triggerBtn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  line-height: 0;
+}
+
+.label {
+  line-height: 1;
+}

--- a/design/src/theme/CodeBlock/Buttons/index.tsx
+++ b/design/src/theme/CodeBlock/Buttons/index.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Swizzled (ejected) CodeBlock button bar. Renders the stock WordWrap + Copy
+// buttons, then our shared "Use an Agent" and "Playground" buttons. The
+// Playground button only appears on Move code blocks (it self-hides otherwise).
+//
+// Based on the upstream @docusaurus/theme-classic CodeBlock/Buttons component.
+
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import CopyButton from "@theme/CodeBlock/Buttons/CopyButton";
+import WordWrapButton from "@theme/CodeBlock/Buttons/WordWrapButton";
+import Button from "@theme/CodeBlock/Buttons/Button";
+import OpenInAgentButton from "@site/src/shared/components/OpenInAgentButton";
+import OpenInPlayMoveButton from "@site/src/shared/components/OpenInPlayMoveButton";
+import styles from "./styles.module.css";
+
+interface Props {
+  className?: string;
+}
+
+// Code block buttons are not server-rendered on purpose: adding them to the
+// initial HTML is useless and expensive (JSX SVG). They become interactive once
+// React hydrates.
+export default function CodeBlockButtons({ className }: Props): ReactNode {
+  return (
+    <BrowserOnly>
+      {() => (
+        <div className={clsx(className, styles.buttonGroup)}>
+          <WordWrapButton />
+          <CopyButton />
+          <OpenInAgentButton ButtonComponent={Button} />
+          <OpenInPlayMoveButton ButtonComponent={Button} />
+        </div>
+      )}
+    </BrowserOnly>
+  );
+}

--- a/design/src/theme/CodeBlock/Buttons/styles.module.css
+++ b/design/src/theme/CodeBlock/Buttons/styles.module.css
@@ -1,0 +1,38 @@
+/*
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copied from @docusaurus/theme-classic CodeBlock/Buttons so the ejected
+// swizzle keeps the upstream button-group layout and hover behavior.
+*/
+
+.buttonGroup {
+  display: flex;
+  column-gap: 0.2rem;
+  position: absolute;
+  /* rtl:ignore */
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+}
+
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 0;
+}
+
+.buttonGroup button:focus-visible,
+.buttonGroup button:hover {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .buttonGroup button {
+  opacity: 0.4;
+}


### PR DESCRIPTION
Added script(s) to auto-generate TS SDK doc from the hashi-ts-sdk repo. Currently requires local regeneration of the ts-sdk.mdx file since the SDK repo is still internal/private. If/when the repo becomes public, will implement workflow for daily sync

Also added "open with agent" and move playground buttons to code blocks to align with other MystenLabs tech docs.