### PR TITLE
committee: Add an extra_fields extension slot to MemberInfo

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -139,6 +139,9 @@ pub struct MemberInfo {
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
     pub next_epoch_encryption_public_key: Vec<u8>,
+
+    /// Open-ended per-member extension slot. Empty today.
+    pub extra_fields: Config,
 }
 
 impl MoveType for MemberInfo {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -989,6 +989,7 @@ async fn scrape_all_member_info(
                  endpoint_url,
                  tls_public_key,
                  next_epoch_encryption_public_key,
+                 extra_fields: _,
              }| {
                 let info = types::MemberInfo {
                     validator_address,
@@ -1046,6 +1047,7 @@ pub(crate) async fn scrape_member_info(
         endpoint_url,
         tls_public_key,
         next_epoch_encryption_public_key,
+        extra_fields: _,
     } = field.value;
 
     let info = types::MemberInfo {

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -4,7 +4,7 @@
 #[allow(unused_function, unused_field)]
 module hashi::committee_set;
 
-use hashi::{committee::{Self, Committee}, config::Config};
+use hashi::{committee::{Self, Committee}, config::{Self, Config}};
 use std::string::String;
 use sui::{
     bag::Bag,
@@ -173,6 +173,10 @@ public struct MemberInfo has store {
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
     next_epoch_encryption_public_key: vector<u8>,
+    /// Open-ended per-member extension slot. Empty today; lets future
+    /// upgrades attach new member data (e.g. per-protocol keys) without a
+    /// MemberInfoV2 migration.
+    extra_fields: Config,
 }
 
 /// Register as a member of Hashi.
@@ -196,6 +200,7 @@ public(package) fun new_member(
         endpoint_url: std::vector::empty().to_string(),
         tls_public_key: std::vector::empty(),
         next_epoch_encryption_public_key: std::vector::empty(),
+        extra_fields: config::empty(),
     };
 
     committee_set.insert_member(member);
@@ -604,5 +609,6 @@ fun create_member_info_for_testing(
         endpoint_url: std::vector::empty().to_string(),
         tls_public_key: std::vector::empty(),
         next_epoch_encryption_public_key: encryption_key,
+        extra_fields: config::empty(),
     }
 }


### PR DESCRIPTION
## Motivation

`MemberInfo` lives in the `CommitteeSet` members Bag and its layout freezes at mainnet. Migrating bag values post-launch is uniquely hazardous: lookups are hard-typed (`contains_with_type<_, MemberInfo>`) and committee formation silently skips entries whose type doesn't match, so a `MemberInfoV2` migration could quietly drop validators. An empty extension slot now means future member data is a key insert, not a type migration.

## Changes

- `MemberInfo.extra_fields: Config` (the key-value store type), initialized empty at registration
- Rust mirror updated (BCS layout change — pre-mainnet only)

**Scope note:** this covers the registration-side struct only. The committee-attested snapshot (`CommitteeMember`/`Committee`, which is also the signed handoff wire format) intentionally does not get a slot here — if any planned protocol needs per-member data inside the signed committee snapshot, that deserves its own PR and an off-chain signing-format bump. Flagging so it's a conscious decision.

## Test plan

- [x] 141/141 Move tests pass
- [x] `cargo check --workspace --all-targets` clean
- [x] prettier-move + cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)