### PR TITLE
deposit: Never garbage-collect an approved deposit request

### DIFF
--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -45,6 +45,10 @@ impl LeaderService {
         }
 
         let mut deposit_requests = self.inner.onchain_state().deposit_requests();
+        // Approved requests carry a committee certificate and are awaiting
+        // confirmation; the on-chain delete path rejects them, so exclude them
+        // from GC entirely rather than proposing deletions that would abort.
+        deposit_requests.retain(|r| r.approval_cert.is_none());
         deposit_requests.sort_by_key(|r| r.created_timestamp_ms);
 
         let Some(oldest_request) = deposit_requests.first() else {

--- a/packages/hashi/sources/btc/deposit_queue.move
+++ b/packages/hashi/sources/btc/deposit_queue.move
@@ -13,6 +13,9 @@ const MAX_DEPOSIT_REQUEST_AGE_MS: u64 = 1000 * 60 * 60 * 24; // 1 days
 const EDepositRequestNotExpired: vector<u8> = b"Deposit request not expired";
 #[error]
 const EDepositAlreadyProcessed: vector<u8> = b"Deposit request has already been processed";
+#[error]
+const ECannotDeleteApprovedDeposit: vector<u8> =
+    b"Cannot delete a deposit request that has been approved by the committee";
 
 // ======== Core Structs ========
 
@@ -152,6 +155,11 @@ public(package) fun delete_expired(
 ) {
     assert!(!self.processed.contains(request_id), EDepositAlreadyProcessed);
     let request: DepositRequest = self.requests.remove(request_id);
+    // An approved request carries a committee certificate and is awaiting
+    // confirmation (possibly blocked by pause/reconfiguration). Deleting it
+    // would destroy a valid, mint-pending approval, so approved requests are
+    // never expirable — only never-approved (genuinely abandoned) requests are.
+    assert!(request.approval_cert.is_none(), ECannotDeleteApprovedDeposit);
     assert!(is_expired(&request, clock), EDepositRequestNotExpired);
 
     let DepositRequest {

--- a/packages/hashi/tests/deposit_queue_tests.move
+++ b/packages/hashi/tests/deposit_queue_tests.move
@@ -43,6 +43,35 @@ fun test_delete_deposit_request() {
 }
 
 #[test]
+#[expected_failure(abort_code = deposit_queue::ECannotDeleteApprovedDeposit)]
+fun test_delete_approved_deposit_request_fails() {
+    let ctx = &mut test_utils::new_tx_context(NON_VOTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+
+    // Create a deposit request and approve it with a (dummy) committee cert.
+    let utxo_id = hashi::utxo::utxo_id(@0xCAFE, 0);
+    let utxo = hashi::utxo::utxo(utxo_id, 1000, option::none());
+    let mut request = deposit_queue::create_deposit(utxo, &clock, ctx);
+    let cert = hashi::committee::new_committee_signature(0, vector[], vector[]);
+    request.approve(cert, &clock);
+    let request_id = request.request_id().to_address();
+    hashi.bitcoin_mut().deposit_queue_mut().insert_deposit(request);
+
+    // Advance well past the expiration window; an approved request must still
+    // not be deletable.
+    let three_days_ms = 1000 * 60 * 60 * 24 * 3;
+    clock.set_for_testing(three_days_ms + 1);
+
+    hashi.bitcoin_mut().deposit_queue_mut().delete_expired(request_id, &clock);
+
+    // Unreachable — expected to abort above.
+    clock.destroy_for_testing();
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
 #[expected_failure(abort_code = deposit_queue::EDepositRequestNotExpired)]
 fun test_delete_unexpired_deposit_request() {
     let ctx = &mut test_utils::new_tx_context(NON_VOTER, 0);


### PR DESCRIPTION
## Motivation

`delete_expired` (`btc/deposit_queue.move`) removed any active request older than `MAX_DEPOSIT_REQUEST_AGE_MS` based purely on the request timestamp, with no check of approval state — and `delete_expired_deposit` exposes that path **permissionlessly**.

Once `approve_deposit` records a committee certificate, the request is awaiting `confirm_deposit`, which can be transiently blocked (pause / reconfiguration) or gated behind the configured time delay. So anyone could delete a valid, mint-pending approved deposit at the expiry boundary — destroying the stored certificate and forcing the user to resubmit and get re-approved. Low severity (recoverable, and the timing window is narrow) but a real griefing vector.

## Fix

Reject deletion of approved requests. An approval is a committee commitment, so a request carrying an `approval_cert` is never expirable — only never-approved (genuinely abandoned) requests are collectable.

- **On-chain:** `delete_expired` asserts `approval_cert.is_none()` (`ECannotDeleteApprovedDeposit`).
- **Off-chain:** the leader's GC scan excludes approved requests, so it doesn't propose deletions that would now abort.

**Why not "expire relative to approval time" instead:** that still leaves a hole when the confirmation delay exceeds the request age (the request would become deletable before it's confirmable). Rejecting approved requests outright closes it completely.

**Why this can't leak storage:** approval requires a committee-verified real Bitcoin deposit, so the set of approved-but-unconfirmed requests is bounded by genuine deposit activity — an attacker cannot fabricate approved entries to pin storage. Abandoned approved requests (e.g. cert went stale across a committee rotation and was never re-approved) are rare and small; if that ever needs cleanup, it can be an authorized action rather than the permissionless GC.

## Test plan

- [x] New Move test `test_delete_approved_deposit_request_fails`: an approved, expired request aborts on delete with `ECannotDeleteApprovedDeposit`
- [x] 142/142 Move tests pass
- [x] `cargo clippy -p hashi --all-features` clean; prettier + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
