### PR TITLE
[guardian] Version KP share state logs

### DIFF
--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -35,7 +35,7 @@ The production guardian key ceremony — genesis setup, run once by the operator
 
 One S3 bucket is involved: the guardian's **log bucket** (object-lock enabled).
 The guardian writes its `init/` attestation, `ceremony/` audit log, and
-`shares/` encrypted-share recovery log here. The operator and key provisioner
+`kp-shares/` encrypted-share recovery log here. The operator and key provisioner
 ceremony commands both read it.
 
 Drives a fresh **ceremony-mode** guardian through the one-time genesis BTC key
@@ -43,7 +43,7 @@ setup (`sharing_seq = 0`). It connects over gRPC and: `operator_init` (ceremony 
 `setup_new_key` → verifies the response signature and shape → confirms each
 encrypted share is addressed only to its labeled KP cert (PKESK recipients,
 parsed without decrypting) → cross-checks the guardian's `ceremony/` audit log
-and `shares/` recovery log.
+and `kp-shares/` recovery log.
 
 Each share is labeled with its recipient cert's `recipient_fingerprint`, so a KP
 finds their share by fingerprint (not positional index).
@@ -61,7 +61,7 @@ Confirms a KP can fetch and decrypt their share from the latest setup or
 rotation ceremony. Trust is anchored to the guardian's S3 attestation log (no
 gRPC to the live guardian): it discovers the latest ceremony session from S3,
 loads that session's attested signing pubkey, verifies its `ceremony/` audit log
-and `shares/` recovery log against the expected `n`/`t`, confirms every
+and `kp-shares/` recovery log against the expected `n`/`t`, confirms every
 encrypted share is addressed only to its labeled KP cert, finds the share labeled
 for this KP's cert fingerprint, decrypts via the yubikey (`gpg --decrypt`), and
 verifies the decrypted share against its commitment.
@@ -134,8 +134,8 @@ is held in this process' memory long enough to verify and re-encrypt it. It:
 4. Recomputes the stable `InitConfig` from limiter config, on-chain MPC master
    `G`, PCR allowlist, and network, then confirms its `config_hash` matches the
    enclave.
-5. Reads this KP's encrypted share from `shares/{seq}-{session}.json` (the
-   ceremony's recovery log), verifies every share's recipients against the
+5. Reads this KP's encrypted share from the latest `kp-shares/{seq}/` state,
+   verifies every share's recipients against the
    roster, finds the one labeled for this KP's cert fingerprint, decrypts it via
    the yubikey (`gpg --decrypt` over a pipe; the plaintext stays in memory and
    never touches disk), and verifies the decrypted share against its commitment.

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -20,7 +20,7 @@ use crate::kp_roster::ensure_cert_in_roster;
 ///
 /// Trust is anchored entirely to the guardian's S3 attestation log: the
 /// `GuardianReader` resolves the session's attested signing pubkey through the
-/// reader cache, and both the `ceremony/` audit entry and `shares/` recovery
+/// reader cache, and both the `ceremony/` audit entry and `kp-shares/` recovery
 /// entry are verified under it. Each step is logged.
 ///
 /// Security: the ciphertext is piped into `gpg --decrypt` over stdin and the
@@ -54,7 +54,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         "KP cert roster loaded"
     );
 
-    // Load this KP's cert. Its fingerprint finds our share in `shares/`, and
+    // Load this KP's cert. Its fingerprint finds our share in `kp-shares/`, and
     // the cert itself lets us confirm the ciphertext is genuinely encrypted to
     // us before we touch the yubikey.
     let kp_pgp_cert_path = cfg.require_kp_pgp_cert_path("key-provisioner ceremony")?;
