### PR TITLE
cli: Add hashi launch command and document the launch-switch rollout

### DIFF
--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -233,6 +233,10 @@ impl HashiNetwork {
         self.upgrade_cap_id
     }
 
+    pub fn guardian(&self) -> &hashi::publish::GuardianConfig {
+        &self.guardian
+    }
+
     pub fn nodes_mut(&mut self) -> &mut [HashiNodeHandle] {
         &mut self.nodes
     }

--- a/crates/e2e-tests/src/main.rs
+++ b/crates/e2e-tests/src/main.rs
@@ -452,35 +452,34 @@ async fn cmd_start(
             .hashi_network_mut()
             .start_pending_validators()
             .await?;
+        print_success("Validators launched; they now register their next-epoch keys on-chain.");
 
-        // Genesis is gated on the launch switch: wait until every validator
-        // has finished registering its next-epoch keys (nodes do this on
-        // startup), then send finish_publish from the publisher key to
-        // configure the deploy and unlock DKG.
-        print_info("Waiting for all validators to finish on-chain key registration...");
-        let expected = test_networks
-            .hashi_network()
-            .nodes()
+        // Genesis is gated on the launch switch (finish_publish): rehearse
+        // the real rollout by having the operator send it via the CLI, which
+        // shows which validators are fully registered before unlocking.
+        let guardian = test_networks.hashi_network().guardian();
+        let guardian_btc_public_key: String = guardian
+            .btc_public_key
             .iter()
-            .map(|node| node.config().validator_address())
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        let mut client = test_networks.sui_network().client.clone();
-        let publisher = test_networks
-            .sui_network()
-            .user_keys
-            .first()
-            .context("No funded user keys in localnet genesis")?;
-        test_networks
-            .hashi_network()
-            .launch_genesis(
-                &mut client,
-                publisher,
-                &expected,
-                std::time::Duration::from_secs(180),
-            )
-            .await?;
-        print_success("finish_publish sent — genesis unlocked; DKG proceeds automatically.");
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        println!();
+        print_info("Unlock genesis with the launch switch once every validator is ready:");
+        println!(
+            "      hashi launch --sui-rpc-url {} \\\n          --package-id {} --hashi-object-id {} \\\n          --bitcoin-chain-id {} \\\n          --guardian-url {} \\\n          --guardian-btc-public-key {} \\\n          --keypair {} -y",
+            state.sui_rpc_url,
+            state.package_id,
+            state.hashi_object_id,
+            hashi::constants::BITCOIN_REGTEST_CHAIN_ID,
+            guardian.url,
+            guardian_btc_public_key,
+            funded_key_path.display(),
+        );
+        print_info(
+            "The command lists registered validators, warns about any still missing keys \
+             (re-run once they are ready), and then sends hashi::finish_publish. \
+             DKG starts automatically afterwards.",
+        );
     }
 
     print_info("Press Ctrl+C to stop the localnet.");
@@ -1030,9 +1029,9 @@ fn print_manual_bootstrap_guide(data_dir: &Path, num_validators: usize) {
         println!("       hashi register --config {d}/validators/validator_{i}.toml -y");
     }
     println!(
-        "  2. Press Enter here to launch the validators. Once they finish registering \
-         their keys, the harness sends the launch tx (hashi::finish_publish) \
-         from the publisher key, unlocking DKG/genesis."
+        "  2. Press Enter here to launch the validators (they register their next-epoch \
+         keys on startup), then run the printed `hashi launch` command to unlock \
+         DKG/genesis."
     );
     println!("  3. Govern as a committee member (HASHI_CLI_CONFIG selects the identity):");
     println!("       HASHI_CLI_CONFIG={d}/cli-validator-0.toml hashi committee epoch");

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -659,6 +659,87 @@ pub struct PublishOpts {
     pub yes: bool,
 }
 
