### PR TITLE
[0/4] docs: update guardian standby flow design

### DIFF
--- a/design/docs/guardian.mdx
+++ b/design/docs/guardian.mdx
@@ -11,14 +11,18 @@ guardian is one party and the Hashi MPC committee is the other.
 
 ## Components
 
-The guardian integration has three distinct flows:
+The guardian integration has four distinct flows:
 
 - **Ceremony mode** is the key-generation control-plane flow. The operator
   initializes a ceremony guardian, supplies the KP roster, and receives the
   guardian BTC public key plus encrypted KP shares.
-- **Withdraw-mode provisioning** initializes the live withdrawal guardian. The
-  operator installs the verified state, and KPs submit threshold encrypted
-  shares through the public relay.
+- **Withdraw-mode provisioning** arms a standby withdrawal guardian while the
+  current active guardian is still alive. The operator installs a stable
+  `InitConfig`; KPs compare `config_hash` against their local pin and submit
+  threshold encrypted shares through the public relay.
+- **Activation** is the operator-triggered takeover step. The standby enclave
+  confirms a quiet window, derives live state from S3, checks the operator's
+  expected state hash, records activation, and only then serves withdrawals.
 - **Normal operation** is a data-plane flow. MPC nodes call the public guardian
   proxy for guardian info, withdrawal signatures, and committee handoff updates.
 
@@ -29,15 +33,18 @@ The main components are:
   Bitcoin signature.
 - **Guardian proxy**: the public gRPC endpoint. It forwards node-facing
   guardian RPCs and relays key-provisioner shares.
-- **Guardian enclave**: the private signer and policy engine. It verifies
-  committee certificates, enforces the limiter, signs Bitcoin inputs, and
-  records signed logs.
+- **Guardian enclave**: the private signer and policy engine. A standby
+  guardian stores static config and the reconstructed BTC key; an active
+  guardian additionally verifies committee certificates, enforces the limiter,
+  signs Bitcoin inputs, and records signed logs.
 - **Key provisioners (KPs)**: independent holders of encrypted guardian key
   shares.
 - **Operator**: the off-enclave actor that drives guardian ceremony and
-  withdraw-mode provisioning.
+  withdraw-mode provisioning and activation.
 - **S3**: immutable log storage for attestation,
-  ceremony, share recovery, heartbeat, withdrawal, and committee-update logs.
+  ceremony, share recovery, heartbeat, genesis, withdrawal, and committee-update
+  logs. Activation records are session lifecycle records in the activating
+  session's init log.
 - **Onchain Hashi state**: the source of committee, config, withdrawal, and MPC
   key state used by nodes and initialization tooling.
 
@@ -70,21 +77,30 @@ sequenceDiagram
     autonumber
 
     participant Operator
-    participant Onchain as Onchain Hashi state
     participant S3
-    participant Proxy as Guardian proxy
     participant Guardian as Guardian enclave
+    participant Proxy as Guardian proxy
     participant KPs as Key provisioners
 
     Note over Operator,Guardian: Operator initialization
-    Operator->>Onchain: Read committee and MPC master G
-    Operator->>S3: Read latest ceremony, limiter, and committee-update logs
-    Operator->>Guardian: OperatorInit(committee, limiter, MPC master G, sharing instance)
-    Guardian->>S3: log(init GuardianInfo(state_hash, limiter, committee))
+    Operator->>Operator: Gather genesis committee and master G from onchain state
+    Operator->>Operator: Gather bucket, limiter config, PCR allowlist, and network
+    Operator->>Operator: Build InitConfig
+    Operator->>Guardian: OperatorInit(S3 config, InitConfig)
+    Guardian->>S3: Read latest ceremony log
+    Guardian->>Guardian: Snapshot sharing instance for this arming
+    Guardian->>S3: Read latest committee-update or genesis record
+    alt no committee-update exists
+        Guardian->>S3: Write or verify write-once genesis record
+    end
+    Guardian->>S3: log(init GuardianInfo(config_hash, sharing instance))
+    Guardian->>S3: start heartbeat stream from OI onward
 
     Note over KPs,Guardian: Threshold share provisioning
