### PR TITLE
Demote the no-op metadata-check log to debug

### DIFF
--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1893,15 +1893,17 @@ pub async fn build_register_or_update_validator_tx(
         .await
         .ok();
     let registering = onchain_member.is_none();
-    if onchain_member.is_none() {
+    if registering {
         tracing::info!(
             %validator_address,
             "Validator not found on-chain, will register"
         );
     } else {
-        tracing::info!(
+        // Debug, not info: this runs on every periodic metadata check, and
+        // most checks send nothing. Callers log the actual outcome.
+        tracing::debug!(
             %validator_address,
-            "Validator already registered, will update metadata"
+            "Validator already registered; checking for stale metadata"
         );
     }
 


### PR DESCRIPTION
Operators asked in the channel whether this repeating log is normal:

```
INFO ... "Validator already registered, will update metadata" ... span: execute_register_or_update_validator
```

It is normal but misleading: `build_register_or_update_validator_tx` logs it unconditionally on every periodic metadata check, **before** the field-by-field diff that usually concludes there is nothing to send. So a healthy no-op check claims it "will update metadata" at INFO, repeatedly.

The already-registered branch now logs at debug with accurate wording ("checking for stale metadata"). No information is lost: the callers already log the real outcome — `Validator registered/updated on-chain` at INFO when something was sent, `Validator metadata is already up-to-date` at debug when not. The not-yet-registered branch stays at INFO, since it is rare and actionable.