+/// Options for the `launch` subcommand.
+///
+/// Like [`PublishOpts`] this does *not* use [`CliGlobalOpts`]: launch is a
+/// one-time publisher action driven off the `hashi publish` output rather
+/// than an operator CLI config.
+#[derive(Args)]
+pub struct LaunchOpts {
+    /// Sui RPC endpoint URL
+    #[clap(
+        long,
+        env = "SUI_RPC_URL",
+        default_value = "https://fullnode.mainnet.sui.io:443"
+    )]
+    pub sui_rpc_url: String,
+
+    /// Path to the `hashi_ids.json` written by `hashi publish`
+    /// (alternative: pass --package-id and --hashi-object-id)
+    #[clap(long, default_value = "hashi_ids.json")]
+    pub hashi_ids: std::path::PathBuf,
+
+    /// Package ID (overrides --hashi-ids; requires --hashi-object-id)
+    #[clap(long)]
+    pub package_id: Option<String>,
+
+    /// Hashi shared-object ID (overrides --hashi-ids; requires --package-id)
+    #[clap(long)]
+    pub hashi_object_id: Option<String>,
+
+    /// Bitcoin chain ID (genesis block hash) to store on-chain
+    #[clap(long)]
+    pub bitcoin_chain_id: String,
+
+    /// Guardian gRPC endpoint URL. Required — every deposit address is a
+    /// 2-of-2 (mpc, guardian) taproot leaf.
+    #[clap(long)]
+    pub guardian_url: String,
+
+    /// Guardian BTC pubkey, x-only hex-encoded (32 bytes). Published
+    /// on-chain for 2-of-2 deposit address derivation.
+    #[clap(long)]
+    pub guardian_btc_public_key: String,
+
+    /// Override `bitcoin_confirmation_threshold` on-chain at launch time.
+    /// Falls back to the Move package's `init_defaults` (currently 6) when omitted.
+    #[clap(long)]
+    pub bitcoin_confirmation_threshold: Option<u64>,
+
+    /// Override `bitcoin_deposit_time_delay_ms` on-chain at launch time.
+    /// Falls back to the Move package's `init_defaults` (currently 600_000) when omitted.
+    #[clap(long)]
+    pub bitcoin_deposit_time_delay_ms: Option<u64>,
+
+    /// Path to the publisher keypair (the `UpgradeCap` owner)
+    #[clap(long, short = 'k', env = "HASHI_KEYPAIR")]
+    pub keypair: Option<std::path::PathBuf>,
+
+    /// `UpgradeCap` object ID. Auto-discovered from the sender's owned
+    /// objects when omitted.
+    #[clap(long)]
+    pub upgrade_cap: Option<String>,
+
+    /// Sender address for --serialize-unsigned-transaction when no local
+    /// keypair exists (e.g. a multisig publisher)
+    #[clap(long)]
+    pub sender: Option<String>,
+
+    /// Build the transaction and print it as base64 (BCS `TransactionData`)
+    /// instead of executing it — for offline / multisig signing via
+    /// `sui keytool sign`. No private key required.
+    #[clap(long = "serialize-unsigned-transaction")]
+    pub serialize_unsigned: bool,
+
+    /// Enable verbose output
+    #[clap(long, short)]
+    pub verbose: bool,
+
+    /// Skip confirmation prompts
+    #[clap(long, short = 'y')]
+    pub yes: bool,
+}
+
 /// Options for the `register` subcommand.
 ///
 /// Unlike other CLI commands this uses a validator config file (the same one
@@ -1178,9 +1259,9 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
     print_success(&format!("upgrade_cap_id:  {upgrade_cap_id}"));
     print_info(
         "The UpgradeCap stays in the publisher's wallet and the deploy is not yet \
-         configured. Once all expected validators have registered, send \
-         `hashi::finish_publish` (the launch switch) with the UpgradeCap, chain id, \
-         and guardian parameters to configure the deploy and unlock genesis.",
+         configured. Once all expected validators have registered, run `hashi launch` \
+         with the chain id and guardian parameters to configure the deploy and unlock \
+         genesis.",
     );
 
     // Write ids to hashi_ids.json
@@ -1189,6 +1270,185 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
     std::fs::write(out_path, &json)?;
     print_success(&format!("Wrote {out_path}"));
 
