### PR TITLE
docs: Sync config and governance docs with on-chain reality

### DIFF
--- a/design/docs/config.mdx
+++ b/design/docs/config.mdx
@@ -33,7 +33,7 @@ unspendable UTXOs.
 | | |
 |---|---|
 | **Type** | `u64` |
-| **Default** | `1000` |
+| **Default** | `600000` (10 minutes) |
 | **Unit** | milliseconds |
 
 The minimum time that must elapse between a deposit being approved by the
@@ -92,6 +92,89 @@ system is unpaused. Reconfiguration and governance actions are not affected.
 The minimum time a withdrawal request must remain in the queue before the user
 can cancel it. Prevents users from using rapid submit-cancel cycles to
 interfere with processing.
+
+### `governance_emergency_pause_threshold_bps`
+
+| | |
+|---|---|
+| **Type** | `u64` |
+| **Default** | `500` (5%) |
+| **Unit** | basis points of committee voting weight |
+
+The vote threshold for an emergency **pause** proposal. Deliberately low so a
+small fraction of the committee can quickly halt deposit and withdrawal
+processing when something looks wrong.
+
+### `governance_emergency_unpause_threshold_bps`
+
+| | |
+|---|---|
+| **Type** | `u64` |
+| **Default** | `6667` (two thirds) |
+| **Unit** | basis points of committee voting weight |
+
+The vote threshold for the **unpause** variant of the same proposal. Resuming
+operation requires a supermajority.
+
+## MPC parameters
+
+The MPC parameters are snapshotted (pinned) onto each committee at
+reconfiguration. An `UpdateConfig` that changes them mid-epoch never affects
+the active committee; new values take effect when the next committee forms.
+
+### `mpc_threshold_in_basis_points`
+
+| | |
+|---|---|
+| **Type** | `u64` |
+| **Default** | `3334` |
+| **Valid range** | `1` to `10000` |
+| **Unit** | basis points of committee voting weight |
+
+The MPC signing threshold: the minimum fraction of total committee voting
+weight whose shares are required to produce a threshold signature.
+
+### `mpc_max_faulty_in_basis_points`
+
+| | |
+|---|---|
+| **Type** | `u64` |
+| **Default** | `3333` |
+| **Valid range** | `0` to `10000` |
+| **Unit** | basis points of committee voting weight |
+
+The assumed upper bound on faulty (offline or adversarial) committee weight.
+MPC protocol parameters are derived under the assumption that at most this
+fraction of weight misbehaves.
+
+### `mpc_weight_reduction_allowed_delta`
+
+| | |
+|---|---|
+| **Type** | `u64` |
+| **Default** | `800` |
+| **Valid range** | `0` to `10000` |
+| **Unit** | basis points |
+
+Committee voting weights are proportionally reduced (compressed) before the
+MPC protocol runs, because each unit of weight corresponds to a share and
+protocol cost scales with total shares. Reduction necessarily distorts
+relative voting power; this parameter bounds the distortion, allowing the
+effective fault-tolerance assumption to shift by at most this many basis
+points relative to the unreduced committee. `0` disables weight reduction,
+so parties keep their full committee weights.
+
+### `mpc_nonce_generation_protocol`
+
+| | |
+|---|---|
+| **Type** | `u64` |
+| **Default** | `0` |
+| **Valid values** | `0` (vanilla), `1` (AVID) |
+
+Selects the protocol the committee uses to generate signing nonces
+(presignatures): `0` is the original protocol, `1` enables AVID-based nonce
+generation.
 
 ## Read-only or genesis-only parameters
 

--- a/design/docs/governance-actions.mdx
+++ b/design/docs/governance-actions.mdx
@@ -29,4 +29,28 @@ active version cannot be disabled, to avoid bricking the protocol.
 ## `UpdateConfig`
 
 Updates a protocol configuration parameter by key. Supports any config
