### PR TITLE
Format Move test files to satisfy updated prettier-plugin-move

### DIFF
--- a/packages/hashi/tests/mpc_signing_tests.move
+++ b/packages/hashi/tests/mpc_signing_tests.move
@@ -12,7 +12,7 @@ use hashi::mpc_signing::{
     ELengthMismatch,
     ENotStale,
     EAllocationMismatch,
-    ENotComplete
+    ENotComplete,
 };
 
 fun sig(byte: u8): vector<u8> {

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -15,7 +15,7 @@ use hashi::{
         EOutputBelowDust,
         EOutputAmountMismatch,
         EOutputAddressMismatch,
-        EMinerFeeExceedsMax
+        EMinerFeeExceedsMax,
     }
 };
 use sui::clock;


### PR DESCRIPTION
The **Formatting** CI job installs `@mysten/prettier-plugin-move@latest`, and a new plugin release now requires trailing commas in multi-line `use` lists. Since the check floats on `latest`, it retroactively fails on two test files that no open PR touches — currently blocking every PR (seen on #804, will hit #805 and others on their next run).

Two-character diff, format-only (`prettier-move -w` output verbatim); `sui move build` verified clean.

Longer-term it may be worth pinning the plugin version in `move-formatter-action` so releases can't break CI retroactively — happy to file that separately.