+    Ok(())
+}
+
+/// Run the `launch` command – send `hashi::finish_publish` (the launch
+/// switch): configure the deploy (chain id, guardian, overrides) and hand
+/// the package `UpgradeCap` into on-chain custody, which unlocks genesis.
+/// The initial committee forms from the validators fully registered at that
+/// moment.
+pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
+    use sui_sdk_types::bcs::ToBcs;
+
+    crate::init_crypto_provider();
+    init_tracing(opts.verbose);
+
+    // In serialize mode keep stdout clean (base64 only); notes go to stderr.
+    set_notes_to_stderr(opts.serialize_unsigned);
+
+    // Resolve ids: explicit flags win, else the hashi_ids.json from publish.
+    let ids: crate::config::HashiIds = match (&opts.package_id, &opts.hashi_object_id) {
+        (Some(package_id), Some(hashi_object_id)) => crate::config::HashiIds {
+            package_id: package_id.parse()?,
+            hashi_object_id: hashi_object_id.parse()?,
+        },
+        (None, None) => {
+            let raw = std::fs::read_to_string(&opts.hashi_ids).with_context(|| {
+                format!(
+                    "failed to read {} (or pass --package-id and --hashi-object-id)",
+                    opts.hashi_ids.display()
+                )
+            })?;
+            serde_json::from_str(&raw)?
+        }
+        _ => anyhow::bail!("--package-id and --hashi-object-id must be provided together"),
+    };
+
+    // Guardian parameters are published on-chain by the launch tx.
+    let btc_public_key = hex::decode(
+        opts.guardian_btc_public_key
+            .strip_prefix("0x")
+            .unwrap_or(&opts.guardian_btc_public_key),
+    )
+    .context("Invalid hex for --guardian-btc-public-key")?;
+    anyhow::ensure!(
+        btc_public_key.len() == 32,
+        "--guardian-btc-public-key must be 32 bytes (x-only), got {} bytes",
+        btc_public_key.len(),
+    );
+    let guardian = crate::publish::GuardianConfig {
+        url: opts.guardian_url.clone(),
+        btc_public_key,
+    };
+    let bitcoin_overrides = crate::publish::BitcoinConfigOverrides {
+        confirmation_threshold: opts.bitcoin_confirmation_threshold,
+        deposit_time_delay_ms: opts.bitcoin_deposit_time_delay_ms,
+    };
+
+    // Resolve the sender (the UpgradeCap owner): a local keypair, or an
+    // explicit --sender for the serialize-unsigned (multisig) path.
+    let signer = opts
+        .keypair
+        .as_deref()
+        .map(crate::config::load_ed25519_private_key_from_path)
+        .transpose()?;
+    let sender: sui_sdk_types::Address = match (&signer, &opts.sender) {
+        (Some(signer), None) => signer.public_key().derive_address(),
+        (None, Some(sender)) => sender.parse()?,
+        (Some(_), Some(_)) => anyhow::bail!("pass either --keypair or --sender, not both"),
+        (None, None) => anyhow::bail!(
+            "pass --keypair, or --sender together with --serialize-unsigned-transaction"
+        ),
+    };
+    if signer.is_none() && !opts.serialize_unsigned {
+        anyhow::bail!("--sender requires --serialize-unsigned-transaction (no key to sign with)");
+    }
+
+    print_info(&format!("Sender (UpgradeCap owner): {sender}"));
+    print_info(&format!("Sui RPC: {}", opts.sui_rpc_url));
+
+    let mut client = sui_rpc::Client::new(&opts.sui_rpc_url)?;
+
+    // Pre-flight: the launch must not have happened yet, and show who would
+    // form the initial committee.
+    let (onchain, _watcher) =
+        crate::onchain::OnchainState::new(&opts.sui_rpc_url, ids, None, None, None).await?;
+    let (num_members, num_ready) = {
+        let state = onchain.state();
+        anyhow::ensure!(
+            state.hashi().config.upgrade_cap.is_none(),
+            "the UpgradeCap is already in on-chain custody — the launch (finish_publish) \
+             has already happened"
+        );
+        let members = state.hashi().committees.members();
+        anyhow::ensure!(
+            !members.is_empty(),
+            "no validators are registered yet; the genesis committee would be empty"
+        );
+        print_info(&format!("Registered validators ({}):", members.len()));
+        let mut num_ready = 0usize;
+        for (address, member) in members {
+            let ready = member.next_epoch_encryption_public_key().is_some();
+            num_ready += usize::from(ready);
+            print_info(&format!(
+                "  {address}  {}",
+                if ready {
+                    "ready"
+                } else {
+                    "MISSING NEXT-EPOCH KEYS (will be excluded from the committee)"
+                }
+            ));
+        }
+        (members.len(), num_ready)
+    };
+    anyhow::ensure!(
+        num_ready > 0,
+        "no validator has finished key registration; genesis would stall"
+    );
+    if num_ready < num_members {
+        print_warning(&format!(
+            "{} of {num_members} registered validators have not finished key registration \
+             and would be excluded from the genesis committee",
+            num_members - num_ready,
+        ));
+    }
+
+    // Locate the cap.
+    let upgrade_cap_id: sui_sdk_types::Address = match &opts.upgrade_cap {
+        Some(id) => id.parse()?,
+        None => {
+            print_info("Locating UpgradeCap among the sender's owned objects ...");
+            crate::publish::find_upgrade_cap(&mut client, sender, ids.package_id).await?
+        }
+    };
+    print_info(&format!("UpgradeCap: {upgrade_cap_id}"));
+
+    if opts.serialize_unsigned {
+        let tx = crate::publish::build_finish_publish_tx(
+            &mut client,
+            sender,
+            &ids,
+            upgrade_cap_id,
+            &opts.bitcoin_chain_id,
+            &guardian,
+            &bitcoin_overrides,
+        )
+        .await?;
+        println!("{}", tx.to_bcs_base64()?);
+        return Ok(());
+    }
+
+    if !opts.yes {
+        print_info(
+            "This sends hashi::finish_publish: it configures the deploy (chain id, \
+             guardian) and hands the UpgradeCap into on-chain custody, UNLOCKING \
+             GENESIS — the initial committee forms from the validators that are fully \
+             registered right now (1 transaction).",
+        );
+        print_info("Use --yes / -y to skip this prompt.");
+        eprint!("Continue? [y/N] ");
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        if !answer.trim().eq_ignore_ascii_case("y") {
+            print_warning("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let signer = signer.expect("presence checked during sender resolution");
+    print_info("Sending launch transaction (hashi::finish_publish) ...");
+    crate::publish::finish_publish(
+        &mut client,
+        &signer,
+        &ids,
+        upgrade_cap_id,
+        &opts.bitcoin_chain_id,
+        &guardian,
+        &bitcoin_overrides,
+    )
+    .await?;
+    print_success("finish_publish executed — genesis unlocked. Validators will now run DKG.");
     Ok(())
 }
 

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -1354,7 +1354,7 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
     // form the initial committee.
     let (onchain, _watcher) =
         crate::onchain::OnchainState::new(&opts.sui_rpc_url, ids, None, None, None).await?;
-    let (num_members, num_ready) = {
+    let roster: Vec<(sui_sdk_types::Address, bool)> = {
         let state = onchain.state();
         anyhow::ensure!(
             state.hashi().config.upgrade_cap.is_none(),
@@ -1366,31 +1366,73 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
             !members.is_empty(),
             "no validators are registered yet; the genesis committee would be empty"
         );
-        print_info(&format!("Registered validators ({}):", members.len()));
-        let mut num_ready = 0usize;
-        for (address, member) in members {
-            let ready = member.next_epoch_encryption_public_key().is_some();
-            num_ready += usize::from(ready);
-            print_info(&format!(
-                "  {address}  {}",
-                if ready {
-                    "ready"
-                } else {
-                    "MISSING NEXT-EPOCH KEYS (will be excluded from the committee)"
-                }
-            ));
-        }
-        (members.len(), num_ready)
+        members
+            .iter()
+            .map(|(address, member)| {
+                (
+                    *address,
+                    member.next_epoch_encryption_public_key().is_some(),
+                )
+            })
+            .collect()
     };
+
+    // Stake-weight the roster: the genesis committee's security is the Sui
+    // voting power it carries, not its head-count. Sui voting power sums to
+    // 10_000 basis points across the active validator set.
+    let voting_powers = fetch_voting_powers(&mut client).await?;
+    let total_power: u64 = voting_powers.values().sum();
+    let power_of = |address: &sui_sdk_types::Address| -> u64 {
+        voting_powers.get(address).copied().unwrap_or(0)
+    };
+    let percent = |power: u64| -> f64 {
+        if total_power == 0 {
+            0.0
+        } else {
+            100.0 * power as f64 / total_power as f64
+        }
+    };
+
+    print_info(&format!("Registered validators ({}):", roster.len()));
+    for (address, ready) in &roster {
+        let status = if !voting_powers.contains_key(address) {
+            "NOT AN ACTIVE SUI VALIDATOR"
+        } else if *ready {
+            "ready"
+        } else {
+            "MISSING NEXT-EPOCH KEYS (will be excluded from the committee)"
+        };
+        print_info(&format!(
+            "  {address}  {:6.2}% stake  {status}",
+            percent(power_of(address)),
+        ));
+    }
+    let num_ready = roster.iter().filter(|(_, ready)| *ready).count();
+    let ready_power: u64 = roster
+        .iter()
+        .filter(|(_, ready)| *ready)
+        .map(|(address, _)| power_of(address))
+        .sum();
+    let registered_power: u64 = roster.iter().map(|(address, _)| power_of(address)).sum();
+    print_info(&format!(
+        "Ready to launch: {num_ready}/{} validators, {:.2}% of total Sui voting power \
+         (registered: {:.2}%)",
+        roster.len(),
+        percent(ready_power),
+        percent(registered_power),
+    ));
+
     anyhow::ensure!(
         num_ready > 0,
         "no validator has finished key registration; genesis would stall"
     );
-    if num_ready < num_members {
+    if num_ready < roster.len() {
         print_warning(&format!(
-            "{} of {num_members} registered validators have not finished key registration \
-             and would be excluded from the genesis committee",
-            num_members - num_ready,
+            "{} of {} registered validators ({:.2}% of total Sui voting power) have not \
+             finished key registration and would be excluded from the genesis committee",
+            roster.len() - num_ready,
+            roster.len(),
+            percent(registered_power - ready_power),
         ));
     }
 
@@ -1450,6 +1492,39 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
     .await?;
     print_success("finish_publish executed — genesis unlocked. Validators will now run DKG.");
     Ok(())
+}
+
+/// Active Sui validators' voting power (basis points of the 10_000 total),
+/// keyed by validator address.
+async fn fetch_voting_powers(
+    client: &mut sui_rpc::Client,
+) -> anyhow::Result<std::collections::HashMap<sui_sdk_types::Address, u64>> {
+    use sui_rpc::field::FieldMaskUtil;
+
+    let mut request = sui_rpc::proto::sui::rpc::v2::GetEpochRequest::default();
+    request.read_mask = Some(sui_rpc::field::FieldMask::from_paths([
+        "system_state.validators.active_validators",
+    ]));
+    let response = client
+        .ledger_client()
+        .get_epoch(request)
+        .await?
+        .into_inner();
+
+    let validators = response
+        .epoch
+        .and_then(|epoch| epoch.system_state)
+        .and_then(|system_state| system_state.validators)
+        .map(|validator_set| validator_set.active_validators)
+        .unwrap_or_default();
+
+    let mut powers = std::collections::HashMap::new();
+    for validator in validators {
+        if let (Some(address), Some(power)) = (validator.address, validator.voting_power) {
+            powers.insert(address.parse::<sui_sdk_types::Address>()?, power);
+        }
+    }
+    Ok(powers)
 }
 
 /// Run the `register` command – register a validator on-chain.

--- a/crates/hashi/src/main.rs
+++ b/crates/hashi/src/main.rs
@@ -70,6 +70,14 @@ enum Commands {
         publish_opts: hashi::cli::PublishOpts,
     },
 
+    /// Send the launch switch (hashi::finish_publish): configure the deploy
+    /// and hand the UpgradeCap into on-chain custody, unlocking genesis. Run
+    /// this after all expected validators have registered.
+    Launch {
+        #[clap(flatten)]
+        launch_opts: hashi::cli::LaunchOpts,
+    },
+
     /// Register a validator on-chain
     Register {
         #[clap(flatten)]
@@ -131,6 +139,7 @@ async fn main() -> anyhow::Result<()> {
             hashi::cli::run(cli_opts, hashi::cli::CliCommand::Backup { action }).await
         }
         Commands::Publish { publish_opts } => hashi::cli::run_publish(publish_opts).await,
+        Commands::Launch { launch_opts } => hashi::cli::run_launch(launch_opts).await,
         Commands::Register { register_opts } => hashi::cli::run_register(register_opts).await,
         Commands::Deposit { cli_opts, action } => {
             hashi::cli::run(cli_opts, hashi::cli::CliCommand::Deposit { action }).await

--- a/crates/hashi/src/publish.rs
+++ b/crates/hashi/src/publish.rs
@@ -320,3 +320,48 @@ pub async fn finish_publish(
 
     Ok(())
 }
+
+/// Find the `UpgradeCap` for `package_id` among the objects owned by
+/// `owner` (the publisher holds it between publish and launch).
+pub async fn find_upgrade_cap(
+    client: &mut Client,
+    owner: Address,
+    package_id: Address,
+) -> Result<Address> {
+    use futures::TryStreamExt as _;
+    use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
+    use sui_rpc::proto::sui::rpc::v2::ListOwnedObjectsRequest;
+
+    let cap_type = StructTag::from_str("0x2::package::UpgradeCap")?;
+    let list_request = ListOwnedObjectsRequest::default()
+        .with_owner(owner)
+        .with_object_type(&cap_type)
+        .with_page_size(100u32)
+        .with_read_mask(FieldMask::from_paths(["object_id"]));
+
+    let candidate_ids: Vec<Address> = client
+        .list_owned_objects(list_request)
+        .try_filter_map(|o| async move { Ok(o.object_id().parse::<Address>().ok()) })
+        .try_collect()
+        .await?;
+
+    for object_id in candidate_ids {
+        let object = client
+            .ledger_client()
+            .get_object(
+                GetObjectRequest::new(&object_id)
+                    .with_read_mask(FieldMask::from_paths(["object_id", "contents"])),
+            )
+            .await?
+            .into_inner();
+        let cap: hashi_types::move_types::UpgradeCap = object.object().contents().deserialize()?;
+        if cap.package == package_id {
+            return Ok(object_id);
+        }
+    }
+
+    anyhow::bail!(
+        "no UpgradeCap for package {package_id} owned by {owner}; it may already be \
+         registered on-chain (launch already done) or held by a different address"
+    )
+}

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -459,7 +459,7 @@ From DKG trigger to operational typically takes 30 to 120 seconds, assuming vali
 
 The admin publishes the Hashi Move package. This produces the `package-id` and `hashi-object-id` you need in both configs. The admin communicates these values to you.
 
-At this point the deploy is **not yet configured**: the package `UpgradeCap` stays in the publisher's wallet, and the chain id and guardian parameters are not on-chain yet. They land later with the launch step (`hashi::finish_publish`) — the **launch switch** that unlocks genesis.
+At this point the deploy is **not yet configured**: the package `UpgradeCap` stays in the publisher's wallet, and the chain id and guardian parameters are not onchain yet. They land later with the launch step (`hashi::finish_publish`), the **launch switch** that unlocks genesis.
 
 ### 5.3 Step 2: register your validator
 
@@ -480,9 +480,9 @@ The registration transaction writes your BLS12-381 public key, Ed25519 TLS publi
 hashi server --config /path/to/validator.toml
 ```
 
-The node starts the gRPC+TLS server, connects to Sui (gRPC) and Bitcoin (RPC + P2P), registers its next-epoch keys on-chain, and begins monitoring for the genesis trigger.
+The node starts the gRPC+TLS server, connects to Sui (gRPC) and Bitcoin (RPC + P2P), registers its next-epoch keys onchain, and begins monitoring for the genesis trigger.
 
-Booting **before the launch step is expected and required** — the launch only happens once every validator has finished key registration, which nodes do on startup. In this pre-launch window the on-chain config is not finalized yet, so the node logs two benign warnings: the `bitcoin_chain_id` cross-check is skipped (it re-verifies on any restart after launch), and the guardian client is deferred (it resolves automatically from on-chain config once the launch lands).
+Booting **before the launch step is expected and required** because the launch only happens once every validator has finished key registration, which nodes do on startup. In this pre-launch window the onchain config is not finalized yet, so the node logs two benign warnings: the `bitcoin_chain_id` cross-check is skipped (it re-verifies on any restart after launch), and the guardian client is deferred (it resolves automatically from onchain config once the launch lands).
 
 ### 5.5 Step 4: launch (admin)
 
@@ -496,9 +496,9 @@ hashi launch \
   --keypair /path/to/publisher.pem   # reads ./hashi_ids.json from publish
 ```
 
-This sends `hashi::finish_publish`: it finalizes the deploy configuration (chain id, guardian) and hands the package `UpgradeCap` into on-chain custody — the launch switch that `start_reconfig` requires before it will form the initial committee. Before sending, the command lists the registered validators and flags any that have not finished key registration (they would be excluded from the genesis committee). The **initial committee is exactly the set of fully-registered validators at this moment**, so the admin should confirm the roster before launching. Multisig publishers can use `--serialize-unsigned-transaction` (with `--sender`) to produce the transaction for offline signing.
+This sends `hashi::finish_publish`: it finalizes the deploy configuration (chain id, guardian) and hands the package `UpgradeCap` into onchain custody, the launch switch that `start_reconfig` requires before it forms the initial committee. Before sending, the command lists the registered validators and flags any that have not finished key registration (they would be excluded from the genesis committee). The **initial committee is exactly the set of fully-registered validators at this moment**, so the admin should confirm the roster before launching. Multisig publishers can use `--serialize-unsigned-transaction` (with `--sender`) to produce the transaction for offline signing.
 
-**No operator action needed** — but your validator must be registered and running before the admin launches, or it will not be part of the genesis committee.
+**No operator action needed**, but your validator must be registered and running before the admin launches; otherwise it is excluded from the genesis committee.
 
 ### 5.6 Step 5: DKG (automatic)
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -450,7 +450,7 @@ Genesis forms the initial Hashi committee and generates the shared Bitcoin maste
 ### 5.1 Timeline
 
 ```
-Package Published → Validators Register → 95% Stake Threshold → DKG (Automatic) → End Reconfig → Presignatures → Operational
+Package Published → Validators Register → Launch (Admin) → DKG (Automatic) → End Reconfig → Presignatures → Operational
 ```
 
 From DKG trigger to operational typically takes 30 to 120 seconds, assuming validators are online and reachable.
@@ -458,6 +458,8 @@ From DKG trigger to operational typically takes 30 to 120 seconds, assuming vali
 ### 5.2 Step 1: package publication (admin)
 
 The admin publishes the Hashi Move package. This produces the `package-id` and `hashi-object-id` you need in both configs. The admin communicates these values to you.
+
+At this point the deploy is **not yet configured**: the package `UpgradeCap` stays in the publisher's wallet, and the chain id and guardian parameters are not on-chain yet. They land later with the launch step (`hashi::finish_publish`) — the **launch switch** that unlocks genesis.
 
 ### 5.3 Step 2: register your validator
 
@@ -478,17 +480,35 @@ The registration transaction writes your BLS12-381 public key, Ed25519 TLS publi
 hashi server --config /path/to/validator.toml
 ```
 
-The node starts the gRPC+TLS server, connects to Sui (gRPC) and Bitcoin (RPC + P2P), and begins monitoring for the genesis trigger.
+The node starts the gRPC+TLS server, connects to Sui (gRPC) and Bitcoin (RPC + P2P), registers its next-epoch keys on-chain, and begins monitoring for the genesis trigger.
 
-### 5.5 Step 4: DKG (automatic)
+Booting **before the launch step is expected and required** — the launch only happens once every validator has finished key registration, which nodes do on startup. In this pre-launch window the on-chain config is not finalized yet, so the node logs two benign warnings: the `bitcoin_chain_id` cross-check is skipped (it re-verifies on any restart after launch), and the guardian client is deferred (it resolves automatically from on-chain config once the launch lands).
 
-Once **95% of total Sui validator stake** has registered with Hashi, the first node to detect this submits `start_reconfig`. All registered validators then run DKG concurrently. **No operator action needed**; monitor logs for `start_reconfig`, `DKG started`, `DKG completed`. DKG times out after 600 s per attempt and retries until it succeeds or a newer epoch supersedes it.
+### 5.5 Step 4: launch (admin)
 
-### 5.6 Step 5: end reconfig (automatic)
+Genesis is gated on an explicit launch step. Once every expected validator has registered and started its node, the publisher runs:
+
+```bash
+hashi launch \
+  --bitcoin-chain-id <genesis block hash> \
+  --guardian-url <guardian gRPC URL> \
+  --guardian-btc-public-key <x-only hex> \
+  --keypair /path/to/publisher.pem   # reads ./hashi_ids.json from publish
+```
+
+This sends `hashi::finish_publish`: it finalizes the deploy configuration (chain id, guardian) and hands the package `UpgradeCap` into on-chain custody — the launch switch that `start_reconfig` requires before it will form the initial committee. Before sending, the command lists the registered validators and flags any that have not finished key registration (they would be excluded from the genesis committee). The **initial committee is exactly the set of fully-registered validators at this moment**, so the admin should confirm the roster before launching. Multisig publishers can use `--serialize-unsigned-transaction` (with `--sender`) to produce the transaction for offline signing.
+
+**No operator action needed** — but your validator must be registered and running before the admin launches, or it will not be part of the genesis committee.
+
+### 5.6 Step 5: DKG (automatic)
+
+Once the launch transaction lands, the first node to detect it submits `start_reconfig`. All registered validators then run DKG concurrently. **No operator action needed**; monitor logs for `start_reconfig`, `DKG started`, `DKG completed`. DKG times out after 600 s per attempt and retries until it succeeds or a newer epoch supersedes it.
+
+### 5.7 Step 6: end reconfig (automatic)
 
 After DKG, validators exchange BLS signatures over the result. Once 2/3 of committee weight has signed, `end_reconfig` is submitted onchain and the committee generates presignatures. **No operator action needed**; monitor logs for `end_reconfig submitted` and presignature generation.
 
-### 5.7 Post-genesis verification
+### 5.8 Post-genesis verification
 
 ```bash
 hashi committee list

--- a/design/docs/reconfiguration.mdx
+++ b/design/docs/reconfiguration.mdx
@@ -50,10 +50,10 @@ At genesis (when no MPC public key exists yet), `start_reconfig` is
 additionally gated on the **launch switch**: it aborts until the publisher
 has sent `hashi::finish_publish` (the `hashi launch` CLI command), which
 finalizes the deploy configuration and hands the package `UpgradeCap` into
-on-chain custody. This gives the publisher explicit control over when — and
-with which registered validators — the initial committee forms. After genesis
+onchain custody. This gives the publisher explicit control over when (and
+with which registered validators) the initial committee forms. After genesis
 the gate is never consulted; Hashi follows Sui's validator set
-unconditionally, since a floor on a normal reconfig would let validators
+unconditionally, because a floor on a normal reconfig would let validators
 brick reconfiguration by withholding registration.
 
 

--- a/design/docs/reconfiguration.mdx
+++ b/design/docs/reconfiguration.mdx
@@ -46,13 +46,13 @@ The new committee membership is determined by the set of validators that
 registered with Hashi for the new epoch. Stake weights come from the Sui
 validator set.
 
-At genesis (when no MPC public key exists yet), `start_reconfig` is
-additionally gated on the **launch switch**: it aborts until the publisher
+At genesis (when no MPC public key exists yet), the **launch switch**
+additionally gates `start_reconfig`: it aborts until the publisher
 has sent `hashi::finish_publish` (the `hashi launch` CLI command), which
 finalizes the deploy configuration and hands the package `UpgradeCap` into
 onchain custody. This gives the publisher explicit control over when (and
 with which registered validators) the initial committee forms. After genesis
-the gate is never consulted; Hashi follows Sui's validator set
+Hashi never consults the gate; it follows Sui's validator set
 unconditionally, because a floor on a normal reconfig would let validators
 brick reconfiguration by withholding registration.
 

--- a/design/docs/reconfiguration.mdx
+++ b/design/docs/reconfiguration.mdx
@@ -46,6 +46,16 @@ The new committee membership is determined by the set of validators that
 registered with Hashi for the new epoch. Stake weights come from the Sui
 validator set.
 
+At genesis (when no MPC public key exists yet), `start_reconfig` is
+additionally gated on the **launch switch**: it aborts until the publisher
+has sent `hashi::finish_publish` (the `hashi launch` CLI command), which
+finalizes the deploy configuration and hands the package `UpgradeCap` into
+on-chain custody. This gives the publisher explicit control over when — and
+with which registered validators — the initial committee forms. After genesis
+the gate is never consulted; Hashi follows Sui's validator set
+unconditionally, since a floor on a normal reconfig would let validators
+brick reconfiguration by withholding registration.
+
 
 ### DKG or Key Rotation
 


### PR DESCRIPTION
Stacked on #772.

## What

Operator-facing support for the launch-switch genesis flow (where `hashi::finish_publish`, deferred to launch time, is the switch):

- **`hashi launch`**: sends `finish_publish`. Resolves ids from `hashi_ids.json` (written by `hashi publish`) or explicit `--package-id`/`--hashi-object-id`; takes `--bitcoin-chain-id`, `--guardian-url`, `--guardian-btc-public-key` and optional bitcoin-config overrides; pre-flights the on-chain state (rejects if the UpgradeCap is already in custody, lists every registered validator with per-validator key-readiness, warns about validators that would be excluded from the genesis committee); auto-discovers the publisher's `UpgradeCap` among owned objects (or takes `--upgrade-cap`); then executes. `--serialize-unsigned-transaction` (with `--sender`) prints the unsigned BCS tx for multisig publishers.
- **Manual localnet mode** rehearses the real rollout: after the operator registers validators and starts the nodes, it prints the exact `hashi launch` command (including the localnet guardian parameters) for the operator to run, instead of auto-sending the launch tx.
- **Docs**: `node-operator-runbook.mdx` gets the new genesis timeline, pre-launch node-warning notes, and a "Step 4: launch (admin)" section; `reconfiguration.mdx` documents the genesis gate in Start Reconfig, including why no floor applies to post-genesis reconfigs.

## Verification

Script-driven end-to-end run against a manual-mode localnet:
1. registered 4 validators via `hashi register`,
2. started the nodes,
3. extracted the harness-printed `hashi launch` command and polled readiness with the side-effect-free `--serialize-unsigned-transaction` path until all 4 showed `ready`,
4. ran the printed command verbatim — `finish_publish` executed, genesis unlocked,
5. a second launch attempt is correctly rejected ("UpgradeCap is already in on-chain custody"),
6. the committee formed (DKG completed; `hashi committee epoch` reports the epoch).