### PR TITLE
[guardian-proxy] Serve /info + /health on the gRPC server's port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,13 +3025,16 @@ dependencies = [
  "axum",
  "bitcoin",
  "hashi-types",
+ "hex",
  "lru 0.16.3",
  "prometheus",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tonic",
  "tonic-health",
+ "tower-http",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,6 +3034,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-health",
+ "tower",
  "tower-http",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_derive = "1.0.219"
 
 axum = "0.8.4"
 tower = "0.5.3"
+tower-http = "0.6"
 reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls"] }
 tokio = { version = "1.46.1", features = ["full"] }
 tokio-stream = "0.1"

--- a/crates/hashi-guardian-proxy/Cargo.toml
+++ b/crates/hashi-guardian-proxy/Cargo.toml
@@ -17,7 +17,10 @@ aws-sdk-s3.workspace = true
 axum.workspace = true
 bitcoin.workspace = true
 prometheus.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tower-http = { workspace = true, features = ["cors"] }
+hex.workspace = true
 
 [dev-dependencies]
 tokio-stream.workspace = true

--- a/crates/hashi-guardian-proxy/Cargo.toml
+++ b/crates/hashi-guardian-proxy/Cargo.toml
@@ -19,6 +19,7 @@ bitcoin.workspace = true
 prometheus.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tower.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 hex.workspace = true
 

