### PR TITLE
[guardian] Parameterize the enclave EIF build's cargo features

### DIFF
--- a/docker/hashi-guardian/Containerfile
+++ b/docker/hashi-guardian/Containerfile
@@ -51,6 +51,10 @@ FROM base AS build
 ARG BUCKET_NAME
 ARG AWS_REGION=us-east-1
 ARG GIT_REVISION
+# Extra cargo features for the guardian build. Empty (the default) is the real
+# enclave build — leave it empty for anything whose PCR0 must match provenance.
+# Dev deploys pass `non-enclave-dev` so a runner-local mock ceremony verifies.
+ARG FEATURES=""
 RUN [ -n "$GIT_REVISION" ] || { echo "GIT_REVISION build-arg must be set"; exit 1; }
 ENV GIT_REVISION=${GIT_REVISION}
 COPY crates /crates
@@ -61,7 +65,7 @@ WORKDIR /
 ENV OPENSSL_STATIC=true
 ENV TARGET=x86_64-unknown-linux-musl
 ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64"
-RUN cargo build --locked --no-default-features --release --target "$TARGET" -p hashi-guardian
+RUN cargo build --locked --no-default-features --release --target "$TARGET" -p hashi-guardian ${FEATURES:+--features "$FEATURES"}
 
 WORKDIR /build_cpio
 ENV KBUILD_BUILD_TIMESTAMP=1

--- a/docker/hashi-guardian/Makefile
+++ b/docker/hashi-guardian/Makefile
@@ -2,6 +2,8 @@ REGISTRY := local
 BUCKET_NAME ?= guardian-test-bucket
 AWS_REGION ?= us-east-1
 GIT_REVISION ?= $(shell git -C ../.. describe --always --exclude '*' --dirty --abbrev=8)
+# Extra cargo features; empty = the real enclave build (see Containerfile).
+FEATURES ?=
 
 .DEFAULT_GOAL :=
 .PHONY: default
@@ -21,6 +23,7 @@ out/nitro.eif: $(shell git ls-files ../../crates/hashi-guardian ../../crates/has
 		--build-arg BUCKET_NAME=$(BUCKET_NAME) \
 		--build-arg AWS_REGION=$(AWS_REGION) \
 		--build-arg GIT_REVISION=$(GIT_REVISION) \
+		--build-arg FEATURES=$(FEATURES) \
 		-f Containerfile \
 		../..
 


### PR DESCRIPTION
Adds a `FEATURES` build-arg to the enclave EIF build (default empty).

- Devnet/PTN deploys will pass `non-enclave-dev` so the deploy pipeline's runner-local mock ceremony can be verified by the enclave's S3 reader
- the testnet/mainnet build keeps it empty. 

Companion PR: MystenLabs/sui-operations#8249 (`eif-features` stack config)