### PR TITLE
[guardian-proxy] Back the wid cache with the guardian's S3 withdrawal log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,8 +3020,14 @@ name = "hashi-guardian-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aws-config",
+ "aws-sdk-s3",
+ "axum",
+ "bitcoin",
  "hashi-types",
  "lru 0.16.3",
+ "prometheus",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/crates/hashi-guardian-proxy/Cargo.toml
+++ b/crates/hashi-guardian-proxy/Cargo.toml
@@ -12,6 +12,12 @@ tonic.workspace = true
 tonic-health.workspace = true
 lru.workspace = true
 hashi-types = { path = "../hashi-types" }
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
+axum.workspace = true
+bitcoin.workspace = true
+prometheus.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 tokio-stream.workspace = true

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -14,11 +14,15 @@
 //! immutable (only signatures change), so the response is stable.
 //!
 //! The enclave persists every signed withdrawal before releasing it, so the
-//! proxy has nothing durable of its own to lose. A log replay passes two gates
-//! (see `replay_from_log`); when the log can't answer, the proxy fails closed
-//! with `UNAVAILABLE` rather than forwarding blind — it cannot distinguish
-//! "never signed" from "signed but unreadable", and forwarding the latter
-//! re-signs and double-debits the limiter.
+//! proxy has nothing durable of its own to lose. On a log hit it verifies the
+//! record's signatures spend the incoming request, then replays them (see
+//! `replay_from_log`); it does not reason about the limiter `seq`, which is the
+//! guardian's to own — the node's mirror self-heals any divergence
+//! (`hashi/src/guardian_limiter.rs`). When the log can't answer, the proxy
+//! fails closed with `UNAVAILABLE` rather than forwarding blind — it cannot
+//! distinguish "never signed" from "signed but unreadable", and forwarding the
+//! latter re-signs a withdrawal the guardian already durably signed, the
+//! double-debit the cache exists to prevent.
 
 use crate::metrics;
 use crate::metrics::ProxyMetrics;
@@ -49,7 +53,6 @@ use tonic::Response;
 use tonic::Status;
 use tracing::error;
 use tracing::info;
-use tracing::warn;
 
 // One entry per withdrawal would leak forever; 10k far exceeds the rate-limited
 // in-flight working set, so a hot wid always outlives its retry window.
@@ -144,8 +147,7 @@ where
     L: LogStore,
 {
     /// Serve a wid from the guardian's S3 withdrawal log. `Ok(None)` means
-    /// "definitively not in the log (or not committed): forward"; `Err` is the
-    /// fail-closed path.
+    /// "definitively not in the log: forward"; `Err` is the fail-closed path.
     async fn replay_from_log(
         &self,
         wid: &WithdrawalID,
@@ -167,40 +169,35 @@ where
             }
         };
 
-        // Gate 1 (committed): a record whose S3 ack never reached the enclave
-        // was reverted, not debited — `seq >= next_seq` — and must re-sign.
+        // Idempotency is by wid; the proxy does not gate on the limiter `seq`.
+        // A record the enclave signed but never committed (a lost-ack S3 write
+        // it then reverted) still replays here: the node's requested seq stays
+        // pinned to its mirror, and its stall reconcile snaps that mirror back
+        // to the guardian's authoritative seq (`hashi/src/guardian_limiter.rs`),
+        // so a served orphan self-heals — at worst a bounded one-withdrawal
+        // limiter under-count, which is the guardian's to close, not the proxy's.
+        //
+        // Integrity gate: never hand the node signatures that don't spend its
+        // transaction. Needs the guardian's live BTC key + master G (the enclave
+        // key rotates per instance, so it can't be cached across rotations).
         let info = match self.guardian_info().await {
             Ok(info) => info,
             Err(e) => {
                 self.metrics
                     .outcome(metrics::OUTCOME_UNAVAILABLE_GUARDIAN_INFO);
-                error!(%wid, error = %e, "Cannot fetch guardian info to gate a log replay.");
+                error!(%wid, error = %e, "Cannot fetch guardian info to verify a log replay.");
                 return Err(unavailable());
             }
         };
