### PR TITLE
[guardian] Verify replayed attestations at the document's own timestamp

### DIFF
--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -654,9 +654,11 @@ impl GuardianS3Client {
             .ok_or_else(|| S3Error(format!("expected OIGuardianInfo at key {info_key}")))?;
 
         // 3. Anchor the pubkey and pin PCR0 to the allowlist entry for the
-        //    reported build.
+        //    reported build. This replays a logged attestation whose short-lived
+        //    leaf cert has typically expired, so the chain is checked at the
+        //    document's own signed timestamp, not now.
         let build_pcrs = allowlist.resolve(&info.untrusted_git_revision)?.clone();
-        attestation.verify(&signing_pubkey, &build_pcrs)?;
+        attestation.verify_replay(&signing_pubkey, &build_pcrs)?;
 
         Ok(VerifiedSessionInfo {
             signing_pubkey,

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -28,9 +28,9 @@ impl NitroAttestation {
         self.0
     }
 
-    /// Verify this Nitro attestation document (COSE signature + AWS cert chain to the
-    /// Nitro root + freshness), that it commits to `signing_pubkey`, and that its
-    /// PCR0 matches `build_pcrs`.
+    /// Verify a LIVE attestation document (COSE signature + AWS cert chain to the
+    /// Nitro root, chain validity checked at the current time), that it commits to
+    /// `signing_pubkey`, and that its PCR0 matches `build_pcrs`.
     ///
     /// In non-enclave dev/test builds the enclave emits a mock document, so the
     /// attestation check is a no-op, mirroring `get_attestation` `non-enclave-dev`
@@ -40,9 +40,33 @@ impl NitroAttestation {
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,
     ) -> GuardianResult<()> {
+        self.verify_at(signing_pubkey, build_pcrs, VerifyTime::Now)
+    }
+
+    /// Verify a REPLAYED attestation document read back from the S3 audit log.
+    ///
+    /// The Nitro leaf certificate lives only a few hours, so a replayed document
+    /// can never chain-validate at the current time. Anchor the chain check at the
+    /// document's own timestamp instead: it is inside the COSE-signed payload (so
+    /// it cannot be altered without breaking the signature just verified), and a
+    /// genuine document's chain was valid at the instant NSM produced it.
+    pub fn verify_replay(
+        &self,
+        signing_pubkey: &GuardianPubKey,
+        build_pcrs: &BuildPcrs,
+    ) -> GuardianResult<()> {
+        self.verify_at(signing_pubkey, build_pcrs, VerifyTime::DocumentTimestamp)
+    }
+
+    fn verify_at(
+        &self,
+        signing_pubkey: &GuardianPubKey,
+        build_pcrs: &BuildPcrs,
+        verify_time: VerifyTime,
+    ) -> GuardianResult<()> {
         #[cfg(any(test, feature = "non-enclave-dev"))]
         {
-            let _ = (signing_pubkey, build_pcrs);
+            let _ = (signing_pubkey, build_pcrs, verify_time);
             // Real attestation is stubbed here — announce it loudly (once) so a
             // `non-enclave-dev` binary can't be mistaken for a real enclave.
             // Gated off `test` so unit tests stay quiet.
@@ -68,7 +92,11 @@ impl NitroAttestation {
             let (signature, signed_message, doc) =
                 parse_nitro_attestation(&self.0, true, true, true)
                     .map_err(|e| InvalidInputs(format!("attestation parse failed: {e}")))?;
-            verify_nitro_attestation(&signature, &signed_message, &doc, now_timestamp_ms())
+            let timestamp_ms = match verify_time {
+                VerifyTime::Now => now_timestamp_ms(),
+                VerifyTime::DocumentTimestamp => doc.timestamp,
+            };
+            verify_nitro_attestation(&signature, &signed_message, &doc, timestamp_ms)
                 .map_err(|e| InvalidInputs(format!("attestation verification failed: {e}")))?;
 
             let attested = doc
@@ -89,6 +117,15 @@ impl NitroAttestation {
             Ok(())
         }
     }
+}
+
+/// When the attestation's cert chain validity is checked: at the current time
+/// (live RPC responses) or at the document's own COSE-signed timestamp
+/// (replays from the S3 audit log, where the short-lived leaf has expired).
+#[derive(Clone, Copy)]
+enum VerifyTime {
+    Now,
+    DocumentTimestamp,
 }
 
 /// A session's verified guardian info: the attestation-anchored signing pubkey,


### PR DESCRIPTION
A Nitro attestation's leaf cert lives only ~3 hours, so verifying an attestation **replayed** from the S3 audit log against `now` fails once the leaf expires (`Certificate timestamp not valid`). This is on the provisioning-critical path: the launch order is `ceremony → finish_publish → DKG → provision`, so the withdraw enclave (at operator_init), `operator provision`, and every KP `key-provisioner` verify re-read the ceremony attestation far more than 3 hours after it was written, and all fail. It surfaced when a KP ran `key-provisioner ceremony` ~4h after the testnet launch ceremony; the fastcrypto bump in #820 is what began enforcing the leaf validity window.

**Fix** — split the two uses of `NitroAttestation::verify`:
- `verify()` — live `GetGuardianInfo` responses — still checks the chain at `now` (freshness matters for a live RPC).
- `verify_replay()` — immutable, object-locked S3 records — checks the chain at the document's **own COSE-signed timestamp**. That timestamp sits inside the payload authenticated by the signature verified first, so a forgery can't backdate an invalid chain to make it validate; a genuine document's chain was valid at the instant NSM produced it. Freshness is neither available nor wanted here — we're deliberately reading an old record, anchored by PCR0 + the session signing key (+ the on-chain BTC key for withdrawals).

`get_verified_session_info` (the S3 session-info resolver) is the only replay caller and moves to `verify_replay`; all live paths are unchanged.

**Validation:** the real cert-time logic is compiled out of unit tests (`non-enclave-dev`/`test` stub to a no-op, matching the existing crate), so this is validated against the **real testnet launch ceremony record (~4h old)**: `key-provisioner ceremony` now clears the attestation-anchored scrape and full roster verify that previously died at `Certificate timestamp not valid`, reaching the YubiKey decrypt step. `make fmt` + clippy clean; `hashi-types`/`hashi-guardian` nextest green.

No redeploy or re-ceremony needed — this is client/replay-side verification only; the gen-2 launch key and its records are unaffected. The future withdraw EIF must be built from a pin that includes this fix (it replay-verifies the ceremony record internally).
