### PR TITLE
deposit: Rename timestamp_ms to creation_timestamp_ms and record confirmation time

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -597,11 +597,12 @@ pub struct OutputUtxo {
 pub struct DepositRequest {
     pub id: Address,
     pub sender: Address,
-    pub timestamp_ms: u64,
+    pub creation_timestamp_ms: u64,
     pub sui_tx_digest: Digest,
     pub utxo: Utxo,
     pub approval_cert: Option<CommitteeSignature>,
     pub approval_timestamp_ms: Option<u64>,
+    pub confirmed_timestamp_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, serde_derive::Deserialize, serde_derive::Serialize)]

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -403,7 +403,7 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
     println!(
         "  {} {}",
         "Requested:".bold(),
-        display::format_timestamp(dep.timestamp_ms)
+        display::format_timestamp(dep.creation_timestamp_ms)
     );
     println!("  {} {}", "Status:".bold(), "Pending".yellow());
 
@@ -448,7 +448,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                         },
                         "status": "pending",
                         "caller": dep.sender.to_string(),
-                        "requested_ms": dep.timestamp_ms,
+                        "requested_ms": dep.creation_timestamp_ms,
                     })
                 })
                 .collect();
@@ -486,7 +486,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                         dep.utxo.id.vout,
                         "Pending".yellow(),
                         display::format_address_full(&dep.sender),
