### PR TITLE
[guardian-proxy] Source the relay KP roster from the S3 share log

### DIFF
--- a/crates/hashi-guardian-proxy/src/config.rs
+++ b/crates/hashi-guardian-proxy/src/config.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use bitcoin::Network;
-use hashi_types::pgp::Fingerprint;
 
 pub struct Config {
     /// gRPC endpoint of the enclave guardian to forward to, e.g.
@@ -41,10 +40,6 @@ pub struct Config {
     /// bitcoin|testnet|signet|regtest). Must match the guardian's config; used
     /// to recompute sighashes when verifying a log replay.
     pub btc_network: Network,
-    /// PGP fingerprints of the KPs allowed to submit shares through the relay
-    /// (`AUTHORIZED_KP_FINGERPRINTS`, comma-separated, default empty). Empty
-    /// fail-closes the relay; the cache/forwarding paths are unaffected.
-    pub authorized_kp_fingerprints: Vec<Fingerprint>,
 }
 
 impl Config {
@@ -71,8 +66,6 @@ impl Config {
             .context("BTC_NETWORK must be set (bitcoin|testnet|signet|regtest)")?
             .parse()
             .context("BTC_NETWORK must be one of bitcoin|testnet|signet|regtest")?;
-        let authorized_kp_fingerprints =
-            parse_kp_roster(&std::env::var("AUTHORIZED_KP_FINGERPRINTS").unwrap_or_default())?;
         Ok(Self {
             backend_url,
             listen_addr,
@@ -83,34 +76,8 @@ impl Config {
             log_bucket,
             log_region,
             btc_network,
-            authorized_kp_fingerprints,
         })
     }
-}
-
-/// Parse the comma-separated KP roster into canonical fingerprints (spacing
-/// and case insensitive), so a config typo fails at startup.
-fn parse_kp_roster(raw: &str) -> Result<Vec<Fingerprint>> {
-    let mut roster = Vec::new();
-    for entry in raw.split(',') {
-        if entry.trim().is_empty() {
-            continue;
-        }
-        let fp = entry
-            .parse::<Fingerprint>()
-            .ok()
-            // Sequoia parses odd-sized hex into `Fingerprint::Unknown` rather
-            // than failing; only real v4/v6 shapes can name a KP cert.
-            .filter(|fp| matches!(fp, Fingerprint::V4(_) | Fingerprint::V6(_)))
-            .with_context(|| {
-                format!(
-                    "AUTHORIZED_KP_FINGERPRINTS entry {entry:?} is not a PGP fingerprint \
-                     (expected 40 or 64 hex chars; spacing and case are ignored)"
-                )
-            })?;
-        roster.push(fp);
-    }
-    Ok(roster)
 }
 
 fn parse_env_u64(key: &str, default: u64) -> Result<u64> {
@@ -119,31 +86,5 @@ fn parse_env_u64(key: &str, default: u64) -> Result<u64> {
             .parse()
             .with_context(|| format!("{key} must be a non-negative integer")),
         Err(_) => Ok(default),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_kp_roster_accepts_spaced_and_bare_hex() {
-        // Spaced gpg form + bare lowercase hex, with a trailing comma.
-        let raw = "AAAA BBBB CCCC DDDD EEEE 1111 2222 3333 4444 5555,\
-                   aaaabbbbccccddddeeee1111222233334444ffff,";
-        let roster = parse_kp_roster(raw).unwrap();
-        let expected: Vec<Fingerprint> = vec![
-            "AAAABBBBCCCCDDDDEEEE11112222333344445555".parse().unwrap(),
-            "AAAABBBBCCCCDDDDEEEE1111222233334444FFFF".parse().unwrap(),
-        ];
-        assert_eq!(roster, expected);
-    }
-
-    #[test]
-    fn parse_kp_roster_empty_and_invalid() {
-        assert!(parse_kp_roster("").unwrap().is_empty());
-        assert!(parse_kp_roster("not-a-fingerprint").is_err());
-        // Hex but not a fingerprint length.
-        assert!(parse_kp_roster("ABCD").is_err());
     }
 }

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -7,6 +7,8 @@
 //! exposing it would let anyone wedge the guardian. Wrapped by
 //! [`crate::cache::CachingGuardianGrpc`] to cache `StandardWithdrawal`.
 
+use std::sync::Arc;
+
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::ProvisionerRotateCertRequest;
 use hashi_types::proto;
@@ -17,17 +19,23 @@ use tonic::Request;
 use tonic::Response;
 use tonic::Status;
 
+use crate::roster::RosterCache;
+use crate::widlog::LogStore;
+
 /// Holds a plain [`Channel`] rather than the node's boxed transport: the generated
 /// server trait requires `Send + Sync + 'static`, and `BoxCloneService` is not `Sync`.
 #[derive(Clone)]
-pub struct Forwarding {
+pub struct Forwarding<L> {
     client: GuardianServiceClient<Channel>,
+    /// Shared with the relay so a cert rotation can drop the cached roster.
+    roster: Arc<RosterCache<L>>,
 }
 
-impl Forwarding {
-    pub fn new(channel: Channel) -> Self {
+impl<L: LogStore> Forwarding<L> {
+    pub fn new(channel: Channel, roster: Arc<RosterCache<L>>) -> Self {
         Self {
             client: GuardianServiceClient::new(channel),
+            roster,
         }
     }
 }
@@ -53,7 +61,7 @@ fn verify_provisioner_rotate_cert_signature(
 // Each method clones the cheap channel-backed client and forwards the whole
 // `Request<T>` so client deadlines/metadata propagate.
 #[tonic::async_trait]
-impl GuardianService for Forwarding {
+impl<L: LogStore> GuardianService for Forwarding<L> {
     async fn get_guardian_info(
         &self,
         request: Request<proto::GetGuardianInfoRequest>,
@@ -89,11 +97,14 @@ impl GuardianService for Forwarding {
         // Admission control only: reject unsigned or corrupt traffic before an
         // enclave round-trip. The enclave repeats verification and authorizes
         // the signer against the latest encrypted-share roster.
-        // TODO: Once proxy authorization uses the S3-backed roster, check the
-        // signer here and invalidate the cached roster after a successful
-        // rotation so the next request observes the replacement cert.
+        // TODO: check the signer against the roster here too.
         verify_provisioner_rotate_cert_signature(request.get_ref())?;
-        self.client.clone().provisioner_rotate_cert(request).await
+        let response = self.client.clone().provisioner_rotate_cert(request).await?;
+        // The enclave has committed the replacement cert to the share log, so
+        // drop the cached roster: otherwise the new cert is rejected until the
+        // TTL lapses.
+        self.roster.invalidate().await;
+        Ok(response)
     }
 
     // --- Rejected: operator/ceremony surface ---
@@ -246,9 +257,11 @@ mod tests {
         })
     }
 
+    type StubStore = crate::widlog::test_store::MemStore;
+
     async fn spawn_stub_proxy() -> (
         StubGuardian,
-        CachingGuardianGrpc<Forwarding, crate::widlog::test_store::MemStore>,
+        CachingGuardianGrpc<Forwarding<StubStore>, StubStore>,
     ) {
         let stub = StubGuardian::default();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -268,8 +281,8 @@ mod tests {
             .unwrap()
             .connect_lazy();
         let cache = CachingGuardianGrpc::new(
-            Forwarding::new(channel),
-            crate::widlog::test_store::MemStore::default(),
+            Forwarding::new(channel, Arc::new(RosterCache::new(StubStore::default()))),
+            StubStore::default(),
             bitcoin::Network::Regtest,
             std::sync::Arc::new(crate::metrics::ProxyMetrics::new()),
         );

--- a/crates/hashi-guardian-proxy/src/lib.rs
+++ b/crates/hashi-guardian-proxy/src/lib.rs
@@ -10,8 +10,9 @@
 //!   in front of the guardian's own S3 withdrawal log ([`widlog`]) as the
 //!   durable, read-only tier.
 //! - [`relay`] serves `GuardianRelayService`: key provisioners submit one share
-//!   each and the relay batches a threshold-many into the guardian's
-//!   `ProvisionerInit`.
+//!   each — authenticated against the ceremony's committed roster read from the
+//!   S3 share log ([`roster`]) — and the relay batches a threshold-many into
+//!   the guardian's `ProvisionerInit`.
 //! - [`info`] serves a read-only HTTP `/info` + `/health` JSON surface (a
 //!   curated limiter/identity view, with CORS) so browser / `fetch` clients can
 //!   read limiter status the gRPC surface only exposes to nodes — on the same
@@ -26,6 +27,7 @@ pub mod forward;
 pub mod info;
 pub mod metrics;
 pub mod relay;
+pub mod roster;
 pub mod widlog;
 
 pub use cache::CachingGuardianGrpc;

--- a/crates/hashi-guardian-proxy/src/main.rs
+++ b/crates/hashi-guardian-proxy/src/main.rs
@@ -9,6 +9,7 @@ use hashi_guardian_proxy::forward::Forwarding;
 use hashi_guardian_proxy::info;
 use hashi_guardian_proxy::metrics::ProxyMetrics;
 use hashi_guardian_proxy::relay::Relay;
+use hashi_guardian_proxy::roster::RosterCache;
 use hashi_guardian_proxy::widlog::S3LogStore;
 use hashi_types::proto::guardian_relay_service_server::GuardianRelayServiceServer;
 use hashi_types::proto::guardian_service_client::GuardianServiceClient;
@@ -64,13 +65,16 @@ async fn main() -> Result<()> {
         .http2_keep_alive_interval(config.keepalive_interval)
         .connect_lazy();
 
-    let relay_svc = Relay::new(channel.clone(), log_store.clone());
+    // One roster cache, shared: the relay authorizes submissions against it and
+    // a cert rotation through the forwarder invalidates it.
+    let roster = Arc::new(RosterCache::new(log_store.clone()));
+    let relay_svc = Relay::new(channel.clone(), roster.clone());
     let info_state = info::InfoState::new(
         GuardianServiceClient::new(channel.clone()),
         config.info_cache_ttl,
     );
     let guardian_svc = CachingGuardianGrpc::new(
-        Forwarding::new(channel),
+        Forwarding::new(channel, roster),
         log_store,
         config.btc_network,
         metrics.clone(),
@@ -80,7 +84,7 @@ async fn main() -> Result<()> {
     // health-checkers; the HTTP `/health` route below covers plain-HTTP liveness.
     let (health_reporter, health_service) = health_reporter();
     health_reporter
-        .set_serving::<GuardianServiceServer<CachingGuardianGrpc<Forwarding, S3LogStore>>>()
+        .set_serving::<GuardianServiceServer<CachingGuardianGrpc<Forwarding<S3LogStore>, S3LogStore>>>()
         .await;
     health_reporter
         .set_serving::<GuardianRelayServiceServer<Relay<S3LogStore>>>()

--- a/crates/hashi-guardian-proxy/src/main.rs
+++ b/crates/hashi-guardian-proxy/src/main.rs
@@ -36,18 +36,12 @@ async fn main() -> Result<()> {
         listen = %config.listen_addr,
         log_bucket = %config.log_bucket,
         network = %config.btc_network,
-        kp_roster = config.authorized_kp_fingerprints.len(),
         "Starting hashi-guardian-proxy (wid-keyed cache + node forwarder + provisioning relay)."
     );
-    if config.authorized_kp_fingerprints.is_empty() {
-        warn!(
-            "AUTHORIZED_KP_FINGERPRINTS is empty: the provisioning relay will reject \
-             all share submissions until a KP roster is configured."
-        );
-    }
 
-    // The wid cache's durable tier. Prove bucket access before serving: a
-    // proxy that can't read the log fails every retry closed.
+    // The wid cache's durable tier and the relay's roster source. Prove bucket
+    // access before serving: a proxy that can't read the log fails every retry
+    // closed.
     let log_store = S3LogStore::connect(config.log_bucket.clone(), config.log_region.clone()).await;
     probe_with_retries(&log_store).await?;
 
@@ -70,17 +64,17 @@ async fn main() -> Result<()> {
         .http2_keep_alive_interval(config.keepalive_interval)
         .connect_lazy();
 
-    let guardian_svc = CachingGuardianGrpc::new(
-        Forwarding::new(channel.clone()),
-        log_store,
-        config.btc_network,
-        metrics.clone(),
-    );
+    let relay_svc = Relay::new(channel.clone(), log_store.clone());
     let info_state = info::InfoState::new(
         GuardianServiceClient::new(channel.clone()),
         config.info_cache_ttl,
     );
-    let relay_svc = Relay::new(channel, config.authorized_kp_fingerprints);
+    let guardian_svc = CachingGuardianGrpc::new(
+        Forwarding::new(channel),
+        log_store,
+        config.btc_network,
+        metrics.clone(),
+    );
 
     // Standard gRPC health service (`grpc.health.v1.Health`) for gRPC
     // health-checkers; the HTTP `/health` route below covers plain-HTTP liveness.
@@ -89,7 +83,7 @@ async fn main() -> Result<()> {
         .set_serving::<GuardianServiceServer<CachingGuardianGrpc<Forwarding, S3LogStore>>>()
         .await;
     health_reporter
-        .set_serving::<GuardianRelayServiceServer<Relay>>()
+        .set_serving::<GuardianRelayServiceServer<Relay<S3LogStore>>>()
         .await;
     // A gRPC health check may query the empty ("") service, so mark it serving
     // too — otherwise such a check flaps the proxy as unhealthy.

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -15,10 +15,8 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Duration;
-use std::time::Instant;
 
-use crate::roster::latest_kp_roster;
+use crate::roster::RosterCache;
 use crate::widlog::LogStore;
 use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::KpSigned;
@@ -86,51 +84,6 @@ struct BackendStatus {
     provisioned: bool,
 }
 
-/// The committed roster changes only at ceremonies/rotations; a short TTL
-/// bounds S3 reads under submission spam without staleness that matters.
-const ROSTER_TTL: Duration = Duration::from_secs(60);
-
-/// TTL-cached view of the S3-committed KP roster. The mutex is held across the
-/// fetch, so concurrent misses collapse into one S3 read.
-struct RosterCache<L> {
-    store: L,
-    cached: Mutex<Option<(Instant, Arc<Vec<Fingerprint>>)>>,
-}
-
-impl<L: LogStore> RosterCache<L> {
-    fn new(store: L) -> Self {
-        Self {
-            store,
-            cached: Mutex::new(None),
-        }
-    }
-
-    async fn get(&self) -> Result<Arc<Vec<Fingerprint>>, Status> {
-        let mut cached = self.cached.lock().await;
-        if let Some((at, roster)) = cached.as_ref() {
-            if at.elapsed() < ROSTER_TTL {
-                return Ok(roster.clone());
-            }
-        }
-        match latest_kp_roster(&self.store).await {
-            Ok(Some(roster)) => {
-                let roster = Arc::new(roster);
-                *cached = Some((Instant::now(), roster.clone()));
-                Ok(roster)
-            }
-            // No ceremony has committed a share set yet: fail closed, uncached
-            // (so the first ceremony is authorized the moment its log lands).
-            Ok(None) => Err(Status::failed_precondition(
-                "no KP share log in the guardian bucket; run the key ceremony first",
-            )),
-            Err(e) => {
-                warn!(error = %format!("{e:#}"), "KP roster read failed");
-                Err(Status::unavailable("KP roster unavailable; retry"))
-            }
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Relay<L> {
     client: GuardianServiceClient<Channel>,
@@ -139,11 +92,26 @@ pub struct Relay<L> {
 }
 
 impl<L: LogStore> Relay<L> {
-    pub fn new(channel: Channel, roster_store: L) -> Self {
+    pub fn new(channel: Channel, roster: Arc<RosterCache<L>>) -> Self {
         Self {
             client: GuardianServiceClient::new(channel),
             accumulator: Arc::new(Mutex::new(Accumulator::default())),
-            roster: Arc::new(RosterCache::new(roster_store)),
+            roster,
+        }
+    }
+
+    /// The ceremony's committed roster, mapped onto the relay's failure modes:
+    /// no share log yet is a definitive "not ready", a read error is transient.
+    async fn authorized_kps(&self) -> Result<Arc<Vec<Fingerprint>>, Status> {
+        match self.roster.get().await {
+            Ok(Some(roster)) => Ok(roster),
+            Ok(None) => Err(Status::failed_precondition(
+                "no KP share log in the guardian bucket; run the key ceremony first",
+            )),
+            Err(e) => {
+                warn!(error = %format!("{e:#}"), "KP roster read failed");
+                Err(Status::unavailable("KP roster unavailable; retry"))
+            }
         }
     }
 
@@ -185,6 +153,10 @@ fn verify_kp_submission<'a>(
     signed_request: &'a KpSigned<SingleProvisionerInitRequest>,
     authorized_kp_fingerprints: &[Fingerprint],
 ) -> Result<&'a SingleProvisionerInitRequest, Status> {
+    // Membership first: it is a lookup against a cached roster, while signature
+    // verification is PGP. Checking the cheap one that actually excludes callers
+    // keeps a flood from costing crypto — the signature alone excludes nobody,
+    // since it is made by the cert the request carries.
     let fingerprint = signed_request.signer_fingerprint();
     if !authorized_kp_fingerprints.contains(&fingerprint) {
         return Err(Status::permission_denied(format!(
@@ -229,14 +201,14 @@ impl<L: LogStore> GuardianRelayService for Relay<L> {
         &self,
         request: Request<proto::SignedSingleProvisionerInitRequest>,
     ) -> Result<Response<proto::SingleProvisionerInitResponse>, Status> {
-        // The ceremony's committed roster, not deploy config: a rotation
-        // re-deals shares without a proxy redeploy. Fails closed when no share
-        // log exists yet.
-        let roster = self.roster.get().await?;
-
+        // Decode before the roster read so a malformed submission costs no S3.
         let submission = request.into_inner();
         let signed_request = KpSigned::<SingleProvisionerInitRequest>::try_from(submission.clone())
             .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
+
+        // The ceremony's committed roster, not deploy config: a rotation
+        // re-deals shares without a proxy redeploy.
+        let roster = self.authorized_kps().await?;
 
         // Authenticate before the lock or any backend read: junk submissions
         // can't poison the batch, hold the mutex, or cost enclave round-trips.
@@ -365,60 +337,6 @@ mod tests {
     use hashi_types::pgp::test_utils::mock_pgp_keypair;
     use hashi_types::pgp::test_utils::sign_detached_in_process;
     use hashi_types::pgp::PgpPublicCert;
-
-    use crate::widlog::test_store::MemStore;
-    use std::sync::atomic::Ordering;
-
-    /// A share log naming exactly one recipient, in the `kp-shares/` layout the
-    /// enclave writes today.
-    fn shares_record_for(fp_hex: &str) -> (String, Vec<u8>) {
-        let record = serde_json::json!({
-            "session_id": "s",
-            "timestamp_ms": 0,
-            "message": { "KpShareState": { "sharing_seq": 0, "cert_seq": 0, "encrypted_shares": [
-                { "id": 1, "recipient_fingerprint": fp_hex, "armored_ciphertext": "" }
-            ]}},
-            "signature": null,
-        });
-        let key = "kp-shares/00000000000000000000/00000000000000000000-s.json".to_string();
-        (key, serde_json::to_vec(&record).unwrap())
-    }
-
-    #[tokio::test]
-    async fn roster_cache_reads_membership_from_the_share_log() {
-        let (cert_armored, _) = mock_pgp_keypair();
-        let cert = PgpPublicCert::new(cert_armored).unwrap();
-        let store = MemStore::default();
-        let (key, bytes) = shares_record_for(&cert.fingerprint().to_hex());
-        store.insert(key, bytes);
-
-        let roster = RosterCache::new(store).get().await.unwrap();
-        assert!(roster.contains(&cert.fingerprint()));
-        assert_eq!(roster.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn roster_cache_serves_the_cached_roster_within_the_ttl() {
-        let store = MemStore::default();
-        let (key, bytes) = shares_record_for("AAAABBBBCCCCDDDDEEEE11112222333344445555");
-        store.insert(key, bytes);
-        let cache = RosterCache::new(store);
-
-        let first = cache.get().await.unwrap();
-        // The store now fails hard; a fresh read would error, the cache must not.
-        cache.store.fail_lists.store(true, Ordering::SeqCst);
-        let second = cache.get().await.unwrap();
-        assert_eq!(first, second);
-    }
-
-    #[tokio::test]
-    async fn missing_share_log_fails_closed() {
-        let err = RosterCache::new(MemStore::default())
-            .get()
-            .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    }
 
     fn submission(id: u32) -> proto::SignedSingleProvisionerInitRequest {
         proto::SignedSingleProvisionerInitRequest {

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -100,6 +100,27 @@ impl<L: LogStore> Relay<L> {
         }
     }
 
+    /// Pre-authenticate a submission: its detached signature must cover these
+    /// exact (session, config, share) bytes, and the signer's cert must be in
+    /// the ceremony's committed roster. Signature first because it needs no
+    /// I/O — a submission that isn't internally consistent never costs an S3
+    /// roster read. DoS guard only; the enclave re-verifies authoritatively.
+    async fn verify_kp_submission<'a>(
+        &self,
+        signed_request: &'a KpSigned<SingleProvisionerInitRequest>,
+    ) -> Result<&'a SingleProvisionerInitRequest, Status> {
+        let request = signed_request
+            .verify_signature()
+            .map_err(|error| Status::unauthenticated(error.to_string()))?;
+        // The ceremony's committed roster, not deploy config: a rotation
+        // re-deals shares without a proxy redeploy.
+        check_rostered(
+            &signed_request.signer_fingerprint(),
+            &self.authorized_kps().await?,
+        )?;
+        Ok(request)
+    }
+
     /// The ceremony's committed roster, mapped onto the relay's failure modes:
     /// no share log yet is a definitive "not ready", a read error is transient.
     async fn authorized_kps(&self) -> Result<Arc<Vec<Fingerprint>>, Status> {
@@ -145,27 +166,13 @@ impl<L: LogStore> Relay<L> {
     }
 }
 
-/// Pre-authenticate a submission: the signer's cert must be in the ceremony's
-/// committed roster and its detached signature must cover these exact
-/// (session, config, share) bytes. This is only a DoS guard; the enclave repeats
-/// signature verification authoritatively.
-fn verify_kp_submission<'a>(
-    signed_request: &'a KpSigned<SingleProvisionerInitRequest>,
-    authorized_kp_fingerprints: &[Fingerprint],
-) -> Result<&'a SingleProvisionerInitRequest, Status> {
-    // Membership first: it is a lookup against a cached roster, while signature
-    // verification is PGP. Checking the cheap one that actually excludes callers
-    // keeps a flood from costing crypto — the signature alone excludes nobody,
-    // since it is made by the cert the request carries.
-    let fingerprint = signed_request.signer_fingerprint();
-    if !authorized_kp_fingerprints.contains(&fingerprint) {
-        return Err(Status::permission_denied(format!(
-            "signer {fingerprint} is not in the relay's authorized KP roster"
-        )));
+fn check_rostered(fingerprint: &Fingerprint, roster: &[Fingerprint]) -> Result<(), Status> {
+    if roster.contains(fingerprint) {
+        return Ok(());
     }
-    signed_request
-        .verify_signature()
-        .map_err(|error| Status::unauthenticated(error.to_string()))
+    Err(Status::permission_denied(format!(
+        "signer {fingerprint} is not in the relay's authorized KP roster"
+    )))
 }
 
 fn done() -> Response<proto::SingleProvisionerInitResponse> {
@@ -201,18 +208,13 @@ impl<L: LogStore> GuardianRelayService for Relay<L> {
         &self,
         request: Request<proto::SignedSingleProvisionerInitRequest>,
     ) -> Result<Response<proto::SingleProvisionerInitResponse>, Status> {
-        // Decode before the roster read so a malformed submission costs no S3.
         let submission = request.into_inner();
         let signed_request = KpSigned::<SingleProvisionerInitRequest>::try_from(submission.clone())
             .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
 
-        // The ceremony's committed roster, not deploy config: a rotation
-        // re-deals shares without a proxy redeploy.
-        let roster = self.authorized_kps().await?;
-
         // Authenticate before the lock or any backend read: junk submissions
         // can't poison the batch, hold the mutex, or cost enclave round-trips.
-        let verified_request = verify_kp_submission(&signed_request, &roster)?;
+        let verified_request = self.verify_kp_submission(&signed_request).await?;
         let expected_session_id = verified_request.expected_session_id().to_string();
         let expected_config_hash = *verified_request.expected_config_hash();
         let expected_genesis_state_hash = verified_request.expected_genesis_state_hash();
@@ -338,6 +340,16 @@ mod tests {
     use hashi_types::pgp::test_utils::sign_detached_in_process;
     use hashi_types::pgp::PgpPublicCert;
 
+    use crate::widlog::test_store::MemStore;
+    use std::sync::atomic::Ordering;
+
+    /// A relay whose backend is never dialled — enough to exercise the roster
+    /// mapping, which happens before any backend call.
+    fn relay_with_roster(store: MemStore) -> Relay<MemStore> {
+        let channel = Channel::from_static("http://127.0.0.1:1").connect_lazy();
+        Relay::new(channel, Arc::new(RosterCache::new(store)))
+    }
+
     fn submission(id: u32) -> proto::SignedSingleProvisionerInitRequest {
         proto::SignedSingleProvisionerInitRequest {
             encrypted_share: Some(proto::GuardianEncryptedShare {
@@ -363,70 +375,80 @@ mod tests {
         }
     }
 
-    #[test]
-    fn verify_kp_submission_gates_on_roster_and_signature() {
+    /// The store holds no share log, so anything that reaches the roster read
+    /// answers FailedPrecondition — an Unauthenticated verdict is proof the
+    /// signature was checked first, before any S3 read.
+    #[tokio::test]
+    async fn bad_signatures_are_rejected_before_the_roster_read() {
         let (cert_armored, secret_armored) = mock_pgp_keypair();
-        let cert = PgpPublicCert::new(cert_armored.clone()).unwrap();
-        let roster = vec![cert.fingerprint()];
-        let session = "sess-a";
+        let cert = PgpPublicCert::new(cert_armored).unwrap();
+        let relay = relay_with_roster(MemStore::default());
 
-        let domain_share = signed_share(1);
-        let config_hash = [7u8; 32];
-        let request = SingleProvisionerInitRequest::new(
-            session.to_string().into(),
-            config_hash,
-            None,
-            domain_share.clone(),
-        );
-        let signed_bytes = KpSigned::signed_bytes(&request);
-        let good_sig = sign_detached_in_process(&secret_armored, &signed_bytes);
-        let signed_request = KpSigned::from_parts(request.clone(), cert.clone(), good_sig.clone());
+        let request = |session: &str, share_id: u16| {
+            SingleProvisionerInitRequest::new(
+                session.to_string().into(),
+                [7u8; 32],
+                None,
+                signed_share(share_id),
+            )
+        };
+        let sign = |req: &SingleProvisionerInitRequest| {
+            sign_detached_in_process(&secret_armored, &KpSigned::signed_bytes(req))
+        };
+        let good_sig = sign(&request("sess-a", 1));
 
-        // A rostered signer with a valid signature over the exact submission passes.
-        verify_kp_submission(&signed_request, &roster).unwrap();
+        for (case, signed) in [
+            (
+                "signature bound to another share",
+                KpSigned::from_parts(request("sess-a", 2), cert.clone(), good_sig.clone()),
+            ),
+            (
+                "signature bound to another session",
+                KpSigned::from_parts(
+                    request("sess-a", 1),
+                    cert.clone(),
+                    sign(&request("other-session", 1)),
+                ),
+            ),
+            (
+                "missing signature",
+                KpSigned::from_parts(request("sess-a", 1), cert.clone(), String::new()),
+            ),
+        ] {
+            let err = relay.verify_kp_submission(&signed).await.unwrap_err();
+            assert_eq!(err.code(), tonic::Code::Unauthenticated, "{case}");
+        }
 
-        // A roster entry parsed from config text (lowercase bare hex) matches too.
-        let from_config: Fingerprint = cert.fingerprint().to_hex().to_lowercase().parse().unwrap();
-        verify_kp_submission(&signed_request, &[from_config]).unwrap();
+        // A signature over the exact submission gets past, on to the roster read.
+        let signed = KpSigned::from_parts(request("sess-a", 1), cert, good_sig);
+        let err = relay.verify_kp_submission(&signed).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
 
-        let other_share = signed_share(2);
-        let other_request = SingleProvisionerInitRequest::new(
-            session.to_string().into(),
-            config_hash,
-            None,
-            other_share,
-        );
-        let signed_other_share =
-            KpSigned::from_parts(other_request, cert.clone(), good_sig.clone());
-        assert!(
-            verify_kp_submission(&signed_other_share, &roster).is_err(),
-            "signature bound to another share must be rejected"
-        );
+    #[test]
+    fn roster_membership_is_by_fingerprint_value() {
+        let cert = PgpPublicCert::new(mock_pgp_keypair().0).unwrap();
+        let fingerprint = cert.fingerprint();
+        check_rostered(&fingerprint, std::slice::from_ref(&fingerprint)).unwrap();
 
-        assert!(
-            verify_kp_submission(&signed_request, &[]).is_err(),
-            "non-rostered signer must be rejected"
-        );
+        // Share-log labels are bare hex, so case must not matter.
+        let lowercase: Fingerprint = fingerprint.to_hex().to_lowercase().parse().unwrap();
+        check_rostered(&fingerprint, &[lowercase]).unwrap();
 
-        let missing_signature = KpSigned::from_parts(request.clone(), cert.clone(), String::new());
-        assert!(
-            verify_kp_submission(&missing_signature, &roster).is_err(),
-            "missing signature must be rejected"
-        );
+        let err = check_rostered(&fingerprint, &[]).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
 
-        let other_session_request = SingleProvisionerInitRequest::new(
-            "other-session".into(),
-            config_hash,
-            None,
-            domain_share,
-        );
-        let other_bytes = KpSigned::signed_bytes(&other_session_request);
-        let stale_sig = sign_detached_in_process(&secret_armored, &other_bytes);
-        let stale_request = KpSigned::from_parts(request, cert, stale_sig);
-        assert!(
-            verify_kp_submission(&stale_request, &roster).is_err(),
-            "signature bound to another session must be rejected"
-        );
+    #[tokio::test]
+    async fn roster_store_failure_is_unavailable_and_unclassified() {
+        let store = MemStore::default();
+        store.fail_lists.store(true, Ordering::SeqCst);
+        let err = relay_with_roster(store).authorized_kps().await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unavailable);
+        // The node classifies guardian errors by substring; this must stay in
+        // its retriable bucket.
+        assert!(!err.message().contains("seq mismatch"));
+        assert!(!err.message().contains("Rate limit exceeded"));
     }
 
     #[test]

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -366,6 +366,60 @@ mod tests {
     use hashi_types::pgp::test_utils::sign_detached_in_process;
     use hashi_types::pgp::PgpPublicCert;
 
+    use crate::widlog::test_store::MemStore;
+    use std::sync::atomic::Ordering;
+
+    /// A share log naming exactly one recipient, in the `kp-shares/` layout the
+    /// enclave writes today.
+    fn shares_record_for(fp_hex: &str) -> (String, Vec<u8>) {
+        let record = serde_json::json!({
+            "session_id": "s",
+            "timestamp_ms": 0,
+            "message": { "KpShareState": { "sharing_seq": 0, "cert_seq": 0, "encrypted_shares": [
+                { "id": 1, "recipient_fingerprint": fp_hex, "armored_ciphertext": "" }
+            ]}},
+            "signature": null,
+        });
+        let key = "kp-shares/00000000000000000000/00000000000000000000-s.json".to_string();
+        (key, serde_json::to_vec(&record).unwrap())
+    }
+
+    #[tokio::test]
+    async fn roster_cache_reads_membership_from_the_share_log() {
+        let (cert_armored, _) = mock_pgp_keypair();
+        let cert = PgpPublicCert::new(cert_armored).unwrap();
+        let store = MemStore::default();
+        let (key, bytes) = shares_record_for(&cert.fingerprint().to_hex());
+        store.insert(key, bytes);
+
+        let roster = RosterCache::new(store).get().await.unwrap();
+        assert!(roster.contains(&cert.fingerprint()));
+        assert_eq!(roster.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn roster_cache_serves_the_cached_roster_within_the_ttl() {
+        let store = MemStore::default();
+        let (key, bytes) = shares_record_for("AAAABBBBCCCCDDDDEEEE11112222333344445555");
+        store.insert(key, bytes);
+        let cache = RosterCache::new(store);
+
+        let first = cache.get().await.unwrap();
+        // The store now fails hard; a fresh read would error, the cache must not.
+        cache.store.fail_lists.store(true, Ordering::SeqCst);
+        let second = cache.get().await.unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn missing_share_log_fails_closed() {
+        let err = RosterCache::new(MemStore::default())
+            .get()
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
     fn submission(id: u32) -> proto::SignedSingleProvisionerInitRequest {
         proto::SignedSingleProvisionerInitRequest {
             encrypted_share: Some(proto::GuardianEncryptedShare {

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -15,7 +15,11 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
+use crate::roster::latest_kp_roster;
+use crate::widlog::LogStore;
 use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::SessionID;
@@ -82,21 +86,64 @@ struct BackendStatus {
     provisioned: bool,
 }
 
-#[derive(Clone)]
-pub struct Relay {
-    client: GuardianServiceClient<Channel>,
-    accumulator: Arc<Mutex<Accumulator>>,
-    /// Fingerprints of the KPs allowed to submit shares (the ceremony roster,
-    /// via deploy config). Empty rejects every submission — fail closed.
-    authorized_kp_fingerprints: Vec<Fingerprint>,
+/// The committed roster changes only at ceremonies/rotations; a short TTL
+/// bounds S3 reads under submission spam without staleness that matters.
+const ROSTER_TTL: Duration = Duration::from_secs(60);
+
+/// TTL-cached view of the S3-committed KP roster. The mutex is held across the
+/// fetch, so concurrent misses collapse into one S3 read.
+struct RosterCache<L> {
+    store: L,
+    cached: Mutex<Option<(Instant, Arc<Vec<Fingerprint>>)>>,
 }
 
-impl Relay {
-    pub fn new(channel: Channel, authorized_kp_fingerprints: Vec<Fingerprint>) -> Self {
+impl<L: LogStore> RosterCache<L> {
+    fn new(store: L) -> Self {
+        Self {
+            store,
+            cached: Mutex::new(None),
+        }
+    }
+
+    async fn get(&self) -> Result<Arc<Vec<Fingerprint>>, Status> {
+        let mut cached = self.cached.lock().await;
+        if let Some((at, roster)) = cached.as_ref() {
+            if at.elapsed() < ROSTER_TTL {
+                return Ok(roster.clone());
+            }
+        }
+        match latest_kp_roster(&self.store).await {
+            Ok(Some(roster)) => {
+                let roster = Arc::new(roster);
+                *cached = Some((Instant::now(), roster.clone()));
+                Ok(roster)
+            }
+            // No ceremony has committed a share set yet: fail closed, uncached
+            // (so the first ceremony is authorized the moment its log lands).
+            Ok(None) => Err(Status::failed_precondition(
+                "no KP share log in the guardian bucket; run the key ceremony first",
+            )),
+            Err(e) => {
+                warn!(error = %format!("{e:#}"), "KP roster read failed");
+                Err(Status::unavailable("KP roster unavailable; retry"))
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Relay<L> {
+    client: GuardianServiceClient<Channel>,
+    accumulator: Arc<Mutex<Accumulator>>,
+    roster: Arc<RosterCache<L>>,
+}
+
+impl<L: LogStore> Relay<L> {
+    pub fn new(channel: Channel, roster_store: L) -> Self {
         Self {
             client: GuardianServiceClient::new(channel),
             accumulator: Arc::new(Mutex::new(Accumulator::default())),
-            authorized_kp_fingerprints,
+            roster: Arc::new(RosterCache::new(roster_store)),
         }
     }
 
@@ -130,8 +177,8 @@ impl Relay {
     }
 }
 
-/// Pre-authenticate a submission: the signer's cert must be in the configured
-/// relay roster and its detached signature must cover these exact
+/// Pre-authenticate a submission: the signer's cert must be in the ceremony's
+/// committed roster and its detached signature must cover these exact
 /// (session, config, share) bytes. This is only a DoS guard; the enclave repeats
 /// signature verification authoritatively.
 fn verify_kp_submission<'a>(
@@ -177,18 +224,15 @@ fn check_share_id(id: u32, num_shares: usize) -> Result<(), Status> {
 }
 
 #[tonic::async_trait]
-impl GuardianRelayService for Relay {
+impl<L: LogStore> GuardianRelayService for Relay<L> {
     async fn single_provisioner_init(
         &self,
         request: Request<proto::SignedSingleProvisionerInitRequest>,
     ) -> Result<Response<proto::SingleProvisionerInitResponse>, Status> {
-        // No roster configured (proxy deployed before its ceremony): fail closed.
-        if self.authorized_kp_fingerprints.is_empty() {
-            return Err(Status::failed_precondition(
-                "relay has no authorized KP roster configured; \
-                 set AUTHORIZED_KP_FINGERPRINTS on the proxy",
-            ));
-        }
+        // The ceremony's committed roster, not deploy config: a rotation
+        // re-deals shares without a proxy redeploy. Fails closed when no share
+        // log exists yet.
+        let roster = self.roster.get().await?;
 
         let submission = request.into_inner();
         let signed_request = KpSigned::<SingleProvisionerInitRequest>::try_from(submission.clone())
@@ -196,8 +240,7 @@ impl GuardianRelayService for Relay {
 
         // Authenticate before the lock or any backend read: junk submissions
         // can't poison the batch, hold the mutex, or cost enclave round-trips.
-        let verified_request =
-            verify_kp_submission(&signed_request, &self.authorized_kp_fingerprints)?;
+        let verified_request = verify_kp_submission(&signed_request, &roster)?;
         let expected_session_id = verified_request.expected_session_id().to_string();
         let expected_config_hash = *verified_request.expected_config_hash();
         let expected_genesis_state_hash = verified_request.expected_genesis_state_hash();

--- a/crates/hashi-guardian-proxy/src/roster.rs
+++ b/crates/hashi-guardian-proxy/src/roster.rs
@@ -1,0 +1,252 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The relay's KP roster, read from the guardian's S3 share log. A ceremony
+//! commits who holds shares — every encrypted share is labeled with its
+//! recipient's PGP fingerprint — so the latest share log IS the authorization
+//! roster: exactly the set that can produce a share worth relaying. The read is
+//! deliberately unverified (no enclave-signature check): the bucket only admits
+//! enclave writes, and this gate is DoS-tier — the enclave still verifies every
+//! share cryptographically (config_hash AAD + commitments).
+//!
+//! Two layouts are in flight (#779 migrates the first to the second):
+//!   `shares/{sharing_seq:020}-{session}.json` (message `Shares`)
+//!   `kp-shares/{sharing_seq:020}/{cert_seq:020}-{session}.json` (`KpShareState`)
+//! The reader prefers `kp-shares/` and falls back to `shares/`, parsing a local
+//! tolerant shape rather than the hashi-types enum, so the proxy keeps working
+//! on either side of that migration and on buckets whose ceremony predates it.
+
+use anyhow::Context as _;
+use hashi_types::pgp::Fingerprint;
+use serde::Deserialize;
+
+use crate::widlog::LogStore;
+
+const LEGACY_SHARES_PREFIX: &str = "shares/";
+const KP_SHARES_PREFIX: &str = "kp-shares/";
+
+/// Recipient fingerprints of the latest committed share set. `Ok(None)` means
+/// no share log exists anywhere (no ceremony yet) — a definitive miss; any
+/// `Err` is indeterminate and the caller must fail closed.
+pub async fn latest_kp_roster<L: LogStore>(log: &L) -> anyhow::Result<Option<Vec<Fingerprint>>> {
+    let Some(key) = latest_share_log_key(log).await? else {
+        return Ok(None);
+    };
+    let bytes = log.get(&key).await?;
+    let roster = parse_roster(&bytes).with_context(|| format!("parse share log {key}"))?;
+    Ok(Some(roster))
+}
+
+/// Key of the latest share-state record: the lex-greatest object under the
+/// lex-greatest `kp-shares/` sharing-seq dir, else the lex-greatest flat
+/// `shares/` key (zero-padded seqs make lex order the seq order).
+async fn latest_share_log_key<L: LogStore>(log: &L) -> anyhow::Result<Option<String>> {
+    if let Some(dir) = log.list_dirs(KP_SHARES_PREFIX).await?.into_iter().max() {
+        let key = log
+            .list_keys(&dir)
+            .await?
+            .into_iter()
+            .max()
+            .with_context(|| format!("share dir {dir} listed but has no keys"))?;
+        return Ok(Some(key));
+    }
+    Ok(log.list_keys(LEGACY_SHARES_PREFIX).await?.into_iter().max())
+}
+
+/// Just the fields the roster needs, tolerant of everything else. Any record
+/// under a share prefix carries one of these two message shapes; anything else
+/// is a poisoned log and fails closed upstream.
+#[derive(Deserialize)]
+struct ShareLogRecord {
+    message: ShareLogMessage,
+}
+
+#[derive(Deserialize)]
+enum ShareLogMessage {
+    Shares(ShareState),
+    KpShareState(ShareState),
+}
+
+#[derive(Deserialize)]
+struct ShareState {
+    encrypted_shares: Vec<LabeledShare>,
+}
+
+#[derive(Deserialize)]
+struct LabeledShare {
+    recipient_fingerprint: String,
+}
+
+fn parse_roster(bytes: &[u8]) -> anyhow::Result<Vec<Fingerprint>> {
+    let record: ShareLogRecord = serde_json::from_slice(bytes)?;
+    let (ShareLogMessage::Shares(state) | ShareLogMessage::KpShareState(state)) = record.message;
+    state
+        .encrypted_shares
+        .iter()
+        .map(|share| parse_recipient_fingerprint(&share.recipient_fingerprint))
+        .collect()
+}
+
+fn parse_recipient_fingerprint(label: &str) -> anyhow::Result<Fingerprint> {
+    label
+        .parse::<Fingerprint>()
+        .ok()
+        // Sequoia parses odd-sized hex into `Fingerprint::Unknown` rather than
+        // failing; only real v4/v6 shapes can name a KP cert.
+        .filter(|fp| matches!(fp, Fingerprint::V4(_) | Fingerprint::V6(_)))
+        .with_context(|| format!("share label {label:?} is not a PGP fingerprint"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widlog::test_store::MemStore;
+
+    const FP_A: &str = "AAAABBBBCCCCDDDDEEEE11112222333344445555";
+    const FP_B: &str = "AAAABBBBCCCCDDDDEEEE1111222233334444FFFF";
+
+    fn fp(hex: &str) -> Fingerprint {
+        hex.parse().unwrap()
+    }
+
+    fn labeled_shares(fingerprints: &[&str]) -> Vec<serde_json::Value> {
+        fingerprints
+            .iter()
+            .enumerate()
+            .map(|(i, fp)| {
+                serde_json::json!({
+                    "id": i + 1,
+                    "recipient_fingerprint": fp,
+                    "armored_ciphertext": "",
+                })
+            })
+            .collect()
+    }
+
+    /// A pre-#779 `shares/` record. Hand-rolled at the JSON layer the parser
+    /// sees: hashi-types no longer models this layout, and binding the fixture
+    /// to the current enum is what the tolerant parse exists to avoid.
+    fn legacy_shares_record(sharing_seq: u64, fingerprints: &[&str]) -> (String, Vec<u8>) {
+        let record = serde_json::json!({
+            "session_id": "test-session",
+            "timestamp_ms": 0,
+            "message": { "Shares": {
+                "sharing_seq": sharing_seq,
+                "encrypted_shares": labeled_shares(fingerprints),
+            }},
+            "signature": null,
+        });
+        let key = format!("shares/{sharing_seq:020}-test-session.json");
+        (key, serde_json::to_vec(&record).unwrap())
+    }
+
+    /// A `kp-shares/` record in #779's shape — the layout the enclave writes
+    /// today.
+    fn kp_shares_record(
+        sharing_seq: u64,
+        cert_seq: u64,
+        fingerprints: &[&str],
+    ) -> (String, Vec<u8>) {
+        let shares = labeled_shares(fingerprints);
+        let record = serde_json::json!({
+            "session_id": "test-session",
+            "timestamp_ms": 0,
+            "message": { "KpShareState": {
+                "sharing_seq": sharing_seq,
+                "cert_seq": cert_seq,
+                "encrypted_shares": shares,
+            }},
+            "signature": null,
+        });
+        let key = format!("kp-shares/{sharing_seq:020}/{cert_seq:020}-test-session.json");
+        (key, serde_json::to_vec(&record).unwrap())
+    }
+
+    #[tokio::test]
+    async fn reads_the_legacy_shares_layout() {
+        let store = MemStore::default();
+        let (key, bytes) = legacy_shares_record(0, &[FP_A, FP_B]);
+        store.insert(key, bytes);
+
+        let roster = latest_kp_roster(&store).await.unwrap().unwrap();
+        assert_eq!(roster, vec![fp(FP_A), fp(FP_B)]);
+    }
+
+    #[tokio::test]
+    async fn latest_sharing_seq_wins_in_the_legacy_layout() {
+        let store = MemStore::default();
+        let (key0, bytes0) = legacy_shares_record(0, &[FP_A]);
+        let (key1, bytes1) = legacy_shares_record(1, &[FP_B]);
+        store.insert(key0, bytes0);
+        store.insert(key1, bytes1);
+
+        let roster = latest_kp_roster(&store).await.unwrap().unwrap();
+        assert_eq!(roster, vec![fp(FP_B)]);
+    }
+
+    #[tokio::test]
+    async fn kp_shares_layout_is_preferred_over_legacy() {
+        let store = MemStore::default();
+        let (legacy_key, legacy_bytes) = legacy_shares_record(0, &[FP_A]);
+        let (key, bytes) = kp_shares_record(0, 0, &[FP_B]);
+        store.insert(legacy_key, legacy_bytes);
+        store.insert(key, bytes);
+
+        let roster = latest_kp_roster(&store).await.unwrap().unwrap();
+        assert_eq!(roster, vec![fp(FP_B)]);
+    }
+
+    #[tokio::test]
+    async fn latest_cert_seq_wins_within_a_sharing_seq() {
+        let store = MemStore::default();
+        let (key0, bytes0) = kp_shares_record(3, 0, &[FP_A]);
+        let (key1, bytes1) = kp_shares_record(3, 1, &[FP_B]);
+        // An older sharing seq must lose to the newer dir regardless of cert_seq.
+        let (key_old, bytes_old) = kp_shares_record(2, 9, &[FP_A]);
+        store.insert(key0, bytes0);
+        store.insert(key1, bytes1);
+        store.insert(key_old, bytes_old);
+
+        let roster = latest_kp_roster(&store).await.unwrap().unwrap();
+        assert_eq!(roster, vec![fp(FP_B)]);
+    }
+
+    #[tokio::test]
+    async fn no_share_log_is_a_definitive_none() {
+        let store = MemStore::default();
+        assert!(latest_kp_roster(&store).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn store_failure_is_an_error_not_a_miss() {
+        let store = MemStore::default();
+        let (key, bytes) = legacy_shares_record(0, &[FP_A]);
+        store.insert(key, bytes);
+        store
+            .fail_lists
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        assert!(latest_kp_roster(&store).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unparseable_latest_record_fails_closed() {
+        // Unlike the wid scan (where a skip degrades to a re-sign), silently
+        // falling back past a garbled newest record could authorize a
+        // rotated-out roster — so a parse failure is an error.
+        let store = MemStore::default();
+        let (key, _) = legacy_shares_record(0, &[FP_A]);
+        store.insert(key, b"not json".to_vec());
+
+        assert!(latest_kp_roster(&store).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn bad_fingerprint_label_fails_closed() {
+        let store = MemStore::default();
+        let (key, bytes) = legacy_shares_record(0, &["ABCD"]);
+        store.insert(key, bytes);
+
+        assert!(latest_kp_roster(&store).await.is_err());
+    }
+}

--- a/crates/hashi-guardian-proxy/src/roster.rs
+++ b/crates/hashi-guardian-proxy/src/roster.rs
@@ -13,6 +13,13 @@
 //!   `kp-shares/{sharing_seq:020}/{cert_seq:020}-{session}.json` (`KpShareState`)
 //! The reader prefers `kp-shares/`, parsing a local tolerant shape rather than
 //! the hashi-types enum so it keeps working across that migration.
+//!
+//! Which `sharing_seq` is current comes from `ceremony/`, not from the newest
+//! `kp-shares/` dir: a ceremony publishes its shares before its `ceremony/`
+//! record, so an aborted one leaves an orphan dir that was never authorized.
+//! This is the resolution the enclave performs
+//! (`hashi-guardian::s3_reader::read_latest_ceremony_state`), and the relay has
+//! to agree with it or it rejects the very KPs the enclave would accept.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -28,6 +35,7 @@ use crate::widlog::LogStore;
 
 const LEGACY_SHARES_PREFIX: &str = "shares/";
 const KP_SHARES_PREFIX: &str = "kp-shares/";
+const CEREMONY_PREFIX: &str = "ceremony/";
 
 /// The committed roster only changes at a ceremony, a re-deal, or a cert
 /// rotation — and rotation invalidates explicitly — so a minute of staleness
@@ -97,20 +105,35 @@ pub async fn latest_kp_roster<L: LogStore>(log: &L) -> anyhow::Result<Option<Vec
     Ok(Some(roster))
 }
 
-/// Key of the latest share-state record: the lex-greatest object under the
-/// lex-greatest `kp-shares/` sharing-seq dir, else the lex-greatest flat
-/// `shares/` key (zero-padded seqs make lex order the seq order).
+/// Key of the share-state record the latest completed ceremony committed: the
+/// lex-greatest `cert_seq` under that ceremony's `sharing_seq` dir. Zero-padded
+/// seqs make lex order the seq order throughout.
+///
+/// Pre-#779 buckets have no `ceremony/` records at all; there the lex-greatest
+/// flat `shares/` key is the whole story.
 async fn latest_share_log_key<L: LogStore>(log: &L) -> anyhow::Result<Option<String>> {
-    if let Some(dir) = log.list_dirs(KP_SHARES_PREFIX).await?.into_iter().max() {
-        let key = log
-            .list_keys(&dir)
-            .await?
-            .into_iter()
-            .max()
-            .with_context(|| format!("share dir {dir} listed but has no keys"))?;
-        return Ok(Some(key));
-    }
-    Ok(log.list_keys(LEGACY_SHARES_PREFIX).await?.into_iter().max())
+    let Some(ceremony_key) = log.list_keys(CEREMONY_PREFIX).await?.into_iter().max() else {
+        return Ok(log.list_keys(LEGACY_SHARES_PREFIX).await?.into_iter().max());
+    };
+    let sharing_seq = ceremony_sharing_seq(&ceremony_key)?;
+    log.list_keys(&format!("{KP_SHARES_PREFIX}{sharing_seq}/"))
+        .await?
+        .into_iter()
+        .max()
+        .map(Some)
+        // Shares are written first, so a ceremony without them is a corrupt
+        // log, not a not-ready one. Fail closed rather than fall back to a
+        // roster this ceremony did not authorize.
+        .with_context(|| format!("ceremony {ceremony_key} has no kp-shares log"))
+}
+
+/// The `sharing_seq` a `ceremony/{sharing_seq:020}-{session}.json` key records,
+/// left as zero-padded text so it indexes `kp-shares/` directly.
+fn ceremony_sharing_seq(key: &str) -> anyhow::Result<&str> {
+    key.strip_prefix(CEREMONY_PREFIX)
+        .and_then(|name| name.split('-').next())
+        .filter(|seq| seq.len() == 20 && seq.bytes().all(|b| b.is_ascii_digit()))
+        .with_context(|| format!("ceremony key {key:?} has no sharing_seq"))
 }
 
 /// Just the fields the roster needs, tolerant of everything else. Any record
@@ -254,6 +277,15 @@ mod tests {
         (key, serde_json::to_vec(&record).unwrap())
     }
 
+    /// Mark `sharing_seq` as completed. Only the key matters — the reader takes
+    /// the seq from there and never opens a ceremony record.
+    fn complete_ceremony(store: &MemStore, sharing_seq: u64) {
+        store.insert(
+            format!("ceremony/{sharing_seq:020}-test-session.json"),
+            b"{}".to_vec(),
+        );
+    }
+
     /// A `kp-shares/` record in #779's shape — the layout the enclave writes
     /// today. One cert per share; use `kp_shares_record_multi_cert` for a KP
     /// holding several.
@@ -307,6 +339,7 @@ mod tests {
         let (key, bytes) = kp_shares_record(0, 0, &[FP_B]);
         store.insert(legacy_key, legacy_bytes);
         store.insert(key, bytes);
+        complete_ceremony(&store, 0);
 
         let roster = latest_kp_roster(&store).await.unwrap().unwrap();
         assert_eq!(roster, vec![fp(FP_B)]);
@@ -317,14 +350,56 @@ mod tests {
         let store = MemStore::default();
         let (key0, bytes0) = kp_shares_record(3, 0, &[FP_A]);
         let (key1, bytes1) = kp_shares_record(3, 1, &[FP_B]);
-        // An older sharing seq must lose to the newer dir regardless of cert_seq.
+        // An older sharing seq must lose regardless of cert_seq.
         let (key_old, bytes_old) = kp_shares_record(2, 9, &[FP_A]);
         store.insert(key0, bytes0);
         store.insert(key1, bytes1);
         store.insert(key_old, bytes_old);
+        complete_ceremony(&store, 2);
+        complete_ceremony(&store, 3);
 
         let roster = latest_kp_roster(&store).await.unwrap().unwrap();
         assert_eq!(roster, vec![fp(FP_B)]);
+    }
+
+    /// The regression: shares are published before the `ceremony/` record, so a
+    /// ceremony that dies in between leaves a `kp-shares/` dir that was never
+    /// authorized. Taking the newest dir would swap the roster out from under
+    /// the KPs the enclave still accepts, and block provisioning.
+    #[tokio::test]
+    async fn an_aborted_ceremony_does_not_move_the_roster() {
+        let store = MemStore::default();
+        let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
+        store.insert(key, bytes);
+        complete_ceremony(&store, 0);
+        // A re-deal wrote its shares, then failed before committing.
+        let (orphan_key, orphan_bytes) = kp_shares_record(1, 0, &[FP_B]);
+        store.insert(orphan_key, orphan_bytes);
+
+        assert_eq!(
+            latest_kp_roster(&store).await.unwrap().unwrap(),
+            vec![fp(FP_A)]
+        );
+
+        // Once that ceremony does commit, the new roster takes over.
+        complete_ceremony(&store, 1);
+        assert_eq!(
+            latest_kp_roster(&store).await.unwrap().unwrap(),
+            vec![fp(FP_B)]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_ceremony_without_its_shares_fails_closed() {
+        let store = MemStore::default();
+        let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
+        store.insert(key, bytes);
+        complete_ceremony(&store, 0);
+        // Its own shares are missing, so falling back to seq 0 would authorize
+        // a roster this ceremony replaced.
+        complete_ceremony(&store, 1);
+
+        assert!(latest_kp_roster(&store).await.is_err());
     }
 
     /// The shape the guardian deployed on testnet writes: a `kp-shares/` record
@@ -358,6 +433,7 @@ mod tests {
             "kp-shares/00000000000000000000/00000000000000000000-916c711a5e81c2b0.json".to_string(),
             serde_json::to_vec(&record).unwrap(),
         );
+        complete_ceremony(&store, 0);
 
         let roster = latest_kp_roster(&store).await.unwrap().unwrap();
         assert_eq!(roster, DEPLOYED.iter().map(|f| fp(f)).collect::<Vec<_>>());
@@ -384,6 +460,7 @@ mod tests {
             "kp-shares/00000000000000000000/00000000000000000000-test-session.json".to_string(),
             serde_json::to_vec(&record).unwrap(),
         );
+        complete_ceremony(&store, 0);
 
         let roster = latest_kp_roster(&store).await.unwrap().unwrap();
         assert_eq!(roster, vec![fp(FP_A), fp(FP_B)]);
@@ -433,6 +510,7 @@ mod tests {
         let store = MemStore::default();
         let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
         store.insert(key, bytes);
+        complete_ceremony(&store, 0);
 
         let roster = RosterCache::new(store).get().await.unwrap().unwrap();
         assert_eq!(*roster, vec![fp(FP_A)]);
@@ -443,6 +521,7 @@ mod tests {
         let store = MemStore::default();
         let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
         store.insert(key, bytes);
+        complete_ceremony(&store, 0);
         let cache = RosterCache::new(store);
 
         let first = cache.get().await.unwrap();
@@ -465,6 +544,7 @@ mod tests {
         let store = MemStore::default();
         let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
         store.insert(key, bytes);
+        complete_ceremony(&store, 0);
         let cache = RosterCache::new(store);
         assert_eq!(*cache.get().await.unwrap().unwrap(), vec![fp(FP_A)]);
 

--- a/crates/hashi-guardian-proxy/src/roster.rs
+++ b/crates/hashi-guardian-proxy/src/roster.rs
@@ -4,17 +4,17 @@
 //! The relay's KP roster, read from the guardian's S3 share log. A ceremony
 //! commits who holds shares — every encrypted share is labeled with its
 //! recipient's PGP fingerprint — so the latest share log IS the authorization
-//! roster: exactly the set that can produce a share worth relaying. The read is
-//! deliberately unverified (no enclave-signature check): the bucket only admits
-//! enclave writes, and this gate is DoS-tier — the enclave still verifies every
+//! roster. The read is deliberately unverified: the bucket only admits enclave
+//! writes and this gate is DoS-tier, with the enclave still verifying every
 //! share cryptographically (config_hash AAD + commitments).
 //!
 //! Two layouts are in flight (#779 migrates the first to the second):
 //!   `shares/{sharing_seq:020}-{session}.json` (message `Shares`)
 //!   `kp-shares/{sharing_seq:020}/{cert_seq:020}-{session}.json` (`KpShareState`)
-//! The reader prefers `kp-shares/` and falls back to `shares/`, parsing a local
-//! tolerant shape rather than the hashi-types enum, so the proxy keeps working
-//! on either side of that migration and on buckets whose ceremony predates it.
+//! The reader prefers `kp-shares/`, parsing a local tolerant shape rather than
+//! the hashi-types enum so it keeps working across that migration.
+
+use std::collections::BTreeMap;
 
 use anyhow::Context as _;
 use hashi_types::pgp::Fingerprint;
@@ -72,9 +72,39 @@ struct ShareState {
     encrypted_shares: Vec<LabeledShare>,
 }
 
+/// A share names its recipient in one of two shapes, and both are live: the
+/// guardian deployed on testnet writes `schema_version: 1` records carrying a
+/// single `recipient_fingerprint`, while current builds write
+/// `schema_version: 2` with `ciphertexts_by_fingerprint`, one entry per cert
+/// since a KP may hold several. A rotation reads the old record before it
+/// writes the new one, so the relay has to accept either.
 #[derive(Deserialize)]
-struct LabeledShare {
-    recipient_fingerprint: String,
+#[serde(untagged)]
+enum LabeledShare {
+    MultiCert {
+        ciphertexts_by_fingerprint: BTreeMap<String, serde_json::Value>,
+    },
+    SingleCert {
+        recipient_fingerprint: String,
+    },
+}
+
+impl LabeledShare {
+    /// Every fingerprint naming this share's holder. More than one only in the
+    /// multi-cert shape, where they are all the same KP.
+    fn fingerprints(&self) -> Vec<&str> {
+        match self {
+            Self::MultiCert {
+                ciphertexts_by_fingerprint,
+            } => ciphertexts_by_fingerprint
+                .keys()
+                .map(String::as_str)
+                .collect(),
+            Self::SingleCert {
+                recipient_fingerprint,
+            } => vec![recipient_fingerprint.as_str()],
+        }
+    }
 }
 
 fn parse_roster(bytes: &[u8]) -> anyhow::Result<Vec<Fingerprint>> {
@@ -83,7 +113,8 @@ fn parse_roster(bytes: &[u8]) -> anyhow::Result<Vec<Fingerprint>> {
     state
         .encrypted_shares
         .iter()
-        .map(|share| parse_recipient_fingerprint(&share.recipient_fingerprint))
+        .flat_map(|share| share.fingerprints())
+        .map(parse_recipient_fingerprint)
         .collect()
 }
 
@@ -109,7 +140,10 @@ mod tests {
         hex.parse().unwrap()
     }
 
-    fn labeled_shares(fingerprints: &[&str]) -> Vec<serde_json::Value> {
+    /// `schema_version: 1` shares — one cert each, named by a scalar. This is
+    /// what the guardian currently deployed on testnet writes, so a rotation
+    /// reads this shape before it writes anything.
+    fn single_cert_shares(fingerprints: &[&str]) -> Vec<serde_json::Value> {
         fingerprints
             .iter()
             .enumerate()
@@ -118,6 +152,25 @@ mod tests {
                     "id": i + 1,
                     "recipient_fingerprint": fp,
                     "armored_ciphertext": "",
+                })
+            })
+            .collect()
+    }
+
+    /// `schema_version: 2` shares — a map, because one KP may hold several
+    /// certs. This is what current builds write.
+    fn multi_cert_shares(per_share: &[&[&str]]) -> Vec<serde_json::Value> {
+        per_share
+            .iter()
+            .enumerate()
+            .map(|(i, fps)| {
+                let ciphertexts: serde_json::Map<String, serde_json::Value> = fps
+                    .iter()
+                    .map(|fp| ((*fp).to_string(), serde_json::json!("")))
+                    .collect();
+                serde_json::json!({
+                    "id": i + 1,
+                    "ciphertexts_by_fingerprint": ciphertexts,
                 })
             })
             .collect()
@@ -132,7 +185,7 @@ mod tests {
             "timestamp_ms": 0,
             "message": { "Shares": {
                 "sharing_seq": sharing_seq,
-                "encrypted_shares": labeled_shares(fingerprints),
+                "encrypted_shares": single_cert_shares(fingerprints),
             }},
             "signature": null,
         });
@@ -141,13 +194,15 @@ mod tests {
     }
 
     /// A `kp-shares/` record in #779's shape — the layout the enclave writes
-    /// today.
+    /// today. One cert per share; use `kp_shares_record_multi_cert` for a KP
+    /// holding several.
     fn kp_shares_record(
         sharing_seq: u64,
         cert_seq: u64,
         fingerprints: &[&str],
     ) -> (String, Vec<u8>) {
-        let shares = labeled_shares(fingerprints);
+        let per_share: Vec<&[&str]> = fingerprints.iter().map(std::slice::from_ref).collect();
+        let shares = multi_cert_shares(&per_share);
         let record = serde_json::json!({
             "session_id": "test-session",
             "timestamp_ms": 0,
@@ -209,6 +264,68 @@ mod tests {
 
         let roster = latest_kp_roster(&store).await.unwrap().unwrap();
         assert_eq!(roster, vec![fp(FP_B)]);
+    }
+
+    /// The shape the guardian deployed on testnet writes: a `kp-shares/` record
+    /// whose shares name one cert each via a scalar `recipient_fingerprint`
+    /// (`schema_version: 1`). Fingerprints are the real gen-3 roster; the
+    /// ciphertexts are elided because the roster read never decrypts.
+    ///
+    /// Regression: the relay parsed only one share shape, so against a real
+    /// bucket it failed closed with "KP roster unavailable" and no KP could
+    /// submit a share.
+    #[tokio::test]
+    async fn deployed_testnet_single_cert_shares_parse() {
+        const DEPLOYED: &[&str] = &[
+            "010AFFD5514AE454CA0D56DAA40FE24388998D2A",
+            "69A798B4CD1FE3F7C827381BC56DF2575EC846C3",
+            "8D798722C24B2A15C15036A1DEFA2C01C4350A31",
+        ];
+        let record = serde_json::json!({
+            "schema_version": 1,
+            "session_id": "916c711a5e81c2b0",
+            "timestamp_ms": 1784219535816u64,
+            "message": { "KpShareState": {
+                "sharing_seq": 0,
+                "cert_seq": 0,
+                "encrypted_shares": single_cert_shares(DEPLOYED),
+            }},
+            "signature": null,
+        });
+        let store = MemStore::default();
+        store.insert(
+            "kp-shares/00000000000000000000/00000000000000000000-916c711a5e81c2b0.json".to_string(),
+            serde_json::to_vec(&record).unwrap(),
+        );
+
+        let roster = latest_kp_roster(&store).await.unwrap().unwrap();
+        assert_eq!(roster, DEPLOYED.iter().map(|f| fp(f)).collect::<Vec<_>>());
+    }
+
+    /// One KP holding several certs contributes every one of them: any of its
+    /// certs can sign a submission that is still that single share holder.
+    #[tokio::test]
+    async fn multi_cert_share_contributes_every_fingerprint() {
+        let store = MemStore::default();
+        let shares = multi_cert_shares(&[&[FP_A, FP_B]]);
+        let record = serde_json::json!({
+            "schema_version": 2,
+            "session_id": "test-session",
+            "timestamp_ms": 0,
+            "message": { "KpShareState": {
+                "sharing_seq": 0,
+                "cert_seq": 0,
+                "encrypted_shares": shares,
+            }},
+            "signature": null,
+        });
+        store.insert(
+            "kp-shares/00000000000000000000/00000000000000000000-test-session.json".to_string(),
+            serde_json::to_vec(&record).unwrap(),
+        );
+
+        let roster = latest_kp_roster(&store).await.unwrap().unwrap();
+        assert_eq!(roster, vec![fp(FP_A), fp(FP_B)]);
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian-proxy/src/roster.rs
+++ b/crates/hashi-guardian-proxy/src/roster.rs
@@ -15,15 +15,75 @@
 //! the hashi-types enum so it keeps working across that migration.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
 use anyhow::Context as _;
 use hashi_types::pgp::Fingerprint;
 use serde::Deserialize;
+use tokio::sync::Mutex;
 
 use crate::widlog::LogStore;
 
 const LEGACY_SHARES_PREFIX: &str = "shares/";
 const KP_SHARES_PREFIX: &str = "kp-shares/";
+
+/// The committed roster only changes at a ceremony, a re-deal, or a cert
+/// rotation — and rotation invalidates explicitly — so a minute of staleness
+/// costs nothing and bounds S3 reads under submission spam.
+const ROSTER_TTL: Duration = Duration::from_secs(60);
+/// "No ceremony yet" is cached far more briefly: the first ceremony should be
+/// authorized promptly once its log lands, but an unauthenticated caller must
+/// not be able to drive an S3 read per request while we wait.
+const MISSING_ROSTER_TTL: Duration = Duration::from_secs(5);
+
+struct Cached {
+    at: Instant,
+    roster: Option<Arc<Vec<Fingerprint>>>,
+}
+
+/// TTL-cached view of [`latest_kp_roster`]. The mutex is held across the fetch,
+/// so concurrent misses collapse into one S3 read.
+pub struct RosterCache<L> {
+    store: L,
+    cached: Mutex<Option<Cached>>,
+}
+
+impl<L: LogStore> RosterCache<L> {
+    pub fn new(store: L) -> Self {
+        Self {
+            store,
+            cached: Mutex::new(None),
+        }
+    }
+
+    /// `Ok(None)` means no ceremony has committed a share set yet.
+    pub async fn get(&self) -> anyhow::Result<Option<Arc<Vec<Fingerprint>>>> {
+        let mut cached = self.cached.lock().await;
+        if let Some(entry) = cached.as_ref() {
+            let ttl = if entry.roster.is_some() {
+                ROSTER_TTL
+            } else {
+                MISSING_ROSTER_TTL
+            };
+            if entry.at.elapsed() < ttl {
+                return Ok(entry.roster.clone());
+            }
+        }
+        let roster = latest_kp_roster(&self.store).await?.map(Arc::new);
+        *cached = Some(Cached {
+            at: Instant::now(),
+            roster: roster.clone(),
+        });
+        Ok(roster)
+    }
+
+    /// Drop the cached roster so the next read observes a just-committed change.
+    pub async fn invalidate(&self) {
+        *self.cached.lock().await = None;
+    }
+}
 
 /// Recipient fingerprints of the latest committed share set. `Ok(None)` means
 /// no share log exists anywhere (no ceremony yet) — a definitive miss; any
@@ -132,6 +192,7 @@ fn parse_recipient_fingerprint(label: &str) -> anyhow::Result<Fingerprint> {
 mod tests {
     use super::*;
     use crate::widlog::test_store::MemStore;
+    use std::sync::atomic::Ordering;
 
     const FP_A: &str = "AAAABBBBCCCCDDDDEEEE11112222333344445555";
     const FP_B: &str = "AAAABBBBCCCCDDDDEEEE1111222233334444FFFF";
@@ -365,5 +426,58 @@ mod tests {
         store.insert(key, bytes);
 
         assert!(latest_kp_roster(&store).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cache_reads_the_committed_roster() {
+        let store = MemStore::default();
+        let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
+        store.insert(key, bytes);
+
+        let roster = RosterCache::new(store).get().await.unwrap().unwrap();
+        assert_eq!(*roster, vec![fp(FP_A)]);
+    }
+
+    #[tokio::test]
+    async fn cache_serves_the_cached_roster_within_the_ttl() {
+        let store = MemStore::default();
+        let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
+        store.insert(key, bytes);
+        let cache = RosterCache::new(store);
+
+        let first = cache.get().await.unwrap();
+        // The store now fails hard; a fresh read would error, the cache must not.
+        cache.store.fail_lists.store(true, Ordering::SeqCst);
+        assert_eq!(first, cache.get().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn cache_reports_a_missing_share_log_as_none() {
+        assert!(RosterCache::new(MemStore::default())
+            .get()
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn invalidate_makes_the_next_read_observe_a_rotated_cert() {
+        let store = MemStore::default();
+        let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
+        store.insert(key, bytes);
+        let cache = RosterCache::new(store);
+        assert_eq!(*cache.get().await.unwrap().unwrap(), vec![fp(FP_A)]);
+
+        // A cert rotation commits a higher cert_seq under the same sharing_seq.
+        let (key, bytes) = kp_shares_record(0, 1, &[FP_B]);
+        cache.store.insert(key, bytes);
+        assert_eq!(
+            *cache.get().await.unwrap().unwrap(),
+            vec![fp(FP_A)],
+            "still cached until invalidated"
+        );
+
+        cache.invalidate().await;
+        assert_eq!(*cache.get().await.unwrap().unwrap(), vec![fp(FP_B)]);
     }
 }

--- a/crates/hashi-guardian-proxy/src/roster.rs
+++ b/crates/hashi-guardian-proxy/src/roster.rs
@@ -27,15 +27,17 @@ use std::time::Duration;
 use std::time::Instant;
 
 use anyhow::Context as _;
+use hashi_types::guardian::log::CeremonyLogMessage;
+use hashi_types::guardian::log::KpShareStateLogMessage;
 use hashi_types::pgp::Fingerprint;
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
 use crate::widlog::LogStore;
 
+/// The pre-#779 layout, read-only: hashi-types no longer models it, so unlike
+/// the current prefixes this one has no constructor to borrow.
 const LEGACY_SHARES_PREFIX: &str = "shares/";
-const KP_SHARES_PREFIX: &str = "kp-shares/";
-const CEREMONY_PREFIX: &str = "ceremony/";
 
 /// The committed roster only changes at a ceremony, a re-deal, or a cert
 /// rotation — and rotation invalidates explicitly — so a minute of staleness
@@ -112,11 +114,16 @@ pub async fn latest_kp_roster<L: LogStore>(log: &L) -> anyhow::Result<Option<Vec
 /// Pre-#779 buckets have no `ceremony/` records at all; there the lex-greatest
 /// flat `shares/` key is the whole story.
 async fn latest_share_log_key<L: LogStore>(log: &L) -> anyhow::Result<Option<String>> {
-    let Some(ceremony_key) = log.list_keys(CEREMONY_PREFIX).await?.into_iter().max() else {
+    let Some(ceremony_key) = log
+        .list_keys(&CeremonyLogMessage::object_key_dir())
+        .await?
+        .into_iter()
+        .max()
+    else {
         return Ok(log.list_keys(LEGACY_SHARES_PREFIX).await?.into_iter().max());
     };
     let sharing_seq = ceremony_sharing_seq(&ceremony_key)?;
-    log.list_keys(&format!("{KP_SHARES_PREFIX}{sharing_seq}/"))
+    log.list_keys(&KpShareStateLogMessage::object_key_dir(sharing_seq))
         .await?
         .into_iter()
         .max()
@@ -127,13 +134,16 @@ async fn latest_share_log_key<L: LogStore>(log: &L) -> anyhow::Result<Option<Str
         .with_context(|| format!("ceremony {ceremony_key} has no kp-shares log"))
 }
 
-/// The `sharing_seq` a `ceremony/{sharing_seq:020}-{session}.json` key records,
-/// left as zero-padded text so it indexes `kp-shares/` directly.
-fn ceremony_sharing_seq(key: &str) -> anyhow::Result<&str> {
-    key.strip_prefix(CEREMONY_PREFIX)
+/// The `sharing_seq` a `ceremony/{sharing_seq:020}-{session}.json` key records.
+/// The canonical padding is required, not just parsed: lex order over these
+/// keys is the seq order only while every one of them pads to the same width.
+fn ceremony_sharing_seq(key: &str) -> anyhow::Result<u64> {
+    key.strip_prefix(&CeremonyLogMessage::object_key_dir())
         .and_then(|name| name.split('-').next())
         .filter(|seq| seq.len() == 20 && seq.bytes().all(|b| b.is_ascii_digit()))
-        .with_context(|| format!("ceremony key {key:?} has no sharing_seq"))
+        .with_context(|| format!("ceremony key {key:?} has no sharing_seq"))?
+        .parse()
+        .with_context(|| format!("ceremony key {key:?} has an out-of-range sharing_seq"))
 }
 
 /// Just the fields the roster needs, tolerant of everything else. Any record
@@ -387,6 +397,23 @@ mod tests {
             latest_kp_roster(&store).await.unwrap().unwrap(),
             vec![fp(FP_B)]
         );
+    }
+
+    /// Selecting the latest ceremony by lex order only holds while every key
+    /// pads to the same width: an unpadded key sorts above every padded one, so
+    /// without the width check this resolves to seq 3 and silently serves the
+    /// superseded roster instead of seq 5's.
+    #[tokio::test]
+    async fn an_unpadded_ceremony_key_fails_closed() {
+        let store = MemStore::default();
+        let (key, bytes) = kp_shares_record(5, 0, &[FP_A]);
+        store.insert(key, bytes);
+        complete_ceremony(&store, 5);
+        let (key, bytes) = kp_shares_record(3, 0, &[FP_B]);
+        store.insert(key, bytes);
+        store.insert("ceremony/3-test-session.json".to_string(), b"{}".to_vec());
+
+        assert!(latest_kp_roster(&store).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -200,6 +200,8 @@ fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSucces
 
 /// The guardian's log bucket over the AWS SDK, read-only. Credentials come
 /// from the default provider chain (task role on Fargate, env vars for MinIO).
+/// Cloning shares the underlying SDK client (the cache and relay each hold one).
+#[derive(Clone)]
 pub struct S3LogStore {
     client: aws_sdk_s3::Client,
     bucket: String,

--- a/docker/hashi-guardian-local/Makefile
+++ b/docker/hashi-guardian-local/Makefile
@@ -27,11 +27,6 @@ ceremony: ## Generate KP keys + run the genesis ceremony (captures the BTC pubke
 	$(COMPOSE) --profile ceremony up -d --build ceremony
 	$(COMPOSE) --profile init run --rm --build init /scripts/ceremony.sh
 	$(COMPOSE) --profile ceremony stop ceremony
-	@fps=$$($(COMPOSE) --profile init run --rm -T --entrypoint cat init /work/kp-fingerprints.csv); \
-	if [ -z "$$fps" ]; then echo "Ceremony left no KP roster at /work/kp-fingerprints.csv; not updating the proxy."; exit 1; fi; \
-	echo "AUTHORIZED_KP_FINGERPRINTS=$$fps" > kp-roster.env; \
-	echo "Handing the KP roster to the proxy relay: $$fps"; \
-	$(COMPOSE) up -d proxy
 
 pubkey: ## Print the ceremony BTC master pubkey (hex)
 	@$(COMPOSE) --profile init run --rm -T --entrypoint cat init /work/guardian-btc-pubkey.hex; echo
@@ -67,4 +62,3 @@ logs: ## Tail logs
 
 down: ## Stop everything and drop volumes
 	$(COMPOSE) --profile ceremony --profile init down -v
-	rm -f kp-roster.env

--- a/docker/hashi-guardian-local/README.md
+++ b/docker/hashi-guardian-local/README.md
@@ -54,10 +54,9 @@ make smoke         # confirm the guardian is activated
 make down          # tear everything down
 ```
 
-`make ceremony` also writes the KP fingerprints to `kp-roster.env` and restarts
-the proxy with them (`AUTHORIZED_KP_FINGERPRINTS`) — the relay rejects share
-submissions from unrostered signers, mirroring the deploy, where the ceremony
-roster reaches the proxy as deploy-time config.
+The relay rejects share submissions from unrostered signers; its roster is the
+recipient set of the ceremony's share log, read straight from MinIO — no config
+handoff, exactly as the deploy's proxy reads it from S3.
 
 Once activated, the deposit/withdraw CLI flows work against the local network,
 co-signed by the containerized guardian.

--- a/docker/hashi-guardian-local/compose.yaml
+++ b/docker/hashi-guardian-local/compose.yaml
@@ -137,11 +137,6 @@ services:
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
       RUST_LOG: ${RUST_LOG:-info}
-    # AUTHORIZED_KP_FINGERPRINTS, written by `make ceremony` once the KP keys
-    # exist. Absent before that: the relay fail-closes until the roster lands.
-    env_file:
-      - path: kp-roster.env
-        required: false
     depends_on:
       enclave:
         condition: service_healthy

--- a/docker/hashi-guardian-local/scripts/ceremony.sh
+++ b/docker/hashi-guardian-local/scripts/ceremony.sh
@@ -22,7 +22,6 @@ HASHI_OBJECT_ID="${HASHI_OBJECT_ID:-0x000000000000000000000000000000000000000000
 export SUI_RPC PACKAGE_ID HASHI_OBJECT_ID
 
 gen_kp_keys
-write_kp_roster
 # `operator ceremony` connects to the ceremony-mode guardian directly.
 render_config "${CEREMONY_GUARDIAN_ENDPOINT:-http://ceremony:3000}" ""
 

--- a/docker/hashi-guardian-local/scripts/lib.sh
+++ b/docker/hashi-guardian-local/scripts/lib.sh
@@ -14,7 +14,6 @@ export GNUPGHOME="${WORK}/gnupg"
 CERTS_DIR="${WORK}/kp-certs"
 CONFIG="${WORK}/guardian-init.local.yaml"
 PUBKEY_FILE="${WORK}/guardian-btc-pubkey.hex"
-ROSTER_FILE="${WORK}/kp-fingerprints.csv"
 
 NUM_SHARES="${NUM_SHARES:-3}"
 THRESHOLD="${THRESHOLD:-2}"
@@ -41,18 +40,6 @@ gen_kp_keys() {
     gpg --armor --export "${fpr}" > "${CERTS_DIR}/kp${i}.asc"
   done
   echo "Wrote ${NUM_SHARES} KP certs to ${CERTS_DIR}."
-}
-
-# Write the KP cert fingerprints (comma-separated) — the relay roster the
-# Makefile hands to the proxy's AUTHORIZED_KP_FINGERPRINTS after the ceremony.
-write_kp_roster() {
-  local i fpr fprs=""
-  for i in $(seq 1 "${NUM_SHARES}"); do
-    fpr="$(gpg --show-keys --with-colons "${CERTS_DIR}/kp${i}.asc" | awk -F: '/^fpr:/{print $10; exit}')"
-    fprs="${fprs:+${fprs},}${fpr}"
-  done
-  printf '%s' "${fprs}" > "${ROSTER_FILE}"
-  echo "Wrote the KP roster (${NUM_SHARES} fingerprints) to ${ROSTER_FILE}."
 }
 
 # Render guardian-init.local.yaml from the template + the running localnet.


### PR DESCRIPTION
## Summary

The relay's KP roster came from deploy config (`AUTHORIZED_KP_FINGERPRINTS`), so a ceremony or re-deal that changed who holds shares needed a matching proxy redeploy to stay in sync. The ceremony already commits that set: every encrypted share in the S3 log is labelled with its recipient's fingerprint, so the committed share log *is* the roster. Read it from there instead.

The read is a DoS-tier gate only — the enclave still verifies every share cryptographically — so it is deliberately unverified, and it fails closed when no share log exists.

## Changes

- New `roster` module: resolves the roster the way the enclave does, anchoring on the latest `ceremony/` record and reading the share state for its `sharing_seq`. Shares are published before the ceremony record, so taking the newest `kp-shares/` dir would pick up an orphan from a ceremony that never finished.
- Build both prefixes with hashi-types' key constructors, the same ones the enclave's reader uses, so the layout has a single definition. The tests still spell the keys out by hand and check that agreement.
- Accept both share-recipient shapes: testnet's deployed guardian writes `schema_version: 1` (`recipient_fingerprint`), current builds write `2` (`ciphertexts_by_fingerprint`). A rotation reads the old before writing the new, so both are live.
- `Relay` is generic over the log store and holds a TTL-cached roster; `S3LogStore` is now `Clone`, shared with the wid cache.
- The relay and the forwarder share one cache, so a successful `ProvisionerRotateCert` drops it — otherwise the replacement cert is rejected until the TTL lapses. "No ceremony yet" gets a much shorter TTL of its own.
- Verify a submission's signature before the roster read, so nothing that isn't internally consistent costs an S3 read.
- Drop `AUTHORIZED_KP_FINGERPRINTS` and its parsing.
