### PR TITLE
[loadtest] Add a crate that drives deposit/withdraw loops against a deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,6 +3841,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "loadtest"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bitcoin",
+ "clap",
+ "corepc-client",
+ "hashi",
+ "hashi-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sui-rpc",
+ "sui-sdk-types",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/loadtest/Cargo.toml
+++ b/crates/loadtest/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "loadtest"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "loadtest"
+path = "src/main.rs"
+
+[dependencies]
+hashi = { path = "../hashi" }
+hashi-types = { path = "../hashi-types" }
+
+sui-sdk-types.workspace = true
+sui-rpc.workspace = true
+
+anyhow.workspace = true
+bitcoin.workspace = true
+clap.workspace = true
+corepc-client.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+toml.workspace = true

--- a/crates/loadtest/README.md
+++ b/crates/loadtest/README.md
@@ -1,0 +1,153 @@
+# `loadtest`
+
+Drives a full **deposit → mint → withdraw → settle** loop against a deployed
+Hashi bridge. Point it at a cluster, say how many deposits and withdrawals you
+want and how big, and it does the rest.
+
+```
+cargo run --release -p loadtest -- run \
+  --deposits 100 --deposit-amount-btc 0.1 \
+  --withdrawals 100 --withdrawal-amount-btc 0.1
+```
+
+Useful for load testing, and for verifying a deployment end to end after a
+redeploy. It is not part of CI — `e2e-tests` covers that against a localnet.
+This one talks to real clusters and real Bitcoin.
+
+The bridge work goes through the same library the `hashi` CLI uses
+(`hashi::cli`, `hashi::sui_tx_executor`), so it cannot drift from the CLI. What
+this crate owns is everything around it that is easy to get wrong: reading the
+deployment's real ids, funding many deposit UTXOs without tripping Bitcoin
+Core's coin selection, retrying PTBs, and knowing when a run has finished.
+
+## Setup
+
+You need a synced `bitcoind` with a funded wallet, `sui`, and `kubectl`.
+
+**1. A signing key.** The file may be PKCS#8 PEM/DER, a `suiprivkey1...` line,
+or a keystore entry, so this is enough:
+
+```bash
+sui keytool export --key-identity "$(sui client active-address)" --json \
+  | jq -r .exportedPrivateKey > signer.key
+chmod 600 signer.key
+```
+
+**2. Funds.**
+
+- SUI gas: roughly `ceil(deposits/333) * 1` + `ceil(withdrawals/250) * 2` SUI.
+- BTC: the wallet needs **one UTXO** covering `deposits * deposit_amount` plus
+  fees — see [funding](#funding) for why one, rather than merely a large total.
+
+**3. Environment** (or the equivalent flags):
+
+```bash
+export HASHI_KEYPAIR=./signer.key
+export BTC_RPC_URL=http://127.0.0.1:38332
+export BTC_RPC_USER=... BTC_RPC_PASSWORD=...
+export BTC_WALLET=mining          # default
+```
+
+Then check before spending anything:
+
+```bash
+cargo run -p loadtest -- doctor
+```
+
+## Usage
+
+```
+loadtest doctor                   # verify a run would work; touches nothing
+loadtest run [opts]               # the full loop
+loadtest deposit [opts]           # fund, register, wait for mint
+loadtest withdraw [opts]          # withdraw against hBTC already held
+```
+
+| Option | Default | |
+|---|---|---|
+| `--deposits` | 100 | number of deposit UTXOs |
+| `--deposit-amount-btc` | 0.1 | BTC per deposit |
+| `--withdrawals` | 100 | number of withdrawal requests |
+| `--withdrawal-amount-btc` | 0.1 | BTC per withdrawal |
+| `--outputs-per-tx` | 250 | deposit outputs per funding tx |
+| `--fee-rate` | 4.0 | funding tx sat/vB |
+| `--withdraw-dest` | fresh address | where withdrawals pay out |
+| `--report <path>` | | write a JSON run report |
+| `--skip-settle` | | submit withdrawals, don't wait for BTC |
+
+**Which deployment.** By default the package id, object id and Sui RPC are read
+from `hashi-server-0`'s `config.toml` via `kubectl`. Use `--namespace` for
+another environment, or pass `--package-id` / `--hashi-object-id` /
+`--sui-rpc-url` to skip `kubectl` entirely.
+
+> Prefer the default. Ids change on **every full redeploy**, and a stale id
+> fails silently rather than loudly: the superseded Hashi object still exists
+> and still accepts deposits, so the run looks green while testing nothing. Ids
+> passed explicitly are cross-checked against the cluster and warned about on
+> mismatch.
+
+## What a run does
+
+1. **Preflight** — ids match the cluster; bitcoind is synced, on the right
+   network, and shares the bridge's genesis; the bridge isn't paused; amounts
+   clear the onchain minimums; wallet and hBTC balances cover the run.
+2. **Fund** — pays `--deposits` outputs to the derived deposit address, split
+   across `--outputs-per-tx` transactions.
+3. **Register** — submits deposit requests in PTBs of 333, straight from the
+   mempool. No need to wait for confirmations: the committee enforces
+   `bitcoin_confirmation_threshold` itself, so registering early only starts its
+   watch sooner.
+4. **Wait for mint** — polls hBTC until the deposits land.
+5. **Withdraw** — submits requests in PTBs of 250, waiting for hBTC to cover
+   each batch, so it also works while deposits are still minting.
+6. **Wait for settlement** — until every request *this run submitted* has left
+   the queue and its Bitcoin transactions have confirmed.
+
+## Notes
+
+#### Funding
+
+`fundrawtransaction` will happily fund 1 BTC from ~1,400 dust inputs, building a
+~95 kvB transaction. Signet's miner caps blocks near 1M weight, so a transaction
+that fat gets skipped **indefinitely, at any fee rate** — it never fits the
+remaining space. This crate therefore preselects the smallest single UTXO that
+covers the run and passes `add_inputs: false`. That is why the wallet needs one
+big UTXO, and why `doctor` fails loudly when it hasn't got one.
+
+The same ceiling caps `--outputs-per-tx`: a P2TR output is 43 vB, so 250 outputs
+≈ 11 kvB. Raising it means fewer, fatter transactions that are harder to mine.
+
+Funding transactions are deliberately **not** replaceable. Deposits are
+registered against the txid seconds after broadcast, so an RBF replacement would
+change the txid and strand them; refusing to signal RBF takes `bumpfee` off the
+table. A stalled funding tx gets CPFP'd instead — spend its change output with a
+high-fee child (`sendrawtransaction <hex> 0` to bypass the fee cap), since
+miners sort by ancestor fee rate.
+
+#### Settlement
+
+Withdrawals batch into a Bitcoin transaction at ~70 requests, or flush after a
+5-minute window — so a *small* run waits the full window before anything is
+built. The guardian also rate-limits withdrawals; past the bucket they trickle
+out as it refills rather than failing. Both make settlement slow, not broken.
+
+Broken looks different: `Guardian signature verification failed` in the node
+logs. The run counts those while it waits and reports them, because a run that
+merely times out otherwise looks the same either way.
+
+#### Retries
+
+Large runs make the peer gRPC layer drop connections. Every PTB is retried 5
+times, and each call is exactly one atomic PTB, so a retry never lands a partial
+batch.
+
+It can land a whole one twice, in the narrow case where the transaction executed
+and only the response was lost. For deposits that is harmless: the duplicate
+request never mints, because `deposit()`'s replay check rejects it once the
+original's UTXO reaches the pool. For withdrawals it burns hBTC twice, which
+surfaces as the run running short of balance near the end.
+
+#### Sui
+
+hBTC lives in Sui's balance accumulator, not `Coin<BTC>` objects — `sui client
+objects` shows nothing while the balance is non-zero. That is expected.

--- a/crates/loadtest/src/bridge.rs
+++ b/crates/loadtest/src/bridge.rs
@@ -75,6 +75,12 @@ impl Bridge {
         HashiClient::new(&self.config).await
     }
 
+    /// A new executor, and with it a new RPC connection.
+    ///
+    /// Built per call on purpose: the load a large run generates makes the peer
+    /// gRPC layer drop connections, and a retry that reused a broken one would
+    /// just fail again. Caching this would quietly cost the reconnect that
+    /// makes retries work.
     fn executor(&self) -> Result<SuiTxExecutor> {
         let signer = self
             .config

--- a/crates/loadtest/src/bridge.rs
+++ b/crates/loadtest/src/bridge.rs
@@ -1,0 +1,201 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The bridge side of a run: deposit-address derivation, request submission and
+//! the reads that tell us how far along a run is.
+//!
+//! This drives the same code paths as the `hashi` CLI, through
+//! [`hashi::cli`] and [`hashi::sui_tx_executor`], so a load test cannot drift
+//! from what the CLI does.
+
+use std::collections::HashSet;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use hashi::cli::client::HashiClient;
+use hashi::cli::commands::deposit::cli_derive_deposit_address;
+use hashi::cli::config::CliConfig;
+use hashi::config::HashiIds;
+use hashi::sui_tx_executor::SuiTxExecutor;
+use hashi_types::bitcoin::BitcoinAddress;
+use hashi_types::bitcoin::witness_program_from_address;
+use sui_rpc::proto::sui::rpc::v2::GetBalanceRequest;
+use sui_sdk_types::Address;
+use sui_sdk_types::StructTag;
+
+/// Deposits per PTB. Three dynamic-field ops per deposit against the 1000-op
+/// object-runtime cap, matching the CLI's `deposit request`.
+pub const DEPOSIT_CHUNK: usize = 333;
+
+/// Withdrawal requests per PTB, matching the CLI's `withdraw request`.
+pub const WITHDRAW_CHUNK: usize = 250;
+
+pub struct Bridge {
+    config: CliConfig,
+    hashi_ids: HashiIds,
+    btc_network: bitcoin::Network,
+}
+
+/// How far this run's withdrawals have progressed.
+///
+/// Every count is restricted to requests this run submitted. The queues are
+/// shared with anything else driving the same deployment, so a run that gated
+/// on their totals would wait on strangers' withdrawals.
+pub struct WithdrawalProgress {
+    /// This run's requests still awaiting a withdrawal transaction.
+    pub queued: usize,
+    /// Withdrawal transactions carrying this run's requests that have not yet
+    /// been confirmed. Confirmed ones leave `withdrawal_txns` for
+    /// `confirmed_txns`, so zero means every batch has landed on Bitcoin.
+    pub in_flight: usize,
+    /// Of those, how many are fully signed.
+    pub signed: usize,
+}
+
+impl Bridge {
+    pub fn new(config: CliConfig, btc_network: bitcoin::Network) -> Result<Self> {
+        config.validate()?;
+        let hashi_ids = HashiIds {
+            package_id: config.package_id(),
+            hashi_object_id: config.hashi_object_id(),
+        };
+        Ok(Self {
+            config,
+            hashi_ids,
+            btc_network,
+        })
+    }
+
+    /// A fresh snapshot of onchain state.
+    ///
+    /// [`HashiClient`] reads the Hashi object once on construction and every
+    /// `fetch_*` serves that snapshot, so polling means rebuilding it.
+    async fn snapshot(&self) -> Result<HashiClient> {
+        HashiClient::new(&self.config).await
+    }
+
+    fn executor(&self) -> Result<SuiTxExecutor> {
+        let signer = self
+            .config
+            .load_keypair()?
+            .context("a signing key is required to submit transactions")?;
+        let client = sui_rpc::Client::new(&self.config.sui_rpc_url)?;
+        Ok(SuiTxExecutor::new(client, signer, self.hashi_ids))
+    }
+
+    /// Derive the 2-of-2 taproot deposit address for `recipient`.
+    ///
+    /// This exercises the whole read path — the object must exist, DKG must
+    /// have produced an MPC key, and the guardian's BTC key must be pinned
+    /// onchain — which makes it a good early check that the deployment is
+    /// really usable.
+    pub async fn deposit_address(&self, recipient: Address) -> Result<BitcoinAddress> {
+        let client = self.snapshot().await?;
+
+        let mpc_pubkey = client.fetch_mpc_public_key();
+        if mpc_pubkey.is_empty() {
+            bail!("no MPC public key onchain; has the committee completed DKG?");
+        }
+        let guardian_btc_pubkey = client
+            .fetch_guardian_btc_public_key()
+            .context("no guardian BTC public key onchain; did finish_publish run with one?")?;
+
+        cli_derive_deposit_address(
+            &mpc_pubkey,
+            &guardian_btc_pubkey,
+            Some(&recipient),
+            self.btc_network,
+        )
+    }
+
+    /// Register one PTB worth of deposits.
+    ///
+    /// `utxos` must be no longer than [`DEPOSIT_CHUNK`] so the call stays a
+    /// single atomic transaction, which is what makes a retry a clean unit of
+    /// work rather than a partially-applied one.
+    pub async fn register_deposits(
+        &self,
+        txid: bitcoin::Txid,
+        utxos: &[(u32, u64)],
+        recipient: Address,
+    ) -> Result<usize> {
+        debug_assert!(utxos.len() <= DEPOSIT_CHUNK);
+        let ids = self
+            .executor()?
+            .execute_create_deposit_requests_batch(txid_to_address(txid), utxos, Some(recipient))
+            .await?;
+        Ok(ids.len())
+    }
+
+    /// Submit `count` identical withdrawal requests in one PTB, returning their
+    /// request ids. `count` must be no longer than [`WITHDRAW_CHUNK`].
+    pub async fn request_withdrawals(
+        &self,
+        amount_sats: u64,
+        destination: &BitcoinAddress,
+        count: usize,
+    ) -> Result<Vec<Address>> {
+        debug_assert!(count <= WITHDRAW_CHUNK);
+        let destination_bytes = witness_program_from_address(destination)?;
+        self.executor()?
+            .execute_create_withdrawal_requests_batch(amount_sats, destination_bytes, count)
+            .await
+    }
+
+    /// hBTC held by `address`.
+    ///
+    /// hBTC lives in Sui's balance accumulator rather than as `Coin<BTC>`
+    /// objects, so this is a balance query, not an object listing.
+    pub async fn balance_sats(&self, address: Address) -> Result<u64> {
+        let btc_type = StructTag::new(
+            self.hashi_ids.package_id,
+            sui_sdk_types::Identifier::from_static("btc"),
+            sui_sdk_types::Identifier::from_static("BTC"),
+            vec![],
+        );
+        let mut client = sui_rpc::Client::new(&self.config.sui_rpc_url)?;
+        let response = client
+            .state_client()
+            .get_balance(
+                GetBalanceRequest::default()
+                    .with_owner(address.to_string())
+                    .with_coin_type(btc_type.to_string()),
+            )
+            .await
+            .context("failed to query hBTC balance")?
+            .into_inner();
+        Ok(response.balance().balance_opt().unwrap_or(0))
+    }
+
+    /// Progress of the requests identified by `mine`.
+    pub async fn withdrawal_progress(&self, mine: &HashSet<Address>) -> Result<WithdrawalProgress> {
+        let client = self.snapshot().await?;
+        let queued = client
+            .fetch_withdrawal_requests()
+            .iter()
+            .filter(|w| mine.contains(&w.id))
+            .count();
+        let in_flight: Vec<_> = client
+            .fetch_withdrawal_txns()
+            .into_iter()
+            .filter(|t| t.request_ids.iter().any(|id| mine.contains(id)))
+            .collect();
+        let signed = in_flight.iter().filter(|t| t.is_fully_signed()).count();
+        Ok(WithdrawalProgress {
+            queued,
+            in_flight: in_flight.len(),
+            signed,
+        })
+    }
+}
+
+/// Reinterpret a Bitcoin txid as a Sui `Address`.
+///
+/// Both are bare 32-byte values, and the Move side takes the txid as an
+/// address-shaped id. `Txid` is stored in Bitcoin's internal byte order, which
+/// is what the Move code and the CLI both expect, so no reversal here.
+fn txid_to_address(txid: bitcoin::Txid) -> Address {
+    use bitcoin::hashes::Hash;
+    Address::new(txid.to_byte_array())
+}

--- a/crates/loadtest/src/btc.rs
+++ b/crates/loadtest/src/btc.rs
@@ -1,0 +1,327 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bitcoin Core RPC and the deposit-funding transaction builder.
+//!
+//! Funding a run means paying N identical outputs to one deposit address, which
+//! Bitcoin Core makes awkward in two independent ways:
+//!
+//! 1. `createrawtransaction` rejects duplicate output addresses outright, so the
+//!    unfunded transaction is assembled here instead.
+//! 2. `fundrawtransaction`'s coin selection will happily fund a 1 BTC send from
+//!    ~1,400 dust inputs, producing a ~95 kvB transaction. Signet's miner caps
+//!    blocks near 1M weight, so a transaction that fat is skipped indefinitely
+//!    at any fee rate — it never fits the remaining space. We therefore
+//!    preselect one large UTXO and pass `add_inputs: false`.
+//!
+//! Preselecting an input has a useful side effect: rust-bitcoin only switches to
+//! SegWit serialization when a transaction has witness data *or* zero inputs, so
+//! a one-input witness-less transaction encodes as legacy — which is the only
+//! thing `fundrawtransaction` will decode.
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use bitcoin::Address;
+use bitcoin::Amount;
+use bitcoin::OutPoint;
+use bitcoin::ScriptBuf;
+use bitcoin::Sequence;
+use bitcoin::Transaction;
+use bitcoin::TxIn;
+use bitcoin::TxOut;
+use bitcoin::Txid;
+use bitcoin::Witness;
+use bitcoin::absolute::LockTime;
+use bitcoin::consensus::encode::serialize_hex;
+use bitcoin::transaction::Version;
+use corepc_client::client_sync::Auth;
+use corepc_client::client_sync::v29::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use serde_json::json;
+
+/// vB contributed by each part of the funding transaction, used only to size the
+/// preselected input. Deliberate over-estimates; the real fee comes from
+/// `fundrawtransaction`.
+const VB_OVERHEAD: u64 = 11;
+const VB_P2WPKH_INPUT: u64 = 68;
+const VB_P2TR_OUTPUT: u64 = 43;
+const VB_CHANGE_OUTPUT: u64 = 31;
+
+pub struct BitcoinRpc {
+    /// Node-scoped, for chain queries and broadcast.
+    node: Client,
+    /// Wallet-scoped, for coin selection, funding and signing.
+    wallet: Client,
+    wallet_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChainInfo {
+    pub chain: String,
+    pub blocks: u64,
+    #[serde(rename = "initialblockdownload")]
+    pub initial_block_download: bool,
+    #[serde(rename = "verificationprogress")]
+    pub verification_progress: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListUnspent {
+    txid: String,
+    vout: u32,
+    amount: f64,
+    spendable: bool,
+    solvable: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct FundResult {
+    hex: String,
+    fee: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SignResult {
+    hex: String,
+    complete: bool,
+}
+
+/// One broadcast funding transaction and the outputs paying the deposit
+/// address. `vouts` comes from decoding the funded transaction, so it already
+/// accounts for wherever Core placed the change.
+#[derive(Debug, Clone)]
+pub struct FundingTx {
+    pub txid: Txid,
+    pub vouts: Vec<u32>,
+    pub amount_sats: u64,
+    pub fee_btc: f64,
+}
+
+impl BitcoinRpc {
+    pub fn new(url: &str, user: &str, password: &str, wallet: &str) -> Result<Self> {
+        let auth = || Auth::UserPass(user.to_string(), password.to_string());
+        let base = url.trim_end_matches('/');
+        Ok(Self {
+            node: hashi::btc_monitor::config::new_rpc_client(base, auth())
+                .with_context(|| format!("failed to connect to bitcoind at {base}"))?,
+            wallet: hashi::btc_monitor::config::new_rpc_client(
+                &format!("{base}/wallet/{wallet}"),
+                auth(),
+            )
+            .with_context(|| format!("failed to open wallet `{wallet}` at {base}"))?,
+            wallet_name: wallet.to_string(),
+        })
+    }
+
+    pub fn chain_info(&self) -> Result<ChainInfo> {
+        self.node
+            .call("getblockchaininfo", &[])
+            .map_err(|e| anyhow!("getblockchaininfo failed: {e}"))
+    }
+
+    /// The genesis hash, which is what hashi pins as `bitcoin_chain_id`.
+    pub fn genesis_hash(&self) -> Result<String> {
+        self.node
+            .call("getblockhash", &[json!(0)])
+            .map_err(|e| anyhow!("getblockhash 0 failed: {e}"))
+    }
+
+    pub fn wallet_balance(&self) -> Result<f64> {
+        self.wallet
+            .call("getbalance", &[])
+            .map_err(|e| anyhow!("getbalance failed: {e}"))
+    }
+
+    /// A fresh P2WPKH address from the wallet.
+    ///
+    /// The type is pinned rather than left to the node's `-addresstype`: a
+    /// wallet configured for legacy addresses would hand back a P2PKH address,
+    /// which has no witness program and so cannot be a withdrawal destination.
+    pub fn new_address(&self, label: &str) -> Result<String> {
+        self.wallet
+            .call("getnewaddress", &[json!(label), json!("bech32")])
+            .map_err(|e| anyhow!("getnewaddress failed: {e}"))
+    }
+
+    pub fn received_by_address(&self, address: &Address, minconf: u32) -> Result<f64> {
+        self.wallet
+            .call(
+                "getreceivedbyaddress",
+                &[json!(address.to_string()), json!(minconf)],
+            )
+            .map_err(|e| anyhow!("getreceivedbyaddress failed: {e}"))
+    }
+
+    /// Confirmations for `txid`, or `None` if the node has never seen it.
+    /// Returns `Some(0)` while it sits in the mempool.
+    pub fn confirmations(&self, txid: &Txid) -> Option<u32> {
+        let tx: Value = self
+            .node
+            .call("getrawtransaction", &[json!(txid.to_string()), json!(true)])
+            .ok()?;
+        Some(tx["confirmations"].as_u64().unwrap_or(0) as u32)
+    }
+
+    /// The smallest spendable UTXO that covers `need`.
+    ///
+    /// Smallest-that-fits keeps the wallet's larger UTXOs intact across runs,
+    /// and taking exactly one input is what keeps the transaction small enough
+    /// to be mined (see the module docs).
+    fn select_input(&self, need: Amount) -> Result<(Txid, u32, Amount)> {
+        let utxos: Vec<ListUnspent> = self
+            .wallet
+            .call("listunspent", &[json!(1), json!(9_999_999)])
+            .map_err(|e| anyhow!("listunspent failed: {e}"))?;
+
+        let mut usable: Vec<_> = utxos
+            .iter()
+            .filter(|u| u.spendable && u.solvable)
+            .filter_map(|u| Amount::from_btc(u.amount).ok().map(|a| (u, a)))
+            .collect();
+        usable.sort_by_key(|(_, amount)| *amount);
+
+        let (utxo, amount) = usable
+            .iter()
+            .find(|(_, amount)| *amount >= need)
+            .ok_or_else(|| {
+                let largest = usable
+                    .last()
+                    .map(|(_, a)| a.to_string())
+                    .unwrap_or_else(|| "none".into());
+                anyhow!(
+                    "wallet `{}` has no single UTXO covering {need} (largest is {largest}, across \
+                     {} spendable UTXOs).\nThis run needs one input that big: funding from many \
+                     small UTXOs builds a transaction too large for signet to mine. Consolidate \
+                     the wallet, or lower --deposits / --deposit-amount-btc.",
+                    self.wallet_name,
+                    usable.len(),
+                )
+            })?;
+
+        let txid = utxo
+            .txid
+            .parse()
+            .context("listunspent returned a bad txid")?;
+        Ok((txid, utxo.vout, *amount))
+    }
+
+    /// Build, fund, sign and broadcast one transaction paying `count` outputs of
+    /// `amount` to `address`.
+    pub fn fund_deposit_outputs(
+        &self,
+        address: &Address,
+        count: usize,
+        amount: Amount,
+        fee_rate: f64,
+    ) -> Result<FundingTx> {
+        let outputs_total = amount
+            .checked_mul(count as u64)
+            .ok_or_else(|| anyhow!("deposit total overflows"))?;
+        let est_vsize =
+            VB_OVERHEAD + VB_P2WPKH_INPUT + VB_P2TR_OUTPUT * count as u64 + VB_CHANGE_OUTPUT;
+        // Double the fee estimate so a slightly-off vsize guess cannot push the
+        // preselected input below what fundrawtransaction actually needs.
+        let fee_headroom = Amount::from_sat((est_vsize as f64 * fee_rate * 2.0).ceil() as u64);
+        let (in_txid, in_vout, in_amount) = self.select_input(outputs_total + fee_headroom)?;
+
+        let script = address.script_pubkey();
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: in_txid,
+                    vout: in_vout,
+                },
+                script_sig: ScriptBuf::new(),
+                // Deliberately not replaceable. Deposits are registered onchain
+                // against this txid seconds from now, and any replacement
+                // changes the txid and strands them. Refusing to signal RBF
+                // takes `bumpfee` off the table; a stalled tx gets CPFP'd.
+                sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,
+                witness: Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: amount,
+                    script_pubkey: script.clone(),
+                };
+                count
+            ],
+        };
+
+        crate::ui::info(&format!(
+            "input {in_txid}:{in_vout} ({in_amount}) -> {count} x {amount} (~{est_vsize} vB)"
+        ));
+
+        let funded: FundResult = self
+            .wallet
+            .call(
+                "fundrawtransaction",
+                &[
+                    json!(serialize_hex(&tx)),
+                    json!({
+                        "add_inputs": false,
+                        "fee_rate": fee_rate,
+                        // Overrides the wallet's -walletrbf default; see the sequence above.
+                        "replaceable": false,
+                        // Park change after the deposit outputs so their vouts stay 0..count.
+                        "changePosition": count,
+                    }),
+                ],
+            )
+            .map_err(|e| anyhow!("fundrawtransaction failed: {e}"))?;
+
+        let signed: SignResult = self
+            .wallet
+            .call("signrawtransactionwithwallet", &[json!(funded.hex)])
+            .map_err(|e| anyhow!("signrawtransactionwithwallet failed: {e}"))?;
+        if !signed.complete {
+            bail!(
+                "wallet `{}` could not fully sign the funding tx",
+                self.wallet_name
+            );
+        }
+
+        let txid: String = self
+            .node
+            .call("sendrawtransaction", &[json!(signed.hex)])
+            .map_err(|e| anyhow!("sendrawtransaction failed: {e}"))?;
+        let txid: Txid = txid
+            .parse()
+            .context("sendrawtransaction returned a bad txid")?;
+
+        // Read the vouts back off the broadcast transaction rather than
+        // trusting changePosition.
+        let decoded: Value = self
+            .node
+            .call("decoderawtransaction", &[json!(signed.hex)])
+            .map_err(|e| anyhow!("decoderawtransaction failed: {e}"))?;
+        let want = script.to_hex_string();
+        let vouts: Vec<u32> = decoded["vout"]
+            .as_array()
+            .map(|outs| {
+                outs.iter()
+                    .filter(|o| o["scriptPubKey"]["hex"].as_str() == Some(want.as_str()))
+                    .filter_map(|o| o["n"].as_u64().map(|n| n as u32))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if vouts.len() != count {
+            bail!(
+                "funded tx {txid} pays {} outputs to the deposit address, expected {count}",
+                vouts.len()
+            );
+        }
+
+        Ok(FundingTx {
+            txid,
+            vouts,
+            amount_sats: amount.to_sat(),
+            fee_btc: funded.fee,
+        })
+    }
+}

--- a/crates/loadtest/src/config.rs
+++ b/crates/loadtest/src/config.rs
@@ -1,0 +1,406 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Working out which deployment to drive, and how.
+//!
+//! Package and object ids move on every full redeploy, and a hand-maintained
+//! env file goes stale silently: the superseded Hashi object still exists and
+//! still accepts deposits, so a run against stale ids looks like it works while
+//! testing nothing. Ids are therefore read from a running pod's `config.toml`
+//! by default, and cross-checked when they are supplied explicitly.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use clap::Args;
+use hashi::btc_monitor::config::parse_btc_network;
+use hashi::cli::config::BitcoinOverrides;
+use hashi::cli::config::CliConfig;
+use serde::Deserialize;
+use serde_json::Value;
+use sui_sdk_types::Address;
+
+use crate::bridge::Bridge;
+
+/// Settings shared by every subcommand.
+///
+/// Split in two so `--help` reads as coherent groups rather than one list
+/// interleaved with the per-run knobs.
+#[derive(Args, Debug, Clone)]
+pub struct CommonOpts {
+    #[command(flatten)]
+    pub deployment: DeploymentOpts,
+
+    #[command(flatten)]
+    pub bitcoin: BitcoinOpts,
+}
+
+#[derive(Args, Debug, Clone)]
+#[command(next_help_heading = "Deployment")]
+pub struct DeploymentOpts {
+    /// Kubernetes namespace to read the deployment's ids from
+    #[arg(long, default_value = "hashi-devnet", global = true)]
+    pub namespace: String,
+
+    /// Pod to read `config.toml` from
+    #[arg(long, default_value = "hashi-server-0", global = true)]
+    pub pod: String,
+
+    /// Hashi Move package id [default: read from the cluster]
+    #[arg(long, env = "HASHI_PACKAGE_ID", global = true)]
+    pub package_id: Option<String>,
+
+    /// Hashi shared object id [default: read from the cluster]
+    #[arg(long, env = "HASHI_OBJECT_ID", global = true)]
+    pub hashi_object_id: Option<String>,
+
+    /// Sui RPC URL [default: read from the cluster]
+    #[arg(long, env = "SUI_RPC_URL", global = true)]
+    pub sui_rpc_url: Option<String>,
+
+    /// Sui address that receives hBTC and signs [default: `sui client active-address`]
+    #[arg(long, env = "SUI_ADDR", global = true)]
+    pub sui_address: Option<String>,
+
+    /// Signing key file: PKCS#8 PEM/DER, a `suiprivkey1...` line, or a keystore entry
+    #[arg(long, short = 'k', env = "HASHI_KEYPAIR", global = true)]
+    pub keypair: Option<PathBuf>,
+}
+
+#[derive(Args, Debug, Clone)]
+#[command(next_help_heading = "Bitcoin")]
+pub struct BitcoinOpts {
+    /// Bitcoin network: mainnet, testnet4, signet or regtest
+    #[arg(long, env = "BTC_NETWORK", default_value = "signet", global = true)]
+    pub btc_network: String,
+
+    /// Bitcoin Core RPC URL
+    #[arg(
+        long,
+        env = "BTC_RPC_URL",
+        default_value = "http://127.0.0.1:38332",
+        global = true
+    )]
+    pub btc_rpc_url: String,
+
+    /// Bitcoin Core RPC username
+    #[arg(long, env = "BTC_RPC_USER", global = true)]
+    pub btc_rpc_user: Option<String>,
+
+    /// Bitcoin Core RPC password
+    #[arg(long, env = "BTC_RPC_PASSWORD", global = true)]
+    pub btc_rpc_password: Option<String>,
+
+    /// Bitcoin Core wallet holding the funding UTXOs
+    #[arg(long, env = "BTC_WALLET", default_value = "mining", global = true)]
+    pub btc_wallet: String,
+}
+
+/// Fully resolved settings for a run.
+pub struct Resolved {
+    pub package_id: Address,
+    pub hashi_object_id: Address,
+    pub sui_address: Address,
+    pub sui_rpc_url: String,
+    pub btc_network: bitcoin::Network,
+    pub btc_rpc_url: String,
+    pub btc_rpc_user: String,
+    pub btc_rpc_password: String,
+    pub btc_wallet: String,
+    pub namespace: String,
+    /// What the cluster reported, when it was reachable. Kept so preflight can
+    /// cross-check ids and genesis without a second `kubectl exec`.
+    pub cluster: Option<ClusterInfo>,
+    /// True when an id actually came from the cluster rather than a flag.
+    pub discovered_from_k8s: bool,
+    cli_config: CliConfig,
+}
+
+impl Resolved {
+    pub fn bridge(&self) -> Result<Bridge> {
+        Bridge::new(self.cli_config.clone(), self.btc_network)
+    }
+}
+
+/// The subset of a node's `config.toml` worth reading.
+#[derive(Debug, Deserialize)]
+struct PodConfig {
+    #[serde(rename = "hashi-ids")]
+    hashi_ids: PodHashiIds,
+    #[serde(rename = "sui-rpc")]
+    sui_rpc: Option<String>,
+    #[serde(rename = "bitcoin-chain-id")]
+    bitcoin_chain_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PodHashiIds {
+    #[serde(rename = "package-id")]
+    package_id: String,
+    #[serde(rename = "hashi-object-id")]
+    hashi_object_id: String,
+}
+
+/// What the cluster says, for cross-checking against local state.
+#[derive(Debug, Clone)]
+pub struct ClusterInfo {
+    pub package_id: String,
+    pub hashi_object_id: String,
+    pub sui_rpc: Option<String>,
+    pub bitcoin_chain_id: Option<String>,
+}
+
+pub fn read_cluster_config(namespace: &str, pod: &str) -> Result<ClusterInfo> {
+    let out = Command::new("kubectl")
+        .args([
+            "-n",
+            namespace,
+            "exec",
+            pod,
+            "-c",
+            "hashi",
+            "--",
+            "cat",
+            "/opt/hashi/config/config.toml",
+        ])
+        .output()
+        .context("failed to run kubectl; is it installed and on PATH?")?;
+    if !out.status.success() {
+        bail!(
+            "kubectl exec {namespace}/{pod} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let cfg: PodConfig = toml::from_str(&String::from_utf8_lossy(&out.stdout))
+        .with_context(|| format!("failed to parse config.toml from {namespace}/{pod}"))?;
+    Ok(ClusterInfo {
+        package_id: cfg.hashi_ids.package_id,
+        hashi_object_id: cfg.hashi_ids.hashi_object_id,
+        sui_rpc: cfg.sui_rpc,
+        bitcoin_chain_id: cfg.bitcoin_chain_id,
+    })
+}
+
+fn sui_active_address() -> Result<String> {
+    let out = Command::new("sui")
+        .args(["client", "active-address"])
+        .output()
+        .context("failed to run `sui`; pass --sui-address instead")?;
+    if !out.status.success() {
+        bail!("`sui client active-address` failed; pass --sui-address instead");
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+impl CommonOpts {
+    /// Resolve every setting, reading the cluster once and using it both to
+    /// fill in what was not given and to cross-check what was.
+    pub fn resolve(&self) -> Result<Resolved> {
+        let d = &self.deployment;
+        let b = &self.bitcoin;
+
+        let needs_cluster =
+            d.package_id.is_none() || d.hashi_object_id.is_none() || d.sui_rpc_url.is_none();
+
+        let cluster = match read_cluster_config(&d.namespace, &d.pod) {
+            Ok(c) => Some(c),
+            // Only fatal when the cluster is the only source for an id.
+            Err(e) if needs_cluster => {
+                return Err(e.context(
+                    "could not read the deployment's ids from the cluster; pass --package-id, \
+                     --hashi-object-id and --sui-rpc-url explicitly to work without kubectl",
+                ));
+            }
+            Err(_) => None,
+        };
+
+        let package_id = d
+            .package_id
+            .clone()
+            .or_else(|| cluster.as_ref().map(|c| c.package_id.clone()))
+            .ok_or_else(|| anyhow!("no package id"))?;
+        let hashi_object_id = d
+            .hashi_object_id
+            .clone()
+            .or_else(|| cluster.as_ref().map(|c| c.hashi_object_id.clone()))
+            .ok_or_else(|| anyhow!("no hashi object id"))?;
+        let sui_rpc_url = d
+            .sui_rpc_url
+            .clone()
+            .or_else(|| cluster.as_ref().and_then(|c| c.sui_rpc.clone()))
+            .ok_or_else(|| anyhow!("no sui rpc url; pass --sui-rpc-url"))?;
+
+        let sui_address_raw = match &d.sui_address {
+            Some(a) => a.clone(),
+            None => sui_active_address()?,
+        };
+        let sui_address = sui_address_raw
+            .parse::<Address>()
+            .with_context(|| format!("invalid --sui-address `{sui_address_raw}`"))?;
+
+        let keypair = d.keypair.clone().ok_or_else(|| {
+            anyhow!(
+                "no signing key: pass --keypair (or set HASHI_KEYPAIR).\nExport one with:\n  \
+                 sui keytool export --key-identity {sui_address} --json | jq -r \
+                 .exportedPrivateKey > signer.key"
+            )
+        })?;
+        if !keypair.exists() {
+            bail!("keypair file {} does not exist", keypair.display());
+        }
+
+        let btc_rpc_user = b
+            .btc_rpc_user
+            .clone()
+            .ok_or_else(|| anyhow!("no --btc-rpc-user (or BTC_RPC_USER)"))?;
+        let btc_rpc_password = b
+            .btc_rpc_password
+            .clone()
+            .ok_or_else(|| anyhow!("no --btc-rpc-password (or BTC_RPC_PASSWORD)"))?;
+        let btc_network = parse_btc_network(Some(&b.btc_network))?;
+
+        // Build the CLI's own config so the bridge side behaves exactly as
+        // `hashi <subcommand>` would. Every field is supplied, so the CLI's
+        // default config file cannot influence a run.
+        let cli_config = CliConfig::load(
+            None,
+            Some(sui_rpc_url.clone()),
+            Some(package_id.clone()),
+            Some(hashi_object_id.clone()),
+            Some(keypair),
+            BitcoinOverrides {
+                rpc_url: Some(b.btc_rpc_url.clone()),
+                rpc_user: Some(btc_rpc_user.clone()),
+                rpc_password: Some(btc_rpc_password.clone()),
+                network: Some(b.btc_network.clone()),
+                private_key: None,
+            },
+        )?;
+
+        Ok(Resolved {
+            package_id: package_id
+                .parse()
+                .with_context(|| format!("invalid package id `{package_id}`"))?,
+            hashi_object_id: hashi_object_id
+                .parse()
+                .with_context(|| format!("invalid hashi object id `{hashi_object_id}`"))?,
+            sui_address,
+            sui_rpc_url,
+            btc_network,
+            btc_rpc_url: b.btc_rpc_url.clone(),
+            btc_rpc_user,
+            btc_rpc_password,
+            btc_wallet: b.btc_wallet.clone(),
+            namespace: d.namespace.clone(),
+            cluster,
+            // The cluster is read whenever reachable; this is only true when an
+            // id actually came from it.
+            discovered_from_k8s: needs_cluster,
+            cli_config,
+        })
+    }
+}
+
+/// The Hashi object's onchain config map.
+///
+/// These override the code defaults and are what the committee actually
+/// enforces, so a run reads them rather than assuming: an amount below
+/// `bitcoin_withdrawal_minimum`, or a paused bridge, rejects every request —
+/// and by then the deposits are funded.
+#[derive(Debug, Default)]
+pub struct OnchainConfig(BTreeMap<String, Value>);
+
+impl OnchainConfig {
+    /// Best-effort read via the `sui` CLI. `None` means "could not read", and
+    /// callers degrade to skipping the check rather than failing.
+    pub fn read(hashi_object_id: Address) -> Option<Self> {
+        let out = Command::new("sui")
+            .args(["client", "object", &hashi_object_id.to_string(), "--json"])
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        let json: Value = serde_json::from_slice(&out.stdout).ok()?;
+        let mut entries = BTreeMap::new();
+        collect_vecmap(&json, &mut entries);
+        (!entries.is_empty()).then_some(Self(entries))
+    }
+
+    /// Values are enum-wrapped (`{"@variant": "U64", "pos0": "123"}`) and Sui
+    /// renders u64 as a string.
+    pub fn u64(&self, key: &str) -> Option<u64> {
+        match self.0.get(key)? {
+            Value::Number(n) => n.as_u64(),
+            Value::String(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+
+    pub fn bool(&self, key: &str) -> Option<bool> {
+        self.0.get(key)?.as_bool()
+    }
+
+    pub fn string(&self, key: &str) -> Option<&str> {
+        self.0.get(key)?.as_str()
+    }
+}
+
+/// Walk the object JSON collecting every `{key, value: {@variant, pos0}}` pair.
+/// Walking rather than modelling keeps this working across object-layout
+/// changes; only the VecMap entry shape has to hold.
+fn collect_vecmap(v: &Value, out: &mut BTreeMap<String, Value>) {
+    match v {
+        Value::Object(map) => {
+            if let (Some(Value::String(k)), Some(value)) = (map.get("key"), map.get("value"))
+                && let Some(inner) = unwrap_variant(value)
+            {
+                out.insert(k.clone(), inner.clone());
+            }
+            map.values().for_each(|child| collect_vecmap(child, out));
+        }
+        Value::Array(items) => items.iter().for_each(|child| collect_vecmap(child, out)),
+        _ => {}
+    }
+}
+
+fn unwrap_variant(v: &Value) -> Option<&Value> {
+    match v {
+        Value::Object(map) if map.contains_key("@variant") => map.get("pos0"),
+        other => Some(other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_config_entries_out_of_the_object_json() {
+        // Shape as `sui client object --json` renders it: VecMap entries nested
+        // under the object contents, values wrapped in an enum variant, and u64
+        // rendered as a string.
+        let json = serde_json::json!({
+            "content": { "config": { "config": { "contents": [
+                { "key": "paused", "value": { "@variant": "Bool", "pos0": false } },
+                { "key": "bitcoin_withdrawal_minimum",
+                  "value": { "@variant": "U64", "pos0": "30000" } },
+                { "key": "guardian_url",
+                  "value": { "@variant": "String", "pos0": "https://g.example" } },
+            ]}}}
+        });
+        let mut entries = BTreeMap::new();
+        collect_vecmap(&json, &mut entries);
+        let cfg = OnchainConfig(entries);
+
+        assert_eq!(cfg.bool("paused"), Some(false));
+        assert_eq!(cfg.u64("bitcoin_withdrawal_minimum"), Some(30_000));
+        assert_eq!(cfg.string("guardian_url"), Some("https://g.example"));
+        assert_eq!(cfg.u64("absent"), None);
+    }
+}

--- a/crates/loadtest/src/main.rs
+++ b/crates/loadtest/src/main.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Drives deposit -> mint -> withdraw -> settle loops against a deployed Hashi
+//! bridge, for load testing and post-deploy verification.
+//!
+//! The bridge work goes through the same library the `hashi` CLI uses. What
+//! this owns is everything around it that is easy to get wrong: reading the
+//! deployment's real ids, funding many deposit UTXOs without tripping Bitcoin
+//! Core's coin selection, retrying PTBs, and knowing when a run has actually
+//! finished.
+
+mod bridge;
+mod btc;
+mod config;
+mod run;
+mod ui;
+
+use anyhow::Result;
+use clap::Parser;
+use clap::Subcommand;
+
+use crate::config::CommonOpts;
+use crate::run::LoopOpts;
+use crate::run::Mode;
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+#[clap(name = "loadtest")]
+#[clap(about = "Run deposit/withdraw loops against a deployed Hashi bridge")]
+#[clap(styles = hashi::cli::STYLES)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+
+    #[command(flatten)]
+    common: CommonOpts,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Check that a run would work, without spending anything
+    Doctor,
+
+    /// Run the full loop: fund, register, wait for mint, withdraw, settle
+    Run(Box<LoopOpts>),
+
+    /// Deposit half only: fund, register, wait for mint
+    Deposit(Box<LoopOpts>),
+
+    /// Withdraw half only, against hBTC already held
+    Withdraw(Box<LoopOpts>),
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    hashi::init_crypto_provider();
+    let args = Args::parse();
+
+    match args.command {
+        Command::Doctor => run::doctor(&args.common).await,
+        Command::Run(opts) => run::run(&args.common, &opts, Mode::Full).await,
+        Command::Deposit(opts) => run::run(&args.common, &opts, Mode::DepositOnly).await,
+        Command::Withdraw(opts) => run::run(&args.common, &opts, Mode::WithdrawOnly).await,
+    }
+}

--- a/crates/loadtest/src/run.rs
+++ b/crates/loadtest/src/run.rs
@@ -1,0 +1,795 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Preflight checks and the deposit -> mint -> withdraw -> settle loop.
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use bitcoin::Address;
+use bitcoin::Amount;
+use clap::Args;
+use hashi_types::bitcoin::BitcoinAddress;
+use serde_json::json;
+
+use crate::bridge::Bridge;
+use crate::bridge::DEPOSIT_CHUNK;
+use crate::bridge::WITHDRAW_CHUNK;
+use crate::btc::BitcoinRpc;
+use crate::btc::FundingTx;
+use crate::config::CommonOpts;
+use crate::config::OnchainConfig;
+use crate::config::Resolved;
+use crate::ui;
+
+/// Attempts per PTB. The peer-gRPC layer drops connections under the load a
+/// large run generates, and a retry reconnects.
+///
+/// A PTB is atomic, so a failed attempt never lands a partial batch. It can
+/// still land a whole one: if the transaction executed and only the response
+/// was lost, the retry re-submits. That is survivable rather than corrupting —
+/// duplicate deposit requests never mint, because `deposit()`'s replay check
+/// rejects them once the original's UTXO reaches the pool — but it does mean a
+/// retried withdrawal batch can burn hBTC twice. See the README.
+const PTB_ATTEMPTS: usize = 5;
+const PTB_RETRY_DELAY: Duration = Duration::from_secs(6);
+
+/// Which halves of the loop to run.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Mode {
+    Full,
+    DepositOnly,
+    WithdrawOnly,
+}
+
+impl Mode {
+    fn deposits(self) -> bool {
+        self != Mode::WithdrawOnly
+    }
+
+    fn withdrawals(self) -> bool {
+        self != Mode::DepositOnly
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Mode::Full => "full",
+            Mode::DepositOnly => "deposit",
+            Mode::WithdrawOnly => "withdraw",
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct LoopOpts {
+    /// Number of deposit UTXOs to create and register
+    #[arg(long, default_value_t = 100)]
+    pub deposits: usize,
+
+    /// BTC per deposit
+    #[arg(long, default_value_t = 0.1)]
+    pub deposit_amount_btc: f64,
+
+    /// Number of withdrawal requests to submit
+    #[arg(long, default_value_t = 100)]
+    pub withdrawals: usize,
+
+    /// BTC per withdrawal
+    #[arg(long, default_value_t = 0.1)]
+    pub withdrawal_amount_btc: f64,
+
+    /// Deposit outputs per funding transaction. Larger batches mean fewer
+    /// transactions but a fatter one; signet's miner caps blocks near 1M weight
+    /// and skips transactions that no longer fit.
+    #[arg(long, default_value_t = 250)]
+    pub outputs_per_tx: usize,
+
+    /// Funding transaction fee rate (sat/vB)
+    #[arg(long, default_value_t = 4.0)]
+    pub fee_rate: f64,
+
+    /// BTC address to withdraw to [default: a fresh address from the wallet,
+    /// which makes the received total exactly this run's]
+    #[arg(long)]
+    pub withdraw_dest: Option<String>,
+
+    /// Seconds to wait for deposits to mint
+    #[arg(long, default_value_t = 3600)]
+    pub mint_timeout: u64,
+
+    /// Seconds to wait for withdrawals to settle on Bitcoin
+    #[arg(long, default_value_t = 5400)]
+    pub settle_timeout: u64,
+
+    /// Seconds between polls
+    #[arg(long, default_value_t = 30)]
+    pub poll_interval: u64,
+
+    /// Submit withdrawals but do not wait for Bitcoin settlement
+    #[arg(long)]
+    pub skip_settle: bool,
+
+    /// Do not scan pod logs for guardian co-signing failures while settling
+    #[arg(long)]
+    pub no_log_watch: bool,
+
+    /// Write a JSON report here
+    #[arg(long)]
+    pub report: Option<std::path::PathBuf>,
+}
+
+impl LoopOpts {
+    fn deposit_amount(&self) -> Result<Amount> {
+        Amount::from_btc(self.deposit_amount_btc).context("bad --deposit-amount-btc")
+    }
+
+    fn withdrawal_amount(&self) -> Result<Amount> {
+        Amount::from_btc(self.withdrawal_amount_btc).context("bad --withdrawal-amount-btc")
+    }
+
+    fn deposit_total(&self) -> Result<Amount> {
+        Ok(self.deposit_amount()? * self.deposits as u64)
+    }
+
+    fn withdrawal_total(&self) -> Result<Amount> {
+        Ok(self.withdrawal_amount()? * self.withdrawals as u64)
+    }
+}
+
+/// Run one fallible step up to [`PTB_ATTEMPTS`] times.
+async fn retrying<T, F, Fut>(label: &str, mut f: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let mut last = None;
+    for attempt in 1..=PTB_ATTEMPTS {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if attempt < PTB_ATTEMPTS {
+                    ui::warn(&format!(
+                        "{label} attempt {attempt}/{PTB_ATTEMPTS} failed: {e}"
+                    ));
+                    tokio::time::sleep(PTB_RETRY_DELAY).await;
+                }
+                last = Some(e);
+            }
+        }
+    }
+    Err(last
+        .expect("at least one attempt ran")
+        .context(format!("{label} failed after {PTB_ATTEMPTS} attempts")))
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------- preflight
+
+pub struct Preflight {
+    pub deposit_address: BitcoinAddress,
+    pub hbtc_start_sats: u64,
+}
+
+/// Verify everything a run depends on, before it spends any BTC.
+///
+/// `needs` describes the run, to size it against available funds; pass `None`
+/// to check reachability only.
+pub async fn preflight(r: &Resolved, needs: Option<(&LoopOpts, Mode)>) -> Result<Preflight> {
+    let bridge = r.bridge()?;
+    let btc = BitcoinRpc::new(
+        &r.btc_rpc_url,
+        &r.btc_rpc_user,
+        &r.btc_rpc_password,
+        &r.btc_wallet,
+    )?;
+
+    if r.discovered_from_k8s {
+        ui::ok(&format!(
+            "ids                 read live from {}",
+            r.namespace
+        ));
+    } else {
+        // Explicitly-passed ids are the stale-env-file trap: the superseded
+        // deployment's Hashi object still exists and still accepts deposits.
+        match &r.cluster {
+            Some(c) if c.package_id != r.package_id.to_string() => ui::warn(&format!(
+                "the package id given is not what {} is running:\n      given   {}\n      \
+                 cluster {}\n      The superseded package still exists and still accepts \
+                 deposits, so this run would look green while testing nothing.\n      \
+                 Unset HASHI_PACKAGE_ID and HASHI_OBJECT_ID (or drop --package-id) to use \
+                 the live ones.",
+                r.namespace, r.package_id, c.package_id
+            )),
+            Some(_) => ui::ok(&format!("ids                 match {}", r.namespace)),
+            None => ui::info("ids                 taken as given (cluster not reachable)"),
+        }
+    }
+
+    let info = btc.chain_info()?;
+    if info.chain != r.btc_network.to_string() {
+        bail!(
+            "bitcoind at {} is on `{}` but --btc-network resolves to `{}`",
+            r.btc_rpc_url,
+            info.chain,
+            r.btc_network
+        );
+    }
+    if info.initial_block_download || info.verification_progress < 0.999 {
+        bail!(
+            "bitcoind is still syncing ({:.2}% at height {}); wait for it to catch up",
+            info.verification_progress * 100.0,
+            info.blocks
+        );
+    }
+    ui::ok(&format!(
+        "bitcoind            {} at height {}",
+        info.chain, info.blocks
+    ));
+
+    // Both sides must be on the same Bitcoin, and signet in particular is a
+    // custom chain per deployment. hashi pins genesis as `bitcoin_chain_id`.
+    let genesis = btc.genesis_hash()?;
+    match r
+        .cluster
+        .as_ref()
+        .and_then(|c| c.bitcoin_chain_id.as_deref())
+    {
+        Some(chain_id) if chain_id != genesis => bail!(
+            "your bitcoind is a different chain from the bridge's:\n  local genesis   {genesis}\n  \
+             bridge chain id {chain_id}\nDeposits made here would never be seen."
+        ),
+        Some(_) => ui::ok("bitcoin chain       genesis matches the bridge"),
+        None => ui::info("bitcoin chain       not verified (bridge chain id unavailable)"),
+    }
+
+    let wallet_balance_btc = btc.wallet_balance()?;
+    ui::ok(&format!(
+        "wallet `{}`     {:.8} BTC",
+        r.btc_wallet, wallet_balance_btc
+    ));
+
+    let deposit_address = bridge.deposit_address(r.sui_address).await.context(
+        "could not derive a deposit address; the package/object ids may be wrong, or the \
+         committee may not have completed DKG",
+    )?;
+    ui::ok(&format!("deposit address     {deposit_address}"));
+
+    let hbtc_start_sats = bridge.balance_sats(r.sui_address).await?;
+    ui::ok(&format!(
+        "hBTC balance        {} sats ({:.8} BTC)",
+        hbtc_start_sats,
+        hbtc_start_sats as f64 / 1e8
+    ));
+
+    // The onchain config overrides the code defaults, so it is the only
+    // authority on what the committee accepts and how long a mint takes.
+    match OnchainConfig::read(r.hashi_object_id) {
+        Some(cfg) => {
+            if cfg.bool("paused") == Some(true) {
+                bail!(
+                    "the bridge is paused onchain; deposits and withdrawals will be rejected \
+                     until governance unpauses it"
+                );
+            }
+            if let Some(url) = cfg.string("guardian_url") {
+                ui::ok(&format!("guardian            {url}"));
+            }
+            if let (Some(confs), Some(delay)) = (
+                cfg.u64("bitcoin_confirmation_threshold"),
+                cfg.u64("bitcoin_deposit_time_delay_ms"),
+            ) {
+                ui::ok(&format!(
+                    "mint gating         {confs} confirmations + {}s delay",
+                    delay / 1000
+                ));
+            }
+            if let Some((opts, mode)) = needs {
+                check_capacity(
+                    r,
+                    opts,
+                    mode,
+                    Some(&cfg),
+                    wallet_balance_btc,
+                    hbtc_start_sats,
+                )?;
+            }
+        }
+        None => {
+            ui::info("onchain config      not read (the `sui` CLI is unavailable)");
+            if let Some((opts, mode)) = needs {
+                check_capacity(r, opts, mode, None, wallet_balance_btc, hbtc_start_sats)?;
+            }
+        }
+    }
+
+    Ok(Preflight {
+        deposit_address,
+        hbtc_start_sats,
+    })
+}
+
+/// Reject runs that cannot finish, before any BTC moves.
+fn check_capacity(
+    r: &Resolved,
+    opts: &LoopOpts,
+    mode: Mode,
+    cfg: Option<&OnchainConfig>,
+    wallet_balance_btc: f64,
+    hbtc_start_sats: u64,
+) -> Result<()> {
+    let held = Amount::from_sat(hbtc_start_sats);
+    let deposit_total = if mode.deposits() {
+        opts.deposit_total()?
+    } else {
+        Amount::ZERO
+    };
+    let withdrawal_total = if mode.withdrawals() {
+        opts.withdrawal_total()?
+    } else {
+        Amount::ZERO
+    };
+
+    if deposit_total.to_btc() > wallet_balance_btc {
+        bail!(
+            "run needs {deposit_total} of deposits but wallet `{}` holds only {:.8} BTC",
+            r.btc_wallet,
+            wallet_balance_btc
+        );
+    }
+
+    // hBTC available to withdraw: what is held now, plus whatever this run mints.
+    let available = held + deposit_total;
+    if withdrawal_total > available {
+        bail!(
+            "run would withdraw {withdrawal_total} but only {available} of hBTC will exist \
+             ({held} already held + {deposit_total} minted by this run)"
+        );
+    }
+
+    // A per-request amount below the onchain minimum is rejected outright, and
+    // by then the deposits would already be funded.
+    let mut checks = Vec::new();
+    if mode.deposits() {
+        checks.push((
+            "bitcoin_deposit_minimum",
+            opts.deposit_amount()?,
+            "--deposit-amount-btc",
+        ));
+    }
+    if mode.withdrawals() {
+        checks.push((
+            "bitcoin_withdrawal_minimum",
+            opts.withdrawal_amount()?,
+            "--withdrawal-amount-btc",
+        ));
+    }
+    for (key, amount, flag) in checks {
+        if let Some(min) = cfg.and_then(|c| c.u64(key))
+            && amount.to_sat() < min
+        {
+            bail!(
+                "{flag} is {} sats, below the onchain {key} of {min} sats",
+                amount.to_sat()
+            );
+        }
+    }
+
+    ui::ok(&format!(
+        "capacity            {deposit_total} in, {withdrawal_total} out"
+    ));
+    Ok(())
+}
+
+// ------------------------------------------------------------------- phases
+
+fn fund(btc: &BitcoinRpc, address: &Address, opts: &LoopOpts) -> Result<Vec<FundingTx>> {
+    let amount = opts.deposit_amount()?;
+    let mut remaining = opts.deposits;
+    let mut txs = Vec::new();
+    let batches = opts.deposits.div_ceil(opts.outputs_per_tx);
+
+    while remaining > 0 {
+        let count = remaining.min(opts.outputs_per_tx);
+        let idx = txs.len() + 1;
+        ui::step(&format!("funding tx {idx}/{batches}: {count} x {amount}"));
+        let tx = btc.fund_deposit_outputs(address, count, amount, opts.fee_rate)?;
+        ui::ok(&format!(
+            "{} ({} outputs, fee {:.8} BTC)",
+            tx.txid,
+            tx.vouts.len(),
+            tx.fee_btc
+        ));
+        txs.push(tx);
+        remaining -= count;
+    }
+    Ok(txs)
+}
+
+/// Register every funded output as a deposit request.
+///
+/// Registration does not wait for confirmations: the committee enforces
+/// `bitcoin_confirmation_threshold` itself, so registering straight from the
+/// mempool only starts its watch sooner.
+async fn register(
+    bridge: &Bridge,
+    txs: &[FundingTx],
+    recipient: sui_sdk_types::Address,
+) -> Result<usize> {
+    let total: usize = txs.iter().map(|t| t.vouts.len()).sum();
+    let mut registered = 0;
+
+    for tx in txs {
+        let outputs: Vec<(u32, u64)> = tx.vouts.iter().map(|v| (*v, tx.amount_sats)).collect();
+        for chunk in outputs.chunks(DEPOSIT_CHUNK) {
+            registered += retrying("deposit registration", || {
+                bridge.register_deposits(tx.txid, chunk, recipient)
+            })
+            .await?;
+            ui::step(&format!("registered {registered}/{total} deposits"));
+        }
+    }
+    Ok(registered)
+}
+
+async fn await_mint(
+    bridge: &Bridge,
+    btc: &BitcoinRpc,
+    r: &Resolved,
+    txs: &[FundingTx],
+    target: Amount,
+    opts: &LoopOpts,
+) -> Result<u64> {
+    let deadline = Instant::now() + Duration::from_secs(opts.mint_timeout);
+
+    loop {
+        let balance = bridge.balance_sats(r.sui_address).await?;
+        // The least-confirmed funding tx gates the last deposit to mint.
+        let confs = txs
+            .iter()
+            .map(|t| btc.confirmations(&t.txid).unwrap_or(0))
+            .min()
+            .unwrap_or(0);
+        ui::step(&format!(
+            "minted {:.8} / {} BTC (funding txs at >={confs} confs)",
+            balance as f64 / 1e8,
+            target.to_btc()
+        ));
+        if balance >= target.to_sat() {
+            return Ok(balance);
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out after {}s waiting to mint {target}; reached {:.8} BTC. The funding txs \
+                 were at {confs} confirmations — if that is still 0, they never got mined and the \
+                 fee rate was likely too low for their size.",
+                opts.mint_timeout,
+                balance as f64 / 1e8
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(opts.poll_interval)).await;
+    }
+}
+
+/// Submit withdrawals, one atomic PTB at a time.
+///
+/// Each batch waits until enough hBTC has minted to cover it, so this also works
+/// while deposits are still landing.
+async fn withdraw(
+    bridge: &Bridge,
+    r: &Resolved,
+    dest: &BitcoinAddress,
+    opts: &LoopOpts,
+) -> Result<HashSet<sui_sdk_types::Address>> {
+    let amount = opts.withdrawal_amount()?;
+    let deadline = Instant::now() + Duration::from_secs(opts.mint_timeout);
+    let mut submitted = HashSet::new();
+
+    while submitted.len() < opts.withdrawals {
+        let count = (opts.withdrawals - submitted.len()).min(WITHDRAW_CHUNK);
+        let need = amount * count as u64;
+
+        let balance = Amount::from_sat(bridge.balance_sats(r.sui_address).await?);
+        if balance < need {
+            if Instant::now() >= deadline {
+                bail!(
+                    "timed out waiting for hBTC to cover the next batch: have {balance}, need \
+                     {need} ({}/{} submitted)",
+                    submitted.len(),
+                    opts.withdrawals
+                );
+            }
+            ui::step(&format!(
+                "waiting for hBTC: have {balance}, need {need} ({}/{} submitted)",
+                submitted.len(),
+                opts.withdrawals
+            ));
+            tokio::time::sleep(Duration::from_secs(opts.poll_interval)).await;
+            continue;
+        }
+
+        let ids = retrying("withdrawal batch", || {
+            bridge.request_withdrawals(amount.to_sat(), dest, count)
+        })
+        .await?;
+        submitted.extend(ids);
+        ui::step(&format!(
+            "submitted {}/{} withdrawals",
+            submitted.len(),
+            opts.withdrawals
+        ));
+    }
+    Ok(submitted)
+}
+
+/// Count guardian co-signing failures across the fleet in the last
+/// `since_secs`.
+///
+/// This is the signal that withdrawals are broken rather than merely slow — both
+/// look identical from the queue alone. Best-effort: without kubectl a run still
+/// works, it just loses this diagnostic.
+fn cosign_failures(namespace: &str, since_secs: u64) -> usize {
+    std::process::Command::new("kubectl")
+        .args([
+            "-n",
+            namespace,
+            "logs",
+            "-l",
+            "app=hashi-server",
+            &format!("--since={since_secs}s"),
+            "--max-log-requests=20",
+        ])
+        .output()
+        .ok()
+        .map(|out| {
+            String::from_utf8_lossy(&out.stdout)
+                .matches("Guardian signature verification failed")
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+struct Settlement {
+    received_btc: f64,
+    cosign_failures: usize,
+}
+
+/// Wait until every withdrawal in `mine` has been confirmed on Bitcoin.
+///
+/// Completion is read from onchain state — this run's requests all out of the
+/// queue, and none of its transactions still in flight — rather than from the
+/// payout total levelling off. A "payouts stopped growing" heuristic would
+/// report success during any lull, and lulls are normal here: the guardian's
+/// rate limiter makes batches trickle out as its bucket refills.
+///
+/// Waiting for `confirmed_txns` rather than stopping at the mempool costs the
+/// Bitcoin confirmation window, but it is what exercises the last third of the
+/// withdrawal lifecycle: broadcast, confirm, and the onchain record that marks
+/// the spent UTXOs.
+async fn await_settle(
+    bridge: &Bridge,
+    btc: &BitcoinRpc,
+    r: &Resolved,
+    dest: &Address,
+    mine: &HashSet<sui_sdk_types::Address>,
+    opts: &LoopOpts,
+) -> Result<Settlement> {
+    let deadline = Instant::now() + Duration::from_secs(opts.settle_timeout);
+    let mut failures = 0;
+
+    loop {
+        let progress = bridge.withdrawal_progress(mine).await?;
+        // minconf 0: a payout counts as soon as it hits the mempool.
+        let received = btc.received_by_address(dest, 0)?;
+        if !opts.no_log_watch {
+            failures += cosign_failures(&r.namespace, opts.poll_interval + 10);
+        }
+
+        ui::step(&format!(
+            "queued={} in-flight_txns={} ({} signed) received={received:.8} BTC{}",
+            progress.queued,
+            progress.in_flight,
+            progress.signed,
+            if failures > 0 {
+                format!(" cosign_failures={failures}")
+            } else {
+                String::new()
+            }
+        ));
+
+        // Confirmed transactions leave `withdrawal_txns` for `confirmed_txns`,
+        // so an empty in-flight set means every batch has landed.
+        if progress.queued == 0 && progress.in_flight == 0 && received > 0.0 {
+            return Ok(Settlement {
+                received_btc: received,
+                cosign_failures: failures,
+            });
+        }
+
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out after {}s: {} of this run's withdrawals still queued, {} of its \
+                 transactions in flight, {received:.8} BTC received.{}",
+                opts.settle_timeout,
+                progress.queued,
+                progress.in_flight,
+                if failures > 0 {
+                    format!(
+                        " {failures} guardian co-signing failures were logged — withdrawals are \
+                         failing, not merely slow."
+                    )
+                } else {
+                    String::new()
+                }
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(opts.poll_interval)).await;
+    }
+}
+
+// -------------------------------------------------------------- entrypoints
+
+pub async fn doctor(common: &CommonOpts) -> Result<()> {
+    let r = common.resolve()?;
+    ui::header("Preflight");
+    ui::info(&format!("package  {}", r.package_id));
+    ui::info(&format!("object   {}", r.hashi_object_id));
+    ui::info(&format!("sui rpc  {}", r.sui_rpc_url));
+    ui::info(&format!("sui addr {}", r.sui_address));
+    eprintln!();
+    preflight(&r, None).await?;
+    eprintln!();
+    ui::ok("ready");
+    Ok(())
+}
+
+pub async fn run(common: &CommonOpts, opts: &LoopOpts, mode: Mode) -> Result<()> {
+    if mode.deposits() && opts.deposits == 0 {
+        bail!("--deposits must be at least 1");
+    }
+    if mode.withdrawals() && opts.withdrawals == 0 {
+        bail!("--withdrawals must be at least 1");
+    }
+    let started = Instant::now();
+    let started_at = now_secs();
+    let r = common.resolve()?;
+
+    ui::header("Preflight");
+    ui::info(&format!("package  {}", r.package_id));
+    ui::info(&format!("object   {}", r.hashi_object_id));
+    ui::info(&format!("sui addr {}", r.sui_address));
+    eprintln!();
+    let pre = preflight(&r, Some((opts, mode))).await?;
+
+    let bridge = r.bridge()?;
+    let btc = BitcoinRpc::new(
+        &r.btc_rpc_url,
+        &r.btc_rpc_user,
+        &r.btc_rpc_password,
+        &r.btc_wallet,
+    )?;
+
+    let mut txs = Vec::new();
+    let mut registered = 0;
+    let mut minted = pre.hbtc_start_sats;
+
+    if mode.deposits() {
+        ui::header(&format!(
+            "Funding {} deposits of {} BTC",
+            opts.deposits, opts.deposit_amount_btc
+        ));
+        txs = fund(&btc, &pre.deposit_address, opts)?;
+
+        ui::header("Registering deposits");
+        registered = register(&bridge, &txs, r.sui_address).await?;
+
+        ui::header("Waiting for mint");
+        let target = Amount::from_sat(pre.hbtc_start_sats) + opts.deposit_total()?;
+        minted = await_mint(&bridge, &btc, &r, &txs, target, opts).await?;
+        ui::ok(&format!(
+            "minted; hBTC balance {:.8} BTC",
+            minted as f64 / 1e8
+        ));
+    }
+
+    let mut submitted = 0;
+    let mut settlement = None;
+    let mut dest = None;
+
+    if mode.withdrawals() {
+        let address = match &opts.withdraw_dest {
+            Some(d) => d
+                .parse::<BitcoinAddress<bitcoin::address::NetworkUnchecked>>()
+                .with_context(|| format!("invalid --withdraw-dest `{d}`"))?
+                .require_network(r.btc_network)
+                .context("--withdraw-dest is not valid on this network")?,
+            // A fresh address makes `getreceivedbyaddress` measure exactly this run.
+            None => btc
+                .new_address("hashi-loadtest")?
+                .parse::<BitcoinAddress<bitcoin::address::NetworkUnchecked>>()?
+                .require_network(r.btc_network)?,
+        };
+
+        ui::header(&format!(
+            "Withdrawing {} x {} BTC to {address}",
+            opts.withdrawals, opts.withdrawal_amount_btc
+        ));
+        let ids = withdraw(&bridge, &r, &address, opts).await?;
+        submitted = ids.len();
+
+        if !opts.skip_settle {
+            ui::header("Waiting for settlement");
+            let s = await_settle(&bridge, &btc, &r, &address, &ids, opts).await?;
+            ui::ok(&format!(
+                "settled; {:.8} BTC received at {address}",
+                s.received_btc
+            ));
+            if s.cosign_failures > 0 {
+                ui::warn(&format!(
+                    "{} guardian co-signing failures were logged during the run",
+                    s.cosign_failures
+                ));
+            }
+            settlement = Some(s);
+        }
+        dest = Some(address);
+    }
+
+    let elapsed = started.elapsed();
+    ui::header("Done");
+    ui::ok(&format!(
+        "{registered} deposits registered, {submitted} withdrawals submitted in {:.1} min",
+        elapsed.as_secs_f64() / 60.0
+    ));
+
+    if let Some(path) = &opts.report {
+        // Only report on halves that actually ran; a `deposits` block in a
+        // withdraw-only run would report flag defaults as if they had happened.
+        let deposits = mode.deposits().then(|| {
+            json!({
+                "requested": opts.deposits,
+                "registered": registered,
+                "amount_btc": opts.deposit_amount_btc,
+                "funding_txids": txs.iter().map(|t| t.txid.to_string()).collect::<Vec<_>>(),
+                "funding_fee_btc": txs.iter().map(|t| t.fee_btc).sum::<f64>(),
+            })
+        });
+        let withdrawals = mode.withdrawals().then(|| {
+            json!({
+                "submitted": submitted,
+                "amount_btc": opts.withdrawal_amount_btc,
+                "destination": dest.as_ref().map(ToString::to_string),
+                "received_btc": settlement.as_ref().map(|s| s.received_btc),
+                "cosign_failures": settlement.as_ref().map(|s| s.cosign_failures),
+            })
+        });
+        let report = json!({
+            "started_at": started_at,
+            "elapsed_secs": elapsed.as_secs(),
+            "mode": mode.as_str(),
+            "package_id": r.package_id.to_string(),
+            "hashi_object_id": r.hashi_object_id.to_string(),
+            "sui_address": r.sui_address.to_string(),
+            "deposit_address": pre.deposit_address.to_string(),
+            "deposits": deposits,
+            "withdrawals": withdrawals,
+            "hbtc_sats": { "before": pre.hbtc_start_sats, "after_mint": minted },
+        });
+        std::fs::write(path, serde_json::to_string_pretty(&report)?)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        ui::ok(&format!("report written to {}", path.display()));
+    }
+    Ok(())
+}

--- a/crates/loadtest/src/ui.rs
+++ b/crates/loadtest/src/ui.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Progress output.
+//!
+//! A run is long and mostly spent waiting, so everything here goes to stderr
+//! with a timestamp: stdout stays free for the report, and a scrollback is the
+//! only forensics available when a run misbehaves overnight.
+
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+fn clock() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (h, m, s) = ((secs / 3600) % 24, (secs / 60) % 60, secs % 60);
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+pub fn header(title: &str) {
+    eprintln!("\n== {title}");
+}
+
+pub fn ok(msg: &str) {
+    eprintln!("{}  + {msg}", clock());
+}
+
+pub fn info(msg: &str) {
+    eprintln!("{}    {msg}", clock());
+}
+
+pub fn step(msg: &str) {
+    eprintln!("{}  . {msg}", clock());
+}
+
+pub fn warn(msg: &str) {
+    eprintln!("{}  ! {msg}", clock());
+}


### PR DESCRIPTION
## Summary

One binary that drives a full deposit → mint → withdraw → settle loop against a deployed bridge, for load testing and post-deploy verification. Replaces the ad-hoc shell and Python we've been doing this with.

```bash
cargo run --release -p loadtest -- run --deposits 100 --withdrawals 100
```

- `doctor` checks a run would work without spending anything; `deposit` / `withdraw` run either half; `--report` writes a JSON summary.
- Bridge work goes through `hashi::cli` + `hashi::sui_tx_executor`, so it can't drift from the CLI.
- Unlike `e2e-tests` (localnet, in CI), this drives real clusters and real Bitcoin. Not wired into CI.

The fiddly parts — reading ids from a live pod rather than trusting a stale env file, funding without tripping Core's coin selection, knowing when a run has actually settled — are explained in `crates/loadtest/README.md`.

Verified end to end against hashi-devnet/signet: deposits funded, registered, minted, withdrawn and settled, with 0 guardian co-signing failures.