### PR TITLE
[guardian] EIF: compute the initrd size from the ramdisk

### DIFF
--- a/docker/hashi-guardian/Containerfile
+++ b/docker/hashi-guardian/Containerfile
@@ -103,13 +103,14 @@ RUN <<-EOF
 EOF
 
 WORKDIR /build_eif
-RUN eif_build \
+# initrd size must equal the ramdisk byte count; compute it (was a stale hardcoded value).
+RUN RAMDISK_BYTES=$(stat -c%s /build_cpio/rootfs.cpio) && eif_build \
 	--kernel /bzImage \
 	--kernel_config /linux.config \
 	--ramdisk /build_cpio/rootfs.cpio \
 	--pcrs_output /nitro.pcrs \
 	--output /nitro.eif \
-	--cmdline 'reboot=k initrd=0x2000000,3228672 root=/dev/ram0 panic=1 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd nit.target=/run.sh'
+	--cmdline "reboot=k initrd=0x2000000,${RAMDISK_BYTES} root=/dev/ram0 panic=1 pci=off nomodules console=ttyS0 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd nit.target=/run.sh"
 
 FROM base AS install
 WORKDIR /rootfs


### PR DESCRIPTION
The `eif_build` cmdline hardcoded the initrd size (`initrd=0x2000000,3228672`) which is far smaller than the actual rootfs (~16 MB once the guardian binary is in it), and it silently drifts every time that binary's size changes.

So we are now computing it from the cpio so it can't go stale.