### PR TITLE
Fail loudly on unloadable TLS key in register; redact key material from load errors

### DIFF
--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -29,8 +29,24 @@ pub fn load_ed25519_private_key(path_or_pem: &str) -> anyhow::Result<Ed25519Priv
                 .map_err(|e| anyhow::anyhow!("PEM parse error: {}", e))
         })
         .map_err(|_: anyhow::Error| {
-            anyhow::anyhow!("unable to load Ed25519 private key from '{}'", path_or_pem)
+            anyhow::anyhow!(
+                "unable to load Ed25519 private key from '{}' — expected a PKCS#8 PEM/DER \
+                 file path or an inline PEM string (`sui keytool` output is not supported)",
+                redact_key_source(path_or_pem)
+            )
         })
+}
+
+/// The configured value may be inline key material rather than a file path —
+/// never echo anything that could be a secret into errors or logs.
+fn redact_key_source(value: &str) -> &str {
+    let looks_like_path =
+        !value.contains('\n') && value.len() <= 128 && !value.starts_with("suiprivkey");
+    if looks_like_path {
+        value
+    } else {
+        "<inline value (redacted)>"
+    }
 }
 
 /// Load an Ed25519 private key from a file path.
@@ -511,6 +527,23 @@ fn get_ephemeral_port() -> std::io::Result<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn key_load_error_names_missing_path_but_redacts_key_material() {
+        // A plain (missing) path is useful context and safe to echo.
+        let err = load_ed25519_private_key("/nonexistent/key.pem").unwrap_err();
+        assert!(err.to_string().contains("/nonexistent/key.pem"));
+
+        // Inline PEM, bech32 sui keys, and long blobs must never be echoed.
+        let bad_pem = "-----BEGIN PRIVATE KEY-----\nnot-actually-valid\n-----END PRIVATE KEY-----";
+        let suiprivkey = "suiprivkey1qzabcdefabcdefabcdefabcdefabcdefabcdef";
+        let long_blob = "A".repeat(200);
+        for secret in [bad_pem, suiprivkey, long_blob.as_str()] {
+            let msg = load_ed25519_private_key(secret).unwrap_err().to_string();
+            assert!(!msg.contains(secret), "error echoed key material: {msg}");
+            assert!(msg.contains("redacted"));
+        }
+    }
 
     #[test]
     fn test_new_for_testing() {

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -2009,23 +2009,38 @@ pub async fn build_register_or_update_validator_tx(
         has_calls = true;
     }
 
-    // 5. Update TLS key if available and changed.
-    if let Ok(tls_key) = config.tls_public_key()
-        && onchain_member
+    // 5. Update TLS key if configured and changed. A configured-but-unloadable
+    // key is a hard error: silently skipping would produce a registration
+    // without `update_tls_public_key` (bad key-file permissions did exactly
+    // this to an operator, who registered incomplete with no warning).
+    if config.tls_private_key.is_some() {
+        let tls_key = config.tls_public_key().map_err(|e| {
+            e.context(
+                "failed to load tls-private-key from the node config; \
+                 fix the file path, format, or permissions (or remove the field \
+                 to skip setting a TLS public key)",
+            )
+        })?;
+        if onchain_member
             .as_ref()
             .map(|m| m.tls_public_key() != Some(&tls_key))
             .unwrap_or(true)
-    {
-        let tls_key_arg = builder.pure(&tls_key.as_bytes().to_vec());
-        builder.move_call(
-            Function::new(
-                hashi_ids.package_id,
-                Identifier::from_static("validator"),
-                Identifier::from_static("update_tls_public_key"),
-            ),
-            vec![hashi_arg, validator_address_arg, tls_key_arg],
+        {
+            let tls_key_arg = builder.pure(&tls_key.as_bytes().to_vec());
+            builder.move_call(
+                Function::new(
+                    hashi_ids.package_id,
+                    Identifier::from_static("validator"),
+                    Identifier::from_static("update_tls_public_key"),
+                ),
+                vec![hashi_arg, validator_address_arg, tls_key_arg],
+            );
+            has_calls = true;
+        }
+    } else {
+        tracing::warn!(
+            "tls-private-key is not configured; registration will not set a TLS public key"
         );
-        has_calls = true;
     }
 
     // 6. Update operator address if provided and changed.


### PR DESCRIPTION
Code half of the operator-onboarding fixes (docs half: #804). Both issues were hit by validators registering on testnet this week.

## Silent `update_tls_public_key` skip (reported by Staking Facilities)

`build_register_or_update_validator_tx` gated the TLS-key call on `if let Ok(tls_key) = config.tls_public_key()` — any load failure (in their case, file permissions) silently dropped the call and `--print-only` emitted a registration tx with no TLS key and no warning. The operator registered incomplete and needed a second transaction to repair.

Now:
- `tls-private-key` **configured but unloadable** → hard error naming the likely causes (path, format, permissions)
- **not configured** → explicit `tracing::warn!` instead of a silent skip

The same builder serves `hashi register` and the server's update path; in both, proceeding without a functioning TLS key is never useful, so a hard error is safe.

## Key material echoed into error messages (related to Chainode Tech's report)

`load_ed25519_private_key`'s failure message interpolated the raw config value. That value can be **inline PEM or a `suiprivkey…` bech32 string — i.e. the private key itself** — which then lands in terminal output and logs. The value is now redacted unless it looks like a file path (single line, ≤128 chars, no `suiprivkey` prefix).

While there, the error now states what formats are accepted (PKCS#8 PEM/DER file path or inline PEM) and that `sui keytool` output is not supported — operators were generating keys with `sui keytool` and getting an unactionable error.

## Verification

- `cargo build -p hashi` and `cargo clippy -p hashi --lib`: clean
- New unit test `key_load_error_names_missing_path_but_redacts_key_material`: missing paths are still echoed (useful context), inline PEM / `suiprivkey` / long blobs are redacted; full `config::tests` suite passes (10/10)