### PR TITLE
docs: Update SDK docs generation script

### DIFF
--- a/.github/workflows/refresh-sdk-docs.yml
+++ b/.github/workflows/refresh-sdk-docs.yml
@@ -1,0 +1,76 @@
+name: refresh-sdk-docs
+
+# Keeps design/docs/ts-sdk.mdx in sync with the README of the public
+# MystenLabs/hashi-ts-sdk repo. The fetch script pulls the README anonymously and
+# reformats it into the Docusaurus page; if the result differs from what's
+# committed, this workflow pushes the change to main, which triggers the existing
+# gh-pages workflow to rebuild and redeploy the docs site.
+#
+# Triggers:
+#   - schedule:            nightly safety net so docs never drift far
+#   - workflow_dispatch:   manual "refresh now" button
+#   - repository_dispatch: fired by the SDK repo on release (event type
+#                          `sdk-release`) for near-immediate refresh. Wiring that
+#                          up in hashi-ts-sdk is optional — see below.
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # 07:00 UTC daily
+  workflow_dispatch:
+  repository_dispatch:
+    types: [ sdk-release ]
+
+# Avoid overlapping refresh runs racing to push to main.
+concurrency:
+  group: refresh-sdk-docs
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch and reformat the SDK README
+        run: node design/scripts/fetch-sdk-readme.js
+
+      - name: Commit refreshed docs if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- design/docs/ts-sdk.mdx; then
+            echo "design/docs/ts-sdk.mdx already up to date — nothing to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add design/docs/ts-sdk.mdx
+          git commit -m "docs: refresh TypeScript SDK page from hashi-ts-sdk README"
+          git push
+          echo "Pushed refreshed docs/ts-sdk.mdx — gh-pages will rebuild."
+
+# ---------------------------------------------------------------------------
+# Optional: refresh immediately when the SDK publishes a release.
+#
+# Add a step like this to a workflow in MystenLabs/hashi-ts-sdk (e.g. its
+# release/changesets job). It needs a token (a fine-grained PAT or GitHub App
+# token) with `contents: write` on THIS repo, stored as a secret there:
+#
+#   - name: Notify hashi docs to refresh
+#     run: |
+#       curl -sf -X POST \
+#         -H "Authorization: Bearer ${{ secrets.HASHI_DOCS_DISPATCH_TOKEN }}" \
+#         -H "Accept: application/vnd.github+json" \
+#         https://api.github.com/repos/MystenLabs/hashi/dispatches \
+#         -d '{"event_type":"sdk-release"}'
+#
+# Without it, the nightly schedule still keeps the page fresh within a day.
+# ---------------------------------------------------------------------------

--- a/design/docs/ts-sdk.mdx
+++ b/design/docs/ts-sdk.mdx
@@ -53,7 +53,7 @@ const signer = Ed25519Keypair.fromSecretKey(/* … */);
 2. Send BTC to that address from any wallet.
 3. Submit the funding `txid` + `vout` to Hashi for committee confirmation.
 
-The committee watches the Bitcoin chain, confirms the funding tx after `bitcoinConfirmationThreshold` blocks, and mints `hBTC` to the `recipient` address.
+The committee watches the Bitcoin chain. Once the funding tx reaches `bitcoinConfirmationThreshold` confirmations the committee **approves** the deposit; after an additional `bitcoinDepositTimeDelayMs` safety window elapses the deposit becomes confirmable and `hBTC` is minted to the `recipient` address. `view.depositStatus(digest).confirmableAtMs` reports that earliest mint time.
 
 ```ts
 const recipient = signer.toSuiAddress();
@@ -125,6 +125,9 @@ const digest = result.Transaction?.digest;
 // One-shot status check — returns null if the digest has no Hashi event.
 const deposit = await client.hashi.view.depositStatus(digest);
 // deposit?.status: "pending" | "confirmed" | "expired" | "unknown"
+// deposit?.approvalTimestampMs — when the committee approved (null until approved)
+// deposit?.confirmableAtMs — earliest mint time = approval + bitcoinDepositTimeDelayMs
+//                            (null until approved)
 
 const withdrawal = await client.hashi.view.withdrawalStatus(digest);
 // withdrawal?.status: "Requested" | "Approved" | "Processing"
@@ -195,27 +198,28 @@ Gas estimation is best-effort — a failed simulation yields `0n` rather than th
 
 ## Reading governance state
 
-Governance parameters — the pause flag, deposit/withdrawal minimums, confirmation threshold, and cancellation cooldown — are read through `client.hashi.view`, the same namespace as the balance, status, history, and fee readers above. Prefer `view.all()` when you need 2+ values — single round-trip, internally consistent snapshot.
+Governance parameters — the pause flag, deposit/withdrawal minimums, confirmation threshold, deposit time delay, and cancellation cooldown — are read through `client.hashi.view`, the same namespace as the balance, status, history, and fee readers above. Prefer `view.all()` when you need 2+ values — single round-trip, internally consistent snapshot.
 
 ```ts
 const snap = await client.hashi.view.all();
 // { paused, bitcoinDepositMinimum, bitcoinWithdrawalMinimum,
