### PR TITLE
docs: Fix operator runbook config template and key-setup guidance

### DIFF
--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -178,11 +178,17 @@ bitcoin-cli -signet getnetworkinfo                        # NODE_COMPACT_FILTERS
 
 ### 2.2 TLS key (dedicated)
 
-Generate a fresh Ed25519 TLS key dedicated to your Hashi node, separate from your Sui validator's TLS key, for clean separation of concerns. This key authenticates your Hashi node to other committee members, and the node registers the corresponding public key onchain during registration. Set `tls-private-key` to a PKCS#8 PEM/DER file path or an inline PEM string.
+Generate a fresh Ed25519 TLS key dedicated to your Hashi node, separate from your Sui validator's TLS key, for clean separation of concerns. This key authenticates your Hashi node to other committee members, and the node registers the corresponding public key onchain during registration. Set `tls-private-key` to a PKCS#8 PEM/DER file path or an inline PEM string:
+
+```bash
+openssl genpkey -algorithm ed25519 -out tls-private-key.pem
+```
 
 ```toml
 tls-private-key = "/path/to/tls-private-key.pem"
 ```
+
+Make sure the file is readable by the user running `hashi` (e.g. `chmod 600` owned by that user) — `hashi register` needs it to include your TLS public key in the registration transaction.
 
 > A planned enhancement is for the node to generate its TLS key on startup, removing this manual step.
 
@@ -195,10 +201,12 @@ Because that key is typically in cold storage or a hardware wallet, use the **of
 ```bash
 # Emit the unsigned registration tx (no private key required)
 hashi register --config /path/to/validator.toml \
-  --operator-address 0x<your-operator-address> \
+  --operator-address 0x<operator-address> \
   --print-only
 # -> sign the printed base64 tx with the validator account key (cold/hardware) and broadcast
 ```
