### PR TITLE
Pre-testnet hardening: error style, event names, gating docs

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -829,8 +829,7 @@ mod tests {
                         .name()
                         .contains("WithdrawalPickedForProcessing")
                     {
-                        match WithdrawalPickedForProcessing::from_bcs(event.contents().value())
-                        {
+                        match WithdrawalPickedForProcessing::from_bcs(event.contents().value()) {
                             Ok(data) => {
                                 info!(
                                     withdrawal_txn_id = %data.withdrawal_txn_id,
@@ -1145,8 +1144,7 @@ mod tests {
                         .name()
                         .contains("WithdrawalPickedForProcessing")
                     {
-                        match WithdrawalPickedForProcessing::from_bcs(event.contents().value())
-                        {
+                        match WithdrawalPickedForProcessing::from_bcs(event.contents().value()) {
                             Ok(data) if data.request_ids.len() >= min_requests => {
                                 info!(
                                     withdrawal_txn_id = %data.withdrawal_txn_id,

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -11,9 +11,9 @@ mod tests {
     use futures::StreamExt;
     use hashi::sui_tx_executor::SuiTxExecutor;
     use hashi_types::bitcoin::BitcoinAddress;
-    use hashi_types::move_types::WithdrawalConfirmedEvent;
-    use hashi_types::move_types::WithdrawalPickedForProcessingEvent;
-    use hashi_types::move_types::WithdrawalSignedEvent;
+    use hashi_types::move_types::WithdrawalConfirmed;
+    use hashi_types::move_types::WithdrawalPickedForProcessing;
+    use hashi_types::move_types::WithdrawalSigned;
     use std::time::Duration;
     use sui_rpc::field::FieldMask;
     use sui_rpc::field::FieldMaskUtil;
@@ -193,7 +193,7 @@ mod tests {
     async fn wait_for_withdrawal_confirmation(
         sui_client: &mut sui_rpc::Client,
         timeout: Duration,
-    ) -> Result<WithdrawalConfirmedEvent> {
+    ) -> Result<WithdrawalConfirmed> {
         info!("Waiting for withdrawal confirmation...");
 
         let start = std::time::Instant::now();
@@ -228,7 +228,7 @@ mod tests {
             };
 
             debug!(
-                "Received checkpoint {}, checking for WithdrawalConfirmedEvent...",
+                "Received checkpoint {}, checking for WithdrawalConfirmed...",
                 checkpoint.cursor()
             );
 
@@ -236,8 +236,8 @@ mod tests {
                 for event in txn.events().events() {
                     let event_type = event.contents().name();
 
-                    if event_type.contains("WithdrawalConfirmedEvent") {
-                        match WithdrawalConfirmedEvent::from_bcs(event.contents().value()) {
+                    if event_type.contains("WithdrawalConfirmed") {
+                        match WithdrawalConfirmed::from_bcs(event.contents().value()) {
                             Ok(event_data) => {
                                 info!(
                                     withdrawal_txn_id = %event_data.withdrawal_txn_id,
@@ -247,7 +247,7 @@ mod tests {
                                 return Ok(event_data);
                             }
                             Err(e) => {
-                                debug!("Failed to parse WithdrawalConfirmedEvent: {}", e);
+                                debug!("Failed to parse WithdrawalConfirmed: {}", e);
                             }
                         }
                     }
@@ -792,7 +792,7 @@ mod tests {
     async fn wait_for_withdrawal_picked(
         sui_client: &mut sui_rpc::Client,
         timeout: Duration,
-    ) -> Result<WithdrawalPickedForProcessingEvent> {
+    ) -> Result<WithdrawalPickedForProcessing> {
         let start = std::time::Instant::now();
         let subscription_read_mask = FieldMask::from_paths([Checkpoint::path_builder()
             .transactions()
@@ -811,7 +811,7 @@ mod tests {
         while let Some(item) = subscription.next().await {
             if start.elapsed() > timeout {
                 return Err(anyhow!(
-                    "Timeout waiting for WithdrawalPickedForProcessingEvent after {:?}",
+                    "Timeout waiting for WithdrawalPickedForProcessing after {:?}",
                     timeout
                 ));
             }
@@ -827,9 +827,9 @@ mod tests {
                     if event
                         .contents()
                         .name()
-                        .contains("WithdrawalPickedForProcessingEvent")
+                        .contains("WithdrawalPickedForProcessing")
                     {
-                        match WithdrawalPickedForProcessingEvent::from_bcs(event.contents().value())
+                        match WithdrawalPickedForProcessing::from_bcs(event.contents().value())
                         {
                             Ok(data) => {
                                 info!(
@@ -839,7 +839,7 @@ mod tests {
                                 return Ok(data);
                             }
                             Err(e) => {
-                                debug!("Failed to parse WithdrawalPickedForProcessingEvent: {}", e);
+                                debug!("Failed to parse WithdrawalPickedForProcessing: {}", e);
                             }
                         }
                     }
@@ -857,7 +857,7 @@ mod tests {
         sui_client: &mut sui_rpc::Client,
         n: usize,
         timeout: Duration,
-    ) -> Result<Vec<WithdrawalConfirmedEvent>> {
+    ) -> Result<Vec<WithdrawalConfirmed>> {
         let start = std::time::Instant::now();
         let subscription_read_mask = FieldMask::from_paths([Checkpoint::path_builder()
             .transactions()
@@ -895,8 +895,8 @@ mod tests {
             };
             for txn in checkpoint.checkpoint().transactions() {
                 for event in txn.events().events() {
-                    if event.contents().name().contains("WithdrawalConfirmedEvent") {
-                        match WithdrawalConfirmedEvent::from_bcs(event.contents().value()) {
+                    if event.contents().name().contains("WithdrawalConfirmed") {
+                        match WithdrawalConfirmed::from_bcs(event.contents().value()) {
                             Ok(data) => {
                                 info!(
                                     withdrawal_txn_id = %data.withdrawal_txn_id,
@@ -906,7 +906,7 @@ mod tests {
                                 events.push(data);
                             }
                             Err(e) => {
-                                debug!("Failed to parse WithdrawalConfirmedEvent: {}", e);
+                                debug!("Failed to parse WithdrawalConfirmed: {}", e);
                             }
                         }
                     }
@@ -924,12 +924,12 @@ mod tests {
     /// Test outline:
     /// 1. Deposit 200 000 sats → one confirmed UTXO in the pool.
     /// 2. Submit withdrawal 1 (30 000 sats). Wait for the committee to commit
-    ///    it (`WithdrawalPickedForProcessingEvent`). No Bitcoin blocks mined
+    ///    it (`WithdrawalPickedForProcessing`). No Bitcoin blocks mined
     ///    yet, so the change UTXO is pending/unconfirmed.
     /// 3. Submit withdrawal 2 (30 000 sats) immediately. Wait for the
     ///    committee to commit it. Assert that it spent the pending change UTXO
     ///    from withdrawal 1.
-    /// 4. Mine blocks and wait for both `WithdrawalConfirmedEvent`s.
+    /// 4. Mine blocks and wait for both `WithdrawalConfirmed`s.
     #[tokio::test]
     async fn test_withdrawal_chains_through_unconfirmed_change_utxo() -> Result<()> {
         init_test_logging();
@@ -1100,14 +1100,14 @@ mod tests {
         Ok(())
     }
 
-    /// Waits for a `WithdrawalPickedForProcessingEvent` that contains at least
+    /// Waits for a `WithdrawalPickedForProcessing` that contains at least
     /// `min_requests` request IDs in a single batch, indicating that the new
     /// multi-request coin selection algorithm batched them together.
     async fn wait_for_batched_withdrawal_picked(
         sui_client: &mut sui_rpc::Client,
         min_requests: usize,
         timeout: Duration,
-    ) -> Result<WithdrawalPickedForProcessingEvent> {
+    ) -> Result<WithdrawalPickedForProcessing> {
         let start = std::time::Instant::now();
         let subscription_read_mask = FieldMask::from_paths([Checkpoint::path_builder()
             .transactions()
@@ -1126,7 +1126,7 @@ mod tests {
         while let Some(item) = subscription.next().await {
             if start.elapsed() > timeout {
                 return Err(anyhow!(
-                    "Timeout waiting for batched WithdrawalPickedForProcessingEvent \
+                    "Timeout waiting for batched WithdrawalPickedForProcessing \
                      (min_requests={min_requests}) after {:?}",
                     timeout
                 ));
@@ -1143,9 +1143,9 @@ mod tests {
                     if event
                         .contents()
                         .name()
-                        .contains("WithdrawalPickedForProcessingEvent")
+                        .contains("WithdrawalPickedForProcessing")
                     {
-                        match WithdrawalPickedForProcessingEvent::from_bcs(event.contents().value())
+                        match WithdrawalPickedForProcessing::from_bcs(event.contents().value())
                         {
                             Ok(data) if data.request_ids.len() >= min_requests => {
                                 info!(
@@ -1157,14 +1157,14 @@ mod tests {
                             }
                             Ok(data) => {
                                 info!(
-                                    "WithdrawalPickedForProcessingEvent with {} request(s) \
+                                    "WithdrawalPickedForProcessing with {} request(s) \
                                      (waiting for batch of ≥{})",
                                     data.request_ids.len(),
                                     min_requests,
                                 );
                             }
                             Err(e) => {
-                                debug!("Failed to parse WithdrawalPickedForProcessingEvent: {}", e);
+                                debug!("Failed to parse WithdrawalPickedForProcessing: {}", e);
                             }
                         }
                     }
@@ -1263,18 +1263,18 @@ mod tests {
         sui_client: &mut sui_rpc::Client,
         min_requests: usize,
         timeout: Duration,
-    ) -> Result<EventWithEffects<WithdrawalPickedForProcessingEvent>> {
+    ) -> Result<EventWithEffects<WithdrawalPickedForProcessing>> {
         wait_for_event_with_effects(
             sui_client,
-            "WithdrawalPickedForProcessingEvent",
+            "WithdrawalPickedForProcessing",
             timeout,
             |bytes| {
-                let data = WithdrawalPickedForProcessingEvent::from_bcs(bytes)?;
+                let data = WithdrawalPickedForProcessing::from_bcs(bytes)?;
                 if data.request_ids.len() >= min_requests {
                     Ok(Some(data))
                 } else {
                     info!(
-                        "WithdrawalPickedForProcessingEvent with {} request(s) \
+                        "WithdrawalPickedForProcessing with {} request(s) \
                          (waiting for batch of ≥{})",
                         data.request_ids.len(),
                         min_requests,
@@ -1290,9 +1290,9 @@ mod tests {
         sui_client: &mut sui_rpc::Client,
         withdrawal_id: Address,
         timeout: Duration,
-    ) -> Result<EventWithEffects<WithdrawalSignedEvent>> {
-        wait_for_event_with_effects(sui_client, "WithdrawalSignedEvent", timeout, |bytes| {
-            let data = WithdrawalSignedEvent::from_bcs(bytes)?;
+    ) -> Result<EventWithEffects<WithdrawalSigned>> {
+        wait_for_event_with_effects(sui_client, "WithdrawalSigned", timeout, |bytes| {
+            let data = WithdrawalSigned::from_bcs(bytes)?;
             Ok((data.withdrawal_txn_id == withdrawal_id).then_some(data))
         })
         .await
@@ -1302,9 +1302,9 @@ mod tests {
         sui_client: &mut sui_rpc::Client,
         withdrawal_id: Address,
         timeout: Duration,
-    ) -> Result<EventWithEffects<WithdrawalConfirmedEvent>> {
-        wait_for_event_with_effects(sui_client, "WithdrawalConfirmedEvent", timeout, |bytes| {
-            let data = WithdrawalConfirmedEvent::from_bcs(bytes)?;
+    ) -> Result<EventWithEffects<WithdrawalConfirmed>> {
+        wait_for_event_with_effects(sui_client, "WithdrawalConfirmed", timeout, |bytes| {
+            let data = WithdrawalConfirmed::from_bcs(bytes)?;
             Ok((data.withdrawal_txn_id == withdrawal_id).then_some(data))
         })
         .await
@@ -1318,10 +1318,10 @@ mod tests {
     ///    Sui, before either is committed. Both requests will be approved
     ///    independently by the committee, then the leader picks up both
     ///    approved requests and batches them into one Bitcoin tx.
-    /// 3. Wait for a `WithdrawalPickedForProcessingEvent` whose `request_ids`
+    /// 3. Wait for a `WithdrawalPickedForProcessing` whose `request_ids`
     ///    has length ≥ 2, confirming the batch.
     /// 4. Assert the Bitcoin tx has two withdrawal outputs (one per request).
-    /// 5. Mine blocks and wait for the single `WithdrawalConfirmedEvent`.
+    /// 5. Mine blocks and wait for the single `WithdrawalConfirmed`.
     #[tokio::test]
     async fn test_batch_withdrawal() -> Result<()> {
         init_test_logging();
@@ -1365,7 +1365,7 @@ mod tests {
             .await?;
         info!("Withdrawal request 2 submitted");
 
-        // Wait for a single WithdrawalPickedForProcessingEvent that batches both
+        // Wait for a single WithdrawalPickedForProcessing that batches both
         // requests into one Bitcoin transaction.
         let picked = wait_for_batched_withdrawal_picked(
             &mut networks.sui_network.client,
@@ -1422,7 +1422,7 @@ mod tests {
     ///    and a max batch size of 2.
     /// 2. Deposit and submit 2 withdrawal requests.
     /// 3. The batch should fire at capacity (2 requests) well before the delay
-    ///    expires, producing a single `WithdrawalPickedForProcessingEvent` with
+    ///    expires, producing a single `WithdrawalPickedForProcessing` with
     ///    exactly 2 request IDs.
     #[tokio::test]
     async fn test_batch_withdrawal_fires_at_capacity() -> Result<()> {

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -541,7 +541,7 @@ pub(crate) async fn apply_onchain_config_overrides(
 
     // Wait for all nodes' watchers to process the checkpoint that contains the
     // last execute transaction. The watcher re-fetches config on each
-    // ProposalExecutedEvent<UpdateConfig>, so once a node reaches this
+    // ProposalExecuted<UpdateConfig>, so once a node reaches this
     // checkpoint its in-memory config will reflect the override.
     let futs = networks
         .hashi_network()

--- a/crates/e2e-tests/src/test_helpers.rs
+++ b/crates/e2e-tests/src/test_helpers.rs
@@ -5,7 +5,7 @@
 //!
 //! Test modules across this crate (`e2e_flow`, `upgrade_tests`, ...) all need
 //! the same boilerplate to drive a localnet: init tracing, look up an hBTC
-//! balance, wait for a `DepositConfirmedEvent`, deposit-and-wait, etc. Define
+//! balance, wait for a `DepositConfirmed`, deposit-and-wait, etc. Define
 //! them here once and import from each test module.
 
 use anyhow::Result;
@@ -15,7 +15,7 @@ use bitcoin::Txid;
 use futures::StreamExt;
 use hashi::sui_tx_executor::SuiTxExecutor;
 use hashi_types::bitcoin::BitcoinAddress;
-use hashi_types::move_types::DepositConfirmedEvent;
+use hashi_types::move_types::DepositConfirmed;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -108,8 +108,8 @@ pub async fn wait_for_deposit_confirmation(
 
         for txn in checkpoint.checkpoint().transactions() {
             for event in txn.events().events() {
-                if event.contents().name().contains("DepositConfirmedEvent")
-                    && let Ok(evt) = DepositConfirmedEvent::from_bcs(event.contents().value())
+                if event.contents().name().contains("DepositConfirmed")
+                    && let Ok(evt) = DepositConfirmed::from_bcs(event.contents().value())
                     && evt.request_id == request_id
                 {
                     info!("Deposit confirmed for request_id: {request_id}");

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -4,7 +4,7 @@
 //! End-to-end test for the package upgrade lifecycle.
 //!
 //! Exercises real cascading effects of upgrading the hashi package:
-//! - Rust watcher picks up the new package version via PackageUpgradedEvent
+//! - Rust watcher picks up the new package version via PackageUpgraded
 //! - Validators auto-confirm deposits against the upgraded package
 //! - Package ID routing updates correctly in OnchainState
 
@@ -25,7 +25,7 @@ use tracing::info;
 
 /// Test the full upgrade lifecycle, exercising real cascading effects.
 ///
-/// 1. Watcher picks up new package — PackageUpgradedEvent updates OnchainState
+/// 1. Watcher picks up new package — PackageUpgraded updates OnchainState
 /// 2. Validators confirm deposits post-upgrade — leader routes calls correctly
 /// 3. Package ID routing — OnchainState.package_id() returns the new package
 #[tokio::test]
@@ -59,7 +59,7 @@ async fn test_upgrade_v1_to_v2() -> Result<()> {
 
     // ── Cascading effect 1: Watcher picks up new package ────────────────
     //
-    // The PackageUpgradedEvent handler in watcher.rs should update
+    // The PackageUpgraded handler in watcher.rs should update
     // OnchainState's package_versions map. Poll until all nodes see the
     // new package — this proves the watcher correctly processes the event.
     info!("waiting for all nodes to detect the new package version...");
@@ -114,7 +114,7 @@ async fn test_upgrade_v1_to_v2() -> Result<()> {
     //
     // This is the real test: deposit BTC, submit a deposit request, and
     // wait for the validators to auto-confirm it. The leader must:
-    // - Observe the DepositRequestedEvent
+    // - Observe the DepositRequested
     // - Build a BLS certificate
     // - Call approve_deposit on the correct (upgraded) package
     // - After the time-delay window, call confirm_deposit

--- a/crates/hashi-monitor/README.md
+++ b/crates/hashi-monitor/README.md
@@ -5,13 +5,13 @@ Hashi monitoring library and CLI tool.
 Audits the cross-system bridge flow on two parallel tracks.
 
 ### Withdrawals (Sui → BTC)
-- **E1**: Hashi approval event on Sui (`WithdrawalPickedForProcessingEvent`).
+- **E1**: Hashi approval event on Sui (`WithdrawalPickedForProcessing`).
 - **E2**: Guardian approval event (success record logged to S3).
 - **E3**: BTC transaction confirmed on Bitcoin.
 
 ### Deposits (BTC → Sui)
 - **E1**: Deposit confirmed on Bitcoin.
-- **E2**: `DepositConfirmedEvent` on Sui.
+- **E2**: `DepositConfirmed` on Sui.
 
 ### Checks
 - **Predecessor existence**: every successor event has a matching predecessor with consistent txid / wid.

--- a/crates/hashi-monitor/src/domain.rs
+++ b/crates/hashi-monitor/src/domain.rs
@@ -4,7 +4,7 @@
 //! Domain model for the monitor.
 //!
 //! We model the cross-system withdrawal flow as a sequence of events:
-//! - E1 or E_hashi: Hashi approval event on sui (corresponds to WithdrawalPickedForProcessingEvent)
+//! - E1 or E_hashi: Hashi approval event on sui (corresponds to WithdrawalPickedForProcessing)
 //! - E2 or E_guardian: Guardian approval event on S3 (corresponds to NormalWithdrawalSuccess)
 //! - E3 or E_btc: BTC tx broadcast
 //!
@@ -62,7 +62,7 @@ pub struct MonitorWithdrawalEvent {
 /// Note: Make sure WithdrawalEventType::NON_TERMINAL_EVENTS and TERMINAL_EVENT are up-to-date.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
 pub enum WithdrawalEventType {
-    /// E_hashi (WithdrawalPickedForProcessingEvent on sui)
+    /// E_hashi (WithdrawalPickedForProcessing on sui)
     E1HashiApproved,
     /// E_guardian (NormalWithdrawalSuccess on s3)
     E2GuardianApproved,
@@ -81,7 +81,7 @@ pub struct MonitorDepositEvent {
 pub enum DepositEventType {
     /// deposit confirmed event on btc
     E1BtcConfirmed,
-    /// DepositConfirmedEvent on Sui
+    /// DepositConfirmed on Sui
     E2HashiDeposited,
 }
 

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -820,29 +820,29 @@ pub struct DealerSubmissionV1 {
 pub enum HashiEvent {
     ValidatorRegistered(ValidatorRegistered),
     ValidatorUpdated(ValidatorUpdated),
-    VoteCastEvent(VoteCastEvent),
-    VoteRemovedEvent(VoteRemovedEvent),
-    ProposalCreatedEvent(ProposalCreatedEvent),
-    ProposalDeletedEvent(ProposalDeletedEvent),
-    ProposalExecutedEvent(ProposalExecutedEvent),
-    QuorumReachedEvent(QuorumReachedEvent),
-    PackageUpgradedEvent(PackageUpgradedEvent),
-    MintEvent(MintEvent),
-    BurnEvent(BurnEvent),
-    DepositRequestedEvent(DepositRequestedEvent),
-    DepositApprovedEvent(DepositApprovedEvent),
-    DepositConfirmedEvent(DepositConfirmedEvent),
-    ExpiredDepositDeletedEvent(ExpiredDepositDeletedEvent),
-    WithdrawalRequestedEvent(WithdrawalRequestedEvent),
-    WithdrawalApprovedEvent(WithdrawalApprovedEvent),
-    WithdrawalPickedForProcessingEvent(WithdrawalPickedForProcessingEvent),
-    WithdrawalSignedEvent(WithdrawalSignedEvent),
-    WithdrawalInputsSignedEvent(WithdrawalInputsSignedEvent),
-    WithdrawalPresigsReassignedEvent(WithdrawalPresigsReassignedEvent),
-    WithdrawalConfirmedEvent(WithdrawalConfirmedEvent),
-    UtxoSpentEvent(UtxoSpentEvent),
-    StartReconfigEvent(StartReconfigEvent),
-    EndReconfigEvent(EndReconfigEvent),
+    VoteCast(VoteCast),
+    VoteRemoved(VoteRemoved),
+    ProposalCreated(ProposalCreated),
+    ProposalDeleted(ProposalDeleted),
+    ProposalExecuted(ProposalExecuted),
+    QuorumReached(QuorumReached),
+    PackageUpgraded(PackageUpgraded),
+    Minted(Minted),
+    Burned(Burned),
+    DepositRequested(DepositRequested),
+    DepositApproved(DepositApproved),
+    DepositConfirmed(DepositConfirmed),
+    ExpiredDepositDeleted(ExpiredDepositDeleted),
+    WithdrawalRequested(WithdrawalRequested),
+    WithdrawalApproved(WithdrawalApproved),
+    WithdrawalPickedForProcessing(WithdrawalPickedForProcessing),
+    WithdrawalSigned(WithdrawalSigned),
+    WithdrawalInputsSigned(WithdrawalInputsSigned),
+    WithdrawalPresigsReassigned(WithdrawalPresigsReassigned),
+    WithdrawalConfirmed(WithdrawalConfirmed),
+    UtxoSpent(UtxoSpent),
+    ReconfigStarted(ReconfigStarted),
+    ReconfigEnded(ReconfigEnded),
 }
 
 impl HashiEvent {
@@ -860,62 +860,62 @@ impl HashiEvent {
         let event = match (event_type.module().as_str(), event_type.name().as_str()) {
             ValidatorRegistered::MODULE_NAME => ValidatorRegistered::from_bcs(bcs.value())?.into(),
             ValidatorUpdated::MODULE_NAME => ValidatorUpdated::from_bcs(bcs.value())?.into(),
-            VoteCastEvent::MODULE_NAME => VoteCastEvent::new(&event_type, bcs.value())?.into(),
-            VoteRemovedEvent::MODULE_NAME => {
-                VoteRemovedEvent::new(&event_type, bcs.value())?.into()
+            VoteCast::MODULE_NAME => VoteCast::new(&event_type, bcs.value())?.into(),
+            VoteRemoved::MODULE_NAME => {
+                VoteRemoved::new(&event_type, bcs.value())?.into()
             }
-            ProposalCreatedEvent::MODULE_NAME => {
-                ProposalCreatedEvent::new(&event_type, bcs.value())?.into()
+            ProposalCreated::MODULE_NAME => {
+                ProposalCreated::new(&event_type, bcs.value())?.into()
             }
-            ProposalDeletedEvent::MODULE_NAME => {
-                ProposalDeletedEvent::new(&event_type, bcs.value())?.into()
+            ProposalDeleted::MODULE_NAME => {
+                ProposalDeleted::new(&event_type, bcs.value())?.into()
             }
-            ProposalExecutedEvent::MODULE_NAME => {
-                ProposalExecutedEvent::new(&event_type, bcs.value())?.into()
+            ProposalExecuted::MODULE_NAME => {
+                ProposalExecuted::new(&event_type, bcs.value())?.into()
             }
-            QuorumReachedEvent::MODULE_NAME => {
-                QuorumReachedEvent::new(&event_type, bcs.value())?.into()
+            QuorumReached::MODULE_NAME => {
+                QuorumReached::new(&event_type, bcs.value())?.into()
             }
-            MintEvent::MODULE_NAME => MintEvent::new(&event_type, bcs.value())?.into(),
-            BurnEvent::MODULE_NAME => BurnEvent::new(&event_type, bcs.value())?.into(),
-            DepositRequestedEvent::MODULE_NAME => {
-                DepositRequestedEvent::from_bcs(bcs.value())?.into()
+            Minted::MODULE_NAME => Minted::new(&event_type, bcs.value())?.into(),
+            Burned::MODULE_NAME => Burned::new(&event_type, bcs.value())?.into(),
+            DepositRequested::MODULE_NAME => {
+                DepositRequested::from_bcs(bcs.value())?.into()
             }
-            DepositApprovedEvent::MODULE_NAME => {
-                DepositApprovedEvent::from_bcs(bcs.value())?.into()
+            DepositApproved::MODULE_NAME => {
+                DepositApproved::from_bcs(bcs.value())?.into()
             }
-            DepositConfirmedEvent::MODULE_NAME => {
-                DepositConfirmedEvent::from_bcs(bcs.value())?.into()
+            DepositConfirmed::MODULE_NAME => {
+                DepositConfirmed::from_bcs(bcs.value())?.into()
             }
-            ExpiredDepositDeletedEvent::MODULE_NAME => {
-                ExpiredDepositDeletedEvent::from_bcs(bcs.value())?.into()
+            ExpiredDepositDeleted::MODULE_NAME => {
+                ExpiredDepositDeleted::from_bcs(bcs.value())?.into()
             }
-            WithdrawalRequestedEvent::MODULE_NAME => {
-                WithdrawalRequestedEvent::from_bcs(bcs.value())?.into()
+            WithdrawalRequested::MODULE_NAME => {
+                WithdrawalRequested::from_bcs(bcs.value())?.into()
             }
-            WithdrawalApprovedEvent::MODULE_NAME => {
-                WithdrawalApprovedEvent::from_bcs(bcs.value())?.into()
+            WithdrawalApproved::MODULE_NAME => {
+                WithdrawalApproved::from_bcs(bcs.value())?.into()
             }
-            WithdrawalPickedForProcessingEvent::MODULE_NAME => {
-                WithdrawalPickedForProcessingEvent::from_bcs(bcs.value())?.into()
+            WithdrawalPickedForProcessing::MODULE_NAME => {
+                WithdrawalPickedForProcessing::from_bcs(bcs.value())?.into()
             }
-            WithdrawalSignedEvent::MODULE_NAME => {
-                WithdrawalSignedEvent::from_bcs(bcs.value())?.into()
+            WithdrawalSigned::MODULE_NAME => {
+                WithdrawalSigned::from_bcs(bcs.value())?.into()
             }
-            WithdrawalInputsSignedEvent::MODULE_NAME => {
-                WithdrawalInputsSignedEvent::from_bcs(bcs.value())?.into()
+            WithdrawalInputsSigned::MODULE_NAME => {
+                WithdrawalInputsSigned::from_bcs(bcs.value())?.into()
             }
-            WithdrawalPresigsReassignedEvent::MODULE_NAME => {
-                WithdrawalPresigsReassignedEvent::from_bcs(bcs.value())?.into()
+            WithdrawalPresigsReassigned::MODULE_NAME => {
+                WithdrawalPresigsReassigned::from_bcs(bcs.value())?.into()
             }
-            WithdrawalConfirmedEvent::MODULE_NAME => {
-                WithdrawalConfirmedEvent::from_bcs(bcs.value())?.into()
+            WithdrawalConfirmed::MODULE_NAME => {
+                WithdrawalConfirmed::from_bcs(bcs.value())?.into()
             }
-            UtxoSpentEvent::MODULE_NAME => UtxoSpentEvent::from_bcs(bcs.value())?.into(),
-            StartReconfigEvent::MODULE_NAME => StartReconfigEvent::from_bcs(bcs.value())?.into(),
-            EndReconfigEvent::MODULE_NAME => EndReconfigEvent::from_bcs(bcs.value())?.into(),
-            PackageUpgradedEvent::MODULE_NAME => {
-                PackageUpgradedEvent::from_bcs(bcs.value())?.into()
+            UtxoSpent::MODULE_NAME => UtxoSpent::from_bcs(bcs.value())?.into(),
+            ReconfigStarted::MODULE_NAME => ReconfigStarted::from_bcs(bcs.value())?.into(),
+            ReconfigEnded::MODULE_NAME => ReconfigEnded::from_bcs(bcs.value())?.into(),
+            PackageUpgraded::MODULE_NAME => {
+                PackageUpgraded::from_bcs(bcs.value())?.into()
             }
             _ => {
                 return Ok(None);
@@ -959,13 +959,13 @@ impl From<ValidatorUpdated> for HashiEvent {
 }
 
 #[derive(Debug)]
-pub struct ProposalCreatedEvent {
+pub struct ProposalCreated {
     pub proposal_id: Address,
     pub timestamp_ms: u64,
     pub proposal_type: TypeTag,
 }
 
-impl ProposalCreatedEvent {
+impl ProposalCreated {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let proposal_type = extract_type_param::<Self>(event_type)?;
         let (proposal_id, timestamp_ms): (Address, u64) = bcs::from_bytes(bcs)?;
@@ -977,25 +977,25 @@ impl ProposalCreatedEvent {
     }
 }
 
-impl MoveType for ProposalCreatedEvent {
+impl MoveType for ProposalCreated {
     const MODULE: &'static str = "proposal";
-    const NAME: &'static str = "ProposalCreatedEvent";
+    const NAME: &'static str = "ProposalCreated";
 }
 
-impl From<ProposalCreatedEvent> for HashiEvent {
-    fn from(value: ProposalCreatedEvent) -> Self {
-        Self::ProposalCreatedEvent(value)
+impl From<ProposalCreated> for HashiEvent {
+    fn from(value: ProposalCreated) -> Self {
+        Self::ProposalCreated(value)
     }
 }
 
 #[derive(Debug)]
-pub struct VoteCastEvent {
+pub struct VoteCast {
     pub proposal_id: Address,
     pub voter: Address,
     pub proposal_type: TypeTag,
 }
 
-impl VoteCastEvent {
+impl VoteCast {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let proposal_type = extract_type_param::<Self>(event_type)?;
         let (proposal_id, voter): (Address, Address) = bcs::from_bytes(bcs)?;
@@ -1007,25 +1007,25 @@ impl VoteCastEvent {
     }
 }
 
-impl MoveType for VoteCastEvent {
+impl MoveType for VoteCast {
     const MODULE: &'static str = "proposal";
-    const NAME: &'static str = "VoteCastEvent";
+    const NAME: &'static str = "VoteCast";
 }
 
-impl From<VoteCastEvent> for HashiEvent {
-    fn from(value: VoteCastEvent) -> Self {
-        Self::VoteCastEvent(value)
+impl From<VoteCast> for HashiEvent {
+    fn from(value: VoteCast) -> Self {
+        Self::VoteCast(value)
     }
 }
 
 #[derive(Debug)]
-pub struct VoteRemovedEvent {
+pub struct VoteRemoved {
     pub proposal_id: Address,
     pub voter: Address,
     pub proposal_type: TypeTag,
 }
 
-impl VoteRemovedEvent {
+impl VoteRemoved {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let proposal_type = extract_type_param::<Self>(event_type)?;
         let (proposal_id, voter): (Address, Address) = bcs::from_bytes(bcs)?;
@@ -1037,24 +1037,24 @@ impl VoteRemovedEvent {
     }
 }
 
-impl MoveType for VoteRemovedEvent {
+impl MoveType for VoteRemoved {
     const MODULE: &'static str = "proposal";
-    const NAME: &'static str = "VoteRemovedEvent";
+    const NAME: &'static str = "VoteRemoved";
 }
 
-impl From<VoteRemovedEvent> for HashiEvent {
-    fn from(value: VoteRemovedEvent) -> Self {
-        Self::VoteRemovedEvent(value)
+impl From<VoteRemoved> for HashiEvent {
+    fn from(value: VoteRemoved) -> Self {
+        Self::VoteRemoved(value)
     }
 }
 
 #[derive(Debug)]
-pub struct ProposalDeletedEvent {
+pub struct ProposalDeleted {
     pub proposal_id: Address,
     pub proposal_type: TypeTag,
 }
 
-impl ProposalDeletedEvent {
+impl ProposalDeleted {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let proposal_type = extract_type_param::<Self>(event_type)?;
         let proposal_id: Address = bcs::from_bytes(bcs)?;
@@ -1065,35 +1065,35 @@ impl ProposalDeletedEvent {
     }
 }
 
-impl MoveType for ProposalDeletedEvent {
+impl MoveType for ProposalDeleted {
     const MODULE: &'static str = "proposal";
-    const NAME: &'static str = "ProposalDeletedEvent";
+    const NAME: &'static str = "ProposalDeleted";
 }
 
-impl From<ProposalDeletedEvent> for HashiEvent {
-    fn from(value: ProposalDeletedEvent) -> Self {
-        Self::ProposalDeletedEvent(value)
+impl From<ProposalDeleted> for HashiEvent {
+    fn from(value: ProposalDeleted) -> Self {
+        Self::ProposalDeleted(value)
     }
 }
 
 #[derive(Debug)]
-pub struct ProposalExecutedEvent {
+pub struct ProposalExecuted {
     pub proposal_id: Address,
     pub proposal_type: TypeTag,
     /// BCS-encoded bytes of the proposal `data` payload (`T` in the Move
-    /// `ProposalExecutedEvent<T>`). Decode using `proposal_type` to get the
+    /// `ProposalExecuted<T>`). Decode using `proposal_type` to get the
     /// typed value.
     pub data_bcs: Vec<u8>,
 }
 
-impl ProposalExecutedEvent {
+impl ProposalExecuted {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let proposal_type = extract_type_param::<Self>(event_type)?;
         // Layout is `(proposal_id: Address, data: T)`; Address is a fixed
         // 32-byte BCS encoding with no length prefix, so split there.
         if bcs.len() < 32 {
             anyhow::bail!(
-                "ProposalExecutedEvent payload too short: {} bytes",
+                "ProposalExecuted payload too short: {} bytes",
                 bcs.len()
             );
         }
@@ -1107,24 +1107,24 @@ impl ProposalExecutedEvent {
     }
 }
 
-impl MoveType for ProposalExecutedEvent {
+impl MoveType for ProposalExecuted {
     const MODULE: &'static str = "proposal";
-    const NAME: &'static str = "ProposalExecutedEvent";
+    const NAME: &'static str = "ProposalExecuted";
 }
 
-impl From<ProposalExecutedEvent> for HashiEvent {
-    fn from(value: ProposalExecutedEvent) -> Self {
-        Self::ProposalExecutedEvent(value)
+impl From<ProposalExecuted> for HashiEvent {
+    fn from(value: ProposalExecuted) -> Self {
+        Self::ProposalExecuted(value)
     }
 }
 
 #[derive(Debug)]
-pub struct QuorumReachedEvent {
+pub struct QuorumReached {
     pub proposal_id: Address,
     pub proposal_type: TypeTag,
 }
 
-impl QuorumReachedEvent {
+impl QuorumReached {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let proposal_type = extract_type_param::<Self>(event_type)?;
         let proposal_id: Address = bcs::from_bytes(bcs)?;
@@ -1135,46 +1135,46 @@ impl QuorumReachedEvent {
     }
 }
 
-impl MoveType for QuorumReachedEvent {
+impl MoveType for QuorumReached {
     const MODULE: &'static str = "proposal";
-    const NAME: &'static str = "QuorumReachedEvent";
+    const NAME: &'static str = "QuorumReached";
 }
 
-impl From<QuorumReachedEvent> for HashiEvent {
-    fn from(value: QuorumReachedEvent) -> Self {
-        Self::QuorumReachedEvent(value)
+impl From<QuorumReached> for HashiEvent {
+    fn from(value: QuorumReached) -> Self {
+        Self::QuorumReached(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct PackageUpgradedEvent {
+pub struct PackageUpgraded {
     pub package: Address,
     pub version: u64,
 }
 
-impl MoveType for PackageUpgradedEvent {
+impl MoveType for PackageUpgraded {
     const MODULE: &'static str = "upgrade";
-    const NAME: &'static str = "PackageUpgradedEvent";
+    const NAME: &'static str = "PackageUpgraded";
 }
 
-impl From<PackageUpgradedEvent> for HashiEvent {
-    fn from(value: PackageUpgradedEvent) -> Self {
-        Self::PackageUpgradedEvent(value)
+impl From<PackageUpgraded> for HashiEvent {
+    fn from(value: PackageUpgraded) -> Self {
+        Self::PackageUpgraded(value)
     }
 }
 
 #[derive(Debug)]
-pub struct MintEvent {
+pub struct Minted {
     pub coin_type: TypeTag,
     pub amount: u64,
 }
 
-impl MoveType for MintEvent {
+impl MoveType for Minted {
     const MODULE: &'static str = "treasury";
-    const NAME: &'static str = "MintEvent";
+    const NAME: &'static str = "Minted";
 }
 
-impl MintEvent {
+impl Minted {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let coin_type = extract_type_param::<Self>(event_type)?;
         Ok(Self {
@@ -1184,24 +1184,24 @@ impl MintEvent {
     }
 }
 
-impl From<MintEvent> for HashiEvent {
-    fn from(value: MintEvent) -> Self {
-        Self::MintEvent(value)
+impl From<Minted> for HashiEvent {
+    fn from(value: Minted) -> Self {
+        Self::Minted(value)
     }
 }
 
 #[derive(Debug)]
-pub struct BurnEvent {
+pub struct Burned {
     pub coin_type: TypeTag,
     pub amount: u64,
 }
 
-impl MoveType for BurnEvent {
+impl MoveType for Burned {
     const MODULE: &'static str = "treasury";
-    const NAME: &'static str = "BurnEvent";
+    const NAME: &'static str = "Burned";
 }
 
-impl BurnEvent {
+impl Burned {
     fn new(event_type: &StructTag, bcs: &[u8]) -> Result<Self, anyhow::Error> {
         let coin_type = extract_type_param::<Self>(event_type)?;
         Ok(Self {
@@ -1211,14 +1211,14 @@ impl BurnEvent {
     }
 }
 
-impl From<BurnEvent> for HashiEvent {
-    fn from(value: BurnEvent) -> Self {
-        Self::BurnEvent(value)
+impl From<Burned> for HashiEvent {
+    fn from(value: Burned) -> Self {
+        Self::Burned(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct DepositRequestedEvent {
+pub struct DepositRequested {
     pub request_id: Address,
     pub utxo_id: UtxoId,
     pub amount: u64,
@@ -1228,14 +1228,14 @@ pub struct DepositRequestedEvent {
     pub sui_tx_digest: Digest,
 }
 
-impl MoveType for DepositRequestedEvent {
+impl MoveType for DepositRequested {
     const MODULE: &'static str = "deposit";
-    const NAME: &'static str = "DepositRequestedEvent";
+    const NAME: &'static str = "DepositRequested";
 }
 
-impl From<DepositRequestedEvent> for HashiEvent {
-    fn from(value: DepositRequestedEvent) -> Self {
-        Self::DepositRequestedEvent(value)
+impl From<DepositRequested> for HashiEvent {
+    fn from(value: DepositRequested) -> Self {
+        Self::DepositRequested(value)
     }
 }
 
@@ -1245,61 +1245,61 @@ impl From<DepositRequestedEvent> for HashiEvent {
 /// `approved_timestamp_ms` is the on-chain clock timestamp recorded on
 /// the request, against which `confirm_deposit` enforces the delay.
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct DepositApprovedEvent {
+pub struct DepositApproved {
     pub request_id: Address,
     pub utxo: Utxo,
     pub cert: CommitteeSignature,
     pub approved_timestamp_ms: u64,
 }
 
-impl MoveType for DepositApprovedEvent {
+impl MoveType for DepositApproved {
     const MODULE: &'static str = "deposit";
-    const NAME: &'static str = "DepositApprovedEvent";
+    const NAME: &'static str = "DepositApproved";
 }
 
-impl From<DepositApprovedEvent> for HashiEvent {
-    fn from(value: DepositApprovedEvent) -> Self {
-        Self::DepositApprovedEvent(value)
+impl From<DepositApproved> for HashiEvent {
+    fn from(value: DepositApproved) -> Self {
+        Self::DepositApproved(value)
     }
 }
 
 /// Emitted by `confirm_deposit` once an approved deposit clears the
 /// time-delay window and the corresponding `hBTC` is minted.
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct DepositConfirmedEvent {
+pub struct DepositConfirmed {
     pub request_id: Address,
     pub utxo: Utxo,
 }
 
-impl MoveType for DepositConfirmedEvent {
+impl MoveType for DepositConfirmed {
     const MODULE: &'static str = "deposit";
-    const NAME: &'static str = "DepositConfirmedEvent";
+    const NAME: &'static str = "DepositConfirmed";
 }
 
-impl From<DepositConfirmedEvent> for HashiEvent {
-    fn from(value: DepositConfirmedEvent) -> Self {
-        Self::DepositConfirmedEvent(value)
+impl From<DepositConfirmed> for HashiEvent {
+    fn from(value: DepositConfirmed) -> Self {
+        Self::DepositConfirmed(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct ExpiredDepositDeletedEvent {
+pub struct ExpiredDepositDeleted {
     pub request_id: Address,
 }
 
-impl MoveType for ExpiredDepositDeletedEvent {
+impl MoveType for ExpiredDepositDeleted {
     const MODULE: &'static str = "deposit";
-    const NAME: &'static str = "ExpiredDepositDeletedEvent";
+    const NAME: &'static str = "ExpiredDepositDeleted";
 }
 
-impl From<ExpiredDepositDeletedEvent> for HashiEvent {
-    fn from(value: ExpiredDepositDeletedEvent) -> Self {
-        Self::ExpiredDepositDeletedEvent(value)
+impl From<ExpiredDepositDeleted> for HashiEvent {
+    fn from(value: ExpiredDepositDeleted) -> Self {
+        Self::ExpiredDepositDeleted(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct WithdrawalRequestedEvent {
+pub struct WithdrawalRequested {
     pub request_id: Address,
     pub btc_amount: u64,
     pub bitcoin_address: Vec<u8>,
@@ -1308,35 +1308,35 @@ pub struct WithdrawalRequestedEvent {
     pub sui_tx_digest: Digest,
 }
 
-impl MoveType for WithdrawalRequestedEvent {
+impl MoveType for WithdrawalRequested {
     const MODULE: &'static str = "withdrawal_queue";
-    const NAME: &'static str = "WithdrawalRequestedEvent";
+    const NAME: &'static str = "WithdrawalRequested";
 }
 
-impl From<WithdrawalRequestedEvent> for HashiEvent {
-    fn from(value: WithdrawalRequestedEvent) -> Self {
-        Self::WithdrawalRequestedEvent(value)
+impl From<WithdrawalRequested> for HashiEvent {
+    fn from(value: WithdrawalRequested) -> Self {
+        Self::WithdrawalRequested(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct WithdrawalApprovedEvent {
+pub struct WithdrawalApproved {
     pub request_id: Address,
 }
 
-impl MoveType for WithdrawalApprovedEvent {
+impl MoveType for WithdrawalApproved {
     const MODULE: &'static str = "withdrawal_queue";
-    const NAME: &'static str = "WithdrawalApprovedEvent";
+    const NAME: &'static str = "WithdrawalApproved";
 }
 
-impl From<WithdrawalApprovedEvent> for HashiEvent {
-    fn from(value: WithdrawalApprovedEvent) -> Self {
-        Self::WithdrawalApprovedEvent(value)
+impl From<WithdrawalApproved> for HashiEvent {
+    fn from(value: WithdrawalApproved) -> Self {
+        Self::WithdrawalApproved(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct WithdrawalPickedForProcessingEvent {
+pub struct WithdrawalPickedForProcessing {
     pub withdrawal_txn_id: Address,
     pub txid: BitcoinTxid,
     pub request_ids: Vec<Address>,
@@ -1349,19 +1349,19 @@ pub struct WithdrawalPickedForProcessingEvent {
     pub randomness: Vec<u8>,
 }
 
-impl MoveType for WithdrawalPickedForProcessingEvent {
+impl MoveType for WithdrawalPickedForProcessing {
     const MODULE: &'static str = "withdrawal_queue";
-    const NAME: &'static str = "WithdrawalPickedForProcessingEvent";
+    const NAME: &'static str = "WithdrawalPickedForProcessing";
 }
 
-impl From<WithdrawalPickedForProcessingEvent> for HashiEvent {
-    fn from(value: WithdrawalPickedForProcessingEvent) -> Self {
-        Self::WithdrawalPickedForProcessingEvent(value)
+impl From<WithdrawalPickedForProcessing> for HashiEvent {
+    fn from(value: WithdrawalPickedForProcessing) -> Self {
+        Self::WithdrawalPickedForProcessing(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct WithdrawalSignedEvent {
+pub struct WithdrawalSigned {
     pub withdrawal_txn_id: Address,
     pub request_ids: Vec<Address>,
     /// Per-input MPC committee Schnorr signatures.
@@ -1371,57 +1371,57 @@ pub struct WithdrawalSignedEvent {
     pub guardian_signatures: Vec<Vec<u8>>,
 }
 
-impl MoveType for WithdrawalSignedEvent {
+impl MoveType for WithdrawalSigned {
     const MODULE: &'static str = "withdrawal_queue";
-    const NAME: &'static str = "WithdrawalSignedEvent";
+    const NAME: &'static str = "WithdrawalSigned";
 }
 
-impl From<WithdrawalSignedEvent> for HashiEvent {
-    fn from(value: WithdrawalSignedEvent) -> Self {
-        Self::WithdrawalSignedEvent(value)
+impl From<WithdrawalSigned> for HashiEvent {
+    fn from(value: WithdrawalSigned) -> Self {
+        Self::WithdrawalSigned(value)
     }
 }
 
 /// Emitted on each incremental chunk write so the watcher can track signing
 /// progress (signed_count / num_inputs); the per-input state lives on the object.
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct WithdrawalInputsSignedEvent {
+pub struct WithdrawalInputsSigned {
     pub withdrawal_txn_id: Address,
     pub signed_count: u64,
     pub num_inputs: u64,
 }
 
-impl MoveType for WithdrawalInputsSignedEvent {
+impl MoveType for WithdrawalInputsSigned {
     const MODULE: &'static str = "withdrawal_queue";
-    const NAME: &'static str = "WithdrawalInputsSignedEvent";
+    const NAME: &'static str = "WithdrawalInputsSigned";
 }
 
-impl From<WithdrawalInputsSignedEvent> for HashiEvent {
-    fn from(value: WithdrawalInputsSignedEvent) -> Self {
-        Self::WithdrawalInputsSignedEvent(value)
+impl From<WithdrawalInputsSigned> for HashiEvent {
+    fn from(value: WithdrawalInputsSigned) -> Self {
+        Self::WithdrawalInputsSigned(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct WithdrawalPresigsReassignedEvent {
+pub struct WithdrawalPresigsReassigned {
     pub withdrawal_txn_id: Address,
     pub epoch: u64,
     pub presig_start_index: u64,
 }
 
-impl MoveType for WithdrawalPresigsReassignedEvent {
+impl MoveType for WithdrawalPresigsReassigned {
     const MODULE: &'static str = "withdrawal_queue";
-    const NAME: &'static str = "WithdrawalPresigsReassignedEvent";
+    const NAME: &'static str = "WithdrawalPresigsReassigned";
 }
 
-impl From<WithdrawalPresigsReassignedEvent> for HashiEvent {
-    fn from(value: WithdrawalPresigsReassignedEvent) -> Self {
-        Self::WithdrawalPresigsReassignedEvent(value)
+impl From<WithdrawalPresigsReassigned> for HashiEvent {
+    fn from(value: WithdrawalPresigsReassigned) -> Self {
+        Self::WithdrawalPresigsReassigned(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct WithdrawalConfirmedEvent {
+pub struct WithdrawalConfirmed {
     pub withdrawal_txn_id: Address,
     pub txid: BitcoinTxid,
     /// Change UTXO IDs promoted to confirmed, in vout order. Empty when there
@@ -1432,65 +1432,65 @@ pub struct WithdrawalConfirmedEvent {
     pub change_utxo_amounts: Vec<u64>,
 }
 
-impl MoveType for WithdrawalConfirmedEvent {
+impl MoveType for WithdrawalConfirmed {
     const MODULE: &'static str = "withdrawal_queue";
-    const NAME: &'static str = "WithdrawalConfirmedEvent";
+    const NAME: &'static str = "WithdrawalConfirmed";
 }
 
-impl From<WithdrawalConfirmedEvent> for HashiEvent {
-    fn from(value: WithdrawalConfirmedEvent) -> Self {
-        Self::WithdrawalConfirmedEvent(value)
+impl From<WithdrawalConfirmed> for HashiEvent {
+    fn from(value: WithdrawalConfirmed) -> Self {
+        Self::WithdrawalConfirmed(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct UtxoSpentEvent {
+pub struct UtxoSpent {
     pub utxo_id: UtxoId,
     pub spent_epoch: u64,
 }
 
-impl MoveType for UtxoSpentEvent {
+impl MoveType for UtxoSpent {
     const MODULE: &'static str = "utxo_pool";
-    const NAME: &'static str = "UtxoSpentEvent";
+    const NAME: &'static str = "UtxoSpent";
 }
 
-impl From<UtxoSpentEvent> for HashiEvent {
-    fn from(value: UtxoSpentEvent) -> Self {
-        Self::UtxoSpentEvent(value)
+impl From<UtxoSpent> for HashiEvent {
+    fn from(value: UtxoSpent) -> Self {
+        Self::UtxoSpent(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct StartReconfigEvent {
+pub struct ReconfigStarted {
     pub epoch: u64,
 }
 
-impl MoveType for StartReconfigEvent {
+impl MoveType for ReconfigStarted {
     const MODULE: &'static str = "reconfig";
-    const NAME: &'static str = "StartReconfigEvent";
+    const NAME: &'static str = "ReconfigStarted";
 }
 
-impl From<StartReconfigEvent> for HashiEvent {
-    fn from(value: StartReconfigEvent) -> Self {
-        Self::StartReconfigEvent(value)
+impl From<ReconfigStarted> for HashiEvent {
+    fn from(value: ReconfigStarted) -> Self {
+        Self::ReconfigStarted(value)
     }
 }
 
 #[derive(Debug, serde_derive::Deserialize)]
-pub struct EndReconfigEvent {
+pub struct ReconfigEnded {
     pub from_epoch: u64,
     pub epoch: u64,
     pub mpc_public_key: Vec<u8>,
 }
 
-impl MoveType for EndReconfigEvent {
+impl MoveType for ReconfigEnded {
     const MODULE: &'static str = "reconfig";
-    const NAME: &'static str = "EndReconfigEvent";
+    const NAME: &'static str = "ReconfigEnded";
 }
 
-impl From<EndReconfigEvent> for HashiEvent {
-    fn from(value: EndReconfigEvent) -> Self {
-        Self::EndReconfigEvent(value)
+impl From<ReconfigEnded> for HashiEvent {
+    fn from(value: ReconfigEnded) -> Self {
+        Self::ReconfigEnded(value)
     }
 }
 

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -861,62 +861,38 @@ impl HashiEvent {
             ValidatorRegistered::MODULE_NAME => ValidatorRegistered::from_bcs(bcs.value())?.into(),
             ValidatorUpdated::MODULE_NAME => ValidatorUpdated::from_bcs(bcs.value())?.into(),
             VoteCast::MODULE_NAME => VoteCast::new(&event_type, bcs.value())?.into(),
-            VoteRemoved::MODULE_NAME => {
-                VoteRemoved::new(&event_type, bcs.value())?.into()
-            }
-            ProposalCreated::MODULE_NAME => {
-                ProposalCreated::new(&event_type, bcs.value())?.into()
-            }
-            ProposalDeleted::MODULE_NAME => {
-                ProposalDeleted::new(&event_type, bcs.value())?.into()
-            }
+            VoteRemoved::MODULE_NAME => VoteRemoved::new(&event_type, bcs.value())?.into(),
+            ProposalCreated::MODULE_NAME => ProposalCreated::new(&event_type, bcs.value())?.into(),
+            ProposalDeleted::MODULE_NAME => ProposalDeleted::new(&event_type, bcs.value())?.into(),
             ProposalExecuted::MODULE_NAME => {
                 ProposalExecuted::new(&event_type, bcs.value())?.into()
             }
-            QuorumReached::MODULE_NAME => {
-                QuorumReached::new(&event_type, bcs.value())?.into()
-            }
+            QuorumReached::MODULE_NAME => QuorumReached::new(&event_type, bcs.value())?.into(),
             Minted::MODULE_NAME => Minted::new(&event_type, bcs.value())?.into(),
             Burned::MODULE_NAME => Burned::new(&event_type, bcs.value())?.into(),
-            DepositRequested::MODULE_NAME => {
-                DepositRequested::from_bcs(bcs.value())?.into()
-            }
-            DepositApproved::MODULE_NAME => {
-                DepositApproved::from_bcs(bcs.value())?.into()
-            }
-            DepositConfirmed::MODULE_NAME => {
-                DepositConfirmed::from_bcs(bcs.value())?.into()
-            }
+            DepositRequested::MODULE_NAME => DepositRequested::from_bcs(bcs.value())?.into(),
+            DepositApproved::MODULE_NAME => DepositApproved::from_bcs(bcs.value())?.into(),
+            DepositConfirmed::MODULE_NAME => DepositConfirmed::from_bcs(bcs.value())?.into(),
             ExpiredDepositDeleted::MODULE_NAME => {
                 ExpiredDepositDeleted::from_bcs(bcs.value())?.into()
             }
-            WithdrawalRequested::MODULE_NAME => {
-                WithdrawalRequested::from_bcs(bcs.value())?.into()
-            }
-            WithdrawalApproved::MODULE_NAME => {
-                WithdrawalApproved::from_bcs(bcs.value())?.into()
-            }
+            WithdrawalRequested::MODULE_NAME => WithdrawalRequested::from_bcs(bcs.value())?.into(),
+            WithdrawalApproved::MODULE_NAME => WithdrawalApproved::from_bcs(bcs.value())?.into(),
             WithdrawalPickedForProcessing::MODULE_NAME => {
                 WithdrawalPickedForProcessing::from_bcs(bcs.value())?.into()
             }
-            WithdrawalSigned::MODULE_NAME => {
-                WithdrawalSigned::from_bcs(bcs.value())?.into()
-            }
+            WithdrawalSigned::MODULE_NAME => WithdrawalSigned::from_bcs(bcs.value())?.into(),
             WithdrawalInputsSigned::MODULE_NAME => {
                 WithdrawalInputsSigned::from_bcs(bcs.value())?.into()
             }
             WithdrawalPresigsReassigned::MODULE_NAME => {
                 WithdrawalPresigsReassigned::from_bcs(bcs.value())?.into()
             }
-            WithdrawalConfirmed::MODULE_NAME => {
-                WithdrawalConfirmed::from_bcs(bcs.value())?.into()
-            }
+            WithdrawalConfirmed::MODULE_NAME => WithdrawalConfirmed::from_bcs(bcs.value())?.into(),
             UtxoSpent::MODULE_NAME => UtxoSpent::from_bcs(bcs.value())?.into(),
             ReconfigStarted::MODULE_NAME => ReconfigStarted::from_bcs(bcs.value())?.into(),
             ReconfigEnded::MODULE_NAME => ReconfigEnded::from_bcs(bcs.value())?.into(),
-            PackageUpgraded::MODULE_NAME => {
-                PackageUpgraded::from_bcs(bcs.value())?.into()
-            }
+            PackageUpgraded::MODULE_NAME => PackageUpgraded::from_bcs(bcs.value())?.into(),
             _ => {
                 return Ok(None);
             }
@@ -1092,10 +1068,7 @@ impl ProposalExecuted {
         // Layout is `(proposal_id: Address, data: T)`; Address is a fixed
         // 32-byte BCS encoding with no length prefix, so split there.
         if bcs.len() < 32 {
-            anyhow::bail!(
-                "ProposalExecuted payload too short: {} bytes",
-                bcs.len()
-            );
+            anyhow::bail!("ProposalExecuted payload too short: {} bytes", bcs.len());
         }
         let proposal_id: Address = bcs::from_bytes(&bcs[..32])?;
         let data_bcs = bcs[32..].to_vec();

--- a/crates/hashi/src/cli/upgrade.rs
+++ b/crates/hashi/src/cli/upgrade.rs
@@ -9,7 +9,7 @@
 //! - Building an upgrade package via `sui move build`
 //! - Constructing the `execute + publish + finalize` PTB
 //! - Constructing the generic `execute` PTB for non-upgrade proposals
-//! - Parsing the proposal ID out of a `ProposalCreatedEvent` in tx effects
+//! - Parsing the proposal ID out of a `ProposalCreated` in tx effects
 //! - Finding the new package ID in the effects of an upgrade transaction
 //!
 //! Orchestration (collecting votes from committee members, driving the full
@@ -253,7 +253,7 @@ pub fn build_execute_proposal_transaction(
 }
 
 /// Extract the newly-created proposal's object ID from a transaction that
-/// called `<module>::propose(...)`. Looks for a single `ProposalCreatedEvent`
+/// called `<module>::propose(...)`. Looks for a single `ProposalCreated`
 /// in the transaction's emitted events.
 ///
 /// The BCS payload of the event is `(proposal_id, timestamp_ms)`; we only
@@ -264,11 +264,11 @@ pub fn extract_proposal_id_from_response(response: &ExecuteTransactionResponse) 
         .events()
         .events()
         .iter()
-        .find(|e| e.contents().name().contains("ProposalCreatedEvent"))
-        .ok_or_else(|| anyhow!("ProposalCreatedEvent not found in transaction effects"))?;
+        .find(|e| e.contents().name().contains("ProposalCreated"))
+        .ok_or_else(|| anyhow!("ProposalCreated not found in transaction effects"))?;
 
     let (id, _ts): (Address, u64) = bcs::from_bytes(event.contents().value())
-        .map_err(|e| anyhow!("failed to deserialize ProposalCreatedEvent payload: {e}"))?;
+        .map_err(|e| anyhow!("failed to deserialize ProposalCreated payload: {e}"))?;
     Ok(id)
 }
 

--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -3,7 +3,7 @@
 
 //! Local emulator of the guardian's token-bucket limiter. Bootstrapped
 //! from the guardian at startup and advanced by the watcher on every
-//! `WithdrawalSignedEvent`. MPC signing only `validate_consume`s.
+//! `WithdrawalSigned`. MPC signing only `validate_consume`s.
 
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
@@ -175,7 +175,7 @@ pub(crate) const STALL_RECONCILE_TICKS: usize = 20;
 /// Flags a local mirror that has fallen out of lockstep with the guardian.
 ///
 /// The guardian bumps `next_seq` at finalize-request time but a node only
-/// advances on the matching on-chain `WithdrawalSignedEvent`, so `local <
+/// advances on the matching on-chain `WithdrawalSigned`, so `local <
 /// guardian` is ordinary in-flight lag and must not, on its own, trip a
 /// reconcile (forward-snapping a healthy mirror would double-count the event
 /// still in flight). We fire only when the mirror has failed to reach the

--- a/crates/hashi/src/leader/withdrawal_transactions.rs
+++ b/crates/hashi/src/leader/withdrawal_transactions.rs
@@ -322,7 +322,7 @@ impl LeaderService {
             }
             // TODO(guardian-seq-durability): the guardian advances next_seq at
             // finalize-request, but the mirror only advances on the on-chain
-            // WithdrawalSignedEvent, so over the multi-checkpoint signing window the
+            // WithdrawalSigned, so over the multi-checkpoint signing window the
             // mirror can lag by several seqs. A leader with a stale/empty
             // `guardian_last_finalized` (e.g. just rotated in) can slip past the
             // should_defer check below and present a stale seq -> guardian rejects ->

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -852,7 +852,7 @@ impl Hashi {
             self.metrics.record_limiter_state(&state, &config);
             self.metrics.guardian_limiter_initialized.set(1);
             // Hand the same Arc to OnchainState so the watcher can advance
-            // it inline when WithdrawalSignedEvent fires.
+            // it inline when WithdrawalSigned fires.
             self.onchain_state().set_local_limiter(limiter);
         }
         self.metrics
@@ -998,7 +998,7 @@ impl Hashi {
     /// Reconcile on a watcher rescrape. A rescrape can't tell a dropped signed event
     /// (real drift) from an in-flight withdrawal (consumed by the guardian, event
     /// pending), so forward-snapping `next_seq` would double-count the in-flight ones
-    /// (the snap counts them, then their `WithdrawalSignedEvent` counts them again).
+    /// (the snap counts them, then their `WithdrawalSigned` counts them again).
     /// So only re-align the bucket at a matching seq; seq drift is left to the stall tick.
     async fn reconcile_guardian_limiter_on_rescrape(&self) {
         let Some((limiter, state)) = self.guardian_limiter_and_state().await else {

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -353,13 +353,13 @@ impl Metrics {
             .unwrap(),
             guardian_limiter_anchor_events_total: register_int_counter_with_registry!(
                 "hashi_guardian_limiter_anchor_events_total",
-                "Total on-chain WithdrawalSignedEvent observations applied to the local guardian-limiter",
+                "Total on-chain WithdrawalSigned observations applied to the local guardian-limiter",
                 registry,
             )
             .unwrap(),
             guardian_limiter_anchor_events_skipped_total: register_int_counter_with_registry!(
                 "hashi_guardian_limiter_anchor_events_skipped_total",
-                "WithdrawalSignedEvent observations skipped as duplicates (checkpoint redelivery or bootstrap replay)",
+                "WithdrawalSigned observations skipped as duplicates (checkpoint redelivery or bootstrap replay)",
                 registry,
             )
             .unwrap(),
@@ -1119,7 +1119,7 @@ pub const GUARDIAN_LIMITER_OUTCOME_SEQ_MISMATCH: &str = "seq_mismatch";
 pub const GUARDIAN_LIMITER_OUTCOME_STALE_TIMESTAMP: &str = "stale_timestamp";
 pub const GUARDIAN_LIMITER_OUTCOME_INSUFFICIENT_CAPACITY: &str = "insufficient_capacity";
 // Apply-only label (no analogue on validate): watcher saw a
-// WithdrawalSignedEvent before the local limiter was bootstrapped.
+// WithdrawalSigned before the local limiter was bootstrapped.
 pub const GUARDIAN_LIMITER_OUTCOME_NO_LIMITER: &str = "no_limiter";
 
 pub const GUARDIAN_LIMITER_CALLSITE_LEADER_PRE_MPC: &str = "leader_pre_mpc";

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -50,7 +50,10 @@ const MAX_PROTOCOL_ATTEMPTS: u32 = 3;
 const START_RECONFIG_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const MPC_RECONFIG_TIMEOUT: Duration = Duration::from_secs(600);
 const RECONCILE_TICK: Duration = Duration::from_secs(15);
-const RECONFIG_E_NOT_RECONFIGURING: u64 = 0;
+/// Move `hashi::reconfig::ENotReconfiguring`, matched by its clever-error
+/// constant name (the `#[error]` abort code encodes a source line, so the
+/// numeric code is not stable).
+const RECONFIG_E_NOT_RECONFIGURING: &str = "ENotReconfiguring";
 
 #[derive(Clone)]
 pub struct MpcHandle {
@@ -1268,10 +1271,14 @@ fn classify_reconfig_submission_error(err: &anyhow::Error) -> ReconfigSubmission
     };
     let location = abort.location();
 
+    let abort_constant_name = abort
+        .clever_error
+        .as_ref()
+        .and_then(|clever| clever.constant_name.as_deref());
     match (
         location.module_opt(),
         location.function_name_opt(),
-        abort.abort_code_opt(),
+        abort_constant_name,
     ) {
         (Some("committee_set"), Some("set_pending_committee_handoff_cert"), _) => {
             ReconfigSubmissionErrorKind::CommitteeHandoffAlreadySubmitted

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use hashi_types::move_types::AbortReconfig;
-use hashi_types::move_types::BurnEvent;
+use hashi_types::move_types::Burned;
 use hashi_types::move_types::HashiEvent;
-use hashi_types::move_types::MintEvent;
+use hashi_types::move_types::Minted;
 use hashi_types::move_types::MpcSig;
 use sui_rpc::Client;
 use sui_rpc::field::FieldMask;
@@ -213,9 +213,9 @@ async fn handle_events(
             HashiEvent::ValidatorUpdated(validator_updated) => {
                 validator_updates.insert(validator_updated.validator);
             }
-            HashiEvent::VoteCastEvent(_) => {}
-            HashiEvent::VoteRemovedEvent(_) => {}
-            HashiEvent::ProposalCreatedEvent(proposal_created_event) => {
+            HashiEvent::VoteCast(_) => {}
+            HashiEvent::VoteRemoved(_) => {}
+            HashiEvent::ProposalCreated(proposal_created_event) => {
                 let proposal = Proposal {
                     id: proposal_created_event.proposal_id,
                     timestamp_ms: proposal_created_event.timestamp_ms,
@@ -230,7 +230,7 @@ async fn handle_events(
                     .active
                     .insert(proposal.id, proposal);
             }
-            HashiEvent::ProposalDeletedEvent(proposal_deleted_event) => {
+            HashiEvent::ProposalDeleted(proposal_deleted_event) => {
                 state
                     .state_mut()
                     .hashi
@@ -238,7 +238,7 @@ async fn handle_events(
                     .active
                     .remove(&proposal_deleted_event.proposal_id);
             }
-            HashiEvent::ProposalExecutedEvent(proposal_executed_event) => {
+            HashiEvent::ProposalExecuted(proposal_executed_event) => {
                 // Move the entry from `active` to `executed` to mirror
                 // the on-chain dual-bag layout. Scope the write lock so
                 // it's released before the async config refetch below.
@@ -301,18 +301,18 @@ async fn handle_events(
                     }
                 }
             }
-            HashiEvent::QuorumReachedEvent(_) => {}
-            HashiEvent::PackageUpgradedEvent(package_upgraded_event) => {
+            HashiEvent::QuorumReached(_) => {}
+            HashiEvent::PackageUpgraded(package_upgraded_event) => {
                 state.add_package_version(
                     package_upgraded_event.version,
                     package_upgraded_event.package,
                 );
             }
-            HashiEvent::MintEvent(MintEvent { coin_type, .. })
-            | HashiEvent::BurnEvent(BurnEvent { coin_type, .. }) => {
+            HashiEvent::Minted(Minted { coin_type, .. })
+            | HashiEvent::Burned(Burned { coin_type, .. }) => {
                 refresh_treasury_cap_supply(client, state, coin_type).await;
             }
-            HashiEvent::DepositRequestedEvent(deposit_requested_event) => {
+            HashiEvent::DepositRequested(deposit_requested_event) => {
                 tracing::info!(deposit_request_id = %deposit_requested_event.request_id, "Deposit request detected");
                 let deposit_request = DepositRequest {
                     id: deposit_requested_event.request_id,
@@ -335,7 +335,7 @@ async fn handle_events(
                     .requests
                     .insert(deposit_request.id, deposit_request);
             }
-            HashiEvent::DepositApprovedEvent(deposit_approved_event) => {
+            HashiEvent::DepositApproved(deposit_approved_event) => {
                 tracing::info!(deposit_request_id = %deposit_approved_event.request_id, "Deposit approved");
                 let mut state = state.state_mut();
                 // Stamp the in-memory request so the leader's next pass
@@ -355,7 +355,7 @@ async fn handle_events(
                         Some(deposit_approved_event.approved_timestamp_ms);
                 }
             }
-            HashiEvent::DepositConfirmedEvent(deposit_confirmed_event) => {
+            HashiEvent::DepositConfirmed(deposit_confirmed_event) => {
                 tracing::info!(deposit_request_id = %deposit_confirmed_event.request_id, "Deposit confirmed");
                 let mut state = state.state_mut();
 
@@ -376,7 +376,7 @@ async fn handle_events(
                     },
                 );
             }
-            HashiEvent::ExpiredDepositDeletedEvent(expired_deposit_deleted_event) => {
+            HashiEvent::ExpiredDepositDeleted(expired_deposit_deleted_event) => {
                 tracing::info!(deposit_request_id = %expired_deposit_deleted_event.request_id, "Expired deposit deleted");
                 state
                     .state_mut()
@@ -385,7 +385,7 @@ async fn handle_events(
                     .requests
                     .remove(&expired_deposit_deleted_event.request_id);
             }
-            HashiEvent::WithdrawalRequestedEvent(withdrawal_requested_event) => {
+            HashiEvent::WithdrawalRequested(withdrawal_requested_event) => {
                 tracing::info!(withdrawal_request_id = %withdrawal_requested_event.request_id, "Withdrawal request detected");
                 let withdrawal_request = WithdrawalRequest {
                     id: withdrawal_requested_event.request_id,
@@ -407,7 +407,7 @@ async fn handle_events(
                     .requests
                     .insert(withdrawal_request.id, withdrawal_request);
             }
-            HashiEvent::WithdrawalApprovedEvent(event) => {
+            HashiEvent::WithdrawalApproved(event) => {
                 tracing::info!(withdrawal_request_id = %event.request_id, "Withdrawal approved");
                 if let Some(request) = state
                     .state_mut()
@@ -419,7 +419,7 @@ async fn handle_events(
                     request.status = super::types::WithdrawalStatus::Approved;
                 }
             }
-            HashiEvent::WithdrawalPickedForProcessingEvent(event) => {
+            HashiEvent::WithdrawalPickedForProcessing(event) => {
                 tracing::info!(withdrawal_txn_id = %event.withdrawal_txn_id, "Withdrawal picked for processing");
                 // Remove requests from the queue
                 {
@@ -482,7 +482,7 @@ async fn handle_events(
                     }
                 }
             }
-            HashiEvent::WithdrawalSignedEvent(event) => {
+            HashiEvent::WithdrawalSigned(event) => {
                 tracing::info!(withdrawal_txn_id = %event.withdrawal_txn_id, "Withdrawal signatures stored on-chain");
                 // Watcher is the sole mutator of the local limiter
                 // post-bootstrap; advance it inline with the mirror update.
@@ -524,7 +524,7 @@ async fn handle_events(
                 if limiter_inputs.is_none() {
                     tracing::debug!(
                         withdrawal_txn_id = %event.withdrawal_txn_id,
-                        "Skipping limiter apply: WithdrawalSignedEvent for already-signed txn"
+                        "Skipping limiter apply: WithdrawalSigned for already-signed txn"
                     );
                     if let Some(metrics) = state.metrics() {
                         metrics.guardian_limiter_anchor_events_skipped_total.inc();
@@ -559,7 +559,7 @@ async fn handle_events(
                                     amount_sats,
                                     timestamp_secs,
                                     withdrawal_txn_id = %event.withdrawal_txn_id,
-                                    "Local limiter advanced from on-chain WithdrawalSignedEvent",
+                                    "Local limiter advanced from on-chain WithdrawalSigned",
                                 );
                             }
                             Err(e) => {
@@ -584,7 +584,7 @@ async fn handle_events(
                     }
                 }
             }
-            HashiEvent::WithdrawalInputsSignedEvent(event) => {
+            HashiEvent::WithdrawalInputsSigned(event) => {
                 tracing::info!(
                     withdrawal_txn_id = %event.withdrawal_txn_id,
                     signed_count = event.signed_count,
@@ -611,7 +611,7 @@ async fn handle_events(
                     }
                 }
             }
-            HashiEvent::WithdrawalPresigsReassignedEvent(event) => {
+            HashiEvent::WithdrawalPresigsReassigned(event) => {
                 tracing::info!(
                     withdrawal_txn_id = %event.withdrawal_txn_id,
                     epoch = event.epoch,
@@ -636,14 +636,14 @@ async fn handle_events(
                     }
                 }
             }
-            HashiEvent::WithdrawalConfirmedEvent(event) => {
+            HashiEvent::WithdrawalConfirmed(event) => {
                 tracing::info!(withdrawal_txn_id = %event.withdrawal_txn_id, "Withdrawal confirmed on-chain");
                 let (sign_to_confirm_ms, total_ms) = {
                     let mut state = state.state_mut();
 
                     // Promote the change UTXOs from pending to confirmed by
                     // clearing `produced_by`. The UTXOs were already inserted at
-                    // commit time; input UTXOs are removed via UtxoSpentEvent.
+                    // commit time; input UTXOs are removed via UtxoSpent.
                     for change_utxo_id in &event.change_utxo_ids {
                         if let Some(record) =
                             state.hashi.utxo_pool.utxo_records.get_mut(change_utxo_id)
@@ -681,7 +681,7 @@ async fn handle_events(
                     }
                 }
             }
-            HashiEvent::UtxoSpentEvent(utxo_spent_event) => {
+            HashiEvent::UtxoSpent(utxo_spent_event) => {
                 let mut state = state.state_mut();
                 // Mark the local record as spent so the orphan scanner can discover it.
                 if let Some(record) = state
@@ -698,7 +698,7 @@ async fn handle_events(
                     .spent_utxos
                     .insert(utxo_spent_event.utxo_id, utxo_spent_event.spent_epoch);
             }
-            HashiEvent::StartReconfigEvent(start_reconfig_event) => {
+            HashiEvent::ReconfigStarted(start_reconfig_event) => {
                 let epoch = start_reconfig_event.epoch;
                 // Fetch new committee
                 let committees_id = state.state().hashi().committees.committees_id();
@@ -717,7 +717,7 @@ async fn handle_events(
                 }
                 state.notify(Notification::StartReconfig(epoch));
             }
-            HashiEvent::EndReconfigEvent(end_reconfig_event) => {
+            HashiEvent::ReconfigEnded(end_reconfig_event) => {
                 let committees_id = state.state().hashi().committees.committees_id();
                 let scraped_committees =
                     super::scrape_committees(client.clone(), committees_id).await;
@@ -732,7 +732,7 @@ async fn handle_events(
                     }
                     Err(e) => tracing::error!(
                         from_epoch = end_reconfig_event.from_epoch,
-                        "failed to scrape committee handoffs after EndReconfigEvent: {e}"
+                        "failed to scrape committee handoffs after ReconfigEnded: {e}"
                     ),
                 }
                 state

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -38,8 +38,8 @@ use hashi_types::committee::Bls12381PrivateKey;
 use hashi_types::committee::CommitteeSignature;
 use hashi_types::committee::EncryptionPublicKey;
 use hashi_types::committee::SignedMessage;
-use hashi_types::move_types::DepositRequestedEvent;
-use hashi_types::move_types::WithdrawalRequestedEvent;
+use hashi_types::move_types::DepositRequested;
+use hashi_types::move_types::WithdrawalRequested;
 
 /// Construct a `CommitteeSignature` via a Move call in the PTB.
 ///
@@ -739,15 +739,15 @@ impl SuiTxExecutor {
         let mut request_ids = Vec::new();
         for event in events.events() {
             let event_type = event.contents().name();
-            if event_type.contains("DepositRequestedEvent") {
-                let event_data = DepositRequestedEvent::from_bcs(event.contents().value())?;
+            if event_type.contains("DepositRequested") {
+                let event_data = DepositRequested::from_bcs(event.contents().value())?;
                 request_ids.push(event_data.request_id);
             }
         }
 
         anyhow::ensure!(
             request_ids.len() == utxos.len(),
-            "Expected {} DepositRequestedEvents but found {}",
+            "Expected {} DepositRequesteds but found {}",
             utxos.len(),
             request_ids.len(),
         );
@@ -834,15 +834,15 @@ impl SuiTxExecutor {
         let events = response.transaction().events();
         let mut request_ids = Vec::new();
         for event in events.events() {
-            if event.contents().name().contains("DepositRequestedEvent") {
-                let event_data = DepositRequestedEvent::from_bcs(event.contents().value())?;
+            if event.contents().name().contains("DepositRequested") {
+                let event_data = DepositRequested::from_bcs(event.contents().value())?;
                 request_ids.push(event_data.request_id);
             }
         }
 
         anyhow::ensure!(
             request_ids.len() == deposits.len(),
-            "Expected {} DepositRequestedEvents but found {}",
+            "Expected {} DepositRequesteds but found {}",
             deposits.len(),
             request_ids.len(),
         );
@@ -967,15 +967,15 @@ impl SuiTxExecutor {
 
         let mut request_ids = Vec::with_capacity(count);
         for event in response.transaction().events().events() {
-            if event.contents().name().contains("WithdrawalRequestedEvent") {
-                let event_data = WithdrawalRequestedEvent::from_bcs(event.contents().value())?;
+            if event.contents().name().contains("WithdrawalRequested") {
+                let event_data = WithdrawalRequested::from_bcs(event.contents().value())?;
                 request_ids.push(event_data.request_id);
             }
         }
 
         anyhow::ensure!(
             request_ids.len() == count,
-            "Expected {} WithdrawalRequestedEvents but found {}",
+            "Expected {} WithdrawalRequesteds but found {}",
             count,
             request_ids.len(),
         );
@@ -1734,12 +1734,12 @@ pub fn deposit_request_id_from_response(
     response: &ExecuteTransactionResponse,
 ) -> anyhow::Result<Address> {
     for event in response.transaction().events().events() {
-        if event.contents().name().contains("DepositRequestedEvent") {
-            let event_data = DepositRequestedEvent::from_bcs(event.contents().value())?;
+        if event.contents().name().contains("DepositRequested") {
+            let event_data = DepositRequested::from_bcs(event.contents().value())?;
             return Ok(event_data.request_id);
         }
     }
-    anyhow::bail!("DepositRequestedEvent not found in transaction events")
+    anyhow::bail!("DepositRequested not found in transaction events")
 }
 
 /// Build the PTB for a withdrawal request. The `Balance<BTC>` is drawn from the
@@ -1790,12 +1790,12 @@ pub fn withdrawal_request_id_from_response(
     response: &ExecuteTransactionResponse,
 ) -> anyhow::Result<Address> {
     for event in response.transaction().events().events() {
-        if event.contents().name().contains("WithdrawalRequestedEvent") {
-            let event_data = WithdrawalRequestedEvent::from_bcs(event.contents().value())?;
+        if event.contents().name().contains("WithdrawalRequested") {
+            let event_data = WithdrawalRequested::from_bcs(event.contents().value())?;
             return Ok(event_data.request_id);
         }
     }
-    anyhow::bail!("WithdrawalRequestedEvent not found in transaction events")
+    anyhow::bail!("WithdrawalRequested not found in transaction events")
 }
 
 /// Build the PTB for cancelling a withdrawal. The refunded `Balance<BTC>` is

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -610,7 +610,7 @@ impl Hashi {
         // so the committee independently re-validates the limit once here, before
         // certifying the finalize — refusing to sign blocks an over-limit broadcast
         // even if the guardian co-signed. Validate-only: the watcher advances the
-        // limiter on `WithdrawalSignedEvent`, never from this path.
+        // limiter on `WithdrawalSigned`, never from this path.
         //
         // TODO(guardian-seq-durability): this gate is necessarily *after* the
         // guardian co-signed (the cert binds the guardian sigs), so a rejection
@@ -1151,7 +1151,7 @@ impl Hashi {
         let configured_max_requests = self.config.withdrawal_max_batch_size().min(requests.len());
 
         // Snapshot both maps under a single read-lock so they are always
-        // mutually consistent (e.g., a WithdrawalConfirmedEvent cannot update
+        // mutually consistent (e.g., a WithdrawalConfirmed cannot update
         // one map but not the other between the two reads).
         let (withdrawal_txns, utxo_records) = {
             let state = self.onchain_state().state();

--- a/design/docs/move-model-lifecycle.mdx
+++ b/design/docs/move-model-lifecycle.mdx
@@ -8,6 +8,21 @@ This document illustrates the lifecycle of key Move models in the deposit and
 withdrawal flows, showing how data structures transform between onchain (Sui)
 and offchain (Bitcoin) states.
 
+## Entry-function gating principle
+
+Every entry function asserts the package version is enabled. Beyond that,
+gating follows one rule: **operations that move funds or advance a state
+machine also gate on pause and (where ordering matters) on reconfiguration;
+garbage collection and operator registration deliberately do not.** Deposits,
+withdrawal approvals, signing, and confirmation all stop when governance
+pauses the system or while a committee handoff is pending. Cleanup entries
+(`cleanup_spent_utxos`, `destroy_all_certs`, `delete_expired_deposit`) and
+validator registration or key rotation stay callable, because an emergency
+pause must not block operators from maintaining nodes or the chain from
+shedding dead state. One asymmetry is intentional: users can *request*
+withdrawals during reconfiguration (the request only escrows their hBTC);
+only committee-driven approval and processing wait for the new committee.
+
 ## Deposit flow
 
 ```mermaid

--- a/design/docs/move-model-lifecycle.mdx
+++ b/design/docs/move-model-lifecycle.mdx
@@ -155,7 +155,7 @@ flowchart TD
     GRL -.->|"GetGuardianInfo<br/>(bootstrap only)"| LL
     BLS_GW -->|"witness signatures + cert"| SUBMIT_SIGS
     SUBMIT_SIGS -->|"signatures<br/>stored on-chain"| PW_SIGNED
-    PW_SIGNED -.->|"WithdrawalSignedEvent<br/>each node's observer:<br/>apply_consume(next_seq, ts, amt)"| LL
+    PW_SIGNED -.->|"WithdrawalSigned<br/>each node's observer:<br/>apply_consume(next_seq, ts, amt)"| LL
     PW_SIGNED -->|"Reconstruct & broadcast<br/>signed BTC tx"| BTC_TX
     BTC_TX --> BTC_UTXO
     BTC_UTXO -.->|"Observe confirmation<br/>(N confirmations)"| SIGN2
@@ -188,7 +188,7 @@ rotation or mempool eviction).
 
 **Limiter coordination.** The `LocalLimiter` on each committee node is a
 deterministic projection of the onchain stream. Its `next_seq` advances
-**only** when the node's watcher observes `WithdrawalSignedEvent` for a
+**only** when the node's watcher observes `WithdrawalSigned` for a
 withdrawal. The MPC signing path uses `validate_consume` (read-only) to
 gate participation, never to mutate state. The leader's flow only reaches
 `sign_withdrawal()` after `finalize_withdrawal_through_guardian` returns
@@ -212,7 +212,7 @@ failures. On startup, each node bootstraps its `LocalLimiter` once through
 | 6    | Leader BLS-certs `StandardWithdrawalRequest` | Aggregated cert over `(wid, seq, ts, utxos)` — input to the guardian RPC    |
 | 7    | Guardian rate-limit check + enclave sig      | `StandardWithdrawal` RPC: verify cert → `consume(wid, seq)` → `EnclaveSig`  |
 | 8    | Leader stores witness signatures onchain     | `sign_withdrawal()` → `WithdrawalTransaction` updated with signatures       |
-| 9    | Each node advances its `LocalLimiter`        | Watcher observes `WithdrawalSignedEvent` → `apply_consume(seq, ts, amt)`    |
+| 9    | Each node advances its `LocalLimiter`        | Watcher observes `WithdrawalSigned` → `apply_consume(seq, ts, amt)`    |
 | 10   | BTC transaction broadcast (and re-broadcast) | Signed tx reconstructed from onchain data, broadcast to Bitcoin             |
 | 11   | Committee signs confirmation certificate     | `CommitteeSignature` created after BTC tx confirmed                         |
 | 12   | Leader confirms withdrawal                   | `WithdrawalTransaction` moved to `.confirmed_txns`, UTXOs marked spent      |

--- a/design/docs/reconfiguration.mdx
+++ b/design/docs/reconfiguration.mdx
@@ -147,7 +147,7 @@ In these cases, governance can create and execute an
 aborted. The proposal is voted on by the current committed committee. When
 quorum is reached, execution re-checks that the same epoch is still pending,
 clears the pending epoch change, removes the pending committee, and emits the
-standard `ProposalExecutedEvent<AbortReconfig>` with the aborted epoch in the
+standard `ProposalExecuted<AbortReconfig>` with the aborted epoch in the
 proposal data. The current Hashi epoch and MPC public key remain unchanged.
 Normal operations can then resume under the last committed committee, and a
 later Sui epoch notification can trigger a fresh `start_reconfig`.

--- a/design/docs/ts-sdk.mdx
+++ b/design/docs/ts-sdk.mdx
@@ -99,10 +99,10 @@ if (result.$kind !== "Transaction") {
   throw new Error(`request failed: ${JSON.stringify(result.FailedTransaction)}`);
 }
 
-// Pull the request id out of the WithdrawalRequestedEvent — needed if
+// Pull the request id out of the WithdrawalRequested — needed if
 // you later want to cancel.
 const evt = result.Transaction.events?.find((e) =>
-  e.eventType.endsWith("::withdrawal_queue::WithdrawalRequestedEvent"),
+  e.eventType.endsWith("::withdrawal_queue::WithdrawalRequested"),
 );
 const requestId = (evt as { json?: { request_id?: string } } | undefined)?.json?.request_id;
 ```

--- a/packages/hashi/sources/btc/deposit.move
+++ b/packages/hashi/sources/btc/deposit.move
@@ -210,6 +210,9 @@ entry fun confirm_deposit(
     };
 }
 
+/// Garbage collection: deliberately NOT gated on pause/reconfig — expiry
+/// refunds nothing (deposits mint on confirmation) and GC must stay
+/// callable during an emergency pause.
 entry fun delete_expired_deposit(
     hashi: &mut Hashi,
     request_id: address,

--- a/packages/hashi/sources/btc/deposit.move
+++ b/packages/hashi/sources/btc/deposit.move
@@ -59,7 +59,7 @@ entry fun deposit(
     let request_id = request.request_id().to_address();
 
     let utxo_ref = request.request_utxo();
-    sui::event::emit(DepositRequestedEvent {
+    sui::event::emit(DepositRequested {
         request_id,
         utxo_id: utxo_ref.id(),
         amount: utxo_ref.amount(),
@@ -128,7 +128,7 @@ entry fun approve_deposit(
 
     hashi.bitcoin_mut().deposit_queue_mut().insert_deposit(request);
 
-    sui::event::emit(DepositApprovedEvent {
+    sui::event::emit(DepositApproved {
         request_id,
         utxo,
         cert,
@@ -182,7 +182,7 @@ entry fun confirm_deposit(
 
     request.confirm(clock);
 
-    sui::event::emit(DepositConfirmedEvent {
+    sui::event::emit(DepositConfirmed {
         request_id,
         utxo,
     });
@@ -218,10 +218,10 @@ entry fun delete_expired_deposit(
     hashi.versioning().assert_version_enabled();
     hashi.bitcoin_mut().deposit_queue_mut().delete_expired(request_id, clock);
 
-    sui::event::emit(ExpiredDepositDeletedEvent { request_id });
+    sui::event::emit(ExpiredDepositDeleted { request_id });
 }
 
-public struct DepositRequestedEvent has copy, drop {
+public struct DepositRequested has copy, drop {
     request_id: address,
     utxo_id: UtxoId,
     amount: u64,
@@ -236,7 +236,7 @@ public struct DepositRequestedEvent has copy, drop {
 /// `approval_timestamp_ms` is the clock timestamp recorded on the
 /// request, against which `confirm_deposit` enforces the time-delay
 /// window.
-public struct DepositApprovedEvent has copy, drop {
+public struct DepositApproved has copy, drop {
     request_id: address,
     utxo: Utxo,
     cert: CommitteeSignature,
@@ -246,11 +246,11 @@ public struct DepositApprovedEvent has copy, drop {
 /// Emitted when an approved deposit has cleared the time-delay window
 /// and the corresponding BTC has been minted (when applicable) and the
 /// UTXO moved into the active pool.
-public struct DepositConfirmedEvent has copy, drop {
+public struct DepositConfirmed has copy, drop {
     request_id: address,
     utxo: Utxo,
 }
 
-public struct ExpiredDepositDeletedEvent has copy, drop {
+public struct ExpiredDepositDeleted has copy, drop {
     request_id: address,
 }

--- a/packages/hashi/sources/btc/utxo_pool.move
+++ b/packages/hashi/sources/btc/utxo_pool.move
@@ -108,7 +108,7 @@ public(package) fun get_utxo(self: &UtxoPool, utxo_id: UtxoId): hashi::utxo::Utx
 public(package) fun mark_spent(self: &mut UtxoPool, utxo_id: UtxoId, epoch: u64) {
     let record: &mut UtxoRecord = self.utxo_records.borrow_mut(utxo_id);
     record.spent_epoch = option::some(epoch);
-    sui::event::emit(UtxoSpentEvent { utxo_id, spent_epoch: epoch });
+    sui::event::emit(UtxoSpent { utxo_id, spent_epoch: epoch });
 }
 
 /// Deferred bookkeeping for a spent UTXO: remove from `utxo_records` and
@@ -136,7 +136,7 @@ public(package) fun confirm_pending(self: &mut UtxoPool, utxo_id: UtxoId) {
     }
 }
 
-public struct UtxoSpentEvent has copy, drop {
+public struct UtxoSpent has copy, drop {
     utxo_id: UtxoId,
     spent_epoch: u64,
 }

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -410,6 +410,9 @@ entry fun confirm_withdrawal(
 /// record from `utxo_records` to `spent_utxos`, reading the spent epoch
 /// from the record's `spent_epoch` field (set by `mark_spent` during
 /// `confirm_withdrawal`). Callers pass the individual UTXO IDs to clean up.
+///
+/// Garbage collection: deliberately NOT gated on pause/reconfig — it moves
+/// no funds and must stay callable during an emergency pause.
 entry fun cleanup_spent_utxos(hashi: &mut Hashi, utxo_ids: vector<UtxoId>) {
     hashi.versioning().assert_version_enabled();
     utxo_ids.do!(|utxo_id| {

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -449,7 +449,7 @@ public(package) fun record_input_signatures(
     let txn: &mut WithdrawalTransaction = self.withdrawal_txns.borrow_mut(withdrawal_id);
     assert!(!txn.txn_fully_signed(), EWithdrawalAlreadyFinalized);
     txn.signing.record(indices, signatures);
-    sui::event::emit(WithdrawalInputsSignedEvent {
+    sui::event::emit(WithdrawalInputsSigned {
         withdrawal_txn_id: withdrawal_id,
         signed_count: txn.signing.signed_count(),
         num_inputs: txn.signing.num_inputs(),
@@ -491,7 +491,7 @@ public(package) fun reallocate_presigs_for_withdrawal_txn(
 ) {
     let txn: &mut WithdrawalTransaction = self.withdrawal_txns.borrow_mut(withdrawal_id);
     txn.signing.reallocate(new_base, current_epoch, allocated_count);
-    sui::event::emit(WithdrawalPresigsReassignedEvent {
+    sui::event::emit(WithdrawalPresigsReassigned {
         withdrawal_txn_id: withdrawal_id,
         epoch: current_epoch,
         presig_start_index: new_base,
@@ -635,7 +635,7 @@ public(package) fun is_approved(self: &WithdrawalStatus): bool {
 // ======== Events ========
 
 public(package) fun emit_withdrawal_requested(request: &WithdrawalRequest) {
-    sui::event::emit(WithdrawalRequestedEvent {
+    sui::event::emit(WithdrawalRequested {
         request_id: request.id.to_address(),
         btc_amount: request.btc_amount,
         bitcoin_address: request.bitcoin_address,
@@ -646,11 +646,11 @@ public(package) fun emit_withdrawal_requested(request: &WithdrawalRequest) {
 }
 
 public(package) fun emit_withdrawal_approved(request_id: address) {
-    sui::event::emit(WithdrawalApprovedEvent { request_id });
+    sui::event::emit(WithdrawalApproved { request_id });
 }
 
 public(package) fun emit_withdrawal_picked_for_processing(self: &WithdrawalTransaction) {
-    sui::event::emit(WithdrawalPickedForProcessingEvent {
+    sui::event::emit(WithdrawalPickedForProcessing {
         withdrawal_txn_id: self.id.to_address(),
         txid: self.txid,
         request_ids: self.request_ids,
@@ -663,7 +663,7 @@ public(package) fun emit_withdrawal_picked_for_processing(self: &WithdrawalTrans
 }
 
 public(package) fun emit_withdrawal_signed(self: &WithdrawalTransaction) {
-    sui::event::emit(WithdrawalSignedEvent {
+    sui::event::emit(WithdrawalSigned {
         withdrawal_txn_id: self.id.to_address(),
         request_ids: self.request_ids,
         signatures: self.signing.to_signatures(),
@@ -675,7 +675,7 @@ public(package) fun emit_withdrawal_confirmed(self: &WithdrawalTransaction) {
     let change_utxo_ids = self.change_utxo_ids();
     let change_utxo_amounts = self.change_outputs.map_ref!(|change| change.amount);
 
-    sui::event::emit(WithdrawalConfirmedEvent {
+    sui::event::emit(WithdrawalConfirmed {
         withdrawal_txn_id: self.id.to_address(),
         txid: self.txid,
         change_utxo_ids,
@@ -685,7 +685,7 @@ public(package) fun emit_withdrawal_confirmed(self: &WithdrawalTransaction) {
 }
 
 public(package) fun emit_withdrawal_cancelled(request: &WithdrawalRequest) {
-    sui::event::emit(WithdrawalCancelledEvent {
+    sui::event::emit(WithdrawalCancelled {
         request_id: request.id.to_address(),
         requester_address: request.sender,
         btc_amount: request.btc_amount,
@@ -694,7 +694,7 @@ public(package) fun emit_withdrawal_cancelled(request: &WithdrawalRequest) {
 
 // ======== Event Structs ========
 
-public struct WithdrawalRequestedEvent has copy, drop {
+public struct WithdrawalRequested has copy, drop {
     request_id: address,
     btc_amount: u64,
     bitcoin_address: vector<u8>,
@@ -703,11 +703,11 @@ public struct WithdrawalRequestedEvent has copy, drop {
     sui_tx_digest: vector<u8>,
 }
 
-public struct WithdrawalApprovedEvent has copy, drop {
+public struct WithdrawalApproved has copy, drop {
     request_id: address,
 }
 
-public struct WithdrawalPickedForProcessingEvent has copy, drop {
+public struct WithdrawalPickedForProcessing has copy, drop {
     withdrawal_txn_id: address,
     txid: address,
     request_ids: vector<address>,
@@ -721,13 +721,13 @@ public struct WithdrawalPickedForProcessingEvent has copy, drop {
 /// Emitted on each incremental chunk write so the watcher can track signing
 /// progress (X / N) and the next leader can resume; the per-input state itself
 /// lives on the object.
-public struct WithdrawalInputsSignedEvent has copy, drop {
+public struct WithdrawalInputsSigned has copy, drop {
     withdrawal_txn_id: address,
     signed_count: u64,
     num_inputs: u64,
 }
 
-public struct WithdrawalSignedEvent has copy, drop {
+public struct WithdrawalSigned has copy, drop {
     withdrawal_txn_id: address,
     request_ids: vector<address>,
     /// Per-input Schnorr signatures from the MPC committee.
@@ -738,13 +738,13 @@ public struct WithdrawalSignedEvent has copy, drop {
     guardian_signatures: vector<vector<u8>>,
 }
 
-public struct WithdrawalPresigsReassignedEvent has copy, drop {
+public struct WithdrawalPresigsReassigned has copy, drop {
     withdrawal_txn_id: address,
     epoch: u64,
     presig_start_index: u64,
 }
 
-public struct WithdrawalConfirmedEvent has copy, drop {
+public struct WithdrawalConfirmed has copy, drop {
     withdrawal_txn_id: address,
     txid: address,
     change_utxo_ids: vector<UtxoId>,
@@ -752,7 +752,7 @@ public struct WithdrawalConfirmedEvent has copy, drop {
     change_utxo_amounts: vector<u64>,
 }
 
-public struct WithdrawalCancelledEvent has copy, drop {
+public struct WithdrawalCancelled has copy, drop {
     request_id: address,
     requester_address: address,
     btc_amount: u64,

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -360,6 +360,9 @@ public(package) fun new_withdrawal_txn(
     let request_count = request_ids.length();
     let output_count = outputs.length();
     assert!(output_count >= request_count, EOutputCountMismatch);
+    // Vouts are u32 (change-output UTXO ids are derived from output indices);
+    // unreachable for real Bitcoin transactions, but make the cast explicit.
+    assert!(output_count <= (std::u32::max_value!() as u64), EOutputCountMismatch);
 
     // Miner fee is split evenly across all withdrawal requests. Any remainder
     // (at most request_count - 1 sats) is a rounding bonus to the miner.

--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -72,6 +72,9 @@ fun submit_cert_internal(
     );
 }
 
+/// Garbage collection: deliberately NOT gated on pause/reconfig — cert
+/// buckets old enough to destroy (see `tob::destroy_all`) carry no live
+/// state, and GC must stay callable during an emergency pause.
 entry fun destroy_all_certs(
     hashi: &mut Hashi,
     epoch: u64,

--- a/packages/hashi/sources/core/committee/committee.move
+++ b/packages/hashi/sources/core/committee/committee.move
@@ -13,14 +13,14 @@ use sui::{
 };
 
 // Error codes
-/// The signers bitmap is invalid.
-const EInvalidBitmap: u64 = 0;
-/// The signature is invalid.
-const ESigVerification: u64 = 1;
-/// The certificate does not have enough stake support.
-const ENotEnoughStake: u64 = 2;
-/// The committee has members with a zero weight.
-const EIncorrectCommittee: u64 = 3;
+#[error]
+const EInvalidBitmap: vector<u8> = b"The signers bitmap is invalid";
+#[error]
+const ESigVerification: vector<u8> = b"The signature is invalid";
+#[error]
+const ENotEnoughStake: vector<u8> = b"The certificate does not have enough stake support";
+#[error]
+const EIncorrectCommittee: vector<u8> = b"The committee has members with a zero weight";
 
 public struct CommitteeMember has copy, drop, store {
     validator_address: address,

--- a/packages/hashi/sources/core/config/config_value.move
+++ b/packages/hashi/sources/core/config/config_value.move
@@ -5,7 +5,8 @@ module hashi::config_value;
 
 use std::string::String;
 
-const EInvalidConfigValue: u64 = 0;
+#[error]
+const EInvalidConfigValue: vector<u8> = b"Config value has a different type than expected";
 
 // Variant order is BCS-load-bearing: the Rust mirror (hashi-types) decodes
 // by variant index, and once published to a persistent network the order is

--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -71,7 +71,7 @@ public(package) fun create<T: store>(
 
     let proposal_id = object::id(&proposal);
     hashi.proposals_mut().active_mut().add(proposal_id, proposal);
-    sui::event::emit(ProposalCreatedEvent<T> { proposal_id, timestamp_ms: created_timestamp_ms });
+    sui::event::emit(ProposalCreated<T> { proposal_id, timestamp_ms: created_timestamp_ms });
     proposal_id
 }
 
@@ -102,7 +102,7 @@ public(package) fun execute<T: copy + drop + store>(
 
     hashi.proposals_mut().executed_mut().add(id.to_address(), proposal);
 
-    sui::event::emit(ProposalExecutedEvent<T> { proposal_id: id, data });
+    sui::event::emit(ProposalExecuted<T> { proposal_id: id, data });
     data
 }
 
@@ -123,9 +123,9 @@ entry fun vote<T: store>(
 
     proposal.votes.push_back(validator_address);
 
-    sui::event::emit(VoteCastEvent<T> { proposal_id, voter: validator_address });
+    sui::event::emit(VoteCast<T> { proposal_id, voter: validator_address });
     if (proposal.quorum_reached(hashi)) {
-        sui::event::emit(QuorumReachedEvent<T> { proposal_id });
+        sui::event::emit(QuorumReached<T> { proposal_id });
     }
 }
 
@@ -145,7 +145,7 @@ entry fun remove_vote<T: store>(
         .destroy_or!(abort ENoVoteFound);
 
     proposal.votes.remove(index);
-    sui::event::emit(VoteRemovedEvent<T> {
+    sui::event::emit(VoteRemoved<T> {
         proposal_id: proposal.id.to_inner(),
         voter: validator_address,
     });
@@ -205,30 +205,30 @@ public fun data<T>(proposal: &Proposal<T>): &T {
 
 // ~~~~~~~ Events ~~~~~~~
 
-public struct ProposalCreatedEvent<phantom T> has copy, drop {
+public struct ProposalCreated<phantom T> has copy, drop {
     proposal_id: ID,
     timestamp_ms: u64,
 }
 
-public struct VoteCastEvent<phantom T> has copy, drop {
+public struct VoteCast<phantom T> has copy, drop {
     proposal_id: ID,
     voter: address,
 }
 
-public struct VoteRemovedEvent<phantom T> has copy, drop {
+public struct VoteRemoved<phantom T> has copy, drop {
     proposal_id: ID,
     voter: address,
 }
 
-public struct ProposalDeletedEvent<phantom T> has copy, drop {
+public struct ProposalDeleted<phantom T> has copy, drop {
     proposal_id: ID,
 }
 
-public struct ProposalExecutedEvent<T> has copy, drop {
+public struct ProposalExecuted<T> has copy, drop {
     proposal_id: ID,
     data: T,
 }
 
-public struct QuorumReachedEvent<phantom T> has copy, drop {
+public struct QuorumReached<phantom T> has copy, drop {
     proposal_id: ID,
 }

--- a/packages/hashi/sources/core/proposal/types/abort_reconfig.move
+++ b/packages/hashi/sources/core/proposal/types/abort_reconfig.move
@@ -14,8 +14,12 @@ use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
 const THRESHOLD_BPS: u64 = 6667;
-const ENotReconfiguring: u64 = 0;
-const EWrongReconfigEpoch: u64 = 1;
+
+#[error]
+const ENotReconfiguring: vector<u8> = b"No reconfiguration is in progress";
+#[error]
+const EWrongReconfigEpoch: vector<u8> =
+    b"Proposal's epoch does not match the pending reconfiguration epoch";
 
 public struct AbortReconfig has copy, drop, store {
     epoch: u64,

--- a/packages/hashi/sources/core/proposal/types/upgrade.move
+++ b/packages/hashi/sources/core/proposal/types/upgrade.move
@@ -60,10 +60,10 @@ public fun finalize_upgrade(hashi: &mut Hashi, receipt: UpgradeReceipt) {
     let upgrade_package = receipt.package();
     hashi.versioning_mut().commit_upgrade(receipt);
     let version = hashi.versioning().upgrade_cap().version();
-    sui::event::emit(PackageUpgradedEvent { package: upgrade_package, version });
+    sui::event::emit(PackageUpgraded { package: upgrade_package, version });
 }
 
-public struct PackageUpgradedEvent has copy, drop {
+public struct PackageUpgraded has copy, drop {
     package: ID,
     version: u64,
 }

--- a/packages/hashi/sources/core/reconfig.move
+++ b/packages/hashi/sources/core/reconfig.move
@@ -6,9 +6,17 @@ module hashi::reconfig;
 
 use hashi::{committee::CommitteeSignature, hashi::Hashi};
 
-const ENotReconfiguring: u64 = 0;
-const EInitialReconfig: u64 = 1;
-const EGenesisNotAuthorized: u64 = 2;
+// NOTE: `ENotReconfiguring` is matched BY NAME in the node's reconfig-abort
+// classifier (crates/hashi/src/mpc/service.rs) to detect the benign
+// "end_reconfig already completed by another node" race — keep the name.
+#[error]
+const ENotReconfiguring: vector<u8> = b"No reconfiguration is in progress";
+#[error]
+const EInitialReconfig: vector<u8> =
+    b"Not allowed during the initial reconfig (no committee handoff exists yet)";
+#[error]
+const EGenesisNotAuthorized: vector<u8> =
+    b"Genesis is locked until the publisher sends finish_publish (the launch switch)";
 
 /// Message that committee members sign to confirm successful key rotation.
 public struct ReconfigCompletionMessage has copy, drop, store {

--- a/packages/hashi/sources/core/reconfig.move
+++ b/packages/hashi/sources/core/reconfig.move
@@ -49,7 +49,7 @@ entry fun start_reconfig(
             config,
             ctx,
         );
-    sui::event::emit(StartReconfigEvent { epoch });
+    sui::event::emit(ReconfigStarted { epoch });
 }
 
 entry fun end_reconfig(
@@ -87,7 +87,7 @@ entry fun end_reconfig(
                 committee_handoff_cert.destroy_some(),
             );
     };
-    sui::event::emit(EndReconfigEvent { from_epoch, epoch, mpc_public_key });
+    sui::event::emit(ReconfigEnded { from_epoch, epoch, mpc_public_key });
 }
 
 entry fun submit_committee_handoff(
@@ -124,11 +124,11 @@ public(package) fun assert_genesis_launch_authorized(self: &Hashi) {
     }
 }
 
-public struct StartReconfigEvent has copy, drop {
+public struct ReconfigStarted has copy, drop {
     epoch: u64,
 }
 
-public struct EndReconfigEvent has copy, drop {
+public struct ReconfigEnded has copy, drop {
     from_epoch: u64,
     epoch: u64,
     /// The MPC committee's threshold public key.

--- a/packages/hashi/sources/core/tob.move
+++ b/packages/hashi/sources/core/tob.move
@@ -8,8 +8,11 @@ module hashi::tob;
 use hashi::committee::CommitteeSignature;
 use sui::linked_table::{Self, LinkedTable};
 
-const EWrongEpoch: u64 = 0;
-const ETooEarlyToDestroy: u64 = 1;
+#[error]
+const EWrongEpoch: vector<u8> = b"Certificate epoch does not match the bucket's epoch";
+#[error]
+const ETooEarlyToDestroy: vector<u8> =
+    b"TOB certificates may only be destroyed two epochs after their epoch";
 
 public enum ProtocolType has copy, drop, store {
     Dkg,

--- a/packages/hashi/sources/core/treasury.move
+++ b/packages/hashi/sources/core/treasury.move
@@ -34,17 +34,17 @@ fun metadata_cap<T>(self: &mut Treasury): &mut MetadataCap<T> {
 }
 
 public(package) fun burn<T>(self: &mut Treasury, balance: Balance<T>) {
-    sui::event::emit(BurnEvent<T> { amount: balance.value() });
+    sui::event::emit(Burned<T> { amount: balance.value() });
     self.treasury_cap<T>().supply_mut().decrease_supply(balance);
 }
 
 public(package) fun mint<T>(self: &mut Treasury, amount: u64, ctx: &mut TxContext): Coin<T> {
-    sui::event::emit(MintEvent<T> { amount });
+    sui::event::emit(Minted<T> { amount });
     self.treasury_cap<T>().mint(amount, ctx)
 }
 
 public(package) fun mint_balance<T>(self: &mut Treasury, amount: u64): Balance<T> {
-    sui::event::emit(MintEvent<T> { amount });
+    sui::event::emit(Minted<T> { amount });
     self.treasury_cap<T>().mint_balance(amount)
 }
 
@@ -70,10 +70,10 @@ public(package) fun create(ctx: &mut TxContext): Treasury {
 // Events
 //
 
-public struct MintEvent<phantom T> has copy, drop {
+public struct Minted<phantom T> has copy, drop {
     amount: u64,
 }
 
-public struct BurnEvent<phantom T> has copy, drop {
+public struct Burned<phantom T> has copy, drop {
     amount: u64,
 }

--- a/packages/hashi/sources/core/validator.move
+++ b/packages/hashi/sources/core/validator.move
@@ -8,6 +8,10 @@ use hashi::hashi::Hashi;
 use std::string::String;
 use sui::event;
 
+/// Registration and key/metadata updates (below) are deliberately NOT gated
+/// on pause/reconfig: operators must be able to rotate keys and prepare
+/// nodes while the system is paused, and blocking updates during reconfig
+/// would let a stalled reconfig freeze operator maintenance.
 entry fun register(
     self: &mut Hashi,
     sui_system: &sui_system::sui_system::SuiSystemState,


### PR DESCRIPTION
Last-window consistency fixes before the first persistent (testnet) deployment, from a full-package audit (guards/auth/storage-growth, freeze surface, BCS mirrors). The audit found no critical issues — these are the items that become expensive or impossible to change once names and codes freeze into indexer/tooling contracts.

## Commits

1. **Error constants unified on `#[error]` message style** (reconfig, tob, committee, config_value, abort_reconfig — the last bare-u64 modules). Aborts now carry human-readable messages. Lockstep: the node's reconfig-abort classifier matched `end_reconfig`'s `ENotReconfiguring` by raw abort code `0`; `#[error]` codes encode the source line, so it now matches the clever-error **constant name** — stable across this conversion and future line drift.

2. **Event names standardized** — past tense, no `Event` suffix (`ValidatorRegistered` was the model; 24 others renamed, e.g. `StartReconfigEvent`→`ReconfigStarted`, `WithdrawalSignedEvent`→`WithdrawalSigned`, `MintEvent`→`Minted`). Rust lockstep in the same commit: hashi-types mirrors + `MoveType` NAME constants (the watcher matches by name), watcher/limiter/metrics/e2e consumers, hashi-monitor docs, design docs.
   ⚠️ **Follow-up required**: hashi-ts-sdk string-matches `::deposit::DepositRequestedEvent` and `::withdrawal_queue::WithdrawalRequestedEvent` (client.ts) — must drop the suffixes before the SDK targets a network running this code.

3. **Pause-gating principle documented** (audit follow-up): the entries flagged as "missing pause guards" (`cleanup_spent_utxos`, `destroy_all_certs`, `delete_expired_deposit`, validator registration/rotation) are *intentionally* ungated — funds movement and state machines gate on pause/reconfig; GC and operator maintenance must stay callable during an emergency pause. Stated at each entry and in `move-model-lifecycle.mdx`. Also makes the u64→u32 vout cast in `new_withdrawal_txn` an explicit bound assert.

## Testing

- Move: 148/148.
- Rust: workspace build, clippy clean, 535 unit tests (hashi + hashi-types) — includes the BCS pins and event-name mirrors.
- e2e `test_dkg` green — the watcher consumes the renamed `ReconfigStarted`/`ReconfigEnded` end to end.

A stacked PR will follow with the package-wide module reorganization (no behavior change).