### PR TITLE
[4/4] guardian-init: add operator activation flow

### DIFF
--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -14,6 +14,7 @@ cargo run -p hashi-guardian-init -- operator ceremony --config guardian-init.sam
 cargo run -p hashi-guardian-init -- key-provisioner ceremony --config guardian-init.sample.yaml
 cargo run -p hashi-guardian-init -- operator provision --config guardian-init.sample.yaml
 cargo run -p hashi-guardian-init -- key-provisioner provision --config guardian-init.sample.yaml
+cargo run -p hashi-guardian-init -- operator activate --config guardian-init.sample.yaml
 ```
 
 Each KP generates a PGP key on a yubikey and exports the public cert to the
@@ -154,6 +155,35 @@ See [`guardian-init.sample.yaml`](guardian-init.sample.yaml) for the unified
 config. This command uses `kp_pgp_cert_path`, `relay_endpoint`, `hashi`,
 `kp_roster`, and `limiter_config`. The MPC committee verifying key `G` is fetched
 from on-chain Hashi state.
+
+## operator activate
+
+Activates a provisioner-initialized **withdraw-mode** standby guardian.
+
+It:
+
+1. Fetches and verifies the live standby `GuardianInfo` against the configured
+   current build, and confirms `provisioner_init` has completed but activation
+   has not.
+2. Verifies the standby's S3 `init/` identity/config still matches the live
+   guardian.
+3. Checks that all other guardian sessions in the configured S3 bucket have
+   been quiet long enough.
+4. Reads the latest `ceremony/` instance and requires it to match the armed
+   standby instance.
+5. Reads the latest `committee-update/` or `genesis/` record, recovers the
+   limiter state from successful withdrawal logs, computes the expected
+   `ActivationState` hash, and calls `OperatorActivate`.
+6. Verifies the guardian reports the expected active committee epoch and limiter
+   state.
+
+```bash
+cargo run -p hashi-guardian-init -- operator activate --config guardian-init.sample.yaml
+```
+
+Config: see [`guardian-init.sample.yaml`](guardian-init.sample.yaml). This
+command uses `guardian_endpoint`, `guardian_s3`, `bitcoin_network`, `hashi`,
+`kp_roster`, and `limiter_config`.
 
 ## tools
 

--- a/crates/hashi-guardian-init/guardian-init.sample.yaml
+++ b/crates/hashi-guardian-init/guardian-init.sample.yaml
@@ -3,11 +3,12 @@
 # Reuse this same file for:
 #   cargo run -p hashi-guardian-init -- operator ceremony --config guardian-init.sample.yaml
 #   cargo run -p hashi-guardian-init -- operator provision --config guardian-init.sample.yaml
+#   cargo run -p hashi-guardian-init -- operator activate --config guardian-init.sample.yaml
 #   cargo run -p hashi-guardian-init -- key-provisioner ceremony --config guardian-init.sample.yaml
 #   cargo run -p hashi-guardian-init -- key-provisioner provision --config guardian-init.sample.yaml
 
 # gRPC endpoint of the guardian. `operator ceremony` expects ceremony mode;
-# future `operator provision` will expect withdraw mode.
+# `operator provision` and `operator activate` expect withdraw mode.
 guardian_endpoint: "http://localhost:3000"
 
 # Relay endpoint the KP's share is submitted to. `key-provisioner provision`

--- a/crates/hashi-guardian-init/src/main.rs
+++ b/crates/hashi-guardian-init/src/main.rs
@@ -11,6 +11,7 @@ mod guardian_info;
 mod kp_ceremony;
 mod kp_provision;
 mod kp_roster;
+mod operator_activate;
 mod operator_ceremony;
 mod operator_provision;
 
@@ -52,6 +53,12 @@ enum OperatorCommand {
     /// Initialize a withdraw-mode guardian with operator-supplied stable config.
     Provision {
         /// Path to operator provision YAML config file.
+        #[arg(long)]
+        config: PathBuf,
+    },
+    /// Activate a provisioner-initialized withdraw-mode guardian.
+    Activate {
+        /// Path to operator activate YAML config file.
         #[arg(long)]
         config: PathBuf,
     },
@@ -99,6 +106,10 @@ async fn main() -> anyhow::Result<()> {
             OperatorCommand::Provision { config } => {
                 let cfg = config::Config::load_yaml(&config)?;
                 operator_provision::run(cfg).await?;
+            }
+            OperatorCommand::Activate { config } => {
+                let cfg = config::Config::load_yaml(&config)?;
+                operator_activate::run(cfg).await?;
             }
         },
         Command::KeyProvisioner { command } => match command {

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -1,0 +1,436 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `operator activate` derives and submits the activation pin for a provisioned
+//! withdraw-mode standby guardian.
+
+use anyhow::Context;
+use anyhow::anyhow;
+use anyhow::ensure;
+use hashi_guardian::s3_reader::BuildPolicy;
+use hashi_guardian::s3_reader::GuardianReader;
+use hashi_types::guardian::ActivationState;
+use hashi_types::guardian::BuildPcrs;
+use hashi_types::guardian::GetGuardianInfoResponse;
+use hashi_types::guardian::GuardianInfo;
+use hashi_types::guardian::HashiCommittee;
+use hashi_types::guardian::InitConfig;
+use hashi_types::guardian::OperatorActivateRequest;
+use hashi_types::guardian::S3Config;
+use hashi_types::guardian::VerifiedGuardianInfo;
+use hashi_types::guardian::proto_conversions::operator_activate_request_to_pb;
+use hashi_types::proto as pb;
+use hashi_types::proto::guardian_service_client::GuardianServiceClient;
+use tonic::transport::Channel;
+use tracing::info;
+
+use crate::config::Config;
+
+/// Activate a provisioner-initialized standby guardian.
+pub async fn run(cfg: Config) -> anyhow::Result<()> {
+    cfg.kp_roster.validate()?;
+    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let allowlist = cfg.kp_roster.pcr_allowlist();
+
+    info!(
+        phase = "setup",
+        bucket = guardian_s3.bucket_name(),
+        region = guardian_s3.region(),
+        endpoint = %cfg.guardian_endpoint,
+        bitcoin_network = ?cfg.bitcoin_network,
+        limiter_refill_rate = cfg.limiter_config.refill_rate,
+        limiter_max_capacity = cfg.limiter_config.max_bucket_capacity,
+        "running operator activate flow",
+    );
+
+    info!(
+        phase = "s3 connect",
+        bucket = guardian_s3.bucket_name(),
+        region = guardian_s3.region(),
+        current_git_revision = %allowlist.current_build().git_revision(),
+        current_pcr0 = hex::encode(allowlist.current_build().pcr0()),
+        prev_build_count = allowlist.prev_builds().len(),
+        "connecting to guardian log bucket",
+    );
+    let mut reader = GuardianReader::new(&guardian_s3, allowlist.clone())
+        .await
+        .context("connect to guardian log bucket")?;
+    info!(phase = "s3 connect", "connected to guardian log bucket");
+
+    info!(
+        phase = "sui connect",
+        sui_rpc = %cfg.hashi.sui_rpc,
+        package_id = %cfg.hashi.hashi_ids.package_id,
+        hashi_object_id = %cfg.hashi.hashi_ids.hashi_object_id,
+        "connecting to Sui RPC for Hashi on-chain state",
+    );
+    let onchain_state = cfg.hashi.onchain_state().await?;
+    info!(phase = "sui connect", "connected to Sui RPC");
+
+    let master_g = onchain_state.onchain_verifying_key_g()?;
+    info!(phase = "setup", master_g = ?master_g, "fetched on-chain MPC master G");
+
+    info!(
+        phase = "guardian connect",
+        endpoint = %cfg.guardian_endpoint,
+        "connecting to withdraw-mode guardian",
+    );
+    let mut client = GuardianServiceClient::connect(cfg.guardian_endpoint.clone())
+        .await
+        .with_context(|| format!("connect to guardian at {}", cfg.guardian_endpoint))?;
+    info!(phase = "guardian connect", endpoint = %cfg.guardian_endpoint, "connected to guardian");
+
+    info!(
+        phase = "guardian preflight",
+        "fetching + verifying provisioned standby GuardianInfo"
+    );
+    let preflight = verified_live_guardian_info(&mut client, allowlist.current_build()).await?;
+    let session_id = preflight.session_id.clone();
+    let signing_pub_key = preflight.signing_pub_key;
+    let pre_info = preflight.info.clone();
+    let standby =
+        verify_provisioned_standby_info(&pre_info, &guardian_s3, &cfg, &allowlist, &master_g)?;
+    info!(
+        phase = "guardian preflight",
+        session_id = %session_id,
+        signing_pubkey = hex::encode(signing_pub_key.as_bytes()),
+        config_hash = hex::encode(standby.config_hash),
+        enclave_btc_pubkey = ?standby.enclave_btc_pubkey,
+        "guardian is current-build, provisioned, and not yet active",
+    );
+
+    info!(
+        phase = "attestation pin",
+        session_id = %session_id,
+        "verifying OI GuardianInfo matches the live guardian identity/config",
+    );
+    let verified_session = reader
+        .get_session_info(&session_id, BuildPolicy::Current)
+        .await?;
+    ensure!(
+        verified_session.signing_pubkey == signing_pub_key,
+        "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
+    );
+    verify_oi_info_matches_provisioned_standby(&verified_session.info, &pre_info)?;
+    info!(
+        phase = "attestation pin",
+        session_id = %session_id,
+        "OI GuardianInfo matches live standby identity/config",
+    );
+
+    info!(
+        phase = "heartbeat check",
+        session_id = %session_id,
+        "checking that the standby session is live and all other sessions are quiet",
+    );
+    reader
+        .ensure_session_live_and_others_quiet(&session_id)
+        .await
+        .context("heartbeat activation check failed")?;
+
+    info!(
+        phase = "ceremony instance",
+        "reading latest ceremony log for the activation instance",
+    );
+    let (ceremony_session, latest_instance, _, _) = reader
+        .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
+        .await?
+        .context("no ceremony log found in S3; key setup has not run")?;
+    ensure!(
+        latest_instance == standby.secret_sharing_instance,
+        "latest ceremony instance differs from armed instance: latest {}, armed {}",
+        latest_instance,
+        standby.secret_sharing_instance
+    );
+    info!(
+        phase = "ceremony instance",
+        ceremony_session = %ceremony_session,
+        sharing_seq = latest_instance.sharing_seq(),
+        "latest ceremony instance matches the armed standby",
+    );
+
+    info!(
+        phase = "activation state",
+        "reading latest committee and recovering limiter state",
+    );
+    let move_committee = reader
+        .read_latest_committee(BuildPolicy::AnyAllowlisted)
+        .await?
+        .context("no committee-update or genesis record found")?;
+    let committee_epoch = move_committee.epoch;
+    let committee: HashiCommittee = move_committee
+        .try_into()
+        .context("invalid serving committee")?;
+    let limiter_state = reader
+        .recover_limiter_state(standby.init_config.limiter_config())
+        .await
+        .context("recover limiter state")?;
+    let activation_state = ActivationState::new(
+        standby.config_hash,
+        latest_instance,
+        committee,
+        limiter_state,
+    );
+    let state_hash = activation_state.digest();
+    info!(
+        phase = "activation state",
+        committee_epoch,
+        limiter_next_seq = limiter_state.next_seq,
+        limiter_tokens_available = limiter_state.num_tokens_available,
+        limiter_last_updated_at = limiter_state.last_updated_at,
+        state_hash = hex::encode(state_hash),
+        "computed expected ActivationState hash",
+    );
+
+    info!(
+        phase = "operator_activate",
+        session_id = %session_id,
+        committee_epoch,
+        limiter_next_seq = limiter_state.next_seq,
+        state_hash = hex::encode(state_hash),
+        "calling OperatorActivate",
+    );
+    let activate_req = operator_activate_request_to_pb(OperatorActivateRequest::new(state_hash));
+    client
+        .operator_activate(activate_req)
+        .await
+        .context("OperatorActivate RPC failed")?;
+    info!(
+        phase = "operator_activate",
+        session_id = %session_id,
+        "operator_activate RPC returned; verifying activated GuardianInfo",
+    );
+
+    info!(
+        phase = "guardian postcheck",
+        session_id = %session_id,
+        "fetching + verifying activated GuardianInfo"
+    );
+    let post = verified_live_guardian_info(&mut client, allowlist.current_build()).await?;
+    verify_activated_info(
+        post,
+        &session_id,
+        signing_pub_key,
+        standby.config_hash,
+        standby.enclave_btc_pubkey,
+        committee_epoch,
+        limiter_state,
+    )?;
+    info!(
+        phase = "guardian postcheck",
+        session_id = %session_id,
+        committee_epoch,
+        limiter_next_seq = limiter_state.next_seq,
+        "activated GuardianInfo matches expected state",
+    );
+
+    info!(
+        phase = "summary",
+        session_id = %session_id,
+        ceremony_session = %ceremony_session,
+        committee_epoch,
+        config_hash = hex::encode(standby.config_hash),
+        state_hash = hex::encode(state_hash),
+        "operator activate complete",
+    );
+    println!("Guardian operator activate complete.");
+    println!("  session_id:       {session_id}");
+    println!("  config_hash:      {}", hex::encode(standby.config_hash));
+    println!("  state_hash:       {}", hex::encode(state_hash));
+    println!("  committee_epoch:  {committee_epoch}");
+    println!("  limiter_next_seq: {}", limiter_state.next_seq);
+    println!("  bitcoin_network:  {}", cfg.bitcoin_network);
+    println!("  bucket:           {}", guardian_s3.bucket_name());
+    println!("  region:           {}", guardian_s3.region());
+
+    Ok(())
+}
+
+struct StandbyChecks {
+    init_config: InitConfig,
+    config_hash: [u8; 32],
+    secret_sharing_instance: hashi_types::guardian::SecretSharingInstance,
+    enclave_btc_pubkey: hashi_types::bitcoin::BitcoinPubkey,
+}
+
+fn verify_provisioned_standby_info(
+    info: &GuardianInfo,
+    guardian_s3: &S3Config,
+    cfg: &Config,
+    allowlist: &hashi_types::guardian::PcrAllowlist,
+    master_g: &hashi_types::bitcoin::HashiMasterG,
+) -> anyhow::Result<StandbyChecks> {
+    let instance = info
+        .secret_sharing_instance
+        .clone()
+        .context("Guardian info missing secret-sharing instance")?;
+    let bucket_info = info
+        .bucket_info
+        .as_ref()
+        .context("Guardian info missing bucket info")?;
+    let config_hash = info
+        .config_hash
+        .context("Guardian info missing config_hash")?;
+    let enclave_btc_pubkey = info
+        .enclave_btc_pubkey
+        .context("Guardian info missing enclave BTC pubkey; provisioner_init is not complete")?;
+    let limiter_config = info
+        .limiter_config
+        .context("Guardian info missing limiter config")?;
+    let mpc_master_g = info
+        .mpc_master_g
+        .context("Guardian info missing MPC master G")?;
+
+    ensure!(
+        info.limiter_state.is_none(),
+        "Guardian has limiter_state => operator activation already ran"
+    );
+    ensure!(
+        info.current_committee_epoch.is_none(),
+        "Guardian has current_committee_epoch => operator activation already ran"
+    );
+    ensure!(
+        &guardian_s3.bucket_info == bucket_info,
+        "Guardian bucket info mismatch: expected {:?}, got {:?}",
+        guardian_s3.bucket_info,
+        bucket_info
+    );
+    ensure!(
+        cfg.limiter_config == limiter_config,
+        "Guardian limiter config mismatch: expected {:?}, got {:?}",
+        cfg.limiter_config,
+        limiter_config
+    );
+    ensure!(
+        master_g == &mpc_master_g,
+        "Guardian MPC master G mismatch: expected {:?}, got {:?}",
+        master_g,
+        mpc_master_g
+    );
+
+    let init_config = InitConfig::new(
+        cfg.limiter_config,
+        *master_g,
+        allowlist.clone(),
+        cfg.bitcoin_network,
+    )?;
+    let expected_config_hash = init_config.digest();
+    ensure!(
+        expected_config_hash == config_hash,
+        "Guardian config_hash mismatch: expected {}, got {}",
+        hex::encode(expected_config_hash),
+        hex::encode(config_hash)
+    );
+
+    Ok(StandbyChecks {
+        init_config,
+        config_hash,
+        secret_sharing_instance: instance,
+        enclave_btc_pubkey,
+    })
+}
+
+fn verify_oi_info_matches_provisioned_standby(
+    oi_info: &GuardianInfo,
+    live_info: &GuardianInfo,
+) -> anyhow::Result<()> {
+    ensure!(
+        oi_info.enclave_btc_pubkey.is_none(),
+        "OI GuardianInfo unexpectedly has a BTC pubkey"
+    );
+    ensure!(
+        oi_info.limiter_state.is_none(),
+        "OI GuardianInfo unexpectedly has limiter_state"
+    );
+    ensure!(
+        oi_info.current_committee_epoch.is_none(),
+        "OI GuardianInfo unexpectedly has current_committee_epoch"
+    );
+    ensure!(
+        oi_info.secret_sharing_instance == live_info.secret_sharing_instance,
+        "OI GuardianInfo secret-sharing instance differs from live standby GuardianInfo"
+    );
+    ensure!(
+        oi_info.bucket_info == live_info.bucket_info,
+        "OI GuardianInfo bucket info differs from live standby GuardianInfo"
+    );
+    ensure!(
+        oi_info.encryption_pubkey == live_info.encryption_pubkey,
+        "OI GuardianInfo encryption pubkey differs from live standby GuardianInfo"
+    );
+    ensure!(
+        oi_info.config_hash == live_info.config_hash,
+        "OI GuardianInfo config_hash differs from live standby GuardianInfo"
+    );
+    ensure!(
+        oi_info.untrusted_git_revision == live_info.untrusted_git_revision,
+        "OI GuardianInfo git revision differs from live standby GuardianInfo"
+    );
+    ensure!(
+        oi_info.limiter_config == live_info.limiter_config,
+        "OI GuardianInfo limiter config differs from live standby GuardianInfo"
+    );
+    ensure!(
+        oi_info.mpc_master_g == live_info.mpc_master_g,
+        "OI GuardianInfo MPC master G differs from live standby GuardianInfo"
+    );
+    Ok(())
+}
+
+fn verify_activated_info(
+    post: VerifiedGuardianInfo,
+    expected_session_id: &str,
+    expected_signing_key: hashi_types::guardian::GuardianPubKey,
+    expected_config_hash: [u8; 32],
+    expected_enclave_btc_pubkey: hashi_types::bitcoin::BitcoinPubkey,
+    expected_committee_epoch: u64,
+    expected_limiter_state: hashi_types::guardian::LimiterState,
+) -> anyhow::Result<()> {
+    ensure!(
+        post.session_id == expected_session_id,
+        "guardian session changed during operator activation: started {}, now {}",
+        expected_session_id,
+        post.session_id
+    );
+    ensure!(
+        post.signing_pub_key == expected_signing_key,
+        "guardian signing key changed during operator activation"
+    );
+    ensure!(
+        post.info.config_hash == Some(expected_config_hash),
+        "Guardian config_hash changed during operator activation"
+    );
+    ensure!(
+        post.info.enclave_btc_pubkey == Some(expected_enclave_btc_pubkey),
+        "Guardian BTC pubkey changed during operator activation"
+    );
+    ensure!(
+        post.info.current_committee_epoch == Some(expected_committee_epoch),
+        "Guardian committee epoch mismatch: expected {}, got {:?}",
+        expected_committee_epoch,
+        post.info.current_committee_epoch
+    );
+    ensure!(
+        post.info.limiter_state == Some(expected_limiter_state),
+        "Guardian limiter state mismatch: expected {:?}, got {:?}",
+        expected_limiter_state,
+        post.info.limiter_state
+    );
+    Ok(())
+}
+
+async fn verified_live_guardian_info(
+    client: &mut GuardianServiceClient<Channel>,
+    current_build: &BuildPcrs,
+) -> anyhow::Result<VerifiedGuardianInfo> {
+    let info_pb = client
+        .get_guardian_info(pb::GetGuardianInfoRequest {})
+        .await
+        .context("GetGuardianInfo RPC failed")?
+        .into_inner();
+    let info_resp = GetGuardianInfoResponse::try_from(info_pb)
+        .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
+    info_resp
+        .verify(current_build)
+        .map_err(|e| anyhow!("verify GuardianInfo attestation/signature: {e:?}"))
+}

--- a/docker/hashi-guardian-local/Dockerfile.dockerignore
+++ b/docker/hashi-guardian-local/Dockerfile.dockerignore
@@ -1,4 +1,5 @@
 target
+.hashi
 .git
 .github
 design

--- a/docker/hashi-guardian-local/Makefile
+++ b/docker/hashi-guardian-local/Makefile
@@ -17,8 +17,8 @@ help: ## Show this help
 	@echo "  1. make up          # MinIO + withdraw guardian + proxy"
 	@echo "  2. make ceremony    # generate KP keys + run the ceremony -> BTC pubkey"
 	@echo "  3. make localnet-cmd  # prints the 'hashi-localnet start ...' to run natively"
-	@echo "  4. make provision   # operator provision + KP provision via the relay"
-	@echo "  5. make smoke       # GetGuardianInfo through the proxy"
+	@echo "  4. make provision   # operator provision + KP provision + activation"
+	@echo "  5. make smoke       # GetGuardianInfo for the activated guardian"
 
 up: ## Build + start MinIO, host, withdraw enclave, proxy (no chain needed)
 	$(COMPOSE) up -d --build minio bucket-init host enclave proxy
@@ -47,7 +47,7 @@ localnet-cmd: ## Print the `hashi-localnet start` command wired to this guardian
 	echo "    --guardian-url http://localhost:3000 \\"; \
 	echo "    --guardian-btc-pubkey $$pubkey"
 
-provision: ## operator provision + KP provision (needs the native localnet running)
+provision: ## operator provision + KP provision + activation (needs the native localnet running)
 	@test -f "$(STATE)" || { echo "No localnet state at $(STATE). Run 'make localnet-cmd' and start it first."; exit 1; }
 	@sui_rpc=$$(jq -r .sui_rpc_url "$(STATE)" | sed 's#127.0.0.1#host.docker.internal#; s#localhost#host.docker.internal#'); \
 	pkg=$$(jq -r .package_id "$(STATE)"); obj=$$(jq -r .hashi_object_id "$(STATE)"); \
@@ -57,7 +57,7 @@ provision: ## operator provision + KP provision (needs the native localnet runni
 	    -e SUI_RPC -e PACKAGE_ID -e HASHI_OBJECT_ID \
 	    init /scripts/provision.sh
 
-smoke: ## GetGuardianInfo through the proxy -> host -> enclave -> guardian
+smoke: ## GetGuardianInfo for the activated guardian through the proxy
 	$(COMPOSE) exec -T proxy grpcurl -plaintext -import-path /proto \
 		-proto sui/hashi/v1alpha/guardian_service.proto \
 		localhost:3000 sui.hashi.v1alpha.GuardianService/GetGuardianInfo

--- a/docker/hashi-guardian-local/README.md
+++ b/docker/hashi-guardian-local/README.md
@@ -4,7 +4,7 @@ A Mac-local replica of the guardian's AWS Nitro topology (each `vsock` hop becom
 a TCP hop between containers), wired to a native `hashi-localnet` for the on-chain
 side, so the full ceremony → provision → withdrawal flow runs locally — no devnet.
 The guardian runs `--features non-enclave-dev` (mock attestation), so this
-exercises the real ceremony/relay/provision path, not PCR attestation.
+exercises the real ceremony/relay/provision/activation path, not PCR attestation.
 
 ```mermaid
 flowchart LR
