### PR TITLE
docs: refresh TypeScript SDK page from hashi-ts-sdk README (style fixes)

### DIFF
--- a/design/docs/ts-sdk.mdx
+++ b/design/docs/ts-sdk.mdx
@@ -12,7 +12,7 @@ TypeScript SDK for the [Hashi](https://github.com/MystenLabs/hashi) protocol. Ha
 
 :::warning
 
-**Not production-ready.** This SDK is pre-1.0 and under active development. The API may change without notice and only Sui testnet and devnet are wired up. Do not use it in production environments yet.
+**Not production-ready.** This SDK is pre-1.0 and under active development. The API might change without notice, and the SDK only supports Sui Testnet and Devnet. Do not use it in production environments yet.
 
 :::
 
@@ -43,7 +43,7 @@ const client = new SuiGrpcClient({
 const signer = Ed25519Keypair.fromSecretKey(/* … */);
 ```
 
-> **Network support.** Sui **testnet** and **devnet** are wired up (Bitcoin **signet** by default). Prefer testnet — devnet support is temporary and will be deprecated. Mainnet is not yet deployed; `hashi({ network: "mainnet" })` will throw until it lands. To target a custom or local deployment, pass `hashiObjectId`, `packageId`, and `bitcoinNetwork` explicitly.
+> **Network support.** The SDK supports Sui **Testnet** and **Devnet** (Bitcoin **signet** by default). Prefer Testnet: Devnet support is temporary and the team plans to deprecate it. Mainnet does not yet have a deployment; `hashi({ network: "mainnet" })` throws until it lands. To target a custom or local deployment, pass `hashiObjectId`, `packageId`, and `bitcoinNetwork` explicitly.
 
 > **Optional client options.** `hashi({ ... })` also accepts `btcRpcUrl` — a Bitcoin Core JSON-RPC URL, required for the [`client.hashi.bitcoin.*`](#bitcoin-rpc-optional) lookups — and `graphqlUrl`, which overrides the Sui GraphQL endpoint used by [`transactionHistory`](#transaction-history) (defaults to `https://fullnode.{network}.sui.io:443/graphql`).
 


### PR DESCRIPTION
Companion to [hashi-ts-sdk#45](https://github.com/MystenLabs/hashi-ts-sdk/pull/45), which fixed the 14 style-guide violations the audit flagged on #823 at their source. Verbatim `fetch-sdk-readme.js` output.

**Merge promptly:** the `docs` CI job fetches the live upstream README at job time, so every open PR's docs check fails from the moment #45 merged until this lands (same dynamic as #823).

Structural follow-up worth a decision from whoever owns the docs pipeline — this is the second manual round-trip in two days:
1. Fix `refresh-sdk-docs` to open a PR instead of pushing to main (its push is rejected by branch protection, so the nightly sync has been failing silently), **or**
2. Pin `fetch-sdk-readme.js` to a README git revision bumped explicitly here, so upstream edits can never break this repo's CI asynchronously.