### PR TITLE
docs: Document the metrics-push config for operators

### DIFF
--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -409,6 +409,10 @@ hashi-object-id = "0x<hashi-object-id>"
 [bitcoin-rpc-auth]
 UserPass = ["YOUR_RPC_USER", "YOUR_STRONG_RPC_PASSWORD"]
 # CookieFile = "/home/USER/.bitcoin/signet/.cookie"
+
+# Optional: push metrics to the Mysten collection endpoint (see section 8.2)
+# [metrics-push]
+# push-url = "https://metrics-proxy.testnet.sui.io:8443/publish/metrics"
 ```
 
 ### 3.2 CLI config
@@ -791,7 +795,24 @@ Metrics are served at `http://127.0.0.1:9180/metrics` (configurable through `met
 curl -s http://localhost:9180/metrics | grep hashi_
 ```
 
-### 8.2 Key metrics
+### 8.2 Metrics push
+
+The node can also push its metrics to a Mysten-operated collection endpoint, which gives the Hashi team fleet-wide visibility during Testnet. Add this section to your validator config and restart the node:
+
+```toml
+[metrics-push]
+push-url = "https://metrics-proxy.testnet.sui.io:8443/publish/metrics"
+# How often to push (default: 60)
+# push-interval-seconds = 60
+```
+
+Notes:
+
+- `[metrics-push]` is a TOML table: keep it at the **end** of the config file with the other sections, per the field-order note in [3.1](#31-validator-config).
+- **No extra credentials are needed.** The push authenticates with your existing `tls-private-key` as a TLS client identity, verified against the TLS public key you registered onchain. It therefore only works after your registration is complete.
+- When the section is absent, the push task does not start and the local scrape endpoint above remains the only metrics surface.
+
+### 8.3 Key metrics
 
 | Metric | Type | What to Watch |
 |--------|------|---------------|
@@ -813,7 +834,7 @@ curl -s http://localhost:9180/metrics | grep hashi_
 | `hashi_sui_tx_submissions_total` | counter | Sui tx submissions (by operation, status). |
 | `hashi_leader_retries_total` | counter | Leader operation retries (by operation, error kind). |
 
-### 8.3 Suggested alerts
+### 8.4 Suggested alerts
 
 | Condition | Severity | Action |
 |-----------|----------|--------|

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -410,9 +410,9 @@ hashi-object-id = "0x<hashi-object-id>"
 UserPass = ["YOUR_RPC_USER", "YOUR_STRONG_RPC_PASSWORD"]
 # CookieFile = "/home/USER/.bitcoin/signet/.cookie"
 
-# Optional: push metrics to the Mysten collection endpoint (see section 8.2)
-# [metrics-push]
-# push-url = "https://metrics-proxy.testnet.sui.io:8443/publish/metrics"
+# Push metrics to the Mysten collection endpoint (see section 8.2)
+[metrics-push]
+push-url = "https://metrics-proxy.testnet.sui.io:8443/publish/metrics"
 ```
 
 ### 3.2 CLI config
@@ -797,7 +797,7 @@ curl -s http://localhost:9180/metrics | grep hashi_
 
 ### 8.2 Metrics push
 
-The node can also push its metrics to a Mysten-operated collection endpoint, which gives the Hashi team fleet-wide visibility during Testnet. Add this section to your validator config and restart the node:
+Configure the node to push its metrics to the Mysten-operated collection endpoint. The Hashi team relies on this for fleet-wide visibility during Testnet, so every operator must include this section in the validator config:
 
 ```toml
 [metrics-push]
@@ -810,7 +810,7 @@ Notes:
 
 - `[metrics-push]` is a TOML table: keep it at the **end** of the config file with the other sections, per the field-order note in [3.1](#31-validator-config).
 - **No extra credentials are needed.** The push authenticates with your existing `tls-private-key` as a TLS client identity, verified against the TLS public key you registered onchain. It therefore only works after your registration is complete.
-- When the section is absent, the push task does not start and the local scrape endpoint above remains the only metrics surface.
+- The node does not fail without this section; it silently starts without the push task. Check your config if the team reports not seeing your metrics.
 
 ### 8.3 Key metrics
 


### PR DESCRIPTION
New **§8.2 Metrics push** with the config Tom specified, verified against the code before documenting:

- `[metrics-push]` / `push-url` / `push-interval-seconds` match `MetricsPushConfig` exactly (kebab-case, `deny_unknown_fields`); the interval defaults to 60 in code, so it's shown commented out
- **Auth**: the push uses the node's existing `tls-private-key` as a TLS client identity, verified against the onchain-registered TLS public key — no credential handout needed, but it only works post-registration (`metrics_push.rs`)
- **Placement**: called out that the table must sit at the end of the config file — the same TOML section-ordering trap that bit operators last week
- Absent section = no push task; local scrape unaffected

Also adds the section (active, not commented out — this is required for Testnet operators) to the §3.1 template’s nested-tables block, and renumbers Key metrics/Suggested alerts to 8.3/8.4 (no inbound anchors existed).

Template re-verified to parse with the intended structure; prose checked against the style-guide audit rules.
