### PR TITLE
[guardian] enclave: export SSL_CERT_FILE so the guardian trusts S3 TLS

### DIFF
--- a/crates/hashi/src/grpc/guardian_client.rs
+++ b/crates/hashi/src/grpc/guardian_client.rs
@@ -8,6 +8,7 @@ use axum::http;
 use sui_http::middleware::callback::CallbackLayer;
 use tonic::body::Body;
 use tonic::transport::Channel;
+use tonic::transport::ClientTlsConfig;
 use tonic::transport::Endpoint;
 use tower::ServiceBuilder;
 use tower::util::BoxCloneService;
@@ -43,12 +44,19 @@ impl std::fmt::Debug for GuardianClient {
 
 impl GuardianClient {
     pub fn new(endpoint: &str) -> Result<Self, tonic::Status> {
-        let channel = Endpoint::from_shared(endpoint.to_string())
+        let mut builder = Endpoint::from_shared(endpoint.to_string())
             .map_err(Into::<BoxError>::into)
             .map_err(tonic::Status::from_error)?
             .connect_timeout(Duration::from_secs(5))
-            .http2_keep_alive_interval(Duration::from_secs(5))
-            .connect_lazy();
+            .http2_keep_alive_interval(Duration::from_secs(5));
+        // tonic rejects an https:// endpoint without a TLS config; http:// stays plaintext.
+        if endpoint.starts_with("https://") {
+            builder = builder
+                .tls_config(ClientTlsConfig::new().with_webpki_roots())
+                .map_err(Into::<BoxError>::into)
+                .map_err(tonic::Status::from_error)?;
+        }
+        let channel = builder.connect_lazy();
         Ok(Self {
             endpoint: endpoint.to_string(),
             channel,

--- a/docker/hashi-guardian/run.sh
+++ b/docker/hashi-guardian/run.sh
@@ -13,9 +13,7 @@
 set -e
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/
 export LD_LIBRARY_PATH=/lib:$LD_LIBRARY_PATH
-# The guardian's TLS clients (S3, Sui RPC) verify against this bundle; the enclave
-# has no system trust store, and a bare init never sources /etc/environment (where
-# the Containerfile also sets it). Without it: "invalid peer certificate: UnknownIssuer".
+# The enclave has no system CA store; point TLS clients (S3, Sui) at the bundled certs.
 export SSL_CERT_FILE=/ca-certificates.crt
 echo "run.sh script is running"
 

--- a/docker/hashi-guardian/run.sh
+++ b/docker/hashi-guardian/run.sh
@@ -13,6 +13,10 @@
 set -e
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/
 export LD_LIBRARY_PATH=/lib:$LD_LIBRARY_PATH
+# The guardian's TLS clients (S3, Sui RPC) verify against this bundle; the enclave
+# has no system trust store, and a bare init never sources /etc/environment (where
+# the Containerfile also sets it). Without it: "invalid peer certificate: UnknownIssuer".
+export SSL_CERT_FILE=/ca-certificates.crt
 echo "run.sh script is running"
 
 # The Nitro loader hands us a bare initramfs root; mount the pseudo-filesystems.


### PR DESCRIPTION
## Summary

The guardian runs in the Nitro enclave, which ships no system CA store, so its TLS clients had no roots to trust and `OperatorInit`'s S3 call failed with `invalid peer certificate: UnknownIssuer`. The CA bundle is already baked into the EIF; nothing pointed at it.

## Changes

- `run.sh`: export `SSL_CERT_FILE=/ca-certificates.crt` so the guardian's S3 and Sui RPC clients trust the bundled certs. (The Containerfile already writes this into `/etc/environment`, but a bare PID-1 init never sources that file.)
