### PR TITLE
utxo_pool: Rename UtxoRecord.locked_by to spent_by

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -954,7 +954,7 @@ mod tests {
 
         // Wait for the committee to commit withdrawal 1. At this point the
         // deposit UTXO is locked and the change UTXO is inserted as pending
-        // (produced_by = Some, locked_by = None). No Bitcoin blocks have been
+        // (produced_by = Some, spent_by = None). No Bitcoin blocks have been
         // mined, so neither the deposit spend nor the change output is
         // confirmed on-chain.
         let picked1 =

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -634,7 +634,7 @@ pub struct Utxo {
 pub struct UtxoRecord {
     pub utxo: Utxo,
     pub produced_by: Option<Address>,
-    pub locked_by: Option<Address>,
+    pub spent_by: Option<Address>,
     pub spent_epoch: Option<u64>,
 }
 

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -359,7 +359,7 @@ mod tests {
                 derivation_path: None,
             },
             produced_by: None,
-            locked_by: None,
+            spent_by: None,
             spent_epoch,
         }
     }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1032,13 +1032,13 @@ impl Metrics {
                     .sum::<u64>() as i64,
             );
         // Track three views of utxo_records:
-        // - available:         all selectable UTXOs (locked_by = None), whether
+        // - available:         all selectable UTXOs (spent_by = None), whether
         //                      confirmed or not; this is the coin-selection pool
         // - unconfirmed_change: subset of available whose producing withdrawal
         //                      has not yet confirmed on Bitcoin (produced_by =
         //                      Some); useful for gauging mempool chain depth
         // - locked:            committed to a pending withdrawal, awaiting
-        //                      Bitcoin confirmation (locked_by = Some)
+        //                      Bitcoin confirmation (spent_by = Some)
         let mut available_count = 0i64;
         let mut unconfirmed_change_count = 0i64;
         let mut locked_count = 0i64;
