### PR TITLE
[3/3] [Guardian] Make guardian S3 logs concise and human-readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-conservative"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ serde_json = "1.0.145"
 fjall = { version = "3.0.0", features = ["bytes_1"] }
 async-trait = "0.1"
 thiserror = "1.0"
-hex = "0.4"
+hex = { version = "0.4", features = ["serde"] }
 bcs = "0.1.6"
 rand = "0.8"
 tap = "1.0.1"

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -507,8 +507,7 @@ async fn submit_provisioner_init_to_relay(
 
     // Detached-sign the exact (session, share) bytes with this KP's offline
     // key; the relay only buffers submissions signed by a rostered cert.
-    let request =
-        SingleProvisionerInitRequest::new(expected_session_id.to_string(), encrypted_share);
+    let request = SingleProvisionerInitRequest::new(expected_session_id.into(), encrypted_share);
     let signed_request = KpSigned::new(request, signer_cert.clone(), None)
         .map_err(anyhow::Error::msg)
         .context("sign the relay submission with the KP key")?;
@@ -551,7 +550,7 @@ async fn prechecks(
     );
 
     anyhow::ensure!(
-        actual_session_id == expected_session_id,
+        actual_session_id.as_str() == expected_session_id,
         "relay endpoint session mismatch: expected {}, got {}",
         expected_session_id,
         actual_session_id

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -31,6 +31,7 @@ use hashi_types::guardian::KpShareStateLogMessage;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::SecretSharingParams;
+use hashi_types::guardian::SessionID;
 use hashi_types::guardian::SetupNewKeyResponse;
 use hashi_types::guardian::Share;
 use hashi_types::pgp::PgpPublicCert;
@@ -89,8 +90,8 @@ impl KpRosterConfig {
 /// `kp-shares/` logs (`key-provisioner ceremony`, `key-provisioner provision`).
 #[derive(Debug, PartialEq)]
 pub struct VerifiedCeremonyState {
-    pub ceremony_session_id: String,
-    pub kp_share_session_id: String,
+    pub ceremony_session_id: SessionID,
+    pub kp_share_session_id: SessionID,
     pub kp_share_cert_seq: u64,
     pub encrypted_shares: KPEncryptedShares,
     pub secret_sharing_instance: SecretSharingInstance,
@@ -100,7 +101,7 @@ pub struct VerifiedCeremonyState {
 impl VerifiedCeremonyState {
     pub fn from_response(
         response: SetupNewKeyResponse,
-        session_id: String,
+        session_id: SessionID,
         expected_sharing_seq: u64,
         expected_n: usize,
         expected_t: usize,
@@ -159,8 +160,8 @@ impl VerifiedCeremonyState {
     /// log and the kp-shares log). Use instead of [`Self::latest_from_s3`] when the
     /// caller has already read those objects and wants to avoid a second walk.
     pub fn from_scraped(
-        ceremony_session_id: String,
-        kp_share_session_id: String,
+        ceremony_session_id: SessionID,
+        kp_share_session_id: SessionID,
         secret_sharing_instance: SecretSharingInstance,
         kp_share_state: KpShareStateLogMessage,
         btc_master_pubkey: BitcoinPubkey,

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -387,7 +387,7 @@ fn verify_activated_info(
     expected_limiter_state: hashi_types::guardian::LimiterState,
 ) -> anyhow::Result<()> {
     ensure!(
-        post.session_id == expected_session_id,
+        post.session_id.as_str() == expected_session_id,
         "guardian session changed during operator activation: started {}, now {}",
         expected_session_id,
         post.session_id

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -327,7 +327,8 @@ mod tests {
         let session = "sess-a";
 
         let domain_share = signed_share(1);
-        let request = SingleProvisionerInitRequest::new(session.to_string(), domain_share.clone());
+        let request =
+            SingleProvisionerInitRequest::new(session.to_string().into(), domain_share.clone());
         let signed_bytes = KpSigned::signed_bytes(&request);
         let good_sig = sign_detached_in_process(&secret_armored, &signed_bytes);
         let signed_request = KpSigned {
@@ -344,7 +345,8 @@ mod tests {
         verify_kp_submission(signed_request.clone(), &[from_config]).unwrap();
 
         let other_share = signed_share(2);
-        let other_request = SingleProvisionerInitRequest::new(session.to_string(), other_share);
+        let other_request =
+            SingleProvisionerInitRequest::new(session.to_string().into(), other_share);
         let signed_other_share = KpSigned {
             data: other_request,
             signer_cert: cert.clone(),

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -117,7 +117,7 @@ impl Relay {
         let threshold = sharing.map(|i| i.threshold());
         let provisioned = verified.info.enclave_btc_pubkey.is_some();
         Ok(BackendStatus {
-            session_id: verified.session_id,
+            session_id: verified.session_id.into(),
             num_shares,
             threshold,
             provisioned,
@@ -212,7 +212,7 @@ impl GuardianRelayService for Relay {
         }
         // The share is HPKE-encrypted to the session the KP pinned; if the
         // backend has since restarted into a new session, the share is useless.
-        if expected_session_id != status.session_id {
+        if expected_session_id.as_str() != status.session_id {
             return Err(Status::failed_precondition(format!(
                 "session mismatch: KP pinned {}, backend live session is {} \
                  (guardian restarted? re-run the provision flow)",
@@ -371,7 +371,7 @@ mod tests {
         );
 
         let other_session_request =
-            SingleProvisionerInitRequest::new("other-session".to_string(), domain_share);
+            SingleProvisionerInitRequest::new("other-session".into(), domain_share);
         let other_bytes = KpSigned::signed_bytes(&other_session_request);
         let stale_sig = sign_detached_in_process(&secret_armored, &other_bytes);
         let stale_request = KpSigned {

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -324,7 +324,7 @@ pub(crate) mod test_store {
 
         let signing_key = GuardianSignKeyPair::from([9u8; 32]);
         let record = LogRecord::new_at_timestamp(
-            "test-session".to_string(),
+            "test-session".into(),
             LogMessageV1::Withdrawal(Box::new(WithdrawalLogMessage::Success {
                 txid: bitcoin::Txid::from_slice(&[3u8; 32]).unwrap(),
                 request_data,

--- a/crates/hashi-guardian/README.md
+++ b/crates/hashi-guardian/README.md
@@ -13,7 +13,10 @@ signing key and derived session ID.
 
 Canonical key layout:
 
-- `init/{session_id}-{init_suffix}.json`
+- `init/{session_id}/01-oi-attestation-unsigned.json`
+- `init/{session_id}/02-oi-guardian-info.json`
+- `init/{session_id}/03-pi-enclave-fully-initialized.json`
+- `init/{session_id}/04-oa-activated.json`
 - `heartbeat/{yyyy}/{mm}/{dd}/{hh}/{session_id}-{counter:020}.json`
 - `withdraw/{yyyy}/{mm}/{dd}/{hh}/success-{seq:020}-{session_id}-wid{wid}.json`
 - `withdraw/{yyyy}/{mm}/{dd}/{hh}/failure-{session_id}-wid{wid}-{rand8}.json`
@@ -26,7 +29,6 @@ Canonical key layout:
 Where:
 
 - `session_id` is the first 16 hex chars of the enclave ephemeral signing pubkey (lowercase). Acts as a short per-session tag in keys; full pubkey verification still happens via the signed log payload (`SessionID::HEX_LEN` in `hashi-types`).
-- `init_suffix` is a semantic label (`oi-attestation-unsigned`, `oi-guardian-info`, `pi-enclave-fully-initialized`).
 - `counter` is a zero-padded decimal sequence number (used in heartbeats only).
 - `seq` (in `withdraw/`) is the zero-padded limiter sequence number consumed by the withdrawal.
 - `sharing_seq` (in `ceremony/`) is a zero-padded rotation counter — `setup_new_key` writes `0`; each `rotate_kps` appends `prev+1`.
@@ -36,7 +38,7 @@ Where:
 
 ## Stream semantics
 
-- `init` logs are per-session and deterministic by semantic message kind.
+- `init` logs are grouped per session and numerically ordered by lifecycle step.
 - `heartbeat` logs are hour-partitioned and strictly ordered per session.
 - `withdraw` logs are hour-partitioned. Successes are seq-sorted within a bucket so the KP rotating in the next enclave can recover limiter state by reading the lexicographically last success key.
 - `ceremony` logs are flat (not date-partitioned). Each entry is a `CeremonyLogMessage` — `NewKey { instance }` written by `setup_new_key` (genesis, `sharing_seq=0`) or `Rotate { old_instance, new_instance }` written by `rotate_kps` (each rotation, `sharing_seq=prev+1`). A rotation records the `old_instance` it consumed so the chain is auditable from the log alone (each entry's `old_instance` should match the prior entry's instance). KPs read the lexicographically last entry to learn the current authoritative instance (commitments + N + T). The log does not carry encrypted shares or a separate recipient roster.

--- a/crates/hashi-guardian/README.md
+++ b/crates/hashi-guardian/README.md
@@ -25,7 +25,7 @@ Canonical key layout:
 
 Where:
 
-- `session_id` is the first 16 hex chars of the enclave ephemeral signing pubkey (lowercase). Acts as a short per-session tag in keys; full pubkey verification still happens via the signed log payload (`SESSION_ID_HEX_LEN` in `hashi-types`).
+- `session_id` is the first 16 hex chars of the enclave ephemeral signing pubkey (lowercase). Acts as a short per-session tag in keys; full pubkey verification still happens via the signed log payload (`SessionID::HEX_LEN` in `hashi-types`).
 - `init_suffix` is a semantic label (`oi-attestation-unsigned`, `oi-guardian-info`, `pi-enclave-fully-initialized`).
 - `counter` is a zero-padded decimal sequence number (used in heartbeats only).
 - `seq` (in `withdraw/`) is the zero-padded limiter sequence number consumed by the withdrawal.

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -508,7 +508,7 @@ impl Enclave {
 
     /// A unique session ID for the current enclave session.
     pub fn s3_session_id(&self) -> SessionID {
-        session_id_from_signing_pubkey(&self.signing_pubkey())
+        SessionID::from_signing_pubkey(&self.signing_pubkey())
     }
 
     async fn write_log(&self, message: LogMessageV1) -> GuardianResult<()> {

--- a/crates/hashi-guardian/src/operator_activate.rs
+++ b/crates/hashi-guardian/src/operator_activate.rs
@@ -85,6 +85,8 @@ pub async fn operator_activate(
         .await
         .map_err(|e| InvalidInputs(format!("recover limiter state: {e}")))?;
     let rate_limiter = RateLimiter::new(*init_config.limiter_config(), limiter_state)?;
+    let sharing_seq = armed_instance.sharing_seq();
+    let committee_epoch = committee.epoch();
 
     let activation_state = ActivationState::new(
         config_hash,
@@ -106,7 +108,13 @@ pub async fn operator_activate(
         .init(committee, rate_limiter)
         .expect("Unable to init activation state");
     enclave
-        .log_init(InitLogMessage::OAActivated { state_hash })
+        .log_init(InitLogMessage::OAActivated {
+            state_hash,
+            config_hash,
+            sharing_seq,
+            committee_epoch,
+            limiter_state,
+        })
         .await
         .expect("Unable to log operator activation");
     enclave

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -831,7 +831,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
         let signing_key = GuardianSignKeyPair::new(rand::thread_rng());
         let log = LogRecord::new(
-            "session".to_string(),
+            "session".into(),
             LogMessageV1::Heartbeat(HeartbeatLogMessage::new(7)),
             &signing_key,
         );
@@ -860,7 +860,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
         let signing_key = GuardianSignKeyPair::new(rand::thread_rng());
         let log = LogRecord::new(
-            "session".to_string(),
+            "session".into(),
             LogMessageV1::Heartbeat(HeartbeatLogMessage::new(7)),
             &signing_key,
         );

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -702,7 +702,7 @@ mod tests {
         let put_ok = mock!(Client::put_object)
             .match_requests(|req| {
                 req.bucket() == Some("bucket")
-                    && req.key() == Some("init/session-oi-attestation-unsigned.json")
+                    && req.key() == Some("init/session/01-oi-attestation-unsigned.json")
                     && req.content_type() == Some("application/json")
                     && req.object_lock_mode() == Some(&ObjectLockMode::Compliance)
                     && req.object_lock_retain_until_date().is_some()
@@ -715,7 +715,7 @@ mod tests {
         let object_lock_duration = Duration::from_mins(5);
         logger
             .write_at_key(
-                "init/session-oi-attestation-unsigned.json",
+                "init/session/01-oi-attestation-unsigned.json",
                 &TestPayload { a: 1 },
                 object_lock_duration,
             )
@@ -896,7 +896,7 @@ mod tests {
         let object_lock_duration = Duration::from_mins(5);
         logger
             .write_at_key(
-                "init/session-oi-attestation-unsigned.json",
+                "init/session/01-oi-attestation-unsigned.json",
                 &TestPayload { a: 1 },
                 object_lock_duration,
             )

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -360,7 +360,7 @@ impl GuardianSessionCache {
             let session_info = s3
                 .get_verified_session_info(session_id, &self.allowlist)
                 .await?;
-            self.sessions.insert(session_id.to_string(), session_info);
+            self.sessions.insert(session_id.into(), session_info);
         }
         Ok(&self.sessions[session_id])
     }

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -168,7 +168,11 @@ mod tests {
             session_id: "test-session".into(),
             timestamp_ms: 0,
             message: LogMessageV1::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
+                sharing_seq: 0,
                 share_ids: vec![],
+                enclave_btc_pubkey: hashi_types::bitcoin::create_btc_keypair_for_test(&[1; 32])
+                    .x_only_public_key()
+                    .0,
             }))
             .into(),
             build_pcrs: build_pcrs(),

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -164,7 +164,7 @@ mod tests {
 
     fn non_heartbeat_log() -> VerifiedLogRecord {
         VerifiedLogRecord {
-            object_key: "init/test-session-pi-enclave-fully-initialized.json".to_string(),
+            object_key: "init/test-session/03-pi-enclave-fully-initialized.json".to_string(),
             session_id: "test-session".into(),
             timestamp_ms: 0,
             message: LogMessageV1::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -37,7 +37,7 @@ impl GuardianReader {
 
         let live_session_info = summary
             .iter()
-            .find(|s| s.session_id == live_session)
+            .find(|s| s.session_id.as_str() == live_session)
             .expect("validated live session must be present");
         info!(
             session_id = %live_session,
@@ -73,7 +73,7 @@ struct GuardianSessionInfo {
 fn summarize_heartbeats_by_session(
     logs: Vec<VerifiedLogRecord>,
 ) -> anyhow::Result<Vec<GuardianSessionInfo>> {
-    let mut map: BTreeMap<String, (UnixSeconds, UnixSeconds)> = BTreeMap::new();
+    let mut map: BTreeMap<SessionID, (UnixSeconds, UnixSeconds)> = BTreeMap::new();
 
     for log in logs {
         if !matches!(log.message, LogMessage::V1(LogMessageV1::Heartbeat(..))) {
@@ -110,7 +110,7 @@ fn validate_session_live_and_others_quiet(
 ) -> anyhow::Result<()> {
     let live_session_info = summary
         .iter()
-        .find(|s| s.session_id == live_session)
+        .find(|s| s.session_id.as_str() == live_session)
         .ok_or_else(|| anyhow::anyhow!("no heartbeat logs found for session {live_session}"))?;
     let live_session_age_secs = now.saturating_sub(live_session_info.last_heartbeat);
     if live_session_age_secs > live_session_max_age_secs {
@@ -124,7 +124,7 @@ fn validate_session_live_and_others_quiet(
 
     let active_sessions = summary
         .iter()
-        .filter(|s| s.session_id != live_session)
+        .filter(|s| s.session_id.as_str() != live_session)
         .filter_map(|s| {
             let age_secs = now.saturating_sub(s.last_heartbeat);
             (age_secs < other_session_quiet_secs)
@@ -155,7 +155,7 @@ mod tests {
     fn heartbeat_log(session_id: &str, timestamp_secs: UnixSeconds) -> VerifiedLogRecord {
         VerifiedLogRecord {
             object_key: format!("heartbeat/{session_id}.json"),
-            session_id: session_id.to_string(),
+            session_id: session_id.into(),
             timestamp_ms: timestamp_secs * 1_000,
             message: LogMessageV1::Heartbeat(HeartbeatLogMessage::new(0)).into(),
             build_pcrs: build_pcrs(),
@@ -165,7 +165,7 @@ mod tests {
     fn non_heartbeat_log() -> VerifiedLogRecord {
         VerifiedLogRecord {
             object_key: "init/test-session-pi-enclave-fully-initialized.json".to_string(),
-            session_id: "test-session".to_string(),
+            session_id: "test-session".into(),
             timestamp_ms: 0,
             message: LogMessageV1::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
                 share_ids: vec![],
@@ -185,9 +185,9 @@ mod tests {
         .unwrap();
 
         assert_eq!(summary.len(), 2);
-        assert_eq!(summary[0].session_id, "a");
+        assert_eq!(summary[0].session_id.as_str(), "a");
         assert_eq!(summary[0].last_heartbeat, 30);
-        assert_eq!(summary[1].session_id, "b");
+        assert_eq!(summary[1].session_id.as_str(), "b");
         assert_eq!(summary[1].last_heartbeat, 20);
     }
 
@@ -202,12 +202,12 @@ mod tests {
     fn validate_session_live_and_others_quiet_accepts_live_session() {
         let summary = vec![
             GuardianSessionInfo {
-                session_id: "live".to_string(),
+                session_id: "live".into(),
                 first_heartbeat: 990,
                 last_heartbeat: 990,
             },
             GuardianSessionInfo {
-                session_id: "old".to_string(),
+                session_id: "old".into(),
                 first_heartbeat: 200,
                 last_heartbeat: 200,
             },
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn validate_session_live_and_others_quiet_fails_when_live_session_missing() {
         let summary = vec![GuardianSessionInfo {
-            session_id: "old".to_string(),
+            session_id: "old".into(),
             first_heartbeat: 200,
             last_heartbeat: 200,
         }];
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn validate_session_live_and_others_quiet_fails_when_live_session_stale() {
         let summary = vec![GuardianSessionInfo {
-            session_id: "live".to_string(),
+            session_id: "live".into(),
             first_heartbeat: 800,
             last_heartbeat: 800,
         }];
@@ -247,12 +247,12 @@ mod tests {
     fn validate_session_live_and_others_quiet_fails_when_other_session_active() {
         let summary = vec![
             GuardianSessionInfo {
-                session_id: "live".to_string(),
+                session_id: "live".into(),
                 first_heartbeat: 990,
                 last_heartbeat: 990,
             },
             GuardianSessionInfo {
-                session_id: "other".to_string(),
+                session_id: "other".into(),
                 first_heartbeat: 950,
                 last_heartbeat: 950,
             },

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -188,7 +188,7 @@ mod tests {
         };
         VerifiedLogRecord {
             object_key: format!("withdraw/success-{next_seq}.json"),
-            session_id: "test-session".to_string(),
+            session_id: "test-session".into(),
             timestamp_ms: 0,
             message: LogMessageV1::Withdrawal(Box::new(msg)).into(),
             build_pcrs: build_pcrs(),
@@ -205,7 +205,7 @@ mod tests {
         };
         VerifiedLogRecord {
             object_key: "withdraw/failure.json".to_string(),
-            session_id: "test-session".to_string(),
+            session_id: "test-session".into(),
             timestamp_ms: 0,
             message: LogMessageV1::Withdrawal(Box::new(msg)).into(),
             build_pcrs: build_pcrs(),

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -7,6 +7,7 @@
 //! shared `crate::operator_init`.
 
 use crate::Enclave;
+use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::guardian::crypto::combine_shares;
 use hashi_types::guardian::crypto::decrypt_verify_shares;
 use hashi_types::guardian::crypto::k256_sk_to_btc_keypair;
@@ -44,6 +45,7 @@ pub async fn provisioner_init(
         .secret_sharing_instance()
         .expect("secret-sharing instance should be set after operator_init");
     let threshold = instance.threshold();
+    let sharing_seq = instance.sharing_seq();
     // Always set here: provisioner_init is withdraw-mode only, and the
     // operator_init check above guarantees a withdraw-mode enclave installed it.
     let config_hash = enclave
@@ -63,11 +65,15 @@ pub async fn provisioner_init(
     info!("Verified {} shares (threshold {threshold}).", shares.len());
 
     let share_ids = shares.iter().map(|s| s.id).collect();
-    finalize_init(&shares, threshold, &enclave).await;
+    let enclave_btc_pubkey = finalize_init(&shares, threshold, &enclave).await;
     // Log to S3 indicating that the BTC key has been reconstructed. OA waits for
     // this durable marker before activating the enclave for withdrawals.
     enclave
-        .log_init(PIEnclaveFullyInitialized { share_ids })
+        .log_init(PIEnclaveFullyInitialized {
+            sharing_seq,
+            share_ids,
+            enclave_btc_pubkey,
+        })
         .await
         .expect("Unable to log EnclaveFullyInitialized");
 
@@ -83,10 +89,15 @@ pub async fn provisioner_init(
 /// Reconstruct the BTC key from the threshold shares and install it. Live
 /// serving state is installed later by operator_activate.
 /// Panics upon an error as the enclaves state is irrecoverable at this point.
-async fn finalize_init(shares: &[Share], threshold: usize, enclave: &Arc<Enclave>) {
+async fn finalize_init(
+    shares: &[Share],
+    threshold: usize,
+    enclave: &Arc<Enclave>,
+) -> BitcoinPubkey {
     info!("Threshold reached, combining shares.");
     let enclave_k256_sk = combine_shares(shares, threshold).expect("Unable to combine shares");
     let enclave_btc_keypair = k256_sk_to_btc_keypair(&enclave_k256_sk);
+    let enclave_btc_pubkey = enclave_btc_keypair.x_only_public_key().0;
 
     info!("Setting enclave keypair.");
     enclave
@@ -95,6 +106,7 @@ async fn finalize_init(shares: &[Share], threshold: usize, enclave: &Arc<Enclave
         .expect("Unable to set enclave keypair");
 
     info!("Enclave initialization complete.");
+    enclave_btc_pubkey
 }
 
 #[cfg(test)]

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -17,7 +17,7 @@ pub type GitRevision = String;
 
 /// Raw AWS Nitro attestation document bytes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct NitroAttestation(Vec<u8>);
+pub struct NitroAttestation(#[serde(with = "crate::guardian::serde_utils::base64_bytes")] Vec<u8>);
 
 impl NitroAttestation {
     pub fn new(bytes: Vec<u8>) -> Self {

--- a/crates/hashi-types/src/guardian/crypto.rs
+++ b/crates/hashi-types/src/guardian/crypto.rs
@@ -188,7 +188,9 @@ pub struct ShareCommitment {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct ShareCommitments(BTreeMap<ShareID, DigestBytes>);
+pub struct ShareCommitments(
+    #[serde(with = "crate::guardian::serde_utils::hex_map_values")] BTreeMap<ShareID, DigestBytes>,
+);
 
 /// Public description of the current BTC key's secret-sharing scheme.
 /// `sharing_seq` versions the instance: setup writes 0, each rotation bumps it by 1.
@@ -726,6 +728,19 @@ mod tests {
                 .collect(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn share_commitments_json_encodes_digests_as_hex() {
+        let commitments = test_commitments(&[1, 2]);
+        let json = serde_json::to_value(&commitments).unwrap();
+
+        assert_eq!(json["1"], "01");
+        assert_eq!(json["2"], "02");
+        assert_eq!(
+            serde_json::from_value::<ShareCommitments>(json).unwrap(),
+            commitments
+        );
     }
 
     fn test_kp_encrypted_share(id: u16) -> KPEncryptedShare {

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -670,7 +670,7 @@ mod tests {
 
         assert_eq!(
             log.object_key(),
-            "init/session-a-oi-attestation-unsigned.json"
+            "init/session-a/01-oi-attestation-unsigned.json"
         );
     }
 

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -68,6 +68,7 @@ impl Serialize for LogRecord {
             session_id: &'a SessionID,
             timestamp_ms: UnixMillis,
             message: &'a M,
+            #[serde(with = "crate::guardian::serde_utils::option_guardian_signature")]
             signature: &'a Option<GuardianSignature>,
         }
 
@@ -97,6 +98,7 @@ impl<'de> Deserialize<'de> for LogRecord {
             session_id: SessionID,
             timestamp_ms: UnixMillis,
             message: Value,
+            #[serde(with = "crate::guardian::serde_utils::option_guardian_signature")]
             signature: Option<GuardianSignature>,
         }
 
@@ -345,15 +347,22 @@ impl LogRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::guardian::CeremonyLogMessage;
     use crate::guardian::CommitteeUpdateLogMessage;
     use crate::guardian::GenesisLogMessage;
+    use crate::guardian::GetGuardianInfoResponse;
     use crate::guardian::GuardianError;
     use crate::guardian::GuardianSigned;
     use crate::guardian::HeartbeatLogMessage;
     use crate::guardian::InitLogMessage;
     use crate::guardian::KPEncryptedShares;
+    use crate::guardian::KpShareStateLogMessage;
     use crate::guardian::LimiterState;
     use crate::guardian::NitroAttestation;
+    use crate::guardian::RotateKpsResponse;
+    use crate::guardian::SecretSharingInstance;
+    use crate::guardian::ShareCommitment;
+    use crate::guardian::ShareCommitments;
     use crate::guardian::StandardWithdrawalRequest;
     use crate::guardian::StandardWithdrawalRequestWire;
     use crate::guardian::StandardWithdrawalResponse;
@@ -362,6 +371,7 @@ mod tests {
     use bitcoin::Network;
     use bitcoin::Txid;
     use bitcoin::hashes::Hash as _;
+    use std::num::NonZeroU16;
 
     fn heartbeat_session_id() -> SessionID {
         SessionID::from_signing_pubkey(&GuardianSignKeyPair::from([13u8; 32]).verification_key())
@@ -406,6 +416,183 @@ mod tests {
             .validate_actual_object_key(&relocated_key)
             .expect_err("relocated record must be rejected");
         assert!(format!("{err:?}").contains("S3 object key mismatch"));
+    }
+
+    fn test_sharing_instance(sharing_seq: u64) -> SecretSharingInstance {
+        let commitments = ShareCommitments::new(
+            (1..=2)
+                .map(|id| ShareCommitment {
+                    id: NonZeroU16::new(id).unwrap(),
+                    digest: vec![id as u8; 33],
+                })
+                .collect(),
+        )
+        .unwrap();
+        SecretSharingInstance::new(commitments, 2, 2, sharing_seq).unwrap()
+    }
+
+    #[test]
+    fn every_log_message_json_round_trips_and_verifies() {
+        let signing_key = GuardianSignKeyPair::from([21u8; 32]);
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
+        let btc_master_pubkey = crate::bitcoin::create_btc_keypair_for_test(&[3u8; 32])
+            .x_only_public_key()
+            .0;
+        let instance_0 = test_sharing_instance(0);
+        let instance_1 = test_sharing_instance(1);
+        let (signed_request, committee_0) =
+            StandardWithdrawalRequest::mock_signed_and_committee_for_testing(Network::Regtest);
+        let (request_sign, request_data) = signed_request.into_parts();
+        let request_data: StandardWithdrawalRequestWire = request_data.into();
+        let response = GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data;
+        let encrypted_shares = GuardianSigned::<RotateKpsResponse>::mock_for_testing()
+            .data
+            .encrypted_shares;
+        let guardian_info = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
+        let committee_0: crate::move_types::Committee = (&committee_0).into();
+        let mut committee_1 = committee_0.clone();
+        committee_1.epoch = 1;
+
+        let cases = vec![
+            (
+                "heartbeat",
+                LogMessageV1::Heartbeat(HeartbeatLogMessage::new(1)),
+            ),
+            (
+                "init OI attestation",
+                LogMessageV1::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
+                    attestation: NitroAttestation::new(vec![1, 2, 3]),
+                    signing_public_key: signing_key.verification_key(),
+                })),
+            ),
+            (
+                "init OI guardian info",
+                LogMessageV1::Init(Box::new(InitLogMessage::OIGuardianInfo(Box::new(
+                    guardian_info,
+                )))),
+            ),
+            (
+                "init PI complete",
+                LogMessageV1::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
+                    sharing_seq: 0,
+                    share_ids: vec![NonZeroU16::new(1).unwrap()],
+                    enclave_btc_pubkey: btc_master_pubkey,
+                })),
+            ),
+            (
+                "init OA activated",
+                LogMessageV1::Init(Box::new(InitLogMessage::OAActivated {
+                    state_hash: [1; 32],
+                    config_hash: [2; 32],
+                    sharing_seq: 0,
+                    committee_epoch: 0,
+                    limiter_state: LimiterState {
+                        num_tokens_available: 10,
+                        last_updated_at: 20,
+                        next_seq: 30,
+                    },
+                })),
+            ),
+            (
+                "withdrawal success",
+                LogMessageV1::Withdrawal(Box::new(WithdrawalLogMessage::Success {
+                    txid: Txid::from_slice(&[3; 32]).unwrap(),
+                    request_data: request_data.clone(),
+                    request_sign: request_sign.clone(),
+                    response,
+                    post_state: LimiterState {
+                        num_tokens_available: 10,
+                        last_updated_at: 20,
+                        next_seq: request_data.seq + 1,
+                    },
+                })),
+            ),
+            (
+                "withdrawal failure",
+                LogMessageV1::Withdrawal(Box::new(WithdrawalLogMessage::Failure {
+                    request_data,
+                    request_sign: request_sign.clone(),
+                    error: GuardianError::RateLimitExceeded,
+                })),
+            ),
+            (
+                "ceremony new key",
+                LogMessageV1::Ceremony(Box::new(CeremonyLogMessage::NewKey {
+                    instance: instance_0.clone(),
+                    btc_master_pubkey,
+                })),
+            ),
+            (
+                "ceremony rotate",
+                LogMessageV1::Ceremony(Box::new(CeremonyLogMessage::Rotate {
+                    old_instance: instance_0,
+                    new_instance: instance_1,
+                    btc_master_pubkey,
+                })),
+            ),
+            (
+                "KP share state",
+                LogMessageV1::KpShareState(Box::new(KpShareStateLogMessage::new(
+                    0,
+                    0,
+                    encrypted_shares,
+                ))),
+            ),
+            (
+                "committee update success",
+                LogMessageV1::CommitteeUpdate(Box::new(CommitteeUpdateLogMessage::Success {
+                    from_epoch: 0,
+                    new_committee: committee_1.clone(),
+                    request_sign: request_sign.clone(),
+                })),
+            ),
+            (
+                "committee update failure",
+                LogMessageV1::CommitteeUpdate(Box::new(CommitteeUpdateLogMessage::Failure {
+                    from_epoch: 0,
+                    new_committee: committee_1,
+                    request_sign,
+                    error: GuardianError::InvalidInputs("test failure".into()),
+                })),
+            ),
+            (
+                "genesis",
+                LogMessageV1::Genesis(Box::new(GenesisLogMessage {
+                    committee: committee_0,
+                })),
+            ),
+        ];
+
+        for (name, message) in cases {
+            let record = LogRecord::new_at_timestamp(
+                session_id.clone(),
+                message,
+                &signing_key,
+                1_700_000_000_000,
+            );
+            let object_key = record.object_key().to_owned();
+            let json = serde_json::to_vec(&record).unwrap();
+            let decoded: LogRecord = serde_json::from_slice(&json)
+                .unwrap_or_else(|error| panic!("{name} failed to deserialize: {error}"));
+
+            assert_eq!(
+                serde_json::to_vec(&decoded).unwrap(),
+                json,
+                "{name} did not reserialize canonically"
+            );
+            decoded
+                .validate_actual_object_key(&object_key)
+                .unwrap_or_else(|error| panic!("{name} failed key validation: {error}"));
+            if decoded.message.is_allowed_unsigned() {
+                decoded
+                    .validate_unsigned()
+                    .unwrap_or_else(|error| panic!("{name} failed validation: {error}"));
+            } else {
+                decoded
+                    .verify(&signing_key.verification_key())
+                    .unwrap_or_else(|error| panic!("{name} failed verification: {error}"));
+            }
+        }
     }
 
     #[test]
@@ -473,6 +660,16 @@ mod tests {
         let json = serde_json::to_value(&log).unwrap();
         assert_eq!(json.get("schema_version").unwrap(), 1);
         assert_eq!(json.get("object_key").unwrap(), &object_key);
+        let signature = json["signature"].as_str().unwrap();
+        assert_eq!(signature.len(), 128);
+        assert!(
+            signature
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        );
+        let mut malformed = json.clone();
+        malformed["signature"] = "00".into();
+        assert!(serde_json::from_value::<LogRecord>(malformed).is_err());
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
         from_s3
@@ -656,7 +853,7 @@ mod tests {
 
     #[test]
     fn object_key_for_init_attestation_unsigned() {
-        let session_id = "session-a".to_string();
+        let session_id: SessionID = "session-a".into();
         let signing_key = GuardianSignKeyPair::from([7u8; 32]);
         let log = LogRecord::new_at_timestamp(
             session_id.clone(),
@@ -672,11 +869,51 @@ mod tests {
             log.object_key(),
             "init/session-a/01-oi-attestation-unsigned.json"
         );
+
+        let json = serde_json::to_value(&log).unwrap();
+        let message = &json["message"]["Init"]["OIAttestationUnsigned"];
+        assert_eq!(message["attestation"], "AQID");
+        assert_eq!(
+            message["signing_public_key"],
+            hex::encode(signing_key.verification_key().as_bytes())
+        );
+        let from_json: LogRecord = serde_json::from_value(json).unwrap();
+        assert_eq!(from_json.object_key(), log.object_key());
+    }
+
+    #[test]
+    fn operator_activation_json_encodes_hashes_as_hex() {
+        let signing_key = GuardianSignKeyPair::from([20u8; 32]);
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
+        let log = LogRecord::new_at_timestamp(
+            session_id,
+            LogMessageV1::Init(Box::new(InitLogMessage::OAActivated {
+                state_hash: [0xab; 32],
+                config_hash: [0xcd; 32],
+                sharing_seq: 7,
+                committee_epoch: 9,
+                limiter_state: LimiterState {
+                    num_tokens_available: 11,
+                    last_updated_at: 12,
+                    next_seq: 13,
+                },
+            })),
+            &signing_key,
+            1_700_000_000_000,
+        );
+
+        let json = serde_json::to_value(&log).unwrap();
+        let message = &json["message"]["Init"]["OAActivated"];
+        assert_eq!(message["state_hash"], hex::encode([0xab; 32]));
+        assert_eq!(message["config_hash"], hex::encode([0xcd; 32]));
+
+        let from_json: LogRecord = serde_json::from_value(json).unwrap();
+        from_json.verify(&signing_key.verification_key()).unwrap();
     }
 
     #[test]
     fn object_key_for_heartbeat() {
-        let session_id = "session-b".to_string();
+        let session_id: SessionID = "session-b".into();
         let signing_key = GuardianSignKeyPair::from([8u8; 32]);
         let seq = 42_u64;
         let timestamp_ms = 1_700_000_000_000;
@@ -696,9 +933,7 @@ mod tests {
 
     #[test]
     fn object_key_and_lock_for_kp_share_state() {
-        use crate::guardian::KpShareStateLogMessage;
-
-        let session_id = "session-d".to_string();
+        let session_id: SessionID = "session-d".into();
         let signing_key = GuardianSignKeyPair::from([10u8; 32]);
         let log = LogRecord::new_at_timestamp(
             session_id,
@@ -723,7 +958,7 @@ mod tests {
 
     #[test]
     fn object_key_and_lock_for_genesis_is_fixed() {
-        let session_id = "session-g".to_string();
+        let session_id: SessionID = "session-g".into();
         let signing_key = GuardianSignKeyPair::from([12u8; 32]);
         let log = LogRecord::new_at_timestamp(
             session_id,
@@ -746,7 +981,7 @@ mod tests {
 
     #[test]
     fn object_key_for_withdrawal_success() {
-        let session_id = "session-c".to_string();
+        let session_id: SessionID = "session-c".into();
         let signing_key = GuardianSignKeyPair::from([9u8; 32]);
         let timestamp_ms = 1_700_000_000_000;
         let wid = WithdrawalID::new([0xcd; 32]);

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -26,7 +26,6 @@ use crate::guardian::SessionID;
 use crate::guardian::SigningIntent;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
-use crate::guardian::session_id_from_signing_pubkey;
 use crate::guardian::signing::sign_intent;
 use crate::guardian::signing::verify_intent;
 use serde::Deserialize;
@@ -323,7 +322,7 @@ impl LogRecord {
     }
 
     fn validate_session_id(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
-        let canonical_session_id = session_id_from_signing_pubkey(signing_public_key);
+        let canonical_session_id = SessionID::from_signing_pubkey(signing_public_key);
         if self.session_id != canonical_session_id {
             return Err(InvalidInputs(format!(
                 "session ID mismatch: record contains {}, signing public key derives {canonical_session_id}",
@@ -365,7 +364,7 @@ mod tests {
     use bitcoin::hashes::Hash as _;
 
     fn heartbeat_session_id() -> SessionID {
-        session_id_from_signing_pubkey(&GuardianSignKeyPair::from([13u8; 32]).verification_key())
+        SessionID::from_signing_pubkey(&GuardianSignKeyPair::from([13u8; 32]).verification_key())
     }
 
     fn signed_heartbeat(timestamp_ms: UnixMillis) -> (String, LogRecord, GuardianSignKeyPair) {
@@ -412,7 +411,7 @@ mod tests {
     #[test]
     fn withdrawal_failure_writer_key_is_stable_and_verifies() {
         let signing_key = GuardianSignKeyPair::from([16u8; 32]);
-        let session_id = session_id_from_signing_pubkey(&signing_key.verification_key());
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
         let signed_request = StandardWithdrawalRequest::mock_signed_for_testing(Network::Regtest);
         let (request_sign, request_data) = signed_request.into_parts();
         let log = LogRecord::new(
@@ -431,7 +430,7 @@ mod tests {
     #[test]
     fn committee_update_failure_writer_key_is_stable_and_verifies() {
         let signing_key = GuardianSignKeyPair::from([17u8; 32]);
-        let session_id = session_id_from_signing_pubkey(&signing_key.verification_key());
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
         let signed_request = StandardWithdrawalRequest::mock_signed_for_testing(Network::Regtest);
         let (request_sign, _) = signed_request.into_parts();
         let log = LogRecord::new(
@@ -549,7 +548,7 @@ mod tests {
     #[test]
     fn signed_log_rejects_changed_failure_random_suffix_relocation() {
         let signing_key = GuardianSignKeyPair::from([18u8; 32]);
-        let session_id = session_id_from_signing_pubkey(&signing_key.verification_key());
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
         let signed_request = StandardWithdrawalRequest::mock_signed_for_testing(Network::Regtest);
         let (request_sign, request_data) = signed_request.into_parts();
         let log = LogRecord::new(
@@ -586,7 +585,7 @@ mod tests {
     #[test]
     fn signed_log_binds_session_even_when_key_does_not_contain_it() {
         let signing_key = GuardianSignKeyPair::from([19u8; 32]);
-        let session_id = session_id_from_signing_pubkey(&signing_key.verification_key());
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
         let log = LogRecord::new_at_timestamp(
             session_id,
             LogMessageV1::Genesis(Box::new(GenesisLogMessage {
@@ -602,7 +601,7 @@ mod tests {
         );
         let mut aliased: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        aliased.session_id = "aliased-session".to_string();
+        aliased.session_id = "aliased-session".into();
         aliased.object_key = GenesisLogMessage::object_key();
 
         let err = aliased
@@ -615,7 +614,7 @@ mod tests {
     #[test]
     fn unsigned_log_rejects_replay_at_another_s3_key() {
         let signing_key = GuardianSignKeyPair::from([14u8; 32]);
-        let session_id = session_id_from_signing_pubkey(&signing_key.verification_key());
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
         let mut log = LogRecord::new_at_timestamp(
             session_id,
             LogMessageV1::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
@@ -640,7 +639,7 @@ mod tests {
     fn unsigned_attestation_rejects_session_not_derived_from_signing_key() {
         let signing_key = GuardianSignKeyPair::from([15u8; 32]);
         let log = LogRecord::new_at_timestamp(
-            "forged-session".to_string(),
+            "forged-session".into(),
             LogMessageV1::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
                 attestation: NitroAttestation::new(vec![1, 2, 3]),
                 signing_public_key: signing_key.verification_key(),

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -237,6 +237,7 @@ pub enum InitLogMessage {
     /// Attestation and signing public key posted in /operator_init
     OIAttestationUnsigned {
         attestation: NitroAttestation,
+        #[serde(with = "crate::guardian::serde_utils::guardian_pubkey")]
         signing_public_key: GuardianPubKey,
     },
     /// Signed GuardianInfo logged in /operator_init (secret-sharing instance,
@@ -251,7 +252,9 @@ pub enum InitLogMessage {
     },
     /// Operator activation succeeded and installed live serving state.
     OAActivated {
+        #[serde(with = "hex::serde")]
         state_hash: [u8; 32],
+        #[serde(with = "hex::serde")]
         config_hash: [u8; 32],
         sharing_seq: u64,
         committee_epoch: u64,

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -243,9 +243,12 @@ pub enum InitLogMessage {
     /// config_hash, encryption/BTC pubkeys). Boxed: much larger than the other
     /// variants (`clippy::large_enum_variant`).
     OIGuardianInfo(Box<GuardianInfo>),
-    /// Threshold reached — enclave BTC key reconstructed (happens once). Records
-    /// the ids of the shares that were combined.
-    PIEnclaveFullyInitialized { share_ids: Vec<ShareID> },
+    /// Threshold reached — enclave BTC key reconstructed (happens once).
+    PIEnclaveFullyInitialized {
+        sharing_seq: u64,
+        share_ids: Vec<ShareID>,
+        enclave_btc_pubkey: BitcoinPubkey,
+    },
     /// Operator activation succeeded and installed live serving state.
     OAActivated { state_hash: [u8; 32] },
 }

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -291,10 +291,10 @@ pub enum CommitteeUpdateLogMessage {
 }
 
 impl InitLogMessage {
-    pub const OI_ATTEST_UNSIGNED: &'static str = "oi-attestation-unsigned";
-    pub const OI_GUARDIAN_INFO: &'static str = "oi-guardian-info";
-    pub const PI_FULLY_INITIALIZED: &'static str = "pi-enclave-fully-initialized";
-    pub const OA_ACTIVATED: &'static str = "oa-activated";
+    pub const OI_ATTEST_UNSIGNED: &'static str = "01-oi-attestation-unsigned";
+    pub const OI_GUARDIAN_INFO: &'static str = "02-oi-guardian-info";
+    pub const PI_FULLY_INITIALIZED: &'static str = "03-pi-enclave-fully-initialized";
+    pub const OA_ACTIVATED: &'static str = "04-oa-activated";
 
     pub fn object_key(&self, session_id: &str) -> String {
         let suffix = match self {
@@ -304,7 +304,7 @@ impl InitLogMessage {
             InitLogMessage::OAActivated { .. } => Self::OA_ACTIVATED,
         };
 
-        format!("{S3_DIR_INIT}/{session_id}-{suffix}.json")
+        Self::object_key_for_suffix(session_id, suffix)
     }
 
     fn object_key_pattern(&self, session_id: &str) -> ObjectKeyPattern {
@@ -312,21 +312,15 @@ impl InitLogMessage {
     }
 
     pub fn attestation_object_key(session_id: &str) -> String {
-        format!(
-            "{}/{}-{}.json",
-            S3_DIR_INIT,
-            session_id,
-            Self::OI_ATTEST_UNSIGNED
-        )
+        Self::object_key_for_suffix(session_id, Self::OI_ATTEST_UNSIGNED)
     }
 
     pub fn guardian_info_object_key(session_id: &str) -> String {
-        format!(
-            "{}/{}-{}.json",
-            S3_DIR_INIT,
-            session_id,
-            Self::OI_GUARDIAN_INFO
-        )
+        Self::object_key_for_suffix(session_id, Self::OI_GUARDIAN_INFO)
+    }
+
+    fn object_key_for_suffix(session_id: &str, suffix: &str) -> String {
+        format!("{S3_DIR_INIT}/{session_id}/{suffix}.json")
     }
 }
 

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -250,7 +250,13 @@ pub enum InitLogMessage {
         enclave_btc_pubkey: BitcoinPubkey,
     },
     /// Operator activation succeeded and installed live serving state.
-    OAActivated { state_hash: [u8; 32] },
+    OAActivated {
+        state_hash: [u8; 32],
+        config_hash: [u8; 32],
+        sharing_seq: u64,
+        committee_epoch: u64,
+        limiter_state: LimiterState,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -56,23 +56,9 @@ use rand_core::CryptoRng;
 use rand_core::RngCore;
 use serde::Deserialize;
 use serde::Serialize;
-// ---------------------------------
-//          Constants
-// ---------------------------------
-
-/// Length of the session ID prefix (hex chars) used in S3 keys. 16 hex =
-/// 64 bits of the signing pubkey, comfortably below any collision risk for
-/// realistic session counts.
-pub const SESSION_ID_HEX_LEN: usize = 16;
-
-/// Canonical guardian session ID — a short prefix of the hex-encoded signing
-/// public key. Used as a per-session tag in S3 object keys; full pubkey
-/// verification still happens via the signed log payload.
-pub fn session_id_from_signing_pubkey(signing_pub_key: &GuardianPubKey) -> SessionID {
-    let mut s = ::hex::encode(signing_pub_key.as_bytes());
-    s.truncate(SESSION_ID_HEX_LEN);
-    s
-}
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
 
 /// Which flows an enclave serves, fixed at boot. A `Ceremony` enclave runs
 /// `setup_new_key`/`rotate_kps`; a `Withdraw` enclave runs `provisioner_init` +
@@ -312,9 +298,70 @@ pub struct RotateKpsResponse {
 /// Used to correlate events across Sui, hashi nodes, and the guardian.
 pub type WithdrawalID = sui_sdk_types::Address;
 
-/// Guardian session identifier — a short prefix of the hex-encoded signing
-/// pubkey (see [`session_id_from_signing_pubkey`]). Tags per-session S3 objects.
-pub type SessionID = String;
+/// Guardian session identifier. Canonical IDs are short prefixes of the
+/// hex-encoded signing public key and tag per-session S3 objects.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(transparent)]
+pub struct SessionID(String);
+
+impl SessionID {
+    /// Length of the signing-public-key prefix used for canonical session IDs.
+    pub const HEX_LEN: usize = 16;
+
+    pub fn from_signing_pubkey(signing_pub_key: &GuardianPubKey) -> Self {
+        let mut session_id = ::hex::encode(signing_pub_key.as_bytes());
+        session_id.truncate(Self::HEX_LEN);
+        Self(session_id)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for SessionID {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for SessionID {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl From<SessionID> for String {
+    fn from(value: SessionID) -> Self {
+        value.0
+    }
+}
+
+impl AsRef<str> for SessionID {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for SessionID {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for SessionID {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for SessionID {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct S3Config {
@@ -600,7 +647,7 @@ impl SingleProvisionerInitRequest {
     }
 
     pub fn expected_session_id(&self) -> &str {
-        &self.expected_session_id
+        self.expected_session_id.as_str()
     }
 
     pub fn encrypted_share(&self) -> &GuardianEncryptedShare {
@@ -764,7 +811,7 @@ impl GetGuardianInfoResponse {
         Ok(VerifiedGuardianInfo {
             info,
             signing_pub_key: self.signing_pub_key,
-            session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
+            session_id: SessionID::from_signing_pubkey(&self.signing_pub_key),
             encrypted_shares: self.encrypted_shares.clone(),
         })
     }
@@ -778,7 +825,7 @@ impl GetGuardianInfoResponse {
         Ok(VerifiedGuardianInfo {
             info,
             signing_pub_key: self.signing_pub_key,
-            session_id: session_id_from_signing_pubkey(&self.signing_pub_key),
+            session_id: SessionID::from_signing_pubkey(&self.signing_pub_key),
             encrypted_shares: self.encrypted_shares.clone(),
         })
     }
@@ -915,7 +962,7 @@ mod tests {
         assert_eq!(verified.signing_pub_key, resp.signing_pub_key);
         assert_eq!(
             verified.session_id,
-            session_id_from_signing_pubkey(&resp.signing_pub_key)
+            SessionID::from_signing_pubkey(&resp.signing_pub_key)
         );
         assert_eq!(verified.info, resp.signed_info.data);
         assert_eq!(verified.encrypted_shares, resp.encrypted_shares);

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -6,6 +6,7 @@ pub mod crypto;
 pub mod errors;
 pub mod log;
 pub mod proto_conversions;
+pub(crate) mod serde_utils;
 pub mod signing;
 pub mod test_utils;
 pub mod time_utils;
@@ -119,9 +120,11 @@ pub struct GuardianInfo {
     /// S3 bucket name (if set). Used by KPs to check S3 bucket info.
     pub bucket_info: Option<S3BucketInfo>,
     /// Encryption key. Used by KPs to encrypt their shares.
+    #[serde(with = "hex::serde")]
     pub encryption_pubkey: EncPubKeyBytes,
     /// Digest of the operator-supplied `InitConfig` (set after operator_init).
     /// KPs recompute it from their verified sources and match to confirm config.
+    #[serde(with = "crate::guardian::serde_utils::option_hex_32")]
     pub config_hash: Option<[u8; 32]>,
     /// Git revision of the guardian build. Untrusted (enclave-self-reported);
     /// verified out-of-band by reproducibly building at this revision and matching
@@ -138,6 +141,7 @@ pub struct GuardianInfo {
     pub current_committee_epoch: Option<u64>,
     /// MPC committee verifying key `G` (the derivation master, NOT the guardian's
     /// own BTC key). Set after operator_init; lets KPs verify it directly.
+    #[serde(with = "crate::guardian::serde_utils::option_mpc_master_g")]
     pub mpc_master_g: Option<HashiMasterG>,
     // TODO: report the full committee too, so its membership is directly
     // verifiable from GuardianInfo; it's large, though.
@@ -953,6 +957,32 @@ impl From<&ActivationState> for ActivationStateRepr {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn guardian_info_json_encodes_binary_fields_as_strings() {
+        let mut info = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
+        info.config_hash = Some([0xab; 32]);
+        let btc_pubkey = crate::bitcoin::create_btc_keypair_for_test(&[3u8; 32])
+            .x_only_public_key()
+            .0;
+        info.mpc_master_g = Some(crate::bitcoin::hashi_master_g_from_btc_xonly_for_test(
+            &btc_pubkey,
+        ));
+
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["encryption_pubkey"], hex::encode([0u8; 32]));
+        assert_eq!(json["config_hash"], hex::encode([0xab; 32]));
+        let mpc_master_g = json["mpc_master_g"].as_str().unwrap();
+        assert_eq!(mpc_master_g.len(), 66);
+        assert!(
+            mpc_master_g
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        );
+
+        let from_json: GuardianInfo = serde_json::from_value(json).unwrap();
+        assert_eq!(from_json, info);
+    }
 
     #[test]
     fn get_guardian_info_verify_signed_info_passes_for_valid_signature() {

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -251,7 +251,8 @@ impl TryFrom<pb::SignedSingleProvisionerInitRequest> for KpSigned<SingleProvisio
         )?;
         let signer_cert =
             PgpPublicCert::new(req.signer_cert).map_err(|e| InvalidInputs(e.to_string()))?;
-        let request = SingleProvisionerInitRequest::new(req.expected_session_id, encrypted_share);
+        let request =
+            SingleProvisionerInitRequest::new(req.expected_session_id.into(), encrypted_share);
         Ok(KpSigned {
             data: request,
             signer_cert,
@@ -578,7 +579,7 @@ impl From<KpSigned<SingleProvisionerInitRequest>> for pb::SignedSingleProvisione
         let (expected_session_id, encrypted_share) = request.into_parts();
         Self {
             encrypted_share: Some(guardian_encrypted_share_to_pb(encrypted_share)),
-            expected_session_id,
+            expected_session_id: expected_session_id.into(),
             signer_cert: signer_cert.armored().to_string(),
             kp_signature: signature,
         }
@@ -1354,7 +1355,7 @@ mod tests {
             .pop()
             .unwrap();
         let request =
-            SingleProvisionerInitRequest::new("session-a".to_string(), encrypted_share.clone());
+            SingleProvisionerInitRequest::new("session-a".into(), encrypted_share.clone());
         let signature =
             sign_detached_in_process(&secret_armored, &KpSigned::signed_bytes(&request));
         let signed = KpSigned {

--- a/crates/hashi-types/src/guardian/serde_utils.rs
+++ b/crates/hashi-types/src/guardian/serde_utils.rs
@@ -1,0 +1,182 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Canonical textual encodings for binary guardian fields.
+//!
+//! Both the S3 JSON and the BCS signing payload use these representations.
+
+use crate::bitcoin::HashiMasterG;
+use crate::guardian::GuardianPubKey;
+use crate::guardian::GuardianSignature;
+use base64ct::Base64;
+use base64ct::Encoding;
+use fastcrypto::serde_helpers::ToFromByteArray;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use serde::de::Error as _;
+use serde::ser::SerializeMap;
+use std::collections::BTreeMap;
+
+fn decode_lower_hex<E: serde::de::Error>(encoded: &str) -> Result<Vec<u8>, E> {
+    if !encoded
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(E::custom("expected lowercase hex without a 0x prefix"));
+    }
+    hex::decode(encoded).map_err(E::custom)
+}
+
+fn decode_lower_hex_array<const N: usize, E: serde::de::Error>(
+    encoded: &str,
+    field: &str,
+) -> Result<[u8; N], E> {
+    let bytes = decode_lower_hex::<E>(encoded)?;
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        E::custom(format!("{field} must be {N} bytes, got {}", bytes.len()))
+    })
+}
+
+pub(crate) mod option_hex_32 {
+    use super::*;
+
+    pub fn serialize<S>(value: &Option<[u8; 32]>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(bytes) => serializer.serialize_some(&hex::encode(bytes)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<[u8; 32]>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|encoded| decode_lower_hex_array(&encoded, "hex value"))
+            .transpose()
+    }
+}
+
+pub(crate) mod base64_bytes {
+    use super::*;
+
+    pub fn serialize<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&Base64::encode_string(value))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        Base64::decode_vec(&encoded).map_err(D::Error::custom)
+    }
+}
+
+pub(crate) mod guardian_pubkey {
+    use super::*;
+
+    pub fn serialize<S>(value: &GuardianPubKey, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&hex::encode(value.as_bytes()))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<GuardianPubKey, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        let bytes = decode_lower_hex_array::<32, D::Error>(&encoded, "guardian public key")?;
+        GuardianPubKey::try_from(bytes.as_slice()).map_err(D::Error::custom)
+    }
+}
+
+pub(crate) mod option_guardian_signature {
+    use super::*;
+
+    pub fn serialize<S>(value: &Option<GuardianSignature>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value
+            .as_ref()
+            .map(|signature| hex::encode(signature.to_bytes()))
+            .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<GuardianSignature>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|encoded| {
+                decode_lower_hex_array::<64, D::Error>(&encoded, "guardian signature")
+                    .map(GuardianSignature::from)
+            })
+            .transpose()
+    }
+}
+
+pub(crate) mod option_mpc_master_g {
+    use super::*;
+
+    pub fn serialize<S>(value: &Option<HashiMasterG>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value
+            .as_ref()
+            .map(|point| hex::encode(point.to_byte_array()))
+            .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<HashiMasterG>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|encoded| {
+                let bytes = decode_lower_hex_array::<33, D::Error>(&encoded, "MPC master G")?;
+                HashiMasterG::from_byte_array(&bytes)
+                    .map_err(|error| D::Error::custom(format!("invalid MPC master G: {error:?}")))
+            })
+            .transpose()
+    }
+}
+
+pub(crate) mod hex_map_values {
+    use super::*;
+
+    pub fn serialize<S, K>(value: &BTreeMap<K, Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        K: Serialize + Ord,
+    {
+        let mut map = serializer.serialize_map(Some(value.len()))?;
+        for (key, bytes) in value {
+            map.serialize_entry(key, &hex::encode(bytes))?;
+        }
+        map.end()
+    }
+
+    pub fn deserialize<'de, D, K>(deserializer: D) -> Result<BTreeMap<K, Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+        K: Deserialize<'de> + Ord,
+    {
+        BTreeMap::<K, String>::deserialize(deserializer)?
+            .into_iter()
+            .map(|(key, encoded)| decode_lower_hex(&encoded).map(|bytes| (key, bytes)))
+            .collect()
+    }
+}


### PR DESCRIPTION
## Summary

- introduce a canonical `SessionID` newtype
- group and enrich initialization logs
- encode binary JSON fields as hex or base64 with V1 round-trip coverage

Stacked on #816.