### PR TITLE
docs: refresh TypeScript SDK page from hashi-ts-sdk README

### DIFF
--- a/design/docs/ts-sdk.mdx
+++ b/design/docs/ts-sdk.mdx
@@ -12,7 +12,7 @@ TypeScript SDK for the [Hashi](https://github.com/MystenLabs/hashi) protocol. Ha
 
 :::warning
 
-**Not production-ready.** This SDK is pre-1.0 and under active development. The API may change without notice and only Sui devnet is wired up. Do not use it in production environments yet.
+**Not production-ready.** This SDK is pre-1.0 and under active development. The API may change without notice and only Sui testnet and devnet are wired up. Do not use it in production environments yet.
 
 :::
 
@@ -36,14 +36,14 @@ import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { hashi } from "@mysten-incubation/hashi";
 
 const client = new SuiGrpcClient({
-  network: "devnet",
-  baseUrl: "https://fullnode.devnet.sui.io:443",
-}).$extend(hashi({ network: "devnet" }));
+  network: "testnet",
+  baseUrl: "https://fullnode.testnet.sui.io:443",
+}).$extend(hashi({ network: "testnet" }));
 
 const signer = Ed25519Keypair.fromSecretKey(/* … */);
 ```
 
-> **Network support.** Only Sui **devnet** is currently wired up (Bitcoin **signet** by default). Testnet and mainnet are not yet deployed; `hashi({ network: "testnet" })` will throw until those land. To target a custom or local deployment, pass `hashiObjectId`, `packageId`, and `bitcoinNetwork` explicitly.
+> **Network support.** Sui **testnet** and **devnet** are wired up (Bitcoin **signet** by default). Prefer testnet — devnet support is temporary and will be deprecated. Mainnet is not yet deployed; `hashi({ network: "mainnet" })` will throw until it lands. To target a custom or local deployment, pass `hashiObjectId`, `packageId`, and `bitcoinNetwork` explicitly.
 
 > **Optional client options.** `hashi({ ... })` also accepts `btcRpcUrl` — a Bitcoin Core JSON-RPC URL, required for the [`client.hashi.bitcoin.*`](#bitcoin-rpc-optional) lookups — and `graphqlUrl`, which overrides the Sui GraphQL endpoint used by [`transactionHistory`](#transaction-history) (defaults to `https://fullnode.{network}.sui.io:443/graphql`).
 
@@ -238,9 +238,9 @@ When the client is constructed with a `btcRpcUrl`, the `client.hashi.bitcoin.*` 
 
 ```ts
 const client = new SuiGrpcClient({
-  network: "devnet",
-  baseUrl: "https://fullnode.devnet.sui.io:443",
-}).$extend(hashi({ network: "devnet", btcRpcUrl: "http://user:pass@127.0.0.1:8332" }));
+  network: "testnet",
+  baseUrl: "https://fullnode.testnet.sui.io:443",
+}).$extend(hashi({ network: "testnet", btcRpcUrl: "http://user:pass@127.0.0.1:8332" }));
 
 // Which output(s) of the funding tx paid the deposit address?
 const output = await client.hashi.bitcoin.lookupVout(btcTxid, btcAddress);


### PR DESCRIPTION
Unblocks CI for every open PR (first seen on #822): `design/docs/ts-sdk.mdx` is generated from the external `hashi-ts-sdk` README, whose latest update (testnet support 🎉) made the committed page stale — so the `docs` job's `make is-dirty` now fails everywhere.

This is the verbatim output of `node design/scripts/fetch-sdk-readme.js`.

## Why the automation didn't catch it

The `refresh-sdk-docs` workflow exists for exactly this, but its `git push` to main is now rejected by branch protection (verified by dispatching it: `GH006: Protected branch update failed ... Changes must be made through a pull request`). Its nightly cron has presumably been failing silently since protection was tightened. **Follow-up needed:** convert the workflow to open a PR (for example `peter-evans/create-pull-request`) or grant it bypass — otherwise this manual dance repeats on every SDK release.