@@ -49,8 +49,8 @@ Needs Docker, plus `sui` and `bitcoind` on `PATH`.
 make up            # MinIO + withdraw guardian + proxy
 make ceremony      # KP roster + genesis ceremony: mints the BTC key, prints its pubkey
 make localnet-cmd  # prints the `hashi-localnet start …` to run NATIVELY (separate terminal)
-make provision     # operator provision, then key-provisioner provision × threshold via the relay
-make smoke         # confirm the guardian is fully initialized
+make provision     # operator provision, KP provision × threshold, then operator activate
+make smoke         # confirm the guardian is activated
 make down          # tear everything down
 ```
 
@@ -59,13 +59,14 @@ the proxy with them (`AUTHORIZED_KP_FINGERPRINTS`) — the relay rejects share
 submissions from unrostered signers, mirroring the deploy, where the ceremony
 roster reaches the proxy as deploy-time config.
 
-Once provisioned, the deposit/withdraw CLI flows work against the local network,
+Once activated, the deposit/withdraw CLI flows work against the local network,
 co-signed by the containerized guardian.
 
 ## Verify
 
-The provisioned guardian's `enclaveBtcPubkey` should equal the ceremony pubkey — the
-key was split into shares and reconstructed inside the enclave via the relay:
+The activated guardian's `enclaveBtcPubkey` should equal the ceremony pubkey — the
+key was split into shares, reconstructed inside the enclave via the relay, and
+then activated by the operator:
 
 ```sh
 make pubkey   # the ceremony BTC master pubkey

