### PR TITLE
cert_submission: Gate DKG and rotation certs on committee key state

### DIFF
--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -5,6 +5,13 @@ module hashi::cert_submission;
 
 use hashi::{committee::CommitteeSignature, hashi::Hashi, tob::ProtocolType};
 
+#[error]
+const EDkgOnlyDuringInitialReconfig: vector<u8> =
+    b"DKG certificates may only be submitted during the initial reconfig (before any MPC key exists)";
+#[error]
+const ERotationRequiresExistingKey: vector<u8> =
+    b"Key-rotation certificates require an existing MPC key (not valid during the initial reconfig)";
+
 entry fun submit_dkg_cert(
     hashi: &mut Hashi,
     epoch: u64,
@@ -13,6 +20,14 @@ entry fun submit_dkg_cert(
     cert: CommitteeSignature,
     ctx: &mut TxContext,
 ) {
+    // DKG and key-rotation certificates share the same `(epoch, None)` TOB
+    // bucket, whose stored `ProtocolType` is fixed by whichever submission
+    // creates it. Gate each ceremony on committee state so the wrong type can
+    // never create or join the bucket: an MPC key exists iff genesis DKG has
+    // completed, so DKG is valid only while the key is still empty. Without
+    // this, a malicious member could submit the wrong-type cert first and
+    // poison the bucket, stalling reconfiguration.
+    assert!(hashi.committee_set().mpc_public_key().is_empty(), EDkgOnlyDuringInitialReconfig);
     let key = hashi::tob::tob_key(epoch, option::none());
     submit_cert_internal(
         hashi,
@@ -34,6 +49,9 @@ entry fun submit_rotation_cert(
     cert: CommitteeSignature,
     ctx: &mut TxContext,
 ) {
+    // Symmetric to `submit_dkg_cert`: rotation is valid only once a genesis MPC
+    // key exists, so a rotation cert cannot poison the initial-DKG bucket.
+    assert!(!hashi.committee_set().mpc_public_key().is_empty(), ERotationRequiresExistingKey);
     let key = hashi::tob::tob_key(epoch, option::none());
     submit_cert_internal(
         hashi,


### PR DESCRIPTION
## Motivation

DKG and key-rotation certificates share the same `(epoch, None)` TOB bucket (both call `tob_key(epoch, none())`). `epoch_certs` fixes the bucket's `ProtocolType` to whichever submission *creates* it and never checks that later submissions match:

```move
if (!self.tob.contains(key)) {
    self.tob.add(key, hashi::tob::create(epoch, protocol_type, ctx));
};
self.tob.borrow_mut(key)   // existing bucket returned regardless of requested protocol_type
```

**Impact (insider liveness / DoS):** a malicious committee member (submission is gated by `member_authorized`) can submit the *wrong* ceremony type first for the current/pending epoch, creating the bucket with that type. Honest submissions of the correct type are then appended to the same bucket, but the off-chain fetch wraps *all* of them with the bucket's stored (wrong) `ProtocolType`, and the ceremony workers discard the variant-mismatched certs. The ceremony never completes, so `end_reconfig` cannot obtain its key and the bridge stays wedged behind `assert_not_reconfiguring` (deposits/withdrawals blocked) until operators recover. Recoverable, but bridge-halting.

## Fix

Gate each ceremony on committee state the attacker cannot fake. An MPC key exists **iff** genesis DKG has completed (`mpc_public_key` starts empty, is set once at the initial reconfig, and is never cleared thereafter — `committee_set.move` asserts it is unchanged on every subsequent rotation). So:

- `submit_dkg_cert` asserts `mpc_public_key().is_empty()` — DKG is valid only during the initial reconfig.
- `submit_rotation_cert` asserts `!mpc_public_key().is_empty()` — rotation is valid only once a key exists.

The wrong ceremony type can now neither create nor join the shared bucket, so poisoning is impossible. This also keeps the off-chain recovery path (which branches on the stored `ProtocolType`) reading the correct type.

**Why this shape:** the alternative — putting the ceremony type into `TobKey` so the buckets are disjoint — is also correct but cascades through the off-chain fetch API (which currently reads the type *out of* the bucket rather than requesting it). The state-gate fix is on-chain only, changes no frozen struct, and fully closes the hole. (`submit_nonce_cert` is unaffected: nonce certs use `Some(batch_index)`, a distinct bucket.)

This is the fix PR #600 would have subsumed via `protocol_id` keying, now that #600 is closed.

## Test plan

- [x] 141/141 Move tests pass (no honest flow regresses — DKG runs while the key is empty, rotation while it exists)
- [x] prettier-move clean

**Coverage caveat:** the `submit_*_cert` functions are `entry` and there is no existing cert-submission unit-test scaffolding, so the guard is not covered by a Move unit test. A negative test (wrong-type submission aborts) and the honest DKG/rotation flows belong in the e2e/localnet suite; worth adding as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
