### PR TITLE
btc: Give BitcoinState its own UID as an extension point

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -59,6 +59,7 @@ pub struct BitcoinStateKey {
 /// Rust version of the Move hashi::bitcoin_state::BitcoinState type.
 #[derive(Debug, serde_derive::Deserialize)]
 pub struct BitcoinState {
+    pub id: Address,
     pub deposit_queue: DepositRequestQueue,
     pub withdrawal_queue: WithdrawalRequestQueue,
     pub utxo_pool: UtxoPool,

--- a/packages/hashi/sources/btc/bitcoin_state.move
+++ b/packages/hashi/sources/btc/bitcoin_state.move
@@ -13,6 +13,9 @@ use sui::{bag::Bag, table::Table};
 public struct BitcoinStateKey has copy, drop, store {}
 
 public struct BitcoinState has store {
+    /// Extension point: dynamic fields can be attached here so new BTC-side
+    /// state can be added after the struct layout freezes at mainnet.
+    id: UID,
     deposit_queue: DepositRequestQueue,
     withdrawal_queue: WithdrawalRequestQueue,
     utxo_pool: UtxoPool,
@@ -25,11 +28,20 @@ public(package) fun key(): BitcoinStateKey { BitcoinStateKey {} }
 
 public(package) fun new(ctx: &mut TxContext): BitcoinState {
     BitcoinState {
+        id: object::new(ctx),
         deposit_queue: hashi::deposit_queue::create(ctx),
         withdrawal_queue: hashi::withdrawal_queue::create(ctx),
         utxo_pool: hashi::utxo_pool::create(ctx),
         user_requests: sui::table::new(ctx),
     }
+}
+
+public(package) fun id(self: &BitcoinState): &UID {
+    &self.id
+}
+
+public(package) fun id_mut(self: &mut BitcoinState): &mut UID {
+    &mut self.id
 }
 
 public(package) fun deposit_queue(self: &BitcoinState): &DepositRequestQueue {


### PR DESCRIPTION
## Motivation

`BitcoinState` is the root BTC container (a dynamic field on the `Hashi` object) and its 4-field layout freezes at mainnet. It currently has no UID, so nothing can ever be hung off it — any new BTC-side state post-launch would force a `BitcoinStateV2` destructure-and-rewrap (breaking every off-chain reader that resolves the df by type) or loose sibling fields on `Hashi.id`. A UID field makes future additions a plain dynamic-field attach.

## Changes

- `BitcoinState.id: UID` (+ `id`/`id_mut` package accessors)
- Rust mirror gains the leading `id: Address` field (BCS layout change — pre-mainnet only)

Not included (open option): a `version: u64` field for gated container migrations — the audit suggested it alongside the UID; happy to add here if wanted.

## Test plan

- [x] 141/141 Move tests pass
- [x] `cargo check --workspace` clean
- [x] prettier-move + cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)