--- a/docker/hashi-guardian-local/scripts/provision.sh
+++ b/docker/hashi-guardian-local/scripts/provision.sh
@@ -4,11 +4,12 @@
 #
 # Provision the withdraw-mode guardian against the running localnet:
 #   1. `operator provision` -> boots the guardian into withdraw mode with the
-#      on-chain committee + MPC master G (reads them from the localnet Sui RPC),
+#      stable config + MPC master G (reads them from the localnet Sui RPC),
 #   2. `key-provisioner provision` x THRESHOLD -> each KP decrypts its share and
 #      submits it to the proxy relay (SingleProvisionerInit); the relay batches a
-#      threshold-many into the guardian's ProvisionerInit, bringing it to
-#      fully-initialized.
+#      threshold-many into the guardian's ProvisionerInit,
+#   3. `operator activate` -> derives live ActivationState from S3 and activates
+#      the fully provisioned standby.
 #
 # Requires the localnet to be up with DKG complete (current_committee +
 # mpc_public_key on-chain), which `hashi-localnet start` guarantees before it
@@ -25,42 +26,40 @@ render_config "${WITHDRAW_GUARDIAN_ENDPOINT:-http://host:3000}" ""
 echo "== operator provision =="
 hashi-guardian-init operator provision --config "${CONFIG}"
 