--- a/crates/hashi-guardian-proxy/src/config.rs
+++ b/crates/hashi-guardian-proxy/src/config.rs
@@ -23,6 +23,12 @@ pub struct Config {
     /// Address the prometheus `/metrics` endpoint listens on
     /// (`METRICS_LISTEN_ADDR`, default `0.0.0.0:9184`).
     pub metrics_listen_addr: SocketAddr,
+    /// Address the read-only HTTP `/info` + `/health` server listens on
+    /// (`HTTP_LISTEN_ADDR`, default `0.0.0.0:3001`).
+    pub http_listen_addr: SocketAddr,
+    /// TTL for the single-slot `/info` response cache
+    /// (`INFO_CACHE_TTL_MS`, default 1000).
+    pub info_cache_ttl: Duration,
     /// TCP connect timeout to the backend
     /// (`GUARDIAN_CONNECT_TIMEOUT_SECS`, default 5).
     pub connect_timeout: Duration,
@@ -56,6 +62,11 @@ impl Config {
             .unwrap_or_else(|_| "0.0.0.0:9184".to_string())
             .parse()
             .context("METRICS_LISTEN_ADDR must be a valid socket address")?;
+        let http_listen_addr = std::env::var("HTTP_LISTEN_ADDR")
+            .unwrap_or_else(|_| "0.0.0.0:3001".to_string())
+            .parse()
+            .context("HTTP_LISTEN_ADDR must be a valid socket address")?;
+        let info_cache_ttl = Duration::from_millis(parse_env_u64("INFO_CACHE_TTL_MS", 1000)?);
         let connect_timeout =
             Duration::from_secs(parse_env_u64("GUARDIAN_CONNECT_TIMEOUT_SECS", 5)?);
         let keepalive_interval = Duration::from_secs(parse_env_u64("GUARDIAN_KEEPALIVE_SECS", 5)?);
@@ -73,6 +84,8 @@ impl Config {
             backend_url,
             listen_addr,
             metrics_listen_addr,
+            http_listen_addr,
+            info_cache_ttl,
             connect_timeout,
             keepalive_interval,
             log_bucket,

--- a/crates/hashi-guardian-proxy/src/config.rs
+++ b/crates/hashi-guardian-proxy/src/config.rs
@@ -17,15 +17,12 @@ pub struct Config {
     /// gRPC endpoint of the enclave guardian to forward to, e.g.
     /// `http://10.0.1.20:3000` (`GUARDIAN_BACKEND_URL`, required).
     pub backend_url: String,
-    /// Address the proxy listens on for node traffic
-    /// (`PROXY_LISTEN_ADDR`, default `0.0.0.0:3000`).
+    /// Address the proxy serves everything on — gRPC (forwarder + relay + health)
+    /// and the HTTP `/info` + `/health` (`PROXY_LISTEN_ADDR`, default `0.0.0.0:3000`).
     pub listen_addr: SocketAddr,
     /// Address the prometheus `/metrics` endpoint listens on
     /// (`METRICS_LISTEN_ADDR`, default `0.0.0.0:9184`).
     pub metrics_listen_addr: SocketAddr,
-    /// Address the read-only HTTP `/info` + `/health` server listens on
-    /// (`HTTP_LISTEN_ADDR`, default `0.0.0.0:3001`).
-    pub http_listen_addr: SocketAddr,
     /// TTL for the single-slot `/info` response cache
     /// (`INFO_CACHE_TTL_MS`, default 1000).
     pub info_cache_ttl: Duration,
@@ -62,10 +59,6 @@ impl Config {
             .unwrap_or_else(|_| "0.0.0.0:9184".to_string())
             .parse()
             .context("METRICS_LISTEN_ADDR must be a valid socket address")?;
-        let http_listen_addr = std::env::var("HTTP_LISTEN_ADDR")
-            .unwrap_or_else(|_| "0.0.0.0:3001".to_string())
-            .parse()
-            .context("HTTP_LISTEN_ADDR must be a valid socket address")?;
         let info_cache_ttl = Duration::from_millis(parse_env_u64("INFO_CACHE_TTL_MS", 1000)?);
         let connect_timeout =
             Duration::from_secs(parse_env_u64("GUARDIAN_CONNECT_TIMEOUT_SECS", 5)?);
@@ -84,7 +77,6 @@ impl Config {
             backend_url,
             listen_addr,
             metrics_listen_addr,
-            http_listen_addr,
             info_cache_ttl,
             connect_timeout,
             keepalive_interval,

--- a/crates/hashi-guardian-proxy/src/info.rs
+++ b/crates/hashi-guardian-proxy/src/info.rs
@@ -1,0 +1,283 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Read-only HTTP surface for the proxy: `GET /info` (a curated JSON projection
+//! of the enclave's signed `GetGuardianInfo`) and `GET /health` (proxy
+//! liveness), with permissive CORS. It lets browser/`fetch` clients like the
+//! hashi-ts-sdk read the withdrawal rate-limiter state that the gRPC surface
+//! only exposes to nodes. `u64`s serialize as strings (JSON/JS `2^53`), and
+//! `limiter`/`btcPubkey`/`committeeEpoch` are `null` until the guardian is
+//! provisioned. The S3 bucket and KP shares are deliberately not exposed.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
+
+use axum::extract::State;
+use axum::http::Method;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::response::Response;
+use axum::routing::get;
+use axum::Json;
+use axum::Router;
+use hashi_types::guardian::GetGuardianInfoResponse;
+use hashi_types::guardian::LimiterConfig;
+use hashi_types::guardian::LimiterState;
+use hashi_types::guardian::VerifiedGuardianInfo;
+use hashi_types::proto;
+use hashi_types::proto::guardian_service_client::GuardianServiceClient;
+use serde::Serialize;
+use serde_json::json;
+use tonic::transport::Channel;
+use tower_http::cors::Any;
+use tower_http::cors::CorsLayer;
+use tracing::error;
+
+/// Curated, read-only projection of `GuardianInfo` served at `GET /info`.
+/// Pubkeys are hex; `signed_at_ms` is a freshness signal.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GuardianInfoView {
+    limiter: Option<LimiterView>,
+    git_revision: String,
+    committee_epoch: Option<String>,
+    btc_pubkey: Option<String>,
+    signing_pub_key: String,
+    signed_at_ms: Option<String>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LimiterView {
+    state: LimiterStateView,
+    config: LimiterConfigView,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LimiterStateView {
+    num_tokens_available_sats: String,
+    last_updated_at_secs: String,
+    next_seq: String,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LimiterConfigView {
+    refill_rate_sats_per_sec: String,
+    max_bucket_capacity_sats: String,
+}
+
+/// gRPC client to the enclave plus a single-slot TTL cache, so a burst of public
+/// `/info` hits collapses to at most one (uncached) `GetGuardianInfo` per `ttl`.
+#[derive(Clone)]
+pub struct InfoState {
+    client: GuardianServiceClient<Channel>,
+    cache: Arc<Mutex<Option<(Instant, GuardianInfoView)>>>,
+    ttl: Duration,
+}
+
+impl InfoState {
+    pub fn new(client: GuardianServiceClient<Channel>, ttl: Duration) -> Self {
+        Self {
+            client,
+            cache: Arc::new(Mutex::new(None)),
+            ttl,
+        }
+    }
+
+    fn cached(&self) -> Option<GuardianInfoView> {
+        let guard = self.cache.lock().expect("info cache mutex poisoned");
+        guard
+            .as_ref()
+            .filter(|(at, _)| at.elapsed() < self.ttl)
+            .map(|(_, view)| view.clone())
+    }
+
+    fn store(&self, view: GuardianInfoView) {
+        *self.cache.lock().expect("info cache mutex poisoned") = Some((Instant::now(), view));
+    }
+}
+
+/// Router for the HTTP status surface, with permissive CORS (public read-only
+/// data, so any origin; no credentials).
+pub fn router(state: InfoState) -> Router {
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::OPTIONS])
+        .allow_headers(Any);
+    Router::new()
+        .route("/info", get(get_info))
+        .route("/health", get(health))
+        .layer(cors)
+        .with_state(state)
+}
+
+/// Proxy liveness only — never gated on the enclave, so an enclave hiccup can't
+/// deregister the target and take `/info` dark.
+async fn health() -> StatusCode {
+    StatusCode::OK
+}
+
+async fn get_info(State(state): State<InfoState>) -> Response {
+    if let Some(view) = state.cached() {
+        return Json(view).into_response();
+    }
+
+    // Fetch outside the lock so the handler stays `Send`; a few racing misses
+    // each hitting the enclave on a cold cache is harmless.
+    let raw = match state
+        .client
+        .clone()
+        .get_guardian_info(proto::GetGuardianInfoRequest {})
+        .await
+    {
+        Ok(resp) => resp.into_inner(),
+        Err(status) => return unavailable("guardian_unreachable", &status.to_string()),
+    };
+
+    // Read the signing timestamp off the raw proto; the domain conversion drops it.
+    let signed_at_ms = raw.signed_info.as_ref().and_then(|s| s.timestamp_ms);
+    let verified = match GetGuardianInfoResponse::try_from(raw)
+        .and_then(|resp| resp.verify_signed_info_without_attestation())
+    {
+        Ok(verified) => verified,
+        Err(e) => {
+            error!(error = ?e, "GetGuardianInfo could not be decoded/verified for /info");
+            return unavailable("guardian_info_invalid", &format!("{e:?}"));
+        }
+    };
+
+    let view = project(&verified, signed_at_ms);
+    state.store(view.clone());
+    Json(view).into_response()
+}
+
+fn unavailable(error: &str, detail: &str) -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({ "error": error, "detail": detail })),
+    )
+        .into_response()
+}
+
+fn project(verified: &VerifiedGuardianInfo, signed_at_ms: Option<u64>) -> GuardianInfoView {
+    let info = &verified.info;
+    GuardianInfoView {
+        limiter: limiter_view(info.limiter_state, info.limiter_config),
+        git_revision: info.untrusted_git_revision.clone(),
+        committee_epoch: info.current_committee_epoch.map(|e| e.to_string()),
+        btc_pubkey: info
+            .enclave_btc_pubkey
+            .as_ref()
+            .map(|pk| hex::encode(pk.serialize())),
+        signing_pub_key: hex::encode(verified.signing_pub_key.as_bytes()),
+        signed_at_ms: signed_at_ms.map(|t| t.to_string()),
+    }
+}
+
+/// Reported only when both halves are present — a half-initialized limiter is
+/// useless, so the client sees `limiter` as a single nullable object.
+fn limiter_view(state: Option<LimiterState>, config: Option<LimiterConfig>) -> Option<LimiterView> {
+    let (state, config) = (state?, config?);
+    Some(LimiterView {
+        state: LimiterStateView {
+            num_tokens_available_sats: state.num_tokens_available.to_string(),
+            last_updated_at_secs: state.last_updated_at.to_string(),
+            next_seq: state.next_seq.to_string(),
+        },
+        config: LimiterConfigView {
+            refill_rate_sats_per_sec: config.refill_rate.to_string(),
+            max_bucket_capacity_sats: config.max_bucket_capacity.to_string(),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limiter_state() -> LimiterState {
+        LimiterState {
+            num_tokens_available: 12_345,
+            last_updated_at: 1_720_000_000,
+            next_seq: 42,
+        }
+    }
+
+    fn limiter_config() -> LimiterConfig {
+        LimiterConfig {
+            refill_rate: 1_000,
+            max_bucket_capacity: 2_000_000,
+        }
+    }
+
+    #[test]
+    fn limiter_view_requires_both_state_and_config() {
+        assert!(limiter_view(None, None).is_none());
+        assert!(limiter_view(Some(limiter_state()), None).is_none());
+        assert!(limiter_view(None, Some(limiter_config())).is_none());
+        assert!(limiter_view(Some(limiter_state()), Some(limiter_config())).is_some());
+    }
+
+    #[test]
+    fn info_view_serializes_to_the_public_contract() {
+        // Fully-initialized guardian: nested limiter, u64s as strings, camelCase.
+        let view = GuardianInfoView {
+            limiter: limiter_view(Some(limiter_state()), Some(limiter_config())),
+            git_revision: "abc123".to_string(),
+            committee_epoch: Some("7".to_string()),
+            btc_pubkey: Some("deadbeef".to_string()),
+            signing_pub_key: "feedface".to_string(),
+            signed_at_ms: Some("1720000000123".to_string()),
+        };
+        assert_eq!(
+            serde_json::to_value(&view).unwrap(),
+            json!({
+                "limiter": {
+                    "state": {
+                        "numTokensAvailableSats": "12345",
+                        "lastUpdatedAtSecs": "1720000000",
+                        "nextSeq": "42",
+                    },
+                    "config": {
+                        "refillRateSatsPerSec": "1000",
+                        "maxBucketCapacitySats": "2000000",
+                    },
+                },
+                "gitRevision": "abc123",
+                "committeeEpoch": "7",
+                "btcPubkey": "deadbeef",
+                "signingPubKey": "feedface",
+                "signedAtMs": "1720000000123",
+            })
+        );
+    }
+
+    #[test]
+    fn uninitialized_info_view_emits_explicit_nulls() {
+        // Pre-provisioning: limiter/committee/btc are absent but the keys stay
+        // present as `null` so the client schema is stable.
+        let view = GuardianInfoView {
+            limiter: None,
+            git_revision: "abc123".to_string(),
+            committee_epoch: None,
+            btc_pubkey: None,
+            signing_pub_key: "feedface".to_string(),
+            signed_at_ms: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&view).unwrap(),
+            json!({
+                "limiter": null,
+                "gitRevision": "abc123",
+                "committeeEpoch": null,
+                "btcPubkey": null,
+                "signingPubKey": "feedface",
+                "signedAtMs": null,
+            })
+        );
+    }
+}

--- a/crates/hashi-guardian-proxy/src/info.rs
+++ b/crates/hashi-guardian-proxy/src/info.rs
@@ -8,6 +8,12 @@
 //! only exposes to nodes. `u64`s serialize as strings (JSON/JS `2^53`), and
 //! `limiter`/`btcPubkey`/`committeeEpoch` are `null` until the guardian is
 //! provisioned. The S3 bucket and KP shares are deliberately not exposed.
+//!
+//! `/info` is public and polled by every SDK client, so it fronts the enclave
+//! with a single-slot TTL cache and single-flight refresh: a burst of hits
+//! collapses to at most one `GetGuardianInfo` per TTL, and while the enclave is
+//! briefly unreachable the last good view is served (its age is visible via
+//! `signedAtMs`) rather than erroring.
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -70,34 +76,157 @@ struct LimiterConfigView {
     max_bucket_capacity_sats: String,
 }
 
-/// gRPC client to the enclave plus a single-slot TTL cache, so a burst of public
-/// `/info` hits collapses to at most one (uncached) `GetGuardianInfo` per `ttl`.
+/// Why an `/info` refresh could not produce a fresh view. Kept transport-shaped
+/// so the source stays decoupled from the HTTP response contract.
+enum InfoError {
+    /// The enclave gRPC call failed (unreachable / deadline / transport).
+    Unreachable(String),
+    /// The response decoded but failed signature verification.
+    Invalid(String),
+}
+
+impl InfoError {
+    fn into_response(self) -> Response {
+        match self {
+            InfoError::Unreachable(detail) => unavailable("guardian_unreachable", &detail),
+            InfoError::Invalid(detail) => unavailable("guardian_info_invalid", &detail),
+        }
+    }
+}
+
+/// Source of a fresh [`GuardianInfoView`]. A trait so the cache can be tested
+/// without a live enclave or a signed response to verify against.
+#[tonic::async_trait]
+trait InfoSource: Send + Sync + 'static {
+    async fn fetch(&self) -> Result<GuardianInfoView, InfoError>;
+}
+
+/// [`InfoSource`] backed by the enclave's gRPC `GetGuardianInfo`, verifying and
+/// projecting the signed response.
+struct GrpcInfoSource {
+    client: GuardianServiceClient<Channel>,
+}
+
+#[tonic::async_trait]
+impl InfoSource for GrpcInfoSource {
+    async fn fetch(&self) -> Result<GuardianInfoView, InfoError> {
+        let raw = self
+            .client
+            .clone()
+            .get_guardian_info(proto::GetGuardianInfoRequest {})
+            .await
+            .map_err(|status| InfoError::Unreachable(status.to_string()))?
+            .into_inner();
+
+        // Read the signing timestamp off the raw proto; the domain conversion drops it.
+        let signed_at_ms = raw.signed_info.as_ref().and_then(|s| s.timestamp_ms);
+        let verified = GetGuardianInfoResponse::try_from(raw)
+            .and_then(|resp| resp.verify_signed_info_without_attestation())
+            .map_err(|e| {
+                error!(error = ?e, "GetGuardianInfo could not be decoded/verified for /info");
+                InfoError::Invalid(format!("{e:?}"))
+            })?;
+        Ok(project(&verified, signed_at_ms))
+    }
+}
+
+/// The `/info` cache: the last projected view plus a refresh lock. Reads take
+/// the fast path off `slot`; a miss elects one refresher via `refresh` so a
+/// burst of public hits collapses to a single backend call.
+struct InfoCache {
+    slot: Mutex<Option<(Instant, GuardianInfoView)>>,
+    refresh: tokio::sync::Mutex<()>,
+}
+
+/// Backend source plus its single-slot TTL cache, so a burst of public `/info`
+/// hits collapses to at most one `GetGuardianInfo` per `ttl`.
 #[derive(Clone)]
 pub struct InfoState {
-    client: GuardianServiceClient<Channel>,
-    cache: Arc<Mutex<Option<(Instant, GuardianInfoView)>>>,
+    source: Arc<dyn InfoSource>,
+    cache: Arc<InfoCache>,
     ttl: Duration,
 }
 
 impl InfoState {
     pub fn new(client: GuardianServiceClient<Channel>, ttl: Duration) -> Self {
+        Self::with_source(Arc::new(GrpcInfoSource { client }), ttl)
+    }
+
+    fn with_source(source: Arc<dyn InfoSource>, ttl: Duration) -> Self {
         Self {
-            client,
-            cache: Arc::new(Mutex::new(None)),
+            source,
+            cache: Arc::new(InfoCache {
+                slot: Mutex::new(None),
+                refresh: tokio::sync::Mutex::new(()),
+            }),
             ttl,
         }
     }
 
-    fn cached(&self) -> Option<GuardianInfoView> {
-        let guard = self.cache.lock().expect("info cache mutex poisoned");
-        guard
-            .as_ref()
+    /// Serve `/info`: a fresh cached view, otherwise one single-flighted
+    /// refresh whose result (or, if the enclave is down, the last good view) is
+    /// shared with every concurrent caller.
+    async fn serve(&self) -> Response {
+        if let Some(view) = self.fresh() {
+            return Json(view).into_response();
+        }
+
+        // Elect a single refresher. Concurrent callers serve the last good view
+        // rather than pile onto the enclave; on a cold cache (nothing to serve)
+        // they instead wait for that one refresh.
+        let refreshed = match self.cache.refresh.try_lock() {
+            Ok(_leader) => self.refresh_locked().await,
+            Err(_) => match self.last_good() {
+                Some(view) => return Json(view).into_response(),
+                None => {
+                    let _leader = self.cache.refresh.lock().await;
+                    self.refresh_locked().await
+                }
+            },
+        };
+
+        match refreshed {
+            Ok(view) => Json(view).into_response(),
+            // Enclave unreachable: the last good view (its age is visible via
+            // `signedAtMs`) beats a hard error for an advisory route.
+            Err(err) => self
+                .last_good()
+                .map(|view| Json(view).into_response())
+                .unwrap_or_else(|| err.into_response()),
+        }
+    }
+
+    /// Refresh from the backend. Call with `refresh` held; re-checks the cache
+    /// first so callers that queued behind the leader reuse its fetch.
+    async fn refresh_locked(&self) -> Result<GuardianInfoView, InfoError> {
+        if let Some(view) = self.fresh() {
+            return Ok(view);
+        }
+        let view = self.source.fetch().await?;
+        self.store(view.clone());
+        Ok(view)
+    }
+
+    /// The cached view if it is still within its TTL.
+    fn fresh(&self) -> Option<GuardianInfoView> {
+        let slot = self.cache.slot.lock().expect("info cache mutex poisoned");
+        slot.as_ref()
             .filter(|(at, _)| at.elapsed() < self.ttl)
             .map(|(_, view)| view.clone())
     }
 
+    /// The last successfully fetched view regardless of age.
+    fn last_good(&self) -> Option<GuardianInfoView> {
+        self.cache
+            .slot
+            .lock()
+            .expect("info cache mutex poisoned")
+            .as_ref()
+            .map(|(_, view)| view.clone())
+    }
+
     fn store(&self, view: GuardianInfoView) {
-        *self.cache.lock().expect("info cache mutex poisoned") = Some((Instant::now(), view));
+        *self.cache.slot.lock().expect("info cache mutex poisoned") = Some((Instant::now(), view));
     }
 }
 
@@ -122,37 +251,7 @@ async fn health() -> StatusCode {
 }
 
 async fn get_info(State(state): State<InfoState>) -> Response {
-    if let Some(view) = state.cached() {
-        return Json(view).into_response();
-    }
-
-    // Fetch outside the lock so the handler stays `Send`; a few racing misses
-    // each hitting the enclave on a cold cache is harmless.
-    let raw = match state
-        .client
-        .clone()
-        .get_guardian_info(proto::GetGuardianInfoRequest {})
-        .await
-    {
-        Ok(resp) => resp.into_inner(),
-        Err(status) => return unavailable("guardian_unreachable", &status.to_string()),
-    };
-
-    // Read the signing timestamp off the raw proto; the domain conversion drops it.
-    let signed_at_ms = raw.signed_info.as_ref().and_then(|s| s.timestamp_ms);
-    let verified = match GetGuardianInfoResponse::try_from(raw)
-        .and_then(|resp| resp.verify_signed_info_without_attestation())
-    {
-        Ok(verified) => verified,
-        Err(e) => {
-            error!(error = ?e, "GetGuardianInfo could not be decoded/verified for /info");
-            return unavailable("guardian_info_invalid", &format!("{e:?}"));
-        }
-    };
-
-    let view = project(&verified, signed_at_ms);
-    state.store(view.clone());
-    Json(view).into_response()
+    state.serve().await
 }
 
 fn unavailable(error: &str, detail: &str) -> Response {
@@ -198,6 +297,9 @@ fn limiter_view(state: Option<LimiterState>, config: Option<LimiterConfig>) -> O
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
     fn limiter_state() -> LimiterState {
         LimiterState {
@@ -279,5 +381,153 @@ mod tests {
                 "signedAtMs": null,
             })
         );
+    }
+
+    fn sample_view() -> GuardianInfoView {
+        GuardianInfoView {
+            limiter: limiter_view(Some(limiter_state()), Some(limiter_config())),
+            git_revision: "abc123".to_string(),
+            committee_epoch: Some("7".to_string()),
+            btc_pubkey: Some("deadbeef".to_string()),
+            signing_pub_key: "feedface".to_string(),
+            signed_at_ms: Some("1720000000123".to_string()),
+        }
+    }
+
+    /// Test source: counts calls, can be flipped `down`, and can delay each
+    /// fetch to widen the window a concurrent burst races in.
+    #[derive(Clone)]
+    struct FakeSource {
+        view: GuardianInfoView,
+        calls: Arc<AtomicUsize>,
+        down: Arc<AtomicBool>,
+        delay: Duration,
+    }
+
+    impl FakeSource {
+        fn new(delay: Duration) -> Self {
+            Self {
+                view: sample_view(),
+                calls: Arc::new(AtomicUsize::new(0)),
+                down: Arc::new(AtomicBool::new(false)),
+                delay,
+            }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl InfoSource for FakeSource {
+        async fn fetch(&self) -> Result<GuardianInfoView, InfoError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
+            if self.down.load(Ordering::SeqCst) {
+                Err(InfoError::Unreachable("fake guardian down".to_string()))
+            } else {
+                Ok(self.view.clone())
+            }
+        }
+    }
+
+    fn state_with(fake: &FakeSource, ttl: Duration) -> InfoState {
+        InfoState::with_source(Arc::new(fake.clone()), ttl)
+    }
+
+    async fn body_json(resp: Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn concurrent_misses_collapse_to_a_single_fetch() {
+        // Six cold-cache hits arrive while the one leader is still fetching; the
+        // rest must reuse its result, not each call the enclave.
+        let fake = FakeSource::new(Duration::from_millis(200));
+        let state = state_with(&fake, Duration::from_secs(10));
+
+        let responses = tokio::join!(
+            state.serve(),
+            state.serve(),
+            state.serve(),
+            state.serve(),
+            state.serve(),
+            state.serve(),
+        );
+        for resp in [
+            responses.0,
+            responses.1,
+            responses.2,
+            responses.3,
+            responses.4,
+            responses.5,
+        ] {
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+        assert_eq!(
+            fake.calls.load(Ordering::SeqCst),
+            1,
+            "a burst must collapse to one GetGuardianInfo"
+        );
+    }
+
+    #[tokio::test]
+    async fn caches_within_ttl_then_refetches_after_expiry() {
+        let fake = FakeSource::new(Duration::ZERO);
+        let state = state_with(&fake, Duration::from_millis(60));
+
+        state.serve().await;
+        state.serve().await;
+        assert_eq!(
+            fake.calls.load(Ordering::SeqCst),
+            1,
+            "a second hit within the TTL serves from cache"
+        );
+
+        tokio::time::sleep(Duration::from_millis(90)).await;
+        state.serve().await;
+        assert_eq!(
+            fake.calls.load(Ordering::SeqCst),
+            2,
+            "a hit past the TTL refetches"
+        );
+    }
+
+    #[tokio::test]
+    async fn serves_stale_view_when_the_enclave_is_briefly_unreachable() {
+        let fake = FakeSource::new(Duration::ZERO);
+        let state = state_with(&fake, Duration::from_millis(60));
+
+        state.serve().await; // prime the cache while the backend is up
+        fake.down.store(true, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(90)).await; // let it go stale
+
+        let resp = state.serve().await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a stale-but-good view beats a hard error"
+        );
+        assert_eq!(
+            body_json(resp).await,
+            serde_json::to_value(sample_view()).unwrap()
+        );
+        assert_eq!(
+            fake.calls.load(Ordering::SeqCst),
+            2,
+            "it still attempted a refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_503_when_unreachable_and_the_cache_is_cold() {
+        let fake = FakeSource::new(Duration::ZERO);
+        fake.down.store(true, Ordering::SeqCst);
+        let state = state_with(&fake, Duration::from_secs(1));
+
+        let resp = state.serve().await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/crates/hashi-guardian-proxy/src/lib.rs
+++ b/crates/hashi-guardian-proxy/src/lib.rs
@@ -12,6 +12,9 @@
 //! - [`relay`] serves `GuardianRelayService`: key provisioners submit one share
 //!   each and the relay batches a threshold-many into the guardian's
 //!   `ProvisionerInit`.
+//! - [`info`] serves a read-only HTTP `/info` + `/health` JSON surface (a
+//!   curated limiter/identity view, with CORS) so browser / `fetch` clients can
+//!   read limiter status that the gRPC surface only exposes to nodes.
 //!
 //! The proxy is liveness-only in the trust model: it can stall but never forge a
 //! withdrawal or read a KP share (shares are end-to-end encrypted to the enclave).
@@ -19,6 +22,7 @@
 pub mod cache;
 pub mod config;
 pub mod forward;
+pub mod info;
 pub mod metrics;
 pub mod relay;
 pub mod widlog;

--- a/crates/hashi-guardian-proxy/src/lib.rs
+++ b/crates/hashi-guardian-proxy/src/lib.rs
@@ -14,7 +14,8 @@
 //!   `ProvisionerInit`.
 //! - [`info`] serves a read-only HTTP `/info` + `/health` JSON surface (a
 //!   curated limiter/identity view, with CORS) so browser / `fetch` clients can
-//!   read limiter status that the gRPC surface only exposes to nodes.
+//!   read limiter status the gRPC surface only exposes to nodes — on the same
+//!   port as gRPC, so the guardian exposes one interface.
 //!
 //! The proxy is liveness-only in the trust model: it can stall but never forge a
 //! withdrawal or read a KP share (shares are end-to-end encrypted to the enclave).

--- a/crates/hashi-guardian-proxy/src/main.rs
+++ b/crates/hashi-guardian-proxy/src/main.rs
@@ -1,14 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Context;
 use anyhow::Result;
 use hashi_guardian_proxy::cache::CachingGuardianGrpc;
 use hashi_guardian_proxy::config::Config;
 use hashi_guardian_proxy::forward::Forwarding;
+use hashi_guardian_proxy::info;
 use hashi_guardian_proxy::metrics::ProxyMetrics;
 use hashi_guardian_proxy::relay::Relay;
 use hashi_guardian_proxy::widlog::S3LogStore;
 use hashi_types::proto::guardian_relay_service_server::GuardianRelayServiceServer;
+use hashi_types::proto::guardian_service_client::GuardianServiceClient;
 use hashi_types::proto::guardian_service_server::GuardianServiceServer;
 use std::sync::Arc;
 use std::time::Duration;
@@ -60,8 +63,9 @@ async fn main() -> Result<()> {
         }
     });
 
-    // Lazy channel to the enclave guardian, shared by forwarder and relay. Mirrors
-    // the node-side client (crates/hashi/src/grpc/guardian_client.rs): same timeout + keepalive.
+    // Lazy channel to the enclave guardian, shared by forwarder, relay, and the
+    // /info reader. Mirrors the node-side client
+    // (crates/hashi/src/grpc/guardian_client.rs): same timeout + keepalive.
     let channel = Endpoint::from_shared(config.backend_url.clone())?
         .connect_timeout(config.connect_timeout)
         .http2_keep_alive_interval(config.keepalive_interval)
@@ -72,6 +76,10 @@ async fn main() -> Result<()> {
         log_store,
         config.btc_network,
         metrics.clone(),
+    );
+    let info_state = info::InfoState::new(
+        GuardianServiceClient::new(channel.clone()),
+        config.info_cache_ttl,
     );
     let relay_svc = Relay::new(channel, config.authorized_kp_fingerprints);
 
@@ -91,13 +99,25 @@ async fn main() -> Result<()> {
         .await;
 
     info!("gRPC proxy listening on {}.", config.listen_addr);
-    Server::builder()
+    let grpc_server = Server::builder()
         .add_service(health_service)
         .add_service(GuardianServiceServer::new(guardian_svc))
         .add_service(GuardianRelayServiceServer::new(relay_svc))
-        .serve(config.listen_addr)
+        .serve(config.listen_addr);
+
+    let http_listener = tokio::net::TcpListener::bind(config.http_listen_addr)
         .await
-        .map_err(|e| anyhow::anyhow!("Server error: {}", e))
+        .with_context(|| format!("bind HTTP info server to {}", config.http_listen_addr))?;
+    info!("HTTP info server listening on {}.", config.http_listen_addr);
+    let http_server = axum::serve(http_listener, info::router(info_state));
+
+    // If either server's accept loop dies, return so the supervisor restarts a
+    // clean task rather than leaving one surface silently dead.
+    tokio::select! {
+        r = grpc_server => r.map_err(|e| anyhow::anyhow!("gRPC server error: {e}"))?,
+        r = http_server => r.map_err(|e| anyhow::anyhow!("HTTP info server error: {e}"))?,
+    }
+    Ok(())
 }
 
 /// Retry transient S3 blips at boot (no target-group crash-loop), but fail

--- a/crates/hashi-guardian-proxy/src/main.rs
+++ b/crates/hashi-guardian-proxy/src/main.rs
@@ -16,7 +16,6 @@ use hashi_types::proto::guardian_service_server::GuardianServiceServer;
 use std::sync::Arc;
 use std::time::Duration;
 use tonic::transport::Endpoint;
-use tonic::transport::Server;
 use tonic_health::server::health_reporter;
 use tracing::error;
 use tracing::info;
@@ -83,8 +82,8 @@ async fn main() -> Result<()> {
     );
     let relay_svc = Relay::new(channel, config.authorized_kp_fingerprints);
 
-    // gRPC health service, mirroring the guardian — the ALB target group
-    // health-checks `grpc.health.v1.Health/Check`.
+    // Standard gRPC health service (`grpc.health.v1.Health`) for gRPC
+    // health-checkers; the HTTP `/health` route below covers plain-HTTP liveness.
     let (health_reporter, health_service) = health_reporter();
     health_reporter
         .set_serving::<GuardianServiceServer<CachingGuardianGrpc<Forwarding, S3LogStore>>>()
@@ -92,32 +91,69 @@ async fn main() -> Result<()> {
     health_reporter
         .set_serving::<GuardianRelayServiceServer<Relay>>()
         .await;
-    // An ALB gRPC health check queries the empty ("") service, so mark it
-    // serving too — otherwise the target group flaps the proxy as unhealthy.
+    // A gRPC health check may query the empty ("") service, so mark it serving
+    // too — otherwise such a check flaps the proxy as unhealthy.
     health_reporter
         .set_service_status("", tonic_health::ServingStatus::Serving)
         .await;
 
-    info!("gRPC proxy listening on {}.", config.listen_addr);
-    let grpc_server = Server::builder()
-        .add_service(health_service)
-        .add_service(GuardianServiceServer::new(guardian_svc))
-        .add_service(GuardianRelayServiceServer::new(relay_svc))
-        .serve(config.listen_addr);
+    // Serve gRPC (forwarder + relay + health) and the HTTP `/info` + `/health` on
+    // ONE port: each tonic service is mounted as an axum route-service, the plain
+    // routes merged in, one `axum::serve`. Mirrors crates/hashi/src/grpc/mod.rs.
+    let router = axum::Router::new()
+        .add_grpc_service(health_service)
+        .add_grpc_service(GuardianServiceServer::new(guardian_svc))
+        .add_grpc_service(GuardianRelayServiceServer::new(relay_svc))
+        .merge(info::router(info_state));
 
-    let http_listener = tokio::net::TcpListener::bind(config.http_listen_addr)
+    let listener = tokio::net::TcpListener::bind(config.listen_addr)
         .await
-        .with_context(|| format!("bind HTTP info server to {}", config.http_listen_addr))?;
-    info!("HTTP info server listening on {}.", config.http_listen_addr);
-    let http_server = axum::serve(http_listener, info::router(info_state));
-
-    // If either server's accept loop dies, return so the supervisor restarts a
-    // clean task rather than leaving one surface silently dead.
-    tokio::select! {
-        r = grpc_server => r.map_err(|e| anyhow::anyhow!("gRPC server error: {e}"))?,
-        r = http_server => r.map_err(|e| anyhow::anyhow!("HTTP info server error: {e}"))?,
-    }
+        .with_context(|| format!("bind proxy server to {}", config.listen_addr))?;
+    info!(
+        "Proxy listening on {} (gRPC + HTTP /info + /health).",
+        config.listen_addr
+    );
+    // If the accept loop dies, return so the supervisor restarts a clean task
+    // rather than leaving the surface silently dead.
+    axum::serve(listener, router)
+        .await
+        .map_err(|e| anyhow::anyhow!("proxy server error: {e}"))?;
     Ok(())
+}
+
+/// Mount a tonic gRPC service as an axum route-service at `/{ServiceName}/*`, so
+/// gRPC and plain-HTTP routes share one router. Mirrors `crates/hashi/src/grpc/mod.rs`.
+trait RouterExt {
+    fn add_grpc_service<S>(self, svc: S) -> Self
+    where
+        S: tower::Service<
+                axum::extract::Request,
+                Response: axum::response::IntoResponse,
+                Error = std::convert::Infallible,
+            > + tonic::server::NamedService
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Future: Send + 'static;
+}
+
+impl RouterExt for axum::Router {
+    fn add_grpc_service<S>(self, svc: S) -> Self
+    where
+        S: tower::Service<
+                axum::extract::Request,
+                Response: axum::response::IntoResponse,
+                Error = std::convert::Infallible,
+            > + tonic::server::NamedService
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        S::Future: Send + 'static,
+    {
+        self.route_service(&format!("/{}/{{*rest}}", S::NAME), svc)
+    }
 }
 
 /// Retry transient S3 blips at boot (no target-group crash-loop), but fail

--- a/crates/hashi-guardian-proxy/tests/single_port.rs
+++ b/crates/hashi-guardian-proxy/tests/single_port.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The proxy serves native gRPC and the plain-HTTP `/info` + `/health` on ONE
+//! port. This guards the crux of that merge: one `axum::serve` must dispatch
+//! both h2c gRPC and HTTP/1.1 on the same socket.
+
+use axum::routing::get;
+use axum::Router;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use tonic::transport::Channel;
+use tonic_health::pb::health_check_response::ServingStatus;
+use tonic_health::pb::health_client::HealthClient;
+use tonic_health::pb::HealthCheckRequest;
+
+#[tokio::test]
+async fn grpc_and_http_share_one_port() {
+    // Same shape as `main`: a tonic gRPC service mounted as an axum
+    // route-service, merged with a plain-HTTP GET route, under one router.
+    let (reporter, health_service) = tonic_health::server::health_reporter();
+    reporter
+        .set_service_status("", tonic_health::ServingStatus::Serving)
+        .await;
+    let router = Router::new()
+        .route_service("/grpc.health.v1.Health/{*rest}", health_service)
+        .merge(Router::new().route("/health", get(|| async { axum::http::StatusCode::OK })));
+
+    // Bind first (the socket is listening before `serve` accepts), so a client
+    // can connect with no startup race.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+
+    // (1) Native gRPC over h2c on the port: the health check returns SERVING.
+    let channel = Channel::from_shared(format!("http://{addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let status = HealthClient::new(channel)
+        .check(HealthCheckRequest {
+            service: String::new(),
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .status();
+    assert_eq!(status, ServingStatus::Serving);
+
+    // (2) Plain HTTP/1.1 GET on the SAME port: `/health` returns 200.
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await
+        .unwrap();
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).await.unwrap();
+    assert!(
+        resp.starts_with("HTTP/1.1 200"),
+        "expected HTTP 200 on the shared port, got: {resp}"
+    );
+}


### PR DESCRIPTION
## Changes

- gRPC + `/info` + `/health` now share one `axum::serve` on `:3000` (each tonic service mounted as an axum route-service). Dropped `HTTP_LISTEN_ADDR` / `:3001`.
- Added a `single_port` test proving native gRPC and plain HTTP coexist on the one socket.
- `/info` JSON contract unchanged; Prometheus `/metrics` stays on its own internal port.

## Companion PRs

- MystenLabs/sui-operations#8350
- MystenLabs/hashi-ts-sdk#38
