### PR TITLE
btc: Standardize lifecycle timestamps on created_timestamp_ms

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -438,7 +438,7 @@ pub struct WithdrawalRequest {
     pub sender: Address,
     pub btc_amount: u64,
     pub bitcoin_address: Vec<u8>,
-    pub timestamp_ms: u64,
+    pub created_timestamp_ms: u64,
     pub status: WithdrawalStatus,
     pub withdrawal_txn_id: Option<Address>,
     pub sui_tx_digest: Digest,
@@ -543,7 +543,7 @@ pub struct WithdrawalTransaction {
     /// the trailing outputs: change output `j` sits at vout
     /// `withdrawal_outputs.len() + j`. Empty when there is no change.
     pub change_outputs: Vec<OutputUtxo>,
-    pub timestamp_ms: u64,
+    pub created_timestamp_ms: u64,
     pub randomness: Vec<u8>,
     /// Per-input MPC signatures, accumulated incrementally and out-of-order.
     pub signing: SigningBatch,
@@ -597,7 +597,7 @@ pub struct OutputUtxo {
 pub struct DepositRequest {
     pub id: Address,
     pub sender: Address,
-    pub creation_timestamp_ms: u64,
+    pub created_timestamp_ms: u64,
     pub sui_tx_digest: Digest,
     pub utxo: Utxo,
     pub approval_cert: Option<CommitteeSignature>,

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -403,7 +403,7 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
     println!(
         "  {} {}",
         "Requested:".bold(),
-        display::format_timestamp(dep.creation_timestamp_ms)
+        display::format_timestamp(dep.created_timestamp_ms)
     );
     println!("  {} {}", "Status:".bold(), "Pending".yellow());
 
@@ -448,7 +448,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                         },
                         "status": "pending",
                         "caller": dep.sender.to_string(),
-                        "requested_ms": dep.creation_timestamp_ms,
+                        "requested_ms": dep.created_timestamp_ms,
                     })
                 })
                 .collect();
@@ -486,7 +486,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                         dep.utxo.id.vout,
                         "Pending".yellow(),
                         display::format_address_full(&dep.sender),
-                        display::format_timestamp(dep.creation_timestamp_ms)
+                        display::format_timestamp(dep.created_timestamp_ms)
                     );
                 }
                 println!("\n  {} deposit(s)", deposits.len());

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -259,7 +259,7 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
         println!(
             "  {} {}",
             "Requested:".bold(),
-            display::format_timestamp(wr.timestamp_ms)
+            display::format_timestamp(wr.created_timestamp_ms)
         );
         println!();
 
@@ -383,7 +383,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                         "amount_sats": wr.btc_amount,
                         "status": if wr.status.is_approved() { "approved" } else { "requested" },
                         "caller": wr.sender.to_string(),
-                        "requested_ms": wr.timestamp_ms,
+                        "requested_ms": wr.created_timestamp_ms,
                     })
                 })
                 .collect();
@@ -441,7 +441,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                             wr.btc_amount,
                             status,
                             display::format_address_full(&wr.sender),