-key-value pair (for example, deposit fee, rate limits).
+key-value pair (for example, deposit fee, rate limits). See
+[Configuration](config.mdx) for the full list of keys and defaults.
+
+## `EmergencyPause`
+
+Pauses or unpauses deposit and withdrawal processing by setting the `paused`
+config flag. The two directions use different vote thresholds: pausing is
+deliberately cheap (`governance_emergency_pause_threshold_bps`, default 5% of
+committee weight) so a small fraction of the committee can quickly halt the
+system, while unpausing requires a supermajority
+(`governance_emergency_unpause_threshold_bps`, default two thirds).
+
+## `UpdateGuardian`
+
+Updates the guardian's URL in the global config. Only the URL is governable:
+the guardian's BTC public key is immutable once set, because rotating it would
+invalidate derived deposit addresses.
+
+## `AbortReconfig`
+
+Aborts a pending reconfiguration for a specific epoch, clearing the pending
+epoch change and removing the pending committee. Voted on by the **current**
+committed committee, which is the only committee with stable onchain voting
+power if the pending committee cannot complete DKG or key rotation. See
+[Reconfiguration](reconfiguration.mdx) for when and how this is used.

--- a/packages/hashi/sources/btc/btc_config.move
+++ b/packages/hashi/sources/btc/btc_config.move
@@ -19,7 +19,7 @@ const DUST_RELAY_MIN_VALUE: u64 = 546;
 
 /// Initialize BTC-specific config defaults. Called after config::create().
 public(package) fun init_defaults(config: &mut Config) {
-    config.upsert(b"bitcoin_deposit_time_delay_ms", config_value::new_u64(10 * 60 * 1_000)); // 15 minutes
+    config.upsert(b"bitcoin_deposit_time_delay_ms", config_value::new_u64(10 * 60 * 1_000)); // 10 minutes
     config.upsert(b"bitcoin_deposit_minimum", config_value::new_u64(30_000));
     config.upsert(b"bitcoin_withdrawal_minimum", config_value::new_u64(30_000));
     config.upsert(b"bitcoin_confirmation_threshold", config_value::new_u64(6));


### PR DESCRIPTION
Audit of the design docs against the live testnet deployment and the last week of main, prompted by operator questions about current config values.

## Wrong default

`config.mdx` said `bitcoin_deposit_time_delay_ms` defaults to **1000 ms**; the Move default, and the value live on testnet, is **600000 ms** (10 minutes). The adjacent comment in `btc_config.move` calls the same constant "15 minutes" — fixed both. (Values verified by reading the deployed Hashi object's config VecMap directly.)

## Missing config keys (5 of 12 undocumented)

`config.mdx` covered 7 keys. Added:
- `governance_emergency_pause_threshold_bps` / `governance_emergency_unpause_threshold_bps` — the asymmetric emergency-pause quorums (5% to pause, two thirds to unpause), semantics verified in `emergency_pause.move`
- `mpc_threshold_in_basis_points`, `mpc_max_faulty_in_basis_points`, `mpc_weight_reduction_allowed_delta`, `mpc_nonce_generation_protocol` — with the pinned-per-committee semantics from `mpc_config::pin` (mid-epoch updates never affect the active committee), valid ranges from `is_valid_value`, and the AVID protocol value (`1`) that the recent AVID PRs made selectable

## Missing proposal types (3 of 7 undocumented)

`governance-actions.mdx` listed Upgrade / EnableVersion / DisableVersion / UpdateConfig as "the current set." Added `EmergencyPause`, `UpdateGuardian` (URL only; the guardian BTC key is immutable because rotation would invalidate derived deposit addresses), and `AbortReconfig` (cross-linked to the reconfiguration doc).

## Audited and found consistent (no change)

- `reconfiguration.mdx` vs #492's `ProposalExecuted<T>` event change
- runbook backup docs vs the inline-key backup-discovery fix
- `UpdateConfig` 2/3 threshold claim (all four base proposal types are 6667 bps)

**Flagged, not addressed here:** AVID has zero design-doc coverage (`mpc-protocol.mdx` never mentions nonce generation) — that needs an author with the protocol context. The runbook's curated "Key metrics" table also predates the two new `hashi_mpc_avid_*` metrics; happy to add them if ops wants them watched.