### PR TITLE
move: Reorganize every module to a canonical layout

### DIFF
--- a/packages/hashi/sources/btc/bitcoin_state.move
+++ b/packages/hashi/sources/btc/bitcoin_state.move
@@ -1,6 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Per-chain Bitcoin state, attached to the `Hashi` shared object as a
+/// dynamic field keyed by `BitcoinStateKey`. Bundles the deposit queue,
+/// withdrawal queue, and UTXO pool behind package-only accessors, and
+/// maintains a per-user index of request IDs so clients can discover all
+/// deposits and withdrawals belonging to an address.
 module hashi::bitcoin_state;
 
 use hashi::{
@@ -9,6 +14,8 @@ use hashi::{
     withdrawal_queue::WithdrawalRequestQueue
 };
 use sui::{bag::Bag, table::Table};
+
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct BitcoinStateKey has copy, drop, store {}
 
@@ -23,6 +30,8 @@ public struct BitcoinState has store {
     /// Allows clients to discover all requests for a given address.
     user_requests: Table<address, Bag>,
 }
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 public(package) fun key(): BitcoinStateKey { BitcoinStateKey {} }
 
@@ -68,7 +77,7 @@ public(package) fun utxo_pool_mut(self: &mut BitcoinState): &mut UtxoPool {
     &mut self.utxo_pool
 }
 
-// ======== User Request Index ========
+// === User Request Index ===
 
 /// Index a request ID under a user address.
 public(package) fun index_user_request(

--- a/packages/hashi/sources/btc/btc.move
+++ b/packages/hashi/sources/btc/btc.move
@@ -1,10 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Module: btc
+/// The hBTC coin type — the Sui-side claim on BTC secured by the bridge.
+/// `create` registers the currency (8 decimals, symbol hBTC) with the Sui
+/// coin registry during system initialization and returns the treasury and
+/// metadata caps, which `hashi::treasury` takes into custody so deposits can
+/// mint and withdrawals can burn hBTC against Bitcoin UTXOs.
 module hashi::btc;
 
 use sui::{coin::TreasuryCap, coin_registry::{CoinRegistry, MetadataCap}};
+
+// ~~~~~~~ Constants ~~~~~~~
 
 const DECIMALS: u8 = 8;
 const SYMBOL: vector<u8> = b"hBTC";
@@ -12,10 +18,14 @@ const NAME: vector<u8> = b"BTC";
 const DESCRIPTION: vector<u8> = b"BTC secured by hashi.";
 const ICON_URL: vector<u8> = b"";
 
+// ~~~~~~~ Structs ~~~~~~~
+
 /// Represents a claim on the BTC secured by hashi.
 public struct BTC has key {
     id: sui::object::UID,
 }
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 public(package) fun create(
     registry: &mut CoinRegistry,

--- a/packages/hashi/sources/btc/btc_config.move
+++ b/packages/hashi/sources/btc/btc_config.move
@@ -7,11 +7,26 @@ module hashi::btc_config;
 
 use hashi::{config::Config, config_value};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 /// Minimum value (satoshis) for a Bitcoin output to be relayed (dust threshold).
 /// Uses the highest threshold (P2PKH 546 sats) as a conservative floor.
 const DUST_RELAY_MIN_VALUE: u64 = 546;
 
-// ======== Accessors ========
+// ~~~~~~~ Package Functions ~~~~~~~
+
+// === Initialization ===
+
+/// Initialize BTC-specific config defaults. Called after config::create().
+public(package) fun init_defaults(config: &mut Config) {
+    config.upsert(b"bitcoin_deposit_time_delay_ms", config_value::new_u64(10 * 60 * 1_000)); // 15 minutes
+    config.upsert(b"bitcoin_deposit_minimum", config_value::new_u64(30_000));
+    config.upsert(b"bitcoin_withdrawal_minimum", config_value::new_u64(30_000));
+    config.upsert(b"bitcoin_confirmation_threshold", config_value::new_u64(6));
+    config.upsert(b"withdrawal_cancellation_cooldown_ms", config_value::new_u64(1000 * 60 * 60)); // 1 hour
+}
+
+// === Accessors ===
 
 public(package) fun bitcoin_chain_id(self: &Config): address {
     self.get(b"bitcoin_chain_id").as_address()
@@ -80,15 +95,4 @@ public(package) fun withdrawal_cancellation_cooldown_ms(self: &Config): u64 {
 
 public(package) fun set_withdrawal_cancellation_cooldown_ms(self: &mut Config, cooldown_ms: u64) {
     self.upsert(b"withdrawal_cancellation_cooldown_ms", config_value::new_u64(cooldown_ms))
-}
-
-// ======== Initialization ========
-
-/// Initialize BTC-specific config defaults. Called after config::create().
-public(package) fun init_defaults(config: &mut Config) {
-    config.upsert(b"bitcoin_deposit_time_delay_ms", config_value::new_u64(10 * 60 * 1_000)); // 15 minutes
-    config.upsert(b"bitcoin_deposit_minimum", config_value::new_u64(30_000));
-    config.upsert(b"bitcoin_withdrawal_minimum", config_value::new_u64(30_000));
-    config.upsert(b"bitcoin_confirmation_threshold", config_value::new_u64(6));
-    config.upsert(b"withdrawal_cancellation_cooldown_ms", config_value::new_u64(1000 * 60 * 60)); // 1 hour
 }

--- a/packages/hashi/sources/btc/deposit.move
+++ b/packages/hashi/sources/btc/deposit.move
@@ -1,6 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// User-facing Bitcoin deposit flow. A depositor registers the UTXO they
+/// sent to the bridge's address, the committee approves it with a
+/// certificate over `(request_id, utxo)`, and — after a configurable time
+/// delay in which a faulty approval can be caught and the service paused —
+/// the deposit is confirmed: hBTC is minted to the recipient encoded in the
+/// UTXO's derivation path and the UTXO joins the active pool. Requests that
+/// are never confirmed can be garbage-collected once they expire.
 module hashi::deposit;
 
 use hashi::{
@@ -16,6 +23,8 @@ use hashi::{
 use fun btc_config::bitcoin_deposit_minimum as Config.deposit_minimum;
 use fun btc_config::bitcoin_deposit_time_delay_ms as Config.deposit_time_delay_ms;
 
+// ~~~~~~~ Errors ~~~~~~~
+
 #[error]
 const EBelowMinimumDeposit: vector<u8> = b"Deposit amount is below the minimum";
 #[error]
@@ -24,19 +33,54 @@ const EDepositTimeDelayNotPassed: vector<u8> = b"Deposit time-delay has not pass
 const EAlreadyApprovedThisEpoch: vector<u8> =
     b"Deposit has already been approved by the current committee";
 
+// ~~~~~~~ Structs ~~~~~~~
+
+// This message struct is committee-signed and its BCS encoding is frozen:
+// never add, remove, or reorder fields.
+
 /// Message signed by the committee to confirm a deposit.
 public struct DepositConfirmationMessage has copy, drop, store {
     request_id: address,
     utxo: Utxo,
 }
 
-#[test_only]
-public fun new_deposit_confirmation_message(
+// ~~~~~~~ Events ~~~~~~~
+
+public struct DepositRequested has copy, drop {
+    request_id: address,
+    utxo_id: UtxoId,
+    amount: u64,
+    derivation_path: Option<address>,
+    timestamp_ms: u64,
+    requester_address: address,
+    sui_tx_digest: vector<u8>,
+}
+
+/// Emitted when a committee certificate has been recorded against a
+/// deposit request. The deposit is not yet final — see `confirm_deposit`.
+/// `approval_timestamp_ms` is the clock timestamp recorded on the
+/// request, against which `confirm_deposit` enforces the time-delay
+/// window.
+public struct DepositApproved has copy, drop {
     request_id: address,
     utxo: Utxo,
-): DepositConfirmationMessage {
-    DepositConfirmationMessage { request_id, utxo }
+    cert: CommitteeSignature,
+    approval_timestamp_ms: u64,
 }
+
+/// Emitted when an approved deposit has cleared the time-delay window
+/// and the corresponding BTC has been minted (when applicable) and the
+/// UTXO moved into the active pool.
+public struct DepositConfirmed has copy, drop {
+    request_id: address,
+    utxo: Utxo,
+}
+
+public struct ExpiredDepositDeleted has copy, drop {
+    request_id: address,
+}
+
+// ~~~~~~~ Entry Functions ~~~~~~~
 
 entry fun deposit(
     hashi: &mut Hashi,
@@ -224,36 +268,12 @@ entry fun delete_expired_deposit(
     sui::event::emit(ExpiredDepositDeleted { request_id });
 }
 
-public struct DepositRequested has copy, drop {
-    request_id: address,
-    utxo_id: UtxoId,
-    amount: u64,
-    derivation_path: Option<address>,
-    timestamp_ms: u64,
-    requester_address: address,
-    sui_tx_digest: vector<u8>,
-}
+// ~~~~~~~ Test Helpers ~~~~~~~
 
-/// Emitted when a committee certificate has been recorded against a
-/// deposit request. The deposit is not yet final — see `confirm_deposit`.
-/// `approval_timestamp_ms` is the clock timestamp recorded on the
-/// request, against which `confirm_deposit` enforces the time-delay
-/// window.
-public struct DepositApproved has copy, drop {
+#[test_only]
+public fun new_deposit_confirmation_message(
     request_id: address,
     utxo: Utxo,
-    cert: CommitteeSignature,
-    approval_timestamp_ms: u64,
-}
-
-/// Emitted when an approved deposit has cleared the time-delay window
-/// and the corresponding BTC has been minted (when applicable) and the
-/// UTXO moved into the active pool.
-public struct DepositConfirmed has copy, drop {
-    request_id: address,
-    utxo: Utxo,
-}
-
-public struct ExpiredDepositDeleted has copy, drop {
-    request_id: address,
+): DepositConfirmationMessage {
+    DepositConfirmationMessage { request_id, utxo }
 }

--- a/packages/hashi/sources/btc/deposit_queue.move
+++ b/packages/hashi/sources/btc/deposit_queue.move
@@ -1,20 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Storage and bookkeeping for Bitcoin deposit requests. Active requests
+/// sit in an ObjectBag awaiting committee approval and confirmation;
+/// confirmed requests move to a processed bag, and requests that were never
+/// confirmed can be deleted once they pass the maximum age. The state
+/// transitions themselves (certificate verification, minting, time-delay
+/// enforcement) are driven by `hashi::deposit`.
 module hashi::deposit_queue;
 
 use hashi::{committee::CommitteeSignature, utxo::Utxo};
 use sui::{clock::Clock, object_bag::ObjectBag};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 // const MAX_DEPOSIT_REQUEST_AGE_MS: u64 = 1000 * 60 * 60 * 24 * 3; // 3 days
 const MAX_DEPOSIT_REQUEST_AGE_MS: u64 = 1000 * 60 * 60 * 24; // 1 days
+
+// ~~~~~~~ Errors ~~~~~~~
 
 #[error(code = 0)]
 const EDepositRequestNotExpired: vector<u8> = b"Deposit request not expired";
 #[error]
 const EDepositAlreadyProcessed: vector<u8> = b"Deposit request has already been processed";
 
-// ======== Core Structs ========
+// ~~~~~~~ Structs ~~~~~~~
 
 /// Deposit request object stored in the `requests` bag until confirmed or expired.
 ///
@@ -47,7 +57,9 @@ public struct DepositRequestQueue has store {
     processed: ObjectBag,
 }
 
-// ======== Constructors ========
+// ~~~~~~~ Package Functions ~~~~~~~
+
+// === Constructors ===
 
 public(package) fun create(ctx: &mut TxContext): DepositRequestQueue {
     DepositRequestQueue {
@@ -70,17 +82,12 @@ public(package) fun create_deposit(utxo: Utxo, clock: &Clock, ctx: &mut TxContex
     }
 }
 
-// ======== Lifecycle Functions ========
+// === Lifecycle ===
 
 /// Insert a new deposit request into the active requests bag.
 public(package) fun insert_deposit(self: &mut DepositRequestQueue, request: DepositRequest) {
     let request_id = request.id.to_address();
     self.requests.add(request_id, request);
-}
-
-/// Check if an active deposit request exists.
-public(package) fun contains(self: &DepositRequestQueue, id: address): bool {
-    self.requests.contains(id)
 }
 
 /// Remove an active deposit request.
@@ -89,24 +96,6 @@ public(package) fun remove_request(
     request_id: address,
 ): DepositRequest {
     self.requests.remove(request_id)
-}
-
-/// Copy the UTXO out of a deposit request (Utxo has copy).
-public(package) fun utxo(request: &DepositRequest): Utxo {
-    request.utxo
-}
-
-/// The committee certificate recorded at approval time, if any. Returns
-/// `None` for requests that have not yet been through `approve_deposit`.
-public(package) fun approval_cert(request: &DepositRequest): Option<CommitteeSignature> {
-    request.approval_cert
-}
-
-/// The clock timestamp at which the request was approved, if any.
-/// Returns `None` for requests that have not yet been through
-/// `approve_deposit`.
-public(package) fun approved_timestamp_ms(request: &DepositRequest): Option<u64> {
-    request.approved_timestamp_ms
 }
 
 /// Record `cert` and the current clock timestamp on `request` to mark it
@@ -122,13 +111,6 @@ public(package) fun approve(request: &mut DepositRequest, cert: CommitteeSignatu
 /// before calling this.
 public(package) fun confirm(request: &mut DepositRequest, clock: &Clock) {
     request.confirmed_timestamp_ms = option::some(clock.timestamp_ms());
-}
-
-/// The clock timestamp at which the request was confirmed, if any.
-/// Returns `None` for requests that have not yet been through
-/// `confirm_deposit`.
-public(package) fun confirmed_timestamp_ms(request: &DepositRequest): Option<u64> {
-    request.confirmed_timestamp_ms
 }
 
 /// Insert a completed deposit into the processed bag.
@@ -168,6 +150,13 @@ public(package) fun delete_expired(
     utxo.delete();
 }
 
+// === Accessors ===
+
+/// Check if an active deposit request exists.
+public(package) fun contains(self: &DepositRequestQueue, id: address): bool {
+    self.requests.contains(id)
+}
+
 /// Borrow an active deposit request.
 public(package) fun borrow_request(
     self: &DepositRequestQueue,
@@ -176,7 +165,30 @@ public(package) fun borrow_request(
     self.requests.borrow(request_id)
 }
 
-// ======== Accessors ========
+/// Copy the UTXO out of a deposit request (Utxo has copy).
+public(package) fun utxo(request: &DepositRequest): Utxo {
+    request.utxo
+}
+
+/// The committee certificate recorded at approval time, if any. Returns
+/// `None` for requests that have not yet been through `approve_deposit`.
+public(package) fun approval_cert(request: &DepositRequest): Option<CommitteeSignature> {
+    request.approval_cert
+}
+
+/// The clock timestamp at which the request was approved, if any.
+/// Returns `None` for requests that have not yet been through
+/// `approve_deposit`.
+public(package) fun approved_timestamp_ms(request: &DepositRequest): Option<u64> {
+    request.approved_timestamp_ms
+}
+
+/// The clock timestamp at which the request was confirmed, if any.
+/// Returns `None` for requests that have not yet been through
+/// `confirm_deposit`.
+public(package) fun confirmed_timestamp_ms(request: &DepositRequest): Option<u64> {
+    request.confirmed_timestamp_ms
+}
 
 public(package) fun request_id(self: &DepositRequest): ID {
     self.id.to_inner()
@@ -198,7 +210,7 @@ public(package) fun request_utxo(self: &DepositRequest): &Utxo {
     &self.utxo
 }
 
-// ======== Internal ========
+// ~~~~~~~ Private Functions ~~~~~~~
 
 fun is_expired(request: &DepositRequest, clock: &Clock): bool {
     clock.timestamp_ms() > request.created_timestamp_ms + MAX_DEPOSIT_REQUEST_AGE_MS

--- a/packages/hashi/sources/btc/utxo.move
+++ b/packages/hashi/sources/btc/utxo.move
@@ -1,15 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Bitcoin UTXO value types shared by the deposit and withdrawal flows. A
+/// `UtxoId` identifies an outpoint (txid:vout) and a `Utxo` pairs it with
+/// its satoshi amount and an optional derivation path (the Sui address a
+/// deposit mints to). The constructors are `public` so PTBs can assemble
+/// UTXOs when calling into the bridge; everything else is package-only.
 #[allow(unused_function, unused_field, unused_use)]
 module hashi::utxo;
 
-public struct Utxo has copy, drop, store {
-    id: UtxoId,
-    // In satoshis
-    amount: u64,
-    derivation_path: Option<address>,
-}
+// ~~~~~~~ Structs ~~~~~~~
 
 /// txid:vout
 public struct UtxoId has copy, drop, store {
@@ -19,6 +19,15 @@ public struct UtxoId has copy, drop, store {
     vout: u32,
 }
 
+public struct Utxo has copy, drop, store {
+    id: UtxoId,
+    // In satoshis
+    amount: u64,
+    derivation_path: Option<address>,
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
+
 public fun utxo_id(txid: address, vout: u32): UtxoId {
     UtxoId { txid, vout }
 }
@@ -26,6 +35,8 @@ public fun utxo_id(txid: address, vout: u32): UtxoId {
 public fun utxo(utxo_id: UtxoId, amount: u64, derivation_path: Option<address>): Utxo {
     Utxo { id: utxo_id, amount, derivation_path }
 }
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 public(package) fun id(self: &Utxo): UtxoId {
     self.id

--- a/packages/hashi/sources/btc/utxo_pool.move
+++ b/packages/hashi/sources/btc/utxo_pool.move
@@ -1,16 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// On-chain bookkeeping for the bridge's Bitcoin UTXO set. Confirmed deposit
+/// outputs and unconfirmed withdrawal change outputs live in `utxo_records`
+/// from insertion until the withdrawal that spends them confirms on Bitcoin,
+/// after which their IDs move to `spent_utxos` — kept permanently as replay
+/// protection so an already-spent outpoint can never be re-inserted.
 #[allow(unused_function, unused_field, unused_use)]
 module hashi::utxo_pool;
 
 use hashi::utxo::{Utxo, UtxoId};
 use sui::bag::Bag;
 
+// ~~~~~~~ Errors ~~~~~~~
+
 #[error]
 const EUtxoAlreadyLocked: vector<u8> = b"UTXO is already locked in a pending withdrawal";
 #[error]
 const EUtxoAlreadyUsed: vector<u8> = b"UTXO is already active or spent";
+
+// ~~~~~~~ Structs ~~~~~~~
 
 /// Tracks a UTXO through its full lifecycle in the pool.
 ///
@@ -39,20 +48,20 @@ public struct UtxoPool has store {
     spent_utxos: Bag, // UtxoId -> u64 (spent_epoch)
 }
 
+// ~~~~~~~ Events ~~~~~~~
+
+public struct UtxoSpent has copy, drop {
+    utxo_id: UtxoId,
+    spent_epoch: u64,
+}
+
+// ~~~~~~~ Package Functions ~~~~~~~
+
 public(package) fun create(ctx: &mut TxContext): UtxoPool {
     UtxoPool {
         utxo_records: sui::bag::new(ctx),
         spent_utxos: sui::bag::new(ctx),
     }
-}
-
-/// Returns true if the UTXO is either in the active records or has been spent.
-public(package) fun is_spent_or_active(self: &UtxoPool, utxo_id: UtxoId): bool {
-    self.utxo_records.contains(utxo_id) || self.spent_utxos.contains(utxo_id)
-}
-
-public(package) fun assert_not_spent_or_active(self: &UtxoPool, utxo_id: UtxoId) {
-    assert!(!self.is_spent_or_active(utxo_id), EUtxoAlreadyUsed);
 }
 
 /// Insert a confirmed UTXO (from a deposit) into the pool.
@@ -92,11 +101,13 @@ public(package) fun insert_pending(self: &mut UtxoPool, utxo: Utxo, withdrawal_i
         )
 }
 
-/// Lock a UTXO for use in a pending withdrawal. Aborts if already locked.
-public(package) fun lock(self: &mut UtxoPool, utxo_id: UtxoId, withdrawal_id: address) {
-    let record: &mut UtxoRecord = self.utxo_records.borrow_mut(utxo_id);
-    assert!(record.spent_by.is_none(), EUtxoAlreadyLocked);
-    record.spent_by = option::some(withdrawal_id);
+/// Returns true if the UTXO is either in the active records or has been spent.
+public(package) fun is_spent_or_active(self: &UtxoPool, utxo_id: UtxoId): bool {
+    self.utxo_records.contains(utxo_id) || self.spent_utxos.contains(utxo_id)
+}
+
+public(package) fun assert_not_spent_or_active(self: &UtxoPool, utxo_id: UtxoId) {
+    assert!(!self.is_spent_or_active(utxo_id), EUtxoAlreadyUsed);
 }
 
 /// Return a copy of a UTXO from the pool.
@@ -105,10 +116,28 @@ public(package) fun get_utxo(self: &UtxoPool, utxo_id: UtxoId): hashi::utxo::Utx
     record.utxo
 }
 
+/// Lock a UTXO for use in a pending withdrawal. Aborts if already locked.
+public(package) fun lock(self: &mut UtxoPool, utxo_id: UtxoId, withdrawal_id: address) {
+    let record: &mut UtxoRecord = self.utxo_records.borrow_mut(utxo_id);
+    assert!(record.spent_by.is_none(), EUtxoAlreadyLocked);
+    record.spent_by = option::some(withdrawal_id);
+}
+
 public(package) fun mark_spent(self: &mut UtxoPool, utxo_id: UtxoId, epoch: u64) {
     let record: &mut UtxoRecord = self.utxo_records.borrow_mut(utxo_id);
     record.spent_epoch = option::some(epoch);
     sui::event::emit(UtxoSpent { utxo_id, spent_epoch: epoch });
+}
+
+/// Promote a pending change UTXO to confirmed once its producing withdrawal
+/// confirms on Bitcoin. If the UTXO was already locked by a subsequent
+/// withdrawal, only `produced_by` is cleared; `spent_by` is left intact.
+/// No-ops if the UTXO is no longer present (it was already spent).
+public(package) fun confirm_pending(self: &mut UtxoPool, utxo_id: UtxoId) {
+    if (self.utxo_records.contains(utxo_id)) {
+        let record: &mut UtxoRecord = self.utxo_records.borrow_mut(utxo_id);
+        record.produced_by = option::none();
+    }
 }
 
 /// Deferred bookkeeping for a spent UTXO: remove from `utxo_records` and
@@ -125,21 +154,7 @@ public(package) fun cleanup_spent(self: &mut UtxoPool, utxo_id: UtxoId) {
     };
 }
 
-/// Promote a pending change UTXO to confirmed once its producing withdrawal
-/// confirms on Bitcoin. If the UTXO was already locked by a subsequent
-/// withdrawal, only `produced_by` is cleared; `spent_by` is left intact.
-/// No-ops if the UTXO is no longer present (it was already spent).
-public(package) fun confirm_pending(self: &mut UtxoPool, utxo_id: UtxoId) {
-    if (self.utxo_records.contains(utxo_id)) {
-        let record: &mut UtxoRecord = self.utxo_records.borrow_mut(utxo_id);
-        record.produced_by = option::none();
-    }
-}
-
-public struct UtxoSpent has copy, drop {
-    utxo_id: UtxoId,
-    spent_epoch: u64,
-}
+// ~~~~~~~ Test Helpers ~~~~~~~
 
 #[test_only]
 public(package) fun has_active_record(self: &UtxoPool, utxo_id: UtxoId): bool {

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -1,7 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Module: withdraw
+/// User-facing Bitcoin withdrawal flow. A user escrows hBTC against a target
+/// Bitcoin address; the committee approves the request, batches one or more
+/// requests into a withdrawal transaction (burning the hBTC and locking the
+/// input UTXOs), accumulates per-input MPC signatures incrementally,
+/// finalizes with the one-shot guardian signatures, and confirms once the
+/// transaction lands on Bitcoin. A not-yet-committed request can be
+/// cancelled by its requester after a cooldown, refunding the hBTC.
 module hashi::withdraw;
 
 use hashi::{
@@ -19,6 +25,8 @@ use fun btc_config::bitcoin_withdrawal_minimum as Config.bitcoin_withdrawal_mini
 use fun btc_config::withdrawal_cancellation_cooldown_ms as
     Config.withdrawal_cancellation_cooldown_ms;
 
+// ~~~~~~~ Errors ~~~~~~~
+
 #[error]
 const EBelowMinimumWithdrawal: vector<u8> = b"Withdrawal amount is below the minimum";
 #[error]
@@ -34,6 +42,11 @@ const ECannotCancelProcessingWithdrawal: vector<u8> =
 #[error]
 const EWithdrawalNotFullySigned: vector<u8> =
     b"Cannot confirm a withdrawal that is not fully signed";
+
+// ~~~~~~~ Structs ~~~~~~~
+
+// The message structs below are committee-signed and their BCS encodings are
+// frozen: never add, remove, or reorder fields.
 
 // MESSAGE STEP 1
 public struct RequestApprovalMessage has copy, drop, store {
@@ -73,88 +86,7 @@ public struct WithdrawalConfirmationMessage has copy, drop, store {
     withdrawal_id: address,
 }
 
-// ======== Message Constructors ========
-
-public(package) fun new_request_approval_message(request_id: address): RequestApprovalMessage {
-    RequestApprovalMessage { request_id }
-}
-
-public(package) fun new_withdrawal_commitment_message(
-    request_ids: vector<address>,
-    selected_utxos: vector<UtxoId>,
-    outputs: vector<OutputUtxo>,
-    txid: address,
-): WithdrawalCommitmentMessage {
-    WithdrawalCommitmentMessage { request_ids, selected_utxos, outputs, txid }
-}
-
-public(package) fun new_withdrawal_signed_message(
-    withdrawal_id: address,
-    request_ids: vector<address>,
-    signatures: vector<vector<u8>>,
-    guardian_signatures: vector<vector<u8>>,
-): WithdrawalSignedMessage {
-    WithdrawalSignedMessage {
-        withdrawal_id,
-        request_ids,
-        signatures,
-        guardian_signatures,
-    }
-}
-
-public(package) fun new_mpc_input_signatures_message(
-    withdrawal_id: address,
-    indices: vector<u64>,
-    signatures: vector<vector<u8>>,
-): MpcInputSignaturesMessage {
-    MpcInputSignaturesMessage { withdrawal_id, indices, signatures }
-}
-
-public(package) fun new_withdrawal_confirmation_message(
-    withdrawal_id: address,
-): WithdrawalConfirmationMessage {
-    WithdrawalConfirmationMessage { withdrawal_id }
-}
-
-/// Request a withdrawal of BTC from the bridge.
-///
-/// The full BTC amount is stored in the withdrawal request. The miner
-/// fee is deducted later at commitment time.
-///
-/// The user must provide at least `bitcoin_withdrawal_minimum()` sats,
-/// which guarantees the amount covers worst-case miner fees plus dust.
-public fun request_withdrawal(
-    hashi: &mut Hashi,
-    clock: &Clock,
-    btc: Balance<BTC>,
-    bitcoin_address: vector<u8>,
-    ctx: &mut TxContext,
-) {
-    hashi.versioning().assert_version_enabled();
-    hashi.assert_unpaused();
-
-    assert!(btc.value() >= hashi.config().bitcoin_withdrawal_minimum(), EBelowMinimumWithdrawal);
-
-    // Only P2WPKH (20 bytes) and P2TR (32 bytes) witness programs are supported.
-    let addr_len = bitcoin_address.length();
-    assert!(addr_len == 20 || addr_len == 32, EInvalidBitcoinAddress);
-
-    // Create the withdrawal request.
-    let request = hashi::withdrawal_queue::create_withdrawal(
-        btc,
-        bitcoin_address,
-        clock,
-        ctx,
-    );
-    let request_id = request.request_id().to_address();
-    hashi::withdrawal_queue::emit_withdrawal_requested(&request);
-
-    // Insert into the active requests bag.
-    hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal(request);
-
-    // Index by sender for client discovery.
-    hashi.bitcoin_mut().index_user_request(ctx.sender(), request_id, ctx);
-}
+// ~~~~~~~ Entry Functions ~~~~~~~
 
 entry fun approve_request(
     hashi: &mut Hashi,
@@ -259,28 +191,6 @@ entry fun commit_withdrawal_tx(
     withdrawal_txn.emit_withdrawal_picked_for_processing();
 
     hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal_txn(withdrawal_txn);
-}
-
-/// Reassign fresh presignatures to the still-unsigned inputs of a withdrawal
-/// whose signing batch is from a previous epoch. Only the pending tail is
-/// re-presigned; already-collected signatures are final and epoch-independent.
-///
-/// Gated like commit/finalize (version-enabled, unpaused, not-reconfiguring): an
-/// in-progress reconfiguration settles first, then this runs afterward to recover
-/// the now-stale batch. Carries no committee cert: it authorizes no signatures,
-/// only re-points pending presig indices, bounded to once-per-withdrawal-per-epoch
-/// by the `mpc_signing` stale-epoch guard.
-entry fun reallocate_presigs(hashi: &mut Hashi, withdrawal_id: address) {
-    hashi.versioning().assert_version_enabled();
-    hashi.assert_unpaused();
-    hashi.assert_not_reconfiguring();
-    let current_epoch = hashi.committee_set().epoch();
-    let pending = hashi.bitcoin().withdrawal_queue().withdrawal_txn_pending_count(withdrawal_id);
-    let new_base = hashi.allocate_presigs(pending);
-    hashi
-        .bitcoin_mut()
-        .withdrawal_queue_mut()
-        .reallocate_presigs_for_withdrawal_txn(withdrawal_id, new_base, current_epoch, pending);
 }
 
 /// Record a chunk of completed per-input MPC signatures into the withdrawal's
@@ -406,6 +316,28 @@ entry fun confirm_withdrawal(
     hashi.bitcoin_mut().withdrawal_queue_mut().insert_confirmed_txn(txn);
 }
 
+/// Reassign fresh presignatures to the still-unsigned inputs of a withdrawal
+/// whose signing batch is from a previous epoch. Only the pending tail is
+/// re-presigned; already-collected signatures are final and epoch-independent.
+///
+/// Gated like commit/finalize (version-enabled, unpaused, not-reconfiguring): an
+/// in-progress reconfiguration settles first, then this runs afterward to recover
+/// the now-stale batch. Carries no committee cert: it authorizes no signatures,
+/// only re-points pending presig indices, bounded to once-per-withdrawal-per-epoch
+/// by the `mpc_signing` stale-epoch guard.
+entry fun reallocate_presigs(hashi: &mut Hashi, withdrawal_id: address) {
+    hashi.versioning().assert_version_enabled();
+    hashi.assert_unpaused();
+    hashi.assert_not_reconfiguring();
+    let current_epoch = hashi.committee_set().epoch();
+    let pending = hashi.bitcoin().withdrawal_queue().withdrawal_txn_pending_count(withdrawal_id);
+    let new_base = hashi.allocate_presigs(pending);
+    hashi
+        .bitcoin_mut()
+        .withdrawal_queue_mut()
+        .reallocate_presigs_for_withdrawal_txn(withdrawal_id, new_base, current_epoch, pending);
+}
+
 /// Finalize the on-chain bookkeeping for spent UTXOs. Moves each UTXO's
 /// record from `utxo_records` to `spent_utxos`, reading the spent epoch
 /// from the record's `spent_epoch` field (set by `mark_spent` during
@@ -418,6 +350,48 @@ entry fun cleanup_spent_utxos(hashi: &mut Hashi, utxo_ids: vector<UtxoId>) {
     utxo_ids.do!(|utxo_id| {
         hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
     });
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
+
+/// Request a withdrawal of BTC from the bridge.
+///
+/// The full BTC amount is stored in the withdrawal request. The miner
+/// fee is deducted later at commitment time.
+///
+/// The user must provide at least `bitcoin_withdrawal_minimum()` sats,
+/// which guarantees the amount covers worst-case miner fees plus dust.
+public fun request_withdrawal(
+    hashi: &mut Hashi,
+    clock: &Clock,
+    btc: Balance<BTC>,
+    bitcoin_address: vector<u8>,
+    ctx: &mut TxContext,
+) {
+    hashi.versioning().assert_version_enabled();
+    hashi.assert_unpaused();
+
+    assert!(btc.value() >= hashi.config().bitcoin_withdrawal_minimum(), EBelowMinimumWithdrawal);
+
+    // Only P2WPKH (20 bytes) and P2TR (32 bytes) witness programs are supported.
+    let addr_len = bitcoin_address.length();
+    assert!(addr_len == 20 || addr_len == 32, EInvalidBitcoinAddress);
+
+    // Create the withdrawal request.
+    let request = hashi::withdrawal_queue::create_withdrawal(
+        btc,
+        bitcoin_address,
+        clock,
+        ctx,
+    );
+    let request_id = request.request_id().to_address();
+    hashi::withdrawal_queue::emit_withdrawal_requested(&request);
+
+    // Insert into the active requests bag.
+    hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal(request);
+
+    // Index by sender for client discovery.
+    hashi.bitcoin_mut().index_user_request(ctx.sender(), request_id, ctx);
 }
 
 /// Cancel a pending withdrawal request and return the stored BTC to the requester.
@@ -460,4 +434,49 @@ public fun cancel_withdrawal(
     hashi.bitcoin_mut().unindex_user_request(ctx.sender(), request_id);
 
     btc
+}
+
+// ~~~~~~~ Package Functions ~~~~~~~
+
+// === Message Constructors ===
+
+public(package) fun new_request_approval_message(request_id: address): RequestApprovalMessage {
+    RequestApprovalMessage { request_id }
+}
+
+public(package) fun new_withdrawal_commitment_message(
+    request_ids: vector<address>,
+    selected_utxos: vector<UtxoId>,
+    outputs: vector<OutputUtxo>,
+    txid: address,
+): WithdrawalCommitmentMessage {
+    WithdrawalCommitmentMessage { request_ids, selected_utxos, outputs, txid }
+}
+
+public(package) fun new_withdrawal_signed_message(
+    withdrawal_id: address,
+    request_ids: vector<address>,
+    signatures: vector<vector<u8>>,
+    guardian_signatures: vector<vector<u8>>,
+): WithdrawalSignedMessage {
+    WithdrawalSignedMessage {
+        withdrawal_id,
+        request_ids,
+        signatures,
+        guardian_signatures,
+    }
+}
+
+public(package) fun new_mpc_input_signatures_message(
+    withdrawal_id: address,
+    indices: vector<u64>,
+    signatures: vector<vector<u8>>,
+): MpcInputSignaturesMessage {
+    MpcInputSignaturesMessage { withdrawal_id, indices, signatures }
+}
+
+public(package) fun new_withdrawal_confirmation_message(
+    withdrawal_id: address,
+): WithdrawalConfirmationMessage {
+    WithdrawalConfirmationMessage { withdrawal_id }
 }

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -1,6 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Storage and state machine for Bitcoin withdrawals. Holds `WithdrawalRequest`
+/// objects as they move from Requested through Approved, Processing, Signed,
+/// and Confirmed, plus the `WithdrawalTransaction` objects that batch them:
+/// each transaction tracks its input UTXOs, withdrawal and change outputs, and
+/// the incrementally collected MPC and guardian signatures. Certificate
+/// verification and funds movement are driven by `hashi::withdraw`.
 module hashi::withdrawal_queue;
 
 use hashi::{
@@ -14,6 +20,8 @@ use hashi::{
 use sui::{balance::Balance, clock::Clock, object_bag::ObjectBag};
 
 use fun btc_config::worst_case_network_fee as Config.worst_case_network_fee;
+
+// ~~~~~~~ Errors ~~~~~~~
 
 #[error]
 const ERequestNotApproved: vector<u8> = b"Withdrawal request has not been approved";
@@ -37,7 +45,7 @@ const EWithdrawalAlreadyFinalized: vector<u8> = b"Withdrawal transaction is alre
 const EWithdrawalNotFullySigned: vector<u8> =
     b"Withdrawal transaction is missing one or more MPC signatures";
 
-// ======== Status Enum ========
+// ~~~~~~~ Structs ~~~~~~~
 
 public enum WithdrawalStatus has copy, drop, store {
     Requested,
@@ -46,8 +54,6 @@ public enum WithdrawalStatus has copy, drop, store {
     Signed,
     Confirmed,
 }
-
-// ======== Core Structs ========
 
 /// Unified withdrawal request object. Tracks the full lifecycle of a withdrawal,
 /// from initial request through to confirmation or cancellation.
@@ -132,11 +138,87 @@ public struct OutputUtxo has copy, drop, store {
     bitcoin_address: vector<u8>,
 }
 
-// ======== Constructors ========
+/// Lightweight info extracted from a request at commit time for validation.
+public struct CommittedRequestInfo has copy, drop, store {
+    btc_amount: u64,
+    bitcoin_address: vector<u8>,
+}
+
+// ~~~~~~~ Events ~~~~~~~
+
+public struct WithdrawalRequested has copy, drop {
+    request_id: address,
+    btc_amount: u64,
+    bitcoin_address: vector<u8>,
+    timestamp_ms: u64,
+    requester_address: address,
+    sui_tx_digest: vector<u8>,
+}
+
+public struct WithdrawalApproved has copy, drop {
+    request_id: address,
+}
+
+public struct WithdrawalPickedForProcessing has copy, drop {
+    withdrawal_txn_id: address,
+    txid: address,
+    request_ids: vector<address>,
+    inputs: vector<Utxo>,
+    withdrawal_outputs: vector<OutputUtxo>,
+    change_outputs: vector<OutputUtxo>,
+    timestamp_ms: u64,
+    randomness: vector<u8>,
+}
+
+/// Emitted on each incremental chunk write so the watcher can track signing
+/// progress (X / N) and the next leader can resume; the per-input state itself
+/// lives on the object.
+public struct WithdrawalInputsSigned has copy, drop {
+    withdrawal_txn_id: address,
+    signed_count: u64,
+    num_inputs: u64,
+}
+
+public struct WithdrawalSigned has copy, drop {
+    withdrawal_txn_id: address,
+    request_ids: vector<address>,
+    /// Per-input Schnorr signatures from the MPC committee.
+    signatures: vector<vector<u8>>,
+    /// Per-input Schnorr signatures from the guardian enclave. Same
+    /// length as `signatures`; the watcher pairs index `i` of both to
+    /// form the witness for input `i` at broadcast time.
+    guardian_signatures: vector<vector<u8>>,
+}
+
+public struct WithdrawalPresigsReassigned has copy, drop {
+    withdrawal_txn_id: address,
+    epoch: u64,
+    presig_start_index: u64,
+}
+
+public struct WithdrawalConfirmed has copy, drop {
+    withdrawal_txn_id: address,
+    txid: address,
+    change_utxo_ids: vector<UtxoId>,
+    request_ids: vector<address>,
+    change_utxo_amounts: vector<u64>,
+}
+
+public struct WithdrawalCancelled has copy, drop {
+    request_id: address,
+    requester_address: address,
+    btc_amount: u64,
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun output_utxo(amount: u64, bitcoin_address: vector<u8>): OutputUtxo {
     OutputUtxo { amount, bitcoin_address }
 }
+
+// ~~~~~~~ Package Functions ~~~~~~~
+
+// === Constructors ===
 
 public(package) fun create(ctx: &mut TxContext): WithdrawalRequestQueue {
     WithdrawalRequestQueue {
@@ -173,7 +255,7 @@ public(package) fun create_withdrawal(
     }
 }
 
-// ======== Request Lifecycle Functions ========
+// === Request Lifecycle ===
 
 /// Insert a new withdrawal request into the active requests bag and index by sender.
 public(package) fun insert_withdrawal(
@@ -316,15 +398,7 @@ public(package) fun is_request_processing(
     self.processed.contains(request_id)
 }
 
-// ======== Committed Request Info ========
-
-/// Lightweight info extracted from a request at commit time for validation.
-public struct CommittedRequestInfo has copy, drop, store {
-    btc_amount: u64,
-    bitcoin_address: vector<u8>,
-}
-
-// ======== WithdrawalTransaction Functions ========
+// === Transaction Lifecycle ===
 
 public(package) fun new_withdrawal_txn(
     ctx: &mut TxContext,
@@ -501,7 +575,7 @@ public(package) fun reallocate_presigs_for_withdrawal_txn(
     });
 }
 
-// ======== WithdrawalTransaction signing views (drive the leader/watcher) ========
+// === Signing Views (drive the leader/watcher) ===
 
 /// Number of inputs still awaiting an MPC signature (what must be re-presigned
 /// on a stale-epoch reallocation).
@@ -530,13 +604,6 @@ public(package) fun withdrawal_txn_mpc_signatures(
 ): vector<vector<u8>> {
     let txn: &WithdrawalTransaction = self.withdrawal_txns.borrow(withdrawal_id);
     txn.signing.to_signatures()
-}
-
-/// Derived broadcast gate: every input has an MPC signature and the one-shot
-/// guardian signatures are attached. Not stored — computed from `signing` and
-/// `guardian_signatures` so it can't fall out of sync.
-fun txn_fully_signed(txn: &WithdrawalTransaction): bool {
-    txn.signing.is_complete() && txn.guardian_signatures.is_some()
 }
 
 public(package) fun withdrawal_txn_is_fully_signed(
@@ -586,7 +653,7 @@ public(package) fun change_utxo_ids(self: &WithdrawalTransaction): vector<UtxoId
     ids
 }
 
-// ======== Accessors ========
+// === Accessors ===
 
 public(package) fun withdrawal_txn_id(self: &WithdrawalTransaction): address {
     self.id.to_address()
@@ -635,7 +702,7 @@ public(package) fun is_approved(self: &WithdrawalStatus): bool {
     }
 }
 
-// ======== Events ========
+// === Event Emitters ===
 
 public(package) fun emit_withdrawal_requested(request: &WithdrawalRequest) {
     sui::event::emit(WithdrawalRequested {
@@ -695,73 +762,16 @@ public(package) fun emit_withdrawal_cancelled(request: &WithdrawalRequest) {
     });
 }
 
-// ======== Event Structs ========
+// ~~~~~~~ Private Functions ~~~~~~~
 
-public struct WithdrawalRequested has copy, drop {
-    request_id: address,
-    btc_amount: u64,
-    bitcoin_address: vector<u8>,
-    timestamp_ms: u64,
-    requester_address: address,
-    sui_tx_digest: vector<u8>,
+/// Derived broadcast gate: every input has an MPC signature and the one-shot
+/// guardian signatures are attached. Not stored — computed from `signing` and
+/// `guardian_signatures` so it can't fall out of sync.
+fun txn_fully_signed(txn: &WithdrawalTransaction): bool {
+    txn.signing.is_complete() && txn.guardian_signatures.is_some()
 }
 
-public struct WithdrawalApproved has copy, drop {
-    request_id: address,
-}
-
-public struct WithdrawalPickedForProcessing has copy, drop {
-    withdrawal_txn_id: address,
-    txid: address,
-    request_ids: vector<address>,
-    inputs: vector<Utxo>,
-    withdrawal_outputs: vector<OutputUtxo>,
-    change_outputs: vector<OutputUtxo>,
-    timestamp_ms: u64,
-    randomness: vector<u8>,
-}
-
-/// Emitted on each incremental chunk write so the watcher can track signing
-/// progress (X / N) and the next leader can resume; the per-input state itself
-/// lives on the object.
-public struct WithdrawalInputsSigned has copy, drop {
-    withdrawal_txn_id: address,
-    signed_count: u64,
-    num_inputs: u64,
-}
-
-public struct WithdrawalSigned has copy, drop {
-    withdrawal_txn_id: address,
-    request_ids: vector<address>,
-    /// Per-input Schnorr signatures from the MPC committee.
-    signatures: vector<vector<u8>>,
-    /// Per-input Schnorr signatures from the guardian enclave. Same
-    /// length as `signatures`; the watcher pairs index `i` of both to
-    /// form the witness for input `i` at broadcast time.
-    guardian_signatures: vector<vector<u8>>,
-}
-
-public struct WithdrawalPresigsReassigned has copy, drop {
-    withdrawal_txn_id: address,
-    epoch: u64,
-    presig_start_index: u64,
-}
-
-public struct WithdrawalConfirmed has copy, drop {
-    withdrawal_txn_id: address,
-    txid: address,
-    change_utxo_ids: vector<UtxoId>,
-    request_ids: vector<address>,
-    change_utxo_amounts: vector<u64>,
-}
-
-public struct WithdrawalCancelled has copy, drop {
-    request_id: address,
-    requester_address: address,
-    btc_amount: u64,
-}
-
-// ======== Test Helpers ========
+// ~~~~~~~ Test Helpers ~~~~~~~
 
 #[test_only]
 public(package) fun new_withdrawal_txn_for_testing(

--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -1,9 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Entry points for submitting TOB dealer certificates. Committee members (or
+/// their delegated operators) post certified dealer-messages hashes for the
+/// DKG, key-rotation, and nonce-generation MPC ceremonies into per-(epoch,
+/// batch, protocol) buckets stored on `Hashi`, and garbage-collect buckets
+/// once they are old enough.
 module hashi::cert_submission;
 
 use hashi::{committee::CommitteeSignature, hashi::Hashi, tob::ProtocolType};
+
+// ~~~~~~~ Entry Functions ~~~~~~~
 
 entry fun submit_dkg_cert(
     hashi: &mut Hashi,
@@ -46,6 +53,24 @@ entry fun submit_nonce_cert(
     submit_cert_internal(hashi, key, epoch, dealer, messages_hash, &cert, ctx);
 }
 
+/// Garbage collection: deliberately NOT gated on pause/reconfig — cert
+/// buckets old enough to destroy (see `tob::destroy_all`) carry no live
+/// state, and GC must stay callable during an emergency pause.
+entry fun destroy_all_certs(
+    hashi: &mut Hashi,
+    epoch: u64,
+    batch_index: Option<u32>,
+    protocol_type: ProtocolType,
+) {
+    hashi.versioning().assert_version_enabled();
+    let key = hashi::tob::tob_key(epoch, batch_index, protocol_type);
+    let current_epoch = hashi.committee_set().epoch();
+    let epoch_certs: hashi::tob::EpochCertsV1 = hashi.tob_mut().remove(key);
+    hashi::tob::destroy_all(epoch_certs, current_epoch);
+}
+
+// ~~~~~~~ Private Functions ~~~~~~~
+
 fun submit_cert_internal(
     hashi: &mut Hashi,
     key: hashi::tob::TobKey,
@@ -70,20 +95,4 @@ fun submit_cert_internal(
         messages_hash,
         cert,
     );
-}
-
-/// Garbage collection: deliberately NOT gated on pause/reconfig — cert
-/// buckets old enough to destroy (see `tob::destroy_all`) carry no live
-/// state, and GC must stay callable during an emergency pause.
-entry fun destroy_all_certs(
-    hashi: &mut Hashi,
-    epoch: u64,
-    batch_index: Option<u32>,
-    protocol_type: ProtocolType,
-) {
-    hashi.versioning().assert_version_enabled();
-    let key = hashi::tob::tob_key(epoch, batch_index, protocol_type);
-    let current_epoch = hashi.committee_set().epoch();
-    let epoch_certs: hashi::tob::EpochCertsV1 = hashi.tob_mut().remove(key);
-    hashi::tob::destroy_all(epoch_certs, current_epoch);
 }

--- a/packages/hashi/sources/core/committee/committee.move
+++ b/packages/hashi/sources/core/committee/committee.move
@@ -1,6 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// BLS signing committees and certificate verification. A `Committee` pins an
+/// epoch's members (validator addresses, BLS public keys, encryption keys,
+/// voting weights) together with the MPC parameters snapshotted at reconfig
+/// time. `verify_certificate` checks an aggregate BLS12-381 min-pk signature
+/// against a signers bitmap, enforces the stake threshold, and wraps the
+/// payload in a `CertifiedMessage` as proof of committee approval.
 #[allow(unused_const)]
 module hashi::committee;
 
@@ -12,7 +18,8 @@ use sui::{
     vec_map::{Self, VecMap}
 };
 
-// Error codes
+// ~~~~~~~ Errors ~~~~~~~
+
 #[error]
 const EInvalidBitmap: vector<u8> = b"The signers bitmap is invalid";
 #[error]
@@ -21,6 +28,8 @@ const ESigVerification: vector<u8> = b"The signature is invalid";
 const ENotEnoughStake: vector<u8> = b"The certificate does not have enough stake support";
 #[error]
 const EIncorrectCommittee: vector<u8> = b"The committee has members with a zero weight";
+
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct CommitteeMember has copy, drop, store {
     validator_address: address,
@@ -42,6 +51,34 @@ public struct Committee has copy, drop, store {
     /// snapshotted from the governed config at reconfig time.
     config: Config,
 }
+
+public struct CommitteeSignature has copy, drop, store {
+    epoch: u64,
+    signature: vector<u8>,
+    signers_bitmap: vector<u8>,
+}
+
+public struct CertifiedMessage<T> has copy, drop, store {
+    message: T,
+    signature: CommitteeSignature,
+    stake_support: u64,
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
+
+public fun new_committee_signature(
+    epoch: u64,
+    signature: vector<u8>,
+    signers_bitmap: vector<u8>,
+): CommitteeSignature {
+    CommitteeSignature {
+        epoch,
+        signature,
+        signers_bitmap,
+    }
+}
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 /// Constructor for committee.
 public(package) fun new_committee(
@@ -236,33 +273,11 @@ public(package) fun verify_certificate<T>(
     }
 }
 
-public struct CommitteeSignature has copy, drop, store {
-    epoch: u64,
-    signature: vector<u8>,
-    signers_bitmap: vector<u8>,
-}
-
-public fun new_committee_signature(
-    epoch: u64,
-    signature: vector<u8>,
-    signers_bitmap: vector<u8>,
-): CommitteeSignature {
-    CommitteeSignature {
-        epoch,
-        signature,
-        signers_bitmap,
-    }
-}
+// === Accessors for CommitteeSignature ===
 
 /// The epoch in which the certificate was produced.
 public(package) fun signature_epoch(self: &CommitteeSignature): u64 {
     self.epoch
-}
-
-public struct CertifiedMessage<T> has copy, drop, store {
-    message: T,
-    signature: CommitteeSignature,
-    stake_support: u64,
 }
 
 // === Accessors for CertifiedMessage ===

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -1,6 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Registry of Hashi committee state: registered member metadata
+/// (`MemberInfo`), per-epoch `Committee`s, the current epoch, the MPC
+/// threshold public key, and the pending epoch change while a reconfiguration
+/// is in flight. Members register (and rotate keys/metadata) here between
+/// epochs; `start_reconfig` builds the next committee from Sui's active
+/// validator set, and `end_reconfig` activates it — storing the outgoing
+/// committee's handoff certificate for non-initial reconfigs.
 #[allow(unused_function, unused_field)]
 module hashi::committee_set;
 
@@ -13,13 +20,7 @@ use sui::{
     group_ops::Element
 };
 
-//
-// Errors
-//
-
-//
-// CommitteeSet
-//
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct CommitteeSet has store {
     members: Bag,
@@ -29,16 +30,6 @@ public struct CommitteeSet has store {
     pending_epoch_change: Option<PendingEpochChange>,
     /// The MPC committee's threshold public key.
     mpc_public_key: vector<u8>,
-}
-
-public(package) fun create(ctx: &mut TxContext): CommitteeSet {
-    CommitteeSet {
-        members: sui::bag::new(ctx),
-        epoch: 0,
-        committees: sui::bag::new(ctx),
-        pending_epoch_change: option::none(),
-        mpc_public_key: std::vector::empty(),
-    }
 }
 
 /// Reconfiguration state while a new committee is pending activation.
@@ -67,81 +58,6 @@ public struct CommitteeHandoff has store {
     next_epoch: u64,
     cert: committee::CommitteeSignature,
 }
-
-fun member(self: &CommitteeSet, validator_address: address): &MemberInfo {
-    &self.members[validator_address]
-}
-
-public(package) fun has_member(self: &CommitteeSet, validator_address: address): bool {
-    self.members.contains_with_type<_, MemberInfo>(validator_address)
-}
-
-/// Returns true if the transaction sender is authorized to act on behalf of the
-/// member registered under `validator_address` — that is, the sender is either
-/// the validator's own Sui address or the operator address it has delegated to.
-/// Returns false if no such member exists.
-///
-/// The validator's own key always retains authority, so it can serve as a
-/// backup if the operator key is lost.
-public(package) fun member_authorized(
-    self: &CommitteeSet,
-    validator_address: address,
-    ctx: &TxContext,
-): bool {
-    self.has_member(validator_address) && self.member(validator_address).is_authorized(ctx)
-}
-
-fun member_mut(self: &mut CommitteeSet, validator_address: address): &mut MemberInfo {
-    &mut self.members[validator_address]
-}
-
-fun insert_member(self: &mut CommitteeSet, member: MemberInfo) {
-    self.members.add(member.validator_address, member)
-}
-
-fun committee(self: &CommitteeSet, epoch: u64): &Committee {
-    &self.committees[epoch]
-}
-
-public(package) fun has_committee(self: &CommitteeSet, epoch: u64): bool {
-    self.committees.contains_with_type<u64, Committee>(epoch)
-}
-
-fun insert_committee(self: &mut CommitteeSet, committee: Committee) {
-    self.committees.add(committee.epoch(), committee)
-}
-
-public(package) fun insert_committee_handoff(
-    self: &mut CommitteeSet,
-    from_epoch: u64,
-    next_epoch: u64,
-    cert: committee::CommitteeSignature,
-) {
-    let key = CommitteeHandoffKey { epoch: from_epoch };
-    assert!(!self.committees.contains_with_type<CommitteeHandoffKey, CommitteeHandoff>(key));
-    self.committees.add(key, CommitteeHandoff { next_epoch, cert })
-}
-
-#[test_only]
-public fun has_committee_handoff_for_testing(self: &CommitteeSet, from_epoch: u64): bool {
-    self
-        .committees
-        .contains_with_type<CommitteeHandoffKey, CommitteeHandoff>(CommitteeHandoffKey {
-            epoch: from_epoch,
-        })
-}
-
-fun remove_committee(self: &mut CommitteeSet, epoch: u64): Committee {
-    self.committees.remove(epoch)
-}
-
-public(package) fun current_committee(self: &CommitteeSet): &Committee {
-    &self.committees[self.epoch()]
-}
-
-//
-// MemberInfo
-//
 
 public struct MemberInfo has store {
     /// Sui Validator Address of this node
@@ -179,6 +95,18 @@ public struct MemberInfo has store {
     extra_fields: Config,
 }
 
+// ~~~~~~~ Package Functions ~~~~~~~
+
+public(package) fun create(ctx: &mut TxContext): CommitteeSet {
+    CommitteeSet {
+        members: sui::bag::new(ctx),
+        epoch: 0,
+        committees: sui::bag::new(ctx),
+        pending_epoch_change: option::none(),
+        mpc_public_key: std::vector::empty(),
+    }
+}
+
 /// Register as a member of Hashi.
 ///
 /// Only BLS key is required at registration time, other info can be set in
@@ -206,15 +134,23 @@ public(package) fun new_member(
     committee_set.insert_member(member);
 }
 
-/// True if the tx sender is authorized to act for this member — its validator
-/// key or its delegated operator key. The validator key always retains authority.
-fun is_authorized(self: &MemberInfo, ctx: &TxContext): bool {
-    let sender = ctx.sender();
-    sender == self.validator_address || sender == self.operator_address
+/// Returns true if the transaction sender is authorized to act on behalf of the
+/// member registered under `validator_address` — that is, the sender is either
+/// the validator's own Sui address or the operator address it has delegated to.
+/// Returns false if no such member exists.
+///
+/// The validator's own key always retains authority, so it can serve as a
+/// backup if the operator key is lost.
+public(package) fun member_authorized(
+    self: &CommitteeSet,
+    validator_address: address,
+    ctx: &TxContext,
+): bool {
+    self.has_member(validator_address) && self.member(validator_address).is_authorized(ctx)
 }
 
-fun assert_authorized(self: &MemberInfo, ctx: &TxContext) {
-    assert!(self.is_authorized(ctx));
+public(package) fun has_member(self: &CommitteeSet, validator_address: address): bool {
+    self.members.contains_with_type<_, MemberInfo>(validator_address)
 }
 
 /// Set the public key of the member.
@@ -296,31 +232,97 @@ public(package) fun set_operator_address(
     member.operator_address = operator_address;
 }
 
-// === Accessors ===
+public(package) fun start_reconfig(
+    self: &mut CommitteeSet,
+    sui_system: &sui_system::sui_system::SuiSystemState,
+    config: Config,
+    ctx: &TxContext,
+): u64 {
+    // We can't trigger reconfig if we are already reconfiguring
+    assert!(!self.is_reconfiguring());
+    // Don't start a reconfig for an epoch where we already have a committee
+    // determined.
+    assert!(!self.has_committee(ctx.epoch()));
+    // We can only trigger reconfig if the current epoch is 0 (for genesis) or
+    // our current epoch is not the same as Sui's epoch
+    assert!(self.epoch == 0 || self.epoch != ctx.epoch());
 
-/// Return the address of the node.
-fun validator_address(self: &MemberInfo): &address {
-    &self.validator_address
+    let committee = self.new_committee_from_validator_set(
+        sui_system,
+        config,
+        ctx,
+    );
+
+    let epoch = committee.epoch();
+    self.pending_epoch_change =
+        option::some(PendingEpochChange {
+            epoch,
+            committee_handoff_cert: option::none(),
+        });
+    self.insert_committee(committee);
+    epoch
 }
 
-/// Return the next epoch public key of the node.
-fun next_epoch_public_key(self: &MemberInfo): &Element<UncompressedG1> {
-    &self.next_epoch_public_key
+public(package) fun set_pending_committee_handoff_cert(
+    self: &mut CommitteeSet,
+    cert: committee::CommitteeSignature,
+) {
+    let mut pending = self.pending_epoch_change.extract();
+    assert!(pending.committee_handoff_cert.is_none());
+    pending.committee_handoff_cert = option::some(cert);
+    self.pending_epoch_change = option::some(pending);
 }
 
-/// Return the endpoint_url of the node.
-fun endpoint_url(self: &MemberInfo): &String {
-    &self.endpoint_url
+public(package) fun end_reconfig(
+    self: &mut CommitteeSet,
+    mpc_public_key: vector<u8>,
+    _ctx: &TxContext,
+): (u64, Option<committee::CommitteeSignature>) {
+    assert!(self.is_reconfiguring());
+    let PendingEpochChange { epoch: next_epoch, committee_handoff_cert } = self
+        .pending_epoch_change
+        .extract();
+    assert!(self.has_committee(next_epoch));
+
+    // If the mpc_public_key is empty, then this is the initial reconfig where
+    // DKG is run and we need to set the produced pubkey.
+    if (self.mpc_public_key.is_empty()) {
+        self.mpc_public_key = mpc_public_key;
+    } else {
+        assert!(committee_handoff_cert.is_some());
+    };
+
+    // On subsequent reconfigs where key resharing is performing instead of
+    // DKG, we need to ensure that the pubkey remains constant
+    assert!(self.mpc_public_key == mpc_public_key);
+
+    self.epoch = next_epoch;
+    (next_epoch, committee_handoff_cert)
 }
 
-/// Return the tls_public_key of the node.
-fun tls_public_key(self: &MemberInfo): &vector<u8> {
-    &self.tls_public_key
+public(package) fun abort_reconfig(self: &mut CommitteeSet, _ctx: &TxContext): u64 {
+    assert!(self.is_reconfiguring());
+    let PendingEpochChange { epoch: next_epoch, committee_handoff_cert } = self
+        .pending_epoch_change
+        .extract();
+    if (committee_handoff_cert.is_some()) {
+        committee_handoff_cert.destroy_some();
+    } else {
+        committee_handoff_cert.destroy_none();
+    };
+    self.remove_committee(next_epoch);
+    next_epoch
 }
 
-/// Return the next epoch encryption public key of the node.
-fun next_epoch_encryption_public_key(self: &MemberInfo): &vector<u8> {
-    &self.next_epoch_encryption_public_key
+public(package) fun insert_committee_handoff(
+    self: &mut CommitteeSet,
+    from_epoch: u64,
+    next_epoch: u64,
+    cert: committee::CommitteeSignature,
+) {
+    let key = CommitteeHandoffKey { epoch: from_epoch };
+    assert!(!self.committees.contains_with_type<CommitteeHandoffKey, CommitteeHandoff>(key));
+    self.committees.add(key, CommitteeHandoff { next_epoch, cert })
 }
 
 /// Return the current epoch.
@@ -328,49 +330,58 @@ public(package) fun epoch(self: &CommitteeSet): u64 {
     self.epoch
 }
 
+public(package) fun current_committee(self: &CommitteeSet): &Committee {
+    &self.committees[self.epoch()]
+}
+
+public(package) fun get_committee(self: &CommitteeSet, epoch: u64): &Committee {
+    &self.committees[epoch]
+}
+
+public(package) fun has_committee(self: &CommitteeSet, epoch: u64): bool {
+    self.committees.contains_with_type<u64, Committee>(epoch)
+}
+
+public(package) fun pending_epoch_change(self: &CommitteeSet): Option<u64> {
+    if (self.pending_epoch_change.is_some()) {
+        option::some(self.pending_epoch_change.borrow().epoch)
+    } else {
+        option::none()
+    }
+}
+
 public(package) fun mpc_public_key(self: &CommitteeSet): &vector<u8> {
     &self.mpc_public_key
 }
 
-// Verifies that the provided bls public key is valid and there is a valid
-// proof of possession.
-fun verify_bls_public_key(
-    epoch: u64,
-    validator_address: address,
-    bls_public_key: vector<u8>,
-    proof_of_possession_signature: vector<u8>,
-): Element<UncompressedG1> {
-    // Verify the proof of possession of the private key
-    assert!(
-        verify_proof_of_possession(
-            epoch,
-            &validator_address,
-            &bls_public_key,
-            &proof_of_possession_signature,
-        ),
-    );
-
-    // Convert the public key to its Uncompressed form
-    g1_to_uncompressed_g1(&g1_from_bytes(&bls_public_key))
+public(package) fun is_reconfiguring(self: &CommitteeSet): bool {
+    self.pending_epoch_change.is_some()
 }
 
-fun verify_proof_of_possession(
-    epoch: u64,
-    validator_address: &address,
-    bls_public_key: &vector<u8>,
-    proof_of_possession_signature: &vector<u8>,
-): bool {
-    let mut message = vector[];
-    message.append(bcs::to_bytes(&hashi::intent::proof_of_possession()));
-    message.append(bcs::to_bytes(&epoch));
-    message.append(bcs::to_bytes(validator_address));
-    bls_public_key.do_ref!(|key_byte| message.append(bcs::to_bytes(key_byte)));
+// ~~~~~~~ Private Functions ~~~~~~~
 
-    bls12381_min_pk_verify(
-        proof_of_possession_signature,
-        bls_public_key,
-        &message,
-    )
+fun member(self: &CommitteeSet, validator_address: address): &MemberInfo {
+    &self.members[validator_address]
+}
+
+fun member_mut(self: &mut CommitteeSet, validator_address: address): &mut MemberInfo {
+    &mut self.members[validator_address]
+}
+
+fun insert_member(self: &mut CommitteeSet, member: MemberInfo) {
+    self.members.add(member.validator_address, member)
+}
+
+fun committee(self: &CommitteeSet, epoch: u64): &Committee {
+    &self.committees[epoch]
+}
+
+fun insert_committee(self: &mut CommitteeSet, committee: Committee) {
+    self.committees.add(committee.epoch(), committee)
+}
+
+fun remove_committee(self: &mut CommitteeSet, epoch: u64): Committee {
+    self.committees.remove(epoch)
 }
 
 fun new_committee_from_validator_set(
@@ -424,102 +435,94 @@ fun new_committee_from_validator_set(
     )
 }
 
-public(package) fun is_reconfiguring(self: &CommitteeSet): bool {
-    self.pending_epoch_change.is_some()
+/// True if the tx sender is authorized to act for this member — its validator
+/// key or its delegated operator key. The validator key always retains authority.
+fun is_authorized(self: &MemberInfo, ctx: &TxContext): bool {
+    let sender = ctx.sender();
+    sender == self.validator_address || sender == self.operator_address
 }
 
-public(package) fun pending_epoch_change(self: &CommitteeSet): Option<u64> {
-    if (self.pending_epoch_change.is_some()) {
-        option::some(self.pending_epoch_change.borrow().epoch)
-    } else {
-        option::none()
-    }
+fun assert_authorized(self: &MemberInfo, ctx: &TxContext) {
+    assert!(self.is_authorized(ctx));
 }
 
-public(package) fun set_pending_committee_handoff_cert(
-    self: &mut CommitteeSet,
-    cert: committee::CommitteeSignature,
-) {
-    let mut pending = self.pending_epoch_change.extract();
-    assert!(pending.committee_handoff_cert.is_none());
-    pending.committee_handoff_cert = option::some(cert);
-    self.pending_epoch_change = option::some(pending);
+// === Accessors ===
+
+/// Return the address of the node.
+fun validator_address(self: &MemberInfo): &address {
+    &self.validator_address
 }
 
-public(package) fun get_committee(self: &CommitteeSet, epoch: u64): &Committee {
-    &self.committees[epoch]
+/// Return the next epoch public key of the node.
+fun next_epoch_public_key(self: &MemberInfo): &Element<UncompressedG1> {
+    &self.next_epoch_public_key
 }
 
-public(package) fun start_reconfig(
-    self: &mut CommitteeSet,
-    sui_system: &sui_system::sui_system::SuiSystemState,
-    config: Config,
-    ctx: &TxContext,
-): u64 {
-    // We can't trigger reconfig if we are already reconfiguring
-    assert!(!self.is_reconfiguring());
-    // Don't start a reconfig for an epoch where we already have a committee
-    // determined.
-    assert!(!self.has_committee(ctx.epoch()));
-    // We can only trigger reconfig if the current epoch is 0 (for genesis) or
-    // our current epoch is not the same as Sui's epoch
-    assert!(self.epoch == 0 || self.epoch != ctx.epoch());
+/// Return the endpoint_url of the node.
+fun endpoint_url(self: &MemberInfo): &String {
+    &self.endpoint_url
+}
 
-    let committee = self.new_committee_from_validator_set(
-        sui_system,
-        config,
-        ctx,
+/// Return the tls_public_key of the node.
+fun tls_public_key(self: &MemberInfo): &vector<u8> {
+    &self.tls_public_key
+}
+
+/// Return the next epoch encryption public key of the node.
+fun next_epoch_encryption_public_key(self: &MemberInfo): &vector<u8> {
+    &self.next_epoch_encryption_public_key
+}
+
+// Verifies that the provided bls public key is valid and there is a valid
+// proof of possession.
+fun verify_bls_public_key(
+    epoch: u64,
+    validator_address: address,
+    bls_public_key: vector<u8>,
+    proof_of_possession_signature: vector<u8>,
+): Element<UncompressedG1> {
+    // Verify the proof of possession of the private key
+    assert!(
+        verify_proof_of_possession(
+            epoch,
+            &validator_address,
+            &bls_public_key,
+            &proof_of_possession_signature,
+        ),
     );
 
-    let epoch = committee.epoch();
-    self.pending_epoch_change =
-        option::some(PendingEpochChange {
-            epoch,
-            committee_handoff_cert: option::none(),
-        });
-    self.insert_committee(committee);
-    epoch
+    // Convert the public key to its Uncompressed form
+    g1_to_uncompressed_g1(&g1_from_bytes(&bls_public_key))
 }
 
-public(package) fun end_reconfig(
-    self: &mut CommitteeSet,
-    mpc_public_key: vector<u8>,
-    _ctx: &TxContext,
-): (u64, Option<committee::CommitteeSignature>) {
-    assert!(self.is_reconfiguring());
-    let PendingEpochChange { epoch: next_epoch, committee_handoff_cert } = self
-        .pending_epoch_change
-        .extract();
-    assert!(self.has_committee(next_epoch));
+fun verify_proof_of_possession(
+    epoch: u64,
+    validator_address: &address,
+    bls_public_key: &vector<u8>,
+    proof_of_possession_signature: &vector<u8>,
+): bool {
+    let mut message = vector[];
+    message.append(bcs::to_bytes(&hashi::intent::proof_of_possession()));
+    message.append(bcs::to_bytes(&epoch));
+    message.append(bcs::to_bytes(validator_address));
+    bls_public_key.do_ref!(|key_byte| message.append(bcs::to_bytes(key_byte)));
 
-    // If the mpc_public_key is empty, then this is the initial reconfig where
-    // DKG is run and we need to set the produced pubkey.
-    if (self.mpc_public_key.is_empty()) {
-        self.mpc_public_key = mpc_public_key;
-    } else {
-        assert!(committee_handoff_cert.is_some());
-    };
-
-    // On subsequent reconfigs where key resharing is performing instead of
-    // DKG, we need to ensure that the pubkey remains constant
-    assert!(self.mpc_public_key == mpc_public_key);
-
-    self.epoch = next_epoch;
-    (next_epoch, committee_handoff_cert)
+    bls12381_min_pk_verify(
+        proof_of_possession_signature,
+        bls_public_key,
+        &message,
+    )
 }
 
-public(package) fun abort_reconfig(self: &mut CommitteeSet, _ctx: &TxContext): u64 {
-    assert!(self.is_reconfiguring());
-    let PendingEpochChange { epoch: next_epoch, committee_handoff_cert } = self
-        .pending_epoch_change
-        .extract();
-    if (committee_handoff_cert.is_some()) {
-        committee_handoff_cert.destroy_some();
-    } else {
-        committee_handoff_cert.destroy_none();
-    };
-    self.remove_committee(next_epoch);
-    next_epoch
+// ~~~~~~~ Test Helpers ~~~~~~~
+
+#[test_only]
+public fun has_committee_handoff_for_testing(self: &CommitteeSet, from_epoch: u64): bool {
+    self
+        .committees
+        .contains_with_type<CommitteeHandoffKey, CommitteeHandoff>(CommitteeHandoffKey {
+            epoch: from_epoch,
+        })
 }
 
 #[test_only]
@@ -539,8 +542,6 @@ public fun set_pending_reconfig_for_testing(self: &mut CommitteeSet, committee: 
 public fun set_mpc_public_key_for_testing(self: &mut CommitteeSet, mpc_public_key: vector<u8>) {
     self.mpc_public_key = mpc_public_key;
 }
-
-// ======== Test-only Functions ========
 
 #[test_only]
 /// Creates a CommitteeSet for testing with a pre-built committee

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -17,11 +17,7 @@ use hashi::config_value::{Self, Value};
 use std::string::String;
 use sui::vec_map::{Self, VecMap};
 
-#[error(code = 3)]
-const EBadGuardianBtcPublicKeyLength: vector<u8> = b"Guardian BTC public key must be 32 bytes";
-#[error(code = 4)]
-const EGuardianBtcPublicKeyImmutable: vector<u8> =
-    b"Guardian BTC public key cannot be changed once set";
+// ~~~~~~~ Constants ~~~~~~~
 
 const PAUSED_KEY: vector<u8> = b"paused";
 const GUARDIAN_URL_KEY: vector<u8> = b"guardian_url";
@@ -31,8 +27,33 @@ const EMERGENCY_PAUSE_THRESHOLD_BPS_KEY: vector<u8> = b"governance_emergency_pau
 const EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY: vector<u8> =
     b"governance_emergency_unpause_threshold_bps";
 
+// ~~~~~~~ Errors ~~~~~~~
+
+#[error(code = 3)]
+const EBadGuardianBtcPublicKeyLength: vector<u8> = b"Guardian BTC public key must be 32 bytes";
+#[error(code = 4)]
+const EGuardianBtcPublicKeyImmutable: vector<u8> =
+    b"Guardian BTC public key cannot be changed once set";
+
+// ~~~~~~~ Structs ~~~~~~~
+
 public struct Config has copy, drop, store {
     config: VecMap<String, Value>,
+}
+
+// ~~~~~~~ Package Functions ~~~~~~~
+
+/// Create the global config with core defaults only. Chain-specific defaults
+/// (e.g. BTC fees) are initialized separately via btc_config::init_defaults.
+public(package) fun create(): Config {
+    let mut config = empty();
+
+    // Core defaults
+    config.upsert(PAUSED_KEY, config_value::new_bool(false));
+    config.upsert(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(500));
+    config.upsert(EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(6667));
+
+    config
 }
 
 /// Create an empty store. Used to build a pinned snapshot (e.g. a `Committee`'s
@@ -80,7 +101,7 @@ public(package) fun is_valid_config_update(self: &Config, key: &String, value: &
     self.config.get(key).same_variant(value)
 }
 
-// ======== Core Accessors ========
+// === Core Accessors ===
 
 public(package) fun paused(self: &Config): bool {
     self.get(PAUSED_KEY).as_bool()
@@ -123,19 +144,4 @@ public(package) fun emergency_pause_threshold_bps(self: &Config): u64 {
 
 public(package) fun emergency_unpause_threshold_bps(self: &Config): u64 {
     self.try_get(EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY).map!(|v| v.as_u64()).destroy_or!(6667)
-}
-
-// ======== Constructor ========
-
-/// Create the global config with core defaults only. Chain-specific defaults
-/// (e.g. BTC fees) are initialized separately via btc_config::init_defaults.
-public(package) fun create(): Config {
-    let mut config = empty();
-
-    // Core defaults
-    config.upsert(PAUSED_KEY, config_value::new_bool(false));
-    config.upsert(EMERGENCY_PAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(500));
-    config.upsert(EMERGENCY_UNPAUSE_THRESHOLD_BPS_KEY, config_value::new_u64(6667));
-
-    config
 }

--- a/packages/hashi/sources/core/config/config_value.move
+++ b/packages/hashi/sources/core/config/config_value.move
@@ -1,12 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Typed value wrapper for config entries: the `Value` enum carries one of the
+/// primitive types a configuration entry can hold, with a public constructor
+/// per variant and package-level helpers for variant checks (`is_*`) and
+/// extraction (`as_*`, aborting on a type mismatch). Storing typed values —
+/// rather than raw bytes — lets `config::is_valid_config_update` reject
+/// governance updates that would change an entry's type.
 module hashi::config_value;
 
 use std::string::String;
 
+// ~~~~~~~ Errors ~~~~~~~
+
 #[error]
 const EInvalidConfigValue: vector<u8> = b"Config value has a different type than expected";
+
+// ~~~~~~~ Structs ~~~~~~~
 
 // Variant order is BCS-load-bearing: the Rust mirror (hashi-types) decodes
 // by variant index, and once published to a persistent network the order is
@@ -21,6 +31,8 @@ public enum Value has copy, drop, store {
     Bool(bool),
     Bytes(vector<u8>),
 }
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun new_u64(value: u64): Value {
     Value::U64(value)
@@ -50,6 +62,8 @@ public fun new_u256(value: u256): Value {
     Value::U256(value)
 }
 
+// ~~~~~~~ Package Functions ~~~~~~~
+
 public(package) fun same_variant(self: &Value, other: &Value): bool {
     match (self) {
         Value::U64(_) => other.is_u64(),
@@ -65,6 +79,20 @@ public(package) fun same_variant(self: &Value, other: &Value): bool {
 public(package) fun is_u64(value: &Value): bool {
     match (value) {
         Value::U64(_) => true,
+        _ => false,
+    }
+}
+
+public(package) fun is_u128(value: &Value): bool {
+    match (value) {
+        Value::U128(_) => true,
+        _ => false,
+    }
+}
+
+public(package) fun is_u256(value: &Value): bool {
+    match (value) {
+        Value::U256(_) => true,
         _ => false,
     }
 }
@@ -104,6 +132,20 @@ public(package) fun as_u64(value: Value): u64 {
     }
 }
 
+public(package) fun as_u128(value: Value): u128 {
+    match (value) {
+        Value::U128(num) => num,
+        _ => abort EInvalidConfigValue,
+    }
+}
+
+public(package) fun as_u256(value: Value): u256 {
+    match (value) {
+        Value::U256(num) => num,
+        _ => abort EInvalidConfigValue,
+    }
+}
+
 public(package) fun as_address(value: Value): address {
     match (value) {
         Value::Address(addr) => addr,
@@ -128,34 +170,6 @@ public(package) fun as_bool(value: Value): bool {
 public(package) fun as_bytes(value: Value): vector<u8> {
     match (value) {
         Value::Bytes(bytes) => bytes,
-        _ => abort EInvalidConfigValue,
-    }
-}
-
-public(package) fun is_u128(value: &Value): bool {
-    match (value) {
-        Value::U128(_) => true,
-        _ => false,
-    }
-}
-
-public(package) fun is_u256(value: &Value): bool {
-    match (value) {
-        Value::U256(_) => true,
-        _ => false,
-    }
-}
-
-public(package) fun as_u128(value: Value): u128 {
-    match (value) {
-        Value::U128(num) => num,
-        _ => abort EInvalidConfigValue,
-    }
-}
-
-public(package) fun as_u256(value: Value): u256 {
-    match (value) {
-        Value::U256(num) => num,
         _ => abort EInvalidConfigValue,
     }
 }

--- a/packages/hashi/sources/core/intent.move
+++ b/packages/hashi/sources/core/intent.move
@@ -16,6 +16,8 @@
 /// - `0x0200..`: reserved for future chains, one block each
 module hashi::intent;
 
+// ~~~~~~~ Constants ~~~~~~~
+
 // ==== Core protocol (0x0000..=0x00FF) ====
 
 /// Proof of possession of a member BLS key (epoch, address, public key).
@@ -45,6 +47,8 @@ const WITHDRAWAL_CONFIRMATION: u16 = 0x0105;
 /// Request for the guardian to co-sign a withdrawal. Verified off-chain
 /// only; reserved here so the registry is complete.
 const GUARDIAN_WITHDRAWAL_REQUEST: u16 = 0x0106;
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 public(package) fun proof_of_possession(): u16 { PROOF_OF_POSSESSION }
 

--- a/packages/hashi/sources/core/mpc_config.move
+++ b/packages/hashi/sources/core/mpc_config.move
@@ -1,9 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Governed MPC protocol parameters — signing threshold, weight-reduction
+/// allowed delta, max-faulty bound, and nonce-generation protocol — each
+/// stored under a permanent config key with a compiled-in default. `pin`
+/// snapshots the full parameter set into a deterministic, canonically-ordered
+/// store that is attached to a `Committee` for its epoch, so mid-epoch
+/// governance changes never affect an active committee.
 module hashi::mpc_config;
 
 use hashi::{config::{Self, Config}, config_value};
+
+// ~~~~~~~ Constants ~~~~~~~
 
 const DEFAULT_THRESHOLD_IN_BASIS_POINTS: u64 = 3334;
 
@@ -19,6 +27,8 @@ const KEY_THRESHOLD_IN_BASIS_POINTS: vector<u8> = b"mpc_threshold_in_basis_point
 const KEY_MAX_FAULTY_IN_BASIS_POINTS: vector<u8> = b"mpc_max_faulty_in_basis_points";
 const KEY_WEIGHT_REDUCTION_ALLOWED_DELTA: vector<u8> = b"mpc_weight_reduction_allowed_delta";
 const KEY_NONCE_GENERATION_PROTOCOL: vector<u8> = b"mpc_nonce_generation_protocol";
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 #[allow(implicit_const_copy)]
 public(package) fun is_valid_value(key: &std::string::String, value: &config_value::Value): bool {
@@ -109,6 +119,8 @@ public(package) fun pin(config: &Config): Config {
     );
     mpc
 }
+
+// ~~~~~~~ Test Helpers ~~~~~~~
 
 #[test_only]
 /// Build a pinned MPC parameter store directly from explicit values, in the

--- a/packages/hashi/sources/core/mpc_signing.move
+++ b/packages/hashi/sources/core/mpc_signing.move
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Module: mpc_signing
-///
 /// Durable, out-of-order accumulator for a withdrawal's per-input threshold
 /// Schnorr signatures. This is the MPC-protocol side of incremental signing:
 /// the dangerous presignature / nonce bookkeeping lives here, behind a
@@ -31,6 +29,8 @@
 ///   - a `Signed` slot holds no index, so there is nothing stale to reuse.
 module hashi::mpc_signing;
 
+// ~~~~~~~ Errors ~~~~~~~
+
 #[error]
 const EZeroInputs: vector<u8> = b"signing batch must have at least one input";
 #[error]
@@ -43,6 +43,8 @@ const ENotStale: vector<u8> = b"signing batch is already on the current epoch";
 const EAllocationMismatch: vector<u8> = b"allocated presig count does not match pending count";
 #[error]
 const ENotComplete: vector<u8> = b"signing batch is not fully signed";
+
+// ~~~~~~~ Structs ~~~~~~~
 
 /// Per-input signing slot.
 public enum MpcSig has drop, store {
@@ -63,7 +65,9 @@ public struct SigningBatch has store {
     epoch: u64,
 }
 
-// ======== Constructors ========
+// ~~~~~~~ Package Functions ~~~~~~~
+
+// === Constructors ===
 
 // TODO(presig-allocation-centralization): `new` and `reallocate` take a
 // pre-allocated `presig_base`/`new_base` from the caller (hashi::allocate_presigs),
@@ -83,7 +87,7 @@ public(package) fun new(num_inputs: u64, presig_base: u64, epoch: u64): SigningB
     SigningBatch { signatures, epoch }
 }
 
-// ======== Mutation ========
+// === Mutation ===
 
 /// Fill the given slots with completed signatures. First-writer-wins applies
 /// both within a call and across calls: a slot that is already `Signed` is left
@@ -146,7 +150,7 @@ public(package) fun reallocate(
     self.epoch = current_epoch;
 }
 
-// ======== Views ========
+// === Views ===
 
 /// Number of still-`Pending` slots (the count that must be re-presigned on a
 /// stale-epoch `reallocate`).
@@ -216,7 +220,7 @@ public(package) fun to_signatures(self: &SigningBatch): vector<vector<u8>> {
     out
 }
 
-// ======== Internal ========
+// ~~~~~~~ Private Functions ~~~~~~~
 
 fun is_pending(self: &MpcSig): bool {
     match (self) {
@@ -225,7 +229,7 @@ fun is_pending(self: &MpcSig): bool {
     }
 }
 
-// ======== Test helpers ========
+// ~~~~~~~ Test Helpers ~~~~~~~
 
 #[test_only]
 public(package) fun destroy_for_testing(self: SigningBatch) {

--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -1,29 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Generic quorum-voting machinery shared by every governance action. A
+/// `Proposal<T>` wraps a typed payload `T` (defined by the proposal-type
+/// modules under `types/`) together with the votes it has gathered; committee
+/// members vote by weight, and once the proposal's quorum threshold is reached
+/// it can be executed exactly once, releasing the payload to the executing
+/// module and archiving the proposal. Proposals expire after seven days, after
+/// which unexecuted ones may be deleted.
 module hashi::proposal;
 
 use hashi::{hashi::Hashi, threshold};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 const MAX_PROPOSAL_DURATION_MS: u64 = 1000 * 60 * 60 * 24 * 7; // 7 days
 
-// ~~~~~~~ Structs ~~~~~~~
-
-public struct Proposal<T> has key, store {
-    id: UID,
-    creator: address,
-    votes: vector<address>,
-    quorum_threshold_bps: u64,
-    created_timestamp_ms: u64,
-    /// Clock timestamp at execution. `None` until the proposal executes.
-    executed_timestamp_ms: Option<u64>,
-    metadata: VecMap<String, String>,
-    data: T,
-}
-
 // ~~~~~~~ Errors ~~~~~~~
+
 #[error(code = 0)]
 const EUnauthorizedCaller: vector<u8> = b"Caller must be a voting member";
 #[error(code = 1)]
@@ -39,7 +35,116 @@ const EProposalExpired: vector<u8> = b"Proposal expired";
 #[error(code = 6)]
 const EProposalAlreadyExecuted: vector<u8> = b"Proposal already executed";
 
+// ~~~~~~~ Structs ~~~~~~~
+
+public struct Proposal<T> has key, store {
+    id: UID,
+    creator: address,
+    votes: vector<address>,
+    quorum_threshold_bps: u64,
+    created_timestamp_ms: u64,
+    /// Clock timestamp at execution. `None` until the proposal executes.
+    executed_timestamp_ms: Option<u64>,
+    metadata: VecMap<String, String>,
+    data: T,
+}
+
+// ~~~~~~~ Events ~~~~~~~
+
+public struct ProposalCreated<phantom T> has copy, drop {
+    proposal_id: ID,
+    timestamp_ms: u64,
+}
+
+public struct VoteCast<phantom T> has copy, drop {
+    proposal_id: ID,
+    voter: address,
+}
+
+public struct VoteRemoved<phantom T> has copy, drop {
+    proposal_id: ID,
+    voter: address,
+}
+
+public struct ProposalDeleted<phantom T> has copy, drop {
+    proposal_id: ID,
+}
+
+public struct ProposalExecuted<T> has copy, drop {
+    proposal_id: ID,
+    data: T,
+}
+
+public struct QuorumReached<phantom T> has copy, drop {
+    proposal_id: ID,
+}
+
+// ~~~~~~~ Entry Functions ~~~~~~~
+
+entry fun vote<T: store>(
+    hashi: &mut Hashi,
+    validator_address: address,
+    proposal_id: ID,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    hashi.versioning().assert_version_enabled();
+    assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
+
+    let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
+
+    assert!(!proposal.votes.contains(&validator_address), EVoteAlreadyCounted);
+    assert!(!proposal.is_expired(clock), EProposalExpired);
+
+    proposal.votes.push_back(validator_address);
+
+    sui::event::emit(VoteCast<T> { proposal_id, voter: validator_address });
+    if (proposal.quorum_reached(hashi)) {
+        sui::event::emit(QuorumReached<T> { proposal_id });
+    }
+}
+
+entry fun remove_vote<T: store>(
+    hashi: &mut Hashi,
+    validator_address: address,
+    proposal_id: ID,
+    ctx: &mut TxContext,
+) {
+    hashi.versioning().assert_version_enabled();
+    assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
+
+    let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
+    let index = proposal
+        .votes
+        .find_index!(|v| v == &validator_address)
+        .destroy_or!(abort ENoVoteFound);
+
+    proposal.votes.remove(index);
+    sui::event::emit(VoteRemoved<T> {
+        proposal_id: proposal.id.to_inner(),
+        voter: validator_address,
+    });
+}
+
 // ~~~~~~~ Public Functions ~~~~~~~
+
+public fun delete_expired<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock): T {
+    hashi.versioning().assert_version_enabled();
+    // Executed proposals are archived in the executed bag and must
+    // never be deletable, even after they expire. Refuse explicitly so
+    // the caller gets `EProposalAlreadyExecuted` instead of the bag's
+    // missing-key abort.
+    assert!(
+        !hashi.proposals().executed().contains(proposal_id.to_address()),
+        EProposalAlreadyExecuted,
+    );
+    let proposal: Proposal<T> = hashi.proposals_mut().active_mut().remove(proposal_id);
+
+    assert!(proposal.is_expired(clock), EProposalNotExpired);
+    proposal.delete()
+}
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 public(package) fun create<T: store>(
     hashi: &mut Hashi,
@@ -106,51 +211,6 @@ public(package) fun execute<T: copy + drop + store>(
     data
 }
 
-entry fun vote<T: store>(
-    hashi: &mut Hashi,
-    validator_address: address,
-    proposal_id: ID,
-    clock: &Clock,
-    ctx: &mut TxContext,
-) {
-    hashi.versioning().assert_version_enabled();
-    assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
-
-    let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
-
-    assert!(!proposal.votes.contains(&validator_address), EVoteAlreadyCounted);
-    assert!(!proposal.is_expired(clock), EProposalExpired);
-
-    proposal.votes.push_back(validator_address);
-
-    sui::event::emit(VoteCast<T> { proposal_id, voter: validator_address });
-    if (proposal.quorum_reached(hashi)) {
-        sui::event::emit(QuorumReached<T> { proposal_id });
-    }
-}
-
-entry fun remove_vote<T: store>(
-    hashi: &mut Hashi,
-    validator_address: address,
-    proposal_id: ID,
-    ctx: &mut TxContext,
-) {
-    hashi.versioning().assert_version_enabled();
-    assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
-
-    let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
-    let index = proposal
-        .votes
-        .find_index!(|v| v == &validator_address)
-        .destroy_or!(abort ENoVoteFound);
-
-    proposal.votes.remove(index);
-    sui::event::emit(VoteRemoved<T> {
-        proposal_id: proposal.id.to_inner(),
-        voter: validator_address,
-    });
-}
-
 public(package) fun quorum_reached<T>(proposal: &Proposal<T>, hashi: &Hashi): bool {
     let valid_voting_power = proposal.votes.fold!(0, |acc, voter| {
         acc + hashi.current_committee().get_member_weight(&voter)
@@ -166,22 +226,6 @@ public(package) fun is_expired<T>(proposal: &Proposal<T>, clock: &Clock): bool {
     clock.timestamp_ms() > proposal.created_timestamp_ms + MAX_PROPOSAL_DURATION_MS
 }
 
-public fun delete_expired<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &Clock): T {
-    hashi.versioning().assert_version_enabled();
-    // Executed proposals are archived in the executed bag and must
-    // never be deletable, even after they expire. Refuse explicitly so
-    // the caller gets `EProposalAlreadyExecuted` instead of the bag's
-    // missing-key abort.
-    assert!(
-        !hashi.proposals().executed().contains(proposal_id.to_address()),
-        EProposalAlreadyExecuted,
-    );
-    let proposal: Proposal<T> = hashi.proposals_mut().active_mut().remove(proposal_id);
-
-    assert!(proposal.is_expired(clock), EProposalNotExpired);
-    proposal.delete()
-}
-
 public(package) fun delete<T>(proposal: Proposal<T>): T {
     let Proposal<T> {
         id,
@@ -192,43 +236,13 @@ public(package) fun delete<T>(proposal: Proposal<T>): T {
     data
 }
 
-// ~~~~~~~ Getters ~~~~~~~
-
 public(package) fun votes<T>(proposal: &Proposal<T>): &vector<address> {
     &proposal.votes
 }
 
+// ~~~~~~~ Test Helpers ~~~~~~~
+
 #[test_only]
 public fun data<T>(proposal: &Proposal<T>): &T {
     &proposal.data
-}
-
-// ~~~~~~~ Events ~~~~~~~
-
-public struct ProposalCreated<phantom T> has copy, drop {
-    proposal_id: ID,
-    timestamp_ms: u64,
-}
-
-public struct VoteCast<phantom T> has copy, drop {
-    proposal_id: ID,
-    voter: address,
-}
-
-public struct VoteRemoved<phantom T> has copy, drop {
-    proposal_id: ID,
-    voter: address,
-}
-
-public struct ProposalDeleted<phantom T> has copy, drop {
-    proposal_id: ID,
-}
-
-public struct ProposalExecuted<T> has copy, drop {
-    proposal_id: ID,
-    data: T,
-}
-
-public struct QuorumReached<phantom T> has copy, drop {
-    proposal_id: ID,
 }

--- a/packages/hashi/sources/core/proposal/proposals.move
+++ b/packages/hashi/sources/core/proposal/proposals.move
@@ -1,9 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Container for the package's governance proposals, hung off `Hashi`.
+/// Active and executed proposals live in two separate object bags so that
+/// each set can be enumerated directly, and executed proposals are archived
+/// indefinitely to keep historical governance actions inspectable.
 module hashi::proposals;
 
 use sui::object_bag::{Self, ObjectBag};
+
+// ~~~~~~~ Structs ~~~~~~~
 
 /// Two-bag store for governance proposals. Listing "active proposals"
 /// and "executed proposals" is then a direct walk over the relevant
@@ -15,6 +21,8 @@ public struct Proposals has store {
     /// so historical governance actions remain inspectable.
     executed: ObjectBag,
 }
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 public(package) fun create(ctx: &mut TxContext): Proposals {
     Proposals {

--- a/packages/hashi/sources/core/proposal/types/abort_reconfig.move
+++ b/packages/hashi/sources/core/proposal/types/abort_reconfig.move
@@ -13,7 +13,11 @@ use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Errors ~~~~~~~
 
 #[error]
 const ENotReconfiguring: vector<u8> = b"No reconfiguration is in progress";
@@ -21,9 +25,13 @@ const ENotReconfiguring: vector<u8> = b"No reconfiguration is in progress";
 const EWrongReconfigEpoch: vector<u8> =
     b"Proposal's epoch does not match the pending reconfiguration epoch";
 
+// ~~~~~~~ Structs ~~~~~~~
+
 public struct AbortReconfig has copy, drop, store {
     epoch: u64,
 }
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun propose(
     hashi: &mut Hashi,

--- a/packages/hashi/sources/core/proposal/types/disable_version.move
+++ b/packages/hashi/sources/core/proposal/types/disable_version.move
@@ -1,17 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Governance proposal for disabling a package version. Once quorum is
+/// reached, `execute` marks the proposed version as disabled in `versioning`,
+/// so every entry point guarded by `assert_version_enabled` stops serving
+/// calls made through that version — the recovery lever if an upgraded
+/// package turns out to be broken.
 module hashi::disable_version;
 
 use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct DisableVersion has copy, drop, store {
     version: u64,
 }
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun propose(
     hashi: &mut Hashi,

--- a/packages/hashi/sources/core/proposal/types/emergency_pause.move
+++ b/packages/hashi/sources/core/proposal/types/emergency_pause.move
@@ -11,9 +11,13 @@ use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
+// ~~~~~~~ Structs ~~~~~~~
+
 public struct EmergencyPause has copy, drop, store {
     pause: bool,
 }
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun propose(
     hashi: &mut Hashi,

--- a/packages/hashi/sources/core/proposal/types/enable_version.move
+++ b/packages/hashi/sources/core/proposal/types/enable_version.move
@@ -1,17 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Governance proposal for enabling a package version. Once quorum is
+/// reached, `execute` marks the proposed version as enabled in `versioning`,
+/// re-admitting calls made through that version at entry points guarded by
+/// `assert_version_enabled` — the counterpart to `disable_version` for
+/// re-activating a previously disabled version.
 module hashi::enable_version;
 
 use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct EnableVersion has copy, drop, store {
     version: u64,
 }
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun propose(
     hashi: &mut Hashi,

--- a/packages/hashi/sources/core/proposal/types/update_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_config.move
@@ -1,11 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Governance proposal for updating entries in the global config. A proposal
+/// carries a map of key/value entries; on execution every entry must refer to
+/// an existing key with a matching value type (and pass MPC-config range
+/// validation) before being upserted, so governance can tune parameters but
+/// never introduce unknown keys or change an entry's type.
 module hashi::update_config;
 
 use hashi::{config_value::Value, hashi::Hashi, mpc_config, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
+
+// ~~~~~~~ Constants ~~~~~~~
+
+const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Errors ~~~~~~~
 
 #[error]
 const EInvalidConfigEntry: vector<u8> = b"Unknown config key or wrong value type in proposed entry";
@@ -13,11 +24,13 @@ const EInvalidConfigEntry: vector<u8> = b"Unknown config key or wrong value type
 #[error]
 const ENoEntriesProvided: vector<u8> = b"UpdateConfig proposal must contain at least one entry";
 
-const THRESHOLD_BPS: u64 = 6667;
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct UpdateConfig has copy, drop, store {
     entries: VecMap<String, Value>,
 }
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun propose(
     hashi: &mut Hashi,

--- a/packages/hashi/sources/core/proposal/types/update_guardian.move
+++ b/packages/hashi/sources/core/proposal/types/update_guardian.move
@@ -1,17 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Governance proposal for updating the guardian's URL in the global config.
+/// Only the URL is governable: the guardian's BTC public key is immutable once
+/// set (rotating it would invalidate derived deposit addresses), and the
+/// ephemeral signing key is intentionally not pinned on-chain — nodes
+/// authenticate the guardian over TLS plus the immutable BTC key.
 module hashi::update_guardian;
 
 use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct UpdateGuardian has copy, drop, store {
     url: String,
 }
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun propose(
     hashi: &mut Hashi,

--- a/packages/hashi/sources/core/proposal/types/upgrade.move
+++ b/packages/hashi/sources/core/proposal/types/upgrade.move
@@ -19,11 +19,24 @@ use hashi::{hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, package::{UpgradeTicket, UpgradeReceipt}, vec_map::VecMap};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct Upgrade has copy, drop, store {
     digest: vector<u8>,
 }
+
+// ~~~~~~~ Events ~~~~~~~
+
+public struct PackageUpgraded has copy, drop {
+    package: ID,
+    version: u64,
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
 
 public fun propose(
     hashi: &mut Hashi,
@@ -61,9 +74,4 @@ public fun finalize_upgrade(hashi: &mut Hashi, receipt: UpgradeReceipt) {
     hashi.versioning_mut().commit_upgrade(receipt);
     let version = hashi.versioning().upgrade_cap().version();
     sui::event::emit(PackageUpgraded { package: upgrade_package, version });
-}
-
-public struct PackageUpgraded has copy, drop {
-    package: ID,
-    version: u64,
 }

--- a/packages/hashi/sources/core/reconfig.move
+++ b/packages/hashi/sources/core/reconfig.move
@@ -1,10 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Module: reconfig
+/// Committee reconfiguration entry points. `start_reconfig` forms the next
+/// committee from Sui's active validator set (pinning the governed MPC
+/// parameters for the new epoch), `submit_committee_handoff` records the
+/// outgoing committee's certificate approving the incoming committee, and
+/// `end_reconfig` verifies the new committee's certificate over the MPC
+/// threshold public key and activates the epoch. The initial (genesis)
+/// reconfig skips the handoff — no prior committee exists — and is gated on
+/// the publisher's launch switch (`hashi::finish_publish`).
 module hashi::reconfig;
 
 use hashi::{committee::CommitteeSignature, hashi::Hashi};
+
+// ~~~~~~~ Errors ~~~~~~~
 
 // NOTE: `ENotReconfiguring` is matched BY NAME in the node's reconfig-abort
 // classifier (crates/hashi/src/mpc/service.rs) to detect the benign
@@ -18,6 +27,8 @@ const EInitialReconfig: vector<u8> =
 const EGenesisNotAuthorized: vector<u8> =
     b"Genesis is locked until the publisher sends finish_publish (the launch switch)";
 
+// ~~~~~~~ Structs ~~~~~~~
+
 /// Message that committee members sign to confirm successful key rotation.
 public struct ReconfigCompletionMessage has copy, drop, store {
     /// The epoch of the new committee.
@@ -29,6 +40,21 @@ public struct ReconfigCompletionMessage has copy, drop, store {
 public struct CommitteeTransitionRequest has copy, drop, store {
     new_committee: hashi::committee::Committee,
 }
+
+// ~~~~~~~ Events ~~~~~~~
+
+public struct ReconfigStarted has copy, drop {
+    epoch: u64,
+}
+
+public struct ReconfigEnded has copy, drop {
+    from_epoch: u64,
+    epoch: u64,
+    /// The MPC committee's threshold public key.
+    mpc_public_key: vector<u8>,
+}
+
+// ~~~~~~~ Entry Functions ~~~~~~~
 
 entry fun start_reconfig(
     self: &mut Hashi,
@@ -111,6 +137,8 @@ entry fun submit_committee_handoff(
     self.committee_set_mut().set_pending_committee_handoff_cert(committee_handoff_cert);
 }
 
+// ~~~~~~~ Package Functions ~~~~~~~
+
 /// At genesis bootstrap (no MPC key yet) the initial committee may only form
 /// after the publisher hands the package `UpgradeCap` into on-chain custody
 /// via `hashi::finish_publish` -- the launch switch. After bootstrap this is
@@ -124,170 +152,48 @@ public(package) fun assert_genesis_launch_authorized(self: &Hashi) {
     }
 }
 
-public struct ReconfigStarted has copy, drop {
-    epoch: u64,
-}
+// ~~~~~~~ Test Helpers ~~~~~~~
 
-public struct ReconfigEnded has copy, drop {
-    from_epoch: u64,
-    epoch: u64,
-    /// The MPC committee's threshold public key.
+#[test_only]
+/// Forwards to `end_reconfig` so it can be exercised from
+/// `hashi::reconfig_tests` (non-public entry functions are not callable from
+/// other modules).
+public fun end_reconfig_for_testing(
+    self: &mut Hashi,
     mpc_public_key: vector<u8>,
+    mpc_cert: CommitteeSignature,
+    ctx: &TxContext,
+) {
+    end_reconfig(self, mpc_public_key, mpc_cert, ctx)
 }
 
 #[test_only]
-const VOTER1: address = @0x1;
-#[test_only]
-const VOTER2: address = @0x2;
-#[test_only]
-const VOTER3: address = @0x3;
-
-#[test_only]
-fun pending_committee_for_testing(epoch: u64): hashi::committee::Committee {
-    use hashi::{committee, mpc_config, test_utils};
-    use sui::bls12381;
-
-    let sk = test_utils::bls_sk_for_testing();
-    let public_key = bls12381::g1_to_uncompressed_g1(
-        &bls12381::g1_from_bytes(&test_utils::bls_min_pk_from_sk(&sk)),
-    );
-    let members = vector[
-        committee::new_committee_member(VOTER1, public_key, sk, 1),
-        committee::new_committee_member(VOTER2, public_key, sk, 1),
-        committee::new_committee_member(VOTER3, public_key, sk, 1),
-    ];
-    committee::new_committee(epoch, members, mpc_config::new_for_testing(3334, 800, 3333, 0))
+/// Forwards to `submit_committee_handoff` so it can be exercised from
+/// `hashi::reconfig_tests` (non-public entry functions are not callable from
+/// other modules).
+public fun submit_committee_handoff_for_testing(
+    self: &mut Hashi,
+    committee_handoff_cert: CommitteeSignature,
+    ctx: &TxContext,
+) {
+    submit_committee_handoff(self, committee_handoff_cert, ctx)
 }
 
 #[test_only]
-fun cert_message<T: copy + drop + store>(epoch: u64, intent: u16, message: &T): vector<u8> {
-    use sui::bcs;
-
-    let mut bytes = bcs::to_bytes(&intent);
-    bytes.append(bcs::to_bytes(&epoch));
-    bytes.append(bcs::to_bytes(message));
-    bytes
+/// Constructs a `ReconfigCompletionMessage` (private fields) for tests that
+/// need to sign one.
+public fun reconfig_completion_message_for_testing(
+    epoch: u64,
+    mpc_public_key: vector<u8>,
+): ReconfigCompletionMessage {
+    ReconfigCompletionMessage { epoch, mpc_public_key }
 }
 
-#[test]
-fun test_end_reconfig_stores_committee_handoff() {
-    use hashi::test_utils;
-
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1, VOTER2, VOTER3];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let next_epoch = 1;
-    let next_committee = pending_committee_for_testing(next_epoch);
-    hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
-
-    let mpc_public_key = vector[1, 2, 3];
-    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
-    let mpc_message = ReconfigCompletionMessage { epoch: next_epoch, mpc_public_key };
-    let mpc_cert = test_utils::sign_certificate(
-        next_epoch,
-        &cert_message(next_epoch, hashi::intent::reconfig_completion(), &mpc_message),
-        3,
-    );
-    let committee_handoff_cert = test_utils::sign_certificate(
-        0,
-        &cert_message(
-            0,
-            hashi::intent::committee_transition(),
-            &CommitteeTransitionRequest { new_committee: next_committee },
-        ),
-        3,
-    );
-
-    submit_committee_handoff(&mut hashi, committee_handoff_cert, ctx);
-    end_reconfig(&mut hashi, mpc_public_key, mpc_cert, ctx);
-
-    assert!(hashi.committee_set().epoch() == next_epoch);
-    assert!(hashi.committee_set().has_committee_handoff_for_testing(0));
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-#[expected_failure]
-fun test_end_reconfig_requires_committee_handoff_after_initial_reconfig() {
-    use hashi::test_utils;
-
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1, VOTER2, VOTER3];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let next_epoch = 1;
-    let next_committee = pending_committee_for_testing(next_epoch);
-    hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
-
-    let mpc_public_key = vector[1];
-    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
-    let mpc_message = ReconfigCompletionMessage { epoch: next_epoch, mpc_public_key };
-    let mpc_cert = test_utils::sign_certificate(
-        next_epoch,
-        &cert_message(next_epoch, hashi::intent::reconfig_completion(), &mpc_message),
-        3,
-    );
-
-    end_reconfig(&mut hashi, mpc_public_key, mpc_cert, ctx);
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-#[expected_failure(abort_code = EInitialReconfig)]
-fun test_submit_committee_handoff_rejects_initial_reconfig() {
-    use hashi::test_utils;
-
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1, VOTER2, VOTER3];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let next_epoch = 1;
-    let next_committee = pending_committee_for_testing(next_epoch);
-    hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
-
-    let committee_handoff_cert = test_utils::sign_certificate(
-        0,
-        &cert_message(
-            0,
-            hashi::intent::committee_transition(),
-            &CommitteeTransitionRequest { new_committee: next_committee },
-        ),
-        3,
-    );
-
-    submit_committee_handoff(&mut hashi, committee_handoff_cert, ctx);
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-#[expected_failure]
-fun test_submit_committee_handoff_rejects_handoff_signed_by_wrong_committee() {
-    use hashi::test_utils;
-
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1, VOTER2, VOTER3];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let next_epoch = 1;
-    let next_committee = pending_committee_for_testing(next_epoch);
-    hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
-
-    let mpc_public_key = vector[1];
-    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
-    let mpc_message = ReconfigCompletionMessage { epoch: next_epoch, mpc_public_key };
-    let mpc_cert = test_utils::sign_certificate(
-        next_epoch,
-        &cert_message(next_epoch, hashi::intent::reconfig_completion(), &mpc_message),
-        3,
-    );
-    let committee_handoff_cert = test_utils::sign_certificate(
-        next_epoch,
-        &cert_message(
-            next_epoch,
-            hashi::intent::committee_transition(),
-            &CommitteeTransitionRequest { new_committee: next_committee },
-        ),
-        3,
-    );
-
-    submit_committee_handoff(&mut hashi, committee_handoff_cert, ctx);
-    end_reconfig(&mut hashi, mpc_public_key, mpc_cert, ctx);
-    std::unit_test::destroy(hashi);
+#[test_only]
+/// Constructs a `CommitteeTransitionRequest` (private fields) for tests that
+/// need to sign one.
+public fun committee_transition_request_for_testing(
+    new_committee: hashi::committee::Committee,
+): CommitteeTransitionRequest {
+    CommitteeTransitionRequest { new_committee }
 }

--- a/packages/hashi/sources/core/threshold.move
+++ b/packages/hashi/sources/core/threshold.move
@@ -1,15 +1,26 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Committee weight-threshold arithmetic. Computes the minimum aggregate
+/// signer weight for a valid certificate (>2/3 quorum, matching the Sui
+/// system's 6667 bps threshold) and general basis-point thresholds using
+/// ceiling division, so the required weight is never below the true
+/// fractional threshold.
 module hashi::threshold;
+
+// ~~~~~~~ Constants ~~~~~~~
 
 const MAX_BPS: u64 = 10000;
 
 /// Quorum threshold (2f + 1 out of 3f) in basis points.
 const CERTIFICATE_THRESHOLD_BPS: u64 = 6667;
 
+// ~~~~~~~ Errors ~~~~~~~
+
 #[error]
 const EThresholdBpsTooHigh: vector<u8> = b"Threshold basis points must be at most 10000";
+
+// ~~~~~~~ Package Functions ~~~~~~~
 
 /// Returns the minimum aggregate signer weight required for a valid
 /// certificate (>2/3 of total weight, matching the Sui system's
@@ -24,72 +35,4 @@ public(package) fun certificate_threshold(total_weight: u16): u16 {
 public(package) fun weight_threshold(total_weight: u64, threshold_bps: u64): u64 {
     assert!(threshold_bps <= MAX_BPS, EThresholdBpsTooHigh);
     (total_weight * threshold_bps).divide_and_round_up(MAX_BPS)
-}
-
-// ======== Tests ========
-
-#[test]
-fun test_certificate_threshold() {
-    // 6667 bps of 3 -> ceil(3*6667/10000) = ceil(2.0001) = 3.
-    assert!(certificate_threshold(3) == 3);
-    // 6667 bps of 10 -> ceil(66670/10000) = 7.
-    assert!(certificate_threshold(10) == 7);
-    // 6667 bps of 6 -> ceil(40002/10000) = 5.
-    assert!(certificate_threshold(6) == 5);
-    // 6667 bps of 1 -> ceil(6667/10000) = 1.
-    assert!(certificate_threshold(1) == 1);
-    // 6667 bps of 0 = 0.
-    assert!(certificate_threshold(0) == 0);
-    // Matches Sui system: 6667 bps of 10000 = 6667.
-    assert!(certificate_threshold(10000) == 6667);
-}
-
-#[test]
-fun test_weight_threshold_basic() {
-    // 66.67% of 3 -> 3*6667 = 20001 -> ceil(20001/10000) = 3.
-    assert!(weight_threshold(3, 6667) == 3);
-    // 66.67% of 6 -> 6*6667 = 40002 -> ceil(40002/10000) = 5.
-    assert!(weight_threshold(6, 6667) == 5);
-    // 66.67% of 10 -> 10*6667 = 66670 -> ceil(66670/10000) = 7.
-    assert!(weight_threshold(10, 6667) == 7);
-}
-
-#[test]
-fun test_weight_threshold_unanimity() {
-    // 100% always requires all weight.
-    assert!(weight_threshold(1, 10000) == 1);
-    assert!(weight_threshold(3, 10000) == 3);
-    assert!(weight_threshold(100, 10000) == 100);
-}
-
-#[test]
-fun test_weight_threshold_zero() {
-    // 0 bps requires no weight.
-    assert!(weight_threshold(100, 0) == 0);
-    // Any threshold of 0 total weight requires 0.
-    assert!(weight_threshold(0, 6667) == 0);
-}
-
-#[test]
-fun test_weight_threshold_exact_division() {
-    // 50% of 10 = 5 (exact, no rounding needed).
-    assert!(weight_threshold(10, 5000) == 5);
-    // 25% of 100 = 25.
-    assert!(weight_threshold(100, 2500) == 25);
-}
-
-#[test]
-fun test_weight_threshold_rounds_up() {
-    // 50% of 3 = 1.5 -> 2.
-    assert!(weight_threshold(3, 5000) == 2);
-    // 1 bps of 1 = 0.0001 -> 1.
-    assert!(weight_threshold(1, 1) == 1);
-    // 33.33% of 10 = 3.333 -> 4.
-    assert!(weight_threshold(10, 3333) == 4);
-}
-
-#[test]
-#[expected_failure(abort_code = EThresholdBpsTooHigh)]
-fun test_weight_threshold_rejects_above_10000() {
-    weight_threshold(100, 10001);
 }

--- a/packages/hashi/sources/core/tob.move
+++ b/packages/hashi/sources/core/tob.move
@@ -1,12 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Totally Ordered Broadcast (TOB)
-
+/// Totally Ordered Broadcast (TOB) certificate storage for MPC ceremonies.
+/// Dealer submissions — a dealer-messages hash plus its committee signature —
+/// are bucketed per (epoch, optional batch, protocol type) in `EpochCertsV1`,
+/// first-submission-wins per dealer. Signature verification is deferred to
+/// off-chain readers, and a bucket may be destroyed once the current epoch is
+/// at least two past the bucket's epoch.
 module hashi::tob;
 
 use hashi::committee::CommitteeSignature;
 use sui::linked_table::{Self, LinkedTable};
+
+// ~~~~~~~ Errors ~~~~~~~
 
 #[error]
 const EWrongEpoch: vector<u8> = b"Certificate epoch does not match the bucket's epoch";
@@ -14,44 +20,18 @@ const EWrongEpoch: vector<u8> = b"Certificate epoch does not match the bucket's 
 const ETooEarlyToDestroy: vector<u8> =
     b"TOB certificates may only be destroyed two epochs after their epoch";
 
+// ~~~~~~~ Structs ~~~~~~~
+
 public enum ProtocolType has copy, drop, store {
     Dkg,
     KeyRotation,
     NonceGeneration,
 }
 
-public(package) fun protocol_type_dkg(): ProtocolType {
-    ProtocolType::Dkg
-}
-
-public(package) fun protocol_type_key_rotation(): ProtocolType {
-    ProtocolType::KeyRotation
-}
-
-public(package) fun protocol_type_nonce_generation(): ProtocolType {
-    ProtocolType::NonceGeneration
-}
-
 public struct TobKey has copy, drop, store {
     epoch: u64,
     batch_index: Option<u32>,
     protocol_type: ProtocolType,
-}
-
-public(package) fun tob_key(
-    epoch: u64,
-    batch_index: Option<u32>,
-    protocol_type: ProtocolType,
-): TobKey {
-    TobKey { epoch, batch_index, protocol_type }
-}
-
-public(package) fun epoch(self: &TobKey): u64 {
-    self.epoch
-}
-
-public(package) fun protocol_type(self: &TobKey): ProtocolType {
-    self.protocol_type
 }
 
 /// Certificates for a single epoch.
@@ -72,6 +52,36 @@ public struct DealerSubmissionV1 has copy, drop, store {
     signature: CommitteeSignature,
 }
 
+// ~~~~~~~ Package Functions ~~~~~~~
+
+public(package) fun protocol_type_dkg(): ProtocolType {
+    ProtocolType::Dkg
+}
+
+public(package) fun protocol_type_key_rotation(): ProtocolType {
+    ProtocolType::KeyRotation
+}
+
+public(package) fun protocol_type_nonce_generation(): ProtocolType {
+    ProtocolType::NonceGeneration
+}
+
+public(package) fun tob_key(
+    epoch: u64,
+    batch_index: Option<u32>,
+    protocol_type: ProtocolType,
+): TobKey {
+    TobKey { epoch, batch_index, protocol_type }
+}
+
+public(package) fun epoch(self: &TobKey): u64 {
+    self.epoch
+}
+
+public(package) fun protocol_type(self: &TobKey): ProtocolType {
+    self.protocol_type
+}
+
 public(package) fun create(
     epoch: u64,
     protocol_type: ProtocolType,
@@ -82,17 +92,6 @@ public(package) fun create(
         protocol_type,
         certs: linked_table::new(ctx),
     }
-}
-
-/// Remove all certificates and destroy the EpochCertsV1 in one transaction.
-/// Can only be called when current_epoch >= epoch + 2.
-public(package) fun destroy_all(epoch_certs: EpochCertsV1, current_epoch: u64) {
-    let EpochCertsV1 { epoch, protocol_type: _, mut certs } = epoch_certs;
-    assert!(current_epoch >= epoch + 2, ETooEarlyToDestroy);
-    while (!certs.is_empty()) {
-        let (_, _) = certs.pop_front();
-    };
-    certs.destroy_empty();
 }
 
 public(package) fun submit_cert(
@@ -129,6 +128,19 @@ public(package) fun submit_cert_with_signature(
     let submission = DealerSubmissionV1 { message, signature: *sig };
     epoch_certs.certs.push_back(dealer, submission);
 }
+
+/// Remove all certificates and destroy the EpochCertsV1 in one transaction.
+/// Can only be called when current_epoch >= epoch + 2.
+public(package) fun destroy_all(epoch_certs: EpochCertsV1, current_epoch: u64) {
+    let EpochCertsV1 { epoch, protocol_type: _, mut certs } = epoch_certs;
+    assert!(current_epoch >= epoch + 2, ETooEarlyToDestroy);
+    while (!certs.is_empty()) {
+        let (_, _) = certs.pop_front();
+    };
+    certs.destroy_empty();
+}
+
+// ~~~~~~~ Test Helpers ~~~~~~~
 
 #[test_only]
 public fun num_certs(self: &EpochCertsV1): u64 {

--- a/packages/hashi/sources/core/treasury.move
+++ b/packages/hashi/sources/core/treasury.move
@@ -1,6 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Custody of the coin capabilities for bridge-issued assets. `Treasury`
+/// holds the `TreasuryCap` and `MetadataCap` of each registered coin type in
+/// an `ObjectBag` keyed by cap type, and exposes package-only mint/burn that
+/// emit `Minted`/`Burned` events for off-chain watchers.
 module hashi::treasury;
 
 use sui::{
@@ -10,9 +14,7 @@ use sui::{
     object_bag::{Self, ObjectBag}
 };
 
-//////////////////////////////////////////////////////
-// Types
-//
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct Key<phantom T> has copy, drop, store {}
 
@@ -20,22 +22,30 @@ public struct Treasury has store {
     objects: ObjectBag,
 }
 
-//////////////////////////////////////////////////////
-// Internal functions
-//
+// ~~~~~~~ Events ~~~~~~~
 
-fun treasury_cap<T>(self: &mut Treasury): &mut TreasuryCap<T> {
-    &mut self.objects[Key<TreasuryCap<T>> {}]
+public struct Minted<phantom T> has copy, drop {
+    amount: u64,
 }
 
-#[allow(unused_function)]
-fun metadata_cap<T>(self: &mut Treasury): &mut MetadataCap<T> {
-    &mut self.objects[Key<MetadataCap<T>> {}]
+public struct Burned<phantom T> has copy, drop {
+    amount: u64,
 }
 
-public(package) fun burn<T>(self: &mut Treasury, balance: Balance<T>) {
-    sui::event::emit(Burned<T> { amount: balance.value() });
-    self.treasury_cap<T>().supply_mut().decrease_supply(balance);
+// ~~~~~~~ Package Functions ~~~~~~~
+
+public(package) fun create(ctx: &mut TxContext): Treasury {
+    Treasury {
+        objects: object_bag::new(ctx),
+    }
+}
+
+public(package) fun register_treasury_cap<T>(self: &mut Treasury, treasury_cap: TreasuryCap<T>) {
+    self.objects.add(Key<TreasuryCap<T>> {}, treasury_cap);
+}
+
+public(package) fun register_metadata_cap<T>(self: &mut Treasury, metadata_cap: MetadataCap<T>) {
+    self.objects.add(Key<MetadataCap<T>> {}, metadata_cap);
 }
 
 public(package) fun mint<T>(self: &mut Treasury, amount: u64, ctx: &mut TxContext): Coin<T> {
@@ -48,32 +58,18 @@ public(package) fun mint_balance<T>(self: &mut Treasury, amount: u64): Balance<T
     self.treasury_cap<T>().mint_balance(amount)
 }
 
-public(package) fun register_treasury_cap<T>(self: &mut Treasury, treasury_cap: TreasuryCap<T>) {
-    self.objects.add(Key<TreasuryCap<T>> {}, treasury_cap);
+public(package) fun burn<T>(self: &mut Treasury, balance: Balance<T>) {
+    sui::event::emit(Burned<T> { amount: balance.value() });
+    self.treasury_cap<T>().supply_mut().decrease_supply(balance);
 }
 
-public(package) fun register_metadata_cap<T>(self: &mut Treasury, metadata_cap: MetadataCap<T>) {
-    self.objects.add(Key<MetadataCap<T>> {}, metadata_cap);
+// ~~~~~~~ Private Functions ~~~~~~~
+
+fun treasury_cap<T>(self: &mut Treasury): &mut TreasuryCap<T> {
+    &mut self.objects[Key<TreasuryCap<T>> {}]
 }
 
-//
-// Constructor
-//
-
-public(package) fun create(ctx: &mut TxContext): Treasury {
-    Treasury {
-        objects: object_bag::new(ctx),
-    }
-}
-
-//
-// Events
-//
-
-public struct Minted<phantom T> has copy, drop {
-    amount: u64,
-}
-
-public struct Burned<phantom T> has copy, drop {
-    amount: u64,
+#[allow(unused_function)]
+fun metadata_cap<T>(self: &mut Treasury): &mut MetadataCap<T> {
+    &mut self.objects[Key<MetadataCap<T>> {}]
 }

--- a/packages/hashi/sources/core/validator.move
+++ b/packages/hashi/sources/core/validator.move
@@ -1,12 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Module: validator
+/// Validator registration and metadata maintenance. Entry points let a Sui
+/// validator register as a Hashi committee member and update its next-epoch
+/// BLS key, operator address, endpoint URL, TLS key, and next-epoch
+/// encryption key. Every mutation emits an event for off-chain watchers.
 module hashi::validator;
 
 use hashi::hashi::Hashi;
 use std::string::String;
 use sui::event;
+
+// ~~~~~~~ Events ~~~~~~~
+
+public struct ValidatorRegistered has copy, drop {
+    validator: address,
+}
+
+public struct ValidatorUpdated has copy, drop {
+    validator: address,
+}
+
+// ~~~~~~~ Entry Functions ~~~~~~~
 
 /// Registration and key/metadata updates (below) are deliberately NOT gated
 /// on pause/reconfig: operators must be able to rotate keys and prepare
@@ -93,12 +108,4 @@ entry fun update_next_epoch_encryption_public_key(
         .set_next_epoch_encryption_public_key(validator, next_epoch_encryption_public_key, ctx);
 
     event::emit(ValidatorUpdated { validator });
-}
-
-public struct ValidatorRegistered has copy, drop {
-    validator: address,
-}
-
-public struct ValidatorUpdated has copy, drop {
-    validator: address,
 }

--- a/packages/hashi/sources/core/versioning.move
+++ b/packages/hashi/sources/core/versioning.move
@@ -12,12 +12,18 @@ module hashi::versioning;
 
 use sui::{package::{Self, UpgradeCap, UpgradeTicket, UpgradeReceipt}, vec_set::{Self, VecSet}};
 
+// ~~~~~~~ Constants ~~~~~~~
+
 const PACKAGE_VERSION: u64 = 1;
+
+// ~~~~~~~ Errors ~~~~~~~
 
 #[error(code = 0)]
 const EVersionDisabled: vector<u8> = b"Version disabled";
 #[error(code = 1)]
 const EDisableCurrentVersion: vector<u8> = b"Cannot disable current version";
+
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct Versioning has store {
     /// Package versions allowed to run; gated on every entry.
@@ -27,7 +33,9 @@ public struct Versioning has store {
     upgrade_cap: Option<UpgradeCap>,
 }
 
-// ======== Constructor ========
+// ~~~~~~~ Package Functions ~~~~~~~
+
+// Constructor
 
 public(package) fun create(): Versioning {
     Versioning {
@@ -36,7 +44,7 @@ public(package) fun create(): Versioning {
     }
 }
 
-// ======== Version Management ========
+// Version management
 
 /// Assert that the package version is currently enabled.
 #[allow(implicit_const_copy)]
@@ -53,7 +61,7 @@ public(package) fun enable_version(self: &mut Versioning, version: u64) {
     self.enabled_versions.insert(version);
 }
 
-// ======== Upgrade Management ========
+// Upgrade management
 
 public(package) fun authorize_upgrade(self: &mut Versioning, digest: vector<u8>): UpgradeTicket {
     let policy = sui::package::upgrade_policy(self.upgrade_cap.borrow());

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -1,7 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Module: hashi
+/// The root shared object of the bridge. `Hashi` aggregates every subsystem —
+/// committee set, config, versioning, treasury, governance proposals, and TOB
+/// certificate storage — and hangs per-chain state (e.g. `BitcoinState`) off
+/// its `UID` as dynamic fields. It also provides the package-wide guards
+/// (pause, reconfig, committee-signature verification) that entry functions
+/// in other modules call through, and the one-time `finish_publish` launch
+/// switch that hands the package `UpgradeCap` into on-chain custody.
 module hashi::hashi;
 
 use hashi::{
@@ -17,6 +23,8 @@ use hashi::{
 use std::string::String;
 use sui::{bag::{Self, Bag}, dynamic_field as df};
 
+// ~~~~~~~ Errors ~~~~~~~
+
 #[error]
 const ESystemPaused: vector<u8> = b"System is currently paused";
 #[error]
@@ -25,6 +33,8 @@ const EReconfiguring: vector<u8> = b"System is currently reconfiguring";
 const ENoCommittee: vector<u8> = b"No committee exists for the current epoch";
 #[error]
 const EWrongUpgradeCap: vector<u8> = b"Upgrade cap does not belong to this package";
+
+// ~~~~~~~ Structs ~~~~~~~
 
 public struct Hashi has key {
     id: UID,
@@ -40,66 +50,7 @@ public struct Hashi has key {
     num_consumed_presigs: u64,
 }
 
-#[allow(unused_function)]
-fun init(ctx: &mut TxContext) {
-    let mut hashi = Hashi {
-        id: object::new(ctx),
-        committee_set: hashi::committee_set::create(ctx),
-        config: {
-            let mut config = hashi::config::create();
-            hashi::btc_config::init_defaults(&mut config);
-            hashi::mpc_config::init_defaults(&mut config);
-            config
-        },
-        versioning: versioning::create(),
-        treasury: hashi::treasury::create(ctx),
-        proposals: proposals::create(ctx),
-        tob: bag::new(ctx),
-        num_consumed_presigs: 0,
-    };
-
-    df::add(&mut hashi.id, bitcoin_state::key(), bitcoin_state::new(ctx));
-
-    sui::transfer::share_object(hashi);
-}
-
-public(package) fun assert_unpaused(self: &Hashi) {
-    // Check if state is PAUSED
-    assert!(!self.config().paused(), ESystemPaused);
-}
-
-/// Verify a committee signature over a message.
-/// Returns the certified message (message + signature + stake support).
-public(package) fun verify<T>(
-    self: &Hashi,
-    intent: u16,
-    message: T,
-    sig: CommitteeSignature,
-): CertifiedMessage<T> {
-    let threshold =
-        threshold::certificate_threshold(self.current_committee().total_weight() as u16) as u64;
-    self.current_committee().verify_certificate(intent, message, sig, threshold)
-}
-
-/// Verify a committee signature against a specific committee (not necessarily current).
-/// Used by reconfig which verifies against the next epoch's committee.
-public(package) fun verify_with_committee<T>(
-    _self: &Hashi,
-    committee: &Committee,
-    intent: u16,
-    message: T,
-    sig: CommitteeSignature,
-): CertifiedMessage<T> {
-    let threshold = threshold::certificate_threshold(committee.total_weight() as u16) as u64;
-    committee.verify_certificate(intent, message, sig, threshold)
-}
-
-public(package) fun assert_not_reconfiguring(self: &Hashi) {
-    // Check that we are not reconfiguring
-    assert!(!self.committee_set().is_reconfiguring(), EReconfiguring);
-    // Check that we still don't need to do genesis
-    assert!(self.committee_set().has_committee(self.committee_set().epoch()), ENoCommittee);
-}
+// ~~~~~~~ Entry Functions ~~~~~~~
 
 // The launch switch. Finalizes input parameters, registers BTC, and hands
 // the package's `UpgradeCap` into on-chain custody (`Versioning`) — which is
@@ -158,6 +109,46 @@ entry fun finish_publish(
     let (treasury_cap, metadata_cap) = hashi::btc::create(coin_registry, ctx);
     self.treasury.register_treasury_cap(treasury_cap);
     self.treasury.register_metadata_cap(metadata_cap);
+}
+
+// ~~~~~~~ Package Functions ~~~~~~~
+
+public(package) fun assert_unpaused(self: &Hashi) {
+    // Check if state is PAUSED
+    assert!(!self.config().paused(), ESystemPaused);
+}
+
+/// Verify a committee signature over a message.
+/// Returns the certified message (message + signature + stake support).
+public(package) fun verify<T>(
+    self: &Hashi,
+    intent: u16,
+    message: T,
+    sig: CommitteeSignature,
+): CertifiedMessage<T> {
+    let threshold =
+        threshold::certificate_threshold(self.current_committee().total_weight() as u16) as u64;
+    self.current_committee().verify_certificate(intent, message, sig, threshold)
+}
+
+/// Verify a committee signature against a specific committee (not necessarily current).
+/// Used by reconfig which verifies against the next epoch's committee.
+public(package) fun verify_with_committee<T>(
+    _self: &Hashi,
+    committee: &Committee,
+    intent: u16,
+    message: T,
+    sig: CommitteeSignature,
+): CertifiedMessage<T> {
+    let threshold = threshold::certificate_threshold(committee.total_weight() as u16) as u64;
+    committee.verify_certificate(intent, message, sig, threshold)
+}
+
+public(package) fun assert_not_reconfiguring(self: &Hashi) {
+    // Check that we are not reconfiguring
+    assert!(!self.committee_set().is_reconfiguring(), EReconfiguring);
+    // Check that we still don't need to do genesis
+    assert!(self.committee_set().has_committee(self.committee_set().epoch()), ENoCommittee);
 }
 
 public(package) fun id(self: &Hashi): &UID {
@@ -246,7 +237,32 @@ public(package) fun reset_num_consumed_presigs(self: &mut Hashi) {
     self.num_consumed_presigs = 0;
 }
 
-// ======== Test-only Functions ========
+// ~~~~~~~ Private Functions ~~~~~~~
+
+#[allow(unused_function)]
+fun init(ctx: &mut TxContext) {
+    let mut hashi = Hashi {
+        id: object::new(ctx),
+        committee_set: hashi::committee_set::create(ctx),
+        config: {
+            let mut config = hashi::config::create();
+            hashi::btc_config::init_defaults(&mut config);
+            hashi::mpc_config::init_defaults(&mut config);
+            config
+        },
+        versioning: versioning::create(),
+        treasury: hashi::treasury::create(ctx),
+        proposals: proposals::create(ctx),
+        tob: bag::new(ctx),
+        num_consumed_presigs: 0,
+    };
+
+    df::add(&mut hashi.id, bitcoin_state::key(), bitcoin_state::new(ctx));
+
+    sui::transfer::share_object(hashi);
+}
+
+// ~~~~~~~ Test Helpers ~~~~~~~
 
 #[test_only]
 public(package) fun tob_contains(self: &Hashi, key: hashi::tob::TobKey): bool {

--- a/packages/hashi/tests/reconfig_tests.move
+++ b/packages/hashi/tests/reconfig_tests.move
@@ -7,6 +7,8 @@ module hashi::reconfig_tests;
 use hashi::{reconfig, test_utils};
 
 const VOTER1: address = @0x1;
+const VOTER2: address = @0x2;
+const VOTER3: address = @0x3;
 
 #[test]
 #[expected_failure(abort_code = reconfig::EGenesisNotAuthorized)]
@@ -35,5 +37,145 @@ fun test_genesis_gate_skipped_after_bootstrap() {
     hashi.committee_set_mut().set_mpc_public_key_for_testing(vector[1]);
 
     reconfig::assert_genesis_launch_authorized(&hashi);
+    std::unit_test::destroy(hashi);
+}
+
+fun pending_committee_for_testing(epoch: u64): hashi::committee::Committee {
+    use hashi::{committee, mpc_config};
+    use sui::bls12381;
+
+    let sk = test_utils::bls_sk_for_testing();
+    let public_key = bls12381::g1_to_uncompressed_g1(
+        &bls12381::g1_from_bytes(&test_utils::bls_min_pk_from_sk(&sk)),
+    );
+    let members = vector[
+        committee::new_committee_member(VOTER1, public_key, sk, 1),
+        committee::new_committee_member(VOTER2, public_key, sk, 1),
+        committee::new_committee_member(VOTER3, public_key, sk, 1),
+    ];
+    committee::new_committee(epoch, members, mpc_config::new_for_testing(3334, 800, 3333, 0))
+}
+
+fun cert_message<T: copy + drop + store>(epoch: u64, intent: u16, message: &T): vector<u8> {
+    use sui::bcs;
+
+    let mut bytes = bcs::to_bytes(&intent);
+    bytes.append(bcs::to_bytes(&epoch));
+    bytes.append(bcs::to_bytes(message));
+    bytes
+}
+
+#[test]
+fun test_end_reconfig_stores_committee_handoff() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let next_epoch = 1;
+    let next_committee = pending_committee_for_testing(next_epoch);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
+
+    let mpc_public_key = vector[1, 2, 3];
+    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
+    let mpc_message = reconfig::reconfig_completion_message_for_testing(
+        next_epoch,
+        mpc_public_key,
+    );
+    let mpc_cert = test_utils::sign_certificate(
+        next_epoch,
+        &cert_message(next_epoch, hashi::intent::reconfig_completion(), &mpc_message),
+        3,
+    );
+    let handoff_message = reconfig::committee_transition_request_for_testing(next_committee);
+    let committee_handoff_cert = test_utils::sign_certificate(
+        0,
+        &cert_message(0, hashi::intent::committee_transition(), &handoff_message),
+        3,
+    );
+
+    reconfig::submit_committee_handoff_for_testing(&mut hashi, committee_handoff_cert, ctx);
+    reconfig::end_reconfig_for_testing(&mut hashi, mpc_public_key, mpc_cert, ctx);
+
+    assert!(hashi.committee_set().epoch() == next_epoch);
+    assert!(hashi.committee_set().has_committee_handoff_for_testing(0));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure]
+fun test_end_reconfig_requires_committee_handoff_after_initial_reconfig() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let next_epoch = 1;
+    let next_committee = pending_committee_for_testing(next_epoch);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
+
+    let mpc_public_key = vector[1];
+    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
+    let mpc_message = reconfig::reconfig_completion_message_for_testing(
+        next_epoch,
+        mpc_public_key,
+    );
+    let mpc_cert = test_utils::sign_certificate(
+        next_epoch,
+        &cert_message(next_epoch, hashi::intent::reconfig_completion(), &mpc_message),
+        3,
+    );
+
+    reconfig::end_reconfig_for_testing(&mut hashi, mpc_public_key, mpc_cert, ctx);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = reconfig::EInitialReconfig)]
+fun test_submit_committee_handoff_rejects_initial_reconfig() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let next_epoch = 1;
+    let next_committee = pending_committee_for_testing(next_epoch);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
+
+    let handoff_message = reconfig::committee_transition_request_for_testing(next_committee);
+    let committee_handoff_cert = test_utils::sign_certificate(
+        0,
+        &cert_message(0, hashi::intent::committee_transition(), &handoff_message),
+        3,
+    );
+
+    reconfig::submit_committee_handoff_for_testing(&mut hashi, committee_handoff_cert, ctx);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure]
+fun test_submit_committee_handoff_rejects_handoff_signed_by_wrong_committee() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let next_epoch = 1;
+    let next_committee = pending_committee_for_testing(next_epoch);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(next_committee);
+
+    let mpc_public_key = vector[1];
+    hashi.committee_set_mut().set_mpc_public_key_for_testing(mpc_public_key);
+    let mpc_message = reconfig::reconfig_completion_message_for_testing(
+        next_epoch,
+        mpc_public_key,
+    );
+    let mpc_cert = test_utils::sign_certificate(
+        next_epoch,
+        &cert_message(next_epoch, hashi::intent::reconfig_completion(), &mpc_message),
+        3,
+    );
+    let handoff_message = reconfig::committee_transition_request_for_testing(next_committee);
+    let committee_handoff_cert = test_utils::sign_certificate(
+        next_epoch,
+        &cert_message(next_epoch, hashi::intent::committee_transition(), &handoff_message),
+        3,
+    );
+
+    reconfig::submit_committee_handoff_for_testing(&mut hashi, committee_handoff_cert, ctx);
+    reconfig::end_reconfig_for_testing(&mut hashi, mpc_public_key, mpc_cert, ctx);
     std::unit_test::destroy(hashi);
 }

--- a/packages/hashi/tests/threshold_tests.move
+++ b/packages/hashi/tests/threshold_tests.move
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module hashi::threshold_tests;
+
+use hashi::threshold;
+
+#[test]
+fun test_certificate_threshold() {
+    // 6667 bps of 3 -> ceil(3*6667/10000) = ceil(2.0001) = 3.
+    assert!(threshold::certificate_threshold(3) == 3);
+    // 6667 bps of 10 -> ceil(66670/10000) = 7.
+    assert!(threshold::certificate_threshold(10) == 7);
+    // 6667 bps of 6 -> ceil(40002/10000) = 5.
+    assert!(threshold::certificate_threshold(6) == 5);
+    // 6667 bps of 1 -> ceil(6667/10000) = 1.
+    assert!(threshold::certificate_threshold(1) == 1);
+    // 6667 bps of 0 = 0.
+    assert!(threshold::certificate_threshold(0) == 0);
+    // Matches Sui system: 6667 bps of 10000 = 6667.
+    assert!(threshold::certificate_threshold(10000) == 6667);
+}
+
+#[test]
+fun test_weight_threshold_basic() {
+    // 66.67% of 3 -> 3*6667 = 20001 -> ceil(20001/10000) = 3.
+    assert!(threshold::weight_threshold(3, 6667) == 3);
+    // 66.67% of 6 -> 6*6667 = 40002 -> ceil(40002/10000) = 5.
+    assert!(threshold::weight_threshold(6, 6667) == 5);
+    // 66.67% of 10 -> 10*6667 = 66670 -> ceil(66670/10000) = 7.
+    assert!(threshold::weight_threshold(10, 6667) == 7);
+}
+
+#[test]
+fun test_weight_threshold_unanimity() {
+    // 100% always requires all weight.
+    assert!(threshold::weight_threshold(1, 10000) == 1);
+    assert!(threshold::weight_threshold(3, 10000) == 3);
+    assert!(threshold::weight_threshold(100, 10000) == 100);
+}
+
+#[test]
+fun test_weight_threshold_zero() {
+    // 0 bps requires no weight.
+    assert!(threshold::weight_threshold(100, 0) == 0);
+    // Any threshold of 0 total weight requires 0.
+    assert!(threshold::weight_threshold(0, 6667) == 0);
+}
+
+#[test]
+fun test_weight_threshold_exact_division() {
+    // 50% of 10 = 5 (exact, no rounding needed).
+    assert!(threshold::weight_threshold(10, 5000) == 5);
+    // 25% of 100 = 25.
+    assert!(threshold::weight_threshold(100, 2500) == 25);
+}
+
+#[test]
+fun test_weight_threshold_rounds_up() {
+    // 50% of 3 = 1.5 -> 2.
+    assert!(threshold::weight_threshold(3, 5000) == 2);
+    // 1 bps of 1 = 0.0001 -> 1.
+    assert!(threshold::weight_threshold(1, 1) == 1);
+    // 33.33% of 10 = 3.333 -> 4.
+    assert!(threshold::weight_threshold(10, 3333) == 4);
+}
+
+#[test]
+#[expected_failure(abort_code = threshold::EThresholdBpsTooHigh)]
+fun test_weight_threshold_rejects_above_10000() {
+    threshold::weight_threshold(100, 10001);
+}


### PR DESCRIPTION
Follow-up to #788: package-wide reorganization of all 33 Move modules to one canonical layout, before testnet freezes the package as the long-lived reference. **Reorder-only** — no function bodies, signatures, or visibilities changed (one scoped exception below).

## The canonical layout

```
/// Module doc comment (real paragraph, required)
// ~~~~~~~ Constants ~~~~~~~
// ~~~~~~~ Errors ~~~~~~~
// ~~~~~~~ Structs ~~~~~~~          enums + domain structs
// ~~~~~~~ Events ~~~~~~~           event structs, directly after — whole data model reads first
// ~~~~~~~ Entry Functions ~~~~~~~  lifecycle order
// ~~~~~~~ Public Functions ~~~~~~~
// ~~~~~~~ Package Functions ~~~~~~~
// ~~~~~~~ Private Functions ~~~~~~~
// ~~~~~~~ Test Helpers ~~~~~~~     #[test_only] only, always last
```

Also: committee-signed message structs (withdraw, deposit) now carry BCS-frozen banner comments; struct fields follow id → identity → config → lifecycle-state → resources; every module has a real doc paragraph.

## Test migration (the one code addition)

In-module `#[test]`s are gone package-wide:
- `threshold.move`'s 7 tests → new `tests/threshold_tests.move`.
- `reconfig.move`'s 4 tests → `tests/reconfig_tests.move`. They exercised non-public entries and private-field message structs, so reconfig gains `#[test_only]` forwarders (`end_reconfig_for_testing`, `submit_committee_handoff_for_testing`) and message constructors — same pattern as `finish_publish_for_testing`. Test names and assertions unchanged.

## Verification

- Reorder-only proven mechanically per chunk: the sorted multiset of non-comment, non-blank lines is identical between base and result for every reorganized file (new doc/banner comments excluded); function signature sets identical.
- Move suite 148/148 after every chunk (four commits, each independently green).
- Workspace build + clippy clean; prettier-move reports all files already conformant.
- e2e smokes on the final result: `test_dkg` and `test_bitcoin_withdrawal_e2e_flow` (the heaviest reorganized modules are the withdrawal path) both pass.