-    KPs->>Onchain: Cross-check committee and MPC master G
-    KPs->>S3: Verify live session, state_hash, and encrypted share
+    KPs->>Guardian: GetGuardianInfo via proxy
+    Guardian-->>KPs: config_hash, session_id, n, t, attestation
+    KPs->>KPs: Verify PCRs and compare config_hash to local pin
+    KPs->>KPs: HPKE-encrypt local share with config_hash as AAD
     KPs->>Proxy: SingleProvisionerInit(encrypted share, expected_session_id)
     Proxy->>Guardian: Fetch live session and provisioning status
     Guardian-->>Proxy: session_id, threshold, provisioned flag
@@ -92,10 +108,36 @@ sequenceDiagram
         Proxy-->>KPs: share accepted, waiting for threshold
     else threshold reached
         Proxy->>Guardian: ProvisionerInit(T encrypted shares)
-        Guardian->>Guardian: Reconstruct BTC key and mark initialized
+        Guardian->>Guardian: Decrypt with config_hash AAD and verify commitments
+        Guardian->>Guardian: Reconstruct BTC key and mark armed standby
         Guardian->>S3: log(init fully-initialized)
-        Proxy-->>KPs: guardian provisioned
+        Proxy-->>KPs: standby armed
     end
+```
+
+## Standby Activation Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant Operator
+    participant S3
+    participant Guardian as Standby guardian enclave
+
+    Operator->>S3: Download ceremony, committee/genesis, and withdrawal logs
+    Operator->>Operator: Compute expected_state_hash
+    Operator->>Guardian: OperatorActivate(expected_state_hash)
+
+    Guardian->>S3: Confirm all other sessions heartbeat-quiet for QUIET_PERIOD
+    Guardian->>S3: Read latest ceremony log
+    Guardian->>Guardian: Refuse if latest sharing_seq differs from arming snapshot
+    Guardian->>S3: Read latest committee-update or genesis record
+    Guardian->>S3: Read max-seq successful withdrawal log
+    Guardian->>Guardian: Derive ActivationState and state_hash
+    Guardian->>Guardian: Refuse if derived hash differs from operator pin
+    Guardian->>S3: log(init operator-activation record)
+    Guardian->>Guardian: Install derived state and mark active
 ```
 
 ## Normal Operation Flow
@@ -112,20 +154,17 @@ sequenceDiagram
     participant Bitcoin
 
     Note over MPC,Guardian: Guardian info
-    MPC->>Proxy: GetGuardianInfo
-    Proxy->>Guardian: GetGuardianInfo
-    Guardian-->>Proxy: SignedGuardianInfo + attestation
-    Proxy-->>MPC: GuardianInfo
+    MPC->>Guardian: GetGuardianInfo via proxy
+    Guardian-->>MPC: GuardianInfo
 
     Note over Onchain,Guardian: Withdrawal signing
     MPC->>Onchain: Read pending withdrawal transaction
     MPC->>MPC: Collect committee cert for withdrawal
-    MPC->>Proxy: StandardWithdrawal(cert, wid, utxos, seq, timestamp)
-    Proxy->>Guardian: StandardWithdrawal
+    MPC->>Guardian: StandardWithdrawal(cert, wid, utxos, seq, timestamp) via proxy
+    Guardian->>Guardian: Require active session
     Guardian->>Guardian: Verify cert, consume limiter tokens, sign BTC inputs
     Guardian->>S3: log(withdraw success or failure)
-    Guardian-->>Proxy: SignedStandardWithdrawalResponse(enclave signatures)
-    Proxy-->>MPC: Guardian BTC signatures
+    Guardian-->>MPC: Guardian BTC signatures
     MPC->>MPC: Produce MPC signatures and combine witnesses
     MPC->>Onchain: sign_withdrawal(guardian signatures + MPC signatures)
     MPC->>Bitcoin: Broadcast fully signed transaction
@@ -133,9 +172,7 @@ sequenceDiagram
     Note over Onchain,Guardian: Committee handoff catch-up
     MPC->>Onchain: Read stored committee handoffs
     MPC->>MPC: Collect outgoing-committee handoff certs
-    MPC->>Proxy: UpdateCommitteeChain(signed handoffs)
-    Proxy->>Guardian: UpdateCommitteeChain
+    MPC->>Guardian: UpdateCommitteeChain(signed handoffs) via proxy
     Guardian->>S3: log(committee-update)
