### PR TITLE
[guardian] Enable a real-attestation ceremony enclave

### DIFF
--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -354,6 +354,22 @@ impl Drop for LimiterGuard {
     }
 }
 
+/// Build identity for `GuardianInfo.untrusted_git_revision` / the `PcrAllowlist`
+/// key. A real ceremony enclave is a distinct measured build (its own PCR0) from
+/// the same-commit withdraw enclave, so it reports a distinct identity — the
+/// allowlist forbids two entries per revision, so otherwise the withdraw enclave
+/// and KPs couldn't pin both PCR0s. `test`/`non-enclave-dev` skip attestation and
+/// share one entry, so the suffix is compiled out (existing mock flow unchanged).
+fn reported_git_revision(mode: EnclaveMode) -> String {
+    // Injected at build time (docker/CI); defaults outside a real build.
+    let base = option_env!("GIT_REVISION").unwrap_or("unknown");
+    if cfg!(not(any(test, feature = "non-enclave-dev"))) && mode == EnclaveMode::Ceremony {
+        format!("{base}-ceremony")
+    } else {
+        base.to_string()
+    }
+}
+
 impl Enclave {
     // ========================================================================
     // Construction & Initialization Status
@@ -494,8 +510,7 @@ impl Enclave {
                 .map(|l| l.bucket_info().clone()),
             encryption_pubkey: self.encryption_public_key().to_bytes().to_vec(),
             config_hash: self.config_hash(),
-            // Injected at build time (docker/CI); defaults outside a real build.
-            untrusted_git_revision: option_env!("GIT_REVISION").unwrap_or("unknown").to_string(),
+            untrusted_git_revision: reported_git_revision(self.mode()),
             enclave_btc_pubkey: self.config.enclave_btc_pubkey().ok(),
             limiter_state: self.state.limiter_state().await,
             limiter_config: match self.state.limiter_config().await {

--- a/docker/hashi-guardian/Containerfile
+++ b/docker/hashi-guardian/Containerfile
@@ -135,6 +135,10 @@ ARG GIT_REVISION
 # enclave build — leave it empty for anything whose PCR0 must match provenance.
 # Dev deploys pass `non-enclave-dev` so a runner-local mock ceremony verifies.
 ARG FEATURES=""
+# Enclave boot mode, baked into run.sh below (see guardian main.rs). Empty (the
+# default) => withdraw; "true" => ceremony. A ceremony enclave is intentionally a
+# distinct, separately-attested EIF with its own PCR0.
+ARG CEREMONY_MODE=""
 RUN [ -n "$GIT_REVISION" ] || { echo "GIT_REVISION build-arg must be set"; exit 1; }
 ENV GIT_REVISION=${GIT_REVISION}
 COPY crates /crates
@@ -159,7 +163,7 @@ COPY --from=user-socat /bin/socat . initramfs
 RUN cp /target/${TARGET}/release/hashi-guardian initramfs/guardian
 # run.sh is the enclave init: the kernel execs /init as PID 1.
 COPY docker/hashi-guardian/run.sh initramfs/init
-RUN sed -i "s/\${BUCKET_NAME}/${BUCKET_NAME}/g; s/\${AWS_REGION}/${AWS_REGION}/g" initramfs/init
+RUN sed -i "s/\${BUCKET_NAME}/${BUCKET_NAME}/g; s/\${AWS_REGION}/${AWS_REGION}/g; s/\${CEREMONY_MODE}/${CEREMONY_MODE}/g" initramfs/init
 RUN chmod 755 initramfs/init
 
 COPY <<-EOF initramfs/etc/environment

--- a/docker/hashi-guardian/Makefile
+++ b/docker/hashi-guardian/Makefile
@@ -4,6 +4,8 @@ AWS_REGION ?= us-east-1
 GIT_REVISION ?= $(shell git -C ../.. describe --always --exclude '*' --dirty --abbrev=8)
 # Extra cargo features; empty = the real enclave build (see Containerfile).
 FEATURES ?=
+# Enclave boot mode; empty = withdraw, "true" = ceremony (see Containerfile).
+CEREMONY_MODE ?=
 
 .DEFAULT_GOAL :=
 .PHONY: default
@@ -24,6 +26,7 @@ out/nitro.eif: $(shell git ls-files ../../crates/hashi-guardian ../../crates/has
 		--build-arg AWS_REGION=$(AWS_REGION) \
 		--build-arg GIT_REVISION=$(GIT_REVISION) \
 		--build-arg FEATURES=$(FEATURES) \
+		--build-arg CEREMONY_MODE=$(CEREMONY_MODE) \
 		-f Containerfile \
 		../..
 

--- a/docker/hashi-guardian/run.sh
+++ b/docker/hashi-guardian/run.sh
@@ -57,4 +57,10 @@ socat TCP4-LISTEN:443,bind=127.0.0.66,reuseaddr,fork VSOCK-CONNECT:3:8103 &
 # Forward VSOCK port 3000 to localhost:3000 (gRPC server)
 socat VSOCK-LISTEN:3000,reuseaddr,fork TCP:localhost:3000 &
 
+# CEREMONY_MODE selects ceremony vs withdraw mode (see guardian main.rs). A real
+# Nitro PID 1 starts with an empty environment, so it is baked here at build time
+# via the Containerfile (like BUCKET_NAME/AWS_REGION); empty => withdraw, "true"
+# => ceremony. A ceremony enclave is therefore a distinct EIF with its own PCR0.
+export CEREMONY_MODE=${CEREMONY_MODE}
+
 exec /guardian


### PR DESCRIPTION
Enables a fully **attestation-verified** guardian key ceremony: a real Nitro **ceremony** enclave (distinct from the withdraw enclave) whose ceremony log the real withdraw enclave can verify during `operator_init`. Two pieces:

1. **`CEREMONY_MODE` build arg** — threads `CEREMONY_MODE` through Makefile → Containerfile → `run.sh` (baked via sed, like `FEATURES`/`BUCKET_NAME`) so the real EIF can be built ceremony-mode with its own PCR0. Empty (the default) leaves the withdraw EIF byte-identical.
2. **Distinct build identity** — a real ceremony enclave reports `<git_revision>-ceremony`. Without it, `PcrAllowlist::new` rejects the ceremony+withdraw pair (same commit → same `git_revision`, different PCR0), so the withdraw enclave can't pin the ceremony PCR0 to verify the ceremony log. Compiled out under `test`/`non-enclave-dev` (attestation is a no-op and both modes share one allowlist entry — the existing mock flow is unchanged).

Config then holds both builds: withdraw = `current_build`, ceremony = `prev_build`.

Companion: MystenLabs/sui-operations#8354 (`eif-ceremony-mode` deploy knob). This touches the attestation/allowlist model (Deepak's domain) and should get his review before merge.