-# The withdraw guardian only begins heartbeating AFTER OperatorInit above, and
-# its first heartbeat lands up to HEARTBEAT_INTERVAL (~60s) later. KP provision's
-# heartbeat_audit needs that beat, and fails fast (before submitting any share)
-# if it isn't there yet — so retry the FIRST KP on that specific error while we
-# wait for it. (In prod the operator/KP steps are minutes apart by human
-# coordination, so this wait is purely a local-orchestration concern.) The relay
-# dedupes by share id, so a retry is idempotent regardless.
-kp_provision() {  # $1 = KP index; waits out the first-heartbeat gap, fails fast otherwise
-  local idx="$1" deadline=$(( SECONDS + 180 )) out
+echo
+echo "== key-provisioner provision x ${THRESHOLD} (via the proxy relay) =="
+for i in $(seq 1 "${THRESHOLD}"); do
+  echo "-- KP ${i}/${THRESHOLD} --"
   # Each KP uses its own cert; shares are submitted to relay_endpoint (the proxy).
-  render_config "${WITHDRAW_GUARDIAN_ENDPOINT:-http://host:3000}" "${CERTS_DIR}/kp${idx}.asc"
+  render_config "${WITHDRAW_GUARDIAN_ENDPOINT:-http://host:3000}" "${CERTS_DIR}/kp${i}.asc"
+  hashi-guardian-init key-provisioner provision --config "${CONFIG}"
+done
+
+operator_activate() {
+  local deadline=$(( SECONDS + 180 )) out
+  render_config "${WITHDRAW_GUARDIAN_ENDPOINT:-http://host:3000}" ""
   while :; do
-    if out="$(hashi-guardian-init key-provisioner provision --config "${CONFIG}" 2>&1)"; then
+    if out="$(hashi-guardian-init operator activate --config "${CONFIG}" 2>&1)"; then
       printf '%s\n' "${out}"
       return 0
     fi
     printf '%s\n' "${out}" >&2
-    if ! grep -q "no heartbeat logs found" <<<"${out}"; then
-      return 1  # a real failure, not the first-heartbeat gap
-    fi
-    if [ "${SECONDS}" -ge "${deadline}" ]; then
-      echo "KP ${idx}: guardian still not heartbeating after 180s — aborting." >&2
+    if ! grep -q "no heartbeat logs found for session" <<<"${out}"; then
       return 1
     fi
-    echo "KP ${idx}: guardian not heartbeating yet; waiting 10s for its first heartbeat..." >&2
+    if [ "${SECONDS}" -ge "${deadline}" ]; then
+      echo "guardian still has no heartbeat after 180s — aborting activation." >&2
+      return 1
+    fi
+    echo "guardian has not heartbeated yet; waiting 10s before activation..." >&2
     sleep 10
   done
 }
 
 echo
-echo "== key-provisioner provision x ${THRESHOLD} (via the proxy relay) =="
-for i in $(seq 1 "${THRESHOLD}"); do
-  echo "-- KP ${i}/${THRESHOLD} --"
-  kp_provision "${i}"
-done
+echo "== operator activate =="
+operator_activate
 
 echo
-echo "Provisioning complete — the guardian should now be fully initialized."
+echo "Provisioning and activation complete — the guardian should now be serving withdrawals."
 echo "Verify:  hashi-guardian-init tools fetch-info --endpoint http://host:3000 --field enclave-btc-pubkey"


### PR DESCRIPTION
## Summary
- add `hashi-guardian-init operator activate --config ...`
- derive the same activation inputs as the enclave from verified S3 state: latest ceremony instance, latest committee/genesis record, recovered limiter state, and heartbeat activation checks
- compute the expected `ActivationState` hash and submit it via `OperatorActivate`
- verify the live guardian remains the same session and reports the expected active committee epoch and limiter state
- document the operator activation step and update the local docker provision flow to run activation after OI/PI

## Notes
- This is CLI/init-tooling only; it does not change the guardian backend or introduce DR/genesis-mode changes.
- The local docker provision script retries `operator activate` while waiting for the standby guardian's first heartbeat.
- `state_hash` is printed for operator visibility and checked by the enclave during `OperatorActivate`; `GuardianInfo` no longer exposes it directly.

## Verification
- `cargo fmt -- --config imports_granularity=Item --config format_code_in_doc_comments=true --check`
- `git diff --check`
- `cargo check -p hashi-guardian-init --bin hashi-guardian-init`
