### PR TITLE
withdraw: Record signed and confirmed timestamps on WithdrawalTransaction

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -545,6 +545,12 @@ pub struct WithdrawalTransaction {
     /// `withdrawal_outputs.len() + j`. Empty when there is no change.
     pub change_outputs: Vec<OutputUtxo>,
     pub created_timestamp_ms: u64,
+    /// Clock timestamp at which the transaction became fully signed
+    /// (guardian signatures attached). `None` until `finalize_withdrawal`.
+    pub signed_timestamp_ms: Option<u64>,
+    /// Clock timestamp at which the Bitcoin transaction was confirmed.
+    /// `None` until `confirm_withdrawal`.
+    pub confirmed_timestamp_ms: Option<u64>,
     pub randomness: Vec<u8>,
     /// Per-input MPC signatures, accumulated incrementally and out-of-order.
     pub signing: SigningBatch,

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1486,6 +1486,11 @@ impl SuiTxExecutor {
         let guardian_signatures_arg =
             build_chunked_vec_vec_u8_arg(&mut builder, guardian_signatures);
         let cert_arg = build_committee_signature_arg(&mut builder, self.hashi_ids.package_id, cert);
+        let clock_arg = builder.object(
+            ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+                .as_shared()
+                .with_mutable(false),
+        );
 
         builder.move_call(
             Function::new(
@@ -1499,6 +1504,7 @@ impl SuiTxExecutor {
                 request_ids_arg,
                 guardian_signatures_arg,
                 cert_arg,
+                clock_arg,
             ],
         );
 
@@ -1565,6 +1571,11 @@ impl SuiTxExecutor {
         );
         let withdrawal_id_arg = builder.pure(withdrawal_id);
         let cert_arg = build_committee_signature_arg(&mut builder, self.hashi_ids.package_id, cert);
+        let clock_arg = builder.object(
+            ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+                .as_shared()
+                .with_mutable(false),
+        );
 
         builder.move_call(
             Function::new(
@@ -1572,7 +1583,7 @@ impl SuiTxExecutor {
                 Identifier::from_static("withdraw"),
                 Identifier::from_static("confirm_withdrawal"),
             ),
-            vec![hashi_arg, withdrawal_id_arg, cert_arg],
+            vec![hashi_arg, withdrawal_id_arg, cert_arg, clock_arg],
         );
 
         let response = self.execute(builder).await?;

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -1687,6 +1687,8 @@ mod tests {
             withdrawal_outputs: withdrawal_outputs.into_iter().map(output).collect(),
             change_outputs: change.into_iter().map(output).collect(),
             created_timestamp_ms: 0,
+            signed_timestamp_ms: None,
+            confirmed_timestamp_ms: None,
             randomness: vec![],
             signing: hashi_types::move_types::SigningBatch {
                 signatures: (0..num_inputs)

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -307,6 +307,7 @@ entry fun finalize_withdrawal(
     request_ids: vector<address>,
     guardian_signatures: vector<vector<u8>>,
     cert: CommitteeSignature,
+    clock: &Clock,
 ) {
     hashi.versioning().assert_version_enabled();
     hashi.assert_unpaused();
@@ -329,11 +330,16 @@ entry fun finalize_withdrawal(
     let WithdrawalSignedMessage { request_ids, guardian_signatures, .. } = approval;
 
     let queue = hashi.bitcoin_mut().withdrawal_queue_mut();
-    queue.finalize_withdrawal_txn(withdrawal_id, guardian_signatures);
+    queue.finalize_withdrawal_txn(withdrawal_id, guardian_signatures, clock);
     queue.update_requests_signed(&request_ids);
 }
 
-entry fun confirm_withdrawal(hashi: &mut Hashi, withdrawal_id: address, cert: CommitteeSignature) {
+entry fun confirm_withdrawal(
+    hashi: &mut Hashi,
+    withdrawal_id: address,
+    cert: CommitteeSignature,
+    clock: &Clock,
+) {
     hashi.versioning().assert_version_enabled();
     hashi.assert_unpaused();
     hashi.verify(WithdrawalConfirmationMessage { withdrawal_id }, cert);
@@ -341,7 +347,8 @@ entry fun confirm_withdrawal(hashi: &mut Hashi, withdrawal_id: address, cert: Co
     // Remove the in-flight withdrawal txn from the hot bag so we can do
     // all the bookkeeping with a direct handle, then re-insert it into the
     // confirmed bag at the end.
-    let txn = hashi.bitcoin_mut().withdrawal_queue_mut().remove_withdrawal_txn(withdrawal_id);
+    let mut txn = hashi.bitcoin_mut().withdrawal_queue_mut().remove_withdrawal_txn(withdrawal_id);
+    txn.mark_confirmed(clock);
     txn.emit_withdrawal_confirmed();
 
     // Update request statuses to Confirmed.

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -102,6 +102,12 @@ public struct WithdrawalTransaction has key, store {
     /// change.
     change_outputs: vector<OutputUtxo>,
     created_timestamp_ms: u64,
+    /// Clock timestamp at which the transaction became fully signed
+    /// (guardian signatures attached). `None` until `finalize_withdrawal`.
+    signed_timestamp_ms: Option<u64>,
+    /// Clock timestamp at which the Bitcoin transaction was confirmed.
+    /// `None` until `confirm_withdrawal`.
+    confirmed_timestamp_ms: Option<u64>,
     randomness: vector<u8>,
     /// Per-input MPC committee signatures, accumulated incrementally and
     /// out-of-order across checkpoints/leaders/epochs. Owns the presignature
@@ -365,6 +371,8 @@ public(package) fun new_withdrawal_txn(
         withdrawal_outputs: outputs,
         change_outputs,
         created_timestamp_ms: clock.timestamp_ms(),
+        signed_timestamp_ms: option::none(),
+        confirmed_timestamp_ms: option::none(),
         randomness,
         signing,
         guardian_signatures: option::none(),
@@ -425,12 +433,20 @@ public(package) fun finalize_withdrawal_txn(
     self: &mut WithdrawalRequestQueue,
     withdrawal_id: address,
     guardian_signatures: vector<vector<u8>>,
+    clock: &Clock,
 ) {
     let txn: &mut WithdrawalTransaction = self.withdrawal_txns.borrow_mut(withdrawal_id);
     assert!(!txn.txn_fully_signed(), EWithdrawalAlreadyFinalized);
     assert!(txn.signing.is_complete(), EWithdrawalNotFullySigned);
     txn.guardian_signatures = option::some(guardian_signatures);
+    txn.signed_timestamp_ms = option::some(clock.timestamp_ms());
     emit_withdrawal_signed(txn);
+}
+
+/// Record the confirmation time on a withdrawal transaction. Called by
+/// `confirm_withdrawal` before the txn moves to the confirmed bag.
+public(package) fun mark_confirmed(self: &mut WithdrawalTransaction, clock: &Clock) {
+    self.confirmed_timestamp_ms = option::some(clock.timestamp_ms());
 }
 
 /// Reassign fresh presig indices to the still-pending inputs of a stale-epoch
@@ -733,6 +749,8 @@ public(package) fun new_withdrawal_txn_for_testing(
         withdrawal_outputs,
         change_outputs,
         created_timestamp_ms: clock.timestamp_ms(),
+        signed_timestamp_ms: option::none(),
+        confirmed_timestamp_ms: option::none(),
         randomness: vector[0, 0, 0, 0],
         signing: mpc_signing::new(num_inputs, 0, 0),
         guardian_signatures: option::none(),

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -243,7 +243,7 @@ fun test_sign_withdrawal_txn() {
     // one-shot guardian signature.
     queue.record_input_signatures(pending_id, vector[0], vector[x"DEADBEEF"]);
     assert!(!queue.withdrawal_txn_is_fully_signed(pending_id));
-    queue.finalize_withdrawal_txn(pending_id, vector[x"AAAAAAAA"]);
+    queue.finalize_withdrawal_txn(pending_id, vector[x"AAAAAAAA"], &clock);
     assert!(queue.withdrawal_txn_is_fully_signed(pending_id));
 
     // Remove and destroy
@@ -288,7 +288,7 @@ fun test_full_withdrawal_queue_lifecycle() {
 
     // Step 4: Sign — record the input's MPC signature, then finalize.
     queue.record_input_signatures(pending_id, vector[0], vector[x"AA"]);
-    queue.finalize_withdrawal_txn(pending_id, vector[x"CC"]);
+    queue.finalize_withdrawal_txn(pending_id, vector[x"CC"], &clock);
 
     // Step 5: Confirm — remove and destroy
     let pending = queue.remove_withdrawal_txn(pending_id);


### PR DESCRIPTION
## Motivation

Stacked on #748. Completes the `WithdrawalTransaction` lifecycle timestamps (`created` / `signed` / `confirmed`). The added fields change the struct's BCS layout, so they must land before mainnet freezes it.

## Changes

**Move:**
- New `WithdrawalTransaction.signed_timestamp_ms: Option<u64>` — set in `finalize_withdrawal_txn` alongside the guardian signatures
- New `WithdrawalTransaction.confirmed_timestamp_ms: Option<u64>` — set by the new `mark_confirmed` in `confirm_withdrawal` before the txn moves to the confirmed bag
- `finalize_withdrawal` and `confirm_withdrawal` entry functions gain a `&Clock` parameter (entry-only, signature change is free)

**Rust:**
- `hashi-types` `WithdrawalTransaction` mirror gains the two `Option<u64>` fields (matching Move BCS layout)
- `execute_finalize_withdrawal` / `execute_confirm_withdrawal` PTB builders pass the Clock object (0x6, immutable)

## Test plan

- [x] 141/141 Move tests pass
- [x] `cargo check --workspace` clean
- [x] prettier-move + cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)