### PR TITLE
proposal: Version-gate vote, remove_vote, and delete_expired

### DIFF
--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -108,6 +108,7 @@ public fun vote<T: store>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    hashi.versioning().assert_version_enabled();
     assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
 
     let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
@@ -129,6 +130,7 @@ public fun remove_vote<T: store>(
     proposal_id: ID,
     ctx: &mut TxContext,
 ) {
+    hashi.versioning().assert_version_enabled();
     assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
 
     let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
@@ -160,6 +162,7 @@ public fun is_expired<T>(proposal: &Proposal<T>, clock: &Clock): bool {
 }
 
 public fun delete_expired<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock): T {
+    hashi.versioning().assert_version_enabled();
     // Executed proposals are archived in the executed bag and must
     // never be deletable, even after they expire. Refuse explicitly so
     // the caller gets `EProposalAlreadyExecuted` instead of the bag's


### PR DESCRIPTION
## Motivation

`proposal::vote`, `proposal::remove_vote`, and `proposal::delete_expired` are the only three transaction-callable state mutators in the package without an `assert_version_enabled` gate (every entry function and every other public mutator gates). This contradicts versioning.move's stated invariant that a disabled version cannot be executed.

This matters pre-mainnet specifically: once published, v1's ungated bytecode remains callable forever — even after governance disables v1, members could still vote/remove votes/delete proposals under old semantics (e.g. the old 7-day expiry constant), flipping quorum on active proposals. The gate cannot be retrofitted into already-published code.

## Changes

- Add `hashi.versioning().assert_version_enabled()` at the top of `vote`, `remove_vote`, and `delete_expired`, matching the existing gate in `execute`.

## Test plan

- [x] 141/141 Move tests pass
- Note: no test asserts the `EVersionDisabled` abort — that path is currently untestable without a `test_only` force-disable helper (`disable_version` refuses to disable the current version), and none of the existing gates test it either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)