-    Guardian-->>Proxy: UpdateCommitteeResponse(current_committee_epoch)
-    Proxy-->>MPC: current_committee_epoch
+    Guardian-->>MPC: current_committee_epoch
 ```

--- a/design/docs/guardian.mdx
+++ b/design/docs/guardian.mdx
@@ -18,8 +18,10 @@ The guardian integration has four distinct flows:
   guardian BTC public key plus encrypted KP shares.
 - **Withdraw-mode provisioning** arms a standby withdrawal guardian while the
   current active guardian is still alive. The operator installs a stable
-  `InitConfig`; KPs compare `config_hash` against their local pin and submit
-  threshold encrypted shares through the public relay.
+  `InitConfig`; each KP independently recomputes `config_hash` from its locally
+  configured limiter config, PCR allowlist, and network plus the onchain master
+  key, requires it to match the enclave's, and submits threshold encrypted shares
+  through the public relay.
 - **Activation** is the operator-triggered takeover step. The standby enclave
   confirms a quiet window, derives live state from S3, checks the operator's
   expected state hash, records activation, and only then serves withdrawals.
@@ -48,7 +50,7 @@ The main components are:
 - **Onchain Hashi state**: the source of committee, config, withdrawal, and MPC
   key state used by nodes and initialization tooling.
 
-## Ceremony Mode Flow
+## Ceremony mode flow
 
 ```mermaid
 sequenceDiagram
@@ -70,7 +72,7 @@ sequenceDiagram
     KPs->>KPs: Decrypt share and verify attestation, recipients, commitment
 ```
 
-## Withdraw-Mode Provisioning Flow
+## Withdraw-mode provisioning flow
 
 ```mermaid
 sequenceDiagram
@@ -113,10 +115,12 @@ sequenceDiagram
 
 First deploy also has a genesis bootstrap path not shown above: if the operator
 finds no `committee-update/` or `genesis/` record in S3, it reads the current
-committee from onchain state and calls `write_genesis_untrusted` after
-`OperatorInit` to seed `genesis/`. Later deploys skip this step.
+committee from onchain state and calls the guardian's `OperatorWriteGenesis` RPC
+after `OperatorInit`. The enclave logs the operator-supplied committee to
+`genesis/` as-is; it is operator-trusted and used on first deploy only. Later
+deploys skip this step.
 
-## Standby Activation Flow
+## Standby activation flow
 
 ```mermaid
 sequenceDiagram
@@ -141,7 +145,7 @@ sequenceDiagram
     Guardian->>Guardian: Install derived state and mark active
 ```
 
