### PR TITLE
Name the Bitcoin Core version requirement when bitcoind responses fail to decode

### DIFF
--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -645,7 +645,10 @@ impl Hashi {
             self.config.bitcoin_rpc_auth(),
         )?;
 
-        let info = rpc.get_blockchain_info()?.into_model()?;
+        let info = rpc
+            .get_blockchain_info()
+            .map_err(bitcoind_rpc_error_with_version_hint)?
+            .into_model()?;
         let expected = self.config.bitcoin_network();
 
         anyhow::ensure!(
@@ -1085,6 +1088,21 @@ impl Hashi {
     }
 }
 
+/// Wrap a bitcoind response-decode failure with a version hint. A response
+/// that is valid JSON but does not match the v29 schema is almost always a
+/// pre-v29 bitcoind (`warnings` was a string, not an array, until Core v28),
+/// so name the real problem instead of surfacing a bare serde error.
+fn bitcoind_rpc_error_with_version_hint(e: corepc_client::client_sync::Error) -> anyhow::Error {
+    match &e {
+        corepc_client::client_sync::Error::JsonRpc(jsonrpc::Error::Json(_))
+        | corepc_client::client_sync::Error::Json(_) => anyhow!(
+            "unexpected getblockchaininfo response from bitcoind: {e}. Hashi requires \
+             Bitcoin Core v29 or newer; check the node's version with `bitcoin-cli getnetworkinfo`"
+        ),
+        _ => anyhow!(e),
+    }
+}
+
 #[derive(Clone)]
 pub struct ServerVersion {
     pub bin: &'static str,
@@ -1165,6 +1183,7 @@ mod test {
 
     use crate::Hashi;
     use crate::ServerVersion;
+    use crate::bitcoind_rpc_error_with_version_hint;
 
     use crate::config::Config;
     use crate::grpc::Client;
@@ -1177,6 +1196,24 @@ mod test {
         let registry = prometheus::Registry::new();
         let hashi = Hashi::new_with_registry(server_version, None, config, &registry).unwrap();
         (hashi, tmpdir)
+    }
+
+    #[test]
+    fn bitcoind_decode_errors_get_version_hint_but_transport_errors_do_not() {
+        // A pre-v29 bitcoind returns `"warnings": ""` where v29 has an array;
+        // the resulting serde error must be wrapped with the version hint.
+        let decode = serde_json::from_str::<Vec<String>>("\"\"").unwrap_err();
+        let e = corepc_client::client_sync::Error::JsonRpc(jsonrpc::Error::Json(decode));
+        let msg = bitcoind_rpc_error_with_version_hint(e).to_string();
+        assert!(msg.contains("Bitcoin Core v29 or newer"), "{msg}");
+
+        // Connectivity problems must not be misattributed to the version.
+        let transport = jsonrpc::Error::Transport(Box::new(std::io::Error::other(
+            "connection refused",
+        )));
+        let e = corepc_client::client_sync::Error::JsonRpc(transport);
+        let msg = bitcoind_rpc_error_with_version_hint(e).to_string();
+        assert!(!msg.contains("Bitcoin Core"), "{msg}");
     }
 
     #[test]

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -1208,9 +1208,8 @@ mod test {
         assert!(msg.contains("Bitcoin Core v29 or newer"), "{msg}");
 
         // Connectivity problems must not be misattributed to the version.
-        let transport = jsonrpc::Error::Transport(Box::new(std::io::Error::other(
-            "connection refused",
-        )));
+        let transport =
+            jsonrpc::Error::Transport(Box::new(std::io::Error::other("connection refused")));
         let e = corepc_client::client_sync::Error::JsonRpc(transport);
         let msg = bitcoind_rpc_error_with_version_hint(e).to_string();
         assert!(!msg.contains("Bitcoin Core"), "{msg}");


### PR DESCRIPTION
An operator hit this at node startup and had no way to act on it:

```
ERROR Failed to initialize BtcMonitor: JSON-RPC error: JSON decode error: invalid type: string "", expected a sequence at line 1 column 414
```

Root cause: they were running a pre-v29 Bitcoin Core. Core v28 changed `getblockchaininfo`'s `warnings` field from a string to an array, and hashi decodes responses with corepc's **v29 schema** (`warnings: Vec<String>`), so older nodes fail with exactly this serde error on the first RPC call.

`verify_bitcoind_network` (the first bitcoind call at startup) now maps response-decode failures (`Error::JsonRpc(jsonrpc::Error::Json(_))` / `Error::Json(_)`) to an error naming the requirement: *"Hashi requires Bitcoin Core v29 or newer; check the node's version with `bitcoin-cli getnetworkinfo`"*. Transport and RPC-level errors pass through unchanged, so connectivity or auth problems are not misattributed to the version.

Unit test covers both arms: the exact pre-v29 shape (`"warnings": ""`) gets the hint; a transport error does not.

Same fail-loudly theme as #805; complements the "v29 or newer" docs fix that landed in #804.