### PR TITLE
[Guardian] Clarify guardian verification helpers

### DIFF
--- a/crates/hashi-guardian-init/src/fetch_info.rs
+++ b/crates/hashi-guardian-init/src/fetch_info.rs
@@ -9,9 +9,8 @@
 //! recorded on chain.
 //!
 //! TODO: Remove this bootstrap helper once deploy no longer records guardian
-//! keys by querying a live guardian. This command verifies the returned
-//! GuardianInfo signature, but it does not verify the guardian's Nitro
-//! attestation or PCRs.
+//! keys by querying a live guardian. This command does not verify the guardian's
+//! signature, Nitro attestation, or PCRs.
 
 use anyhow::Context;
 use anyhow::Result;
@@ -50,18 +49,16 @@ pub async fn run(args: Args) -> Result<()> {
         .await
         .context("GetGuardianInfo RPC failed")?
         .into_inner();
-    let verified = GetGuardianInfoResponse::try_from(resp)
+    let response = GetGuardianInfoResponse::try_from(resp)
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
-    let verified = verified
-        // TODO: Accept PCR config here and use `verify_live` for attestation/PCR checks.
-        .verify_signed_info_without_attestation()
-        .map_err(|e| anyhow!("verify GuardianInfo signature: {e:?}"))?;
+    // TODO: Accept PCR config here and use `verify_live` for attestation/PCR checks.
+    let (info, signing_pub_key) = response.into_info_unchecked();
     match args.field {
         Field::SigningPubKey => {
-            println!("{}", hex::encode(verified.signing_pub_key.as_bytes()));
+            println!("{}", hex::encode(signing_pub_key.as_bytes()));
         }
         Field::EnclaveBtcPubkey => {
-            let btc_pk = verified.info.enclave_btc_pubkey.ok_or_else(|| {
+            let btc_pk = info.enclave_btc_pubkey.ok_or_else(|| {
                 anyhow!(
                     "guardian /info did not return enclave_btc_pubkey; \
                      provisioner_init may not have completed"

--- a/crates/hashi-guardian-init/src/fetch_info.rs
+++ b/crates/hashi-guardian-init/src/fetch_info.rs
@@ -53,7 +53,7 @@ pub async fn run(args: Args) -> Result<()> {
     let verified = GetGuardianInfoResponse::try_from(resp)
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
     let verified = verified
-        // TODO: Accept PCR config here and use `verify` for attestation/PCR checks.
+        // TODO: Accept PCR config here and use `verify_live` for attestation/PCR checks.
         .verify_signed_info_without_attestation()
         .map_err(|e| anyhow!("verify GuardianInfo signature: {e:?}"))?;
     match args.field {

--- a/crates/hashi-guardian-init/src/guardian_info.rs
+++ b/crates/hashi-guardian-init/src/guardian_info.rs
@@ -24,7 +24,7 @@ pub async fn verified_live_guardian_info(
     let info_resp = GetGuardianInfoResponse::try_from(info_pb)
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
     info_resp
-        .verify(current_build)
+        .verify_live(current_build)
         .map_err(|e| anyhow!("verify GuardianInfo attestation/signature: {e:?}"))
 }
 

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -5,13 +5,10 @@
 //! withdraw-mode standby guardian.
 
 use anyhow::Context;
-use anyhow::anyhow;
 use anyhow::ensure;
 use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::ActivationState;
-use hashi_types::guardian::BuildPcrs;
-use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::HashiCommittee;
 use hashi_types::guardian::InitConfig;
@@ -20,12 +17,11 @@ use hashi_types::guardian::S3Config;
 use hashi_types::guardian::VerifiedGuardianInfo;
 use hashi_types::guardian::WithdrawStage;
 use hashi_types::guardian::proto_conversions::operator_activate_request_to_pb;
-use hashi_types::proto as pb;
 use hashi_types::proto::guardian_service_client::GuardianServiceClient;
-use tonic::transport::Channel;
 use tracing::info;
 
 use crate::config::Config;
+use crate::guardian_info::verified_live_guardian_info;
 
 /// Activate a provisioner-initialized standby guardian.
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
@@ -434,20 +430,4 @@ fn verify_activated_info(
         post.info.limiter_state
     );
     Ok(())
-}
-
-async fn verified_live_guardian_info(
-    client: &mut GuardianServiceClient<Channel>,
-    current_build: &BuildPcrs,
-) -> anyhow::Result<VerifiedGuardianInfo> {
-    let info_pb = client
-        .get_guardian_info(pb::GetGuardianInfoRequest {})
-        .await
-        .context("GetGuardianInfo RPC failed")?
-        .into_inner();
-    let info_resp = GetGuardianInfoResponse::try_from(info_pb)
-        .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
-    info_resp
-        .verify(current_build)
-        .map_err(|e| anyhow!("verify GuardianInfo attestation/signature: {e:?}"))
 }

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -238,7 +238,8 @@ where
             .map_err(|e| anyhow::anyhow!("parse guardian info: {e:?}"))?;
         // The proxy talks to the enclave over its own direct channel; like the
         // node, it does not re-verify the info envelope (worst case is liveness).
-        Ok(response.into_info_unchecked())
+        let (info, _) = response.into_info_unchecked();
+        Ok(info)
     }
 }
 

--- a/crates/hashi-guardian-proxy/src/info.rs
+++ b/crates/hashi-guardian-proxy/src/info.rs
@@ -29,9 +29,10 @@ use axum::routing::get;
 use axum::Json;
 use axum::Router;
 use hashi_types::guardian::GetGuardianInfoResponse;
+use hashi_types::guardian::GuardianInfo;
+use hashi_types::guardian::GuardianPubKey;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
-use hashi_types::guardian::VerifiedGuardianInfo;
 use hashi_types::proto;
 use hashi_types::proto::guardian_service_client::GuardianServiceClient;
 use serde::Serialize;
@@ -81,7 +82,7 @@ struct LimiterConfigView {
 enum InfoError {
     /// The enclave gRPC call failed (unreachable / deadline / transport).
     Unreachable(String),
-    /// The response decoded but failed signature verification.
+    /// The response could not be converted to the guardian domain type.
     Invalid(String),
 }
 
@@ -120,13 +121,12 @@ impl InfoSource for GrpcInfoSource {
 
         // Read the signing timestamp off the raw proto; the domain conversion drops it.
         let signed_at_ms = raw.signed_info.as_ref().and_then(|s| s.timestamp_ms);
-        let verified = GetGuardianInfoResponse::try_from(raw)
-            .and_then(|resp| resp.verify_signed_info_without_attestation())
-            .map_err(|e| {
-                error!(error = ?e, "GetGuardianInfo could not be decoded/verified for /info");
-                InfoError::Invalid(format!("{e:?}"))
-            })?;
-        Ok(project(&verified, signed_at_ms))
+        let response = GetGuardianInfoResponse::try_from(raw).map_err(|e| {
+            error!(error = ?e, "GetGuardianInfo could not be decoded for /info");
+            InfoError::Invalid(format!("{e:?}"))
+        })?;
+        let (info, signing_pub_key) = response.into_info_unchecked();
+        Ok(project(&info, &signing_pub_key, signed_at_ms))
     }
 }
 
@@ -262,8 +262,11 @@ fn unavailable(error: &str, detail: &str) -> Response {
         .into_response()
 }
 
-fn project(verified: &VerifiedGuardianInfo, signed_at_ms: Option<u64>) -> GuardianInfoView {
-    let info = &verified.info;
+fn project(
+    info: &GuardianInfo,
+    signing_pub_key: &GuardianPubKey,
+    signed_at_ms: Option<u64>,
+) -> GuardianInfoView {
     GuardianInfoView {
         limiter: limiter_view(info.limiter_state, info.limiter_config),
         git_revision: info.untrusted_git_revision.clone(),
@@ -272,7 +275,7 @@ fn project(verified: &VerifiedGuardianInfo, signed_at_ms: Option<u64>) -> Guardi
             .enclave_btc_pubkey
             .as_ref()
             .map(|pk| hex::encode(pk.serialize())),
-        signing_pub_key: hex::encode(verified.signing_pub_key.as_bytes()),
+        signing_pub_key: hex::encode(signing_pub_key.as_bytes()),
         signed_at_ms: signed_at_ms.map(|t| t.to_string()),
     }
 }

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -19,6 +19,7 @@ use hashi_types::guardian::proto_conversions::guardian_encrypted_share_to_pb;
 use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::GuardianError;
 use hashi_types::guardian::KpSigned;
+use hashi_types::guardian::SessionID;
 use hashi_types::guardian::SingleProvisionerInitRequest;
 use hashi_types::pgp::Fingerprint;
 use hashi_types::proto;
@@ -98,9 +99,8 @@ impl Relay {
         }
     }
 
-    /// Backend's live session, provisioning threshold, and provisioned flag.
-    /// Verifies the signed info's signature but not the Nitro attestation — the KP
-    /// anchored attestation before submitting, and the relay is liveness-only.
+    /// Backend's self-reported session, provisioning threshold, and provisioned flag.
+    /// The relay is liveness-only, so it does not verify the signature or attestation.
     async fn backend_status(&self) -> Result<BackendStatus, Status> {
         let pb = self
             .client
@@ -110,15 +110,14 @@ impl Relay {
             .into_inner();
         let resp = GetGuardianInfoResponse::try_from(pb)
             .map_err(|e| Status::internal(format!("decode backend GuardianInfo: {e:?}")))?;
-        let verified = resp
-            .verify_signed_info_without_attestation()
-            .map_err(|e| Status::internal(format!("verify backend GuardianInfo: {e:?}")))?;
-        let sharing = verified.info.secret_sharing_instance.as_ref();
+        let (info, signing_pub_key) = resp.into_info_unchecked();
+        let session_id = SessionID::from_signing_pubkey(&signing_pub_key);
+        let sharing = info.secret_sharing_instance.as_ref();
         let num_shares = sharing.map(|i| i.num_shares());
         let threshold = sharing.map(|i| i.threshold());
-        let provisioned = verified.info.enclave_btc_pubkey.is_some();
+        let provisioned = info.enclave_btc_pubkey.is_some();
         Ok(BackendStatus {
-            session_id: verified.session_id.into(),
+            session_id: session_id.into(),
             num_shares,
             threshold,
             provisioned,

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -35,7 +35,7 @@ impl NitroAttestation {
     /// In non-enclave dev/test builds the enclave emits a mock document, so the
     /// attestation check is a no-op, mirroring `get_attestation` `non-enclave-dev`
     /// stub behavior. Real verification runs only in enclave builds.
-    pub fn verify(
+    pub fn verify_live(
         &self,
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -448,7 +448,7 @@ mod tests {
         let encrypted_shares = GuardianSigned::<RotateKpsResponse>::mock_for_testing()
             .data
             .encrypted_shares;
-        let guardian_info = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
+        let (guardian_info, _) = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
         let committee_0: crate::move_types::Committee = (&committee_0).into();
         let mut committee_1 = committee_0.clone();
         committee_1.epoch = 1;

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -804,7 +804,7 @@ impl GetGuardianInfoResponse {
             )));
         }
         self.attestation
-            .verify(&self.signing_pub_key, expected_build)?;
+            .verify_live(&self.signing_pub_key, expected_build)?;
         Ok(VerifiedGuardianInfo {
             info,
             signing_pub_key: self.signing_pub_key,

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -792,6 +792,9 @@ impl GetGuardianInfoResponse {
 
     /// Verify a live guardian response.
     ///
+    /// Used by operator and KP tooling while initializing a guardian (ceremony,
+    /// provisioning, and activation).
+    ///
     /// Checks:
     /// - `signed_info` is signed by `signing_pub_key`;
     /// - its git revision matches `expected_build`;

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -790,11 +790,13 @@ impl GetGuardianInfoResponse {
         }
     }
 
-    /// Verify the response end to end and return the trusted guardian payload:
-    /// the attestation anchors `signing_pub_key`, `signed_info` must be signed by
-    /// it, the signed git revision must match `expected_build`, and PCR0 must
-    /// match `expected_build`.
-    pub fn verify(&self, expected_build: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
+    /// Verify a live response end to end and return the trusted guardian payload.
+    /// "Live" means the Nitro certificate chain is checked at the verifier's
+    /// current time, unlike S3 replay verification, which checks the chain at the
+    /// document's COSE-signed timestamp. The attestation anchors `signing_pub_key`,
+    /// `signed_info` must be signed by it, the signed git revision must match
+    /// `expected_build`, and PCR0 must match `expected_build`.
+    pub fn verify_live(&self, expected_build: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
         if info.untrusted_git_revision != expected_build.git_revision() {
             return Err(InvalidInputs(format!(
@@ -816,7 +818,7 @@ impl GetGuardianInfoResponse {
     /// Verify only the signed `GuardianInfo` payload.
     ///
     /// This does not authenticate the enclave image, the Nitro attestation, or
-    /// PCRs. Prefer [`Self::verify`] whenever the caller has PCR config.
+    /// PCRs. Prefer [`Self::verify_live`] whenever the caller has PCR config.
     pub fn verify_signed_info_without_attestation(&self) -> GuardianResult<VerifiedGuardianInfo> {
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
         Ok(VerifiedGuardianInfo {
@@ -993,14 +995,14 @@ mod tests {
     }
 
     #[test]
-    fn get_guardian_info_verify_uses_signed_info_verification() {
+    fn get_guardian_info_verify_live_uses_signed_info_verification() {
         let mut resp = GetGuardianInfoResponse::mock_for_testing();
         let mut sig_bytes: [u8; 64] = resp.signed_info.signature.to_bytes();
         sig_bytes[0] ^= 0xff;
         resp.signed_info.signature = GuardianSignature::from(sig_bytes);
 
         assert!(matches!(
-            resp.verify(&BuildPcrs::new("test-revision", vec![0]))
+            resp.verify_live(&BuildPcrs::new("test-revision", vec![0]))
                 .unwrap_err(),
             InvalidInputs(_)
         ));

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -790,12 +790,14 @@ impl GetGuardianInfoResponse {
         }
     }
 
-    /// Verify a live response end to end and return the trusted guardian payload.
-    /// "Live" means the Nitro certificate chain is checked at the verifier's
-    /// current time, unlike S3 replay verification, which checks the chain at the
-    /// document's COSE-signed timestamp. The attestation anchors `signing_pub_key`,
-    /// `signed_info` must be signed by it, the signed git revision must match
-    /// `expected_build`, and PCR0 must match `expected_build`.
+    /// Verify a live guardian response.
+    ///
+    /// Checks:
+    /// - `signed_info` is signed by `signing_pub_key`;
+    /// - its git revision matches `expected_build`;
+    /// - the Nitro attestation has a valid signature;
+    /// - the certificate chain is valid now;
+    /// - the attested public key and PCR0 match `signing_pub_key` and `expected_build`.
     pub fn verify_live(&self, expected_build: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
         if info.untrusted_git_revision != expected_build.git_revision() {
@@ -815,26 +817,10 @@ impl GetGuardianInfoResponse {
         })
     }
 
-    /// Verify only the signed `GuardianInfo` payload.
-    ///
-    /// This does not authenticate the enclave image, the Nitro attestation, or
-    /// PCRs. Prefer [`Self::verify_live`] whenever the caller has PCR config.
-    pub fn verify_signed_info_without_attestation(&self) -> GuardianResult<VerifiedGuardianInfo> {
-        let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
-        Ok(VerifiedGuardianInfo {
-            info,
-            signing_pub_key: self.signing_pub_key,
-            session_id: SessionID::from_signing_pubkey(&self.signing_pub_key),
-            encrypted_shares: self.encrypted_shares.clone(),
-        })
-    }
-
-    /// Extract the guardian's self-reported `GuardianInfo` WITHOUT verifying the
-    /// signature or attestation. The node uses this after authenticating the
-    /// guardian over TLS; withdrawals are gated by the on-chain BTC key, and the
-    /// ed25519 signing key is verified only by KPs/monitors on the S3 audit logs.
-    pub fn into_info_unchecked(self) -> GuardianInfo {
-        self.signed_info.into_data_unchecked()
+    /// Extract the guardian's self-reported info and signing key WITHOUT verifying
+    /// the signature or attestation.
+    pub fn into_info_unchecked(self) -> (GuardianInfo, GuardianPubKey) {
+        (self.signed_info.into_data_unchecked(), self.signing_pub_key)
     }
 }
 
@@ -955,7 +941,7 @@ mod tests {
 
     #[test]
     fn guardian_info_json_encodes_binary_fields_as_strings() {
-        let mut info = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
+        let (mut info, _) = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
         info.config_hash = Some([0xab; 32]);
         let btc_pubkey = crate::bitcoin::create_btc_keypair_for_test(&[3u8; 32])
             .x_only_public_key()
@@ -981,17 +967,14 @@ mod tests {
     }
 
     #[test]
-    fn get_guardian_info_verify_signed_info_passes_for_valid_signature() {
+    fn get_guardian_info_into_info_unchecked_returns_info_and_signing_key() {
         let resp = GetGuardianInfoResponse::mock_for_testing();
-        let verified = resp.verify_signed_info_without_attestation().unwrap();
+        let expected_info = resp.signed_info.data.clone();
+        let expected_signing_pub_key = resp.signing_pub_key;
+        let (info, signing_pub_key) = resp.into_info_unchecked();
 
-        assert_eq!(verified.signing_pub_key, resp.signing_pub_key);
-        assert_eq!(
-            verified.session_id,
-            SessionID::from_signing_pubkey(&resp.signing_pub_key)
-        );
-        assert_eq!(verified.info, resp.signed_info.data);
-        assert_eq!(verified.encrypted_shares, resp.encrypted_shares);
+        assert_eq!(info, expected_info);
+        assert_eq!(signing_pub_key, expected_signing_pub_key);
     }
 
     #[test]
@@ -1004,31 +987,6 @@ mod tests {
         assert!(matches!(
             resp.verify_live(&BuildPcrs::new("test-revision", vec![0]))
                 .unwrap_err(),
-            InvalidInputs(_)
-        ));
-    }
-
-    #[test]
-    fn get_guardian_info_verify_signed_info_fails_when_pubkey_did_not_sign() {
-        let mut resp = GetGuardianInfoResponse::mock_for_testing();
-        let wrong_signing_key = GuardianSignKeyPair::new(rand::thread_rng());
-        resp.signing_pub_key = wrong_signing_key.verification_key();
-
-        assert!(matches!(
-            resp.verify_signed_info_without_attestation().unwrap_err(),
-            InvalidInputs(_)
-        ));
-    }
-
-    #[test]
-    fn get_guardian_info_verify_signed_info_fails_when_signature_tampered() {
-        let mut resp = GetGuardianInfoResponse::mock_for_testing();
-        let mut sig_bytes: [u8; 64] = resp.signed_info.signature.to_bytes();
-        sig_bytes[0] ^= 0xff;
-        resp.signed_info.signature = GuardianSignature::from(sig_bytes);
-
-        assert!(matches!(
-            resp.verify_signed_info_without_attestation().unwrap_err(),
             InvalidInputs(_)
         ));
     }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -929,7 +929,8 @@ impl Hashi {
                 );
                 anyhow::anyhow!("parse GetGuardianInfoResponse: {e:?}")
             })?;
-        Ok(resp.into_info_unchecked())
+        let (info, _) = resp.into_info_unchecked();
+        Ok(info)
     }
 
     /// Fetch the guardian's authoritative `LimiterState` and the live local


### PR DESCRIPTION
## Summary

- reuse the shared `verified_live_guardian_info` helper in operator activation
- rename Nitro and guardian-response current-time verification to `verify_live`
- document the operator/KP initialization callers and checks performed by live verification
- remove `verify_signed_info_without_attestation` from liveness-only consumers
- make `into_info_unchecked` return both `GuardianInfo` and its signing key so the relay can derive the session ID

## Verification

- `make fmt`