### PR TITLE
Add nextest slow-timeout and CI job timeout so hung tests fail fast

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,3 +19,4 @@ failure-output = "immediate-final"
 success-output = "never"
 # Don't stop on first failure - run all tests
 fail-fast = false
+slow-timeout = { period = "120s", terminate-after = 10 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-ghcloud
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
#16 