-//   bitcoinConfirmationThreshold, withdrawalCancellationCooldownMs,
-//   worstCaseNetworkFee, ... }
+//   bitcoinConfirmationThreshold, bitcoinDepositTimeDelayMs,
+//   withdrawalCancellationCooldownMs, worstCaseNetworkFee, ... }
 ```
 
 ## Errors
 
 Direct methods throw typed errors before signing whenever a precondition can be checked client-side. `instanceof` to distinguish:
 
-| Error                        | Thrown when                                                                |
-| ---------------------------- | -------------------------------------------------------------------------- |
-| `InvalidParamsError`         | `txid`/`recipient` not 0x-prefixed 32-byte hex, or `utxos` empty/duplicate |
-| `InvalidBitcoinAddressError` | `bitcoinAddress` fails bech32(m) decode or HRP mismatches the BTC network  |
-| `HashiPausedError`           | Governance has paused the operation (`deposit` or `withdraw`)              |
-| `AmountBelowMinimumError`    | A UTXO or withdrawal amount is below the on-chain minimum                  |
-| `HashiFetchError`            | The Hashi shared object can't be read or has an unexpected shape           |
-| `HashiConfigError`           | A governance config entry is missing or malformed                          |
+| Error                        | Thrown when                                                                                                |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `InvalidParamsError`         | `txid`/`recipient` not 0x-prefixed 32-byte hex, or `utxos` empty/duplicate                                 |
+| `InvalidBitcoinAddressError` | `bitcoinAddress` fails bech32(m) decode or HRP mismatches the BTC network                                  |
+| `HashiPausedError`           | Governance has paused the operation (`deposit` or `withdraw`)                                              |
+| `AmountBelowMinimumError`    | A UTXO or withdrawal amount is below the on-chain minimum                                                  |
+| `HashiFetchError`            | The Hashi shared object can't be read or has an unexpected shape                                           |
+| `HashiConfigError`           | A governance config entry is missing or malformed                                                          |
+| `HashiGuardianError`         | The guardian `/info` can't be resolved, reached, or parsed, or the limiter isn't initialized (see `.code`) |
 
 ## Advanced: composable transactions
 
@@ -248,6 +252,32 @@ const confirmations = await client.hashi.bitcoin.confirmations(btcTxid);
 ```
 
 Calling any `bitcoin.*` method without `btcRpcUrl` configured throws.
+
+## Guardian rate limiter (optional)
+
+Withdrawals are co-signed by the Hashi **guardian**, which throttles signing with a token-bucket rate limiter. When the client can resolve a guardian URL — from `guardianUrl`, a custom `guardianInfoProvider`, or the on-chain `guardian_url` config — the `client.hashi.guardian.*` namespace reads the guardian's public, read-only `/info` endpoint to surface that limiter's headroom.
+
+```ts
+const client = new SuiGrpcClient({
+  network: "devnet",
+  baseUrl: "https://fullnode.devnet.sui.io:443",
+}).$extend(
+  hashi({ network: "devnet", guardianUrl: "https://hashi-guardian-devnet.mystenlabs.com" }),
+);
+
+// Guardian identity + limiter. `limiter` is null before the guardian is provisioned.
+const info = await client.hashi.guardian.info();
+
+// Projected capacity now, bucket fill %, and the refill-to-full ETA.
+const status = await client.hashi.guardian.limiterStatus();
+// { availableNowSats, bucketFillPercent, fullAtSecs, state, config }
+
+// Can the guardian sign a 50,000-sat withdrawal right now?
+const check = await client.hashi.guardian.canWithdraw(50_000n);
+// { allowed, availableNowSats, estimatedWaitSecs }
+```
+
+`guardianUrl` overrides the on-chain `guardian_url`; a `guardianInfoProvider` overrides both (useful for caching or a custom transport). The on-chain `guardian_url` is only published at launch, so a client constructed beforehand re-reads the chain on each call until it resolves — throwing `HashiGuardianError` (`code: "not-configured"`) meanwhile — then caches the URL once found. `limiterStatus()` and `canWithdraw()` throw `HashiGuardianError` (`code: "not-initialized"`) before the guardian is provisioned — use `guardian.info()`, whose `limiter` is `null`, to detect that state without a try/catch.
 
 ## Bitcoin address derivation
 

