### PR TITLE
config: Add U128 and U256 variants to the config Value enum

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -216,6 +216,10 @@ pub enum ConfigValue {
     String(String),
     Bool(bool),
     Bytes(Vec<u8>),
+    U128(u128),
+    /// Move `u256`, as its 32 little-endian BCS bytes (no Rust u256 primitive;
+    /// a fixed-size array BCS-encodes to exactly the same 32 bytes).
+    U256([u8; 32]),
 }
 
 /// MPC parameter keys, in the canonical order Move's `mpc_config::pin` writes
@@ -1621,5 +1625,33 @@ mod tests {
         let decoded: Config = bcs::from_bytes(&bytes).expect("deserialize");
         assert_eq!(decoded, mpc);
         assert!(matches!(decoded.entries()[0].1, ConfigValue::U64(3334)));
+    }
+
+    /// Pins the BCS encoding of the wide-integer `ConfigValue` variants against
+    /// what Move produces: 1-byte variant tag (U128 = 5, U256 = 6) followed by
+    /// the little-endian integer bytes (16 for u128, 32 for u256).
+    #[test]
+    fn config_value_wide_integer_bcs_round_trip() {
+        let u128_value = ConfigValue::U128(1u128 << 100);
+        let bytes = bcs::to_bytes(&u128_value).expect("serialize");
+        let mut expected = vec![5u8];
+        expected.extend_from_slice(&(1u128 << 100).to_le_bytes());
+        assert_eq!(bytes, expected);
+        assert_eq!(
+            bcs::from_bytes::<ConfigValue>(&bytes).expect("deserialize"),
+            u128_value
+        );
+
+        let mut le = [0u8; 32];
+        le[16] = 1; // 2^128, unrepresentable in u128
+        let u256_value = ConfigValue::U256(le);
+        let bytes = bcs::to_bytes(&u256_value).expect("serialize");
+        let mut expected = vec![6u8];
+        expected.extend_from_slice(&le);
+        assert_eq!(bytes, expected);
+        assert_eq!(
+            bcs::from_bytes::<ConfigValue>(&bytes).expect("deserialize"),
+            u256_value
+        );
     }
 }

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -212,14 +212,14 @@ pub struct UpgradeCap {
 #[derive(Debug, Clone, PartialEq, serde_derive::Deserialize, serde_derive::Serialize)]
 pub enum ConfigValue {
     U64(u64),
-    Address(Address),
-    String(String),
-    Bool(bool),
-    Bytes(Vec<u8>),
     U128(u128),
     /// Move `u256`, as its 32 little-endian BCS bytes (no Rust u256 primitive;
     /// a fixed-size array BCS-encodes to exactly the same 32 bytes).
     U256([u8; 32]),
+    Address(Address),
+    String(String),
+    Bool(bool),
+    Bytes(Vec<u8>),
 }
 
 /// MPC parameter keys, in the canonical order Move's `mpc_config::pin` writes
@@ -1628,13 +1628,13 @@ mod tests {
     }
 
     /// Pins the BCS encoding of the wide-integer `ConfigValue` variants against
-    /// what Move produces: 1-byte variant tag (U128 = 5, U256 = 6) followed by
+    /// what Move produces: 1-byte variant tag (U128 = 1, U256 = 2) followed by
     /// the little-endian integer bytes (16 for u128, 32 for u256).
     #[test]
     fn config_value_wide_integer_bcs_round_trip() {
         let u128_value = ConfigValue::U128(1u128 << 100);
         let bytes = bcs::to_bytes(&u128_value).expect("serialize");
-        let mut expected = vec![5u8];
+        let mut expected = vec![1u8];
         expected.extend_from_slice(&(1u128 << 100).to_le_bytes());
         assert_eq!(bytes, expected);
         assert_eq!(
@@ -1646,7 +1646,7 @@ mod tests {
         le[16] = 1; // 2^128, unrepresentable in u128
         let u256_value = ConfigValue::U256(le);
         let bytes = bcs::to_bytes(&u256_value).expect("serialize");
-        let mut expected = vec![6u8];
+        let mut expected = vec![2u8];
         expected.extend_from_slice(&le);
         assert_eq!(bytes, expected);
         assert_eq!(

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -723,6 +723,9 @@ fn build_config_value(
         ConfigValue::String(v) => ("new_string", builder.pure(v)),
         ConfigValue::Bool(v) => ("new_bool", builder.pure(v)),
         ConfigValue::Bytes(v) => ("new_bytes", builder.pure(v)),
+        ConfigValue::U128(v) => ("new_u128", builder.pure(v)),
+        // The 32 LE bytes BCS-encode identically to a Move `u256` pure arg.
+        ConfigValue::U256(v) => ("new_u256", builder.pure(v)),
     };
 
     builder.move_call(

--- a/packages/hashi/sources/core/config/config_value.move
+++ b/packages/hashi/sources/core/config/config_value.move
@@ -7,17 +7,18 @@ use std::string::String;
 
 const EInvalidConfigValue: u64 = 0;
 
+// Variant order is BCS-load-bearing: the Rust mirror (hashi-types) decodes
+// by variant index, and once published to a persistent network the order is
+// frozen — package upgrades reject enums whose existing variants change, so
+// new variants may then only be appended at the end.
 public enum Value has copy, drop, store {
     U64(u64),
+    U128(u128),
+    U256(u256),
     Address(address),
     String(String),
     Bool(bool),
     Bytes(vector<u8>),
-    // New variants must be appended (never inserted or reordered): package
-    // upgrades reject enums whose existing variant order changes, and the
-    // Rust mirror (hashi-types) decodes by BCS variant index.
-    U128(u128),
-    U256(u256),
 }
 
 public fun new_u64(value: u64): Value {

--- a/packages/hashi/sources/core/config/config_value.move
+++ b/packages/hashi/sources/core/config/config_value.move
@@ -13,6 +13,11 @@ public enum Value has copy, drop, store {
     String(String),
     Bool(bool),
     Bytes(vector<u8>),
+    // New variants must be appended (never inserted or reordered): package
+    // upgrades reject enums whose existing variant order changes, and the
+    // Rust mirror (hashi-types) decodes by BCS variant index.
+    U128(u128),
+    U256(u256),
 }
 
 public fun new_u64(value: u64): Value {
@@ -35,6 +40,14 @@ public fun new_bytes(value: vector<u8>): Value {
     Value::Bytes(value)
 }
 
+public fun new_u128(value: u128): Value {
+    Value::U128(value)
+}
+
+public fun new_u256(value: u256): Value {
+    Value::U256(value)
+}
+
 public(package) fun same_variant(self: &Value, other: &Value): bool {
     match (self) {
         Value::U64(_) => other.is_u64(),
@@ -42,6 +55,8 @@ public(package) fun same_variant(self: &Value, other: &Value): bool {
         Value::String(_) => other.is_string(),
         Value::Bool(_) => other.is_bool(),
         Value::Bytes(_) => other.is_bytes(),
+        Value::U128(_) => other.is_u128(),
+        Value::U256(_) => other.is_u256(),
     }
 }
 
@@ -111,6 +126,34 @@ public(package) fun as_bool(value: Value): bool {
 public(package) fun as_bytes(value: Value): vector<u8> {
     match (value) {
         Value::Bytes(bytes) => bytes,
+        _ => abort EInvalidConfigValue,
+    }
+}
+
+public(package) fun is_u128(value: &Value): bool {
+    match (value) {
+        Value::U128(_) => true,
+        _ => false,
+    }
+}
+
+public(package) fun is_u256(value: &Value): bool {
+    match (value) {
+        Value::U256(_) => true,
+        _ => false,
+    }
+}
+
+public(package) fun as_u128(value: Value): u128 {
+    match (value) {
+        Value::U128(num) => num,
+        _ => abort EInvalidConfigValue,
+    }
+}
+
+public(package) fun as_u256(value: Value): u256 {
+    match (value) {
+        Value::U256(num) => num,
         _ => abort EInvalidConfigValue,
     }
 }

--- a/packages/hashi/tests/config_tests.move
+++ b/packages/hashi/tests/config_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module hashi::config_tests;
 
-use hashi::{btc_config, config, test_utils};
+use hashi::{btc_config, config, config_value, test_utils};
 use std::string;
 
 const VOTER1: address = @0x1;
@@ -148,4 +148,31 @@ fun test_bitcoin_withdrawal_minimum_updates() {
     assert!(btc_config::bitcoin_withdrawal_minimum(hashi.config()) < baseline);
 
     std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_config_value_wide_integers_round_trip() {
+    let mut config = config::empty();
+
+    // Values that cannot fit the next-smaller integer width.
+    let big_u128 = 1u128 << 100;
+    config.upsert(b"test_u128", config_value::new_u128(big_u128));
+    assert!(config.get(b"test_u128").as_u128() == big_u128);
+
+    let big_u256 = 1u256 << 200;
+    config.upsert(b"test_u256", config_value::new_u256(big_u256));
+    assert!(config.get(b"test_u256").as_u256() == big_u256);
+}
+
+#[test]
+fun test_config_value_same_variant_distinguishes_integer_widths() {
+    let u64_value = config_value::new_u64(1);
+    let u128_value = config_value::new_u128(1);
+    let u256_value = config_value::new_u256(1);
+
+    assert!(u128_value.same_variant(&config_value::new_u128(2)));
+    assert!(u256_value.same_variant(&config_value::new_u256(2)));
+    assert!(!u64_value.same_variant(&u128_value));
+    assert!(!u128_value.same_variant(&u256_value));
+    assert!(!u256_value.same_variant(&u64_value));
 }


### PR DESCRIPTION
## What

Appends `U128(u128)` and `U256(u256)` variants to `config_value::Value`, with the matching constructor/predicate/extractor functions and `same_variant` arms. The Rust mirror (`hashi_types::move_types::ConfigValue`) gains the same variants — u256 represented as its 32 little-endian BCS bytes, which a fixed-size `[u8; 32]` encodes byte-identically — and the proposal transaction builder maps the new variants to their Move constructors. A pinned BCS round-trip test covers the new tags (U128 = 5, U256 = 6).

No config keys use the new variants yet; this is purely reserving representational space.

## Why now

Pre-mainnet hardening from the native-bridge→Hashi asset-migration readiness analysis: Sui's compatible-upgrade policy permits adding modules and functions but **never adding enum variants** (`move-binary-format` rejects any upgrade where an enum has more variants than before). Once we publish to mainnet, `Value` is frozen forever.

The concrete future need is wide-integer config values: ETH-era parameters are wei-denominated, and u64 overflows at ~18.4 ETH — too small for values like daily limits. Without these variants, post-mainnet ETH config would be stuck encoding amounts as `Bytes` or off-unit denominations permanently. Adding them now costs nothing.

## Notes

- Variants are appended at the end — BCS decodes by variant index, so existing on-chain values and the Rust mirror are unaffected.
- CLI `update-config` string parsing (`u64:`/`bool:` prefixes) deliberately does not gain `u128:`/`u256:` yet — that's Rust-side and can be added whenever the first wide-integer key exists.

## Testing

- Move: `config_tests::test_config_value_wide_integers_round_trip` + `test_config_value_same_variant_distinguishes_integer_widths`; full suite 144/144.
- Rust: `move_types::tests::config_value_wide_integer_bcs_round_trip` pins the exact BCS bytes; hashi-types and hashi suites green.