### PR TITLE
Enable HTTPS for the bitcoind JSON-RPC transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,6 +2922,7 @@ dependencies = [
  "jiff",
  "jsonrpc",
  "lru 0.16.3",
+ "minreq",
  "prometheus",
  "prometheus-closure-metric",
  "proptest",
@@ -3371,7 +3372,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4063,8 +4064,11 @@ version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
 dependencies = [
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -5102,7 +5106,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6476,7 +6480,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots",
+ "webpki-roots 1.0.6",
  "zstd",
 ]
 
@@ -6969,6 +6973,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ bitcoin = { version = "0.32.8", features =["serde"] }
 corepc-client = { version = "0.10.0", features = ["client-sync"] }
 jsonrpc = "0.18.0"
 kyoto = { package = "bip157", version = "0.6.0" }
+# Direct dependency only to turn on minreq's rustls-based `https` feature for
+# the bitcoind JSON-RPC transport (jsonrpc's `minreq_http` does not expose it,
+# and without it any https:// bitcoin-rpc URL fails at runtime).
+minreq = { version = "2", features = ["https"] }
 lru = "0.16"
 
 # Dependencies for grpc and protobuf

--- a/crates/hashi/Cargo.toml
+++ b/crates/hashi/Cargo.toml
@@ -18,6 +18,8 @@ bitcoin.workspace = true
 corepc-client.workspace = true
 jsonrpc.workspace = true
 kyoto.workspace = true
+# Unused directly; enables minreq's `https` feature for the bitcoind RPC client.
+minreq.workspace = true
 lru.workspace = true
 
 # Dependencies for the protobuf definitions

--- a/design/docs/ts-sdk.mdx
+++ b/design/docs/ts-sdk.mdx
@@ -12,7 +12,7 @@ TypeScript SDK for the [Hashi](https://github.com/MystenLabs/hashi) protocol. Ha
 
 :::warning
 
-**Not production-ready.** This SDK is pre-1.0 and under active development. The API may change without notice and only Sui testnet and devnet are wired up. Do not use it in production environments yet.
+**Not production-ready.** This SDK is pre-1.0 and under active development. The API might change without notice, and the SDK only supports Sui Testnet and Devnet. Do not use it in production environments yet.
 
 :::
 
@@ -43,7 +43,7 @@ const client = new SuiGrpcClient({
 const signer = Ed25519Keypair.fromSecretKey(/* … */);
 ```
 
-> **Network support.** Sui **testnet** and **devnet** are wired up (Bitcoin **signet** by default). Prefer testnet — devnet support is temporary and will be deprecated. Mainnet is not yet deployed; `hashi({ network: "mainnet" })` will throw until it lands. To target a custom or local deployment, pass `hashiObjectId`, `packageId`, and `bitcoinNetwork` explicitly.
+> **Network support.** The SDK supports Sui **Testnet** and **Devnet** (Bitcoin **signet** by default). Prefer Testnet: Devnet support is temporary and the team plans to deprecate it. Mainnet does not yet have a deployment; `hashi({ network: "mainnet" })` throws until it lands. To target a custom or local deployment, pass `hashiObjectId`, `packageId`, and `bitcoinNetwork` explicitly.
 
 > **Optional client options.** `hashi({ ... })` also accepts `btcRpcUrl` — a Bitcoin Core JSON-RPC URL, required for the [`client.hashi.bitcoin.*`](#bitcoin-rpc-optional) lookups — and `graphqlUrl`, which overrides the Sui GraphQL endpoint used by [`transactionHistory`](#transaction-history) (defaults to `https://fullnode.{network}.sui.io:443/graphql`).
 


### PR DESCRIPTION
Reported by Stakin in the operator channel:

```
ERROR Failed to initialize BtcMonitor: JSON-RPC error: transport error: minreq: request url contains https:// but the https feature is not enabled
```

Any `https://` value in `bitcoin-rpc` failed at startup, which rules out hosted Bitcoin RPC providers (QuickNode and friends — which the runbook explicitly offers as an option) and TLS-terminated self-hosted nodes.

## Root cause

The transport chain is `corepc-client` → `jsonrpc` (`minreq_http` feature) → `minreq`, and no crate in the graph enables minreq's TLS feature, so minreq hard-errors on any https URL (`HttpsFeatureNotEnabled`).

## Fix

Direct workspace dependency on `minreq` with its rustls-based `https` feature — cargo feature unification enables it for the transitive copy `jsonrpc` uses. The dependency is otherwise unused (commented as such in both Cargo.tomls). Rustls-based rather than openssl, consistent with the rest of the stack.

## Verification

- `cargo tree -p minreq -e features` confirms `https`/`https-rustls` now active, driven by hashi
- Runtime-verified with a temporary test: an `https://` RPC URL now completes the TLS handshake and fails with an ordinary HTTP error instead of `HttpsFeatureNotEnabled` (test not committed — it needs network access)

## Also carried: ts-sdk.mdx refresh

This PR additionally carries the regenerated `design/docs/ts-sdk.mdx` (verbatim `fetch-sdk-readme.js` output) matching [hashi-ts-sdk#45](https://github.com/MystenLabs/hashi-ts-sdk/pull/45)'s style fixes — the docs CI job fetches the live upstream README, so every PR's `docs` check fails until this lands on main. Folded here instead of a separate PR (#826, closed) to land both in one merge.
