### PR TITLE
hashi: Tighten public visibility to keep signatures evolvable

### DIFF
--- a/packages/hashi/sources/btc/deposit.move
+++ b/packages/hashi/sources/btc/deposit.move
@@ -38,7 +38,7 @@ public fun new_deposit_confirmation_message(
     DepositConfirmationMessage { request_id, utxo }
 }
 
-public fun deposit(
+entry fun deposit(
     hashi: &mut Hashi,
     utxo: hashi::utxo::Utxo,
     clock: &sui::clock::Clock,
@@ -202,7 +202,7 @@ entry fun confirm_deposit(
     };
 }
 
-public fun delete_expired_deposit(
+entry fun delete_expired_deposit(
     hashi: &mut Hashi,
     request_id: address,
     clock: &sui::clock::Clock,

--- a/packages/hashi/sources/btc/utxo.move
+++ b/packages/hashi/sources/btc/utxo.move
@@ -27,15 +27,15 @@ public fun utxo(utxo_id: UtxoId, amount: u64, derivation_path: Option<address>):
     Utxo { id: utxo_id, amount, derivation_path }
 }
 
-public fun id(self: &Utxo): UtxoId {
+public(package) fun id(self: &Utxo): UtxoId {
     self.id
 }
 
-public fun amount(self: &Utxo): u64 {
+public(package) fun amount(self: &Utxo): u64 {
     self.amount
 }
 
-public fun derivation_path(self: &Utxo): Option<address> {
+public(package) fun derivation_path(self: &Utxo): Option<address> {
     self.derivation_path
 }
 

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -625,7 +625,7 @@ public(package) fun request_bitcoin_address(self: &WithdrawalRequest): &vector<u
     &self.bitcoin_address
 }
 
-public fun is_approved(self: &WithdrawalStatus): bool {
+public(package) fun is_approved(self: &WithdrawalStatus): bool {
     match (self) {
         WithdrawalStatus::Approved => true,
         _ => false,

--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -106,7 +106,7 @@ public(package) fun execute<T: copy + drop + store>(
     data
 }
 
-public fun vote<T: store>(
+entry fun vote<T: store>(
     hashi: &mut Hashi,
     validator_address: address,
     proposal_id: ID,
@@ -129,7 +129,7 @@ public fun vote<T: store>(
     }
 }
 
-public fun remove_vote<T: store>(
+entry fun remove_vote<T: store>(
     hashi: &mut Hashi,
     validator_address: address,
     proposal_id: ID,
@@ -151,7 +151,7 @@ public fun remove_vote<T: store>(
     });
 }
 
-public fun quorum_reached<T>(proposal: &Proposal<T>, hashi: &Hashi): bool {
+public(package) fun quorum_reached<T>(proposal: &Proposal<T>, hashi: &Hashi): bool {
     let valid_voting_power = proposal.votes.fold!(0, |acc, voter| {
         acc + hashi.current_committee().get_member_weight(&voter)
     });
@@ -162,7 +162,7 @@ public fun quorum_reached<T>(proposal: &Proposal<T>, hashi: &Hashi): bool {
     valid_voting_power >= required
 }
 
-public fun is_expired<T>(proposal: &Proposal<T>, clock: &Clock): bool {
+public(package) fun is_expired<T>(proposal: &Proposal<T>, clock: &Clock): bool {
     clock.timestamp_ms() > proposal.created_timestamp_ms + MAX_PROPOSAL_DURATION_MS
 }
 
@@ -194,7 +194,7 @@ public(package) fun delete<T>(proposal: Proposal<T>): T {
 
 // ~~~~~~~ Getters ~~~~~~~
 
-public fun votes<T>(proposal: &Proposal<T>): &vector<address> {
+public(package) fun votes<T>(proposal: &Proposal<T>): &vector<address> {
     &proposal.votes
 }
 

--- a/packages/hashi/sources/core/tob.move
+++ b/packages/hashi/sources/core/tob.move
@@ -17,15 +17,15 @@ public enum ProtocolType has copy, drop, store {
     NonceGeneration,
 }
 
-public fun protocol_type_dkg(): ProtocolType {
+public(package) fun protocol_type_dkg(): ProtocolType {
     ProtocolType::Dkg
 }
 
-public fun protocol_type_key_rotation(): ProtocolType {
+public(package) fun protocol_type_key_rotation(): ProtocolType {
     ProtocolType::KeyRotation
 }
 
-public fun protocol_type_nonce_generation(): ProtocolType {
+public(package) fun protocol_type_nonce_generation(): ProtocolType {
     ProtocolType::NonceGeneration
 }
 
@@ -34,11 +34,11 @@ public struct TobKey has copy, drop, store {
     batch_index: Option<u32>,
 }
 
-public fun tob_key(epoch: u64, batch_index: Option<u32>): TobKey {
+public(package) fun tob_key(epoch: u64, batch_index: Option<u32>): TobKey {
     TobKey { epoch, batch_index }
 }
 
-public fun epoch(self: &TobKey): u64 {
+public(package) fun epoch(self: &TobKey): u64 {
     self.epoch
 }
 

--- a/packages/hashi/sources/core/validator.move
+++ b/packages/hashi/sources/core/validator.move
@@ -8,7 +8,7 @@ use hashi::hashi::Hashi;
 use std::string::String;
 use sui::event;
 
-public fun register(
+entry fun register(
     self: &mut Hashi,
     sui_system: &sui_system::sui_system::SuiSystemState,
     ctx: &mut TxContext,
@@ -21,7 +21,7 @@ public fun register(
     });
 }
 
-public fun update_next_epoch_public_key(
+entry fun update_next_epoch_public_key(
     self: &mut Hashi,
     validator: address,
     next_epoch_public_key: vector<u8>,
@@ -41,7 +41,7 @@ public fun update_next_epoch_public_key(
     event::emit(ValidatorUpdated { validator });
 }
 
-public fun update_operator_address(
+entry fun update_operator_address(
     self: &mut Hashi,
     validator: address,
     operator: address,
@@ -53,7 +53,7 @@ public fun update_operator_address(
     event::emit(ValidatorUpdated { validator });
 }
 
-public fun update_endpoint_url(
+entry fun update_endpoint_url(
     self: &mut Hashi,
     validator: address,
     endpoint_url: String,
@@ -65,7 +65,7 @@ public fun update_endpoint_url(
     event::emit(ValidatorUpdated { validator });
 }
 
-public fun update_tls_public_key(
+entry fun update_tls_public_key(
     self: &mut Hashi,
     validator: address,
     tls_public_key: vector<u8>,
@@ -77,7 +77,7 @@ public fun update_tls_public_key(
     event::emit(ValidatorUpdated { validator });
 }
 
-public fun update_next_epoch_encryption_public_key(
+entry fun update_next_epoch_encryption_public_key(
     self: &mut Hashi,
     validator: address,
     next_epoch_encryption_public_key: vector<u8>,


### PR DESCRIPTION
## Motivation

`public fun` signatures freeze permanently at first mainnet publish; `entry` and `public(package)` do not. This reclassifies functions that don't need `public` so their signatures stay evolvable (e.g. a future chain can add a `protocol_id` parameter to validator registration or a governance action).

## Changes

**→ `entry`** (user/validator actions returning `()`; still PTB-callable by name, so off-chain is unaffected):
- `validator`: `register` + the five `update_*` setters
- `deposit`: `deposit`, `delete_expired_deposit`
- `proposal`: `vote`, `remove_vote`

**→ `public(package)`** (intra-package only, no off-chain/PTB callers):
- `tob`: `tob_key`, `protocol_type_dkg`/`_key_rotation`/`_nonce_generation`, `epoch`
- `proposal`: `votes`, `is_expired`, `quorum_reached`
- `utxo`: `amount`, `id`, `derivation_path`
- `withdrawal_queue`: `is_approved` (currently unused)

**Kept `public`** where the frozen signature is unavoidable: PTB-input constructors (`config_value::new_*`, `utxo`/`utxo_id`, `output_utxo`, `new_committee_signature`), the `Balance`-passing withdrawal entrypoints (`request_withdrawal`/`cancel_withdrawal`), the upgrade hot-potato returns (`execute`/`finalize_upgrade`), and the `propose`/`execute` governance API (returns `ID`/hot potato).

## Test plan

- [x] 141/141 Move tests pass
- [x] `cargo check --workspace` clean
- [x] prettier-move clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