+
+`--operator-address` is the Sui address of the **fresh operator key** you generate in [2.4](#24-operator-key-day-to-day-signing) — it is *not* your validator address. Passing it here delegates day-to-day signing in the same transaction, so the validator account key can go straight back to cold storage.
 
 > Do **not** rely on the plain `hashi register` (execute) path for the first registration unless your configured `operator-private-key` *is* the validator account key. The builder forces the sender to the validator address while the execute path signs with the operator key, producing a signer/sender mismatch.
 
@@ -231,7 +239,7 @@ operator-private-key = "/path/to/hashi-operator-key.pem"
 
 > A raw hex private key (the `hexWithoutFlag` output of `sui keytool convert`) is **not** accepted, because it does not carry the key-scheme flag. Convert it to one of the formats above with `sui keytool convert`.
 
-**Delegating to the operator key.** After registration (signed by the validator account key, see [2.3](#23-registration-must-be-signed-by-the-account-key)), authorize the operator key by setting it as the member's operator address with `--operator-address`:
+**Delegating to the operator key.** Delegation is set with `--operator-address`, normally passed during initial registration as shown in [2.3](#23-registration-must-be-signed-by-the-account-key) — one transaction registers *and* delegates. If you registered without it (or are rotating the operator key), run the same command again; it is idempotent and sends only the missing updates, but the transaction must again be signed by the validator account key:
 
 ```bash
 hashi register --config /path/to/validator.toml \
@@ -253,10 +261,14 @@ Hashi creates encrypted backups of critical state (MPC key shares, DB, config) e
 - **Option 1 (recommended): YubiKey.** Generate the key on the device; the private key never leaves it.
 - **Option 2: local OpenPGP key.** Generate with `sq` or `gpg`.
 
-Set the armored public certificate (inline or a path) in the node config:
+Set the armored public certificate **inline** in the node config, as a TOML multi-line string. The config field does not resolve file paths (a path fails with `invalid OpenPGP certificate`); only the `hashi backup save --backup-pgp-cert` CLI override accepts a path:
 
 ```toml
-backup-pgp-cert = "/path/to/hashi-backup-cert.asc"   # armored OpenPGP public cert, or inline armored text
+backup-pgp-cert = """
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+...
+-----END PGP PUBLIC KEY BLOCK-----
+"""
 backup-dir = "/var/lib/hashi/backups"
 ```
 
@@ -274,6 +286,8 @@ Hashi uses two configuration files:
 ### 3.1 Validator config
 
 All fields use kebab-case. Optional fields show their defaults in comments.
+
+> **Field order matters.** In TOML, every key that appears after a `[section]` header belongs to that section. Keep all top-level keys **above** the `[hashi-ids]` and `[bitcoin-rpc-auth]` sections (as in the template below); a top-level key placed after a section header is rejected at startup with an unknown-field error.
 
 ```toml
 # ── Identity ──────────────────────────────────────────────────────────
@@ -332,8 +346,14 @@ db = "/var/lib/hashi/db"
 
 # ── Backup (OpenPGP / Sequoia) ────────────────────────────────────────
 
-# Armored OpenPGP public certificate (file path or inline) for encrypted backups
-# backup-pgp-cert = "/path/to/hashi-backup-cert.asc"
+# Armored OpenPGP public certificate for encrypted backups. Inline armored
+# text only (use a TOML multi-line string) — file paths are NOT resolved for
+# this field (only the `hashi backup save --backup-pgp-cert` CLI flag takes a path).
+# backup-pgp-cert = """
+# -----BEGIN PGP PUBLIC KEY BLOCK-----
+# ...
+# -----END PGP PUBLIC KEY BLOCK-----
+# """
 
 # Backup output directory (default: /tmp)
 # backup-dir = "/var/lib/hashi/backups"
@@ -373,7 +393,7 @@ db = "/var/lib/hashi/db"
 # TOML table headers apply to every following key until the next table,
 # so keep all root-level settings above this section.
 
-# Hashi package and object IDs (provided after package publication)
+# Hashi package and object IDs. Use your network's values from the Networks table.
 [hashi-ids]
 package-id = "0x<package-id>"
 hashi-object-id = "0x<hashi-object-id>"

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -188,7 +188,7 @@ openssl genpkey -algorithm ed25519 -out tls-private-key.pem
 tls-private-key = "/path/to/tls-private-key.pem"
 ```
 
-Make sure the file is readable by the user running `hashi` (e.g. `chmod 600` owned by that user) — `hashi register` needs it to include your TLS public key in the registration transaction.
+Make sure the file is readable by the user running `hashi` (for example, `chmod 600` owned by that user). `hashi register` needs it to include your TLS public key in the registration transaction.
 
 > A planned enhancement is for the node to generate its TLS key on startup, removing this manual step.
 
@@ -206,7 +206,7 @@ hashi register --config /path/to/validator.toml \
 # -> sign the printed base64 tx with the validator account key (cold/hardware) and broadcast
 ```
 
-`--operator-address` is the Sui address of the **fresh operator key** you generate in [2.4](#24-operator-key-day-to-day-signing) — it is *not* your validator address. Passing it here delegates day-to-day signing in the same transaction, so the validator account key can go straight back to cold storage.
+`--operator-address` is the Sui address of the **fresh operator key** you generate in [2.4](#24-operator-key-day-to-day-signing). It is *not* your validator address. Passing it here delegates day-to-day signing in the same transaction, so the validator account key can go straight back to cold storage.
 
 > Do **not** rely on the plain `hashi register` (execute) path for the first registration unless your configured `operator-private-key` *is* the validator account key. The builder forces the sender to the validator address while the execute path signs with the operator key, producing a signer/sender mismatch.
 
@@ -239,7 +239,7 @@ operator-private-key = "/path/to/hashi-operator-key.pem"
 
 > A raw hex private key (the `hexWithoutFlag` output of `sui keytool convert`) is **not** accepted, because it does not carry the key-scheme flag. Convert it to one of the formats above with `sui keytool convert`.
 
-**Delegating to the operator key.** Delegation is set with `--operator-address`, normally passed during initial registration as shown in [2.3](#23-registration-must-be-signed-by-the-account-key) — one transaction registers *and* delegates. If you registered without it (or are rotating the operator key), run the same command again; it is idempotent and sends only the missing updates, but the transaction must again be signed by the validator account key:
+**Delegating to the operator key.** Delegation is set with `--operator-address`, normally passed during initial registration as shown in [2.3](#23-registration-must-be-signed-by-the-account-key), so one transaction registers *and* delegates. If you registered without it (or are rotating the operator key), run the same command again; it is idempotent and sends only the missing updates, but the transaction must again be signed by the validator account key:
 
 ```bash
 hashi register --config /path/to/validator.toml \
@@ -347,7 +347,7 @@ db = "/var/lib/hashi/db"
 # ── Backup (OpenPGP / Sequoia) ────────────────────────────────────────
 
 # Armored OpenPGP public certificate for encrypted backups. Inline armored
-# text only (use a TOML multi-line string) — file paths are NOT resolved for
+# text only (use a TOML multi-line string); file paths are NOT resolved for
 # this field (only the `hashi backup save --backup-pgp-cert` CLI flag takes a path).
 # backup-pgp-cert = """
 # -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -113,7 +113,7 @@ For the **JSON-RPC** channel you can run your own archival Signet node or use a 
 
 The **P2P / BIP-157** channel (the embedded light client's compact-filter sync) needs a peer that serves filters (`peerblockfilters=1`). Run your own Signet node for this, or use a provider that exposes Signet P2P with compact-filter serving. The simplest setup that satisfies both channels is a single self-hosted archival Signet node.
 
-**RPC methods Hashi calls** (so you can scope RPC permissions): `getrawtransaction` (verbose), `sendrawtransaction`, `estimatesmartfee`, `gettxout`, `getblockchaininfo`, `getblockheader` (verbose). Hashi targets **Bitcoin Core v29**.
+**RPC methods Hashi calls** (so you can scope RPC permissions): `getrawtransaction` (verbose), `sendrawtransaction`, `estimatesmartfee`, `gettxout`, `getblockchaininfo`, `getblockheader` (verbose). Hashi requires **Bitcoin Core v29 or newer**; the latest release works fine.
 
 **`bitcoin.conf`, run as an archival, non-pruned node** (Signet shown; for another network use its ports and network flag from the [Networks](#networks) table):
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -261,14 +261,10 @@ Hashi creates encrypted backups of critical state (MPC key shares, DB, config) e
 - **Option 1 (recommended): YubiKey.** Generate the key on the device; the private key never leaves it.
 - **Option 2: local OpenPGP key.** Generate with `sq` or `gpg`.
 
-Set the armored public certificate **inline** in the node config, as a TOML multi-line string. The config field does not resolve file paths (a path fails with `invalid OpenPGP certificate`); only the `hashi backup save --backup-pgp-cert` CLI override accepts a path:
+Set the armored public certificate (a file path or inline armored text) in the node config:
 
 ```toml
-backup-pgp-cert = """
------BEGIN PGP PUBLIC KEY BLOCK-----
-...
------END PGP PUBLIC KEY BLOCK-----
-"""
+backup-pgp-cert = "/path/to/hashi-backup-cert.asc"   # armored OpenPGP public cert, or inline armored text
 backup-dir = "/var/lib/hashi/backups"
 ```
 
@@ -346,14 +342,8 @@ db = "/var/lib/hashi/db"
 
 # ── Backup (OpenPGP / Sequoia) ────────────────────────────────────────
 
-# Armored OpenPGP public certificate for encrypted backups. Inline armored
-# text only (use a TOML multi-line string); file paths are NOT resolved for
-# this field (only the `hashi backup save --backup-pgp-cert` CLI flag takes a path).
-# backup-pgp-cert = """
-# -----BEGIN PGP PUBLIC KEY BLOCK-----
-# ...
-# -----END PGP PUBLIC KEY BLOCK-----
-# """
+# Armored OpenPGP public certificate (file path or inline) for encrypted backups
+# backup-pgp-cert = "/path/to/hashi-backup-cert.asc"
 
 # Backup output directory (default: /tmp)
 # backup-dir = "/var/lib/hashi/backups"


### PR DESCRIPTION
Fixes for issues validators hit during testnet onboarding (reported by ContributionDAO, Staking Facilities, Chainode Tech, Brightlystake, and Michal Zegarek in the operator channel).

> **Rebased twice over overlapping main work** (#806, #807, e1cf8393, 21ba9d40). Superseded pieces were dropped each time; this PR now carries only what remains relevant.

## Bitcoin Core version is a minimum, not a target

§1.5 said "Hashi targets Bitcoin Core v29", which read as an exact-version requirement. Per Brandon: any v29+ works, including the latest release. Now stated as "v29 or newer".

## TLS key generation

Added the `openssl genpkey` command to §2.2 and a file-permissions note (an unreadable TLS key file caused an incomplete registration; the loud-failure code fix is #805). TLS keys remain PEM/DER-only — unaffected by the new multi-format operator-key loading.

## §2.3 vs §2.4 confusion

Both sections showed the same `hashi register` command with differently-named placeholders, and it wasn't stated whether that address is the validator address or the fresh operator key. Unified the placeholder, stated it's the operator key's address, and clarified that one registration tx both registers and delegates — re-running is idempotent.

## Config template polish (on top of #807)

A prose "field order matters" note above the template (describing the post-#807 unknown-field error), and the `[hashi-ids]` template comment now points at the Networks table where the published IDs live.

## Dropped as superseded

- Template section reorder → #807
- backup-pgp-cert inline-only wording → #806 made the field accept paths; original wording restored
- "sui keytool formats not accepted" §2.4 guidance → 21ba9d40 + e1cf8393 added native suiprivkey/Base64 support and documented all formats

Also includes the style-guide audit fixes (no em dashes in prose, "for example" instead of "e.g.").
