### PR TITLE
[btc-monitor] Default bitcoin-start-height per network (Signet → 300000)

### DIFF
--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -40,7 +40,7 @@ impl Default for MonitorConfig {
         Self {
             network: Network::Bitcoin,
             trusted_peers: Vec::new(),
-            start_height: 800_000,
+            start_height: DEFAULT_START_HEIGHT,
             bitcoind_rpc_url: "http://localhost:8332".to_string(),
             bitcoind_rpc_auth: corepc_client::client_sync::Auth::None,
             data_dir: None,
@@ -184,6 +184,21 @@ pub fn network_from_chain_id(chain_id: &str) -> Option<Network> {
     .find(|&net| genesis_block(net).block_hash() == hash)
 }
 
+/// Fallback start height when `bitcoin-start-height` is unset. On Mainnet any
+/// height past Taproot activation works; it maps to the Taproot checkpoint.
+const DEFAULT_START_HEIGHT: u32 = 800_000;
+
+/// Height the Hashi Signet deployment launched from; no bridge deposit predates
+/// it, so Signet nodes anchor here instead of re-syncing from genesis.
+const SIGNET_DEFAULT_START_HEIGHT: u32 = 297_756;
+
+pub fn default_start_height(network: Network) -> u32 {
+    match network {
+        Network::Signet => SIGNET_DEFAULT_START_HEIGHT,
+        _ => DEFAULT_START_HEIGHT,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -210,5 +225,13 @@ mod tests {
     fn test_regtest_genesis_mapping() {
         let network = network_from_chain_id(crate::constants::BITCOIN_REGTEST_CHAIN_ID);
         assert_eq!(network, Some(Network::Regtest));
+    }
+
+    #[test]
+    fn default_start_height_is_network_aware() {
+        assert_eq!(default_start_height(Network::Signet), 297_756);
+        assert_eq!(default_start_height(Network::Bitcoin), 800_000);
+        assert_eq!(default_start_height(Network::Testnet4), 800_000);
+        assert_eq!(default_start_height(Network::Regtest), 800_000);
     }
 }

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -188,12 +188,14 @@ pub fn network_from_chain_id(chain_id: &str) -> Option<Network> {
 /// height past Taproot activation works; it maps to the Taproot checkpoint.
 const DEFAULT_START_HEIGHT: u32 = 800_000;
 
-/// Signet tip when Hashi moved from testnet4 to Signet, and the height
-/// sui-operations pins for every Signet deployment. No Hashi Signet deposit
-/// predates it, so nodes anchor here instead of re-syncing from genesis.
+/// Anchor for the Hashi Testnet deployment on Signet, which launched around
+/// height 313343. Nodes start here instead of re-syncing from genesis.
+///
 /// Only ever lower this: the anchor is a floor, and deposits below it are
-/// invisible to the light client.
-const SIGNET_DEFAULT_START_HEIGHT: u32 = 297_756;
+/// invisible to the light client. It sits above the 2026-03-30 testnet4-to-
+/// Signet migration (297756), so it does not cover the Signet deployments that
+/// predate Testnet; those pass `bitcoin-start-height` explicitly.
+const SIGNET_DEFAULT_START_HEIGHT: u32 = 300_000;
 
 pub fn default_start_height(network: Network) -> u32 {
     match network {
@@ -232,7 +234,7 @@ mod tests {
 
     #[test]
     fn default_start_height_is_network_aware() {
-        assert_eq!(default_start_height(Network::Signet), 297_756);
+        assert_eq!(default_start_height(Network::Signet), 300_000);
         assert_eq!(default_start_height(Network::Bitcoin), 800_000);
         assert_eq!(default_start_height(Network::Testnet4), 800_000);
         assert_eq!(default_start_height(Network::Regtest), 800_000);

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -188,13 +188,8 @@ pub fn network_from_chain_id(chain_id: &str) -> Option<Network> {
 /// height past Taproot activation works; it maps to the Taproot checkpoint.
 const DEFAULT_START_HEIGHT: u32 = 800_000;
 
-/// Anchor for the Hashi Testnet deployment on Signet, which launched around
-/// height 313343. Nodes start here instead of re-syncing from genesis.
-///
-/// Only ever lower this: the anchor is a floor, and deposits below it are
-/// invisible to the light client. It sits above the 2026-03-30 testnet4-to-
-/// Signet migration (297756), so it does not cover the Signet deployments that
-/// predate Testnet; those pass `bitcoin-start-height` explicitly.
+/// Anchors Signet nodes below the Hashi Testnet deployment (~height 313343).
+/// Only ever lower this; deposits below the anchor are never seen.
 const SIGNET_DEFAULT_START_HEIGHT: u32 = 300_000;
 
 pub fn default_start_height(network: Network) -> u32 {

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -188,8 +188,11 @@ pub fn network_from_chain_id(chain_id: &str) -> Option<Network> {
 /// height past Taproot activation works; it maps to the Taproot checkpoint.
 const DEFAULT_START_HEIGHT: u32 = 800_000;
 
-/// Height the Hashi Signet deployment launched from; no bridge deposit predates
-/// it, so Signet nodes anchor here instead of re-syncing from genesis.
+/// Signet tip when Hashi moved from testnet4 to Signet, and the height
+/// sui-operations pins for every Signet deployment. No Hashi Signet deposit
+/// predates it, so nodes anchor here instead of re-syncing from genesis.
+/// Only ever lower this: the anchor is a floor, and deposits below it are
+/// invisible to the light client.
 const SIGNET_DEFAULT_START_HEIGHT: u32 = 297_756;
 
 pub fn default_start_height(network: Network) -> u32 {

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -347,7 +347,9 @@ impl Config {
     }
 
     pub fn bitcoin_start_height(&self) -> u32 {
-        self.bitcoin_start_height.unwrap_or(800_000)
+        self.bitcoin_start_height.unwrap_or_else(|| {
+            crate::btc_monitor::config::default_start_height(self.bitcoin_network())
+        })
     }
 
     pub fn bitcoin_rpc_auth(&self) -> corepc_client::client_sync::Auth {
@@ -618,6 +620,33 @@ mod tests {
     fn test_withdrawal_max_batch_size_defaults_to_absolute_cap() {
         let config = Config::default();
         assert_eq!(config.withdrawal_max_batch_size(), 298);
+    }
+
+    #[test]
+    fn bitcoin_start_height_defaults_per_network() {
+        // Unset on Signet uses the Signet deployment anchor, not the 800k default.
+        let signet = Config {
+            bitcoin_chain_id: Some(crate::constants::BITCOIN_SIGNET_CHAIN_ID.to_string()),
+            bitcoin_start_height: None,
+            ..Config::default()
+        };
+        assert_eq!(signet.bitcoin_start_height(), 297_756);
+
+        // Unset on Mainnet keeps the existing default.
+        let mainnet = Config {
+            bitcoin_chain_id: Some(crate::constants::BITCOIN_MAINNET_CHAIN_ID.to_string()),
+            bitcoin_start_height: None,
+            ..Config::default()
+        };
+        assert_eq!(mainnet.bitcoin_start_height(), 800_000);
+
+        // An explicit value always wins.
+        let overridden = Config {
+            bitcoin_chain_id: Some(crate::constants::BITCOIN_SIGNET_CHAIN_ID.to_string()),
+            bitcoin_start_height: Some(123_456),
+            ..Config::default()
+        };
+        assert_eq!(overridden.bitcoin_start_height(), 123_456);
     }
 
     #[test]

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -630,7 +630,7 @@ mod tests {
             bitcoin_start_height: None,
             ..Config::default()
         };
-        assert_eq!(signet.bitcoin_start_height(), 297_756);
+        assert_eq!(signet.bitcoin_start_height(), 300_000);
 
         // Unset on Mainnet keeps the existing default.
         let mainnet = Config {

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -159,13 +159,13 @@ The corresponding Hashi config pointers (full template in [3.1](#31-validator-co
 bitcoin-chain-id = "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"  # signet genesis
 bitcoin-rpc = "http://127.0.0.1:38332"            # Hashi's own default is 8332 — you MUST override it
 bitcoin-trusted-peers = ["127.0.0.1:38333"]       # host:port (port is mandatory)
-# bitcoin-start-height = <a height at/below the first relevant Signet deposit>
+# bitcoin-start-height defaults to 297756 on Signet (deployment launch height); override only to change the anchor
 
 [bitcoin-rpc-auth]
 UserPass = ["YOUR_RPC_USER", "YOUR_STRONG_RPC_PASSWORD"]
 ```
 
-> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults to `800000` (Mainnet-oriented); set it for Signet so the light client does not skip early deposits.
+> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `297756` on Signet (the deployment's launch height, so the light client anchors near the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor.
 
 **Verify your node:**
 
@@ -380,8 +380,8 @@ bitcoin-rpc = "http://127.0.0.1:38332"
 # Trusted Bitcoin P2P peers for the embedded BIP-157 light client (host:port; port mandatory)
 bitcoin-trusted-peers = ["127.0.0.1:38333"]
 
-# Block height the light client begins syncing from (default: 800000, mainnet-oriented)
-# bitcoin-start-height = <height at/below first relevant Signet deposit>
+# Light-client sync start height; defaults to 297756 on Signet, a post-Taproot height on Mainnet (override to change the anchor)
+# bitcoin-start-height = 297756
 
 # ── Storage ───────────────────────────────────────────────────────────
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -165,7 +165,7 @@ bitcoin-trusted-peers = ["127.0.0.1:38333"]       # host:port (port is mandatory
 UserPass = ["YOUR_RPC_USER", "YOUR_STRONG_RPC_PASSWORD"]
 ```
 
-> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `300000` on Signet (below the Testnet deployment, so the light client anchors under the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor, and only downwards — the anchor is a floor, and deposits below it are never seen.
+> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `300000` on Signet (below the Testnet deployment, so the light client anchors under the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor.
 
 **Verify your node:**
 
@@ -1211,15 +1211,15 @@ Lost connectivity to Bitcoin peers after 15 consecutive failures. Restarting Kyo
 
 ---
 
-**Symptom:** `hashi_kyoto_best_height` sits far below your Bitcoin node's height and climbs from near zero, dropping back to near zero after every light client restart. The log shows:
+**Symptom:** `hashi_kyoto_best_height` sits far below your Bitcoin node's height, restarting from near zero after each light client restart. The log shows:
 
 ```
 Start height 800000 is beyond bitcoind's tip; anchoring Kyoto at genesis
 ```
 
-**Likely cause:** the light client could not read a block at `bitcoin-start-height` from your Bitcoin node, so it anchored at genesis. Either the height is past your node's tip, or the node is still syncing and has not reached it yet. No deposits are missed — genesis is the conservative fallback — but the client replays the whole chain, and replays it again every time its supervision loop rebuilds it.
+**Likely cause:** the light client could not read a block at `bitcoin-start-height`, so it anchored at genesis and replays the whole chain on every rebuild. Either the height is past your node's tip, or the node is still syncing. No deposits are missed; genesis is the conservative fallback.
 
-**Fix:** leave `bitcoin-start-height` unset to take the per-network default, or set it to a height at or below your first relevant deposit, as noted in [1.5](#15-bitcoin-node). If your Bitcoin node is still syncing, let it pass the configured height and then restart Hashi — the anchor is resolved once at startup, so a running node will not pick it up on its own. A healthy start logs `Anchoring Kyoto at start height <height> (<hash>)` instead.
+**Fix:** leave `bitcoin-start-height` unset to take the per-network default, or set it at or below your first relevant deposit, as noted in [1.5](#15-bitcoin-node). If your Bitcoin node is still syncing, restart Hashi once it passes that height — the anchor is resolved once at startup.
 
 ---
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -159,13 +159,13 @@ The corresponding Hashi config pointers (full template in [3.1](#31-validator-co
 bitcoin-chain-id = "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"  # signet genesis
 bitcoin-rpc = "http://127.0.0.1:38332"            # Hashi's own default is 8332 — you MUST override it
 bitcoin-trusted-peers = ["127.0.0.1:38333"]       # host:port (port is mandatory)
-# bitcoin-start-height defaults to 297756 on Signet (the height Hashi moved onto Signet); override only to change the anchor
+# bitcoin-start-height defaults to 300000 on Signet (below the Testnet deployment); override only to change the anchor
 
 [bitcoin-rpc-auth]
 UserPass = ["YOUR_RPC_USER", "YOUR_STRONG_RPC_PASSWORD"]
 ```
 
-> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `297756` on Signet (the height Hashi moved onto Signet, so the light client anchors below the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor, and only downwards — the anchor is a floor, and deposits below it are never seen.
+> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `300000` on Signet (below the Testnet deployment, so the light client anchors under the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor, and only downwards — the anchor is a floor, and deposits below it are never seen.
 
 **Verify your node:**
 
@@ -380,8 +380,8 @@ bitcoin-rpc = "http://127.0.0.1:38332"
 # Trusted Bitcoin P2P peers for the embedded BIP-157 light client (host:port; port mandatory)
 bitcoin-trusted-peers = ["127.0.0.1:38333"]
 
-# Light-client sync start height; defaults to 297756 on Signet, a post-Taproot height on Mainnet (override to change the anchor)
-# bitcoin-start-height = 297756
+# Light-client sync start height; defaults to 300000 on Signet, a post-Taproot height on Mainnet (override to change the anchor)
+# bitcoin-start-height = 300000
 
 # ── Storage ───────────────────────────────────────────────────────────
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -159,13 +159,13 @@ The corresponding Hashi config pointers (full template in [3.1](#31-validator-co
 bitcoin-chain-id = "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"  # signet genesis
 bitcoin-rpc = "http://127.0.0.1:38332"            # Hashi's own default is 8332 — you MUST override it
 bitcoin-trusted-peers = ["127.0.0.1:38333"]       # host:port (port is mandatory)
-# bitcoin-start-height defaults to 297756 on Signet (deployment launch height); override only to change the anchor
+# bitcoin-start-height defaults to 297756 on Signet (the height Hashi moved onto Signet); override only to change the anchor
 
 [bitcoin-rpc-auth]
 UserPass = ["YOUR_RPC_USER", "YOUR_STRONG_RPC_PASSWORD"]
 ```
 
-> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `297756` on Signet (the deployment's launch height, so the light client anchors near the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor.
+> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `297756` on Signet (the height Hashi moved onto Signet, so the light client anchors below the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor, and only downwards — the anchor is a floor, and deposits below it are never seen.
 
 **Verify your node:**
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -1211,11 +1211,15 @@ Lost connectivity to Bitcoin peers after 15 consecutive failures. Restarting Kyo
 
 ---
 
-**Symptom:** the light client syncs normally, but early deposits are never detected.
+**Symptom:** `hashi_kyoto_best_height` sits far below your Bitcoin node's height and climbs from near zero, dropping back to near zero after every light client restart. The log shows:
 
-**Likely cause:** `bitcoin-start-height` defaults to `800000`, a Mainnet-oriented height. On Signet this skips the entire range where your test deposits live.
+```
+Start height 800000 is beyond bitcoind's tip; anchoring Kyoto at genesis
+```
 
-**Fix:** set `bitcoin-start-height` to a height at or below your first relevant deposit, as noted in [1.5](#15-bitcoin-node).
+**Likely cause:** the light client could not read a block at `bitcoin-start-height` from your Bitcoin node, so it anchored at genesis. Either the height is past your node's tip, or the node is still syncing and has not reached it yet. No deposits are missed — genesis is the conservative fallback — but the client replays the whole chain, and replays it again every time its supervision loop rebuilds it.
+
+**Fix:** leave `bitcoin-start-height` unset to take the per-network default, or set it to a height at or below your first relevant deposit, as noted in [1.5](#15-bitcoin-node). If your Bitcoin node is still syncing, let it pass the configured height and then restart Hashi — the anchor is resolved once at startup, so a running node will not pick it up on its own. A healthy start logs `Anchoring Kyoto at start height <height> (<hash>)` instead.
 
 ---
 


### PR DESCRIPTION
## Summary

When `bitcoin-start-height` is unset we fell back to `800000`, which sits past the Signet tip. So Signet operators who didn't set it ended up anchoring the light client at genesis and re-syncing the whole chain. This defaults the start height per network so Signet picks a sane value on its own.