@@ -1046,7 +1046,7 @@ impl Metrics {
         let mut unconfirmed_change_value = 0u64;
         let mut locked_value = 0u64;
         for record in hashi.utxo_pool.utxo_records().values() {
-            if record.locked_by.is_some() {
+            if record.spent_by.is_some() {
                 locked_count += 1;
                 locked_value += record.utxo.amount;
             } else {

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -728,7 +728,7 @@ impl UtxoPool {
     pub fn active_utxos(&self) -> impl Iterator<Item = (&UtxoId, &Utxo)> {
         self.utxo_records
             .iter()
-            .filter(|(_, r)| r.locked_by.is_none())
+            .filter(|(_, r)| r.spent_by.is_none())
             .map(|(id, r)| (id, &r.utxo))
     }
 

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -371,7 +371,7 @@ async fn handle_events(
                     super::types::UtxoRecord {
                         utxo,
                         produced_by: None,
-                        locked_by: None,
+                        spent_by: None,
                         spent_epoch: None,
                     },
                 );
@@ -454,7 +454,7 @@ async fn handle_events(
                     for input in &event.inputs {
                         if let Some(record) = state.hashi.utxo_pool.utxo_records.get_mut(&input.id)
                         {
-                            record.locked_by = Some(event.withdrawal_txn_id);
+                            record.spent_by = Some(event.withdrawal_txn_id);
                         }
                     }
                     // Change outputs are the trailing outputs: change output `j`
@@ -475,7 +475,7 @@ async fn handle_events(
                             super::types::UtxoRecord {
                                 utxo: change_utxo,
                                 produced_by: Some(event.withdrawal_txn_id),
-                                locked_by: None,
+                                spent_by: None,
                                 spent_epoch: None,
                             },
                         );

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -277,9 +277,9 @@ impl Hashi {
                     .get(id)
                     .ok_or_else(|| anyhow!("UTXO {id:?} not found in the pool"))?;
                 anyhow::ensure!(
-                    record.locked_by.is_none(),
+                    record.spent_by.is_none(),
                     "UTXO {id:?} is locked by pending withdrawal {:?}",
-                    record.locked_by.unwrap()
+                    record.spent_by.unwrap()
                 );
                 Ok(record)
             })
@@ -1117,7 +1117,7 @@ impl Hashi {
         // Map available (unlocked) UTXOs to UtxoCandidates.
         let candidates: Vec<UtxoCandidate> = utxo_records
             .values()
-            .filter(|r| r.locked_by.is_none())
+            .filter(|r| r.spent_by.is_none())
             .map(|r| {
                 let status =
                     build_utxo_status(self, r, &withdrawal_txns, &tx_confirmations, &utxo_records);

--- a/packages/hashi/sources/btc/utxo_pool.move
+++ b/packages/hashi/sources/btc/utxo_pool.move
@@ -20,16 +20,17 @@ const EUtxoAlreadyUsed: vector<u8> = b"UTXO is already active or spent";
 ///
 /// `produced_by`: None = confirmed deposit or promoted change output;
 ///                Some(id) = unconfirmed change output of that withdrawal.
-/// `locked_by`:   None = available for coin selection;
-///                Some(id) = currently locked in that pending withdrawal.
+/// `spent_by`:    None = available for coin selection;
+///                Some(id) = reserved (locked) by that pending withdrawal to
+///                be spent; there is no unlock, so this withdrawal will spend it.
 ///
-/// A UTXO is selectable when `locked_by` is None, regardless of
+/// A UTXO is selectable when `spent_by` is None, regardless of
 /// `produced_by`. This allows chaining withdrawals through mempool change
 /// outputs before the parent transaction confirms.
 public struct UtxoRecord has store {
     utxo: Utxo,
     produced_by: Option<address>,
-    locked_by: Option<address>,
+    spent_by: Option<address>,
     spent_epoch: Option<u64>,
 }
 
@@ -65,7 +66,7 @@ public(package) fun insert_active(self: &mut UtxoPool, utxo: Utxo) {
             UtxoRecord {
                 utxo,
                 produced_by: option::none(),
-                locked_by: option::none(),
+                spent_by: option::none(),
                 spent_epoch: option::none(),
             },
         )
@@ -73,7 +74,7 @@ public(package) fun insert_active(self: &mut UtxoPool, utxo: Utxo) {
 
 /// Insert an unconfirmed change UTXO produced by a pending withdrawal.
 ///
-/// The UTXO is immediately selectable (`locked_by = None`) but flagged as
+/// The UTXO is immediately selectable (`spent_by = None`) but flagged as
 /// unconfirmed until `confirm_pending()` is called after the producing
 /// transaction confirms on Bitcoin.
 public(package) fun insert_pending(self: &mut UtxoPool, utxo: Utxo, withdrawal_id: address) {
@@ -85,7 +86,7 @@ public(package) fun insert_pending(self: &mut UtxoPool, utxo: Utxo, withdrawal_i
             UtxoRecord {
                 utxo,
                 produced_by: option::some(withdrawal_id),
-                locked_by: option::none(),
+                spent_by: option::none(),
                 spent_epoch: option::none(),
             },
         )
@@ -94,8 +95,8 @@ public(package) fun insert_pending(self: &mut UtxoPool, utxo: Utxo, withdrawal_i
 /// Lock a UTXO for use in a pending withdrawal. Aborts if already locked.
 public(package) fun lock(self: &mut UtxoPool, utxo_id: UtxoId, withdrawal_id: address) {
     let record: &mut UtxoRecord = self.utxo_records.borrow_mut(utxo_id);
-    assert!(record.locked_by.is_none(), EUtxoAlreadyLocked);
-    record.locked_by = option::some(withdrawal_id);
+    assert!(record.spent_by.is_none(), EUtxoAlreadyLocked);
+    record.spent_by = option::some(withdrawal_id);
 }
 
 /// Return a copy of a UTXO from the pool.
@@ -115,7 +116,7 @@ public(package) fun mark_spent(self: &mut UtxoPool, utxo_id: UtxoId, epoch: u64)
 /// No-ops if the record has already been cleaned up.
 public(package) fun cleanup_spent(self: &mut UtxoPool, utxo_id: UtxoId) {
     if (self.utxo_records.contains(utxo_id)) {
-        let UtxoRecord { utxo, produced_by: _, locked_by: _, spent_epoch } = self
+        let UtxoRecord { utxo, produced_by: _, spent_by: _, spent_epoch } = self
             .utxo_records
             .remove(utxo_id);
         let epoch = spent_epoch.destroy_some();
@@ -126,7 +127,7 @@ public(package) fun cleanup_spent(self: &mut UtxoPool, utxo_id: UtxoId) {
 
 /// Promote a pending change UTXO to confirmed once its producing withdrawal
 /// confirms on Bitcoin. If the UTXO was already locked by a subsequent
-/// withdrawal, only `produced_by` is cleared; `locked_by` is left intact.
+/// withdrawal, only `produced_by` is cleared; `spent_by` is left intact.
 /// No-ops if the UTXO is no longer present (it was already spent).
 public(package) fun confirm_pending(self: &mut UtxoPool, utxo_id: UtxoId) {
     if (self.utxo_records.contains(utxo_id)) {


### PR DESCRIPTION
## Motivation

From the audit-notes cleanup list. Renames `UtxoRecord.locked_by` → `spent_by` so it pairs with the sibling `produced_by` for a clean producer/consumer reading: `produced_by` is the withdrawal that created a (change) UTXO, `spent_by` is the withdrawal that consumes it. Since a locked UTXO is never unlocked, the reserving withdrawal is the one that ends up spending it.

Pure field rename — BCS-compatible, and the field is internal live bookkeeping that never appears in a retained/historical object (a spent `UtxoRecord` is destroyed at `cleanup_spent`, leaving only a compact `spent_utxos` marker).

## Scope decisions (called out for review)

- **`spent_epoch` intentionally left unchanged.** The original note suggested `spent_epoch → confirmed_epoch`, but `spent_epoch` is consistent across the record field, the `spent_utxos` bag, and `UtxoSpentEvent`, and `confirmed_epoch` reads ambiguously (it sounds like the epoch the UTXO was *confirmed as a deposit/change*, the other end of its life). Renaming just the record field would desync the vocabulary. Happy to do the full cascade if preferred.
- **`lock()` / `EUtxoAlreadyLocked` kept.** The verb still describes the reservation action, but note the minor asymmetry it introduces: `lock()` now assigns `record.spent_by`. The struct-level `produced_by`/`spent_by` symmetry is worth more than that mutation-site oddity IMO, but flagging it — easy to revert to `locked_by` if you'd rather keep `lock` and the field name aligned.

## Changes

- Move: `UtxoRecord.locked_by` → `spent_by` + doc comments.
- Rust: `hashi-types` mirror and all consumers (leader, watcher, metrics, coin selection, e2e).

## Test plan

- [x] 141/141 Move tests pass
- [x] `cargo check --workspace --all-targets` clean; `clippy --all-features` clean; prettier + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
