### PR TITLE
withdraw: Require a fully-signed transaction to confirm a withdrawal

### DIFF
--- a/crates/hashi/src/grpc/bridge_service.rs
+++ b/crates/hashi/src/grpc/bridge_service.rs
@@ -322,6 +322,7 @@ impl BridgeService for HttpService {
         let member_signature = self
             .inner
             .sign_withdrawal_confirmation(&withdrawal_txn_id)
+            .await
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
         tracing::info!("Signed withdrawal confirmation");
         Ok(Response::new(SignWithdrawalConfirmationResponse {

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -455,7 +455,7 @@ impl Hashi {
         self.sign_message_proto(approval)
     }
 
-    pub fn sign_withdrawal_confirmation(
+    pub async fn sign_withdrawal_confirmation(
         &self,
         withdrawal_txn_id: &Address,
     ) -> anyhow::Result<hashi_types::proto::MemberSignature> {
@@ -465,6 +465,37 @@ impl Hashi {
             .ok_or_else(|| {
                 anyhow!("WithdrawalTransaction {withdrawal_txn_id} not found on-chain")
             })?;
+
+        // Confirmation is the terminal transition: it marks the withdrawal's
+        // inputs spent and finalizes requests whose BTC was already burned at
+        // commit. A malicious leader can aggregate confirmation signatures
+        // directly, so each validator must independently refuse to sign unless
+        // the withdrawal is genuinely finalizable — the leader's own checks are
+        // no defense here.
+
+        // (1) The on-chain transaction must be fully signed (every input has an
+        // MPC signature and the guardian signatures are attached), i.e. a
+        // broadcastable Bitcoin transaction actually exists.
+        anyhow::ensure!(
+            txn.is_fully_signed(),
+            "Refusing to sign confirmation for withdrawal {withdrawal_txn_id}: \
+             on-chain transaction is not fully signed"
+        );
+
+        // (2) That Bitcoin transaction must itself be confirmed to the
+        // configured threshold. This observational check is what a malicious
+        // leader cannot forge.
+        let confirmation_threshold = self.onchain_state().bitcoin_confirmation_threshold();
+        let txid: bitcoin::Txid = txn.txid.into();
+        match self.btc_monitor().get_transaction_status(txid).await? {
+            TxStatus::Confirmed { confirmations } if confirmations >= confirmation_threshold => {}
+            status => anyhow::bail!(
+                "Refusing to sign confirmation for withdrawal {withdrawal_txn_id}: \
+                 Bitcoin transaction {txid} not confirmed to threshold \
+                 {confirmation_threshold} (status: {status:?})"
+            ),
+        }
+
         let confirmation = WithdrawalConfirmation {
             withdrawal_id: txn.id,
         };

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -31,6 +31,9 @@ const ECooldownNotElapsed: vector<u8> = b"Cancellation cooldown has not elapsed"
 #[error]
 const ECannotCancelProcessingWithdrawal: vector<u8> =
     b"Cannot cancel a withdrawal that is already being processed";
+#[error]
+const EWithdrawalNotFullySigned: vector<u8> =
+    b"Cannot confirm a withdrawal that is not fully signed";
 
 // MESSAGE STEP 1
 public struct RequestApprovalMessage has copy, drop, store {
@@ -348,6 +351,18 @@ entry fun confirm_withdrawal(
     hashi.versioning().assert_version_enabled();
     hashi.assert_unpaused();
     hashi.verify(WithdrawalConfirmationMessage { withdrawal_id }, cert);
+
+    // Refuse to confirm a withdrawal that is not fully signed (every input has
+    // an MPC signature and the guardian signatures are attached). The
+    // confirmation cert only binds `withdrawal_id`, so without this gate a
+    // committee confirmation could finalize a committed-but-unsigned withdrawal
+    // — marking its inputs spent and burning user BTC with no broadcastable
+    // Bitcoin transaction. Off-chain signers additionally verify Bitcoin
+    // confirmation before contributing to this cert.
+    assert!(
+        hashi.bitcoin().withdrawal_queue().withdrawal_txn_is_fully_signed(withdrawal_id),
+        EWithdrawalNotFullySigned,
+    );
 
     // Remove the in-flight withdrawal txn from the hot bag so we can do
     // all the bookkeeping with a direct handle, then re-insert it into the


### PR DESCRIPTION
## Motivation

`confirm_withdrawal` (`btc/withdraw.move`) is the terminal transition: it marks the withdrawal's input UTXOs spent, promotes change outputs, and finalizes the requests — whose BTC was **already burned at commit time**. It authorized this solely by verifying a committee certificate over `WithdrawalConfirmationMessage { withdrawal_id }`, with **no check that the withdrawal was ever signed**.

The only thing standing between "committed" and "confirmed" was honest validators refusing to sign the confirmation. But the validator signer (`sign_withdrawal_confirmation`) signed a confirmation for any withdrawal id that merely existed on-chain — no fully-signed check, no independent Bitcoin-confirmation check. The Bitcoin-confirmation check that does exist is **leader-side only** (`withdrawal_transactions.rs`), which is no defense against a *malicious* leader orchestrating the signature collection.

**Impact:** a malicious leader could aggregate confirmation signatures from honest validators for a committed-but-unsigned withdrawal and finalize it — marking bridge UTXOs spent and finalizing burned-BTC requests with no broadcastable Bitcoin transaction ever existing. Loss of funds / UTXO-accounting corruption.

## Fix — two layers

**On-chain (`confirm_withdrawal`):** assert `withdrawal_txn_is_fully_signed(withdrawal_id)` before touching state (new error `EWithdrawalNotFullySigned`). An unsigned withdrawal becomes structurally un-confirmable regardless of the cert presented.

**Off-chain (`sign_withdrawal_confirmation`):** each validator now independently refuses to sign unless (1) the on-chain txn is fully signed and (2) its Bitcoin transaction is confirmed to the configured threshold, observed via the node's own `btc_monitor`. This is the guard a malicious leader cannot forge. The signer becomes `async`; the gRPC handler awaits it.

## Liveness analysis

**Layer 1 (on-chain gate): no liveness impact.** The leader's broadcast worklist is already gated on the exact same predicate — the broadcast loops filter with `withdrawal_txns.retain(|p| p.is_fully_signed())`, and `finalize_withdrawal` is documented as flipping the broadcast gate. So the honest ordering is: finalize on-chain (sets fully-signed) → broadcast to Bitcoin → observe confirmation → `confirm_withdrawal`. By the time confirmation is possible the txn is already fully-signed, so the assert is always satisfied for any legitimately-broadcast withdrawal. There is no reachable honest state of "paid out on Bitcoin but not fully-signed on-chain," so the gate cannot strand funds — it only rejects a state that should never exist.

**Layer 2 (off-chain signer): a deliberate, recoverable liveness dependency.** Confirmation now requires a *threshold* of validators to each independently observe the Bitcoin transaction confirmed via their own `btc_monitor`, rather than signing on the leader's say-so — that is the security property. Consequences:

- **New dependency, not a new systemic assumption.** It is the same `btc_monitor` confirmation dependency the deposit-approval path already relies on. If a threshold of honest validators have working, synced monitors, confirmation proceeds; a validator with a lagging monitor abstains until it catches up. The condition that would block confirmation (most validators' Bitcoin monitors down) already breaks deposits today.
- **Transient refusals self-heal.** Propagation lag or a reorg dropping the tx below threshold causes momentary refusals; the leader's confirm loop retries and it resolves once re-confirmed. No permanent stall.
- **Net safety gain at a small liveness cost.** Previously validators would blindly sign a confirmation for a tx that could still be reorged out; now they wait until it is threshold-deep before marking UTXOs spent.

## Test plan

- [x] 141/141 Move tests pass
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --all-features` clean
- [x] prettier-move + cargo fmt clean

**Coverage caveat (please read):** no existing test exercises the `confirm_withdrawal` entry path anywhere in the suite. The on-chain gate rests on the `withdrawal_txn_is_fully_signed` predicate, which *is* directly tested (`withdrawal_queue_tests.move`: false when unsigned, true after finalize). A proper positive+negative confirmation test belongs in the e2e crate (which drives real commit → sign → confirm flows) and is worth adding as a follow-up rather than bolting cert scaffolding into the Move unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