@@ -87,7 +87,7 @@ pub async fn run(cfg: Config) -> Result<()> {
 
     info!(
         phase = "ceremony scrape",
-        "scraping latest ceremony/ + shares/ logs (attestation-anchored)",
+        "scraping latest ceremony/ + kp-shares/ logs (attestation-anchored)",
     );
     let state = VerifiedCeremonyState::latest_from_s3(
         &mut reader,
@@ -97,8 +97,10 @@ pub async fn run(cfg: Config) -> Result<()> {
     .await?;
     info!(
         phase = "ceremony scrape",
-        session_id = %state.session_id,
+        ceremony_session_id = %state.ceremony_session_id,
+        kp_share_session_id = %state.kp_share_session_id,
         sharing_seq = state.secret_sharing_instance.sharing_seq(),
+        cert_seq = state.kp_share_cert_seq,
         n = state.secret_sharing_instance.num_shares(),
         t = state.secret_sharing_instance.threshold(),
         share_count = state.encrypted_shares.len(),
@@ -114,7 +116,7 @@ pub async fn run(cfg: Config) -> Result<()> {
     state.verify_encrypted_share_recipients(&certs)?;
     info!(
         phase = "roster verify",
-        "ceremony/ and shares/ logs verified against expected params and KP certs",
+        "ceremony/ and kp-shares/ logs verified against expected params and KP certs",
     );
 
     // 3. Find this KP's share by exact fingerprint match (both sides derive
@@ -127,7 +129,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         .find(|s| s.recipient_fingerprint == want_fp_hex)
         .ok_or_else(|| {
             anyhow!(
-                "no share in the shares/ log is labeled for this KP's fingerprint \
+                "no share in the kp-shares log is labeled for this KP's fingerprint \
                  {want_fp} (labeled fingerprints: {:?})",
                 state
                     .encrypted_shares
@@ -190,9 +192,11 @@ pub async fn run(cfg: Config) -> Result<()> {
 
     info!(
         phase = "summary",
-        session_id = %state.session_id,
+        ceremony_session_id = %state.ceremony_session_id,
+        kp_share_session_id = %state.kp_share_session_id,
         share_id = share_id.get(),
         sharing_seq = state.secret_sharing_instance.sharing_seq(),
+        cert_seq = state.kp_share_cert_seq,
         fingerprint = %want_fp,
         commitment = hex::encode(&expected_commitment.digest),
         "ceremony share verified",

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -17,9 +17,9 @@
 //!    instance the new guardian was booted with; it must match.
 //! 4. The stable `InitConfig` is recomputed from limiter config, master G, PCR
 //!    allowlist, and network; its `config_hash` is confirmed.
-//! 5. This KP's encrypted share is read from `shares/{seq}-{session}.json`
-//!    (attestation-anchored), every share's recipients are verified against
-//!    the roster, and this KP's share is located by fingerprint.
+//! 5. This KP's encrypted share is read from the latest `kp-shares/{seq}/`
+//!    state (attestation-anchored), every share's recipients are verified
+//!    against the roster, and this KP's share is located by fingerprint.
 //! 6. The share is decrypted via the yubikey (`gpg --decrypt` over a pipe;
 //!    plaintext stays in memory) and verified against its commitment.
 //! 7. The decrypted share is HPKE-encrypted to the new guardian's
@@ -252,7 +252,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         phase = "ceremony instance",
         "scraping authoritative ceremony/ log for the secret-sharing instance",
     );
-    let (ceremony_session, scraped_instance, roster, btc_master_pubkey) = reader
+    let (ceremony_session, scraped_instance, btc_master_pubkey) = reader
         .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
@@ -263,7 +263,6 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         sharing_seq,
         n = scraped_instance.num_shares(),
         t = scraped_instance.threshold(),
-        roster_len = roster.len(),
         "scraped latest ceremony entry",
     );
     anyhow::ensure!(
@@ -306,21 +305,22 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
 
     // 5. Read + verify this KP's encrypted share. The ceremony state is
     //    constructed directly from the S3 log reads above so we don't pay for a
-    //    second ceremony/ + shares/ walk.
+    //    second ceremony/ + kp-shares/ walk.
     info!(
         phase = "share read",
         ceremony_session = %ceremony_session,
         sharing_seq,
-        "reading + verifying this KP's encrypted share from shares/",
+        "reading + verifying this KP's encrypted share from kp-shares/",
     );
-    let encrypted_shares = reader
-        .read_shares(&ceremony_session, sharing_seq, BuildPolicy::AnyAllowlisted)
-        .await?;
+    let (kp_share_session, kp_share_state) = reader
+        .read_latest_kp_share_state(sharing_seq, BuildPolicy::AnyAllowlisted)
+        .await?
+        .context("no kp-shares log found in S3; key setup has not run")?;
     let state = VerifiedCeremonyState::from_scraped(
         ceremony_session.clone(),
+        kp_share_session.clone(),
         scraped_instance.clone(),
-        encrypted_shares,
-        &roster,
+        kp_share_state,
         btc_master_pubkey,
         cfg.kp_roster.num_shares,
         cfg.kp_roster.threshold,
@@ -328,10 +328,11 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     state.verify_encrypted_share_recipients(&certs)?;
     info!(
         phase = "share read",
+        kp_share_session = %kp_share_session,
+        cert_seq = state.kp_share_cert_seq,
         share_count = state.encrypted_shares.len(),
-        roster_matches = true,
         all_recipients_verified = true,
-        "shares/ log verified: every share is addressed only to its labeled KP cert",
+        "kp-shares log verified: every share is addressed only to its labeled KP cert",
     );
 
     // Find this KP's share by exact fingerprint match. Given the roster checks
@@ -343,7 +344,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         .find(|s| s.recipient_fingerprint == want_fp_hex)
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "no share in the shares/ log is labeled for this KP's fingerprint \
+                "no share in the kp-shares log is labeled for this KP's fingerprint \
                  {want_fp} (labeled fingerprints: {:?})",
                 state
                     .encrypted_shares

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -8,7 +8,7 @@
 //! - load a roster of KP OpenPGP certs
 //! - discover the latest attested ceremony from S3
 //! - validate the ceremony's `secret_sharing_instance` against expected params
-//! - confirm every encrypted share in `shares/` is addressed only to its
+//! - confirm every encrypted share in `kp-shares/` is addressed only to its
 //!   labeled cert (without decrypting)
 //!
 //! `provision` additionally decrypts one share via the yubikey and re-encrypts
@@ -27,6 +27,7 @@ use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::guardian::KPEncryptedShare;
 use hashi_types::guardian::KPEncryptedShares;
 use hashi_types::guardian::KPFingerprint;
+use hashi_types::guardian::KpShareState;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::SecretSharingParams;
@@ -85,10 +86,12 @@ impl KpRosterConfig {
 
 /// Validated ceremony state. May come from the live `SetupNewKeyResponse`
 /// (`operator ceremony`) or be reconstructed from the guardian's `ceremony/` +
-/// `shares/` logs (`key-provisioner ceremony`, `key-provisioner provision`).
+/// `kp-shares/` logs (`key-provisioner ceremony`, `key-provisioner provision`).
 #[derive(Debug, PartialEq)]
 pub struct VerifiedCeremonyState {
-    pub session_id: String,
+    pub ceremony_session_id: String,
+    pub kp_share_session_id: String,
+    pub kp_share_cert_seq: u64,
     pub encrypted_shares: KPEncryptedShares,
     pub secret_sharing_instance: SecretSharingInstance,
     pub btc_master_pubkey: BitcoinPubkey,
@@ -103,7 +106,9 @@ impl VerifiedCeremonyState {
         expected_t: usize,
     ) -> Result<Self> {
         let state = Self {
-            session_id,
+            ceremony_session_id: session_id.clone(),
+            kp_share_session_id: session_id,
+            kp_share_cert_seq: 0,
             encrypted_shares: response.encrypted_shares,
             secret_sharing_instance: response.secret_sharing_instance,
             btc_master_pubkey: response.btc_master_pubkey,
@@ -126,18 +131,24 @@ impl VerifiedCeremonyState {
         // historical ceremony with `BuildPolicy::AnyAllowlisted` to learn N.
         // Keep this helper current-build-only for target verification, and add
         // a separate discovery path there.
-        let (session_id, instance, roster, btc_master_pubkey) = reader
+        let (ceremony_session_id, instance, btc_master_pubkey) = reader
             .read_latest_ceremony(BuildPolicy::Current)
             .await?
             .ok_or_else(|| anyhow!("no ceremony logs found in guardian S3 bucket"))?;
-        let encrypted_shares = reader
-            .read_shares(&session_id, instance.sharing_seq(), BuildPolicy::Current)
-            .await?;
+        let (kp_share_session_id, kp_share_state) = reader
+            .read_latest_kp_share_state(instance.sharing_seq(), BuildPolicy::Current)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "no kp-shares log found for sharing_seq {}",
+                    instance.sharing_seq()
+                )
+            })?;
         Self::from_scraped(
-            session_id,
+            ceremony_session_id,
+            kp_share_session_id,
             instance,
-            encrypted_shares,
-            &roster,
+            kp_share_state,
             btc_master_pubkey,
             expected_n,
             expected_t,
@@ -145,25 +156,32 @@ impl VerifiedCeremonyState {
     }
 
     /// Assemble + validate from parts already scraped from S3 (the ceremony
-    /// log and the shares log). Use instead of [`Self::latest_from_s3`] when the
+    /// log and the kp-shares log). Use instead of [`Self::latest_from_s3`] when the
     /// caller has already read those objects and wants to avoid a second walk.
     pub fn from_scraped(
-        session_id: String,
+        ceremony_session_id: String,
+        kp_share_session_id: String,
         secret_sharing_instance: SecretSharingInstance,
-        encrypted_shares: KPEncryptedShares,
-        roster: &[KPFingerprint],
+        kp_share_state: KpShareState,
         btc_master_pubkey: BitcoinPubkey,
         expected_n: usize,
         expected_t: usize,
     ) -> Result<Self> {
+        anyhow::ensure!(
+            kp_share_state.sharing_seq == secret_sharing_instance.sharing_seq(),
+            "kp-shares sharing_seq ({}) differs from ceremony sharing_seq ({})",
+            kp_share_state.sharing_seq,
+            secret_sharing_instance.sharing_seq()
+        );
         let state = Self {
-            session_id,
-            encrypted_shares,
+            ceremony_session_id,
+            kp_share_session_id,
+            kp_share_cert_seq: kp_share_state.cert_seq,
+            encrypted_shares: kp_share_state.encrypted_shares,
             secret_sharing_instance,
             btc_master_pubkey,
         };
         state.validate_shape(expected_n, expected_t)?;
-        state.ensure_roster_matches(roster)?;
         Ok(state)
     }
 
@@ -184,19 +202,6 @@ impl VerifiedCeremonyState {
             self.encrypted_shares.len() == expected_n,
             "expected {expected_n} encrypted shares, got {}",
             self.encrypted_shares.len()
-        );
-        Ok(())
-    }
-
-    /// Confirm the agreed `ceremony/` roster matches the recipient fingerprints
-    /// on the `shares/` ciphertexts. The roster is ordered by share id, so this
-    /// check preserves the ceremony log's share-id-to-KP binding.
-    pub fn ensure_roster_matches(&self, roster: &[KPFingerprint]) -> Result<()> {
-        let got = self.encrypted_shares.recipient_roster();
-        anyhow::ensure!(
-            roster == got.as_slice(),
-            "ceremony/ roster differs from shares/ recipient fingerprints: expected \
-             {roster:?}, got {got:?}"
         );
         Ok(())
     }
@@ -268,7 +273,7 @@ impl VerifiedCeremonyState {
             );
         }
         info!(
-            "all {} shares encrypted to their labeled certs",
+            "all {} KP share-state entries encrypted to their labeled certs",
             self.encrypted_shares.len()
         );
         Ok(())
@@ -489,38 +494,19 @@ mod tests {
     }
 
     #[test]
-    fn verified_ceremony_state_matches_roster() {
-        // Shares arrive in arbitrary id order (`[3, 1, 2]`), but
-        // KPEncryptedShares normalizes them by share id. The ceremony roster is
-        // ordered by share id too, so a permutation must fail.
+    fn verified_ceremony_state_rejects_mismatched_kp_share_state_seq() {
         let resp = response(&[3, 1, 2], &[1, 2, 3]);
-        let state = VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2)
-            .expect("valid state");
-        let canonical = vec![
-            "DUMMY FINGERPRINT 1".to_string(),
-            "DUMMY FINGERPRINT 2".to_string(),
-            "DUMMY FINGERPRINT 3".to_string(),
-        ];
-        let reordered = vec![
-            "DUMMY FINGERPRINT 3".to_string(),
-            "DUMMY FINGERPRINT 1".to_string(),
-            "DUMMY FINGERPRINT 2".to_string(),
-        ];
-
-        state
-            .ensure_roster_matches(&canonical)
-            .expect("canonical roster matches");
-        let err = state.ensure_roster_matches(&reordered).unwrap_err();
-        assert!(format!("{err}").contains("roster differs"), "{err}");
-
-        // A genuinely different fingerprint set must still fail.
-        let different = vec![
-            "DUMMY FINGERPRINT 1".to_string(),
-            "DUMMY FINGERPRINT 2".to_string(),
-            "DUMMY FINGERPRINT 9".to_string(),
-        ];
-        let err = state.ensure_roster_matches(&different).unwrap_err();
-        assert!(format!("{err}").contains("roster differs"), "{err}");
+        let err = VerifiedCeremonyState::from_scraped(
+            "ceremony-session".into(),
+            "kp-share-session".into(),
+            resp.secret_sharing_instance,
+            KpShareState::new(1, 0, resp.encrypted_shares),
+            resp.btc_master_pubkey,
+            3,
+            2,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("kp-shares sharing_seq"), "{err}");
     }
 
     #[test]

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -132,7 +132,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         phase = "ceremony instance",
         "reading latest ceremony log for the activation instance",
     );
-    let (ceremony_session, latest_instance, _, _) = reader
+    let (ceremony_session, latest_instance, _) = reader
         .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -7,7 +7,7 @@
 //! [`OperatorInit`] (ceremony mode, S3-only) -> [`SetupNewKey`] -> inspect each
 //! returned encrypted share to confirm it is addressed to the expected KP cert
 //! (without decrypting) -> cross-check the guardian's `ceremony/` audit log and
-//! `shares/` recovery log.
+//! `kp-shares/` recovery log.
 //!
 //! [`OperatorInit`]: hashi_types::guardian::OperatorInitRequest
 //! [`SetupNewKey`]: hashi_types::guardian::SetupNewKeyRequest
@@ -20,10 +20,10 @@ use anyhow::ensure;
 use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::KpShareState;
 use hashi_types::guardian::OperatorInitRequest;
 use hashi_types::guardian::SetupNewKeyRequest;
 use hashi_types::guardian::SetupNewKeyResponse;
-use hashi_types::guardian::SharesLogMessage;
 use hashi_types::guardian::proto_conversions::operator_init_request_to_pb;
 use hashi_types::guardian::proto_conversions::setup_new_key_request_to_pb;
 use hashi_types::pgp::load_certs;
@@ -183,7 +183,8 @@ pub async fn run(cfg: Config) -> Result<()> {
     )?;
     info!(
         phase = "setup_new_key",
-        session_id = %live.session_id,
+        ceremony_session_id = %live.ceremony_session_id,
+        kp_share_session_id = %live.kp_share_session_id,
         sharing_seq = live.secret_sharing_instance.sharing_seq(),
         "verified SetupNewKeyResponse signature + shape",
     );
@@ -201,11 +202,11 @@ pub async fn run(cfg: Config) -> Result<()> {
         "all returned shares verified against expected KP certs",
     );
 
-    // 9. Cross-check the latest guardian ceremony/ and shares/ logs.
-    //    KPs will fetch the same shares/ object during key-provisioner ceremony.
+    // 9. Cross-check the latest guardian ceremony/ and kp-shares/ logs.
+    //    KPs will fetch the same KP share state during key-provisioner ceremony.
     info!(
         phase = "log cross-check",
-        "cross-checking the latest guardian ceremony/ and shares/ logs",
+        "cross-checking the latest guardian ceremony/ and kp-shares/ logs",
     );
     let logged = VerifiedCeremonyState::latest_from_s3(
         &mut reader,
@@ -215,21 +216,24 @@ pub async fn run(cfg: Config) -> Result<()> {
     .await?;
     anyhow::ensure!(
         logged == live,
-        "ceremony/ and shares/ logs differ from the SetupNewKeyResponse"
+        "ceremony/ and kp-shares/ logs differ from the SetupNewKeyResponse"
     );
     info!(
         phase = "log cross-check",
-        "ceremony/ and shares/ logs match the SetupNewKeyResponse",
+        "ceremony/ and kp-shares/ logs match the SetupNewKeyResponse",
     );
 
     // 10. Summary.
     info!(
         phase = "summary",
-        session_id = %live.session_id,
+        ceremony_session_id = %live.ceremony_session_id,
+        kp_share_session_id = %live.kp_share_session_id,
         sharing_seq = live.secret_sharing_instance.sharing_seq(),
-        shares_key = %SharesLogMessage::object_key(
-            &live.session_id,
-            live.secret_sharing_instance.sharing_seq()
+        cert_seq = live.kp_share_cert_seq,
+        kp_shares_key = %KpShareState::object_key(
+            &live.kp_share_session_id,
+            live.secret_sharing_instance.sharing_seq(),
+            live.kp_share_cert_seq
         ),
         n = live.secret_sharing_instance.num_shares(),
         t = live.secret_sharing_instance.threshold(),

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -138,19 +138,20 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         phase = "ceremony instance",
         "scraping authoritative ceremony/ log for the secret-sharing instance",
     );
-    let (ceremony_session, scraped_instance, roster, btc_master_pubkey) = reader
+    let (ceremony_session, scraped_instance, btc_master_pubkey) = reader
         .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     let sharing_seq = scraped_instance.sharing_seq();
-    let encrypted_shares = reader
-        .read_shares(&ceremony_session, sharing_seq, BuildPolicy::AnyAllowlisted)
-        .await?;
+    let (kp_share_session, kp_share_state) = reader
+        .read_latest_kp_share_state(sharing_seq, BuildPolicy::AnyAllowlisted)
+        .await?
+        .context("no kp-shares log found in S3; key setup has not run")?;
     let ceremony_state = VerifiedCeremonyState::from_scraped(
         ceremony_session.clone(),
+        kp_share_session.clone(),
         scraped_instance.clone(),
-        encrypted_shares,
-        &roster,
+        kp_share_state,
         btc_master_pubkey,
         cfg.kp_roster.num_shares,
         cfg.kp_roster.threshold,
@@ -159,11 +160,13 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     info!(
         phase = "ceremony instance",
         ceremony_session = %ceremony_session,
+        kp_share_session = %kp_share_session,
         sharing_seq,
+        cert_seq = ceremony_state.kp_share_cert_seq,
         n = scraped_instance.num_shares(),
         t = scraped_instance.threshold(),
         share_count = ceremony_state.encrypted_shares.len(),
-        "ceremony instance and encrypted shares verified against expected roster",
+        "ceremony instance and KP share state verified against expected roster",
     );
 
     let init_config = InitConfig::new(

--- a/crates/hashi-guardian/README.md
+++ b/crates/hashi-guardian/README.md
@@ -11,7 +11,7 @@ Canonical key layout:
 - `withdraw/{yyyy}/{mm}/{dd}/{hh}/success-{seq:020}-{session_id}-wid{wid}.json`
 - `withdraw/{yyyy}/{mm}/{dd}/{hh}/failure-{session_id}-wid{wid}-{rand8}.json`
 - `ceremony/{sharing_seq:020}-{session_id}.json`
-- `shares/{sharing_seq:020}-{session_id}.json`
+- `kp-shares/{sharing_seq:020}/{cert_seq:020}-{session_id}.json`
 - `genesis/record.json`
 - `committee-update/{new_epoch:020}-{session_id}.json`
 - `committee-update/failure-{proposed_epoch:020}-{session_id}-{rand8}.json`
@@ -23,6 +23,7 @@ Where:
 - `counter` is a zero-padded decimal sequence number (used in heartbeats only).
 - `seq` (in `withdraw/`) is the zero-padded limiter sequence number consumed by the withdrawal.
 - `sharing_seq` (in `ceremony/`) is a zero-padded rotation counter — `setup_new_key` writes `0`; each `rotate_kps` appends `prev+1`.
+- `cert_seq` (in `kp-shares/`) is a zero-padded recipient-cert state counter within one `sharing_seq`. Setup/rotation write `0`; future individual KP cert rotations append higher values.
 - `new_epoch` / `proposed_epoch` (in `committee-update/`) are the zero-padded committee epoch numbers — `new_epoch` is the just-applied epoch for successes; `proposed_epoch` is the requested epoch for failures. Hashi reconfig is sparse, so neither is guaranteed to be `from_epoch + 1`.
 - `rand8` is a random 8-hex suffix to avoid key collisions (failures only — successes are uniquely keyed by seq).
 
@@ -31,8 +32,8 @@ Where:
 - `init` logs are per-session and deterministic by semantic message kind.
 - `heartbeat` logs are hour-partitioned and strictly ordered per session.
 - `withdraw` logs are hour-partitioned. Successes are seq-sorted within a bucket so the KP rotating in the next enclave can recover limiter state by reading the lexicographically last success key.
-- `ceremony` logs are flat (not date-partitioned). Each entry is a `CeremonyLogMessage` — `NewKey { instance }` written by `setup_new_key` (genesis, `sharing_seq=0`) or `Rotate { old_instance, new_instance }` written by `rotate_kps` (each rotation, `sharing_seq=prev+1`). A rotation records the `old_instance` it consumed so the chain is auditable from the log alone (each entry's `old_instance` should match the prior entry's instance). KPs read the lexicographically last entry to learn the current authoritative instance (commitments + N + T). The log does not carry the encrypted shares (those live in `shares/`); it does commit the recipient roster (per-share fingerprints) so a KP can check the full recipient set against the immutable record.
-- `shares` logs are flat and carry the ceremony's encrypted shares (the ciphertexts `ceremony/` omits), keyed by the same `sharing_seq` so each pairs with its `ceremony/` instance. Written by `setup_new_key` (`sharing_seq=0`) and each `rotate_kps`. Persisted purely for recovery liveness — a KP who lost their share point-reads `shares/{sharing_seq:020}-{session_id}.json`, verifies its enclave signature, and checks the decrypted share against the instance's commitments. Integrity is the signature, not S3 immutability, so these get only a short object lock (a fetch-window guarantee) and stay readable until purged.
+- `ceremony` logs are flat (not date-partitioned). Each entry is a `CeremonyLogMessage` — `NewKey { instance }` written by `setup_new_key` (genesis, `sharing_seq=0`) or `Rotate { old_instance, new_instance }` written by `rotate_kps` (each rotation, `sharing_seq=prev+1`). A rotation records the `old_instance` it consumed so the chain is auditable from the log alone (each entry's `old_instance` should match the prior entry's instance). KPs read the lexicographically last entry to learn the current authoritative instance (commitments + N + T). The log does not carry encrypted shares or a separate recipient roster.
+- `kp-shares` logs carry the current encrypted KP share state for a `sharing_seq`. Written by `setup_new_key` (`sharing_seq=0, cert_seq=0`) and each `rotate_kps` (`cert_seq=0` for the new instance). Future cert rotations can append higher `cert_seq` entries under the same `sharing_seq`; readers take the lexicographically last entry under `kp-shares/{sharing_seq:020}/`. The recipient roster is derived from the share labels (`recipient_fingerprint` ordered by share id). Integrity is the enclave signature, not S3 immutability, so these get only a short object lock (a fetch-window guarantee) and stay readable until purged.
 - `genesis` is a fixed singleton record carrying the operator-trusted bootstrap committee before any `committee-update/` success exists.
 - `committee-update` logs are flat (not date-partitioned). Successes are epoch-sorted; failures lead with `failure-` so all successes sort first — the lex-last non-`failure-` key is the latest successfully-applied epoch.
 
@@ -40,6 +41,6 @@ Where:
 
 - `init/{session_id}-...` keeps init logs session-addressable.
 - `heartbeat/...` and `withdraw/...` date partitions support efficient hour-based polling.
-- `ceremony/` and `committee-update/` are flat because the consumer always wants "latest"; a lex sort over the whole prefix is cheap and gives that directly. `genesis/record.json` is fixed because there is at most one bootstrap committee.
-- Zero-padding (`{seq:020}` in `withdraw/`, `{sharing_seq:020}` in `ceremony/`, `{new_epoch:020}` in `committee-update/`) makes lexicographic order over the keys equal seq/epoch order. The signed log payload embeds the same value, so a fetched object's filename and content can be cross-checked.
-- Prefixes (`init`, `heartbeat`, `withdraw`, `ceremony`, `genesis`, `committee-update`) allow independent S3 deletion policies.
+- `ceremony/` and `committee-update/` are flat because the consumer always wants "latest"; a lex sort over the whole prefix is cheap and gives that directly. `kp-shares/` is nested by `sharing_seq` because readers want the latest cert state within one current sharing instance. `genesis/record.json` is fixed because there is at most one bootstrap committee.
+- Zero-padding (`{seq:020}` in `withdraw/`, `{sharing_seq:020}` in `ceremony/`, `{cert_seq:020}` in `kp-shares/`, `{new_epoch:020}` in `committee-update/`) makes lexicographic order over the keys equal seq/epoch order. The signed log payload embeds the same value, so a fetched object's filename and content can be cross-checked.
+- Prefixes (`init`, `heartbeat`, `withdraw`, `ceremony`, `kp-shares`, `genesis`, `committee-update`) allow independent S3 deletion policies.

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -85,16 +85,17 @@ async fn finalize_rotation(
 
     let new_sharing_seq = old_instance.sharing_seq() + 1;
     let new_instance = SecretSharingInstance::new(share_commitments, n, t, new_sharing_seq)?;
-    info!("Persisting rotation sharing_seq={new_sharing_seq} to shares/ + ceremony/.");
+    info!(
+        "Persisting rotation sharing_seq={new_sharing_seq} cert_seq=0 to kp-shares/ + ceremony/."
+    );
     enclave
-        .log_shares(new_sharing_seq, encrypted_shares.clone())
+        .log_kp_share_state(new_sharing_seq, 0, encrypted_shares.clone())
         .await?;
 
     enclave
         .log_ceremony(CeremonyLogMessage::Rotate {
             old_instance: old_instance.clone(),
             new_instance,
-            roster: encrypted_shares.recipient_roster(),
             btc_master_pubkey,
         })
         .await?;
@@ -222,7 +223,6 @@ mod tests {
         let CeremonyLogMessage::Rotate {
             old_instance,
             new_instance,
-            roster,
             btc_master_pubkey: _,
         } = *ceremony
         else {
@@ -235,25 +235,25 @@ mod tests {
         assert_eq!(new_instance.sharing_seq(), 1);
         assert_eq!(new_instance.num_shares(), new_n);
         assert_eq!(new_instance.threshold(), new_t);
-        // Roster commits one recipient fingerprint per new share.
-        assert_eq!(roster.len(), new_n);
 
-        // The new shares are persisted to shares/ keyed by the new sharing_seq.
+        // The new shares are persisted to kp-shares/ keyed by the new sharing_seq
+        // and initial cert_seq=0.
         let shares_logs: Vec<_> = captured
             .iter()
-            .filter(|(k, _)| k.starts_with("shares/"))
+            .filter(|(k, _)| k.starts_with("kp-shares/"))
             .collect();
-        assert_eq!(shares_logs.len(), 1, "expected one shares/ log");
+        assert_eq!(shares_logs.len(), 1, "expected one kp-shares/ log");
         let (shares_key, shares_body) = shares_logs[0];
         assert!(
-            shares_key.starts_with("shares/00000000000000000001-"),
-            "expected sharing_seq=1, got key {shares_key}"
+            shares_key.starts_with("kp-shares/00000000000000000001/00000000000000000000-"),
+            "expected sharing_seq=1 cert_seq=0, got key {shares_key}"
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let LogMessage::Shares(shares) = shares_record.message else {
-            panic!("expected Shares variant");
+        let LogMessage::KpShareState(shares) = shares_record.message else {
+            panic!("expected KpShareState variant");
         };
         assert_eq!(shares.sharing_seq, 1);
+        assert_eq!(shares.cert_seq, 0);
         assert_eq!(shares.encrypted_shares.len(), new_n);
     }
 

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -13,7 +13,7 @@ use tracing::info;
 /// Set up a new BTC key. Flow:
 ///     1. KPs send their OpenPGP certificates to the operator
 ///     2. Operator calls setup_new_key
-///     3. KPs fetch commitments/roster from `ceremony/` and ciphertexts from `shares/`
+///     3. KPs fetch commitments from `ceremony/` and ciphertexts from `kp-shares/`
 pub async fn setup_new_key(
     enclave: Arc<Enclave>,
     request: SetupNewKeyRequest,
@@ -59,13 +59,14 @@ pub async fn setup_new_key(
     let ss_instance = SecretSharingInstance::new(share_commitments.clone(), n, t, 0)
         .expect("(n, t) validated by SetupNewKeyRequest; commitments produced with matching count");
 
-    info!("Persisting setup sharing_seq=0 to shares/ + ceremony/.");
-    enclave.log_shares(0, encrypted_shares.clone()).await?;
+    info!("Persisting setup sharing_seq=0 cert_seq=0 to kp-shares/ + ceremony/.");
+    enclave
+        .log_kp_share_state(0, 0, encrypted_shares.clone())
+        .await?;
 
     enclave
         .log_ceremony(CeremonyLogMessage::NewKey {
             instance: ss_instance.clone(),
-            roster: encrypted_shares.recipient_roster(),
             btc_master_pubkey,
         })
         .await?;
@@ -149,7 +150,6 @@ mod tests {
         };
         let CeremonyLogMessage::NewKey {
             instance,
-            roster,
             btc_master_pubkey,
         } = *ceremony
         else {
@@ -158,28 +158,32 @@ mod tests {
         assert_eq!(instance.sharing_seq(), 0);
         assert_eq!(instance.num_shares(), TEST_N);
         assert_eq!(instance.threshold(), TEST_T);
-        // The roster commits one recipient fingerprint per share.
-        assert_eq!(roster.len(), TEST_N);
         // The ceremony log records the same BTC master pubkey as the response.
         assert_eq!(btc_master_pubkey, validated_resp.btc_master_pubkey);
 
-        // The encrypted shares are persisted to shares/ keyed by sharing_seq,
-        // and carry the ciphertexts the ceremony log omits.
+        // The encrypted shares are persisted to kp-shares/ keyed by sharing_seq
+        // and cert_seq, and carry the ciphertexts the ceremony log omits.
         let shares_logs: Vec<_> = captured
             .iter()
-            .filter(|(k, _)| k.starts_with("shares/"))
+            .filter(|(k, _)| k.starts_with("kp-shares/"))
             .collect();
-        assert_eq!(shares_logs.len(), 1, "expected one shares/ log");
+        assert_eq!(shares_logs.len(), 1, "expected one kp-shares/ log");
         let (shares_key, shares_body) = shares_logs[0];
         assert_eq!(
             *shares_key,
-            format!("shares/{:020}-{}.json", 0, enclave.s3_session_id())
+            format!(
+                "kp-shares/{:020}/{:020}-{}.json",
+                0,
+                0,
+                enclave.s3_session_id()
+            )
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let LogMessage::Shares(shares) = shares_record.message else {
-            panic!("expected Shares variant");
+        let LogMessage::KpShareState(shares) = shares_record.message else {
+            panic!("expected KpShareState variant");
         };
         assert_eq!(shares.sharing_seq, 0);
+        assert_eq!(shares.cert_seq, 0);
         assert_eq!(shares.encrypted_shares.len(), TEST_N);
         assert!(std::str::from_utf8(shares_body)
             .unwrap()

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -551,17 +551,20 @@ impl Enclave {
         self.write_log(LogMessage::Ceremony(Box::new(state))).await
     }
 
-    /// Persist the ceremony's encrypted shares to `shares/` for recovery. Keyed
-    /// by `sharing_seq` so it pairs with the matching `ceremony/` instance.
-    pub async fn log_shares(
+    /// Persist the current encrypted KP share state to `kp-shares/` for recovery.
+    /// `sharing_seq` pairs it with the matching `ceremony/` instance, while
+    /// `cert_seq` versions recipient-cert rotations within that instance.
+    pub async fn log_kp_share_state(
         &self,
         sharing_seq: u64,
+        cert_seq: u64,
         encrypted_shares: KPEncryptedShares,
     ) -> GuardianResult<()> {
-        self.write_log(LogMessage::Shares(Box::new(SharesLogMessage {
+        self.write_log(LogMessage::KpShareState(Box::new(KpShareState::new(
             sharing_seq,
+            cert_seq,
             encrypted_shares,
-        })))
+        ))))
         .await
     }
 

--- a/crates/hashi-guardian/src/operator_activate.rs
+++ b/crates/hashi-guardian/src/operator_activate.rs
@@ -61,7 +61,7 @@ pub async fn operator_activate(
         .await
         .map_err(|e| InvalidInputs(format!("heartbeat activation check failed: {e}")))?;
 
-    let (_, latest_instance, _, _) = reader
+    let (_, latest_instance, _) = reader
         .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
         .await
         .map_err(|e| InternalError(format!("read latest ceremony: {e}")))?

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -43,7 +43,7 @@ impl InitInstall {
     ) -> GuardianResult<Self> {
         let mut reader =
             GuardianReader::from_s3_client(logger.clone(), config.pcr_allowlist().clone());
-        let (_, secret_sharing_instance, _, _) = reader
+        let (_, secret_sharing_instance, _) = reader
             .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
             .await
             .map_err(|e| InvalidInputs(format!("read latest ceremony: {e}")))?

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -469,7 +469,7 @@ impl GuardianS3Client {
 
     /// Plain point read + deserialize, with no object-lock assertion and no
     /// version/deletion check. For objects whose integrity comes from their own
-    /// signature rather than S3 immutability (e.g. `shares/`, which carry only a
+    /// signature rather than S3 immutability (e.g. `kp-shares/`, which carry only a
     /// short lock that is expected to expire). A tampered object fails the
     /// caller's signature check; a purged one surfaces as a get error.
     pub async fn get_object_no_lock<T: DeserializeOwned>(&self, key: &str) -> GuardianResult<T> {

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -22,15 +22,13 @@ use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GenesisLogMessage;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::KPEncryptedShares;
-use hashi_types::guardian::KPFingerprint;
+use hashi_types::guardian::KpShareState;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::SharesLogMessage;
 use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::VerifiedSessionInfo;
 use hashi_types::guardian::S3_DIR_CEREMONY;
@@ -176,24 +174,17 @@ impl GuardianReader {
         Ok(self
             .read_latest_ceremony(build_policy)
             .await?
-            .map(|(_, instance, _, _)| instance))
+            .map(|(_, instance, _)| instance))
     }
 
     /// Like [`Self::read_latest_ceremony_instance`], but also returns the writing
-    /// session id, recipient roster, and BTC master pubkey. The session id
-    /// locates the matching `shares/` object; the roster is checked against the
-    /// agreed KP set.
+    /// session id and BTC master pubkey. `kp-shares/` is read independently so
+    /// later KP cert rotations can advance `cert_seq` without rewriting the
+    /// `ceremony/` instance.
     pub async fn read_latest_ceremony(
         &mut self,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<
-        Option<(
-            SessionID,
-            SecretSharingInstance,
-            Vec<KPFingerprint>,
-            BitcoinPubkey,
-        )>,
-    > {
+    ) -> anyhow::Result<Option<(SessionID, SecretSharingInstance, BitcoinPubkey)>> {
         let keys = self
             .s3
             .list_all_keys_in_dir(&format!("{}/", S3_DIR_CEREMONY))
@@ -205,17 +196,12 @@ impl GuardianReader {
     }
 
     /// Read + verify the `ceremony/` record at `key`, returning its writing
-    /// session, resulting instance, roster, and BTC master pubkey.
+    /// session, resulting instance, and BTC master pubkey.
     async fn read_ceremony_record(
         &mut self,
         key: &str,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<(
-        SessionID,
-        SecretSharingInstance,
-        Vec<KPFingerprint>,
-        BitcoinPubkey,
-    )> {
+    ) -> anyhow::Result<(SessionID, SecretSharingInstance, BitcoinPubkey)> {
         let record = self.s3.get_log_record(key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         let session_id = record.session_id.clone();
@@ -224,38 +210,41 @@ impl GuardianReader {
         let LogMessage::Ceremony(msg) = record.message else {
             anyhow::bail!("expected a ceremony log at {key}");
         };
-        let (instance, roster, btc_master_pubkey) = ceremony_instance_and_roster(*msg, key)?;
-        Ok((session_id, instance, roster, btc_master_pubkey))
+        let (instance, btc_master_pubkey) = ceremony_instance_and_pubkey(*msg, key)?;
+        Ok((session_id, instance, btc_master_pubkey))
     }
 
-    /// Read + verify the encrypted shares at `shares/{seq}-{session}.json`. Point
-    /// read by exact key (recovery anchors on the ceremony instance's seq), so a
-    /// purged older `shares/` object never blocks reading the current one.
+    /// Read + verify the latest encrypted KP share state for `sharing_seq`.
+    /// The lex-greatest object under `kp-shares/{sharing_seq:020}/` has the
+    /// latest `cert_seq`, so future per-KP cert rotation can advance the share
+    /// recipient state without changing the `ceremony/` instance.
     ///
     /// Uses the lock-agnostic read: shares carry only a short lock that is
     /// expected to expire, and their integrity is the enclave signature checked
     /// below — not S3 immutability — so the immutable-log lock assertion in
     /// `get_log_record` doesn't apply.
-    pub async fn read_shares(
+    pub async fn read_latest_kp_share_state(
         &mut self,
-        session_id: &str,
         sharing_seq: u64,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<KPEncryptedShares> {
-        let key = SharesLogMessage::object_key(session_id, sharing_seq);
-        let record: LogRecord = self.s3.get_object_no_lock(&key).await?;
-        if record.session_id != session_id {
-            anyhow::bail!(
-                "session id mismatch at {key}: expected {session_id}, got {}",
-                record.session_id
-            );
-        }
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        let build_pcrs = record.build_pcrs.clone();
-        self.enforce_build_policy("shares log", build_policy, &build_pcrs)?;
-        let LogMessage::Shares(msg) = record.message else {
-            anyhow::bail!("expected a shares log at {key}");
+    ) -> anyhow::Result<Option<(SessionID, KpShareState)>> {
+        let prefix = KpShareState::object_prefix(sharing_seq);
+        let keys = self.s3.list_all_keys_in_dir(&prefix).await?;
+        let Some(key) = keys.into_iter().max() else {
+            return Ok(None);
         };
+        let record: LogRecord = self.s3.get_object_no_lock(&key).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
+        let session_id = record.session_id.clone();
+        let build_pcrs = record.build_pcrs.clone();
+        self.enforce_build_policy("kp-shares log", build_policy, &build_pcrs)?;
+        let LogMessage::KpShareState(msg) = record.message else {
+            anyhow::bail!("expected a kp-shares log at {key}");
+        };
+        let expected_key = KpShareState::object_key(&session_id, msg.sharing_seq, msg.cert_seq);
+        if key != expected_key {
+            anyhow::bail!("kp-shares key mismatch: expected {expected_key}, got {key}");
+        }
         if msg.sharing_seq != sharing_seq {
             anyhow::bail!(
                 "sharing_seq mismatch: {} != {}",
@@ -263,7 +252,7 @@ impl GuardianReader {
                 sharing_seq
             );
         }
-        Ok(msg.encrypted_shares)
+        Ok(Some((session_id, *msg)))
     }
 
     /// Latest serving committee, preferring `committee-update/` and falling back
@@ -392,23 +381,21 @@ impl GuardianSessionCache {
     }
 }
 
-/// The resulting instance + recipient roster from a ceremony message: `NewKey`
-/// yields its instance; `Rotate` yields `new_instance`, asserting the rotation
-/// bumps `sharing_seq` by exactly one over the consumed `old_instance`.
-fn ceremony_instance_and_roster(
+/// The resulting instance from a ceremony message: `NewKey` yields its instance;
+/// `Rotate` yields `new_instance`, asserting the rotation bumps `sharing_seq` by
+/// exactly one over the consumed `old_instance`.
+fn ceremony_instance_and_pubkey(
     msg: CeremonyLogMessage,
     key: &str,
-) -> anyhow::Result<(SecretSharingInstance, Vec<KPFingerprint>, BitcoinPubkey)> {
+) -> anyhow::Result<(SecretSharingInstance, BitcoinPubkey)> {
     Ok(match msg {
         CeremonyLogMessage::NewKey {
             instance,
-            roster,
             btc_master_pubkey,
-        } => (instance, roster, btc_master_pubkey),
+        } => (instance, btc_master_pubkey),
         CeremonyLogMessage::Rotate {
             old_instance,
             new_instance,
-            roster,
             btc_master_pubkey,
         } => {
             let expected = old_instance
@@ -421,7 +408,7 @@ fn ceremony_instance_and_roster(
                 old_instance.sharing_seq(),
                 new_instance.sharing_seq()
             );
-            (new_instance, roster, btc_master_pubkey)
+            (new_instance, btc_master_pubkey)
         }
     })
 }

--- a/crates/hashi-types/src/guardian/crypto.rs
+++ b/crates/hashi-types/src/guardian/crypto.rs
@@ -161,8 +161,7 @@ impl KPEncryptedShares {
         self.0
     }
 
-    /// Recipient PGP fingerprints ordered by share id — the roster committed
-    /// into the `ceremony/` log so a KP can check the full recipient set.
+    /// Recipient PGP fingerprints ordered by share id.
     pub fn recipient_roster(&self) -> Vec<KPFingerprint> {
         self.iter()
             .map(|s| s.recipient_fingerprint.clone())

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -10,7 +10,7 @@ use super::S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE;
 use super::S3_OBJECT_LOCK_DURATION_GENESIS;
 use super::S3_OBJECT_LOCK_DURATION_HEARTBEAT;
 use super::S3_OBJECT_LOCK_DURATION_INIT;
-use super::S3_OBJECT_LOCK_DURATION_SHARES;
+use super::S3_OBJECT_LOCK_DURATION_KP_SHARES;
 use super::S3_OBJECT_LOCK_DURATION_WITHDRAW;
 use super::message::LogMessage;
 use crate::guardian::BuildPcrs;
@@ -91,7 +91,7 @@ impl LogRecord {
             LogMessage::Heartbeat { .. } => S3_OBJECT_LOCK_DURATION_HEARTBEAT,
             LogMessage::Withdrawal(..) => S3_OBJECT_LOCK_DURATION_WITHDRAW,
             LogMessage::Ceremony(..) => S3_OBJECT_LOCK_DURATION_CEREMONY,
-            LogMessage::Shares(..) => S3_OBJECT_LOCK_DURATION_SHARES,
+            LogMessage::KpShareState(..) => S3_OBJECT_LOCK_DURATION_KP_SHARES,
             LogMessage::CommitteeUpdate(..) => S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE,
             LogMessage::Genesis(..) => S3_OBJECT_LOCK_DURATION_GENESIS,
         }
@@ -222,26 +222,30 @@ mod tests {
     }
 
     #[test]
-    fn object_key_and_lock_for_shares() {
-        use crate::guardian::SharesLogMessage;
+    fn object_key_and_lock_for_kp_share_state() {
+        use crate::guardian::KpShareState;
 
         let session_id = "session-d".to_string();
         let signing_key = GuardianSignKeyPair::from([10u8; 32]);
         let mut log = LogRecord::new(
             session_id,
-            LogMessage::Shares(Box::new(SharesLogMessage {
-                sharing_seq: 7,
-                encrypted_shares: KPEncryptedShares::new(vec![]).unwrap(),
-            })),
+            LogMessage::KpShareState(Box::new(KpShareState::new(
+                7,
+                3,
+                KPEncryptedShares::new(vec![]).unwrap(),
+            ))),
             &signing_key,
         );
         set_timestamp(&mut log, 1_700_000_000_000);
 
         assert_eq!(
             log.object_key(),
-            "shares/00000000000000000007-session-d.json"
+            "kp-shares/00000000000000000007/00000000000000000003-session-d.json"
         );
-        assert_eq!(log.object_lock_duration(), S3_OBJECT_LOCK_DURATION_SHARES);
+        assert_eq!(
+            log.object_lock_duration(),
+            S3_OBJECT_LOCK_DURATION_KP_SHARES
+        );
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -10,7 +10,7 @@ use super::S3_DIR_COMMITTEE_UPDATE;
 use super::S3_DIR_GENESIS;
 use super::S3_DIR_HEARTBEAT;
 use super::S3_DIR_INIT;
-use super::S3_DIR_SHARES;
+use super::S3_DIR_KP_SHARES;
 use super::S3_DIR_WITHDRAW;
 use crate::bitcoin::BitcoinPubkey;
 use crate::committee::CommitteeSignature;
@@ -18,7 +18,6 @@ use crate::guardian::GuardianError;
 use crate::guardian::GuardianInfo;
 use crate::guardian::GuardianPubKey;
 use crate::guardian::KPEncryptedShares;
-use crate::guardian::KPFingerprint;
 use crate::guardian::LimiterState;
 use crate::guardian::NitroAttestation;
 use crate::guardian::SecretSharingInstance;
@@ -41,7 +40,7 @@ pub enum LogMessage {
     Init(Box<InitLogMessage>),
     Withdrawal(Box<WithdrawalLogMessage>),
     Ceremony(Box<CeremonyLogMessage>),
-    Shares(Box<SharesLogMessage>),
+    KpShareState(Box<KpShareState>),
     CommitteeUpdate(Box<CommitteeUpdateLogMessage>),
     Genesis(Box<GenesisLogMessage>),
 }
@@ -62,36 +61,60 @@ impl GenesisLogMessage {
     }
 }
 
-/// Encrypted KP shares persisted for recovery, written to `shares/` after each
-/// ceremony. Keyed by `sharing_seq` so it pairs with the matching `ceremony/`
-/// instance; carries the ciphertexts the `ceremony/` log deliberately omits.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SharesLogMessage {
+/// Current encrypted KP share state for a secret-sharing instance. The initial
+/// ceremony writes `cert_seq = 0`; later individual KP cert rotations can write
+/// higher `cert_seq` entries for the same `sharing_seq` without changing the
+/// `ceremony/` instance.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct KpShareState {
     pub sharing_seq: u64,
+    pub cert_seq: u64,
     pub encrypted_shares: KPEncryptedShares,
 }
 
-impl SharesLogMessage {
-    /// `shares/{sharing_seq:020}-{session_id}.json` — the object key a reader
-    /// fetches for `(session_id, sharing_seq)`.
-    pub fn object_key(session_id: &str, sharing_seq: u64) -> String {
-        super::seq_scoped_object_key(S3_DIR_SHARES, sharing_seq, session_id)
+impl KpShareState {
+    pub fn new(sharing_seq: u64, cert_seq: u64, encrypted_shares: KPEncryptedShares) -> Self {
+        Self {
+            sharing_seq,
+            cert_seq,
+            encrypted_shares,
+        }
+    }
+
+    /// `kp-shares/{sharing_seq:020}/` — the prefix containing every cert-state
+    /// version for one `SecretSharingInstance`.
+    pub fn object_prefix(sharing_seq: u64) -> String {
+        format!("{S3_DIR_KP_SHARES}/{sharing_seq:020}/")
+    }
+
+    /// `kp-shares/{sharing_seq:020}/{cert_seq:020}-{session_id}.json` — the
+    /// object key for one written KP share state.
+    pub fn object_key(session_id: &str, sharing_seq: u64, cert_seq: u64) -> String {
+        format!(
+            "{}{:020}-{session_id}.json",
+            Self::object_prefix(sharing_seq),
+            cert_seq
+        )
+    }
+
+    pub fn log_dir(&self) -> String {
+        Self::object_prefix(self.sharing_seq)
+    }
+
+    pub fn log_name(&self, session_id: &str) -> String {
+        format!("{:020}-{session_id}.json", self.cert_seq)
     }
 }
 
-/// The authoritative share state, written to `ceremony/` after each ceremony.
-/// Carries the instance (commitments + n/t/seq) plus the recipient roster; the
-/// ciphertexts live in `shares/`. A rotation records the `old_instance` it
-/// consumed so the chain is auditable from the log alone.
+/// The authoritative secret-sharing instance, written to `ceremony/` after each
+/// ceremony. Carries the commitments + n/t/seq; encrypted KP shares live in
+/// `kp-shares/`. A rotation records the `old_instance` it consumed so the chain
+/// is auditable from the log alone.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum CeremonyLogMessage {
     /// Initial key setup (`setup_new_key`); `instance` has `sharing_seq` 0.
     NewKey {
         instance: SecretSharingInstance,
-        /// Recipient fingerprints ordered by share id; lets a KP check the full
-        /// roster against the agreed set from the immutable log, not just the
-        /// operator-served shares.
-        roster: Vec<KPFingerprint>,
         /// The x-only BTC master pubkey this ceremony produced; lets KPs and
         /// monitors cross-check it against the on-chain `guardian_btc_public_key`.
         btc_master_pubkey: BitcoinPubkey,
@@ -100,8 +123,6 @@ pub enum CeremonyLogMessage {
     Rotate {
         old_instance: SecretSharingInstance,
         new_instance: SecretSharingInstance,
-        /// Recipient fingerprints for `new_instance`; see [`Self::NewKey`].
-        roster: Vec<KPFingerprint>,
         /// See [`Self::NewKey`]; invariant across rotations (the same key is re-shared).
         btc_master_pubkey: BitcoinPubkey,
     },
@@ -298,7 +319,7 @@ impl LogMessage {
                     .to_string()
             }
             LogMessage::Ceremony(..) => format!("{}/", S3_DIR_CEREMONY),
-            LogMessage::Shares(..) => format!("{}/", S3_DIR_SHARES),
+            LogMessage::KpShareState(state) => state.log_dir(),
             LogMessage::CommitteeUpdate(..) => format!("{}/", S3_DIR_COMMITTEE_UPDATE),
             LogMessage::Genesis(..) => format!("{}/", S3_DIR_GENESIS),
         }
@@ -311,7 +332,7 @@ impl LogMessage {
             LogMessage::Heartbeat { seq } => format!("{}-{:020}.json", prefix, seq),
             LogMessage::Withdrawal(withdrawal_message) => withdrawal_message.log_name(prefix),
             LogMessage::Ceremony(ss) => format!("{:020}-{}.json", ss.sharing_seq(), prefix),
-            LogMessage::Shares(s) => format!("{:020}-{}.json", s.sharing_seq, prefix),
+            LogMessage::KpShareState(state) => state.log_name(prefix),
             LogMessage::CommitteeUpdate(committee_message) => committee_message.log_name(prefix),
             LogMessage::Genesis(_) => GenesisLogMessage::LOG_NAME.to_string(),
         }

--- a/crates/hashi-types/src/guardian/log/mod.rs
+++ b/crates/hashi-types/src/guardian/log/mod.rs
@@ -33,7 +33,7 @@ pub const S3_OBJECT_LOCK_DURATION_GENESIS: Duration = ONE_WEEK;
 /// Shares carry their own enclave signature, so the lock isn't for integrity —
 /// it only guarantees a window in which the operator can't purge them before KPs
 /// fetch. Short on purpose; they stay readable after expiry until deleted.
-pub const S3_OBJECT_LOCK_DURATION_SHARES: Duration = ONE_DAY;
+pub const S3_OBJECT_LOCK_DURATION_KP_SHARES: Duration = ONE_DAY;
 
 /// S3 sub-prefixes used for guardian log streams.
 /// See `crates/hashi-guardian/README.md` for canonical key layout.
@@ -41,13 +41,6 @@ pub const S3_DIR_INIT: &str = "init";
 pub const S3_DIR_WITHDRAW: &str = "withdraw";
 pub const S3_DIR_HEARTBEAT: &str = "heartbeat";
 pub const S3_DIR_CEREMONY: &str = "ceremony";
-pub const S3_DIR_SHARES: &str = "shares";
+pub const S3_DIR_KP_SHARES: &str = "kp-shares";
 pub const S3_DIR_COMMITTEE_UPDATE: &str = "committee-update";
 pub const S3_DIR_GENESIS: &str = "genesis";
-
-/// Single definition of the flat, sequence-scoped key layout
-/// (`{dir}/{sharing_seq:020}-{session_id}.json`) behind the
-/// [`SharesLogMessage::object_key`] helper.
-pub(crate) fn seq_scoped_object_key(dir: &str, sharing_seq: u64, session_id: &str) -> String {
-    format!("{dir}/{sharing_seq:020}-{session_id}.json")
-}

--- a/docker/hashi-guardian-local/compose.yaml
+++ b/docker/hashi-guardian-local/compose.yaml
@@ -98,7 +98,7 @@ services:
 
   # The one-time CEREMONY-mode guardian. Profiled, so `make up` skips it; brought
   # up only for `make ceremony`. Reached directly (not via the proxy). Uses the
-  # same `host` S3 bridge to write ceremony/ + shares/ to MinIO.
+  # same `host` S3 bridge to write ceremony/ + kp-shares/ to MinIO.
   ceremony:
     <<: *build
     entrypoint: ["/bin/sh", "/run.local.sh"]

--- a/docker/hashi-guardian-local/scripts/ceremony.sh
+++ b/docker/hashi-guardian-local/scripts/ceremony.sh
@@ -5,7 +5,7 @@
 # Genesis ceremony against the ceremony-mode guardian (chain-free):
 #   1. generate the test KP roster,
 #   2. `operator ceremony` -> the guardian generates the BTC key in-enclave,
-#      splits it, encrypts shares to the KP certs, writes ceremony/ + shares/
+#      splits it, encrypts shares to the KP certs, writes ceremony/ + kp-shares/
 #      to MinIO, and returns the x-only BTC master pubkey,
 #   3. capture that pubkey for `hashi-localnet start --guardian-btc-pubkey`.
 #


### PR DESCRIPTION
## Summary
- introduce first-class `KpShareState` logs under `kp-shares/{sharing_seq}/{cert_seq}-{session}.json`
- stop duplicating the KP recipient roster in `ceremony/`; derive it from encrypted share labels
- update guardian ceremony writers, S3 reader APIs, guardian-init verification flows, and docs to use latest KP share state

## Notes
- setup/rotation write `cert_seq = 0`; future individual KP cert rotation can append higher cert-state versions for the same `sharing_seq`
- this PR intentionally does not add the cert-rotation RPC yet; it establishes the log contract that endpoint will use

## Tests
- `cargo fmt -- --config imports_granularity=Item --config format_code_in_doc_comments=true --check`
- `cargo check -p hashi-types -p hashi-guardian -p hashi-guardian-init`
- `cargo test -p hashi-types guardian::log::envelope --lib`
- `cargo test -p hashi-guardian ceremony_mode --lib`
- `cargo test -p hashi-guardian-init kp_roster`