-                            display::format_timestamp(wr.timestamp_ms)
+                            display::format_timestamp(wr.created_timestamp_ms)
                         );
                     }
                 }

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -101,8 +101,7 @@ impl Hashi {
                 // compare the immutable core fields only.
                 let core_matches = onchain_request.id == deposit_request.id
                     && onchain_request.sender == deposit_request.sender
-                    && onchain_request.creation_timestamp_ms
-                        == deposit_request.creation_timestamp_ms
+                    && onchain_request.created_timestamp_ms == deposit_request.created_timestamp_ms
                     && onchain_request.sui_tx_digest == deposit_request.sui_tx_digest
                     && onchain_request.utxo == deposit_request.utxo;
                 if !core_matches {

--- a/crates/hashi/src/grpc/bridge_service.rs
+++ b/crates/hashi/src/grpc/bridge_service.rs
@@ -360,7 +360,7 @@ fn parse_deposit_request(
     Ok(DepositRequest {
         id,
         sender: requester_address,
-        creation_timestamp_ms: request.timestamp_ms,
+        created_timestamp_ms: request.timestamp_ms,
         sui_tx_digest,
         utxo: Utxo {
             id: UtxoId {

--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -54,7 +54,7 @@ impl LeaderService {
 
     fn reload_pending_unapproved_deposit_requests(&mut self, mode: UnapprovedDepositReloadMode) {
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
-        deposit_requests.sort_by_key(|r| r.creation_timestamp_ms);
+        deposit_requests.sort_by_key(|r| r.created_timestamp_ms);
         let deposit_ids: HashSet<Address> =
             deposit_requests.iter().map(|request| request.id).collect();
         self.inflight_deposits
@@ -131,7 +131,7 @@ impl LeaderService {
         let current_epoch = self.inner.onchain_state().epoch();
 
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
-        deposit_requests.sort_by_key(|r| r.creation_timestamp_ms);
+        deposit_requests.sort_by_key(|r| r.created_timestamp_ms);
         let approved_deposit_requests: Vec<_> = deposit_requests
             .into_iter()
             .filter(|request| !self.never_retry_deposit_ids.contains(&request.id))
@@ -487,7 +487,7 @@ fn deposit_request_to_proto(req: &DepositRequest) -> SignDepositConfirmationRequ
             .utxo
             .derivation_path
             .map(|p| p.as_bytes().to_vec().into()),
-        timestamp_ms: req.creation_timestamp_ms,
+        timestamp_ms: req.created_timestamp_ms,
         requester_address: req.sender.as_bytes().to_vec().into(),
         sui_tx_digest: req.sui_tx_digest.as_bytes().to_vec().into(),
     }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -45,14 +45,14 @@ impl LeaderService {
         }
 
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
-        deposit_requests.sort_by_key(|r| r.creation_timestamp_ms);
+        deposit_requests.sort_by_key(|r| r.created_timestamp_ms);
 
         let Some(oldest_request) = deposit_requests.first() else {
             return;
         };
 
         if checkpoint_timestamp_ms
-            < oldest_request.creation_timestamp_ms
+            < oldest_request.created_timestamp_ms
                 + MAX_DEPOSIT_REQUEST_AGE_MS
                 + DEPOSIT_REQUEST_DELETE_DELAY_MS
         {
@@ -62,7 +62,7 @@ impl LeaderService {
         let expired_requests: Vec<_> = deposit_requests
             .iter()
             .filter(|r| {
-                checkpoint_timestamp_ms > r.creation_timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS
+                checkpoint_timestamp_ms > r.created_timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS
             })
             .take(MAX_DEPOSIT_REQUEST_DELETIONS_PER_GC)
             .cloned()

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -57,7 +57,7 @@ impl LeaderService {
             .into_iter()
             .filter(|r| r.status.is_requested())
             .collect();
-        unapproved.sort_by_key(|r| r.timestamp_ms);
+        unapproved.sort_by_key(|r| r.created_timestamp_ms);
 
         let unapproved_ids: Vec<Address> = unapproved.iter().map(|r| r.id).collect();
         self.withdrawal_approval_retry_tracker
@@ -449,7 +449,7 @@ impl LeaderService {
             .into_iter()
             .filter(|r| r.status.is_approved())
             .collect();
-        approved.sort_by_key(|r| r.timestamp_ms);
+        approved.sort_by_key(|r| r.created_timestamp_ms);
 
         // Prune stuck-warn entries so a re-stuck request warns again.
         let pending_ids: HashSet<Address> = approved.iter().map(|r| r.id).collect();
@@ -549,14 +549,14 @@ impl LeaderService {
         let batch_is_full = batch.len() >= max_batch;
         let oldest_has_waited = batch
             .first()
-            .is_some_and(|r| checkpoint_timestamp_ms >= r.timestamp_ms + delay_ms);
+            .is_some_and(|r| checkpoint_timestamp_ms >= r.created_timestamp_ms + delay_ms);
 
         if !batch_is_full && !oldest_has_waited && !at_capacity {
             debug!(
                 "Holding {} approved request(s): oldest is {}ms old, \
                  waiting for {}ms delay or {} requests",
                 batch.len(),
-                checkpoint_timestamp_ms.saturating_sub(batch[0].timestamp_ms),
+                checkpoint_timestamp_ms.saturating_sub(batch[0].created_timestamp_ms),
                 delay_ms,
                 max_batch,
             );

--- a/crates/hashi/src/leader/withdrawal_transactions.rs
+++ b/crates/hashi/src/leader/withdrawal_transactions.rs
@@ -199,7 +199,7 @@ impl LeaderService {
 
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
         withdrawal_txns.retain(|p| !p.is_fully_signed());
-        withdrawal_txns.sort_by_key(|p| p.timestamp_ms);
+        withdrawal_txns.sort_by_key(|p| p.created_timestamp_ms);
 
         let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
         self.inflight_withdrawal_signings
@@ -889,7 +889,7 @@ impl LeaderService {
         debug!("Entering process_signed_withdrawal_txns");
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
         withdrawal_txns.retain(|p| p.is_fully_signed());
-        withdrawal_txns.sort_by_key(|p| p.timestamp_ms);
+        withdrawal_txns.sort_by_key(|p| p.created_timestamp_ms);
 
         let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
         self.inflight_withdrawal_broadcasts
@@ -957,7 +957,7 @@ impl LeaderService {
     fn process_pending_btc_block_withdrawal_checks(&mut self) {
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
         withdrawal_txns.retain(|p| p.is_fully_signed());
-        withdrawal_txns.sort_by_key(|p| p.timestamp_ms);
+        withdrawal_txns.sort_by_key(|p| p.created_timestamp_ms);
 
         let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
         self.inflight_withdrawal_btc_block_checks

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -317,7 +317,7 @@ async fn handle_events(
                 let deposit_request = DepositRequest {
                     id: deposit_requested_event.request_id,
                     sender: deposit_requested_event.requester_address,
-                    creation_timestamp_ms: deposit_requested_event.timestamp_ms,
+                    created_timestamp_ms: deposit_requested_event.timestamp_ms,
                     sui_tx_digest: deposit_requested_event.sui_tx_digest,
                     utxo: super::types::Utxo {
                         id: deposit_requested_event.utxo_id,
@@ -392,7 +392,7 @@ async fn handle_events(
                     sender: withdrawal_requested_event.requester_address,
                     btc_amount: withdrawal_requested_event.btc_amount,
                     bitcoin_address: withdrawal_requested_event.bitcoin_address.clone(),
-                    timestamp_ms: withdrawal_requested_event.timestamp_ms,
+                    created_timestamp_ms: withdrawal_requested_event.timestamp_ms,
                     status: super::types::WithdrawalStatus::Requested,
                     withdrawal_txn_id: None,
                     sui_tx_digest: withdrawal_requested_event.sui_tx_digest,
@@ -485,7 +485,7 @@ async fn handle_events(
                 // Watcher is the sole mutator of the local limiter
                 // post-bootstrap; advance it inline with the mirror update.
                 // Advance uses the event's checkpoint timestamp (~sign-time)
-                // rather than `txn.timestamp_ms` (creation time) to stay in
+                // rather than `txn.created_timestamp_ms` (creation time) to stay in
                 // lockstep with the guardian's `last_updated_at`.
                 // Gate on `signatures.is_none()` for idempotency across checkpoint redelivery and bootstrap replay.
                 let (limiter_inputs, pick_to_sign_ms) = {
@@ -513,7 +513,7 @@ async fn handle_events(
                             let amount_sats = withdrawal_limiter_consumption_amount(txn);
                             let timestamp_secs = checkpoint_timestamp_ms / 1000;
                             let pick_to_sign =
-                                checkpoint_timestamp_ms.saturating_sub(txn.timestamp_ms);
+                                checkpoint_timestamp_ms.saturating_sub(txn.created_timestamp_ms);
                             (Some((amount_sats, timestamp_secs)), Some(pick_to_sign))
                         }
                         _ => (None, None),
@@ -658,7 +658,7 @@ async fn handle_events(
                         .withdrawal_queue
                         .withdrawal_txns
                         .remove(&event.withdrawal_txn_id)
-                        .map(|txn| txn.timestamp_ms);
+                        .map(|txn| txn.created_timestamp_ms);
                     (
                         signed_at.map(|s| checkpoint_timestamp_ms.saturating_sub(s)),
                         pick_at.map(|p| checkpoint_timestamp_ms.saturating_sub(p)),

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -578,7 +578,7 @@ impl Hashi {
                         self.bound_leader_timestamp(ts)?;
                         ts
                     }
-                    None => txn.timestamp_ms / 1000,
+                    None => txn.created_timestamp_ms / 1000,
                 };
                 let result = limiter.validate_consume(expected_seq, timestamp_secs, amount_sats);
                 self.metrics.record_limiter_validate(
@@ -1138,7 +1138,7 @@ impl Hashi {
                 id: r.id,
                 recipient: r.bitcoin_address.clone(),
                 amount: r.btc_amount,
-                timestamp_ms: r.timestamp_ms,
+                timestamp_ms: r.created_timestamp_ms,
             })
             .collect();
 
@@ -1686,7 +1686,7 @@ mod tests {
             inputs: inputs.into_iter().map(input).collect(),
             withdrawal_outputs: withdrawal_outputs.into_iter().map(output).collect(),
             change_outputs: change.into_iter().map(output).collect(),
-            timestamp_ms: 0,
+            created_timestamp_ms: 0,
             randomness: vec![],
             signing: hashi_types::move_types::SigningBatch {
                 signatures: (0..num_inputs)

--- a/packages/hashi/sources/btc/deposit.move
+++ b/packages/hashi/sources/btc/deposit.move
@@ -64,7 +64,7 @@ public fun deposit(
         utxo_id: utxo_ref.id(),
         amount: utxo_ref.amount(),
         derivation_path: utxo_ref.derivation_path(),
-        timestamp_ms: request.request_creation_timestamp_ms(),
+        timestamp_ms: request.request_created_timestamp_ms(),
         requester_address: request.request_sender(),
         sui_tx_digest: request.request_sui_tx_digest(),
     });

--- a/packages/hashi/sources/btc/deposit_queue.move
+++ b/packages/hashi/sources/btc/deposit_queue.move
@@ -25,7 +25,7 @@ const EDepositAlreadyProcessed: vector<u8> = b"Deposit request has already been 
 public struct DepositRequest has key, store {
     id: UID,
     sender: address,
-    creation_timestamp_ms: u64,
+    created_timestamp_ms: u64,
     sui_tx_digest: vector<u8>,
     utxo: Utxo,
     /// Committee certificate recorded at approval time. `None` until
@@ -61,7 +61,7 @@ public(package) fun create_deposit(utxo: Utxo, clock: &Clock, ctx: &mut TxContex
     DepositRequest {
         id: object::new(ctx),
         sender: ctx.sender(),
-        creation_timestamp_ms: clock.timestamp_ms(),
+        created_timestamp_ms: clock.timestamp_ms(),
         sui_tx_digest: *ctx.digest(),
         utxo,
         approval_cert: option::none(),
@@ -157,7 +157,7 @@ public(package) fun delete_expired(
     let DepositRequest {
         id,
         sender: _,
-        creation_timestamp_ms: _,
+        created_timestamp_ms: _,
         sui_tx_digest: _,
         utxo,
         approval_cert: _,
@@ -186,8 +186,8 @@ public(package) fun request_sender(self: &DepositRequest): address {
     self.sender
 }
 
-public(package) fun request_creation_timestamp_ms(self: &DepositRequest): u64 {
-    self.creation_timestamp_ms
+public(package) fun request_created_timestamp_ms(self: &DepositRequest): u64 {
+    self.created_timestamp_ms
 }
 
 public(package) fun request_sui_tx_digest(self: &DepositRequest): vector<u8> {
@@ -201,5 +201,5 @@ public(package) fun request_utxo(self: &DepositRequest): &Utxo {
 // ======== Internal ========
 
 fun is_expired(request: &DepositRequest, clock: &Clock): bool {
-    clock.timestamp_ms() > request.creation_timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS
+    clock.timestamp_ms() > request.created_timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS
 }

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -408,7 +408,10 @@ public fun cancel_withdrawal(
 
     // Enforce cooldown.
     let cooldown = hashi.config().withdrawal_cancellation_cooldown_ms();
-    assert!(clock.timestamp_ms() >= request.request_timestamp_ms() + cooldown, ECooldownNotElapsed);
+    assert!(
+        clock.timestamp_ms() >= request.request_created_timestamp_ms() + cooldown,
+        ECooldownNotElapsed,
+    );
 
     hashi::withdrawal_queue::emit_withdrawal_cancelled(request);
 

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -61,7 +61,7 @@ public struct WithdrawalRequest has key, store {
     sender: address,
     btc_amount: u64,
     bitcoin_address: vector<u8>,
-    timestamp_ms: u64,
+    created_timestamp_ms: u64,
     status: WithdrawalStatus,
     withdrawal_txn_id: Option<address>,
     sui_tx_digest: vector<u8>,
@@ -101,7 +101,7 @@ public struct WithdrawalTransaction has key, store {
     /// `withdrawal_outputs.length() + j`. Empty when the transaction has no
     /// change.
     change_outputs: vector<OutputUtxo>,
-    timestamp_ms: u64,
+    created_timestamp_ms: u64,
     randomness: vector<u8>,
     /// Per-input MPC committee signatures, accumulated incrementally and
     /// out-of-order across checkpoints/leaders/epochs. Owns the presignature
@@ -150,7 +150,7 @@ public(package) fun create_withdrawal(
         sender: ctx.sender(),
         btc_amount,
         bitcoin_address,
-        timestamp_ms: clock.timestamp_ms(),
+        created_timestamp_ms: clock.timestamp_ms(),
         status: WithdrawalStatus::Requested,
         withdrawal_txn_id: option::none(),
         sui_tx_digest: *ctx.digest(),
@@ -253,7 +253,7 @@ public(package) fun cancel_withdrawal(
         sender: _,
         btc_amount: _,
         bitcoin_address: _,
-        timestamp_ms: _,
+        created_timestamp_ms: _,
         status: _,
         withdrawal_txn_id: _,
         sui_tx_digest: _,
@@ -364,7 +364,7 @@ public(package) fun new_withdrawal_txn(
         inputs,
         withdrawal_outputs: outputs,
         change_outputs,
-        timestamp_ms: clock.timestamp_ms(),
+        created_timestamp_ms: clock.timestamp_ms(),
         randomness,
         signing,
         guardian_signatures: option::none(),
@@ -563,8 +563,8 @@ public(package) fun request_sender(self: &WithdrawalRequest): address {
     self.sender
 }
 
-public(package) fun request_timestamp_ms(self: &WithdrawalRequest): u64 {
-    self.timestamp_ms
+public(package) fun request_created_timestamp_ms(self: &WithdrawalRequest): u64 {
+    self.created_timestamp_ms
 }
 
 public(package) fun request_btc_amount(self: &WithdrawalRequest): u64 {
@@ -593,7 +593,7 @@ public(package) fun emit_withdrawal_requested(request: &WithdrawalRequest) {
         request_id: request.id.to_address(),
         btc_amount: request.btc_amount,
         bitcoin_address: request.bitcoin_address,
-        timestamp_ms: request.timestamp_ms,
+        timestamp_ms: request.created_timestamp_ms,
         requester_address: request.sender,
         sui_tx_digest: request.sui_tx_digest,
     });
@@ -611,7 +611,7 @@ public(package) fun emit_withdrawal_picked_for_processing(self: &WithdrawalTrans
         inputs: self.inputs,
         withdrawal_outputs: self.withdrawal_outputs,
         change_outputs: self.change_outputs,
-        timestamp_ms: self.timestamp_ms,
+        timestamp_ms: self.created_timestamp_ms,
         randomness: self.randomness,
     });
 }
@@ -732,7 +732,7 @@ public(package) fun new_withdrawal_txn_for_testing(
         inputs,
         withdrawal_outputs,
         change_outputs,
-        timestamp_ms: clock.timestamp_ms(),
+        created_timestamp_ms: clock.timestamp_ms(),
         randomness: vector[0, 0, 0, 0],
         signing: mpc_signing::new(num_inputs, 0, 0),
         guardian_signatures: option::none(),


### PR DESCRIPTION
## Motivation

Per the review thread: `created` matches the other lifecycle fields (`signed`, `confirmed`), so this PR now standardizes **both** request structs on `created_timestamp_ms` — including flipping the deposit side that #747 merged as `creation_timestamp_ms`.

## Changes

- `DepositRequest.creation_timestamp_ms` → `created_timestamp_ms` (flips #747's naming)
- `WithdrawalRequest.timestamp_ms` → `created_timestamp_ms`
- `WithdrawalTransaction.timestamp_ms` → `created_timestamp_ms`
- Accessors follow (`request_created_timestamp_ms`)
- Rust mirrors and all consumers renamed; **no BCS layout change** (renames only), event and proto field names unchanged
- Also fixes the `#[cfg(test)]` `make_txn` helper that broke CI (clippy builds test targets; local check missed `--all-targets`)

## Test plan

- [x] 141/141 Move tests pass
- [x] `cargo check --workspace --all-targets` clean
- [x] prettier-move + cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)