--- a/design/scripts/fetch-sdk-readme.js
+++ b/design/scripts/fetch-sdk-readme.js
@@ -7,14 +7,14 @@
 // Usage:
 //   node scripts/fetch-sdk-readme.js
 //
-// hashi-ts-sdk is a PRIVATE repo, so fetching needs a GitHub token. The token
-// is read from GITHUB_TOKEN / GH_TOKEN; if neither is set the script falls back
-// to the `gh` CLI (which uses your `gh auth login` credentials). When no
-// credentials are available — e.g. an external contributor or a docs CI that
-// can't see the private repo — the script logs a notice and leaves the existing
-// committed docs/ts-sdk.mdx in place, so builds never break. Because of that the
-// generated file IS committed; rerun this script (npm run fetch-sdk-readme) to
-// refresh it whenever the SDK README changes.
+// hashi-ts-sdk is a PUBLIC repo, so the README is fetched anonymously over HTTPS
+// — no GitHub token or `gh` CLI needed. If the fetch fails (offline build, a
+// transient network/GitHub error), the script logs a notice and leaves the
+// existing committed docs/ts-sdk.mdx in place, so builds never break. Because of
+// that the generated file IS committed and serves as the offline fallback; the
+// .github/workflows/refresh-sdk-docs.yml workflow keeps it fresh automatically
+// (nightly + on SDK release), and you can rerun this script by hand
+// (npm run fetch-sdk-readme, from design/) any time.
 //
 // Formatting applied to the raw README markdown:
 //   - drops the leading H1 (the title comes from front matter instead)
@@ -27,12 +27,12 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
 
 const REPO = "MystenLabs/hashi-ts-sdk";
 const BRANCH = "main";
 const REPO_BLOB = `https://github.com/${REPO}/blob/${BRANCH}`;
 const REPO_RAW = `https://raw.githubusercontent.com/${REPO}/${BRANCH}`;
+const README_URL = `${REPO_RAW}/README.md`;
 
 const SITE_ROOT = path.resolve(__dirname, ".."); // design/
 const OUT_FILE = path.join(SITE_ROOT, "docs/ts-sdk.mdx");
@@ -50,36 +50,14 @@ const ALERT_ADMONITION = {
 // ---------------------------------------------------------------------------
 
 async function fetchReadme() {
-  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-  if (token) {
-    const res = await fetch(`https://api.github.com/repos/${REPO}/readme`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github.raw",
-        "User-Agent": "hashi-docs-fetch-sdk-readme",
-      },
-    });
-    if (!res.ok) {
-      throw new Error(`GitHub API responded ${res.status} ${res.statusText}`);
-    }
-    return await res.text();
-  }
-
-  // No token in the environment — fall back to the gh CLI.
-  return execSync(`gh api repos/${REPO}/readme -H "Accept: application/vnd.github.raw"`, {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
+  // hashi-ts-sdk is public, so the raw README is fetchable anonymously.
+  const res = await fetch(README_URL, {
+    headers: { "User-Agent": "hashi-docs-fetch-sdk-readme" },
   });
-}
-
-function hasCredentials() {
-  if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) return true;
-  try {
-    execSync("gh auth status", { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
+  if (!res.ok) {
+    throw new Error(`GET ${README_URL} responded ${res.status} ${res.statusText}`);
   }
+  return await res.text();
 }
 
 // ---------------------------------------------------------------------------
@@ -183,19 +161,6 @@ function format(readme) {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  if (!hasCredentials()) {
-    if (fs.existsSync(OUT_FILE)) {
-      console.log(
-        "ℹ️  fetch-sdk-readme: no GitHub credentials; keeping committed docs/ts-sdk.mdx",
-      );
-      return;
-    }
-    console.warn(
-      "⚠️  fetch-sdk-readme: no GitHub credentials and no committed docs/ts-sdk.mdx to fall back on.",
-    );
-    return;
-  }
-
   console.log(`📥 fetch-sdk-readme: importing ${REPO}@${BRANCH} README`);
 
   try {


### PR DESCRIPTION
Since hashi-ts-sdk repo is now public, updated script + added workflow for nightly checks to keep content synced