### PR TITLE
[guardian] node: TLS for the guardian gRPC client (https endpoints)

### DIFF
--- a/crates/hashi/src/grpc/guardian_client.rs
+++ b/crates/hashi/src/grpc/guardian_client.rs
@@ -8,6 +8,7 @@ use axum::http;
 use sui_http::middleware::callback::CallbackLayer;
 use tonic::body::Body;
 use tonic::transport::Channel;
+use tonic::transport::ClientTlsConfig;
 use tonic::transport::Endpoint;
 use tower::ServiceBuilder;
 use tower::util::BoxCloneService;
@@ -43,12 +44,22 @@ impl std::fmt::Debug for GuardianClient {
 
 impl GuardianClient {
     pub fn new(endpoint: &str) -> Result<Self, tonic::Status> {
-        let channel = Endpoint::from_shared(endpoint.to_string())
+        let mut builder = Endpoint::from_shared(endpoint.to_string())
             .map_err(Into::<BoxError>::into)
             .map_err(tonic::Status::from_error)?
             .connect_timeout(Duration::from_secs(5))
-            .http2_keep_alive_interval(Duration::from_secs(5))
-            .connect_lazy();
+            .http2_keep_alive_interval(Duration::from_secs(5));
+        // A public guardian/proxy endpoint is HTTPS (CA-signed at the ALB). tonic
+        // rejects an https:// URI with no TLS config (HttpsUriWithoutTlsSupport),
+        // which fails limiter bootstrap + committee reconcile. Enable webpki roots
+        // for https; http:// (in-cluster, local, tests) stays plaintext h2c.
+        if endpoint.starts_with("https://") {
+            builder = builder
+                .tls_config(ClientTlsConfig::new().with_webpki_roots())
+                .map_err(Into::<BoxError>::into)
+                .map_err(tonic::Status::from_error)?;
+        }
+        let channel = builder.connect_lazy();
         Ok(Self {
             endpoint: endpoint.to_string(),
             channel,

--- a/crates/hashi/src/grpc/guardian_client.rs
+++ b/crates/hashi/src/grpc/guardian_client.rs
@@ -49,10 +49,7 @@ impl GuardianClient {
             .map_err(tonic::Status::from_error)?
             .connect_timeout(Duration::from_secs(5))
             .http2_keep_alive_interval(Duration::from_secs(5));
-        // A public guardian/proxy endpoint is HTTPS (CA-signed at the ALB). tonic
-        // rejects an https:// URI with no TLS config (HttpsUriWithoutTlsSupport),
-        // which fails limiter bootstrap + committee reconcile. Enable webpki roots
-        // for https; http:// (in-cluster, local, tests) stays plaintext h2c.
+        // tonic rejects an https:// endpoint without a TLS config; http:// stays plaintext.
         if endpoint.starts_with("https://") {
             builder = builder
                 .tls_config(ClientTlsConfig::new().with_webpki_roots())


### PR DESCRIPTION
## Summary

The nodes talk to the guardian over gRPC, but the client built its tonic channel with no TLS config. Now that the guardian sits behind a public HTTPS proxy, every call failed at connect (`HttpsUriWithoutTlsSupport`), so no node could bootstrap its rate limiter or reconcile the committee.

## Changes

- `guardian_client.rs`: give the tonic endpoint a webpki-roots TLS config for `https://` URLs; `http://` (in-cluster, local, tests) stays plaintext h2c.