-## Normal Operation Flow
+## Normal operation flow
 
 ```mermaid
 sequenceDiagram

--- a/design/docs/guardian.mdx
+++ b/design/docs/guardian.mdx
@@ -9,4 +9,133 @@ Hashi uses a withdrawal guardian: a second signatory on the managed Bitcoin
 deposits. All deposits are spendable only with a 2-of-2 multisig where the
 guardian is one party and the Hashi MPC committee is the other.
 
-Additional details about the guardian integration are added before Testnet.
+## Components
+
+The guardian integration has three distinct flows:
+
+- **Ceremony mode** is the key-generation control-plane flow. The operator
+  initializes a ceremony guardian, supplies the KP roster, and receives the
+  guardian BTC public key plus encrypted KP shares.
+- **Withdraw-mode provisioning** initializes the live withdrawal guardian. The
+  operator installs the verified state, and KPs submit threshold encrypted
+  shares through the public relay.
+- **Normal operation** is a data-plane flow. MPC nodes call the public guardian
+  proxy for guardian info, withdrawal signatures, and committee handoff updates.
+
+The main components are:
+
+- **MPC nodes**: the Hashi validator committee. Nodes collect committee
+  certificates, run the MPC signer, and call the guardian for the second
+  Bitcoin signature.
+- **Guardian proxy**: the public gRPC endpoint. It forwards node-facing
+  guardian RPCs and relays key-provisioner shares.
+- **Guardian enclave**: the private signer and policy engine. It verifies
+  committee certificates, enforces the limiter, signs Bitcoin inputs, and
+  records signed logs.
+- **Key provisioners (KPs)**: independent holders of encrypted guardian key
+  shares.
+- **Operator**: the off-enclave actor that drives guardian ceremony and
+  withdraw-mode provisioning.
+- **S3**: immutable log storage for attestation,
+  ceremony, share recovery, heartbeat, withdrawal, and committee-update logs.
+- **Onchain Hashi state**: the source of committee, config, withdrawal, and MPC
+  key state used by nodes and initialization tooling.
+
+## Ceremony Mode Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant Operator
+    participant S3
+    participant Guardian as Guardian enclave
+    participant KPs as Key provisioners
+
+    Operator->>Guardian: OperatorInit(S3 config)
+    Guardian->>S3: log(init attestation + GuardianInfo)
+    Operator->>Guardian: SetupNewKey(KP PGP certs, n, t)
+    Guardian->>S3: log(ceremony/NewKey + shares)
+    Guardian-->>Operator: encrypted KP shares + guardian BTC pubkey
+
+    KPs->>S3: Read init, ceremony, and shares logs
+    S3-->>KPs: encrypted share addressed to this KP
+    KPs->>KPs: Decrypt share and verify attestation, recipients, commitment
+```
+
+## Withdraw-Mode Provisioning Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant Operator
+    participant Onchain as Onchain Hashi state
+    participant S3
+    participant Proxy as Guardian proxy
+    participant Guardian as Guardian enclave
+    participant KPs as Key provisioners
+
+    Note over Operator,Guardian: Operator initialization
+    Operator->>Onchain: Read committee and MPC master G
+    Operator->>S3: Read latest ceremony, limiter, and committee-update logs
+    Operator->>Guardian: OperatorInit(committee, limiter, MPC master G, sharing instance)
+    Guardian->>S3: log(init GuardianInfo(state_hash, limiter, committee))
+
+    Note over KPs,Guardian: Threshold share provisioning
+    KPs->>Onchain: Cross-check committee and MPC master G
+    KPs->>S3: Verify live session, state_hash, and encrypted share
+    KPs->>Proxy: SingleProvisionerInit(encrypted share, expected_session_id)
+    Proxy->>Guardian: Fetch live session and provisioning status
+    Guardian-->>Proxy: session_id, threshold, provisioned flag
+    alt fewer than threshold shares collected
+        Proxy-->>KPs: share accepted, waiting for threshold
+    else threshold reached
+        Proxy->>Guardian: ProvisionerInit(T encrypted shares)
+        Guardian->>Guardian: Reconstruct BTC key and mark initialized
+        Guardian->>S3: log(init fully-initialized)
+        Proxy-->>KPs: guardian provisioned
+    end
+```
+
+## Normal Operation Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant Onchain as Onchain Hashi state
+    participant MPC as MPC nodes
+    participant Proxy as Guardian proxy
+    participant Guardian as Guardian enclave
+    participant S3
+    participant Bitcoin
+
+    Note over MPC,Guardian: Guardian info
+    MPC->>Proxy: GetGuardianInfo
+    Proxy->>Guardian: GetGuardianInfo
+    Guardian-->>Proxy: SignedGuardianInfo + attestation
+    Proxy-->>MPC: GuardianInfo
+
+    Note over Onchain,Guardian: Withdrawal signing
+    MPC->>Onchain: Read pending withdrawal transaction
+    MPC->>MPC: Collect committee cert for withdrawal
+    MPC->>Proxy: StandardWithdrawal(cert, wid, utxos, seq, timestamp)
+    Proxy->>Guardian: StandardWithdrawal
+    Guardian->>Guardian: Verify cert, consume limiter tokens, sign BTC inputs
+    Guardian->>S3: log(withdraw success or failure)
+    Guardian-->>Proxy: SignedStandardWithdrawalResponse(enclave signatures)
+    Proxy-->>MPC: Guardian BTC signatures
+    MPC->>MPC: Produce MPC signatures and combine witnesses
+    MPC->>Onchain: sign_withdrawal(guardian signatures + MPC signatures)
+    MPC->>Bitcoin: Broadcast fully signed transaction
+
+    Note over Onchain,Guardian: Committee handoff catch-up
+    MPC->>Onchain: Read stored committee handoffs
+    MPC->>MPC: Collect outgoing-committee handoff certs
+    MPC->>Proxy: UpdateCommitteeChain(signed handoffs)
+    Proxy->>Guardian: UpdateCommitteeChain
+    Guardian->>S3: log(committee-update)
+    Guardian-->>Proxy: UpdateCommitteeResponse(current_committee_epoch)
+    Proxy-->>MPC: current_committee_epoch
+```

--- a/design/docs/guardian.mdx
+++ b/design/docs/guardian.mdx
@@ -78,27 +78,23 @@ sequenceDiagram
 
     participant Operator
     participant S3
