### PR TITLE
[2/3] [Guardian] Version guardian S3 log schema

### DIFF
--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -21,6 +21,7 @@ use crate::metrics::ProxyMetrics;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::log::S3_DIR_WITHDRAW;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::StandardWithdrawalResponse;
 use hashi_types::guardian::WithdrawalID;
@@ -167,7 +168,7 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
     let timestamp_ms = record.timestamp_ms;
-    let LogMessage::Withdrawal(message) = record.message else {
+    let LogMessage::V1(LogMessageV1::Withdrawal(message)) = record.message else {
         anyhow::bail!("not a withdrawal record");
     };
     let WithdrawalLogMessage::Success {
@@ -324,7 +325,7 @@ pub(crate) mod test_store {
         let signing_key = GuardianSignKeyPair::from([9u8; 32]);
         let record = LogRecord::new_at_timestamp(
             "test-session".to_string(),
-            LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Success {
+            LogMessageV1::Withdrawal(Box::new(WithdrawalLogMessage::Success {
                 txid: bitcoin::Txid::from_slice(&[3u8; 32]).unwrap(),
                 request_data,
                 request_sign,

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -117,6 +117,7 @@ mod tests {
     use hashi_types::guardian::crypto::split_secret;
     use hashi_types::guardian::test_utils::mock_pgp_certs;
     use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV1;
     use hashi_types::guardian::LogRecord;
     use k256::SecretKey;
 
@@ -217,7 +218,7 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let LogMessage::Ceremony(ceremony) = record.message else {
+        let LogMessage::V1(LogMessageV1::Ceremony(ceremony)) = record.message else {
             panic!("expected Ceremony variant");
         };
         let CeremonyLogMessage::Rotate {
@@ -249,7 +250,7 @@ mod tests {
             "expected sharing_seq=1 cert_seq=0, got key {shares_key}"
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let LogMessage::KpShareState(shares) = shares_record.message else {
+        let LogMessage::V1(LogMessageV1::KpShareState(shares)) = shares_record.message else {
             panic!("expected KpShareState variant");
         };
         assert_eq!(shares.sharing_seq, 1);

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -92,6 +92,7 @@ mod tests {
     use crate::mock_logger_capturing;
     use crate::OperatorInitTestArgs;
     use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV1;
     use hashi_types::guardian::LogRecord;
     use hashi_types::pgp::test_utils::mock_pgp_certs;
 
@@ -145,7 +146,7 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let LogMessage::Ceremony(ceremony) = record.message else {
+        let LogMessage::V1(LogMessageV1::Ceremony(ceremony)) = record.message else {
             panic!("expected Ceremony variant");
         };
         let CeremonyLogMessage::NewKey {
@@ -179,7 +180,7 @@ mod tests {
             )
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let LogMessage::KpShareState(shares) = shares_record.message else {
+        let LogMessage::V1(LogMessageV1::KpShareState(shares)) = shares_record.message else {
             panic!("expected KpShareState variant");
         };
         assert_eq!(shares.sharing_seq, 0);

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -511,7 +511,7 @@ impl Enclave {
         session_id_from_signing_pubkey(&self.signing_pubkey())
     }
 
-    async fn write_log(&self, message: LogMessage) -> GuardianResult<()> {
+    async fn write_log(&self, message: LogMessageV1) -> GuardianResult<()> {
         let log = LogRecord::new(
             self.s3_session_id(),
             message,
@@ -521,7 +521,7 @@ impl Enclave {
         self.config.s3_logger()?.write_log_record(log).await
     }
 
-    async fn write_log_or_abort(&self, message: LogMessage) -> GuardianResult<()> {
+    async fn write_log_or_abort(&self, message: LogMessageV1) -> GuardianResult<()> {
         let log = LogRecord::new(
             self.s3_session_id(),
             message,
@@ -538,30 +538,30 @@ impl Enclave {
     /// S3 write/access issues. The incomplete enclave cannot serve and will restart,
     /// so S3 being ahead after a lost acknowledgement is acceptable.
     pub async fn log_init(&self, msg: InitLogMessage) -> GuardianResult<()> {
-        self.write_log(LogMessage::Init(Box::new(msg))).await
+        self.write_log(LogMessageV1::Init(Box::new(msg))).await
     }
 
     pub async fn log_withdraw(&self, msg: WithdrawalLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Withdrawal(Box::new(msg)))
+        self.write_log_or_abort(LogMessageV1::Withdrawal(Box::new(msg)))
             .await
     }
 
     pub async fn log_committee_update(&self, msg: CommitteeUpdateLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::CommitteeUpdate(Box::new(msg)))
+        self.write_log_or_abort(LogMessageV1::CommitteeUpdate(Box::new(msg)))
             .await
     }
 
     pub async fn log_genesis(&self, msg: GenesisLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Genesis(Box::new(msg)))
+        self.write_log_or_abort(LogMessageV1::Genesis(Box::new(msg)))
             .await
     }
 
     pub async fn log_heartbeat(&self, msg: HeartbeatLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Heartbeat(msg)).await
+        self.write_log_or_abort(LogMessageV1::Heartbeat(msg)).await
     }
 
     pub async fn log_ceremony(&self, state: CeremonyLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Ceremony(Box::new(state)))
+        self.write_log_or_abort(LogMessageV1::Ceremony(Box::new(state)))
             .await
     }
 
@@ -574,7 +574,7 @@ impl Enclave {
         cert_seq: u64,
         encrypted_shares: KPEncryptedShares,
     ) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::KpShareState(Box::new(
+        self.write_log_or_abort(LogMessageV1::KpShareState(Box::new(
             KpShareStateLogMessage::new(sharing_seq, cert_seq, encrypted_shares),
         )))
         .await

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -22,6 +22,7 @@ use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::GuardianError::S3Error;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::InitLogMessage;
+use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::VerifiedSessionInfo;
 use serde::Serialize;
@@ -614,7 +615,8 @@ impl GuardianS3Client {
         let attestation_record = self.get_log_record(&att_key).await?;
         let (_, _, attestation_message) = attestation_record.validate_unsigned()?;
         let (attestation, signing_pubkey) = attestation_message
-            .into_init_log()
+            .into_v1()
+            .and_then(LogMessageV1::into_init_log)
             .and_then(|x| match x {
                 InitLogMessage::OIAttestationUnsigned {
                     attestation,
@@ -629,7 +631,8 @@ impl GuardianS3Client {
         let info_record = self.get_log_record(&info_key).await?;
         let (_, _, info_message) = info_record.verify(&signing_pubkey)?;
         let info = info_message
-            .into_init_log()
+            .into_v1()
+            .and_then(LogMessageV1::into_init_log)
             .and_then(|x| match x {
                 InitLogMessage::OIGuardianInfo(info) => Some(*info),
                 _ => None,
@@ -660,7 +663,7 @@ mod tests {
     use aws_smithy_mocks::RuleMode;
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::HeartbeatLogMessage;
-    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV1;
 
     fn mk_logger_with_client(client: Client) -> GuardianS3Client {
         let config = S3Config {
@@ -815,7 +818,7 @@ mod tests {
         let signing_key = GuardianSignKeyPair::new(rand::thread_rng());
         let log = LogRecord::new(
             "session".to_string(),
-            LogMessage::Heartbeat(HeartbeatLogMessage::new(7)),
+            LogMessageV1::Heartbeat(HeartbeatLogMessage::new(7)),
             &signing_key,
         );
 
@@ -844,7 +847,7 @@ mod tests {
         let signing_key = GuardianSignKeyPair::new(rand::thread_rng());
         let log = LogRecord::new(
             "session".to_string(),
-            LogMessage::Heartbeat(HeartbeatLogMessage::new(7)),
+            LogMessageV1::Heartbeat(HeartbeatLogMessage::new(7)),
             &signing_key,
         );
 

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -365,20 +365,30 @@ impl GuardianS3Client {
 
         Ok(())
     }
+}
 
+/// Controls whether an S3 read requires Compliance-mode object-lock metadata.
+pub(crate) enum LockCheck {
+    /// Reject the object unless Compliance lock metadata is present.
+    Required,
+    /// Do not inspect lock metadata. Used for signed records whose short lock
+    /// is expected to expire, such as KP-share state.
+    Skipped,
+}
+
+/// Controls whether an S3 read validates that the key has no overwrite or
+/// deletion history.
+pub(crate) enum HistoryCheck {
+    /// Validate the exact key's history before fetching it.
+    Required,
+    /// The caller already validated the history of the enclosing prefix.
+    AlreadyChecked,
+}
+
+impl GuardianS3Client {
     // ========================================================================
     // S3 Reads
     // ========================================================================
-
-    /// Lists every key under `prefix`, refusing to proceed if the bucket has any
-    /// delete markers or non-latest versions in scope (which would indicate
-    /// tampering / lock-expiry beyond what the immutable-log model allows).
-    /// Returned keys are unique and sorted lexicographically.
-    ///
-    /// Keys-only counterpart to [`Self::list_all_log_records_in_dir`].
-    pub async fn list_all_keys_in_dir(&self, prefix: &str) -> GuardianResult<Vec<String>> {
-        self.ensure_no_duplicates_or_deletions(prefix).await
-    }
 
     /// Lists immediate subdirectories under `prefix` (S3 `CommonPrefixes`,
     /// returned by `list_objects_v2` with `delimiter='/'`). Used to tree-walk
@@ -424,11 +434,13 @@ impl GuardianS3Client {
         Ok(out.into_iter().collect())
     }
 
-    /// Checks that all matching object keys do not have either deletions or overwrites.
-    /// The prefix can either correspond to a directory or a complete object key.
-    ///
-    /// Returns: list of keys.
-    async fn ensure_no_duplicates_or_deletions(&self, prefix: &str) -> GuardianResult<Vec<String>> {
+    /// Lists every key under `prefix`, refusing to proceed if any matching
+    /// object has a delete marker or non-latest version. The prefix may be a
+    /// directory or a complete object key. Returned keys are unique and sorted.
+    pub async fn validate_prefix_history_and_list_keys(
+        &self,
+        prefix: &str,
+    ) -> GuardianResult<Vec<String>> {
         let s3_client = &self.client;
         let s3_config = &self.config;
 
@@ -515,21 +527,39 @@ impl GuardianS3Client {
         dir: &S3HourScopedDirectory,
     ) -> GuardianResult<Vec<LogRecord>> {
         let prefix = dir.to_string();
-        let keys = self.ensure_no_duplicates_or_deletions(&prefix).await?;
+        let keys = self.validate_prefix_history_and_list_keys(&prefix).await?;
         let mut out = Vec::with_capacity(keys.len());
         for key in keys {
-            out.push(self.get_log_record_inner(&key, true).await?);
+            // The prefix history was checked above. Immutable batch logs are
+            // also expected to remain under Compliance lock.
+            out.push(
+                self.get_log_record_inner(&key, LockCheck::Required, HistoryCheck::AlreadyChecked)
+                    .await?,
+            );
         }
         Ok(out)
     }
 
-    /// Fetches and deserializes a record, rejecting a mismatch between its
-    /// signed intended key and the actual S3 key.
-    async fn get_log_record_inner(
+    /// Fetches and deserializes a record with explicit S3 integrity checks,
+    /// always rejecting a mismatch between its signed intended key and the
+    /// actual S3 key. `HistoryCheck::AlreadyChecked` requires the caller to have
+    /// validated the key's enclosing prefix.
+    pub(crate) async fn get_log_record_inner(
         &self,
         key: &str,
-        require_object_lock: bool,
+        lock_check: LockCheck,
+        history_check: HistoryCheck,
     ) -> GuardianResult<LogRecord> {
+        if matches!(history_check, HistoryCheck::Required) {
+            let keys = self.validate_prefix_history_and_list_keys(key).await?;
+            if keys.len() != 1 || keys[0] != key {
+                return Err(S3Error(format!(
+                    "expected exactly one object for key {}, found {:?}",
+                    key, keys
+                )));
+            }
+        }
+
         let response = self
             .client
             .get_object()
@@ -546,7 +576,7 @@ impl GuardianS3Client {
             })?;
 
         // NOTE: When required, we are explicitly assuming locks are unexpired.
-        if require_object_lock
+        if matches!(lock_check, LockCheck::Required)
             && (response.object_lock_mode() != Some(&ObjectLockMode::Compliance)
                 || response.object_lock_retain_until_date().is_none())
         {
@@ -574,30 +604,14 @@ impl GuardianS3Client {
         Ok(record)
     }
 
-    /// Plain point read + deserialize, with no object-lock assertion and no
-    /// version/deletion check. For objects whose integrity comes from their own
-    /// signature rather than S3 immutability (e.g. `kp-shares/`, which carry only a
-    /// short lock that is expected to expire). A tampered object fails the
-    /// caller's signature check; a purged one surfaces as a get error.
-    pub async fn get_log_record_no_lock(&self, key: &str) -> GuardianResult<LogRecord> {
-        self.get_log_record_inner(key, false).await
-    }
-
     /// Reads an immutable-log object, asserting its Compliance lock metadata is
     /// present but not that it is unexpired.
     /// TODO: also reject when `retain_until <= now` — once the lock lapses the
     /// version check below no longer detects tampering (see
-    /// `ensure_no_duplicates_or_deletions`).
+    /// `validate_prefix_history_and_list_keys`).
     pub(crate) async fn get_log_record(&self, key: &str) -> GuardianResult<LogRecord> {
-        let keys = self.ensure_no_duplicates_or_deletions(key).await?;
-        if keys.len() != 1 || keys[0] != key {
-            return Err(S3Error(format!(
-                "expected exactly one object for key {}, found {:?}",
-                key, keys
-            )));
-        }
-
-        self.get_log_record_inner(key, true).await
+        self.get_log_record_inner(key, LockCheck::Required, HistoryCheck::Required)
+            .await
     }
 
     /// Resolve a session's [`VerifiedSessionInfo`]: read the AWS-self-signed

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -24,6 +24,7 @@ use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::KpShareStateLogMessage;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
@@ -207,7 +208,7 @@ impl GuardianReader {
         let session_id = record.session_id.clone();
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy("ceremony log", build_policy, &build_pcrs)?;
-        let LogMessage::Ceremony(msg) = record.message else {
+        let LogMessage::V1(LogMessageV1::Ceremony(msg)) = record.message else {
             anyhow::bail!("expected a ceremony log at {key}");
         };
         let (instance, btc_master_pubkey) = ceremony_instance_and_pubkey(*msg, key)?;
@@ -238,7 +239,7 @@ impl GuardianReader {
         let session_id = record.session_id.clone();
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy("kp-shares log", build_policy, &build_pcrs)?;
-        let LogMessage::KpShareState(msg) = record.message else {
+        let LogMessage::V1(LogMessageV1::KpShareState(msg)) = record.message else {
             anyhow::bail!("expected a kp-shares log at {key}");
         };
         if msg.sharing_seq != sharing_seq {
@@ -284,7 +285,7 @@ impl GuardianReader {
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy("committee-update log", build_policy, &record.build_pcrs)?;
-        let LogMessage::CommitteeUpdate(msg) = record.message else {
+        let LogMessage::V1(LogMessageV1::CommitteeUpdate(msg)) = record.message else {
             anyhow::bail!("expected a committee-update log at {key}");
         };
         match *msg {
@@ -315,7 +316,7 @@ impl GuardianReader {
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy("genesis log", build_policy, &record.build_pcrs)?;
-        let LogMessage::Genesis(msg) = record.message else {
+        let LogMessage::V1(LogMessageV1::Genesis(msg)) = record.message else {
             anyhow::bail!("expected a genesis log at {key}");
         };
         Ok(Some(*msg))

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -12,6 +12,8 @@
 //! advances/retreats and feeds to [`GuardianReader::read_dir`].
 
 use crate::s3_client::GuardianS3Client;
+use crate::s3_client::HistoryCheck;
+use crate::s3_client::LockCheck;
 use anyhow::Context;
 use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
@@ -188,7 +190,7 @@ impl GuardianReader {
     ) -> anyhow::Result<Option<(SessionID, SecretSharingInstance, BitcoinPubkey)>> {
         let keys = self
             .s3
-            .list_all_keys_in_dir(&format!("{}/", S3_DIR_CEREMONY))
+            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_CEREMONY))
             .await?;
         let Some(key) = pick_latest_key(keys, S3_DIR_CEREMONY) else {
             return Ok(None);
@@ -230,11 +232,19 @@ impl GuardianReader {
         build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<(SessionID, KpShareStateLogMessage)>> {
         let prefix = KpShareStateLogMessage::object_key_dir(sharing_seq);
-        let keys = self.s3.list_all_keys_in_dir(&prefix).await?;
+        let keys = self
+            .s3
+            .validate_prefix_history_and_list_keys(&prefix)
+            .await?;
         let Some(key) = keys.into_iter().max() else {
             return Ok(None);
         };
-        let record = self.s3.get_log_record_no_lock(&key).await?;
+        // The prefix history was checked above. KP-share locks are short-lived
+        // and expected to expire, so integrity comes from the signature below.
+        let record = self
+            .s3
+            .get_log_record_inner(&key, LockCheck::Skipped, HistoryCheck::AlreadyChecked)
+            .await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         let session_id = record.session_id.clone();
         let build_pcrs = record.build_pcrs.clone();
@@ -277,7 +287,7 @@ impl GuardianReader {
     ) -> anyhow::Result<Option<Committee>> {
         let keys = self
             .s3
-            .list_all_keys_in_dir(&format!("{}/", S3_DIR_COMMITTEE_UPDATE))
+            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE))
             .await?;
         let Some(key) = pick_latest_key(keys, S3_DIR_COMMITTEE_UPDATE) else {
             return Ok(None);
@@ -305,7 +315,7 @@ impl GuardianReader {
         let key = GenesisLogMessage::object_key();
         let keys = self
             .s3
-            .list_all_keys_in_dir(&format!("{}/", S3_DIR_GENESIS))
+            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_GENESIS))
             .await?;
         if keys.is_empty() {
             return Ok(None);

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -9,6 +9,7 @@ use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::time_utils::unix_millis_to_seconds;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::SessionID;
 use hashi_types::guardian::VerifiedLogRecord;
 use std::collections::BTreeMap;
@@ -75,7 +76,7 @@ fn summarize_heartbeats_by_session(
     let mut map: BTreeMap<String, (UnixSeconds, UnixSeconds)> = BTreeMap::new();
 
     for log in logs {
-        if !matches!(log.message, LogMessage::Heartbeat(..)) {
+        if !matches!(log.message, LogMessage::V1(LogMessageV1::Heartbeat(..))) {
             anyhow::bail!("non-heartbeat logs found");
         }
 
@@ -156,7 +157,7 @@ mod tests {
             object_key: format!("heartbeat/{session_id}.json"),
             session_id: session_id.to_string(),
             timestamp_ms: timestamp_secs * 1_000,
-            message: LogMessage::Heartbeat(HeartbeatLogMessage::new(0)),
+            message: LogMessageV1::Heartbeat(HeartbeatLogMessage::new(0)).into(),
             build_pcrs: build_pcrs(),
         }
     }
@@ -166,9 +167,10 @@ mod tests {
             object_key: "init/test-session-pi-enclave-fully-initialized.json".to_string(),
             session_id: "test-session".to_string(),
             timestamp_ms: 0,
-            message: LogMessage::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
+            message: LogMessageV1::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
                 share_ids: vec![],
-            })),
+            }))
+            .into(),
             build_pcrs: build_pcrs(),
         }
     }

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -121,7 +121,7 @@ async fn hour_bucket_has_success(
     bucket: &str,
 ) -> anyhow::Result<bool> {
     let keys = s3_client
-        .list_all_keys_in_dir(&format!("{bucket}success-"))
+        .validate_prefix_history_and_list_keys(&format!("{bucket}success-"))
         .await
         .map_err(|e| anyhow::anyhow!(e))?;
     Ok(!keys.is_empty())

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -30,6 +30,7 @@ use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
@@ -129,7 +130,7 @@ async fn hour_bucket_has_success(
 fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {
     logs.into_iter()
         .filter_map(|log| {
-            let LogMessage::Withdrawal(boxed) = log.message else {
+            let LogMessage::V1(LogMessageV1::Withdrawal(boxed)) = log.message else {
                 return None;
             };
             match *boxed {
@@ -189,7 +190,7 @@ mod tests {
             object_key: format!("withdraw/success-{next_seq}.json"),
             session_id: "test-session".to_string(),
             timestamp_ms: 0,
-            message: LogMessage::Withdrawal(Box::new(msg)),
+            message: LogMessageV1::Withdrawal(Box::new(msg)).into(),
             build_pcrs: build_pcrs(),
         }
     }
@@ -206,7 +207,7 @@ mod tests {
             object_key: "withdraw/failure.json".to_string(),
             session_id: "test-session".to_string(),
             timestamp_ms: 0,
-            message: LogMessage::Withdrawal(Box::new(msg)),
+            message: LogMessageV1::Withdrawal(Box::new(msg)).into(),
             build_pcrs: build_pcrs(),
         }
     }

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -9,6 +9,7 @@ use crate::domain::WithdrawalEventType;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_guardian::s3_reader::withdraw_cursor;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
@@ -27,7 +28,7 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
     type Error = anyhow::Error;
 
     fn try_from(log: VerifiedLogRecord) -> Result<Self, Self::Error> {
-        let LogMessage::Withdrawal(withdrawal_message) = log.message else {
+        let LogMessage::V1(LogMessageV1::Withdrawal(withdrawal_message)) = log.message else {
             anyhow::bail!("non-withdrawal logs found");
         };
 

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -187,16 +187,15 @@ impl LogRecord {
     }
 
     pub fn object_lock_duration(&self) -> Duration {
-        match &self.message {
-            LogMessage::V1(LogMessageV1::Init(..)) => S3_OBJECT_LOCK_DURATION_INIT,
-            LogMessage::V1(LogMessageV1::Heartbeat(..)) => S3_OBJECT_LOCK_DURATION_HEARTBEAT,
-            LogMessage::V1(LogMessageV1::Withdrawal(..)) => S3_OBJECT_LOCK_DURATION_WITHDRAW,
-            LogMessage::V1(LogMessageV1::Ceremony(..)) => S3_OBJECT_LOCK_DURATION_CEREMONY,
-            LogMessage::V1(LogMessageV1::KpShareState(..)) => S3_OBJECT_LOCK_DURATION_KP_SHARES,
-            LogMessage::V1(LogMessageV1::CommitteeUpdate(..)) => {
-                S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE
-            }
-            LogMessage::V1(LogMessageV1::Genesis(..)) => S3_OBJECT_LOCK_DURATION_GENESIS,
+        let LogMessage::V1(message) = &self.message;
+        match message {
+            LogMessageV1::Init(..) => S3_OBJECT_LOCK_DURATION_INIT,
+            LogMessageV1::Heartbeat(..) => S3_OBJECT_LOCK_DURATION_HEARTBEAT,
+            LogMessageV1::Withdrawal(..) => S3_OBJECT_LOCK_DURATION_WITHDRAW,
+            LogMessageV1::Ceremony(..) => S3_OBJECT_LOCK_DURATION_CEREMONY,
+            LogMessageV1::KpShareState(..) => S3_OBJECT_LOCK_DURATION_KP_SHARES,
+            LogMessageV1::CommitteeUpdate(..) => S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE,
+            LogMessageV1::Genesis(..) => S3_OBJECT_LOCK_DURATION_GENESIS,
         }
     }
 

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -13,6 +13,7 @@ use super::S3_OBJECT_LOCK_DURATION_INIT;
 use super::S3_OBJECT_LOCK_DURATION_KP_SHARES;
 use super::S3_OBJECT_LOCK_DURATION_WITHDRAW;
 use super::message::LogMessage;
+use super::message::LogMessageV1;
 use super::message::ObjectKeyPattern;
 use crate::guardian::BuildPcrs;
 use crate::guardian::GuardianError::InvalidInputs;
@@ -30,11 +31,13 @@ use crate::guardian::signing::sign_intent;
 use crate::guardian::signing::verify_intent;
 use serde::Deserialize;
 use serde::Serialize;
+use serde::de::Error as _;
+use serde_json::Value;
 use std::time::Duration;
 
 /// Write: `LogMessage` -> `LogRecord` -> JSON body.
 /// Read: actual S3 key + JSON body -> untrusted `LogRecord` -> `VerifiedLogRecord`.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct LogRecord {
     /// Final S3 destination selected before signing. Readers must compare this
     /// signed intended key with the actual key returned by S3.
@@ -48,9 +51,76 @@ pub struct LogRecord {
 
 #[derive(Serialize)]
 struct LogSigningPayload<'a> {
+    schema_version: u64,
     session_id: &'a SessionID,
     object_key: &'a str,
     message: &'a LogMessage,
+}
+
+impl Serialize for LogRecord {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct LogRecordWire<'a, M> {
+            schema_version: u64,
+            object_key: &'a str,
+            session_id: &'a SessionID,
+            timestamp_ms: UnixMillis,
+            message: &'a M,
+            signature: &'a Option<GuardianSignature>,
+        }
+
+        match &self.message {
+            LogMessage::V1(message) => LogRecordWire {
+                schema_version: LogMessage::SCHEMA_VERSION_V1,
+                object_key: &self.object_key,
+                session_id: &self.session_id,
+                timestamp_ms: self.timestamp_ms,
+                message,
+                signature: &self.signature,
+            }
+            .serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for LogRecord {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct LogRecordWire {
+            schema_version: u64,
+            object_key: String,
+            session_id: SessionID,
+            timestamp_ms: UnixMillis,
+            message: Value,
+            signature: Option<GuardianSignature>,
+        }
+
+        let raw = LogRecordWire::deserialize(deserializer)?;
+        let message = match raw.schema_version {
+            LogMessage::SCHEMA_VERSION_V1 => serde_json::from_value::<LogMessageV1>(raw.message)
+                .map(LogMessage::V1)
+                .map_err(D::Error::custom)?,
+            version => {
+                return Err(D::Error::custom(format!(
+                    "unsupported log schema version: {version}"
+                )));
+            }
+        };
+
+        Ok(Self {
+            object_key: raw.object_key,
+            session_id: raw.session_id,
+            timestamp_ms: raw.timestamp_ms,
+            message,
+            signature: raw.signature,
+        })
+    }
 }
 
 impl SigningIntent for LogSigningPayload<'_> {
@@ -89,7 +159,7 @@ impl VerifiedLogRecord {
 impl LogRecord {
     pub fn new(
         session_id: SessionID,
-        message: LogMessage,
+        message: impl Into<LogMessage>,
         signing_key: &GuardianSignKeyPair,
     ) -> Self {
         Self::new_at_timestamp(session_id, message, signing_key, now_timestamp_ms())
@@ -97,10 +167,11 @@ impl LogRecord {
 
     pub fn new_at_timestamp(
         session_id: SessionID,
-        message: LogMessage,
+        message: impl Into<LogMessage>,
         signing_key: &GuardianSignKeyPair,
         timestamp_ms: UnixMillis,
     ) -> Self {
+        let message = message.into();
         let object_key = message
             .object_key_pattern(&session_id, timestamp_ms)
             .finalize();
@@ -117,13 +188,15 @@ impl LogRecord {
 
     pub fn object_lock_duration(&self) -> Duration {
         match &self.message {
-            LogMessage::Init(..) => S3_OBJECT_LOCK_DURATION_INIT,
-            LogMessage::Heartbeat(..) => S3_OBJECT_LOCK_DURATION_HEARTBEAT,
-            LogMessage::Withdrawal(..) => S3_OBJECT_LOCK_DURATION_WITHDRAW,
-            LogMessage::Ceremony(..) => S3_OBJECT_LOCK_DURATION_CEREMONY,
-            LogMessage::KpShareState(..) => S3_OBJECT_LOCK_DURATION_KP_SHARES,
-            LogMessage::CommitteeUpdate(..) => S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE,
-            LogMessage::Genesis(..) => S3_OBJECT_LOCK_DURATION_GENESIS,
+            LogMessage::V1(LogMessageV1::Init(..)) => S3_OBJECT_LOCK_DURATION_INIT,
+            LogMessage::V1(LogMessageV1::Heartbeat(..)) => S3_OBJECT_LOCK_DURATION_HEARTBEAT,
+            LogMessage::V1(LogMessageV1::Withdrawal(..)) => S3_OBJECT_LOCK_DURATION_WITHDRAW,
+            LogMessage::V1(LogMessageV1::Ceremony(..)) => S3_OBJECT_LOCK_DURATION_CEREMONY,
+            LogMessage::V1(LogMessageV1::KpShareState(..)) => S3_OBJECT_LOCK_DURATION_KP_SHARES,
+            LogMessage::V1(LogMessageV1::CommitteeUpdate(..)) => {
+                S3_OBJECT_LOCK_DURATION_COMMITTEE_UPDATE
+            }
+            LogMessage::V1(LogMessageV1::Genesis(..)) => S3_OBJECT_LOCK_DURATION_GENESIS,
         }
     }
 
@@ -203,7 +276,7 @@ impl LogRecord {
             ));
         }
         self.validate_object_key()?;
-        let LogMessage::Init(init) = &self.message else {
+        let LogMessage::V1(LogMessageV1::Init(init)) = &self.message else {
             unreachable!("is_allowed_unsigned only permits an init message");
         };
         let super::message::InitLogMessage::OIAttestationUnsigned {
@@ -263,6 +336,7 @@ impl LogRecord {
 
     fn signing_payload(&self) -> LogSigningPayload<'_> {
         LogSigningPayload {
+            schema_version: self.message.schema_version(),
             session_id: &self.session_id,
             object_key: &self.object_key,
             message: &self.message,
@@ -299,7 +373,7 @@ mod tests {
         let signing_key = GuardianSignKeyPair::from([13u8; 32]);
         let record = LogRecord::new_at_timestamp(
             heartbeat_session_id(),
-            LogMessage::Heartbeat(HeartbeatLogMessage::new(42)),
+            LogMessageV1::Heartbeat(HeartbeatLogMessage::new(42)),
             &signing_key,
             timestamp_ms,
         );
@@ -344,7 +418,7 @@ mod tests {
         let (request_sign, request_data) = signed_request.into_parts();
         let log = LogRecord::new(
             session_id,
-            LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Failure {
+            LogMessageV1::Withdrawal(Box::new(WithdrawalLogMessage::Failure {
                 request_data: request_data.into(),
                 request_sign,
                 error: GuardianError::RateLimitExceeded,
@@ -363,7 +437,7 @@ mod tests {
         let (request_sign, _) = signed_request.into_parts();
         let log = LogRecord::new(
             session_id,
-            LogMessage::CommitteeUpdate(Box::new(CommitteeUpdateLogMessage::Failure {
+            LogMessageV1::CommitteeUpdate(Box::new(CommitteeUpdateLogMessage::Failure {
                 from_epoch: 6,
                 new_committee: crate::move_types::Committee {
                     epoch: 7,
@@ -391,7 +465,7 @@ mod tests {
         assert_eq!(timestamp_ms, 1_700_000_000_000);
         assert!(matches!(
             message,
-            LogMessage::Heartbeat(HeartbeatLogMessage { seq: 42 })
+            LogMessage::V1(LogMessageV1::Heartbeat(HeartbeatLogMessage { seq: 42 }))
         ));
     }
 
@@ -399,6 +473,7 @@ mod tests {
     fn object_key_is_signed_and_serialized() {
         let (object_key, log, signing_key) = signed_heartbeat(1_700_000_000_000);
         let json = serde_json::to_value(&log).unwrap();
+        assert_eq!(json.get("schema_version").unwrap(), 1);
         assert_eq!(json.get("object_key").unwrap(), &object_key);
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
@@ -408,6 +483,19 @@ mod tests {
         from_s3
             .verify(&signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
+    }
+
+    #[test]
+    fn unsupported_schema_version_is_rejected() {
+        let (_, log, _) = signed_heartbeat(1_700_000_000_000);
+        let mut json = serde_json::to_value(log).unwrap();
+        json["schema_version"] = serde_json::json!(2);
+
+        let err = serde_json::from_value::<LogRecord>(json).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported log schema version: 2")
+        );
     }
 
     #[test]
@@ -446,7 +534,7 @@ mod tests {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
         let mut tampered: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        tampered.message = LogMessage::Heartbeat(HeartbeatLogMessage::new(43));
+        tampered.message = LogMessageV1::Heartbeat(HeartbeatLogMessage::new(43)).into();
         tampered.object_key = format!(
             "heartbeat/2023/11/14/22/{}-00000000000000000043.json",
             heartbeat_session_id()
@@ -467,7 +555,7 @@ mod tests {
         let (request_sign, request_data) = signed_request.into_parts();
         let log = LogRecord::new(
             session_id,
-            LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Failure {
+            LogMessageV1::Withdrawal(Box::new(WithdrawalLogMessage::Failure {
                 request_data: request_data.into(),
                 request_sign,
                 error: GuardianError::RateLimitExceeded,
@@ -502,7 +590,7 @@ mod tests {
         let session_id = session_id_from_signing_pubkey(&signing_key.verification_key());
         let log = LogRecord::new_at_timestamp(
             session_id,
-            LogMessage::Genesis(Box::new(GenesisLogMessage {
+            LogMessageV1::Genesis(Box::new(GenesisLogMessage {
                 committee: crate::move_types::Committee {
                     epoch: 0,
                     members: vec![],
@@ -531,7 +619,7 @@ mod tests {
         let session_id = session_id_from_signing_pubkey(&signing_key.verification_key());
         let mut log = LogRecord::new_at_timestamp(
             session_id,
-            LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
+            LogMessageV1::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
                 attestation: NitroAttestation::new(vec![1, 2, 3]),
                 signing_public_key: signing_key.verification_key(),
             })),
@@ -554,7 +642,7 @@ mod tests {
         let signing_key = GuardianSignKeyPair::from([15u8; 32]);
         let log = LogRecord::new_at_timestamp(
             "forged-session".to_string(),
-            LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
+            LogMessageV1::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
                 attestation: NitroAttestation::new(vec![1, 2, 3]),
                 signing_public_key: signing_key.verification_key(),
             })),
@@ -574,7 +662,7 @@ mod tests {
         let signing_key = GuardianSignKeyPair::from([7u8; 32]);
         let log = LogRecord::new_at_timestamp(
             session_id.clone(),
-            LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
+            LogMessageV1::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
                 attestation: NitroAttestation::new(vec![1, 2, 3]),
                 signing_public_key: signing_key.verification_key(),
             })),
@@ -597,7 +685,7 @@ mod tests {
 
         let log = LogRecord::new_at_timestamp(
             session_id.clone(),
-            LogMessage::Heartbeat(HeartbeatLogMessage::new(seq)),
+            LogMessageV1::Heartbeat(HeartbeatLogMessage::new(seq)),
             &signing_key,
             timestamp_ms,
         );
@@ -616,7 +704,7 @@ mod tests {
         let signing_key = GuardianSignKeyPair::from([10u8; 32]);
         let log = LogRecord::new_at_timestamp(
             session_id,
-            LogMessage::KpShareState(Box::new(KpShareStateLogMessage::new(
+            LogMessageV1::KpShareState(Box::new(KpShareStateLogMessage::new(
                 7,
                 3,
                 KPEncryptedShares::new(vec![]).unwrap(),
@@ -641,7 +729,7 @@ mod tests {
         let signing_key = GuardianSignKeyPair::from([12u8; 32]);
         let log = LogRecord::new_at_timestamp(
             session_id,
-            LogMessage::Genesis(Box::new(GenesisLogMessage {
+            LogMessageV1::Genesis(Box::new(GenesisLogMessage {
                 committee: crate::move_types::Committee {
                     epoch: 0,
                     members: vec![],
@@ -672,7 +760,7 @@ mod tests {
 
         let log = LogRecord::new_at_timestamp(
             session_id.clone(),
-            LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Success {
+            LogMessageV1::Withdrawal(Box::new(WithdrawalLogMessage::Success {
                 txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
                 request_data,
                 request_sign,

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The `LogMessage` family the enclave emits and its per-message S3 object-key
+//! The versioned `LogMessage` family the enclave emits and its per-message S3 object-key
 //! rules. The `LogRecord` wrapper that carries these to S3 lives in
 //! `super::envelope`.
 //!
@@ -43,10 +43,35 @@ use bitcoin::Txid;
 use serde::Deserialize;
 use serde::Serialize;
 
-/// All log messages emitted by the guardian enclave.
-/// Uses enum discriminator for automatic domain separation between variants.
-#[derive(Debug, Serialize, Deserialize)]
+/// The versioned message stored in a [`super::LogRecord`]. Its version is
+/// serialized as the record's sibling `schema_version` field rather than as an
+/// additional JSON enum layer.
+#[derive(Debug)]
 pub enum LogMessage {
+    V1(LogMessageV1),
+}
+
+impl From<LogMessageV1> for LogMessage {
+    fn from(message: LogMessageV1) -> Self {
+        Self::V1(message)
+    }
+}
+
+impl Serialize for LogMessage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::V1(message) => message.serialize(serializer),
+        }
+    }
+}
+
+/// All schema-version-1 log messages emitted by the guardian enclave.
+/// Uses an enum discriminator for automatic domain separation between variants.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum LogMessageV1 {
     Heartbeat(HeartbeatLogMessage),
     Init(Box<InitLogMessage>),
     Withdrawal(Box<WithdrawalLogMessage>),
@@ -353,9 +378,9 @@ impl CommitteeUpdateLogMessage {
     }
 }
 
-impl LogMessage {
+impl LogMessageV1 {
     pub fn is_allowed_unsigned(&self) -> bool {
-        if let LogMessage::Init(init_message) = self {
+        if let LogMessageV1::Init(init_message) = self {
             matches!(**init_message, InitLogMessage::OIAttestationUnsigned { .. })
         } else {
             false
@@ -384,8 +409,44 @@ impl LogMessage {
 
     pub fn into_init_log(self) -> Option<InitLogMessage> {
         match self {
-            LogMessage::Init(init_message) => Some(*init_message),
+            LogMessageV1::Init(init_message) => Some(*init_message),
             _ => None,
+        }
+    }
+}
+
+impl LogMessage {
+    pub const SCHEMA_VERSION_V1: u64 = 1;
+
+    pub fn schema_version(&self) -> u64 {
+        match self {
+            Self::V1(_) => Self::SCHEMA_VERSION_V1,
+        }
+    }
+
+    pub fn is_allowed_unsigned(&self) -> bool {
+        match self {
+            Self::V1(message) => message.is_allowed_unsigned(),
+        }
+    }
+
+    pub fn must_be_signed(&self) -> bool {
+        !self.is_allowed_unsigned()
+    }
+
+    pub(super) fn object_key_pattern(
+        &self,
+        session_id: &str,
+        timestamp_ms: UnixMillis,
+    ) -> ObjectKeyPattern {
+        match self {
+            Self::V1(message) => message.object_key_pattern(session_id, timestamp_ms),
+        }
+    }
+
+    pub fn into_v1(self) -> Option<LogMessageV1> {
+        match self {
+            Self::V1(message) => Some(message),
         }
     }
 }


### PR DESCRIPTION
## Summary

Version guardian log messages while keeping `LogRecord` stable:

- `LogMessage::V1(LogMessageV1)` records the source schema
- JSON keeps the existing flat `message` shape with a numeric `schema_version`
- the version is signed and selects deserialization; unsupported versions are rejected

A future schema adds `LogMessage::V2(LogMessageV2)` and another dispatch arm.

Stacked on #801.