-        let (Some(enclave_btc_pubkey), Some(master_g), Some(limiter_state)) = (
-            info.enclave_btc_pubkey,
-            info.mpc_master_g,
-            info.limiter_state,
-        ) else {
+        let (Some(enclave_btc_pubkey), Some(master_g)) =
+            (info.enclave_btc_pubkey, info.mpc_master_g)
+        else {
             self.metrics
                 .outcome(metrics::OUTCOME_UNAVAILABLE_GUARDIAN_INFO);
-            error!(%wid, "Guardian info lacks BTC pubkey / master G / limiter state; cannot gate a log replay.");
+            error!(%wid, "Guardian info lacks BTC pubkey / master G; cannot verify a log replay.");
             return Err(unavailable());
         };
-        if found.consumed_seq >= limiter_state.next_seq {
-            self.metrics.uncommitted_records.inc();
-            warn!(
-                %wid,
-                record_seq = found.consumed_seq,
-                next_seq = limiter_state.next_seq,
-                "Log record was never committed by the enclave; forwarding for a fresh sign."
-            );
-            return Ok(None);
-        }
 
-        // Gate 2 (integrity): the replay path must never hand the node
-        // signatures that don't spend its transaction.
         if let Err(e) = verify_recorded_signatures(
             request,
             &found.response.enclave_signatures,
@@ -821,7 +818,7 @@ mod tests {
         let stub = stub.with_info(stub_info_pb(
             fixture.enclave_btc_pubkey,
             fixture.master_g,
-            // The record's seq is committed: next_seq is past it.
+            // next_seq is carried in guardian info but no longer gated on.
             fixture.consumed_seq + 1,
         ));
         let store = MemStore::default();
@@ -850,30 +847,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn uncommitted_record_forwards_for_a_fresh_sign() {
-        // An orphan record (S3 put acked but the enclave reverted: its seq is
-        // not below next_seq) was never debited — it must re-sign, not replay.
+    async fn record_at_or_above_next_seq_is_still_served_by_wid() {
+        // A record whose seq is not below the guardian's next_seq (e.g. a
+        // lost-ack S3 write the enclave reverted) still carries signatures the
+        // enclave really produced, so the proxy replays it by wid rather than
+        // forwarding. The proxy owns no seq logic; the node's stall reconcile
+        // self-heals any divergence (hashi/src/guardian_limiter.rs). Contrast
+        // the removed committed-gate, which forwarded here and re-signed.
         let fixture = replay_fixture(7);
         let (stub, count) = StubGuardian::ok();
         let stub = stub.with_info(stub_info_pb(
             fixture.enclave_btc_pubkey,
             fixture.master_g,
-            fixture.consumed_seq,
+            fixture.consumed_seq, // next_seq == the record's seq
         ));
         let store = MemStore::default();
         store.insert(fixture.record_key.clone(), fixture.record_bytes.clone());
         let cache = cache_over(stub, store);
 
-        cache
+        let replayed = cache
             .standard_withdrawal(Request::new(fixture.request.clone()))
             .await
-            .unwrap();
+            .unwrap()
+            .into_inner();
 
         assert_eq!(
             count.load(Ordering::SeqCst),
-            1,
-            "must forward to the enclave"
+            0,
+            "served from the log by wid, not forwarded"
         );
+        assert!(!replayed
+            .data
+            .as_ref()
+            .unwrap()
+            .enclave_signatures
+            .is_empty());
     }
 
     #[tokio::test]
@@ -906,8 +914,8 @@ mod tests {
 
     #[tokio::test]
     async fn guardian_info_failure_fails_closed() {
-        // A record exists but the enclave can't be asked for next_seq: the
-        // committed gate can't run, so the proxy fails closed.
+        // A record exists but the enclave can't be asked for its BTC key: the
+        // integrity gate can't run, so the proxy fails closed.
         let fixture = replay_fixture(7);
         let (stub, count) = StubGuardian::ok(); // no .with_info(..)
         let store = MemStore::default();

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -1,37 +1,80 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Wid-keyed response cache for the guardian's `StandardWithdrawal` RPC. Lives in
-//! the out-of-enclave proxy so it can be hardened or swapped independently of the
-//! signing oracle (the enclave now serves the bare `GuardianService`).
+//! Wid-keyed response cache for the guardian's `StandardWithdrawal` RPC: an
+//! in-process LRU in front of the guardian's own S3 withdrawal log as the
+//! durable tier. Lives in the out-of-enclave proxy so it can be hardened or
+//! swapped independently of the signing oracle.
 //!
-//! Keyed by `wid`, not `(wid, seq)`: the guardian debits the limiter and advances
-//! `next_seq` when it signs, before hashi has the signed event on-chain. If hashi
-//! retries the same wid at a bumped seq (its limiter mirror reconciled forward
-//! while the event was still pending), re-consuming would drain the bucket for a
-//! withdrawal that was already signed. Replaying by `wid` avoids that — safe
-//! because a committed wid's inputs/outputs are immutable (only signatures
-//! change), so the response is stable and carries no seq.
+//! Keyed by `wid`, not `(wid, seq)`: the guardian debits the limiter and
+//! advances `next_seq` when it signs, before hashi has the signed event
+//! on-chain. If hashi retries the same wid at a bumped seq (its limiter mirror
+//! reconciled forward while the event was still pending), re-consuming would
+//! drain the bucket for a withdrawal that was already signed. Replaying by
+//! `wid` avoids that — safe because a committed wid's inputs/outputs are
+//! immutable (only signatures change), so the response is stable.
 //!
-//! In-memory and bounded (LRU, `CACHE_CAPACITY` entries): a wid lost to eviction
-//! or a proxy restart re-consumes the enclave limiter on its next retry — same as
-//! the old in-enclave behaviour, so no regression. A durable backend (e.g.
-//! DynamoDB) is a future option this extraction enables.
+//! The durable tier is read-only: the enclave writes its `Success` record
+//! *before* releasing signatures and fails closed if the write fails, so any
+//! signature a node has ever seen has a record — the proxy has nothing durable
+//! of its own to lose, across restarts or otherwise. A replay from the log
+//! passes two gates first: the record's seq must be committed (below the
+//! enclave's `next_seq`; an S3 put whose ack was lost leaves a record the
+//! enclave reverted, which must re-sign, not replay), and the recorded
+//! signatures must verify against the guardian BTC key over sighashes
+//! recomputed from the incoming request (a bucket writer must not be able to
+//! wedge withdrawals with a poisoned record).
+//!
+//! When the log can't answer — LIST/GET failure, scan cap, guardian info
+//! unavailable, verification failure — the proxy fails closed with
+//! `UNAVAILABLE` rather than forwarding blind: it cannot distinguish "never
+//! signed" from "signed but unreadable", and forwarding the latter re-signs
+//! and double-debits the limiter. Errors from the enclave are never cached.
 
+use crate::metrics;
+use crate::metrics::ProxyMetrics;
+use crate::widlog::find_success_record;
+use crate::widlog::FoundSuccess;
+use crate::widlog::LogStore;
+use crate::widlog::WidLogError;
+use bitcoin::Network;
+use hashi_types::bitcoin::BitcoinPubkey;
+use hashi_types::bitcoin::BitcoinSignature;
+use hashi_types::bitcoin::HashiMasterG;
+use hashi_types::bitcoin::BTC_LIB;
+use hashi_types::guardian::proto_conversions::pb_to_signed_standard_withdrawal_request_wire;
+use hashi_types::guardian::AddressValidation;
+use hashi_types::guardian::GetGuardianInfoResponse;
+use hashi_types::guardian::GuardianInfo;
+use hashi_types::guardian::HashiSigned;
+use hashi_types::guardian::StandardWithdrawalRequest;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::proto;
 use hashi_types::proto::guardian_service_server::GuardianService;
 use lru::LruCache;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::sync::Mutex;
 use tonic::Request;
 use tonic::Response;
 use tonic::Status;
+use tracing::error;
 use tracing::info;
+use tracing::warn;
 
 // One entry per withdrawal would leak forever; 10k far exceeds the rate-limited
 // in-flight working set, so a hot wid always outlives its retry window.
 const CACHE_CAPACITY: usize = 10_000;
+
+/// Fail-closed error surfaced when the durable tier can't answer. Kept clear of
+/// "seq mismatch" and "Rate limit exceeded": the node classifies guardian
+/// errors by those substrings (`crates/hashi/src/leader/guardian.rs`) and this
+/// one must land in its retriable bucket.
+pub const WID_CACHE_UNAVAILABLE_MSG: &str = "wid cache unavailable; retry";
+
+fn unavailable() -> Status {
+    Status::unavailable(WID_CACHE_UNAVAILABLE_MSG)
+}
 
 struct CacheEntry {
     /// The seq the guardian consumed this wid at. Kept for observability only —
@@ -40,23 +83,40 @@ struct CacheEntry {
     response: proto::SignedStandardWithdrawalResponse,
 }
 
-pub struct CachingGuardianGrpc<S> {
+pub struct CachingGuardianGrpc<S, L> {
     inner: S,
-    cache: Mutex<LruCache<WithdrawalID, CacheEntry>>,
+    l1: Mutex<LruCache<WithdrawalID, CacheEntry>>,
+    log: L,
+    /// Network the guardian validates requests against; needed to recompute
+    /// sighashes when verifying a log replay.
+    network: Network,
+    metrics: Arc<ProxyMetrics>,
 }
 
-impl<S> CachingGuardianGrpc<S> {
-    pub fn new(inner: S) -> Self {
+impl<S, L> CachingGuardianGrpc<S, L> {
+    pub fn new(inner: S, log: L, network: Network, metrics: Arc<ProxyMetrics>) -> Self {
         Self::with_capacity(
             inner,
+            log,
+            network,
+            metrics,
             NonZeroUsize::new(CACHE_CAPACITY).expect("CACHE_CAPACITY > 0"),
         )
     }
 
-    fn with_capacity(inner: S, capacity: NonZeroUsize) -> Self {
+    fn with_capacity(
+        inner: S,
+        log: L,
+        network: Network,
+        metrics: Arc<ProxyMetrics>,
+        capacity: NonZeroUsize,
+    ) -> Self {
         Self {
             inner,
-            cache: Mutex::new(LruCache::new(capacity)),
+            l1: Mutex::new(LruCache::new(capacity)),
+            log,
+            network,
+            metrics,
         }
     }
 
@@ -67,7 +127,7 @@ impl<S> CachingGuardianGrpc<S> {
         &self,
         wid: &WithdrawalID,
     ) -> Option<(u64, proto::SignedStandardWithdrawalResponse)> {
-        let mut cache = self.cache.lock().expect("cache mutex poisoned");
+        let mut cache = self.l1.lock().expect("cache mutex poisoned");
         cache
             .get(wid)
             .map(|entry| (entry.consumed_seq, entry.response.clone()))
@@ -79,13 +139,174 @@ impl<S> CachingGuardianGrpc<S> {
         consumed_seq: u64,
         response: proto::SignedStandardWithdrawalResponse,
     ) {
-        self.cache.lock().expect("cache mutex poisoned").put(
+        self.l1.lock().expect("cache mutex poisoned").put(
             wid,
             CacheEntry {
                 consumed_seq,
                 response,
             },
         );
+    }
+}
+
+impl<S, L> CachingGuardianGrpc<S, L>
+where
+    S: GuardianService,
+    L: LogStore,
+{
+    /// Serve a wid from the guardian's S3 withdrawal log. `Ok(None)` means
+    /// "definitively not in the log (or not committed): forward"; `Err` is the
+    /// fail-closed path.
+    async fn replay_from_log(
+        &self,
+        wid: &WithdrawalID,
+        requested_seq: u64,
+        request: &proto::SignedStandardWithdrawalRequest,
+    ) -> Result<Option<proto::SignedStandardWithdrawalResponse>, Status> {
+        let found = match find_success_record(&self.log, wid, requested_seq, &self.metrics).await {
+            Ok(Some(found)) => found,
+            Ok(None) => return Ok(None),
+            Err(WidLogError::CapExceeded) => {
+                self.metrics.outcome(metrics::OUTCOME_UNAVAILABLE_SCAN_CAP);
+                error!(%wid, requested_seq, "Wid log scan hit its LIST cap; refusing to forward blind.");
+                return Err(unavailable());
+            }
+            Err(WidLogError::Store(e)) => {
+                self.metrics.outcome(metrics::OUTCOME_UNAVAILABLE_LOG_STORE);
+                error!(%wid, requested_seq, error = %e, "Wid log unavailable; refusing to forward blind.");
+                return Err(unavailable());
+            }
+        };
+
+        // Gate 1 (committed): the enclave holds the limiter across its S3 write
+        // and reverts if the write's ack never arrived — such an orphan record
+        // has `seq >= next_seq` and its withdrawal was never debited, so it must
+        // re-sign, not replay.
+        let info = match self.guardian_info().await {
+            Ok(info) => info,
+            Err(e) => {
+                self.metrics
+                    .outcome(metrics::OUTCOME_UNAVAILABLE_GUARDIAN_INFO);
+                error!(%wid, error = %e, "Cannot fetch guardian info to gate a log replay.");
+                return Err(unavailable());
+            }
+        };
+        let (Some(enclave_btc_pubkey), Some(master_g), Some(limiter_state)) = (
+            info.enclave_btc_pubkey,
+            info.mpc_master_g,
+            info.limiter_state,
+        ) else {
+            self.metrics
+                .outcome(metrics::OUTCOME_UNAVAILABLE_GUARDIAN_INFO);
+            error!(%wid, "Guardian info lacks BTC pubkey / master G / limiter state; cannot gate a log replay.");
+            return Err(unavailable());
+        };
+        if found.consumed_seq >= limiter_state.next_seq {
+            self.metrics.outcome(metrics::OUTCOME_FORWARDED_UNCOMMITTED);
+            warn!(
+                %wid,
+                record_seq = found.consumed_seq,
+                next_seq = limiter_state.next_seq,
+                "Log record was never committed by the enclave; forwarding for a fresh sign."
+            );
+            return Ok(None);
+        }
+
+        // Gate 2 (integrity): recompute this request's sighashes and verify the
+        // recorded signatures against the guardian BTC key, so the replay path
+        // can never hand the node signatures that don't spend its transaction.
+        if let Err(e) = verify_recorded_signatures(
+            request,
+            &found.response.enclave_signatures,
+            &enclave_btc_pubkey,
+            &master_g,
+            self.network,
+        ) {
+            self.metrics
+                .outcome(metrics::OUTCOME_UNAVAILABLE_VERIFY_FAILED);
+            error!(
+                %wid,
+                error = %e,
+                "Log record signatures do not verify; possible bucket tampering or version skew."
+            );
+            return Err(unavailable());
+        }
+
+        let response = synthesize_response(&found);
+        self.store(*wid, found.consumed_seq, response.clone());
+        self.metrics.outcome(metrics::OUTCOME_S3_HIT);
+        info!(
+            %wid,
+            requested_seq,
+            consumed_seq = found.consumed_seq,
+            "Replaying StandardWithdrawal response from the guardian's S3 log (idempotent by wid)."
+        );
+        Ok(Some(response))
+    }
+
+    async fn guardian_info(&self) -> anyhow::Result<GuardianInfo> {
+        let info_pb = self
+            .inner
+            .get_guardian_info(Request::new(proto::GetGuardianInfoRequest::default()))
+            .await
+            .map_err(|s| anyhow::anyhow!("get_guardian_info: {s}"))?
+            .into_inner();
+        let response = GetGuardianInfoResponse::try_from(info_pb)
+            .map_err(|e| anyhow::anyhow!("parse guardian info: {e:?}"))?;
+        // The proxy talks to the enclave over its own direct channel; like the
+        // node, it does not re-verify the info envelope (worst case is liveness).
+        Ok(response.into_info_unchecked())
+    }
+}
+
+/// Verify recorded BTC signatures against the sighashes of the *incoming*
+/// request (the same immutable tx as the recorded one, by the wid invariant).
+fn verify_recorded_signatures(
+    request: &proto::SignedStandardWithdrawalRequest,
+    signatures: &[BitcoinSignature],
+    enclave_btc_pubkey: &BitcoinPubkey,
+    master_g: &HashiMasterG,
+    network: Network,
+) -> anyhow::Result<()> {
+    let wire = pb_to_signed_standard_withdrawal_request_wire(request.clone())
+        .map_err(|e| anyhow::anyhow!("parse request: {e:?}"))?;
+    let signed = HashiSigned::<StandardWithdrawalRequest>::validate_addr(wire, network)
+        .map_err(|e| anyhow::anyhow!("validate request: {e:?}"))?;
+    let (messages, _txid) = signed
+        .message()
+        .utxos()
+        .signing_messages_and_txid(enclave_btc_pubkey, master_g);
+    anyhow::ensure!(
+        messages.len() == signatures.len(),
+        "record has {} signatures for {} inputs",
+        signatures.len(),
+        messages.len()
+    );
+    for (i, (message, signature)) in messages.iter().zip(signatures).enumerate() {
+        BTC_LIB
+            .verify_schnorr(&signature.signature, message, enclave_btc_pubkey)
+            .map_err(|e| anyhow::anyhow!("input {i}: {e}"))?;
+    }
+    Ok(())
+}
+
+fn synthesize_response(found: &FoundSuccess) -> proto::SignedStandardWithdrawalResponse {
+    proto::SignedStandardWithdrawalResponse {
+        data: Some(proto::StandardWithdrawalResponseData {
+            enclave_signatures: found
+                .response
+                .enclave_signatures
+                .iter()
+                .map(|sig| sig.to_vec().into())
+                .collect(),
+        }),
+        timestamp_ms: Some(found.timestamp_ms),
+        // The log record predates the response envelope (the enclave signs the
+        // envelope only after the S3 write), so a replay cannot carry the
+        // original. The node's wire parse requires a 64-byte value but never
+        // verifies it (`into_data_unchecked`; see leader/guardian.rs), so zeros
+        // are honest: they can't be mistaken for a real signature.
+        signature: Some(vec![0u8; 64].into()),
     }
 }
 
@@ -100,9 +321,10 @@ fn extract_wid_and_seq(
 }
 
 #[tonic::async_trait]
-impl<S> GuardianService for CachingGuardianGrpc<S>
+impl<S, L> GuardianService for CachingGuardianGrpc<S, L>
 where
     S: GuardianService,
+    L: LogStore,
 {
     async fn get_guardian_info(
         &self,
@@ -150,26 +372,31 @@ where
         &self,
         request: Request<proto::SignedStandardWithdrawalRequest>,
     ) -> Result<Response<proto::SignedStandardWithdrawalResponse>, Status> {
-        let key = extract_wid_and_seq(request.get_ref());
+        let Some((wid, seq)) = extract_wid_and_seq(request.get_ref()) else {
+            // No wid to key on; let the enclave produce the precise rejection.
+            return self.inner.standard_withdrawal(request).await;
+        };
 
-        if let Some((wid, seq)) = key {
-            if let Some((consumed_seq, cached)) = self.try_hit(&wid) {
-                info!(
-                    %wid,
-                    requested_seq = seq,
-                    consumed_seq,
-                    "Cache hit; replaying stored StandardWithdrawal response (idempotent by wid)"
-                );
-                return Ok(Response::new(cached));
-            }
+        if let Some((consumed_seq, cached)) = self.try_hit(&wid) {
+            self.metrics.outcome(metrics::OUTCOME_L1_HIT);
+            info!(
+                %wid,
+                requested_seq = seq,
+                consumed_seq,
+                "Cache hit; replaying stored StandardWithdrawal response (idempotent by wid)."
+            );
+            return Ok(Response::new(cached));
         }
 
+        if let Some(replayed) = self.replay_from_log(&wid, seq, request.get_ref()).await? {
+            return Ok(Response::new(replayed));
+        }
+
+        self.metrics.outcome(metrics::OUTCOME_FORWARDED);
         let response_inner = self.inner.standard_withdrawal(request).await?.into_inner();
 
-        if let Some((wid, seq)) = key {
-            self.store(wid, seq, response_inner.clone());
-            info!(%wid, seq, "Stored StandardWithdrawal response in cache");
-        }
+        self.store(wid, seq, response_inner.clone());
+        info!(%wid, seq, "Stored StandardWithdrawal response in cache");
 
         Ok(Response::new(response_inner))
     }
@@ -199,9 +426,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::widlog::test_store::success_record_json;
+    use crate::widlog::test_store::MemStore;
+    use hashi_types::bitcoin::create_btc_keypair_for_test;
+    use hashi_types::bitcoin::hashi_master_g_from_btc_xonly_for_test;
+    use hashi_types::bitcoin::sign_btc_tx;
+    use hashi_types::guardian::proto_conversions::get_guardian_info_response_to_pb;
+    use hashi_types::guardian::proto_conversions::signed_standard_withdrawal_request_to_pb;
+    use hashi_types::guardian::GuardianSignKeyPair;
+    use hashi_types::guardian::GuardianSigned;
+    use hashi_types::guardian::KPEncryptedShares;
+    use hashi_types::guardian::LimiterState;
+    use hashi_types::guardian::NitroAttestation;
+    use hashi_types::guardian::StandardWithdrawalResponse;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
-    use std::sync::Arc;
 
     type ResponseFn =
         dyn Fn() -> Result<proto::SignedStandardWithdrawalResponse, Status> + Send + Sync;
@@ -209,6 +448,7 @@ mod tests {
     struct StubGuardian {
         call_count: Arc<AtomicUsize>,
         result: Arc<ResponseFn>,
+        info: Option<proto::GetGuardianInfoResponse>,
     }
 
     impl StubGuardian {
@@ -218,6 +458,7 @@ mod tests {
                 Self {
                     call_count: call_count.clone(),
                     result: Arc::new(|| Ok(mock_response())),
+                    info: None,
                 },
                 call_count,
             )
@@ -229,9 +470,15 @@ mod tests {
                 Self {
                     call_count: call_count.clone(),
                     result: Arc::new(|| Err(Status::failed_precondition("simulated"))),
+                    info: None,
                 },
                 call_count,
             )
+        }
+
+        fn with_info(mut self, info: proto::GetGuardianInfoResponse) -> Self {
+            self.info = Some(info);
+            self
         }
     }
 
@@ -241,7 +488,10 @@ mod tests {
             &self,
             _: Request<proto::GetGuardianInfoRequest>,
         ) -> Result<Response<proto::GetGuardianInfoResponse>, Status> {
-            unimplemented!("not exercised by tests")
+            match &self.info {
+                Some(info) => Ok(Response::new(info.clone())),
+                None => Err(Status::unavailable("no stub info configured")),
+            }
         }
         async fn setup_new_key(
             &self,
@@ -300,6 +550,17 @@ mod tests {
         }
     }
 
+    fn test_metrics() -> Arc<ProxyMetrics> {
+        Arc::new(ProxyMetrics::new())
+    }
+
+    fn cache_over(
+        stub: StubGuardian,
+        store: MemStore,
+    ) -> CachingGuardianGrpc<StubGuardian, MemStore> {
+        CachingGuardianGrpc::new(stub, store, Network::Regtest, test_metrics())
+    }
+
     fn mock_request(wid: [u8; 32], seq: u64) -> Request<proto::SignedStandardWithdrawalRequest> {
         Request::new(proto::SignedStandardWithdrawalRequest {
             data: Some(proto::StandardWithdrawalRequestData {
@@ -322,10 +583,88 @@ mod tests {
         }
     }
 
+    /// A signed GetGuardianInfoResponse pb carrying the given keys + next_seq.
+    fn stub_info_pb(
+        enclave_btc_pubkey: BitcoinPubkey,
+        master_g: HashiMasterG,
+        next_seq: u64,
+    ) -> proto::GetGuardianInfoResponse {
+        let signing_key = GuardianSignKeyPair::from([7u8; 32]);
+        let info = GuardianInfo {
+            secret_sharing_instance: None,
+            bucket_info: None,
+            encryption_pubkey: vec![0u8; 32],
+            config_hash: None,
+            untrusted_git_revision: "test".to_string(),
+            enclave_btc_pubkey: Some(enclave_btc_pubkey),
+            limiter_state: Some(LimiterState {
+                num_tokens_available: 0,
+                last_updated_at: 0,
+                next_seq,
+            }),
+            limiter_config: None,
+            current_committee_epoch: None,
+            mpc_master_g: Some(master_g),
+        };
+        let signed_info = GuardianSigned::new(info, &signing_key, 1);
+        let domain = GetGuardianInfoResponse::new(
+            NitroAttestation::new(vec![1, 2, 3]),
+            signing_key.verification_key(),
+            signed_info,
+            KPEncryptedShares::new(vec![]).expect("empty shares"),
+        );
+        get_guardian_info_response_to_pb(domain)
+    }
+
+    /// A real request + a genuinely-signed Success record for it: the request pb
+    /// the node would send, and the log record whose signatures verify against
+    /// (enclave keypair, master G) over that request's sighashes.
+    struct ReplayFixture {
+        request: proto::SignedStandardWithdrawalRequest,
+        record_key: String,
+        record_bytes: Vec<u8>,
+        enclave_btc_pubkey: BitcoinPubkey,
+        master_g: HashiMasterG,
+        consumed_seq: u64,
+    }
+
+    fn replay_fixture(seq: u64) -> ReplayFixture {
+        let wid = WithdrawalID::new([0xcd; 32]);
+        let signed_request =
+            StandardWithdrawalRequest::mock_signed_for_testing_with_wid(Network::Regtest, wid);
+
+        let enclave_kp = create_btc_keypair_for_test(&[8u8; 32]);
+        let enclave_btc_pubkey = enclave_kp.x_only_public_key().0;
+        let master_g = hashi_master_g_from_btc_xonly_for_test(
+            &create_btc_keypair_for_test(&[6u8; 32])
+                .x_only_public_key()
+                .0,
+        );
+
+        let (messages, _txid) = signed_request
+            .message()
+            .utxos()
+            .signing_messages_and_txid(&enclave_btc_pubkey, &master_g);
+        let response = StandardWithdrawalResponse {
+            enclave_signatures: sign_btc_tx(&messages, &enclave_kp),
+        };
+
+        let request = signed_standard_withdrawal_request_to_pb(&signed_request);
+        let (record_key, record_bytes) = success_record_json(wid, seq, 1_700_000_000_000, response);
+        ReplayFixture {
+            request,
+            record_key,
+            record_bytes,
+            enclave_btc_pubkey,
+            master_g,
+            consumed_seq: seq,
+        }
+    }
+
     #[tokio::test]
     async fn same_wid_and_seq_hits_cache_after_first_call() {
         let (stub, count) = StubGuardian::ok();
-        let cache = CachingGuardianGrpc::new(stub);
+        let cache = cache_over(stub, MemStore::default());
 
         let r1 = cache
             .standard_withdrawal(mock_request([0xaa; 32], 0))
@@ -353,7 +692,7 @@ mod tests {
         // replay the cached response without re-consuming the guardian limiter —
         // otherwise the bucket drains for a withdrawal that was already signed.
         let (stub, count) = StubGuardian::ok();
-        let cache = CachingGuardianGrpc::new(stub);
+        let cache = cache_over(stub, MemStore::default());
 
         let r1 = cache
             .standard_withdrawal(mock_request([0xaa; 32], 0))
@@ -377,7 +716,7 @@ mod tests {
     #[tokio::test]
     async fn errors_are_not_cached() {
         let (stub, count) = StubGuardian::err();
-        let cache = CachingGuardianGrpc::new(stub);
+        let cache = cache_over(stub, MemStore::default());
 
         let r1 = cache.standard_withdrawal(mock_request([0xaa; 32], 0)).await;
         let r2 = cache.standard_withdrawal(mock_request([0xaa; 32], 0)).await;
@@ -389,7 +728,7 @@ mod tests {
     #[tokio::test]
     async fn missing_wid_falls_through_to_inner() {
         let (stub, count) = StubGuardian::ok();
-        let cache = CachingGuardianGrpc::new(stub);
+        let cache = cache_over(stub, MemStore::default());
 
         let req = Request::new(proto::SignedStandardWithdrawalRequest {
             data: Some(proto::StandardWithdrawalRequestData {
@@ -408,7 +747,7 @@ mod tests {
     #[tokio::test]
     async fn distinct_wids_are_cached_independently() {
         let (stub, count) = StubGuardian::ok();
-        let cache = CachingGuardianGrpc::new(stub);
+        let cache = cache_over(stub, MemStore::default());
 
         cache
             .standard_withdrawal(mock_request([0xaa; 32], 0))
@@ -436,7 +775,13 @@ mod tests {
     #[tokio::test]
     async fn evicts_lru_entry_when_over_capacity() {
         let (stub, count) = StubGuardian::ok();
-        let cache = CachingGuardianGrpc::with_capacity(stub, NonZeroUsize::new(2).unwrap());
+        let cache = CachingGuardianGrpc::with_capacity(
+            stub,
+            MemStore::default(),
+            Network::Regtest,
+            test_metrics(),
+            NonZeroUsize::new(2).unwrap(),
+        );
 
         // Three distinct wids into a capacity-2 cache evicts the first (LRU).
         for wid in [[0xa1; 32], [0xb2; 32], [0xc3; 32]] {
@@ -447,7 +792,8 @@ mod tests {
         }
         assert_eq!(count.load(Ordering::SeqCst), 3);
 
-        // The evicted wid misses and re-forwards; a still-cached wid keeps hitting.
+        // The evicted wid misses L1 and the (empty) log, and re-forwards; a
+        // still-cached wid keeps hitting.
         cache
             .standard_withdrawal(mock_request([0xa1; 32], 0))
             .await
@@ -462,5 +808,221 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count.load(Ordering::SeqCst), 4, "cached wid must still hit");
+    }
+
+    #[tokio::test]
+    async fn log_store_failure_fails_closed_without_forwarding() {
+        let (stub, count) = StubGuardian::ok();
+        let store = MemStore::default();
+        store.fail_lists.store(true, Ordering::SeqCst);
+        let cache = cache_over(stub, store);
+
+        let status = cache
+            .standard_withdrawal(mock_request([0xaa; 32], 0))
+            .await
+            .expect_err("must fail closed");
+
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert_eq!(count.load(Ordering::SeqCst), 0, "must not forward blind");
+        // The node classifies guardian errors by these substrings; the
+        // fail-closed error must land in its retriable bucket.
+        assert!(!status.message().contains("seq mismatch"));
+        assert!(!status.message().contains("Rate limit exceeded"));
+    }
+
+    #[tokio::test]
+    async fn log_replay_serves_verified_record_and_populates_l1() {
+        let fixture = replay_fixture(7);
+        let (stub, count) = StubGuardian::ok();
+        let stub = stub.with_info(stub_info_pb(
+            fixture.enclave_btc_pubkey,
+            fixture.master_g,
+            // The record's seq is committed: next_seq is past it.
+            fixture.consumed_seq + 1,
+        ));
+        let store = MemStore::default();
+        store.insert(fixture.record_key.clone(), fixture.record_bytes.clone());
+        let cache = cache_over(stub, store);
+
+        let replayed = cache
+            .standard_withdrawal(Request::new(fixture.request.clone()))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(count.load(Ordering::SeqCst), 0, "served from the log");
+        let sigs = &replayed.data.as_ref().unwrap().enclave_signatures;
+        assert!(!sigs.is_empty());
+        assert_eq!(replayed.signature.as_ref().unwrap().len(), 64);
+
+        // Second retry is an L1 hit — same response, still no forward.
+        let again = cache
+            .standard_withdrawal(Request::new(fixture.request.clone()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+        assert_eq!(replayed, again);
+    }
+
+    #[tokio::test]
+    async fn uncommitted_record_forwards_for_a_fresh_sign() {
+        // An orphan record (S3 put acked but the enclave reverted: its seq is
+        // not below next_seq) was never debited — it must re-sign, not replay.
+        let fixture = replay_fixture(7);
+        let (stub, count) = StubGuardian::ok();
+        let stub = stub.with_info(stub_info_pb(
+            fixture.enclave_btc_pubkey,
+            fixture.master_g,
+            fixture.consumed_seq,
+        ));
+        let store = MemStore::default();
+        store.insert(fixture.record_key.clone(), fixture.record_bytes.clone());
+        let cache = cache_over(stub, store);
+
+        cache
+            .standard_withdrawal(Request::new(fixture.request.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "must forward to the enclave"
+        );
+    }
+
+    #[tokio::test]
+    async fn unverifiable_record_fails_closed() {
+        // Same record, but the guardian reports a different BTC key: the
+        // recorded signatures no longer verify — poisoned record or version
+        // skew — and the proxy must neither serve NOR forward.
+        let fixture = replay_fixture(7);
+        let wrong_key = create_btc_keypair_for_test(&[42u8; 32])
+            .x_only_public_key()
+            .0;
+        let (stub, count) = StubGuardian::ok();
+        let stub = stub.with_info(stub_info_pb(
+            wrong_key,
+            fixture.master_g,
+            fixture.consumed_seq + 1,
+        ));
+        let store = MemStore::default();
+        store.insert(fixture.record_key.clone(), fixture.record_bytes.clone());
+        let cache = cache_over(stub, store);
+
+        let status = cache
+            .standard_withdrawal(Request::new(fixture.request.clone()))
+            .await
+            .expect_err("must fail closed");
+
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn guardian_info_failure_fails_closed() {
+        // A record exists but the enclave can't be asked for next_seq: the
+        // committed gate can't run, so the proxy fails closed.
+        let fixture = replay_fixture(7);
+        let (stub, count) = StubGuardian::ok(); // no .with_info(..)
+        let store = MemStore::default();
+        store.insert(fixture.record_key.clone(), fixture.record_bytes.clone());
+        let cache = cache_over(stub, store);
+
+        let status = cache
+            .standard_withdrawal(Request::new(fixture.request.clone()))
+            .await
+            .expect_err("must fail closed");
+
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+
+    /// The deploy-survival property against a real object store: a fresh proxy
+    /// instance (empty L1) serves a wid whose Success record was written before
+    /// it existed, without touching the enclave. Run against the local replica's
+    /// MinIO (`docker/hashi-guardian-local`, `make up`):
+    ///
+    /// ```text
+    /// GUARDIAN_LOG_BUCKET=hashi-guardian-dev GUARDIAN_LOG_REGION=us-east-1 \
+    /// AWS_ENDPOINT_URL_S3=http://127.0.0.1:19000 \
+    /// AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
+    /// cargo nextest run -p hashi-guardian-proxy --run-ignored all s3_log_replay
+    /// ```
+    #[tokio::test]
+    #[ignore = "needs a live MinIO/S3: set GUARDIAN_LOG_BUCKET/GUARDIAN_LOG_REGION (+ AWS_* env)"]
+    async fn s3_log_replay_survives_proxy_restarts() {
+        let bucket = std::env::var("GUARDIAN_LOG_BUCKET").expect("GUARDIAN_LOG_BUCKET");
+        let region = std::env::var("GUARDIAN_LOG_REGION").expect("GUARDIAN_LOG_REGION");
+
+        // Unique wid per run: records persist across runs in a real bucket, and
+        // a stale record for a reused wid would carry signatures over a stale
+        // mock transaction.
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos();
+        let mut wid_bytes = [0x5a_u8; 32];
+        wid_bytes[..4].copy_from_slice(&nanos.to_be_bytes());
+        let wid = WithdrawalID::new(wid_bytes);
+
+        let signed_request =
+            StandardWithdrawalRequest::mock_signed_for_testing_with_wid(Network::Regtest, wid);
+        let enclave_kp = create_btc_keypair_for_test(&[8u8; 32]);
+        let enclave_btc_pubkey = enclave_kp.x_only_public_key().0;
+        let master_g = hashi_master_g_from_btc_xonly_for_test(
+            &create_btc_keypair_for_test(&[6u8; 32])
+                .x_only_public_key()
+                .0,
+        );
+        let (messages, _txid) = signed_request
+            .message()
+            .utxos()
+            .signing_messages_and_txid(&enclave_btc_pubkey, &master_g);
+        let response = StandardWithdrawalResponse {
+            enclave_signatures: sign_btc_tx(&messages, &enclave_kp),
+        };
+        let request = signed_standard_withdrawal_request_to_pb(&signed_request);
+        let (record_key, record_bytes) = success_record_json(wid, 7, 1_700_000_000_000, response);
+
+        // Write the record the way the enclave would have (plain put; the proxy
+        // itself is read-only on the bucket).
+        let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(region.clone()))
+            .load()
+            .await;
+        let mut builder = aws_sdk_s3::config::Builder::from(&aws_config);
+        if std::env::var_os("AWS_ENDPOINT_URL_S3").is_some() {
+            builder = builder.force_path_style(true);
+        }
+        let s3 = aws_sdk_s3::Client::from_conf(builder.build());
+        s3.put_object()
+            .bucket(&bucket)
+            .key(&record_key)
+            .body(record_bytes.into())
+            .send()
+            .await
+            .expect("write the success record");
+
+        // A brand-new proxy instance: empty L1, real S3LogStore.
+        let store = crate::widlog::S3LogStore::connect(bucket, region).await;
+        store.probe().await.expect("bucket must be readable");
+        let (stub, count) = StubGuardian::ok();
+        let stub = stub.with_info(stub_info_pb(enclave_btc_pubkey, master_g, 8));
+        let cache = CachingGuardianGrpc::new(stub, store, Network::Regtest, test_metrics());
+
+        let replayed = cache
+            .standard_withdrawal(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "must be served from the S3 log, not the enclave"
+        );
+        assert!(!replayed.data.unwrap().enclave_signatures.is_empty());
     }
 }

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Wid-keyed response cache for the guardian's `StandardWithdrawal` RPC: an
-//! in-process LRU in front of the guardian's own S3 withdrawal log as the
-//! durable tier. Lives in the out-of-enclave proxy so it can be hardened or
-//! swapped independently of the signing oracle.
+//! in-process LRU in front of the guardian's own S3 withdrawal log
+//! ([`crate::widlog`]) as the durable, read-only tier.
 //!
 //! Keyed by `wid`, not `(wid, seq)`: the guardian debits the limiter and
 //! advances `next_seq` when it signs, before hashi has the signed event
@@ -14,22 +13,12 @@
 //! `wid` avoids that — safe because a committed wid's inputs/outputs are
 //! immutable (only signatures change), so the response is stable.
 //!
-//! The durable tier is read-only: the enclave writes its `Success` record
-//! *before* releasing signatures and fails closed if the write fails, so any
-//! signature a node has ever seen has a record — the proxy has nothing durable
-//! of its own to lose, across restarts or otherwise. A replay from the log
-//! passes two gates first: the record's seq must be committed (below the
-//! enclave's `next_seq`; an S3 put whose ack was lost leaves a record the
-//! enclave reverted, which must re-sign, not replay), and the recorded
-//! signatures must verify against the guardian BTC key over sighashes
-//! recomputed from the incoming request (a bucket writer must not be able to
-//! wedge withdrawals with a poisoned record).
-//!
-//! When the log can't answer — LIST/GET failure, scan cap, guardian info
-//! unavailable, verification failure — the proxy fails closed with
-//! `UNAVAILABLE` rather than forwarding blind: it cannot distinguish "never
-//! signed" from "signed but unreadable", and forwarding the latter re-signs
-//! and double-debits the limiter. Errors from the enclave are never cached.
+//! The enclave persists every signed withdrawal before releasing it, so the
+//! proxy has nothing durable of its own to lose. A log replay passes two gates
+//! (see `replay_from_log`); when the log can't answer, the proxy fails closed
+//! with `UNAVAILABLE` rather than forwarding blind — it cannot distinguish
+//! "never signed" from "signed but unreadable", and forwarding the latter
+//! re-signs and double-debits the limiter.
 
 use crate::metrics;
 use crate::metrics::ProxyMetrics;
@@ -178,10 +167,8 @@ where
             }
         };
 
-        // Gate 1 (committed): the enclave holds the limiter across its S3 write
-        // and reverts if the write's ack never arrived — such an orphan record
-        // has `seq >= next_seq` and its withdrawal was never debited, so it must
-        // re-sign, not replay.
+        // Gate 1 (committed): a record whose S3 ack never reached the enclave
+        // was reverted, not debited — `seq >= next_seq` — and must re-sign.
         let info = match self.guardian_info().await {
             Ok(info) => info,
             Err(e) => {
@@ -202,7 +189,7 @@ where
             return Err(unavailable());
         };
         if found.consumed_seq >= limiter_state.next_seq {
-            self.metrics.outcome(metrics::OUTCOME_FORWARDED_UNCOMMITTED);
+            self.metrics.uncommitted_records.inc();
             warn!(
                 %wid,
                 record_seq = found.consumed_seq,
@@ -212,9 +199,8 @@ where
             return Ok(None);
         }
 
-        // Gate 2 (integrity): recompute this request's sighashes and verify the
-        // recorded signatures against the guardian BTC key, so the replay path
-        // can never hand the node signatures that don't spend its transaction.
+        // Gate 2 (integrity): the replay path must never hand the node
+        // signatures that don't spend its transaction.
         if let Err(e) = verify_recorded_signatures(
             request,
             &found.response.enclave_signatures,
@@ -301,11 +287,9 @@ fn synthesize_response(found: &FoundSuccess) -> proto::SignedStandardWithdrawalR
                 .collect(),
         }),
         timestamp_ms: Some(found.timestamp_ms),
-        // The log record predates the response envelope (the enclave signs the
-        // envelope only after the S3 write), so a replay cannot carry the
-        // original. The node's wire parse requires a 64-byte value but never
-        // verifies it (`into_data_unchecked`; see leader/guardian.rs), so zeros
-        // are honest: they can't be mistaken for a real signature.
+        // The record predates the response envelope (the enclave signs it after
+        // the S3 write). Nodes require a 64-byte value but never verify it
+        // (`into_data_unchecked`), so zeros can't pass for a real signature.
         signature: Some(vec![0u8; 64].into()),
     }
 }
@@ -939,10 +923,8 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 0);
     }
 
-    /// The deploy-survival property against a real object store: a fresh proxy
-    /// instance (empty L1) serves a wid whose Success record was written before
-    /// it existed, without touching the enclave. Run against the local replica's
-    /// MinIO (`docker/hashi-guardian-local`, `make up`):
+    /// A fresh proxy instance (empty L1) serves a wid whose record predates it,
+    /// without touching the enclave. Against the local replica's MinIO:
     ///
     /// ```text
     /// GUARDIAN_LOG_BUCKET=hashi-guardian-dev GUARDIAN_LOG_REGION=us-east-1 \

--- a/crates/hashi-guardian-proxy/src/config.rs
+++ b/crates/hashi-guardian-proxy/src/config.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
+use bitcoin::Network;
 use hashi_types::pgp::Fingerprint;
 
 pub struct Config {
@@ -19,12 +20,24 @@ pub struct Config {
     /// Address the proxy listens on for node traffic
     /// (`PROXY_LISTEN_ADDR`, default `0.0.0.0:3000`).
     pub listen_addr: SocketAddr,
+    /// Address the prometheus `/metrics` endpoint listens on
+    /// (`METRICS_LISTEN_ADDR`, default `0.0.0.0:9184`).
+    pub metrics_listen_addr: SocketAddr,
     /// TCP connect timeout to the backend
     /// (`GUARDIAN_CONNECT_TIMEOUT_SECS`, default 5).
     pub connect_timeout: Duration,
     /// HTTP/2 keepalive ping interval to the backend
     /// (`GUARDIAN_KEEPALIVE_SECS`, default 5).
     pub keepalive_interval: Duration,
+    /// The guardian's S3 log bucket, read as the wid cache's durable tier
+    /// (`GUARDIAN_LOG_BUCKET` + `GUARDIAN_LOG_REGION`, required). Credentials
+    /// come from the AWS default provider chain.
+    pub log_bucket: String,
+    pub log_region: String,
+    /// BTC network the guardian signs for (`BTC_NETWORK`, required:
+    /// bitcoin|testnet|signet|regtest). Must match the guardian's config; used
+    /// to recompute sighashes when verifying a log replay.
+    pub btc_network: Network,
     /// PGP fingerprints of the KPs allowed to submit shares through the relay
     /// (`AUTHORIZED_KP_FINGERPRINTS`, comma-separated, default empty). Empty
     /// fail-closes the relay; the cache/forwarding paths are unaffected.
@@ -39,16 +52,32 @@ impl Config {
             .unwrap_or_else(|_| "0.0.0.0:3000".to_string())
             .parse()
             .context("PROXY_LISTEN_ADDR must be a valid socket address")?;
+        let metrics_listen_addr = std::env::var("METRICS_LISTEN_ADDR")
+            .unwrap_or_else(|_| "0.0.0.0:9184".to_string())
+            .parse()
+            .context("METRICS_LISTEN_ADDR must be a valid socket address")?;
         let connect_timeout =
             Duration::from_secs(parse_env_u64("GUARDIAN_CONNECT_TIMEOUT_SECS", 5)?);
         let keepalive_interval = Duration::from_secs(parse_env_u64("GUARDIAN_KEEPALIVE_SECS", 5)?);
+        let log_bucket = std::env::var("GUARDIAN_LOG_BUCKET")
+            .context("GUARDIAN_LOG_BUCKET must be set (the guardian's S3 log bucket)")?;
+        let log_region = std::env::var("GUARDIAN_LOG_REGION")
+            .context("GUARDIAN_LOG_REGION must be set (region of the guardian's S3 log bucket)")?;
+        let btc_network = std::env::var("BTC_NETWORK")
+            .context("BTC_NETWORK must be set (bitcoin|testnet|signet|regtest)")?
+            .parse()
+            .context("BTC_NETWORK must be one of bitcoin|testnet|signet|regtest")?;
         let authorized_kp_fingerprints =
             parse_kp_roster(&std::env::var("AUTHORIZED_KP_FINGERPRINTS").unwrap_or_default())?;
         Ok(Self {
             backend_url,
             listen_addr,
+            metrics_listen_addr,
             connect_timeout,
             keepalive_interval,
+            log_bucket,
+            log_region,
+            btc_network,
             authorized_kp_fingerprints,
         })
     }

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -220,7 +220,10 @@ mod tests {
         })
     }
 
-    async fn spawn_stub_proxy() -> (StubGuardian, CachingGuardianGrpc<Forwarding>) {
+    async fn spawn_stub_proxy() -> (
+        StubGuardian,
+        CachingGuardianGrpc<Forwarding, crate::widlog::test_store::MemStore>,
+    ) {
         let stub = StubGuardian::default();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -238,7 +241,13 @@ mod tests {
         let channel = tonic::transport::Endpoint::from_shared(format!("http://{addr}"))
             .unwrap()
             .connect_lazy();
-        (stub, CachingGuardianGrpc::new(Forwarding::new(channel)))
+        let cache = CachingGuardianGrpc::new(
+            Forwarding::new(channel),
+            crate::widlog::test_store::MemStore::default(),
+            bitcoin::Network::Regtest,
+            std::sync::Arc::new(crate::metrics::ProxyMetrics::new()),
+        );
+        (stub, cache)
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian-proxy/src/lib.rs
+++ b/crates/hashi-guardian-proxy/src/lib.rs
@@ -4,9 +4,11 @@
 //! Out-of-enclave gRPC proxy for the hashi guardian. It fronts the enclave with
 //! a stable, hardenable surface:
 //!
-//! - [`forward`] forwards the four node-facing `GuardianService` RPCs to the
+//! - [`forward`] forwards the node-facing `GuardianService` RPCs to the
 //!   enclave (rejecting operator/ceremony RPCs), and [`cache`] wraps it so
-//!   `StandardWithdrawal` responses are idempotent by `wid`.
+//!   `StandardWithdrawal` responses are idempotent by `wid` — an in-process LRU
+//!   in front of the guardian's own S3 withdrawal log ([`widlog`]) as the
+//!   durable, read-only tier.
 //! - [`relay`] serves `GuardianRelayService`: key provisioners submit one share
 //!   each and the relay batches a threshold-many into the guardian's
 //!   `ProvisionerInit`.
@@ -17,7 +19,9 @@
 pub mod cache;
 pub mod config;
 pub mod forward;
+pub mod metrics;
 pub mod relay;
+pub mod widlog;
 
 pub use cache::CachingGuardianGrpc;
 pub use config::Config;

--- a/crates/hashi-guardian-proxy/src/main.rs
+++ b/crates/hashi-guardian-proxy/src/main.rs
@@ -44,9 +44,8 @@ async fn main() -> Result<()> {
         );
     }
 
-    // The guardian's S3 withdrawal log — the wid cache's durable tier. Prove
-    // bucket access before serving: a proxy that can't read the log would fail
-    // every retry closed, and a supervisor restart converges once access works.
+    // The wid cache's durable tier. Prove bucket access before serving: a
+    // proxy that can't read the log fails every retry closed.
     let log_store = S3LogStore::connect(config.log_bucket.clone(), config.log_region.clone()).await;
     probe_with_retries(&log_store).await?;
 
@@ -101,9 +100,8 @@ async fn main() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Server error: {}", e))
 }
 
-/// Bounded boot probe: retry transient S3 blips so a task start doesn't
-/// crash-loop through the target group, but still fail fast on a real
-/// misconfiguration (bad bucket, missing role).
+/// Retry transient S3 blips at boot (no target-group crash-loop), but fail
+/// fast on real misconfiguration (bad bucket, missing role).
 async fn probe_with_retries(log_store: &S3LogStore) -> Result<()> {
     const ATTEMPTS: u32 = 5;
     for attempt in 1..=ATTEMPTS {

--- a/crates/hashi-guardian-proxy/src/main.rs
+++ b/crates/hashi-guardian-proxy/src/main.rs
@@ -5,12 +5,17 @@ use anyhow::Result;
 use hashi_guardian_proxy::cache::CachingGuardianGrpc;
 use hashi_guardian_proxy::config::Config;
 use hashi_guardian_proxy::forward::Forwarding;
+use hashi_guardian_proxy::metrics::ProxyMetrics;
 use hashi_guardian_proxy::relay::Relay;
+use hashi_guardian_proxy::widlog::S3LogStore;
 use hashi_types::proto::guardian_relay_service_server::GuardianRelayServiceServer;
 use hashi_types::proto::guardian_service_server::GuardianServiceServer;
+use std::sync::Arc;
+use std::time::Duration;
 use tonic::transport::Endpoint;
 use tonic::transport::Server;
 use tonic_health::server::health_reporter;
+use tracing::error;
 use tracing::info;
 use tracing::warn;
 
@@ -27,6 +32,8 @@ async fn main() -> Result<()> {
     info!(
         backend = %config.backend_url,
         listen = %config.listen_addr,
+        log_bucket = %config.log_bucket,
+        network = %config.btc_network,
         kp_roster = config.authorized_kp_fingerprints.len(),
         "Starting hashi-guardian-proxy (wid-keyed cache + node forwarder + provisioning relay)."
     );
@@ -37,6 +44,23 @@ async fn main() -> Result<()> {
         );
     }
 
+    // The guardian's S3 withdrawal log — the wid cache's durable tier. Prove
+    // bucket access before serving: a proxy that can't read the log would fail
+    // every retry closed, and a supervisor restart converges once access works.
+    let log_store = S3LogStore::connect(config.log_bucket.clone(), config.log_region.clone()).await;
+    probe_with_retries(&log_store).await?;
+
+    let metrics = Arc::new(ProxyMetrics::new());
+    tokio::spawn({
+        let metrics = metrics.clone();
+        let addr = config.metrics_listen_addr;
+        async move {
+            if let Err(e) = metrics.serve(addr).await {
+                error!(error = %e, "Metrics server exited.");
+            }
+        }
+    });
+
     // Lazy channel to the enclave guardian, shared by forwarder and relay. Mirrors
     // the node-side client (crates/hashi/src/grpc/guardian_client.rs): same timeout + keepalive.
     let channel = Endpoint::from_shared(config.backend_url.clone())?
@@ -44,14 +68,19 @@ async fn main() -> Result<()> {
         .http2_keep_alive_interval(config.keepalive_interval)
         .connect_lazy();
 
-    let guardian_svc = CachingGuardianGrpc::new(Forwarding::new(channel.clone()));
+    let guardian_svc = CachingGuardianGrpc::new(
+        Forwarding::new(channel.clone()),
+        log_store,
+        config.btc_network,
+        metrics.clone(),
+    );
     let relay_svc = Relay::new(channel, config.authorized_kp_fingerprints);
 
     // gRPC health service, mirroring the guardian — the ALB target group
     // health-checks `grpc.health.v1.Health/Check`.
     let (health_reporter, health_service) = health_reporter();
     health_reporter
-        .set_serving::<GuardianServiceServer<CachingGuardianGrpc<Forwarding>>>()
+        .set_serving::<GuardianServiceServer<CachingGuardianGrpc<Forwarding, S3LogStore>>>()
         .await;
     health_reporter
         .set_serving::<GuardianRelayServiceServer<Relay>>()
@@ -70,6 +99,24 @@ async fn main() -> Result<()> {
         .serve(config.listen_addr)
         .await
         .map_err(|e| anyhow::anyhow!("Server error: {}", e))
+}
+
+/// Bounded boot probe: retry transient S3 blips so a task start doesn't
+/// crash-loop through the target group, but still fail fast on a real
+/// misconfiguration (bad bucket, missing role).
+async fn probe_with_retries(log_store: &S3LogStore) -> Result<()> {
+    const ATTEMPTS: u32 = 5;
+    for attempt in 1..=ATTEMPTS {
+        match log_store.probe().await {
+            Ok(()) => return Ok(()),
+            Err(e) if attempt < ATTEMPTS => {
+                warn!(attempt, error = %e, "Wid log bucket probe failed; retrying.");
+                tokio::time::sleep(Duration::from_secs(2 * u64::from(attempt))).await;
+            }
+            Err(e) => return Err(e.context("wid log bucket is not readable")),
+        }
+    }
+    unreachable!("loop returns on success or final error")
 }
 
 /// Make any panic abort the process instead of unwinding. The wid-keyed cache

--- a/crates/hashi-guardian-proxy/src/metrics.rs
+++ b/crates/hashi-guardian-proxy/src/metrics.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Prometheus metrics for the proxy, served on `METRICS_LISTEN_ADDR`. The
+//! request counter's `outcome` label is the wid cache's decision surface —
+//! `unavailable_*` outcomes are the fail-closed paths and worth alerting on
+//! (`unavailable_verify_failed` in particular: a log record whose signatures
+//! don't verify is either bucket tampering or version skew).
+
+use prometheus::Encoder;
+use prometheus::Histogram;
+use prometheus::HistogramOpts;
+use prometheus::IntCounter;
+use prometheus::IntCounterVec;
+use prometheus::Opts;
+use prometheus::Registry;
+use prometheus::TextEncoder;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tracing::info;
+
+pub const OUTCOME_L1_HIT: &str = "l1_hit";
+pub const OUTCOME_S3_HIT: &str = "s3_hit";
+pub const OUTCOME_FORWARDED: &str = "forwarded";
+/// A log record existed but the enclave never committed its seq (S3 ack lost
+/// before the limiter commit); forwarded so the enclave signs and debits it
+/// properly instead of replaying an un-debited record.
+pub const OUTCOME_FORWARDED_UNCOMMITTED: &str = "forwarded_uncommitted";
+pub const OUTCOME_UNAVAILABLE_LOG_STORE: &str = "unavailable_log_store";
+pub const OUTCOME_UNAVAILABLE_SCAN_CAP: &str = "unavailable_scan_cap";
+pub const OUTCOME_UNAVAILABLE_VERIFY_FAILED: &str = "unavailable_verify_failed";
+pub const OUTCOME_UNAVAILABLE_GUARDIAN_INFO: &str = "unavailable_guardian_info";
+
+pub struct ProxyMetrics {
+    registry: Registry,
+    /// `StandardWithdrawal` requests by cache outcome.
+    pub requests: IntCounterVec,
+    /// LIST calls per S3 lookup (hit or miss); the scan cap bounds the tail.
+    pub scan_lists: Histogram,
+    /// Wid-matching log records that failed to parse (schema skew or garbage).
+    pub record_parse_failures: IntCounter,
+}
+
+impl ProxyMetrics {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let registry = Registry::new();
+        let requests = IntCounterVec::new(
+            Opts::new(
+                "guardian_proxy_withdrawal_requests_total",
+                "StandardWithdrawal requests by wid-cache outcome",
+            ),
+            &["outcome"],
+        )
+        .expect("valid metric");
+        let scan_lists = Histogram::with_opts(
+            HistogramOpts::new(
+                "guardian_proxy_widlog_scan_lists",
+                "S3 LIST calls per wid log lookup",
+            )
+            .buckets(vec![2.0, 5.0, 10.0, 25.0, 50.0, 100.0]),
+        )
+        .expect("valid metric");
+        let record_parse_failures = IntCounter::new(
+            "guardian_proxy_widlog_parse_failures_total",
+            "Wid-matching log records that failed to parse",
+        )
+        .expect("valid metric");
+
+        registry
+            .register(Box::new(requests.clone()))
+            .expect("register");
+        registry
+            .register(Box::new(scan_lists.clone()))
+            .expect("register");
+        registry
+            .register(Box::new(record_parse_failures.clone()))
+            .expect("register");
+
+        Self {
+            registry,
+            requests,
+            scan_lists,
+            record_parse_failures,
+        }
+    }
+
+    pub fn outcome(&self, outcome: &str) {
+        self.requests.with_label_values(&[outcome]).inc();
+    }
+
+    fn render(&self) -> String {
+        let mut buf = Vec::new();
+        TextEncoder::new()
+            .encode(&self.registry.gather(), &mut buf)
+            .expect("encode metrics");
+        String::from_utf8(buf).expect("metrics are utf-8")
+    }
+
+    /// Serve `GET /metrics` forever; spawned alongside the gRPC server.
+    pub async fn serve(self: Arc<Self>, addr: SocketAddr) -> anyhow::Result<()> {
+        let app = axum::Router::new().route(
+            "/metrics",
+            axum::routing::get(move || {
+                let metrics = self.clone();
+                async move { metrics.render() }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        info!("Metrics listening on {addr}.");
+        axum::serve(listener, app).await?;
+        Ok(())
+    }
+}

--- a/crates/hashi-guardian-proxy/src/metrics.rs
+++ b/crates/hashi-guardian-proxy/src/metrics.rs
@@ -33,9 +33,6 @@ pub struct ProxyMetrics {
     pub scan_lists: Histogram,
     /// Wid-matching log records that failed to parse (schema skew or garbage).
     pub record_parse_failures: IntCounter,
-    /// Log records the enclave never committed (S3 ack lost, limiter reverted);
-    /// these forward for a fresh sign instead of replaying.
-    pub uncommitted_records: IntCounter,
 }
 
 impl ProxyMetrics {
@@ -63,11 +60,6 @@ impl ProxyMetrics {
             "Wid-matching log records that failed to parse",
         )
         .expect("valid metric");
-        let uncommitted_records = IntCounter::new(
-            "guardian_proxy_widlog_uncommitted_records_total",
-            "Log records found but never committed by the enclave",
-        )
-        .expect("valid metric");
 
         registry
             .register(Box::new(requests.clone()))
@@ -78,16 +70,12 @@ impl ProxyMetrics {
         registry
             .register(Box::new(record_parse_failures.clone()))
             .expect("register");
-        registry
-            .register(Box::new(uncommitted_records.clone()))
-            .expect("register");
 
         Self {
             registry,
             requests,
             scan_lists,
             record_parse_failures,
-            uncommitted_records,
         }
     }
 

--- a/crates/hashi-guardian-proxy/src/metrics.rs
+++ b/crates/hashi-guardian-proxy/src/metrics.rs
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Prometheus metrics for the proxy, served on `METRICS_LISTEN_ADDR`. The
-//! request counter's `outcome` label is the wid cache's decision surface —
-//! `unavailable_*` outcomes are the fail-closed paths and worth alerting on
-//! (`unavailable_verify_failed` in particular: a log record whose signatures
-//! don't verify is either bucket tampering or version skew).
+//! `unavailable_*` outcomes are the fail-closed paths and worth alerting on,
+//! `unavailable_verify_failed` especially (bucket tampering or version skew).
 
 use prometheus::Encoder;
 use prometheus::Histogram;
@@ -22,10 +20,6 @@ use tracing::info;
 pub const OUTCOME_L1_HIT: &str = "l1_hit";
 pub const OUTCOME_S3_HIT: &str = "s3_hit";
 pub const OUTCOME_FORWARDED: &str = "forwarded";
-/// A log record existed but the enclave never committed its seq (S3 ack lost
-/// before the limiter commit); forwarded so the enclave signs and debits it
-/// properly instead of replaying an un-debited record.
-pub const OUTCOME_FORWARDED_UNCOMMITTED: &str = "forwarded_uncommitted";
 pub const OUTCOME_UNAVAILABLE_LOG_STORE: &str = "unavailable_log_store";
 pub const OUTCOME_UNAVAILABLE_SCAN_CAP: &str = "unavailable_scan_cap";
 pub const OUTCOME_UNAVAILABLE_VERIFY_FAILED: &str = "unavailable_verify_failed";
@@ -39,6 +33,9 @@ pub struct ProxyMetrics {
     pub scan_lists: Histogram,
     /// Wid-matching log records that failed to parse (schema skew or garbage).
     pub record_parse_failures: IntCounter,
+    /// Log records the enclave never committed (S3 ack lost, limiter reverted);
+    /// these forward for a fresh sign instead of replaying.
+    pub uncommitted_records: IntCounter,
 }
 
 impl ProxyMetrics {
@@ -66,6 +63,11 @@ impl ProxyMetrics {
             "Wid-matching log records that failed to parse",
         )
         .expect("valid metric");
+        let uncommitted_records = IntCounter::new(
+            "guardian_proxy_widlog_uncommitted_records_total",
+            "Log records found but never committed by the enclave",
+        )
+        .expect("valid metric");
 
         registry
             .register(Box::new(requests.clone()))
@@ -76,12 +78,16 @@ impl ProxyMetrics {
         registry
             .register(Box::new(record_parse_failures.clone()))
             .expect("register");
+        registry
+            .register(Box::new(uncommitted_records.clone()))
+            .expect("register");
 
         Self {
             registry,
             requests,
             scan_lists,
             record_parse_failures,
+            uncommitted_records,
         }
     }
 

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -1,0 +1,611 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Read-only access to the guardian's S3 withdrawal log, used as the durable
+//! tier of the wid cache. The enclave writes one `Success` record per signed
+//! withdrawal *before* it releases the signatures (fail-closed, see
+//! `hashi-guardian/src/withdraw_mode/standard.rs`), so any signature a node has
+//! ever seen has a durable record here — the proxy never writes.
+//!
+//! Success keys are `withdraw/YYYY/MM/DD/HH/success-{seq:020}-{session}-wid{wid}.json`
+//! (hour buckets; lexicographic order within a bucket is seq order; the wid only
+//! appears as a suffix, so lookups scan buckets newest-first). The scan is
+//! bounded by the request's `seq`: the node only retries a wid the guardian
+//! signed at seq `S` while its own mirror reads `S` or `S+1`, so once two
+//! consecutive success-bearing buckets top out below `seq - 1` the record cannot
+//! be further back. Two buckets (not one) so a forward clock step in the enclave
+//! can't hide the record behind a single future-labelled bucket; failure-only
+//! buckets are skipped by listing the `success-` prefix and never terminate the
+//! scan. An exhausted prefix tree is a definitive miss; hitting the LIST cap is
+//! NOT — the caller must fail closed on it, never forward.
+
+use crate::metrics::ProxyMetrics;
+use hashi_types::guardian::log::S3_DIR_WITHDRAW;
+use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogRecord;
+use hashi_types::guardian::StandardWithdrawalResponse;
+use hashi_types::guardian::WithdrawalID;
+use hashi_types::guardian::WithdrawalLogMessage;
+use tracing::warn;
+
+/// Total LIST calls a single lookup may issue. A terminating scan needs ~4 tree
+/// walks + 2-3 bucket lists; the cap only trips when the requested seq is far
+/// below everything in the bucket (e.g. a rogue client), and it must surface as
+/// "cache unavailable", not "not found".
+const SCAN_LIST_CAP: usize = 100;
+
+const SUCCESS_KEY_PREFIX: &str = "success-";
+
+#[derive(Debug)]
+pub enum WidLogError {
+    /// A LIST or GET failed; the lookup is indeterminate.
+    Store(anyhow::Error),
+    /// The scan exceeded [`SCAN_LIST_CAP`] without terminating.
+    CapExceeded,
+}
+
+/// A parsed `Success` record for a wid.
+pub struct FoundSuccess {
+    /// The seq the guardian consumed the wid at (`request_data.seq`).
+    pub consumed_seq: u64,
+    /// Timestamp of the log record, reused as the replayed response timestamp.
+    pub timestamp_ms: u64,
+    pub response: StandardWithdrawalResponse,
+}
+
+/// Minimal object-store surface the scanner needs. `list_dirs` is an S3
+/// delimiter listing (returns immediate sub-prefixes), `list_keys` a plain
+/// prefix listing in ascending key order, both fully paginated.
+#[tonic::async_trait]
+pub trait LogStore: Send + Sync + 'static {
+    async fn list_dirs(&self, prefix: &str) -> anyhow::Result<Vec<String>>;
+    async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>>;
+    async fn get(&self, key: &str) -> anyhow::Result<Vec<u8>>;
+}
+
+/// Find the newest `Success` record for `wid`, walking hour buckets newest to
+/// oldest. `Ok(None)` is a *definitive* miss (safe to forward to the enclave);
+/// any `Err` means the lookup is indeterminate and the caller must fail closed.
+pub async fn find_success_record<L: LogStore>(
+    log: &L,
+    wid: &WithdrawalID,
+    request_seq: u64,
+    metrics: &ProxyMetrics,
+) -> Result<Option<FoundSuccess>, WidLogError> {
+    let suffix = format!("-wid{wid}.json");
+    let threshold = request_seq.saturating_sub(1);
+    let mut lists_used = 0usize;
+    let mut strikes = 0u32;
+
+    let scan = async {
+        for year in list_desc(log, &format!("{S3_DIR_WITHDRAW}/"), &mut lists_used).await? {
+            for month in list_desc(log, &year, &mut lists_used).await? {
+                for day in list_desc(log, &month, &mut lists_used).await? {
+                    for hour in list_desc(log, &day, &mut lists_used).await? {
+                        let keys = list_keys_capped(
+                            log,
+                            &format!("{hour}{SUCCESS_KEY_PREFIX}"),
+                            &mut lists_used,
+                        )
+                        .await?;
+                        if keys.is_empty() {
+                            // Failure-only (or empty) bucket: indeterminate for
+                            // the seq bound, keep walking.
+                            continue;
+                        }
+
+                        // Newest (max-seq) candidate first within the bucket.
+                        for key in keys.iter().rev().filter(|k| k.ends_with(&suffix)) {
+                            let bytes = log.get(key).await.map_err(WidLogError::Store)?;
+                            match parse_success(&bytes, wid) {
+                                Ok(found) => return Ok(Some(found)),
+                                Err(e) => {
+                                    // Version-skewed or malformed record: skip it.
+                                    // Ending as a miss degrades to a re-sign (one
+                                    // limiter double-debit) and self-heals, where
+                                    // failing closed would wedge until a proxy fix.
+                                    metrics.record_parse_failures.inc();
+                                    warn!(key, error = %e, "unreadable success record for wid; skipping");
+                                }
+                            }
+                        }
+
+                        let bucket_max = keys.iter().rev().find_map(|k| parse_success_seq(k));
+                        match bucket_max {
+                            Some(max) if max < threshold => {
+                                strikes += 1;
+                                if strikes >= 2 {
+                                    return Ok(None);
+                                }
+                            }
+                            Some(_) => strikes = 0,
+                            // Only unparseable success keys: indeterminate.
+                            None => {}
+                        }
+                    }
+                }
+            }
+        }
+        // Walked every existing bucket: the record does not exist.
+        Ok(None)
+    };
+    let result = scan.await;
+    metrics.scan_lists.observe(lists_used as f64);
+    result
+}
+
+async fn list_desc<L: LogStore>(
+    log: &L,
+    prefix: &str,
+    lists_used: &mut usize,
+) -> Result<Vec<String>, WidLogError> {
+    charge_list(lists_used)?;
+    let mut dirs = log.list_dirs(prefix).await.map_err(WidLogError::Store)?;
+    dirs.sort_unstable();
+    dirs.reverse();
+    Ok(dirs)
+}
+
+async fn list_keys_capped<L: LogStore>(
+    log: &L,
+    prefix: &str,
+    lists_used: &mut usize,
+) -> Result<Vec<String>, WidLogError> {
+    charge_list(lists_used)?;
+    log.list_keys(prefix).await.map_err(WidLogError::Store)
+}
+
+fn charge_list(lists_used: &mut usize) -> Result<(), WidLogError> {
+    *lists_used += 1;
+    if *lists_used > SCAN_LIST_CAP {
+        return Err(WidLogError::CapExceeded);
+    }
+    Ok(())
+}
+
+/// Parse the zero-padded seq out of a `.../success-{seq:020}-...` key.
+fn parse_success_seq(key: &str) -> Option<u64> {
+    let name = key.rsplit('/').next()?;
+    let rest = name.strip_prefix(SUCCESS_KEY_PREFIX)?;
+    rest.get(..20)?.parse().ok()
+}
+
+fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
+    let record: LogRecord = serde_json::from_slice(bytes)?;
+    let timestamp_ms = record.timestamp_ms;
+    let LogMessage::Withdrawal(message) = record.message else {
+        anyhow::bail!("not a withdrawal record");
+    };
+    let WithdrawalLogMessage::Success {
+        request_data,
+        response,
+        ..
+    } = *message
+    else {
+        anyhow::bail!("not a success record");
+    };
+    anyhow::ensure!(
+        request_data.wid == *wid,
+        "record is for wid {}, expected {}",
+        request_data.wid,
+        wid
+    );
+    Ok(FoundSuccess {
+        consumed_seq: request_data.seq,
+        timestamp_ms,
+        response,
+    })
+}
+
+/// The guardian's log bucket over the AWS SDK, read-only. Credentials come from
+/// the default provider chain (task role on Fargate, static env vars against
+/// MinIO); an `AWS_ENDPOINT_URL_S3` override implies an S3-compatible service
+/// that needs path-style addressing, mirroring the enclave's client.
+pub struct S3LogStore {
+    client: aws_sdk_s3::Client,
+    bucket: String,
+}
+
+impl S3LogStore {
+    pub async fn connect(bucket: String, region: String) -> Self {
+        let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(region))
+            .load()
+            .await;
+        let mut builder = aws_sdk_s3::config::Builder::from(&aws_config);
+        if std::env::var_os("AWS_ENDPOINT_URL_S3").is_some() {
+            builder = builder.force_path_style(true);
+        }
+        Self {
+            client: aws_sdk_s3::Client::from_conf(builder.build()),
+            bucket,
+        }
+    }
+
+    /// One-key LIST to prove bucket access at boot (an empty result is fine —
+    /// the withdraw log may not exist yet).
+    pub async fn probe(&self) -> anyhow::Result<()> {
+        self.client
+            .list_objects_v2()
+            .bucket(&self.bucket)
+            .prefix(format!("{S3_DIR_WITHDRAW}/"))
+            .max_keys(1)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("list {}: {}", self.bucket, e.into_service_error()))?;
+        Ok(())
+    }
+}
+
+#[tonic::async_trait]
+impl LogStore for S3LogStore {
+    async fn list_dirs(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        let mut dirs = Vec::new();
+        let mut pages = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.bucket)
+            .prefix(prefix)
+            .delimiter("/")
+            .into_paginator()
+            .send();
+        while let Some(page) = pages.next().await {
+            let page = page.map_err(|e| anyhow::anyhow!("list dirs {prefix}: {e}"))?;
+            dirs.extend(
+                page.common_prefixes()
+                    .iter()
+                    .filter_map(|p| p.prefix().map(String::from)),
+            );
+        }
+        Ok(dirs)
+    }
+
+    async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        let mut keys = Vec::new();
+        let mut pages = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.bucket)
+            .prefix(prefix)
+            .into_paginator()
+            .send();
+        while let Some(page) = pages.next().await {
+            let page = page.map_err(|e| anyhow::anyhow!("list keys {prefix}: {e}"))?;
+            keys.extend(
+                page.contents()
+                    .iter()
+                    .filter_map(|o| o.key().map(String::from)),
+            );
+        }
+        Ok(keys)
+    }
+
+    async fn get(&self, key: &str) -> anyhow::Result<Vec<u8>> {
+        let object = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("get {key}: {}", e.into_service_error()))?;
+        let bytes = object
+            .body
+            .collect()
+            .await
+            .map_err(|e| anyhow::anyhow!("read {key}: {e}"))?;
+        Ok(bytes.into_bytes().to_vec())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_store {
+    use super::*;
+    use bitcoin::hashes::Hash as _;
+    use bitcoin::Network;
+    use hashi_types::guardian::GuardianSignKeyPair;
+    use hashi_types::guardian::LogRecord;
+    use hashi_types::guardian::StandardWithdrawalRequest;
+    use hashi_types::guardian::StandardWithdrawalRequestWire;
+    use std::collections::BTreeMap;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Mutex;
+
+    /// A genuine `LogRecord` for a Success, serialized exactly as the enclave
+    /// writes it, keyed by `LogRecord::object_key()`.
+    pub(crate) fn success_record_json(
+        wid: WithdrawalID,
+        seq: u64,
+        timestamp_ms: u64,
+        response: StandardWithdrawalResponse,
+    ) -> (String, Vec<u8>) {
+        let signed_request =
+            StandardWithdrawalRequest::mock_signed_for_testing_with_wid(Network::Regtest, wid);
+        let (request_sign, request_data) = signed_request.into_parts();
+        let mut request_data: StandardWithdrawalRequestWire = request_data.into();
+        request_data.seq = seq;
+
+        let signing_key = GuardianSignKeyPair::from([9u8; 32]);
+        let mut record = LogRecord::new(
+            "test-session".to_string(),
+            LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Success {
+                txid: bitcoin::Txid::from_slice(&[3u8; 32]).unwrap(),
+                request_data,
+                request_sign,
+                response,
+                post_state: hashi_types::guardian::LimiterState {
+                    num_tokens_available: 0,
+                    last_updated_at: 0,
+                    next_seq: seq + 1,
+                },
+            })),
+            &signing_key,
+        );
+        record.timestamp_ms = timestamp_ms;
+        let key = record.object_key();
+        (key, serde_json::to_vec(&record).unwrap())
+    }
+
+    /// In-memory `LogStore` with S3 listing semantics (delimiter dirs, ascending
+    /// keys) and failure toggles.
+    #[derive(Default)]
+    pub(crate) struct MemStore {
+        objects: Mutex<BTreeMap<String, Vec<u8>>>,
+        pub(crate) fail_lists: AtomicBool,
+        pub(crate) fail_gets: AtomicBool,
+        pub(crate) list_calls: AtomicUsize,
+    }
+
+    impl MemStore {
+        pub(crate) fn insert(&self, key: impl Into<String>, bytes: Vec<u8>) {
+            self.objects.lock().unwrap().insert(key.into(), bytes);
+        }
+    }
+
+    #[tonic::async_trait]
+    impl LogStore for MemStore {
+        async fn list_dirs(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+            self.list_calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_lists.load(Ordering::SeqCst) {
+                anyhow::bail!("simulated list failure");
+            }
+            let objects = self.objects.lock().unwrap();
+            let mut dirs: Vec<String> = objects
+                .keys()
+                .filter_map(|k| {
+                    let rest = k.strip_prefix(prefix)?;
+                    let end = rest.find('/')?;
+                    Some(format!("{prefix}{}", &rest[..=end]))
+                })
+                .collect();
+            dirs.dedup();
+            Ok(dirs)
+        }
+
+        async fn list_keys(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+            self.list_calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_lists.load(Ordering::SeqCst) {
+                anyhow::bail!("simulated list failure");
+            }
+            let objects = self.objects.lock().unwrap();
+            Ok(objects
+                .keys()
+                .filter(|k| k.starts_with(prefix))
+                .cloned()
+                .collect())
+        }
+
+        async fn get(&self, key: &str) -> anyhow::Result<Vec<u8>> {
+            if self.fail_gets.load(Ordering::SeqCst) {
+                anyhow::bail!("simulated get failure");
+            }
+            self.objects
+                .lock()
+                .unwrap()
+                .get(key)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("no such key {key}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_store::success_record_json;
+    use super::test_store::MemStore;
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    fn test_metrics() -> ProxyMetrics {
+        ProxyMetrics::new()
+    }
+
+    fn wid(byte: u8) -> WithdrawalID {
+        WithdrawalID::new([byte; 32])
+    }
+
+    fn mock_response() -> StandardWithdrawalResponse {
+        StandardWithdrawalResponse {
+            enclave_signatures: vec![],
+        }
+    }
+
+    // 2023-11-14T22 bucket, per the envelope.rs key tests.
+    const TS_HOUR_A: u64 = 1_700_000_000_000;
+    // One hour later.
+    const TS_HOUR_B: u64 = TS_HOUR_A + 3_600_000;
+    // One hour before A.
+    const TS_HOUR_Z: u64 = TS_HOUR_A - 3_600_000;
+
+    #[tokio::test]
+    async fn finds_record_in_newest_bucket() {
+        let store = MemStore::default();
+        let (key, bytes) = success_record_json(wid(0xaa), 7, TS_HOUR_A, mock_response());
+        store.insert(key, bytes);
+
+        let found = find_success_record(&store, &wid(0xaa), 7, &test_metrics())
+            .await
+            .unwrap()
+            .expect("record should be found");
+        assert_eq!(found.consumed_seq, 7);
+        assert_eq!(found.timestamp_ms, TS_HOUR_A);
+    }
+
+    #[tokio::test]
+    async fn empty_store_is_a_definitive_miss() {
+        let store = MemStore::default();
+        // request_seq 0 exercises the saturating threshold too.
+        let result = find_success_record(&store, &wid(0xaa), 0, &test_metrics())
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn failure_only_buckets_never_terminate_the_scan() {
+        let store = MemStore::default();
+        // Newer bucket holds only failure records (not listed by the success-
+        // prefix); the wid's Success sits one bucket older.
+        store.insert(
+            "withdraw/2023/11/14/23/failure-test-session-wid0xdead-00000001.json",
+            b"{}".to_vec(),
+        );
+        let (key, bytes) = success_record_json(wid(0xaa), 7, TS_HOUR_A, mock_response());
+        store.insert(key, bytes);
+
+        let found = find_success_record(&store, &wid(0xaa), 7, &test_metrics())
+            .await
+            .unwrap();
+        assert!(found.is_some(), "failure-only bucket must be walked past");
+    }
+
+    #[tokio::test]
+    async fn bumped_seq_retry_still_finds_the_record() {
+        // The reconcile snap bumps the node's seq to S+1; threshold slack must
+        // keep the bucket holding seq S inside the scan.
+        let store = MemStore::default();
+        let (key, bytes) = success_record_json(wid(0xaa), 7, TS_HOUR_A, mock_response());
+        store.insert(key, bytes);
+
+        let found = find_success_record(&store, &wid(0xaa), 8, &test_metrics())
+            .await
+            .unwrap();
+        assert_eq!(found.unwrap().consumed_seq, 7);
+    }
+
+    #[tokio::test]
+    async fn scan_stops_after_two_low_buckets() {
+        let store = MemStore::default();
+        // Two success-bearing buckets both below threshold: the wid is absent
+        // and the scan must stop without walking further back.
+        let (key_b, bytes_b) = success_record_json(wid(0xbb), 5, TS_HOUR_B, mock_response());
+        let (key_a, bytes_a) = success_record_json(wid(0xcc), 4, TS_HOUR_A, mock_response());
+        let (key_z, bytes_z) = success_record_json(wid(0xdd), 3, TS_HOUR_Z, mock_response());
+        store.insert(key_b, bytes_b);
+        store.insert(key_a, bytes_a);
+        store.insert(key_z, bytes_z);
+
+        let result = find_success_record(&store, &wid(0xaa), 20, &test_metrics())
+            .await
+            .unwrap();
+        assert!(result.is_none());
+        // Tree walks + the two bucket lists, but never the third (oldest) bucket:
+        // year/month/day each listed once (same day), hours once, buckets B and A.
+        let calls = store.list_calls.load(Ordering::SeqCst);
+        assert!(
+            calls <= 7,
+            "scan should stop after two strikes, used {calls} lists"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_skewed_bucket_does_not_hide_the_record() {
+        // Enclave clock jumped ahead: a future-labelled bucket holds seq 5 (below
+        // threshold), while the wid's record at seq 9 sits in an older bucket.
+        // One low bucket must not terminate the scan.
+        let store = MemStore::default();
+        let (key_skew, bytes_skew) = success_record_json(wid(0xbb), 5, TS_HOUR_B, mock_response());
+        let (key, bytes) = success_record_json(wid(0xaa), 9, TS_HOUR_A, mock_response());
+        store.insert(key_skew, bytes_skew);
+        store.insert(key, bytes);
+
+        let found = find_success_record(&store, &wid(0xaa), 10, &test_metrics())
+            .await
+            .unwrap();
+        assert_eq!(found.unwrap().consumed_seq, 9);
+    }
+
+    #[tokio::test]
+    async fn list_failure_is_an_error_not_a_miss() {
+        let store = MemStore::default();
+        let (key, bytes) = success_record_json(wid(0xaa), 7, TS_HOUR_A, mock_response());
+        store.insert(key, bytes);
+        store.fail_lists.store(true, Ordering::SeqCst);
+
+        let result = find_success_record(&store, &wid(0xaa), 7, &test_metrics()).await;
+        assert!(matches!(result, Err(WidLogError::Store(_))));
+    }
+
+    #[tokio::test]
+    async fn get_failure_is_an_error_not_a_miss() {
+        let store = MemStore::default();
+        let (key, bytes) = success_record_json(wid(0xaa), 7, TS_HOUR_A, mock_response());
+        store.insert(key, bytes);
+        store.fail_gets.store(true, Ordering::SeqCst);
+
+        let result = find_success_record(&store, &wid(0xaa), 7, &test_metrics()).await;
+        assert!(matches!(result, Err(WidLogError::Store(_))));
+    }
+
+    #[tokio::test]
+    async fn unparseable_matching_record_degrades_to_a_miss() {
+        let store = MemStore::default();
+        let (key, _) = success_record_json(wid(0xaa), 7, TS_HOUR_A, mock_response());
+        store.insert(key, b"not json".to_vec());
+
+        let metrics = test_metrics();
+        let result = find_success_record(&store, &wid(0xaa), 7, &metrics)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+        assert_eq!(metrics.record_parse_failures.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn scan_cap_is_an_error_not_a_miss() {
+        let store = MemStore::default();
+        // A deep history whose seqs all clear the threshold (never a strike):
+        // enough day buckets that the scan must give up at the cap.
+        for day in 1..=28 {
+            for hour in [4u64, 10, 16] {
+                let ts = 1_690_000_000_000 + ((day * 24 + hour) * 3_600_000);
+                let (key, bytes) = success_record_json(wid(0xbb), 1000 + day, ts, mock_response());
+                store.insert(key, bytes);
+            }
+        }
+
+        let result = find_success_record(&store, &wid(0xaa), 2, &test_metrics()).await;
+        assert!(matches!(result, Err(WidLogError::CapExceeded)));
+    }
+
+    #[test]
+    fn success_seq_parses_from_real_key_shape() {
+        let (key, _) = success_record_json(wid(0xaa), 42, TS_HOUR_A, mock_response());
+        assert_eq!(parse_success_seq(&key), Some(42));
+        assert_eq!(
+            parse_success_seq("withdraw/2023/11/14/22/failure-s-wid0xaa-0000.json"),
+            None
+        );
+    }
+
+    #[test]
+    fn wid_suffix_matches_the_real_key_shape() {
+        // The scanner's suffix filter must match `WithdrawalLogMessage::log_name`
+        // exactly; a drift here silently disables the durable tier.
+        let w = wid(0xcd);
+        let (key, _) = success_record_json(w, 7, TS_HOUR_A, mock_response());
+        assert!(key.ends_with(&format!("-wid{w}.json")));
+    }
+}

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -1,25 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Read-only access to the guardian's S3 withdrawal log, used as the durable
-//! tier of the wid cache. The enclave writes one `Success` record per signed
-//! withdrawal *before* it releases the signatures (fail-closed, see
-//! `hashi-guardian/src/withdraw_mode/standard.rs`), so any signature a node has
-//! ever seen has a durable record here — the proxy never writes.
+//! Read-only access to the guardian's S3 withdrawal log — the wid cache's
+//! durable tier. The enclave writes one `Success` record per signed withdrawal
+//! *before* releasing the signatures and fails closed if the write fails
+//! (`withdraw_mode/standard.rs`), so every signature a node has seen has a
+//! record here; the proxy never writes.
 //!
-//! Success keys are `withdraw/YYYY/MM/DD/HH/success-{seq:020}-{session}-wid{wid}.json`
-//! (hour buckets; lexicographic order within a bucket is seq order; the wid only
-//! appears as a suffix, so lookups scan buckets newest-first). The scan is
-//! bounded by the request's `seq`: the node only retries a wid the guardian
-//! signed at seq `S` while its own mirror reads `S` or `S+1`, so once two
-//! consecutive success-bearing buckets top out below `seq - 1` the record cannot
-//! be further back. Two buckets (not one) so a forward clock step in the enclave
-//! can't hide the record behind a single future-labelled bucket; failure-only
-//! buckets are skipped by listing the `success-` prefix and never terminate the
-//! scan. An exhausted prefix tree is a definitive miss; hitting the LIST cap is
-//! NOT — the caller must fail closed on it, never forward.
+//! Keys are `withdraw/YYYY/MM/DD/HH/success-{seq:020}-{session}-wid{wid}.json`,
+//! with the wid only a suffix — so a lookup walks hour buckets newest-first.
+//! The request's `seq` bounds the walk: a retried wid was signed at `seq` or
+//! `seq - 1` (the node's mirror trails the guardian by at most the reconcile
+//! snap), so once two consecutive success-bearing buckets top out below
+//! `seq - 1` the record can't be further back (two, not one, so a forward
+//! clock step can't hide it behind a single future-labelled bucket). Exhausted
+//! prefixes are a definitive miss; hitting the LIST cap is NOT — the caller
+//! must fail closed on it, never forward.
 
 use crate::metrics::ProxyMetrics;
+use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::log::S3_DIR_WITHDRAW;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogRecord;
@@ -28,10 +27,8 @@ use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::WithdrawalLogMessage;
 use tracing::warn;
 
-/// Total LIST calls a single lookup may issue. A terminating scan needs ~4 tree
-/// walks + 2-3 bucket lists; the cap only trips when the requested seq is far
-/// below everything in the bucket (e.g. a rogue client), and it must surface as
-/// "cache unavailable", not "not found".
+// A terminating scan needs ~4 tree walks + 2-3 bucket lists; the cap only
+// trips on a seq far below everything in the log (e.g. a rogue client).
 const SCAN_LIST_CAP: usize = 100;
 
 const SUCCESS_KEY_PREFIX: &str = "success-";
@@ -89,8 +86,7 @@ pub async fn find_success_record<L: LogStore>(
                         )
                         .await?;
                         if keys.is_empty() {
-                            // Failure-only (or empty) bucket: indeterminate for
-                            // the seq bound, keep walking.
+                            // Failure-only bucket: says nothing about the seq bound.
                             continue;
                         }
 
@@ -100,9 +96,7 @@ pub async fn find_success_record<L: LogStore>(
                             match parse_success(&bytes, wid) {
                                 Ok(found) => return Ok(Some(found)),
                                 Err(e) => {
-                                    // Version-skewed or malformed record: skip it.
-                                    // Ending as a miss degrades to a re-sign (one
-                                    // limiter double-debit) and self-heals, where
+                                    // Skip (schema skew): a miss re-signs and heals;
                                     // failing closed would wedge until a proxy fix.
                                     metrics.record_parse_failures.inc();
                                     warn!(key, error = %e, "unreadable success record for wid; skipping");
@@ -197,10 +191,8 @@ fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSucces
     })
 }
 
-/// The guardian's log bucket over the AWS SDK, read-only. Credentials come from
-/// the default provider chain (task role on Fargate, static env vars against
-/// MinIO); an `AWS_ENDPOINT_URL_S3` override implies an S3-compatible service
-/// that needs path-style addressing, mirroring the enclave's client.
+/// The guardian's log bucket over the AWS SDK, read-only. Credentials come
+/// from the default provider chain (task role on Fargate, env vars for MinIO).
 pub struct S3LogStore {
     client: aws_sdk_s3::Client,
     bucket: String,
@@ -232,7 +224,7 @@ impl S3LogStore {
             .max_keys(1)
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("list {}: {}", self.bucket, e.into_service_error()))?;
+            .map_err(|e| anyhow::anyhow!("list {}: {}", self.bucket, DisplayErrorContext(e)))?;
         Ok(())
     }
 }
@@ -250,7 +242,8 @@ impl LogStore for S3LogStore {
             .into_paginator()
             .send();
         while let Some(page) = pages.next().await {
-            let page = page.map_err(|e| anyhow::anyhow!("list dirs {prefix}: {e}"))?;
+            let page = page
+                .map_err(|e| anyhow::anyhow!("list dirs {prefix}: {}", DisplayErrorContext(e)))?;
             dirs.extend(
                 page.common_prefixes()
                     .iter()
@@ -270,7 +263,8 @@ impl LogStore for S3LogStore {
             .into_paginator()
             .send();
         while let Some(page) = pages.next().await {
-            let page = page.map_err(|e| anyhow::anyhow!("list keys {prefix}: {e}"))?;
+            let page = page
+                .map_err(|e| anyhow::anyhow!("list keys {prefix}: {}", DisplayErrorContext(e)))?;
             keys.extend(
                 page.contents()
                     .iter()
@@ -288,7 +282,7 @@ impl LogStore for S3LogStore {
             .key(key)
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("get {key}: {}", e.into_service_error()))?;
+            .map_err(|e| anyhow::anyhow!("get {key}: {}", DisplayErrorContext(e)))?;
         let bytes = object
             .body
             .collect()

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -40,7 +40,7 @@ const SUCCESS_KEY_PREFIX: &str = "success-";
 pub enum WidLogError {
     /// A LIST or GET failed; the lookup is indeterminate.
     Store(anyhow::Error),
-    /// The scan exceeded [`SCAN_LIST_CAP`] without terminating.
+    /// The scan exceeded `SCAN_LIST_CAP` without terminating.
     CapExceeded,
 }
 

--- a/docker/hashi-guardian-local/compose.yaml
+++ b/docker/hashi-guardian-local/compose.yaml
@@ -120,9 +120,8 @@ services:
 
   # The out-of-enclave proxy: the only port published to the host. Holds the wid
   # cache + serves the SingleProvisionerInit relay. Forwards to the withdraw
-  # guardian via the host bridge. Reads the guardian's withdrawal log (MinIO
-  # directly — the proxy sits outside the enclave's S3 forwarder chain) as the
-  # cache's durable tier.
+  # guardian via the host bridge; reads the wid log straight from MinIO (it sits
+  # outside the enclave's S3 forwarder chain).
   proxy:
     <<: *build
     command: ["/usr/bin/hashi-guardian-proxy"]

--- a/docker/hashi-guardian-local/compose.yaml
+++ b/docker/hashi-guardian-local/compose.yaml
@@ -120,7 +120,9 @@ services:
 
   # The out-of-enclave proxy: the only port published to the host. Holds the wid
   # cache + serves the SingleProvisionerInit relay. Forwards to the withdraw
-  # guardian via the host bridge.
+  # guardian via the host bridge. Reads the guardian's withdrawal log (MinIO
+  # directly — the proxy sits outside the enclave's S3 forwarder chain) as the
+  # cache's durable tier.
   proxy:
     <<: *build
     command: ["/usr/bin/hashi-guardian-proxy"]
@@ -129,6 +131,12 @@ services:
     environment:
       GUARDIAN_BACKEND_URL: http://host:3000
       PROXY_LISTEN_ADDR: 0.0.0.0:3000
+      GUARDIAN_LOG_BUCKET: hashi-guardian-dev
+      GUARDIAN_LOG_REGION: us-east-1
+      BTC_NETWORK: regtest
+      AWS_ENDPOINT_URL_S3: http://minio:9000
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
       RUST_LOG: ${RUST_LOG:-info}
     # AUTHORIZED_KP_FINGERPRINTS, written by `make ceremony` once the KP keys
     # exist. Absent before that: the relay fail-closes until the roster lands.
@@ -138,6 +146,8 @@ services:
     depends_on:
       enclave:
         condition: service_healthy
+      bucket-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "socat -T2 OPEN:/dev/null TCP4:127.0.0.1:3000"]
       interval: 3s


### PR DESCRIPTION
## Changes

- For the in-process LRU cache on the proxy:
  - on a miss, scan `withdraw/` for the wid's success record (newest-first hour buckets, bounded by the request's seq, capped LIST count).
  - Replay a record only if the enclave actually committed it (its seq is below `next_seq` from GetGuardianInfo) and its signatures verify against the guardian BTC key over sighashes recomputed from the request.
  - Fail closed with a retriable `UNAVAILABLE` whenever the log can't answer (S3 error, over-cap scan, guardian info unreachable, failed verification) — never forward blind.
- Replayed responses carry a zeroed envelope signature: the record predates the envelope, and nodes don't verify it.
- Per-outcome cache metrics on a new `/metrics` endpoint.
- New proxy env: `GUARDIAN_LOG_BUCKET` / `GUARDIAN_LOG_REGION` / `BTC_NETWORK`, creds via the AWS default chain. 
- Local replica: the proxy reads the compose MinIO directly; the redis sidecar is gone.