-    participant Guardian as Guardian enclave
+    participant Guardian as Standby guardian enclave
     participant Proxy as Guardian proxy
     participant KPs as Key provisioners
 
     Note over Operator,Guardian: Operator initialization
-    Operator->>Operator: Gather genesis committee and master G from onchain state
-    Operator->>Operator: Gather bucket, limiter config, PCR allowlist, and network
+    Operator->>Operator: Gather master G from onchain state
+    Operator->>Operator: Gather bucket plus limiter config plus PCR allowlist plus network
     Operator->>Operator: Build InitConfig
     Operator->>Guardian: OperatorInit(S3 config, InitConfig)
     Guardian->>S3: Read latest ceremony log
     Guardian->>Guardian: Snapshot sharing instance for this arming
-    Guardian->>S3: Read latest committee-update or genesis record
-    alt no committee-update exists
-        Guardian->>S3: Write or verify write-once genesis record
-    end
     Guardian->>S3: log(init GuardianInfo(config_hash, sharing instance))
     Guardian->>S3: start heartbeat stream from OI onward
 
     Note over KPs,Guardian: Threshold share provisioning
     KPs->>Guardian: GetGuardianInfo via proxy
-    Guardian-->>KPs: config_hash, session_id, n, t, attestation
+    Guardian-->>KPs: config_hash plus session_id plus n/t plus attestation
     KPs->>KPs: Verify PCRs and compare config_hash to local pin
     KPs->>KPs: HPKE-encrypt local share with config_hash as AAD
     KPs->>Proxy: SingleProvisionerInit(encrypted share, expected_session_id)
@@ -115,6 +111,11 @@ sequenceDiagram
     end
 ```
 
+First deploy also has a genesis bootstrap path not shown above: if the operator
+finds no `committee-update/` or `genesis/` record in S3, it reads the current
+committee from onchain state and calls `write_genesis_untrusted` after
+`OperatorInit` to seed `genesis/`. Later deploys skip this step.
+
 ## Standby Activation Flow
 
 ```mermaid
@@ -123,17 +124,17 @@ sequenceDiagram
 
     participant Operator
     participant S3
-    participant Guardian as Standby guardian enclave
+    participant Guardian as Guardian enclave
 
-    Operator->>S3: Download ceremony, committee/genesis, and withdrawal logs
+    Operator->>S3: Download ceremony instance plus committee/genesis plus limiter post-state
     Operator->>Operator: Compute expected_state_hash
     Operator->>Guardian: OperatorActivate(expected_state_hash)
 
     Guardian->>S3: Confirm all other sessions heartbeat-quiet for QUIET_PERIOD
     Guardian->>S3: Read latest ceremony log
-    Guardian->>Guardian: Refuse if latest sharing_seq differs from arming snapshot
+    Guardian->>Guardian: Refuse if latest ceremony instance differs from arming snapshot
     Guardian->>S3: Read latest committee-update or genesis record
-    Guardian->>S3: Read max-seq successful withdrawal log
+    Guardian->>S3: Recover limiter state from max-seq success or genesis
     Guardian->>Guardian: Derive ActivationState and state_hash
     Guardian->>Guardian: Refuse if derived hash differs from operator pin
     Guardian->>S3: log(init operator-activation record)
@@ -149,7 +150,7 @@ sequenceDiagram
     participant Onchain as Onchain Hashi state
     participant MPC as MPC nodes
     participant Proxy as Guardian proxy
-    participant Guardian as Guardian enclave
+    participant Guardian as Active guardian enclave
     participant S3
     participant Bitcoin
 
@@ -161,8 +162,7 @@ sequenceDiagram
     MPC->>Onchain: Read pending withdrawal transaction
     MPC->>MPC: Collect committee cert for withdrawal
     MPC->>Guardian: StandardWithdrawal(cert, wid, utxos, seq, timestamp) via proxy
-    Guardian->>Guardian: Require active session
-    Guardian->>Guardian: Verify cert, consume limiter tokens, sign BTC inputs
+    Guardian->>Guardian: Require active session then verify cert then consume limiter tokens then sign BTC inputs
     Guardian->>S3: log(withdraw success or failure)
     Guardian-->>MPC: Guardian BTC signatures
     MPC->>MPC: Produce MPC signatures and combine witnesses


### PR DESCRIPTION
## Summary
- add guardian flow diagrams as a baseline
- update the Guardian docs with the standby provisioning and activation design
- document InitConfig/config_hash and ActivationState/state_hash flow