-                        display::format_timestamp(dep.timestamp_ms)
+                        display::format_timestamp(dep.creation_timestamp_ms)
                     );
                 }
                 println!("\n  {} deposit(s)", deposits.len());

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -101,7 +101,8 @@ impl Hashi {
                 // compare the immutable core fields only.
                 let core_matches = onchain_request.id == deposit_request.id
                     && onchain_request.sender == deposit_request.sender
-                    && onchain_request.timestamp_ms == deposit_request.timestamp_ms
+                    && onchain_request.creation_timestamp_ms
+                        == deposit_request.creation_timestamp_ms
                     && onchain_request.sui_tx_digest == deposit_request.sui_tx_digest
                     && onchain_request.utxo == deposit_request.utxo;
                 if !core_matches {

--- a/crates/hashi/src/grpc/bridge_service.rs
+++ b/crates/hashi/src/grpc/bridge_service.rs
@@ -360,7 +360,7 @@ fn parse_deposit_request(
     Ok(DepositRequest {
         id,
         sender: requester_address,
-        timestamp_ms: request.timestamp_ms,
+        creation_timestamp_ms: request.timestamp_ms,
         sui_tx_digest,
         utxo: Utxo {
             id: UtxoId {
@@ -374,6 +374,7 @@ fn parse_deposit_request(
         // the on-chain version separately when verifying.
         approval_cert: None,
         approval_timestamp_ms: None,
+        confirmed_timestamp_ms: None,
     })
 }
 

--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -54,7 +54,7 @@ impl LeaderService {
 
     fn reload_pending_unapproved_deposit_requests(&mut self, mode: UnapprovedDepositReloadMode) {
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
-        deposit_requests.sort_by_key(|r| r.timestamp_ms);
+        deposit_requests.sort_by_key(|r| r.creation_timestamp_ms);
         let deposit_ids: HashSet<Address> =
             deposit_requests.iter().map(|request| request.id).collect();
         self.inflight_deposits
@@ -131,7 +131,7 @@ impl LeaderService {
         let current_epoch = self.inner.onchain_state().epoch();
 
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
-        deposit_requests.sort_by_key(|r| r.timestamp_ms);
+        deposit_requests.sort_by_key(|r| r.creation_timestamp_ms);
         let approved_deposit_requests: Vec<_> = deposit_requests
             .into_iter()
             .filter(|request| !self.never_retry_deposit_ids.contains(&request.id))
@@ -487,7 +487,7 @@ fn deposit_request_to_proto(req: &DepositRequest) -> SignDepositConfirmationRequ
             .utxo
             .derivation_path
             .map(|p| p.as_bytes().to_vec().into()),
-        timestamp_ms: req.timestamp_ms,
+        timestamp_ms: req.creation_timestamp_ms,
         requester_address: req.sender.as_bytes().to_vec().into(),
         sui_tx_digest: req.sui_tx_digest.as_bytes().to_vec().into(),
     }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -45,14 +45,14 @@ impl LeaderService {
         }
 
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
-        deposit_requests.sort_by_key(|r| r.timestamp_ms);
+        deposit_requests.sort_by_key(|r| r.creation_timestamp_ms);
 
         let Some(oldest_request) = deposit_requests.first() else {
             return;
         };
 
         if checkpoint_timestamp_ms
-            < oldest_request.timestamp_ms
+            < oldest_request.creation_timestamp_ms
                 + MAX_DEPOSIT_REQUEST_AGE_MS
                 + DEPOSIT_REQUEST_DELETE_DELAY_MS
         {
@@ -61,7 +61,9 @@ impl LeaderService {
 
         let expired_requests: Vec<_> = deposit_requests
             .iter()
-            .filter(|r| checkpoint_timestamp_ms > r.timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS)
+            .filter(|r| {
+                checkpoint_timestamp_ms > r.creation_timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS
+            })
             .take(MAX_DEPOSIT_REQUEST_DELETIONS_PER_GC)
             .cloned()
             .collect();

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -317,7 +317,7 @@ async fn handle_events(
                 let deposit_request = DepositRequest {
                     id: deposit_requested_event.request_id,
                     sender: deposit_requested_event.requester_address,
-                    timestamp_ms: deposit_requested_event.timestamp_ms,
+                    creation_timestamp_ms: deposit_requested_event.timestamp_ms,
                     sui_tx_digest: deposit_requested_event.sui_tx_digest,
                     utxo: super::types::Utxo {
                         id: deposit_requested_event.utxo_id,
@@ -326,6 +326,7 @@ async fn handle_events(
                     },
                     approval_cert: None,
                     approval_timestamp_ms: None,
+                    confirmed_timestamp_ms: None,
                 };
                 state
                     .state_mut()

--- a/packages/hashi/sources/btc/deposit.move
+++ b/packages/hashi/sources/btc/deposit.move
@@ -64,7 +64,7 @@ public fun deposit(
         utxo_id: utxo_ref.id(),
         amount: utxo_ref.amount(),
         derivation_path: utxo_ref.derivation_path(),
-        timestamp_ms: request.request_timestamp_ms(),
+        timestamp_ms: request.request_creation_timestamp_ms(),
         requester_address: request.request_sender(),
         sui_tx_digest: request.request_sui_tx_digest(),
     });
@@ -156,7 +156,7 @@ entry fun confirm_deposit(
 
     // Remove from active requests and copy the UTXO. Aborts if the request
     // was never approved (no stored cert or timestamp).
-    let request = hashi.bitcoin_mut().deposit_queue_mut().remove_request(request_id);
+    let mut request = hashi.bitcoin_mut().deposit_queue_mut().remove_request(request_id);
     let utxo = request.utxo();
     let cert = request.approval_cert().destroy_some();
     let approval_timestamp_ms = request.approval_timestamp_ms().destroy_some();
@@ -171,6 +171,8 @@ entry fun confirm_deposit(
         approval_timestamp_ms + hashi.config().deposit_time_delay_ms() <= clock.timestamp_ms(),
         EDepositTimeDelayNotPassed,
     );
+
+    request.confirm(clock);
 
     sui::event::emit(DepositConfirmedEvent {
         request_id,

--- a/packages/hashi/sources/btc/deposit_queue.move
+++ b/packages/hashi/sources/btc/deposit_queue.move
@@ -25,7 +25,7 @@ const EDepositAlreadyProcessed: vector<u8> = b"Deposit request has already been 
 public struct DepositRequest has key, store {
     id: UID,
     sender: address,
-    timestamp_ms: u64,
+    creation_timestamp_ms: u64,
     sui_tx_digest: vector<u8>,
     utxo: Utxo,
     /// Committee certificate recorded at approval time. `None` until
@@ -34,6 +34,9 @@ public struct DepositRequest has key, store {
     /// Clock timestamp at the moment of approval. `None` until
     /// `approve_deposit` has been called.
     approval_timestamp_ms: Option<u64>,
+    /// Clock timestamp at the moment of confirmation. `None` until
+    /// `confirm_deposit` has been called.
+    confirmed_timestamp_ms: Option<u64>,
 }
 
 public struct DepositRequestQueue has store {
@@ -58,11 +61,12 @@ public(package) fun create_deposit(utxo: Utxo, clock: &Clock, ctx: &mut TxContex
     DepositRequest {
         id: object::new(ctx),
         sender: ctx.sender(),
-        timestamp_ms: clock.timestamp_ms(),
+        creation_timestamp_ms: clock.timestamp_ms(),
         sui_tx_digest: *ctx.digest(),
         utxo,
         approval_cert: option::none(),
         approval_timestamp_ms: option::none(),
+        confirmed_timestamp_ms: option::none(),
     }
 }
 
@@ -113,6 +117,20 @@ public(package) fun approve(request: &mut DepositRequest, cert: CommitteeSignatu
     request.approval_timestamp_ms = option::some(clock.timestamp_ms());
 }
 
+/// Record the current clock timestamp on `request` to mark it as
+/// confirmed. Caller is responsible for enforcing the time-delay window
+/// before calling this.
+public(package) fun confirm(request: &mut DepositRequest, clock: &Clock) {
+    request.confirmed_timestamp_ms = option::some(clock.timestamp_ms());
+}
+
+/// The clock timestamp at which the request was confirmed, if any.
+/// Returns `None` for requests that have not yet been through
+/// `confirm_deposit`.
+public(package) fun confirmed_timestamp_ms(request: &DepositRequest): Option<u64> {
+    request.confirmed_timestamp_ms
+}
+
 /// Insert a completed deposit into the processed bag.
 /// Returns (request_id, recipient) so the caller can index by user.
 public(package) fun insert_processed(
@@ -139,11 +157,12 @@ public(package) fun delete_expired(
     let DepositRequest {
         id,
         sender: _,
-        timestamp_ms: _,
+        creation_timestamp_ms: _,
         sui_tx_digest: _,
         utxo,
         approval_cert: _,
         approval_timestamp_ms: _,
+        confirmed_timestamp_ms: _,
     } = request;
     id.delete();
     utxo.delete();
@@ -167,8 +186,8 @@ public(package) fun request_sender(self: &DepositRequest): address {
     self.sender
 }
 
-public(package) fun request_timestamp_ms(self: &DepositRequest): u64 {
-    self.timestamp_ms
+public(package) fun request_creation_timestamp_ms(self: &DepositRequest): u64 {
+    self.creation_timestamp_ms
 }
 
 public(package) fun request_sui_tx_digest(self: &DepositRequest): vector<u8> {
@@ -182,5 +201,5 @@ public(package) fun request_utxo(self: &DepositRequest): &Utxo {
 // ======== Internal ========
 
 fun is_expired(request: &DepositRequest, clock: &Clock): bool {
-    clock.timestamp_ms() > request.timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS
+    clock.timestamp_ms() > request.creation_timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS
 }


### PR DESCRIPTION
## Motivation

Part of the pre-mainnet struct-evolution cleanup. `DepositRequest` gains explicit lifecycle timestamps: the ambiguous `timestamp_ms` becomes `creation_timestamp_ms`, and the confirmation time is now recorded on-chain. The added field has to land before mainnet freezes the struct layout; this also sets the timestamp naming convention the withdrawal-side structs will adopt in a follow-up PR.

## Changes

**Move:**
- `DepositRequest.timestamp_ms` → `creation_timestamp_ms` (rename only, BCS-compatible)
- New `DepositRequest.confirmed_timestamp_ms: Option<u64>`, set by `confirm_deposit` once the time-delay window clears (new `deposit_queue::confirm` setter mirroring `approve`)
- Accessor `request_timestamp_ms` → `request_creation_timestamp_ms`; new `confirmed_timestamp_ms` accessor
- Event field names are unchanged

**Rust:**
- `hashi-types` `DepositRequest` mirror updated (rename + new trailing `Option<u64>`, matching the Move BCS layout)
- All field consumers updated (leader, watcher, gRPC bridge service, CLI, GC); proto field names unchanged

## Test plan

- [x] 141/141 Move tests pass
- [x] `cargo check --workspace` clean
- [x] prettier-move + cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)