### PR TITLE
[Guardian] Read ceremony and KP share state together

### DIFF
--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -59,12 +59,12 @@ command uses `guardian_endpoint`, `hashi`, and `kp_roster`.
 
 Confirms a KP can fetch and decrypt their share from the latest setup or
 rotation ceremony. Trust is anchored to the guardian's S3 attestation log (no
-gRPC to the live guardian): it discovers the latest ceremony session from S3,
-loads that session's attested signing pubkey, verifies its `ceremony/` audit log
-and `kp-shares/` recovery log against the expected `n`/`t`, confirms every
-encrypted share is addressed only to its labeled KP cert, finds the share labeled
-for this KP's cert fingerprint, decrypts via the yubikey (`gpg --decrypt`), and
-verifies the decrypted share against its commitment.
+gRPC to the live guardian): it discovers the latest ceremony and KP-share state
+from S3, verifies each record against its writing session's attested signing
+pubkey and the expected `n`/`t`, confirms every encrypted share is addressed
+only to its labeled KP cert, finds the share labeled for this KP's cert
+fingerprint, decrypts via the yubikey (`gpg --decrypt`), and verifies the
+decrypted share against its commitment.
 
 The operator `run` command verifies live `/info` signed info and Nitro
 attestation against the configured current build before trusting the session
@@ -99,7 +99,7 @@ It:
 4. Builds the withdraw-mode `InitConfig` from limiter config, on-chain MPC
    master `G`, the KP PCR allowlist, and configured Bitcoin network.
 5. Calls withdraw-mode `OperatorInit` with guardian S3 config and `InitConfig`;
-   the enclave reads the latest ceremony instance from S3 before installing.
+   the enclave reads and pins the latest complete ceremony and KP-share state.
 6. On first deploy only, writes the on-chain committee to `genesis/record.json`
    through `OperatorWriteGenesis`.
 7. Verifies the live and S3-logged `GuardianInfo` match the installed ceremony
@@ -169,12 +169,10 @@ It:
    guardian.
 3. Checks that all other guardian sessions in the configured S3 bucket have
    been quiet long enough.
-4. Reads the latest `ceremony/` instance and requires it to match the armed
-   standby instance.
-5. Reads the latest `committee-update/` or `genesis/` record, recovers the
+4. Reads the latest `committee-update/` or `genesis/` record, recovers the
    limiter state from successful withdrawal logs, computes the expected
    `ActivationState` hash, and calls `OperatorActivate`.
-6. Verifies the guardian reports the expected active committee epoch and limiter
+5. Verifies the guardian reports the expected active committee epoch and limiter
    state.
 
 ```bash

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -91,7 +91,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         "scraping latest ceremony/ + kp-shares/ logs (attestation-anchored)",
     );
     let state = reader
-        .read_latest_ceremony_and_kp_share_state(BuildPolicy::Current)
+        .read_latest_ceremony_state(BuildPolicy::Current)
         .await?
         .context("no ceremony logs found in guardian S3 bucket")?;
     state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -6,15 +6,17 @@
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::pgp::PgpPublicCert;
 use hashi_types::pgp::load_certs;
 use tracing::info;
 
 use crate::config::Config;
-use crate::kp_roster::VerifiedCeremonyState;
 use crate::kp_roster::decrypt_share;
 use crate::kp_roster::ensure_cert_in_roster;
+use crate::kp_roster::validate_ceremony_state_shape;
+use crate::kp_roster::verify_encrypted_share_recipients;
 
 /// Verify this KP can fetch and decrypt its ceremony share.
 ///
@@ -89,19 +91,15 @@ pub async fn run(cfg: Config) -> Result<()> {
         phase = "ceremony scrape",
         "scraping latest ceremony/ + kp-shares/ logs (attestation-anchored)",
     );
-    let state = VerifiedCeremonyState::latest_from_s3(
-        &mut reader,
-        BuildPolicy::Current,
-        cfg.kp_roster.num_shares,
-        cfg.kp_roster.threshold,
-    )
-    .await?;
+    let state = reader
+        .read_latest_ceremony_and_kp_share_state(BuildPolicy::Current)
+        .await?
+        .context("no ceremony logs found in guardian S3 bucket")?;
+    validate_ceremony_state_shape(&state, cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(
         phase = "ceremony scrape",
-        ceremony_session_id = %state.ceremony_session_id,
-        kp_share_session_id = %state.kp_share_session_id,
         sharing_seq = state.secret_sharing_instance.sharing_seq(),
-        cert_seq = state.kp_share_cert_seq,
+        cert_seq = state.cert_seq,
         n = state.secret_sharing_instance.num_shares(),
         t = state.secret_sharing_instance.threshold(),
         share_count = state.encrypted_shares.len(),
@@ -114,7 +112,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         share_count = state.encrypted_shares.len(),
         "verifying every share is addressed only to its labeled KP cert (without decrypting)",
     );
-    state.verify_encrypted_share_recipients(&certs)?;
+    verify_encrypted_share_recipients(&state, &certs)?;
     info!(
         phase = "roster verify",
         "ceremony/ and kp-shares/ logs verified against expected params and KP certs",
@@ -193,11 +191,9 @@ pub async fn run(cfg: Config) -> Result<()> {
 
     info!(
         phase = "summary",
-        ceremony_session_id = %state.ceremony_session_id,
-        kp_share_session_id = %state.kp_share_session_id,
         share_id = share_id.get(),
         sharing_seq = state.secret_sharing_instance.sharing_seq(),
-        cert_seq = state.kp_share_cert_seq,
+        cert_seq = state.cert_seq,
         fingerprint = %want_fp,
         commitment = hex::encode(&expected_commitment.digest),
         "ceremony share verified",

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -103,7 +103,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         n = state.secret_sharing_instance.num_shares(),
         t = state.secret_sharing_instance.threshold(),
         share_count = state.encrypted_shares.len(),
-        "discovered + validated latest ceremony session",
+        "discovered + validated latest ceremony state",
     );
 
     // 2. Confirm every share is addressed only to its labeled KP cert.

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -15,7 +15,6 @@ use tracing::info;
 use crate::config::Config;
 use crate::kp_roster::decrypt_share;
 use crate::kp_roster::ensure_cert_in_roster;
-use crate::kp_roster::validate_ceremony_state_shape;
 use crate::kp_roster::verify_encrypted_share_recipients;
 
 /// Verify this KP can fetch and decrypt its ceremony share.
@@ -95,7 +94,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         .read_latest_ceremony_and_kp_share_state(BuildPolicy::Current)
         .await?
         .context("no ceremony logs found in guardian S3 bucket")?;
-    validate_ceremony_state_shape(&state, cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
+    state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(
         phase = "ceremony scrape",
         sharing_seq = state.secret_sharing_instance.sharing_seq(),

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -91,6 +91,7 @@ pub async fn run(cfg: Config) -> Result<()> {
     );
     let state = VerifiedCeremonyState::latest_from_s3(
         &mut reader,
+        BuildPolicy::Current,
         cfg.kp_roster.num_shares,
         cfg.kp_roster.threshold,
     )

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -33,6 +33,7 @@
 
 use anyhow::Context;
 use hashi_guardian::s3_reader::BuildPolicy;
+use hashi_guardian::s3_reader::CeremonyAndKpShareState;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::EncPubKey;
@@ -249,14 +250,20 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         "guardian info checks passed (bucket, limiter config, mpc_master_g, standby not activated)",
     );
 
-    // 3. Confirm the new guardian was booted with the same secret-sharing
-    //    instance the authoritative `ceremony/` log records.
+    // 3. Read the ceremony + KP share state and confirm the new guardian was
+    //    booted with the same secret-sharing instance.
     info!(
         phase = "ceremony instance",
-        "scraping authoritative ceremony/ log for the secret-sharing instance",
+        "scraping authoritative ceremony/ and kp-shares/ logs",
     );
-    let (ceremony_session, scraped_instance, btc_master_pubkey) = reader
-        .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
+    let CeremonyAndKpShareState {
+        ceremony_session_id: ceremony_session,
+        kp_share_session_id: kp_share_session,
+        secret_sharing_instance: scraped_instance,
+        btc_master_pubkey,
+        kp_share_state,
+    } = reader
+        .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     let sharing_seq = scraped_instance.sharing_seq();
@@ -306,19 +313,14 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         "recomputed config_hash matches enclave",
     );
 
-    // 5. Read + verify this KP's encrypted share. The ceremony state is
-    //    constructed directly from the S3 log reads above so we don't pay for a
-    //    second ceremony/ + kp-shares/ walk.
+    // 5. Verify this KP's encrypted share from the ceremony + KP-share state
+    //    read above.
     info!(
         phase = "share read",
         ceremony_session = %ceremony_session,
         sharing_seq,
-        "reading + verifying this KP's encrypted share from kp-shares/",
+        "verifying this KP's encrypted share from kp-shares/",
     );
-    let (kp_share_session, kp_share_state) = reader
-        .read_latest_kp_share_state(sharing_seq, BuildPolicy::AnyAllowlisted)
-        .await?
-        .context("no kp-shares log found in S3; key setup has not run")?;
     let state = VerifiedCeremonyState::from_scraped(
         ceremony_session.clone(),
         kp_share_session.clone(),

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -56,7 +56,6 @@ use crate::guardian_info::ensure_oi_info_matches_post_init;
 use crate::guardian_info::verified_live_guardian_info;
 use crate::kp_roster::decrypt_share;
 use crate::kp_roster::ensure_cert_in_roster;
-use crate::kp_roster::validate_ceremony_state_shape;
 use crate::kp_roster::verify_encrypted_share_recipients;
 
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
@@ -310,7 +309,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         phase = "share read",
         sharing_seq, "verifying this KP's encrypted share from kp-shares/",
     );
-    validate_ceremony_state_shape(&state, cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
+    state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     verify_encrypted_share_recipients(&state, &certs)?;
     info!(
         phase = "share read",

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -256,7 +256,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         "scraping authoritative ceremony/ and kp-shares/ logs",
     );
     let state = reader
-        .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     let sharing_seq = state.secret_sharing_instance.sharing_seq();

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -33,7 +33,6 @@
 
 use anyhow::Context;
 use hashi_guardian::s3_reader::BuildPolicy;
-use hashi_guardian::s3_reader::CeremonyAndKpShareState;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::EncPubKey;
@@ -55,9 +54,10 @@ use tracing::info;
 use crate::config::Config;
 use crate::guardian_info::ensure_oi_info_matches_post_init;
 use crate::guardian_info::verified_live_guardian_info;
-use crate::kp_roster::VerifiedCeremonyState;
 use crate::kp_roster::decrypt_share;
 use crate::kp_roster::ensure_cert_in_roster;
+use crate::kp_roster::validate_ceremony_state_shape;
+use crate::kp_roster::verify_encrypted_share_recipients;
 
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
@@ -256,36 +256,27 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         phase = "ceremony instance",
         "scraping authoritative ceremony/ and kp-shares/ logs",
     );
-    let CeremonyAndKpShareState {
-        ceremony_session_id: ceremony_session,
-        kp_share_session_id: kp_share_session,
-        secret_sharing_instance: scraped_instance,
-        btc_master_pubkey,
-        kp_share_state,
-    } = reader
+    let state = reader
         .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
-    let sharing_seq = scraped_instance.sharing_seq();
+    let sharing_seq = state.secret_sharing_instance.sharing_seq();
     info!(
         phase = "ceremony instance",
-        ceremony_session = %ceremony_session,
         sharing_seq,
-        n = scraped_instance.num_shares(),
-        t = scraped_instance.threshold(),
+        n = state.secret_sharing_instance.num_shares(),
+        t = state.secret_sharing_instance.threshold(),
         "scraped latest ceremony entry",
     );
     anyhow::ensure!(
-        scraped_instance == *enclave_ss_instance,
+        state.secret_sharing_instance == *enclave_ss_instance,
         "Enclave secret sharing instance mismatch: expected {:?}, got {:?}",
-        scraped_instance,
+        state.secret_sharing_instance,
         enclave_ss_instance
     );
     info!(
         phase = "ceremony instance",
-        ceremony_session = %ceremony_session,
-        sharing_seq,
-        "ceremony instance matches enclave",
+        sharing_seq, "ceremony instance matches enclave",
     );
 
     // 4. Recompute the stable config the operator armed the enclave with; its
@@ -317,24 +308,13 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     //    read above.
     info!(
         phase = "share read",
-        ceremony_session = %ceremony_session,
-        sharing_seq,
-        "verifying this KP's encrypted share from kp-shares/",
+        sharing_seq, "verifying this KP's encrypted share from kp-shares/",
     );
-    let state = VerifiedCeremonyState::from_scraped(
-        ceremony_session.clone(),
-        kp_share_session.clone(),
-        scraped_instance.clone(),
-        kp_share_state,
-        btc_master_pubkey,
-        cfg.kp_roster.num_shares,
-        cfg.kp_roster.threshold,
-    )?;
-    state.verify_encrypted_share_recipients(&certs)?;
+    validate_ceremony_state_shape(&state, cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
+    verify_encrypted_share_recipients(&state, &certs)?;
     info!(
         phase = "share read",
-        kp_share_session = %kp_share_session,
-        cert_seq = state.kp_share_cert_seq,
+        cert_seq = state.cert_seq,
         share_count = state.encrypted_shares.len(),
         all_recipients_verified = true,
         "kp-shares log verified: every share is addressed only to its labeled KP cert",
@@ -424,7 +404,6 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     info!(
         phase = "summary",
         session_id = %session_id,
-        ceremony_session = %ceremony_session,
         share_id = decrypted.id.get(),
         fingerprint = %want_fp,
         sharing_seq,

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -21,11 +21,9 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::KPEncryptedShare;
 use hashi_types::guardian::KPFingerprint;
-use hashi_types::guardian::KpShareStateLogMessage;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::SecretSharingParams;
 use hashi_types::guardian::SetupNewKeyResponse;
@@ -88,23 +86,12 @@ pub fn ceremony_state_from_response(
     expected_n: usize,
     expected_t: usize,
 ) -> Result<CeremonyState> {
-    let SetupNewKeyResponse {
-        encrypted_shares,
-        secret_sharing_instance,
-        btc_master_pubkey,
-    } = response;
-    let sharing_seq = secret_sharing_instance.sharing_seq();
+    let state = CeremonyState::from(response);
+    let sharing_seq = state.secret_sharing_instance.sharing_seq();
     anyhow::ensure!(
         sharing_seq == expected_sharing_seq,
         "ceremony sharing_seq ({sharing_seq}) differs from expected ({expected_sharing_seq})"
     );
-    let state = CeremonyState::new(
-        CeremonyLogMessage::NewKey {
-            instance: secret_sharing_instance,
-            btc_master_pubkey,
-        },
-        KpShareStateLogMessage::new(sharing_seq, 0, encrypted_shares),
-    )?;
     validate_ceremony_state_shape(&state, expected_n, expected_t)?;
     Ok(state)
 }
@@ -275,7 +262,9 @@ fn scalar_from_decrypted_plaintext(plaintext: &[u8]) -> Result<Scalar> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hashi_types::guardian::CeremonyLogMessage;
     use hashi_types::guardian::KPEncryptedShares;
+    use hashi_types::guardian::KpShareStateLogMessage;
     use hashi_types::guardian::SecretSharingInstance;
     use hashi_types::guardian::ShareCommitment;
     use hashi_types::guardian::ShareCommitments;

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -22,6 +22,7 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use hashi_guardian::s3_reader::BuildPolicy;
+use hashi_guardian::s3_reader::CeremonyAndKpShareState;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::guardian::KPEncryptedShare;
@@ -132,19 +133,16 @@ impl VerifiedCeremonyState {
         // historical ceremony with `BuildPolicy::AnyAllowlisted` to learn N.
         // Keep this helper current-build-only for target verification, and add
         // a separate discovery path there.
-        let (ceremony_session_id, instance, btc_master_pubkey) = reader
-            .read_latest_ceremony(BuildPolicy::Current)
+        let CeremonyAndKpShareState {
+            ceremony_session_id,
+            kp_share_session_id,
+            secret_sharing_instance: instance,
+            btc_master_pubkey,
+            kp_share_state,
+        } = reader
+            .read_latest_ceremony_and_kp_share_state(BuildPolicy::Current)
             .await?
             .ok_or_else(|| anyhow!("no ceremony logs found in guardian S3 bucket"))?;
-        let (kp_share_session_id, kp_share_state) = reader
-            .read_latest_kp_share_state(instance.sharing_seq(), BuildPolicy::Current)
-            .await?
-            .ok_or_else(|| {
-                anyhow!(
-                    "no kp-shares log found for sharing_seq {}",
-                    instance.sharing_seq()
-                )
-            })?;
         Self::from_scraped(
             ceremony_session_id,
             kp_share_session_id,

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -262,9 +262,7 @@ fn scalar_from_decrypted_plaintext(plaintext: &[u8]) -> Result<Scalar> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hashi_types::guardian::CeremonyLogMessage;
     use hashi_types::guardian::KPEncryptedShares;
-    use hashi_types::guardian::KpShareStateLogMessage;
     use hashi_types::guardian::SecretSharingInstance;
     use hashi_types::guardian::ShareCommitment;
     use hashi_types::guardian::ShareCommitments;
@@ -353,46 +351,21 @@ mod tests {
     }
 
     #[test]
-    fn ceremony_state_accepts_well_formed() {
-        let resp = response(&[1, 2, 3], &[1, 2, 3]);
-        ceremony_state_from_response(resp, 0, 3, 2).expect("well-formed response should pass");
-    }
-
-    #[test]
-    fn ceremony_state_equality_covers_btc_pubkey() {
-        // operator_ceremony gates publishing on `logged == live` (S3 log vs
-        // response), so the pubkey is only guarded if it's part of the equality.
-        let other_pubkey = hashi_types::guardian::crypto::k256_sk_to_btc_xonly_pubkey(
-            &k256::SecretKey::from_slice(&[7u8; 32]).unwrap(),
-        );
-        assert_ne!(dummy_btc_pubkey(), other_pubkey);
-
-        let state = |pubkey| {
-            let mut resp = response(&[1, 2, 3], &[1, 2, 3]);
-            resp.btc_master_pubkey = pubkey;
-            ceremony_state_from_response(resp, 0, 3, 2).unwrap()
-        };
-
-        assert_eq!(state(dummy_btc_pubkey()), state(dummy_btc_pubkey()));
-        assert_ne!(state(dummy_btc_pubkey()), state(other_pubkey));
-    }
-
-    #[test]
-    fn ceremony_state_rejects_wrong_share_count() {
+    fn ceremony_state_from_response_rejects_wrong_share_count() {
         let resp = response(&[1, 2], &[1, 2, 3]);
         let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
         assert!(format!("{err}").contains("encrypted shares"), "{err}");
     }
 
     #[test]
-    fn ceremony_state_rejects_wrong_instance_num_shares() {
+    fn ceremony_state_from_response_rejects_wrong_instance_num_shares() {
         let resp = response(&[1, 2], &[1, 2]);
         let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
         assert!(format!("{err}").contains("num_shares"), "{err}");
     }
 
     #[test]
-    fn ceremony_state_rejects_wrong_instance_threshold() {
+    fn ceremony_state_from_response_rejects_wrong_instance_threshold() {
         let instance = SecretSharingInstance::new(commitments(&[1, 2, 3]), 3, 3, 0).unwrap();
         let resp = response_with_instance(&[1, 2, 3], instance);
         let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
@@ -400,29 +373,11 @@ mod tests {
     }
 
     #[test]
-    fn ceremony_state_rejects_wrong_instance_sharing_seq() {
+    fn ceremony_state_from_response_rejects_wrong_instance_sharing_seq() {
         let instance = SecretSharingInstance::new(commitments(&[1, 2, 3]), 3, 2, 1).unwrap();
         let resp = response_with_instance(&[1, 2, 3], instance);
         let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
         assert!(format!("{err}").contains("sharing_seq"), "{err}");
-    }
-
-    #[test]
-    fn ceremony_state_rejects_mismatched_kp_share_state_seq() {
-        let SetupNewKeyResponse {
-            encrypted_shares,
-            secret_sharing_instance,
-            btc_master_pubkey,
-        } = response(&[3, 1, 2], &[1, 2, 3]);
-        let err = CeremonyState::new(
-            CeremonyLogMessage::NewKey {
-                instance: secret_sharing_instance,
-                btc_master_pubkey,
-            },
-            KpShareStateLogMessage::new(1, 0, encrypted_shares),
-        )
-        .unwrap_err();
-        assert!(format!("{err}").contains("kp-shares sharing_seq"), "{err}");
     }
 
     #[test]

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -126,13 +126,10 @@ impl VerifiedCeremonyState {
 
     pub async fn latest_from_s3(
         reader: &mut GuardianReader,
+        build_policy: BuildPolicy,
         expected_n: usize,
         expected_t: usize,
     ) -> Result<Self> {
-        // TODO: KP-begins discovery for rotations needs to read the latest
-        // historical ceremony with `BuildPolicy::AnyAllowlisted` to learn N.
-        // Keep this helper current-build-only for target verification, and add
-        // a separate discovery path there.
         let CeremonyAndKpShareState {
             ceremony_session_id,
             kp_share_session_id,
@@ -140,7 +137,7 @@ impl VerifiedCeremonyState {
             btc_master_pubkey,
             kp_share_state,
         } = reader
-            .read_latest_ceremony_and_kp_share_state(BuildPolicy::Current)
+            .read_latest_ceremony_and_kp_share_state(build_policy)
             .await?
             .ok_or_else(|| anyhow!("no ceremony logs found in guardian S3 bucket"))?;
         Self::from_scraped(

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -21,18 +21,13 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use hashi_guardian::s3_reader::BuildPolicy;
-use hashi_guardian::s3_reader::CeremonyAndKpShareState;
-use hashi_guardian::s3_reader::GuardianReader;
-use hashi_types::bitcoin::BitcoinPubkey;
+use hashi_types::guardian::CeremonyLogMessage;
+use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::KPEncryptedShare;
-use hashi_types::guardian::KPEncryptedShares;
 use hashi_types::guardian::KPFingerprint;
 use hashi_types::guardian::KpShareStateLogMessage;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::SecretSharingParams;
-use hashi_types::guardian::SessionID;
 use hashi_types::guardian::SetupNewKeyResponse;
 use hashi_types::guardian::Share;
 use hashi_types::pgp::PgpPublicCert;
@@ -86,194 +81,131 @@ impl KpRosterConfig {
     }
 }
 
-/// Validated ceremony state. May come from the live `SetupNewKeyResponse`
-/// (`operator ceremony`) or be reconstructed from the guardian's `ceremony/` +
-/// `kp-shares/` logs (`key-provisioner ceremony`, `key-provisioner provision`).
-#[derive(Debug, PartialEq)]
-pub struct VerifiedCeremonyState {
-    pub ceremony_session_id: SessionID,
-    pub kp_share_session_id: SessionID,
-    pub kp_share_cert_seq: u64,
-    pub encrypted_shares: KPEncryptedShares,
-    pub secret_sharing_instance: SecretSharingInstance,
-    pub btc_master_pubkey: BitcoinPubkey,
+/// Convert the live ceremony response into the same state shape read from S3.
+pub fn ceremony_state_from_response(
+    response: SetupNewKeyResponse,
+    expected_sharing_seq: u64,
+    expected_n: usize,
+    expected_t: usize,
+) -> Result<CeremonyState> {
+    let SetupNewKeyResponse {
+        encrypted_shares,
+        secret_sharing_instance,
+        btc_master_pubkey,
+    } = response;
+    let sharing_seq = secret_sharing_instance.sharing_seq();
+    anyhow::ensure!(
+        sharing_seq == expected_sharing_seq,
+        "ceremony sharing_seq ({sharing_seq}) differs from expected ({expected_sharing_seq})"
+    );
+    let state = CeremonyState::new(
+        CeremonyLogMessage::NewKey {
+            instance: secret_sharing_instance,
+            btc_master_pubkey,
+        },
+        KpShareStateLogMessage::new(sharing_seq, 0, encrypted_shares),
+    )?;
+    validate_ceremony_state_shape(&state, expected_n, expected_t)?;
+    Ok(state)
 }
 
-impl VerifiedCeremonyState {
-    pub fn from_response(
-        response: SetupNewKeyResponse,
-        session_id: SessionID,
-        expected_sharing_seq: u64,
-        expected_n: usize,
-        expected_t: usize,
-    ) -> Result<Self> {
-        let state = Self {
-            ceremony_session_id: session_id.clone(),
-            kp_share_session_id: session_id,
-            kp_share_cert_seq: 0,
-            encrypted_shares: response.encrypted_shares,
-            secret_sharing_instance: response.secret_sharing_instance,
-            btc_master_pubkey: response.btc_master_pubkey,
-        };
-        anyhow::ensure!(
-            state.secret_sharing_instance.sharing_seq() == expected_sharing_seq,
-            "ceremony sharing_seq ({}) differs from expected ({expected_sharing_seq})",
-            state.secret_sharing_instance.sharing_seq()
-        );
-        state.validate_shape(expected_n, expected_t)?;
-        Ok(state)
-    }
+/// Confirm the ceremony uses the expected sharing shape and carries exactly
+/// `expected_n` encrypted shares.
+pub fn validate_ceremony_state_shape(
+    state: &CeremonyState,
+    expected_n: usize,
+    expected_t: usize,
+) -> Result<()> {
+    anyhow::ensure!(
+        state.secret_sharing_instance.num_shares() == expected_n,
+        "ceremony num_shares ({}) differs from expected ({expected_n})",
+        state.secret_sharing_instance.num_shares()
+    );
+    anyhow::ensure!(
+        state.secret_sharing_instance.threshold() == expected_t,
+        "ceremony threshold ({}) differs from expected ({expected_t})",
+        state.secret_sharing_instance.threshold()
+    );
+    anyhow::ensure!(
+        state.encrypted_shares.len() == expected_n,
+        "expected {expected_n} encrypted shares, got {}",
+        state.encrypted_shares.len()
+    );
+    Ok(())
+}
 
-    pub async fn latest_from_s3(
-        reader: &mut GuardianReader,
-        build_policy: BuildPolicy,
-        expected_n: usize,
-        expected_t: usize,
-    ) -> Result<Self> {
-        let CeremonyAndKpShareState {
-            ceremony_session_id,
-            kp_share_session_id,
-            secret_sharing_instance: instance,
-            btc_master_pubkey,
-            kp_share_state,
-        } = reader
-            .read_latest_ceremony_and_kp_share_state(build_policy)
-            .await?
-            .ok_or_else(|| anyhow!("no ceremony logs found in guardian S3 bucket"))?;
-        Self::from_scraped(
-            ceremony_session_id,
-            kp_share_session_id,
-            instance,
-            kp_share_state,
-            btc_master_pubkey,
-            expected_n,
-            expected_t,
-        )
-    }
+/// For each encrypted share, confirm (a) its `recipient_fingerprint` label
+/// names exactly one of the operator-supplied certs, and (b) the ciphertext is
+/// actually encrypted only to that cert (parsed via PKESK without decrypting).
+///
+/// Identity is by fingerprint, not positional index — a share is matched to its
+/// cert by `recipient_fingerprint`, independent of ordering.
+pub fn verify_encrypted_share_recipients(
+    state: &CeremonyState,
+    certs: &[PgpPublicCert],
+) -> Result<()> {
+    let by_fingerprint: std::collections::HashMap<KPFingerprint, &PgpPublicCert> = certs
+        .iter()
+        .map(|c| (c.fingerprint().to_hex(), c))
+        .collect();
+    anyhow::ensure!(
+        by_fingerprint.len() == certs.len(),
+        "duplicate fingerprints among the supplied KP certs"
+    );
 
-    /// Assemble + validate from parts already scraped from S3 (the ceremony
-    /// log and the kp-shares log). Use instead of [`Self::latest_from_s3`] when the
-    /// caller has already read those objects and wants to avoid a second walk.
-    pub fn from_scraped(
-        ceremony_session_id: SessionID,
-        kp_share_session_id: SessionID,
-        secret_sharing_instance: SecretSharingInstance,
-        kp_share_state: KpShareStateLogMessage,
-        btc_master_pubkey: BitcoinPubkey,
-        expected_n: usize,
-        expected_t: usize,
-    ) -> Result<Self> {
-        anyhow::ensure!(
-            kp_share_state.sharing_seq == secret_sharing_instance.sharing_seq(),
-            "kp-shares sharing_seq ({}) differs from ceremony sharing_seq ({})",
-            kp_share_state.sharing_seq,
-            secret_sharing_instance.sharing_seq()
-        );
-        let state = Self {
-            ceremony_session_id,
-            kp_share_session_id,
-            kp_share_cert_seq: kp_share_state.cert_seq,
-            encrypted_shares: kp_share_state.encrypted_shares,
-            secret_sharing_instance,
-            btc_master_pubkey,
-        };
-        state.validate_shape(expected_n, expected_t)?;
-        Ok(state)
-    }
-
-    /// Confirm the state uses the expected sharing shape and carries exactly
-    /// `expected_n` encrypted shares.
-    pub fn validate_shape(&self, expected_n: usize, expected_t: usize) -> Result<()> {
-        anyhow::ensure!(
-            self.secret_sharing_instance.num_shares() == expected_n,
-            "ceremony num_shares ({}) differs from expected ({expected_n})",
-            self.secret_sharing_instance.num_shares()
-        );
-        anyhow::ensure!(
-            self.secret_sharing_instance.threshold() == expected_t,
-            "ceremony threshold ({}) differs from expected ({expected_t})",
-            self.secret_sharing_instance.threshold()
-        );
-        anyhow::ensure!(
-            self.encrypted_shares.len() == expected_n,
-            "expected {expected_n} encrypted shares, got {}",
-            self.encrypted_shares.len()
-        );
-        Ok(())
-    }
-
-    /// For each encrypted share, confirm (a) its `recipient_fingerprint` label
-    /// names exactly one of the operator-supplied certs, and (b) the ciphertext
-    /// is actually encrypted only to that cert (parsed via PKESK without
-    /// decrypting).
-    ///
-    /// Identity is by fingerprint, not positional index — a share is matched to
-    /// its cert by `recipient_fingerprint`, independent of ordering.
-    pub fn verify_encrypted_share_recipients(&self, certs: &[PgpPublicCert]) -> Result<()> {
-        let by_fingerprint: std::collections::HashMap<KPFingerprint, &PgpPublicCert> = certs
-            .iter()
-            .map(|c| (c.fingerprint().to_hex(), c))
-            .collect();
-        anyhow::ensure!(
-            by_fingerprint.len() == certs.len(),
-            "duplicate fingerprints among the supplied KP certs"
-        );
-
-        let mut expected_fingerprints: Vec<KPFingerprint> =
-            by_fingerprint.keys().cloned().collect();
-        expected_fingerprints.sort_unstable();
-        let mut labeled_fingerprints: Vec<KPFingerprint> = self
-            .encrypted_shares
-            .iter()
-            .map(|s| s.recipient_fingerprint.clone())
-            .collect();
-        labeled_fingerprints.sort_unstable();
-        anyhow::ensure!(
-            labeled_fingerprints == expected_fingerprints,
-            "encrypted share recipient roster differs from expected KP certs: expected \
+    let mut expected_fingerprints: Vec<KPFingerprint> = by_fingerprint.keys().cloned().collect();
+    expected_fingerprints.sort_unstable();
+    let mut labeled_fingerprints: Vec<KPFingerprint> = state
+        .encrypted_shares
+        .iter()
+        .map(|s| s.recipient_fingerprint.clone())
+        .collect();
+    labeled_fingerprints.sort_unstable();
+    anyhow::ensure!(
+        labeled_fingerprints == expected_fingerprints,
+        "encrypted share recipient roster differs from expected KP certs: expected \
              {expected_fingerprints:?}, got {labeled_fingerprints:?}"
-        );
+    );
 
-        for share in self.encrypted_shares.iter() {
-            let expected_cert = by_fingerprint
-                .get(&share.recipient_fingerprint)
-                .with_context(|| {
-                    format!(
-                        "share id {} is labeled for fingerprint {}, which is not among the \
+    for share in state.encrypted_shares.iter() {
+        let expected_cert = by_fingerprint
+            .get(&share.recipient_fingerprint)
+            .with_context(|| {
+                format!(
+                    "share id {} is labeled for fingerprint {}, which is not among the \
                              operator-supplied KP certs",
-                        share.id.get(),
-                        share.recipient_fingerprint
-                    )
-                })?;
-            let recipients = pgp_message_recipients(&share.armored_ciphertext)
-                .with_context(|| format!("parse PGP recipients for share id {}", share.id.get()))?;
-            anyhow::ensure!(
-                !recipients.is_empty(),
-                "share id {} has no PGP recipients",
-                share.id.get()
-            );
-            for handle in &recipients {
-                anyhow::ensure!(
-                    cert_owns_key_handle(expected_cert, handle),
-                    "share id {} (labeled {}) is encrypted to key {handle}, which is not in \
-                     that cert",
                     share.id.get(),
                     share.recipient_fingerprint
-                );
-            }
-            info!(
-                share_id = share.id.get(),
-                fingerprint = %share.recipient_fingerprint,
-                recipient_count = recipients.len(),
-                "verified share is encrypted only to its labeled cert"
+                )
+            })?;
+        let recipients = pgp_message_recipients(&share.armored_ciphertext)
+            .with_context(|| format!("parse PGP recipients for share id {}", share.id.get()))?;
+        anyhow::ensure!(
+            !recipients.is_empty(),
+            "share id {} has no PGP recipients",
+            share.id.get()
+        );
+        for handle in &recipients {
+            anyhow::ensure!(
+                cert_owns_key_handle(expected_cert, handle),
+                "share id {} (labeled {}) is encrypted to key {handle}, which is not in \
+                     that cert",
+                share.id.get(),
+                share.recipient_fingerprint
             );
         }
         info!(
-            "all {} KP share-state entries encrypted to their labeled certs",
-            self.encrypted_shares.len()
+            share_id = share.id.get(),
+            fingerprint = %share.recipient_fingerprint,
+            recipient_count = recipients.len(),
+            "verified share is encrypted only to its labeled cert"
         );
-        Ok(())
     }
+    info!(
+        "all {} KP share-state entries encrypted to their labeled certs",
+        state.encrypted_shares.len()
+    );
+    Ok(())
 }
 
 /// Confirm this KP's own cert is one of the operator-supplied roster certs.
@@ -343,6 +275,8 @@ fn scalar_from_decrypted_plaintext(plaintext: &[u8]) -> Result<Scalar> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hashi_types::guardian::KPEncryptedShares;
+    use hashi_types::guardian::SecretSharingInstance;
     use hashi_types::guardian::ShareCommitment;
     use hashi_types::guardian::ShareCommitments;
     use hashi_types::pgp::encrypt_armored;
@@ -430,14 +364,13 @@ mod tests {
     }
 
     #[test]
-    fn verified_ceremony_state_accepts_well_formed() {
+    fn ceremony_state_accepts_well_formed() {
         let resp = response(&[1, 2, 3], &[1, 2, 3]);
-        VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2)
-            .expect("well-formed response should pass");
+        ceremony_state_from_response(resp, 0, 3, 2).expect("well-formed response should pass");
     }
 
     #[test]
-    fn verified_ceremony_state_equality_covers_btc_pubkey() {
+    fn ceremony_state_equality_covers_btc_pubkey() {
         // operator_ceremony gates publishing on `logged == live` (S3 log vs
         // response), so the pubkey is only guarded if it's part of the equality.
         let other_pubkey = hashi_types::guardian::crypto::k256_sk_to_btc_xonly_pubkey(
@@ -448,7 +381,7 @@ mod tests {
         let state = |pubkey| {
             let mut resp = response(&[1, 2, 3], &[1, 2, 3]);
             resp.btc_master_pubkey = pubkey;
-            VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2).unwrap()
+            ceremony_state_from_response(resp, 0, 3, 2).unwrap()
         };
 
         assert_eq!(state(dummy_btc_pubkey()), state(dummy_btc_pubkey()));
@@ -456,50 +389,48 @@ mod tests {
     }
 
     #[test]
-    fn verified_ceremony_state_rejects_wrong_share_count() {
+    fn ceremony_state_rejects_wrong_share_count() {
         let resp = response(&[1, 2], &[1, 2, 3]);
-        let err =
-            VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2).unwrap_err();
+        let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
         assert!(format!("{err}").contains("encrypted shares"), "{err}");
     }
 
     #[test]
-    fn verified_ceremony_state_rejects_wrong_instance_num_shares() {
+    fn ceremony_state_rejects_wrong_instance_num_shares() {
         let resp = response(&[1, 2], &[1, 2]);
-        let err =
-            VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2).unwrap_err();
+        let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
         assert!(format!("{err}").contains("num_shares"), "{err}");
     }
 
     #[test]
-    fn verified_ceremony_state_rejects_wrong_instance_threshold() {
+    fn ceremony_state_rejects_wrong_instance_threshold() {
         let instance = SecretSharingInstance::new(commitments(&[1, 2, 3]), 3, 3, 0).unwrap();
         let resp = response_with_instance(&[1, 2, 3], instance);
-        let err =
-            VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2).unwrap_err();
+        let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
         assert!(format!("{err}").contains("threshold"), "{err}");
     }
 
     #[test]
-    fn verified_ceremony_state_rejects_wrong_instance_sharing_seq() {
+    fn ceremony_state_rejects_wrong_instance_sharing_seq() {
         let instance = SecretSharingInstance::new(commitments(&[1, 2, 3]), 3, 2, 1).unwrap();
         let resp = response_with_instance(&[1, 2, 3], instance);
-        let err =
-            VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2).unwrap_err();
+        let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
         assert!(format!("{err}").contains("sharing_seq"), "{err}");
     }
 
     #[test]
-    fn verified_ceremony_state_rejects_mismatched_kp_share_state_seq() {
-        let resp = response(&[3, 1, 2], &[1, 2, 3]);
-        let err = VerifiedCeremonyState::from_scraped(
-            "ceremony-session".into(),
-            "kp-share-session".into(),
-            resp.secret_sharing_instance,
-            KpShareStateLogMessage::new(1, 0, resp.encrypted_shares),
-            resp.btc_master_pubkey,
-            3,
-            2,
+    fn ceremony_state_rejects_mismatched_kp_share_state_seq() {
+        let SetupNewKeyResponse {
+            encrypted_shares,
+            secret_sharing_instance,
+            btc_master_pubkey,
+        } = response(&[3, 1, 2], &[1, 2, 3]);
+        let err = CeremonyState::new(
+            CeremonyLogMessage::NewKey {
+                instance: secret_sharing_instance,
+                btc_master_pubkey,
+            },
+            KpShareStateLogMessage::new(1, 0, encrypted_shares),
         )
         .unwrap_err();
         assert!(format!("{err}").contains("kp-shares sharing_seq"), "{err}");
@@ -511,11 +442,9 @@ mod tests {
         let cert2 = mock_cert();
         let cert3 = mock_cert();
         let resp = encrypted_response(&[&cert1, &cert2, &cert3]);
-        let state = VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2)
-            .expect("valid state");
+        let state = ceremony_state_from_response(resp, 0, 3, 2).expect("valid state");
 
-        state
-            .verify_encrypted_share_recipients(&[cert3, cert1, cert2])
+        verify_encrypted_share_recipients(&state, &[cert3, cert1, cert2])
             .expect("recipient validation should be by fingerprint, not config order");
     }
 
@@ -525,12 +454,9 @@ mod tests {
         let cert2 = mock_cert();
         let cert3 = mock_cert();
         let resp = encrypted_response(&[&cert1, &cert1, &cert3]);
-        let state = VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2)
-            .expect("valid state");
+        let state = ceremony_state_from_response(resp, 0, 3, 2).expect("valid state");
 
-        let err = state
-            .verify_encrypted_share_recipients(&[cert1, cert2, cert3])
-            .unwrap_err();
+        let err = verify_encrypted_share_recipients(&state, &[cert1, cert2, cert3]).unwrap_err();
         assert!(
             format!("{err}").contains("recipient roster differs"),
             "{err}"
@@ -544,12 +470,9 @@ mod tests {
         let cert3 = mock_cert();
         let unexpected = mock_cert();
         let resp = encrypted_response(&[&cert1, &cert2, &unexpected]);
-        let state = VerifiedCeremonyState::from_response(resp, "session".into(), 0, 3, 2)
-            .expect("valid state");
+        let state = ceremony_state_from_response(resp, 0, 3, 2).expect("valid state");
 
-        let err = state
-            .verify_encrypted_share_recipients(&[cert1, cert2, cert3])
-            .unwrap_err();
+        let err = verify_encrypted_share_recipients(&state, &[cert1, cert2, cert3]).unwrap_err();
         assert!(
             format!("{err}").contains("recipient roster differs"),
             "{err}"

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -26,7 +26,6 @@ use hashi_types::guardian::KPEncryptedShare;
 use hashi_types::guardian::KPFingerprint;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::SecretSharingParams;
-use hashi_types::guardian::SetupNewKeyResponse;
 use hashi_types::guardian::Share;
 use hashi_types::pgp::PgpPublicCert;
 use hashi_types::pgp::cert_owns_key_handle;
@@ -77,48 +76,6 @@ impl KpRosterConfig {
     pub fn pcr_allowlist(&self) -> PcrAllowlist {
         self.pcr_allowlist.clone()
     }
-}
-
-/// Convert the live ceremony response into the same state shape read from S3.
-pub fn ceremony_state_from_response(
-    response: SetupNewKeyResponse,
-    expected_sharing_seq: u64,
-    expected_n: usize,
-    expected_t: usize,
-) -> Result<CeremonyState> {
-    let state = CeremonyState::from(response);
-    let sharing_seq = state.secret_sharing_instance.sharing_seq();
-    anyhow::ensure!(
-        sharing_seq == expected_sharing_seq,
-        "ceremony sharing_seq ({sharing_seq}) differs from expected ({expected_sharing_seq})"
-    );
-    validate_ceremony_state_shape(&state, expected_n, expected_t)?;
-    Ok(state)
-}
-
-/// Confirm the ceremony uses the expected sharing shape and carries exactly
-/// `expected_n` encrypted shares.
-pub fn validate_ceremony_state_shape(
-    state: &CeremonyState,
-    expected_n: usize,
-    expected_t: usize,
-) -> Result<()> {
-    anyhow::ensure!(
-        state.secret_sharing_instance.num_shares() == expected_n,
-        "ceremony num_shares ({}) differs from expected ({expected_n})",
-        state.secret_sharing_instance.num_shares()
-    );
-    anyhow::ensure!(
-        state.secret_sharing_instance.threshold() == expected_t,
-        "ceremony threshold ({}) differs from expected ({expected_t})",
-        state.secret_sharing_instance.threshold()
-    );
-    anyhow::ensure!(
-        state.encrypted_shares.len() == expected_n,
-        "expected {expected_n} encrypted shares, got {}",
-        state.encrypted_shares.len()
-    );
-    Ok(())
 }
 
 /// For each encrypted share, confirm (a) its `recipient_fingerprint` label
@@ -264,19 +221,12 @@ mod tests {
     use super::*;
     use hashi_types::guardian::KPEncryptedShares;
     use hashi_types::guardian::SecretSharingInstance;
+    use hashi_types::guardian::SetupNewKeyResponse;
     use hashi_types::guardian::ShareCommitment;
     use hashi_types::guardian::ShareCommitments;
     use hashi_types::pgp::encrypt_armored;
     use hashi_types::pgp::test_utils::mock_pgp_keypair;
     use std::num::NonZeroU16;
-
-    fn share(id: u16) -> KPEncryptedShare {
-        KPEncryptedShare {
-            id: NonZeroU16::new(id).unwrap(),
-            recipient_fingerprint: format!("DUMMY FINGERPRINT {id}"),
-            armored_ciphertext: "dummy".into(),
-        }
-    }
 
     fn commitments(ids: &[u16]) -> ShareCommitments {
         let vec: Vec<ShareCommitment> = ids
@@ -293,26 +243,6 @@ mod tests {
         hashi_types::guardian::crypto::k256_sk_to_btc_xonly_pubkey(
             &k256::SecretKey::from_slice(&[9u8; 32]).unwrap(),
         )
-    }
-
-    fn response(shares: &[u16], commitment_ids: &[u16]) -> SetupNewKeyResponse {
-        response_with_instance(
-            shares,
-            SecretSharingInstance::new(commitments(commitment_ids), commitment_ids.len(), 2, 0)
-                .unwrap(),
-        )
-    }
-
-    fn response_with_instance(
-        shares: &[u16],
-        secret_sharing_instance: SecretSharingInstance,
-    ) -> SetupNewKeyResponse {
-        SetupNewKeyResponse {
-            encrypted_shares: KPEncryptedShares::new(shares.iter().map(|&i| share(i)).collect())
-                .unwrap(),
-            secret_sharing_instance,
-            btc_master_pubkey: dummy_btc_pubkey(),
-        }
     }
 
     fn mock_cert() -> PgpPublicCert {
@@ -351,42 +281,12 @@ mod tests {
     }
 
     #[test]
-    fn ceremony_state_from_response_rejects_wrong_share_count() {
-        let resp = response(&[1, 2], &[1, 2, 3]);
-        let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
-        assert!(format!("{err}").contains("encrypted shares"), "{err}");
-    }
-
-    #[test]
-    fn ceremony_state_from_response_rejects_wrong_instance_num_shares() {
-        let resp = response(&[1, 2], &[1, 2]);
-        let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
-        assert!(format!("{err}").contains("num_shares"), "{err}");
-    }
-
-    #[test]
-    fn ceremony_state_from_response_rejects_wrong_instance_threshold() {
-        let instance = SecretSharingInstance::new(commitments(&[1, 2, 3]), 3, 3, 0).unwrap();
-        let resp = response_with_instance(&[1, 2, 3], instance);
-        let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
-        assert!(format!("{err}").contains("threshold"), "{err}");
-    }
-
-    #[test]
-    fn ceremony_state_from_response_rejects_wrong_instance_sharing_seq() {
-        let instance = SecretSharingInstance::new(commitments(&[1, 2, 3]), 3, 2, 1).unwrap();
-        let resp = response_with_instance(&[1, 2, 3], instance);
-        let err = ceremony_state_from_response(resp, 0, 3, 2).unwrap_err();
-        assert!(format!("{err}").contains("sharing_seq"), "{err}");
-    }
-
-    #[test]
     fn verify_encrypted_share_recipients_accepts_reordered_expected_certs() {
         let cert1 = mock_cert();
         let cert2 = mock_cert();
         let cert3 = mock_cert();
         let resp = encrypted_response(&[&cert1, &cert2, &cert3]);
-        let state = ceremony_state_from_response(resp, 0, 3, 2).expect("valid state");
+        let state = CeremonyState::from(resp);
 
         verify_encrypted_share_recipients(&state, &[cert3, cert1, cert2])
             .expect("recipient validation should be by fingerprint, not config order");
@@ -398,7 +298,7 @@ mod tests {
         let cert2 = mock_cert();
         let cert3 = mock_cert();
         let resp = encrypted_response(&[&cert1, &cert1, &cert3]);
-        let state = ceremony_state_from_response(resp, 0, 3, 2).expect("valid state");
+        let state = CeremonyState::from(resp);
 
         let err = verify_encrypted_share_recipients(&state, &[cert1, cert2, cert3]).unwrap_err();
         assert!(
@@ -414,7 +314,7 @@ mod tests {
         let cert3 = mock_cert();
         let unexpected = mock_cert();
         let resp = encrypted_response(&[&cert1, &cert2, &unexpected]);
-        let state = ceremony_state_from_response(resp, 0, 3, 2).expect("valid state");
+        let state = CeremonyState::from(resp);
 
         let err = verify_encrypted_share_recipients(&state, &[cert1, cert2, cert3]).unwrap_err();
         assert!(

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -133,10 +133,11 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         phase = "ceremony instance",
         "reading latest ceremony log for the activation instance",
     );
-    let (ceremony_session, latest_instance, _) = reader
+    let latest_ceremony = reader
         .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
+    let (latest_instance, _) = latest_ceremony.into_instance_and_pubkey();
     ensure!(
         latest_instance == standby.secret_sharing_instance,
         "latest ceremony instance differs from armed instance: latest {}, armed {}",
@@ -145,7 +146,6 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     );
     info!(
         phase = "ceremony instance",
-        ceremony_session = %ceremony_session,
         sharing_seq = latest_instance.sharing_seq(),
         "latest ceremony instance matches the armed standby",
     );

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -228,7 +228,6 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     info!(
         phase = "summary",
         session_id = %session_id,
-        ceremony_session = %ceremony_session,
         committee_epoch,
         config_hash = hex::encode(standby.config_hash),
         state_hash = hex::encode(state_hash),

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -130,14 +130,14 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         .context("heartbeat activation check failed")?;
 
     info!(
-        phase = "ceremony instance",
-        "reading latest ceremony log for the activation instance",
+        phase = "ceremony state",
+        "reading latest ceremony and KP share state for activation",
     );
-    let latest_ceremony = reader
-        .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
+    let latest_ceremony_state = reader
+        .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
         .await?
-        .context("no ceremony log found in S3; key setup has not run")?;
-    let (latest_instance, _) = latest_ceremony.into_instance_and_pubkey();
+        .context("no ceremony state found in S3; key setup has not run")?;
+    let latest_instance = latest_ceremony_state.secret_sharing_instance;
     ensure!(
         latest_instance == standby.secret_sharing_instance,
         "latest ceremony instance differs from armed instance: latest {}, armed {}",
@@ -145,9 +145,10 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         standby.secret_sharing_instance
     );
     info!(
-        phase = "ceremony instance",
+        phase = "ceremony state",
         sharing_seq = latest_instance.sharing_seq(),
-        "latest ceremony instance matches the armed standby",
+        cert_seq = latest_ceremony_state.cert_seq,
+        "latest ceremony state matches the armed instance",
     );
 
     info!(

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -130,28 +130,6 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         .context("heartbeat activation check failed")?;
 
     info!(
-        phase = "ceremony state",
-        "reading latest ceremony and KP share state for activation",
-    );
-    let latest_ceremony_state = reader
-        .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
-        .await?
-        .context("no ceremony state found in S3; key setup has not run")?;
-    let latest_instance = latest_ceremony_state.secret_sharing_instance;
-    ensure!(
-        latest_instance == standby.secret_sharing_instance,
-        "latest ceremony instance differs from armed instance: latest {}, armed {}",
-        latest_instance,
-        standby.secret_sharing_instance
-    );
-    info!(
-        phase = "ceremony state",
-        sharing_seq = latest_instance.sharing_seq(),
-        cert_seq = latest_ceremony_state.cert_seq,
-        "latest ceremony state matches the armed instance",
-    );
-
-    info!(
         phase = "activation state",
         "reading latest committee and recovering limiter state",
     );
@@ -169,7 +147,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         .context("recover limiter state")?;
     let activation_state = ActivationState::new(
         standby.config_hash,
-        latest_instance,
+        standby.secret_sharing_instance.clone(),
         committee,
         limiter_state,
     );

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -206,7 +206,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         "cross-checking the latest guardian ceremony/ and kp-shares/ logs",
     );
     let logged = reader
-        .read_latest_ceremony_and_kp_share_state(BuildPolicy::Current)
+        .read_latest_ceremony_state(BuildPolicy::Current)
         .await?
         .context("no ceremony logs found in guardian S3 bucket")?;
     logged.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -215,6 +215,7 @@ pub async fn run(cfg: Config) -> Result<()> {
     );
     let logged = VerifiedCeremonyState::latest_from_s3(
         &mut reader,
+        BuildPolicy::Current,
         cfg.kp_roster.num_shares,
         cfg.kp_roster.threshold,
     )

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -21,7 +21,6 @@ use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::CeremonyStage;
 use hashi_types::guardian::GuardianSigned;
-use hashi_types::guardian::KpShareStateLogMessage;
 use hashi_types::guardian::OperatorInitRequest;
 use hashi_types::guardian::SetupNewKeyRequest;
 use hashi_types::guardian::SetupNewKeyResponse;
@@ -33,7 +32,9 @@ use tracing::info;
 
 use crate::config::Config;
 use crate::guardian_info::verified_live_guardian_info;
-use crate::kp_roster::VerifiedCeremonyState;
+use crate::kp_roster::ceremony_state_from_response;
+use crate::kp_roster::validate_ceremony_state_shape;
+use crate::kp_roster::verify_encrypted_share_recipients;
 
 /// Run the one-time production guardian key ceremony.
 ///
@@ -179,17 +180,14 @@ pub async fn run(cfg: Config) -> Result<()> {
     let response = signed_resp
         .verify(&signing_pub_key)
         .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e:?}"))?;
-    let live = VerifiedCeremonyState::from_response(
+    let live = ceremony_state_from_response(
         response,
-        session_id.clone(),
         sharing_seq,
         cfg.kp_roster.num_shares,
         cfg.kp_roster.threshold,
     )?;
     info!(
         phase = "setup_new_key",
-        ceremony_session_id = %live.ceremony_session_id,
-        kp_share_session_id = %live.kp_share_session_id,
         sharing_seq = live.secret_sharing_instance.sharing_seq(),
         "verified SetupNewKeyResponse signature + shape",
     );
@@ -201,7 +199,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         share_count = live.encrypted_shares.len(),
         "verifying every returned share is addressed only to its labeled KP cert (without decrypting)",
     );
-    live.verify_encrypted_share_recipients(&certs)?;
+    verify_encrypted_share_recipients(&live, &certs)?;
     info!(
         phase = "roster verify",
         "all returned shares verified against expected KP certs",
@@ -213,13 +211,11 @@ pub async fn run(cfg: Config) -> Result<()> {
         phase = "log cross-check",
         "cross-checking the latest guardian ceremony/ and kp-shares/ logs",
     );
-    let logged = VerifiedCeremonyState::latest_from_s3(
-        &mut reader,
-        BuildPolicy::Current,
-        cfg.kp_roster.num_shares,
-        cfg.kp_roster.threshold,
-    )
-    .await?;
+    let logged = reader
+        .read_latest_ceremony_and_kp_share_state(BuildPolicy::Current)
+        .await?
+        .context("no ceremony logs found in guardian S3 bucket")?;
+    validate_ceremony_state_shape(&logged, cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     anyhow::ensure!(
         logged == live,
         "ceremony/ and kp-shares/ logs differ from the SetupNewKeyResponse"
@@ -232,15 +228,8 @@ pub async fn run(cfg: Config) -> Result<()> {
     // 10. Summary.
     info!(
         phase = "summary",
-        ceremony_session_id = %live.ceremony_session_id,
-        kp_share_session_id = %live.kp_share_session_id,
         sharing_seq = live.secret_sharing_instance.sharing_seq(),
-        cert_seq = live.kp_share_cert_seq,
-        kp_shares_key = %KpShareStateLogMessage::object_key(
-            &live.kp_share_session_id,
-            live.secret_sharing_instance.sharing_seq(),
-            live.kp_share_cert_seq
-        ),
+        cert_seq = live.cert_seq,
         n = live.secret_sharing_instance.num_shares(),
         t = live.secret_sharing_instance.threshold(),
         "guardian key ceremony complete",

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -20,6 +20,7 @@ use anyhow::ensure;
 use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::CeremonyStage;
+use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::GuardianSigned;
 use hashi_types::guardian::OperatorInitRequest;
 use hashi_types::guardian::SetupNewKeyRequest;
@@ -32,8 +33,6 @@ use tracing::info;
 
 use crate::config::Config;
 use crate::guardian_info::verified_live_guardian_info;
-use crate::kp_roster::ceremony_state_from_response;
-use crate::kp_roster::validate_ceremony_state_shape;
 use crate::kp_roster::verify_encrypted_share_recipients;
 
 /// Run the one-time production guardian key ceremony.
@@ -176,16 +175,11 @@ pub async fn run(cfg: Config) -> Result<()> {
 
     // 7. Verify the response signature under the pinned session's signing key,
     //    and sanity-check the shape; keep the now-verified BTC master pubkey.
-    let sharing_seq = 0u64;
     let response = signed_resp
         .verify(&signing_pub_key)
         .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e:?}"))?;
-    let live = ceremony_state_from_response(
-        response,
-        sharing_seq,
-        cfg.kp_roster.num_shares,
-        cfg.kp_roster.threshold,
-    )?;
+    let live = CeremonyState::from(response);
+    live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(
         phase = "setup_new_key",
         sharing_seq = live.secret_sharing_instance.sharing_seq(),
@@ -215,7 +209,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         .read_latest_ceremony_and_kp_share_state(BuildPolicy::Current)
         .await?
         .context("no ceremony logs found in guardian S3 bucket")?;
-    validate_ceremony_state_shape(&logged, cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
+    logged.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     anyhow::ensure!(
         logged == live,
         "ceremony/ and kp-shares/ logs differ from the SetupNewKeyResponse"

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -22,7 +22,6 @@ use tracing::info;
 use crate::config::Config;
 use crate::guardian_info::ensure_oi_info_matches_post_init;
 use crate::guardian_info::verified_live_guardian_info;
-use crate::kp_roster::validate_ceremony_state_shape;
 use crate::kp_roster::verify_encrypted_share_recipients;
 
 /// Initialize a fresh withdraw-mode guardian with operator-supplied stable config.
@@ -145,11 +144,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
-    validate_ceremony_state_shape(
-        &ceremony_state,
-        cfg.kp_roster.num_shares,
-        cfg.kp_roster.threshold,
-    )?;
+    ceremony_state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     verify_encrypted_share_recipients(&ceremony_state, &certs)?;
     let scraped_instance = ceremony_state.secret_sharing_instance.clone();
     let sharing_seq = scraped_instance.sharing_seq();

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -141,7 +141,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         "scraping authoritative ceremony/ and kp-shares/ logs",
     );
     let ceremony_state = reader
-        .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     ceremony_state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -5,7 +5,6 @@ use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::ensure;
 use hashi_guardian::s3_reader::BuildPolicy;
-use hashi_guardian::s3_reader::CeremonyAndKpShareState;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::InitConfig;
@@ -23,7 +22,8 @@ use tracing::info;
 use crate::config::Config;
 use crate::guardian_info::ensure_oi_info_matches_post_init;
 use crate::guardian_info::verified_live_guardian_info;
-use crate::kp_roster::VerifiedCeremonyState;
+use crate::kp_roster::validate_ceremony_state_shape;
+use crate::kp_roster::verify_encrypted_share_recipients;
 
 /// Initialize a fresh withdraw-mode guardian with operator-supplied stable config.
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
@@ -141,33 +141,22 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         phase = "ceremony instance",
         "scraping authoritative ceremony/ and kp-shares/ logs",
     );
-    let CeremonyAndKpShareState {
-        ceremony_session_id: ceremony_session,
-        kp_share_session_id: kp_share_session,
-        secret_sharing_instance: scraped_instance,
-        btc_master_pubkey,
-        kp_share_state,
-    } = reader
+    let ceremony_state = reader
         .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
-    let sharing_seq = scraped_instance.sharing_seq();
-    let ceremony_state = VerifiedCeremonyState::from_scraped(
-        ceremony_session.clone(),
-        kp_share_session.clone(),
-        scraped_instance.clone(),
-        kp_share_state,
-        btc_master_pubkey,
+    validate_ceremony_state_shape(
+        &ceremony_state,
         cfg.kp_roster.num_shares,
         cfg.kp_roster.threshold,
     )?;
-    ceremony_state.verify_encrypted_share_recipients(&certs)?;
+    verify_encrypted_share_recipients(&ceremony_state, &certs)?;
+    let scraped_instance = ceremony_state.secret_sharing_instance.clone();
+    let sharing_seq = scraped_instance.sharing_seq();
     info!(
         phase = "ceremony instance",
-        ceremony_session = %ceremony_session,
-        kp_share_session = %kp_share_session,
         sharing_seq,
-        cert_seq = ceremony_state.kp_share_cert_seq,
+        cert_seq = ceremony_state.cert_seq,
         n = scraped_instance.num_shares(),
         t = scraped_instance.threshold(),
         share_count = ceremony_state.encrypted_shares.len(),

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -265,7 +265,6 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     info!(
         phase = "summary",
         session_id = %session_id,
-        ceremony_session = %ceremony_session,
         sharing_seq,
         config_hash = hex::encode(config_hash),
         bitcoin_network = ?cfg.bitcoin_network,

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -5,6 +5,7 @@ use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::ensure;
 use hashi_guardian::s3_reader::BuildPolicy;
+use hashi_guardian::s3_reader::CeremonyAndKpShareState;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::InitConfig;
@@ -138,17 +139,19 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
 
     info!(
         phase = "ceremony instance",
-        "scraping authoritative ceremony/ log for the secret-sharing instance",
+        "scraping authoritative ceremony/ and kp-shares/ logs",
     );
-    let (ceremony_session, scraped_instance, btc_master_pubkey) = reader
-        .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
+    let CeremonyAndKpShareState {
+        ceremony_session_id: ceremony_session,
+        kp_share_session_id: kp_share_session,
+        secret_sharing_instance: scraped_instance,
+        btc_master_pubkey,
+        kp_share_state,
+    } = reader
+        .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     let sharing_seq = scraped_instance.sharing_seq();
-    let (kp_share_session, kp_share_state) = reader
-        .read_latest_kp_share_state(sharing_seq, BuildPolicy::AnyAllowlisted)
-        .await?
-        .context("no kp-shares log found in S3; key setup has not run")?;
     let ceremony_state = VerifiedCeremonyState::from_scraped(
         ceremony_session.clone(),
         kp_share_session.clone(),

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -76,9 +76,9 @@ pub struct EnclaveState {
 struct InitializationState {
     /// Withdraw-mode input: stable configuration installed by `operator_init`.
     init_config: OnceLock<InitConfig>,
-    /// Withdraw-mode input: expected ceremony commitments and parameters,
-    /// installed by `operator_init` for `provisioner_init` to validate against.
-    secret_sharing_instance: RwLock<Option<SecretSharingInstance>>,
+    /// Withdraw-mode input: the ceremony instance and its share-to-KP assignment,
+    /// installed by `operator_init` for `provisioner_init` validation.
+    ceremony_state: RwLock<Option<CeremonyState>>,
     /// Ceremony-mode output: encrypted shares produced by `setup_new_key` or
     /// `rotate_kps`, retained for KPs to fetch from `get_guardian_info`.
     latest_encrypted_shares: OnceLock<KPEncryptedShares>,
@@ -88,11 +88,11 @@ impl InitializationState {
     /// Drop withdraw-mode inputs that may become stale once the enclave is active.
     /// Stable config and ceremony-mode output remain available.
     fn clear(&self) {
-        self.secret_sharing_instance
+        self.ceremony_state
             .write()
-            .expect("secret-sharing instance lock poisoned")
+            .expect("ceremony state lock poisoned")
             .take()
-            .expect("secret-sharing instance must exist before activation");
+            .expect("ceremony state must exist before activation");
     }
 }
 
@@ -454,9 +454,9 @@ impl Enclave {
                     && self.init_state.init_config.get().is_some()
                     && self
                         .init_state
-                        .secret_sharing_instance
+                        .ceremony_state
                         .read()
-                        .expect("secret-sharing instance lock poisoned")
+                        .expect("ceremony state lock poisoned")
                         .is_some()
                     && self.config.hashi_btc_master_pubkey.get().is_some()
             }
@@ -602,27 +602,28 @@ impl Enclave {
     // ========================================================================
 
     pub fn secret_sharing_instance(&self) -> GuardianResult<SecretSharingInstance> {
-        self.init_state
-            .secret_sharing_instance
-            .read()
-            .expect("secret-sharing instance lock poisoned")
-            .clone()
-            .ok_or(InvalidInputs("Secret-sharing instance not set".into()))
+        Ok(self.ceremony_state()?.secret_sharing_instance)
     }
 
-    pub fn set_secret_sharing_instance(
-        &self,
-        instance: SecretSharingInstance,
-    ) -> GuardianResult<()> {
+    pub fn ceremony_state(&self) -> GuardianResult<CeremonyState> {
+        self.init_state
+            .ceremony_state
+            .read()
+            .expect("ceremony state lock poisoned")
+            .clone()
+            .ok_or(InvalidInputs("Ceremony state not set".into()))
+    }
+
+    pub fn set_ceremony_state(&self, state: CeremonyState) -> GuardianResult<()> {
         let mut slot = self
             .init_state
-            .secret_sharing_instance
+            .ceremony_state
             .write()
-            .expect("secret-sharing instance lock poisoned");
+            .expect("ceremony state lock poisoned");
         if slot.is_some() {
-            return Err(InvalidInputs("Secret-sharing instance already set".into()));
+            return Err(InvalidInputs("Ceremony state already set".into()));
         }
-        *slot = Some(instance);
+        *slot = Some(state);
         Ok(())
     }
 

--- a/crates/hashi-guardian/src/operator_activate.rs
+++ b/crates/hashi-guardian/src/operator_activate.rs
@@ -38,10 +38,9 @@ pub async fn operator_activate(
     let config_hash = enclave
         .config_hash()
         .ok_or_else(|| InvalidInputs("config_hash not set".into()))?;
-    let armed_ceremony_state = enclave
-        .ceremony_state()
-        .map_err(|_| InvalidInputs("ceremony state not set".into()))?;
-    let armed_instance = armed_ceremony_state.secret_sharing_instance.clone();
+    let armed_instance = enclave
+        .secret_sharing_instance()
+        .map_err(|_| InvalidInputs("secret-sharing instance not set".into()))?;
 
     let s3 = enclave
         .config
@@ -54,17 +53,6 @@ pub async fn operator_activate(
         .ensure_session_live_and_others_quiet(&enclave.s3_session_id())
         .await
         .map_err(|e| InvalidInputs(format!("heartbeat activation check failed: {e}")))?;
-
-    let latest_ceremony_state = reader
-        .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
-        .await
-        .map_err(|e| InternalError(format!("read latest ceremony state: {e}")))?
-        .ok_or_else(|| InvalidInputs("no ceremony state found during activation".into()))?;
-    if latest_ceremony_state != armed_ceremony_state {
-        return Err(InvalidInputs(
-            "latest ceremony state differs from armed state".into(),
-        ));
-    }
 
     let committee: HashiCommittee = reader
         .read_latest_committee(BuildPolicy::AnyAllowlisted)

--- a/crates/hashi-guardian/src/operator_activate.rs
+++ b/crates/hashi-guardian/src/operator_activate.rs
@@ -54,11 +54,12 @@ pub async fn operator_activate(
         .await
         .map_err(|e| InvalidInputs(format!("heartbeat activation check failed: {e}")))?;
 
-    let (_, latest_instance, _) = reader
+    let latest_ceremony = reader
         .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
         .await
         .map_err(|e| InternalError(format!("read latest ceremony: {e}")))?
         .ok_or_else(|| InvalidInputs("no ceremony log found during activation".into()))?;
+    let (latest_instance, _) = latest_ceremony.into_instance_and_pubkey();
     if latest_instance != armed_instance {
         return Err(InvalidInputs(format!(
             "latest ceremony instance differs from armed instance: latest {latest_instance}, armed {armed_instance}"

--- a/crates/hashi-guardian/src/operator_activate.rs
+++ b/crates/hashi-guardian/src/operator_activate.rs
@@ -38,9 +38,10 @@ pub async fn operator_activate(
     let config_hash = enclave
         .config_hash()
         .ok_or_else(|| InvalidInputs("config_hash not set".into()))?;
-    let armed_instance = enclave
-        .secret_sharing_instance()
-        .map_err(|_| InvalidInputs("secret-sharing instance not set".into()))?;
+    let armed_ceremony_state = enclave
+        .ceremony_state()
+        .map_err(|_| InvalidInputs("ceremony state not set".into()))?;
+    let armed_instance = armed_ceremony_state.secret_sharing_instance.clone();
 
     let s3 = enclave
         .config
@@ -54,16 +55,15 @@ pub async fn operator_activate(
         .await
         .map_err(|e| InvalidInputs(format!("heartbeat activation check failed: {e}")))?;
 
-    let latest_ceremony = reader
-        .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
+    let latest_ceremony_state = reader
+        .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
         .await
-        .map_err(|e| InternalError(format!("read latest ceremony: {e}")))?
-        .ok_or_else(|| InvalidInputs("no ceremony log found during activation".into()))?;
-    let (latest_instance, _) = latest_ceremony.into_instance_and_pubkey();
-    if latest_instance != armed_instance {
-        return Err(InvalidInputs(format!(
-            "latest ceremony instance differs from armed instance: latest {latest_instance}, armed {armed_instance}"
-        )));
+        .map_err(|e| InternalError(format!("read latest ceremony state: {e}")))?
+        .ok_or_else(|| InvalidInputs("no ceremony state found during activation".into()))?;
+    if latest_ceremony_state != armed_ceremony_state {
+        return Err(InvalidInputs(
+            "latest ceremony state differs from armed state".into(),
+        ));
     }
 
     let committee: HashiCommittee = reader

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -21,17 +21,14 @@ use GuardianError::*;
 /// The withdraw-mode arming state to install, built from `InitConfig`.
 pub(crate) struct InitInstall {
     init_config: InitConfig,
-    secret_sharing_instance: SecretSharingInstance,
+    ceremony_state: CeremonyState,
 }
 
 impl InitInstall {
-    pub(crate) fn from_parts(
-        config: InitConfig,
-        secret_sharing_instance: SecretSharingInstance,
-    ) -> Self {
+    pub(crate) fn from_parts(config: InitConfig, ceremony_state: CeremonyState) -> Self {
         Self {
             init_config: config,
-            secret_sharing_instance,
+            ceremony_state,
         }
     }
 
@@ -43,16 +40,13 @@ impl InitInstall {
     ) -> GuardianResult<Self> {
         let mut reader =
             GuardianReader::from_s3_client(logger.clone(), config.pcr_allowlist().clone());
-        let CeremonyState {
-            secret_sharing_instance,
-            ..
-        } = reader
+        let ceremony_state = reader
             .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
             .await
             .map_err(|e| InvalidInputs(format!("read latest ceremony and KP share state: {e}")))?
             .ok_or_else(|| InvalidInputs("no ceremony log found for withdraw init".into()))?;
 
-        Ok(Self::from_parts(config, secret_sharing_instance))
+        Ok(Self::from_parts(config, ceremony_state))
     }
 
     /// Install the bundle onto a fresh enclave. Infallible by design (see the
@@ -69,13 +63,16 @@ impl InitInstall {
 
         info!(
             "Storing secret-sharing instance: n={}, t={}, {} commitments.",
-            self.secret_sharing_instance.num_shares(),
-            self.secret_sharing_instance.threshold(),
-            self.secret_sharing_instance.commitments().len()
+            self.ceremony_state.secret_sharing_instance.num_shares(),
+            self.ceremony_state.secret_sharing_instance.threshold(),
+            self.ceremony_state
+                .secret_sharing_instance
+                .commitments()
+                .len()
         );
         enclave
-            .set_secret_sharing_instance(self.secret_sharing_instance)
-            .expect("Unable to set secret-sharing instance");
+            .set_ceremony_state(self.ceremony_state)
+            .expect("Unable to set ceremony state");
 
         info!("Setting init config.");
         enclave
@@ -202,9 +199,8 @@ mod tests {
         let withdraw = match mode {
             EnclaveMode::Withdraw => {
                 let config = InitConfig::mock_for_testing(None);
-                let secret_sharing_instance =
-                    crate::test_utils::OperatorInitTestArgs::default().secret_sharing_instance;
-                Some(InitInstall::from_parts(config, secret_sharing_instance))
+                let args = crate::test_utils::OperatorInitTestArgs::default();
+                Some(InitInstall::from_parts(config, args.ceremony_state))
             }
             EnclaveMode::Ceremony => None,
         };

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -41,7 +41,7 @@ impl InitInstall {
         let mut reader =
             GuardianReader::from_s3_client(logger.clone(), config.pcr_allowlist().clone());
         let ceremony_state = reader
-            .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
+            .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
             .await
             .map_err(|e| InvalidInputs(format!("read latest ceremony and KP share state: {e}")))?
             .ok_or_else(|| InvalidInputs("no ceremony log found for withdraw init".into()))?;

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -8,7 +8,6 @@
 
 use crate::attestation::get_attestation;
 use crate::s3_reader::BuildPolicy;
-use crate::s3_reader::CeremonyAndKpShareState;
 use crate::s3_reader::GuardianReader;
 use crate::Enclave;
 use crate::GuardianS3Client;
@@ -44,7 +43,7 @@ impl InitInstall {
     ) -> GuardianResult<Self> {
         let mut reader =
             GuardianReader::from_s3_client(logger.clone(), config.pcr_allowlist().clone());
-        let CeremonyAndKpShareState {
+        let CeremonyState {
             secret_sharing_instance,
             ..
         } = reader

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -8,6 +8,7 @@
 
 use crate::attestation::get_attestation;
 use crate::s3_reader::BuildPolicy;
+use crate::s3_reader::CeremonyAndKpShareState;
 use crate::s3_reader::GuardianReader;
 use crate::Enclave;
 use crate::GuardianS3Client;
@@ -35,18 +36,21 @@ impl InitInstall {
         }
     }
 
-    /// Build the arming bundle from the stable config and S3-derived ceremony
-    /// state. Shared by `operator_init` and tests.
+    /// Build the arming bundle from the stable config and S3-derived ceremony +
+    /// KP share state. Shared by `operator_init` and tests.
     pub(crate) async fn from_config(
         logger: &GuardianS3Client,
         config: InitConfig,
     ) -> GuardianResult<Self> {
         let mut reader =
             GuardianReader::from_s3_client(logger.clone(), config.pcr_allowlist().clone());
-        let (_, secret_sharing_instance, _) = reader
-            .read_latest_ceremony(BuildPolicy::AnyAllowlisted)
+        let CeremonyAndKpShareState {
+            secret_sharing_instance,
+            ..
+        } = reader
+            .read_latest_ceremony_and_kp_share_state(BuildPolicy::AnyAllowlisted)
             .await
-            .map_err(|e| InvalidInputs(format!("read latest ceremony: {e}")))?
+            .map_err(|e| InvalidInputs(format!("read latest ceremony and KP share state: {e}")))?
             .ok_or_else(|| InvalidInputs("no ceremony log found for withdraw init".into()))?;
 
         Ok(Self::from_parts(config, secret_sharing_instance))

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -19,7 +19,6 @@ use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
-use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GenesisLogMessage;
 use hashi_types::guardian::GuardianInfo;
@@ -213,7 +212,7 @@ impl GuardianReader {
         let LogMessage::V1(LogMessageV1::Ceremony(msg)) = record.message else {
             anyhow::bail!("expected a ceremony log at {key}");
         };
-        let (instance, btc_master_pubkey) = ceremony_instance_and_pubkey(*msg, key)?;
+        let (instance, btc_master_pubkey) = (*msg).into_instance_and_pubkey();
         Ok((session_id, instance, btc_master_pubkey))
     }
 
@@ -417,38 +416,6 @@ impl GuardianSessionCache {
             })
             .with_context(|| "failed to verify guardian enclave signature")
     }
-}
-
-/// The resulting instance from a ceremony message: `NewKey` yields its instance;
-/// `Rotate` yields `new_instance`, asserting the rotation bumps `sharing_seq` by
-/// exactly one over the consumed `old_instance`.
-fn ceremony_instance_and_pubkey(
-    msg: CeremonyLogMessage,
-    key: &str,
-) -> anyhow::Result<(SecretSharingInstance, BitcoinPubkey)> {
-    Ok(match msg {
-        CeremonyLogMessage::NewKey {
-            instance,
-            btc_master_pubkey,
-        } => (instance, btc_master_pubkey),
-        CeremonyLogMessage::Rotate {
-            old_instance,
-            new_instance,
-            btc_master_pubkey,
-        } => {
-            let expected = old_instance
-                .sharing_seq()
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("Rotate old sharing_seq is u64::MAX at {key}"))?;
-            anyhow::ensure!(
-                new_instance.sharing_seq() == expected,
-                "Rotate ceremony log at {key} has non-contiguous sharing_seq: old={}, new={}",
-                old_instance.sharing_seq(),
-                new_instance.sharing_seq()
-            );
-            (new_instance, btc_master_pubkey)
-        }
-    })
 }
 
 /// Pick the lex-greatest key, skipping any whose name starts with `<dir>/failure-`.

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -260,7 +260,7 @@ impl GuardianReader {
                 format!("no kp-shares log found for latest ceremony sharing_seq {sharing_seq}")
             })?;
         Ok(Some(CeremonyState::new(ceremony, kp_share_state).expect(
-            "KP share state must match the requested ceremony sharing_seq",
+            "ceremony and KP share state must have a consistent shape",
         )))
     }
 

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -255,7 +255,9 @@ impl GuardianReader {
             .with_context(|| {
                 format!("no kp-shares log found for latest ceremony sharing_seq {sharing_seq}")
             })?;
-        Ok(Some(CeremonyState::new(ceremony, kp_share_state)?))
+        Ok(Some(CeremonyState::new(ceremony, kp_share_state).expect(
+            "KP share state must match the requested ceremony sharing_seq",
+        )))
     }
 
     /// Latest serving committee, preferring `committee-update/` and falling back

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -15,7 +15,6 @@ use crate::s3_client::GuardianS3Client;
 use crate::s3_client::HistoryCheck;
 use crate::s3_client::LockCheck;
 use anyhow::Context;
-use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
@@ -31,7 +30,6 @@ use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
-use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::SessionID;
 use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::VerifiedSessionInfo;
@@ -168,8 +166,7 @@ impl GuardianReader {
     }
 
     /// The latest ceremony from `ceremony/` — the max-`sharing_seq` (lex-last)
-    /// entry, attestation- and signature-verified. Returns its writing session,
-    /// secret-sharing instance, and BTC master pubkey. `None` if no ceremony has
+    /// entry, attestation- and signature-verified. `None` if no ceremony has
     /// been logged yet.
     ///
     /// `kp-shares/` is read independently so later KP cert rotations can advance
@@ -177,19 +174,7 @@ impl GuardianReader {
     pub async fn read_latest_ceremony(
         &mut self,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<(SessionID, SecretSharingInstance, BitcoinPubkey)>> {
-        let Some((session_id, message)) = self.read_latest_ceremony_message(build_policy).await?
-        else {
-            return Ok(None);
-        };
-        let (instance, btc_master_pubkey) = message.into_instance_and_pubkey();
-        Ok(Some((session_id, instance, btc_master_pubkey)))
-    }
-
-    async fn read_latest_ceremony_message(
-        &mut self,
-        build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<(SessionID, CeremonyLogMessage)>> {
+    ) -> anyhow::Result<Option<CeremonyLogMessage>> {
         let keys = self
             .s3
             .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_CEREMONY))
@@ -197,25 +182,14 @@ impl GuardianReader {
         let Some(key) = pick_latest_key(keys, S3_DIR_CEREMONY) else {
             return Ok(None);
         };
-        Ok(Some(self.read_ceremony_record(&key, build_policy).await?))
-    }
-
-    /// Read + verify the `ceremony/` record at `key`, returning its writing
-    /// session, resulting instance, and BTC master pubkey.
-    async fn read_ceremony_record(
-        &mut self,
-        key: &str,
-        build_policy: BuildPolicy,
-    ) -> anyhow::Result<(SessionID, CeremonyLogMessage)> {
-        let record = self.s3.get_log_record(key).await?;
+        let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        let session_id = record.session_id.clone();
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy("ceremony log", build_policy, &build_pcrs)?;
         let LogMessage::V1(LogMessageV1::Ceremony(msg)) = record.message else {
             anyhow::bail!("expected a ceremony log at {key}");
         };
-        Ok((session_id, *msg))
+        Ok(Some(*msg))
     }
 
     /// Read + verify the latest encrypted KP share state for `sharing_seq`.
@@ -271,7 +245,7 @@ impl GuardianReader {
         &mut self,
         build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<CeremonyState>> {
-        let Some((_, ceremony)) = self.read_latest_ceremony_message(build_policy).await? else {
+        let Some(ceremony) = self.read_latest_ceremony(build_policy).await? else {
             return Ok(None);
         };
         let sharing_seq = ceremony.sharing_seq();

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -9,7 +9,7 @@
 //! that records the build PCRs verified for each session. Streams are
 //! hour-partitioned (`withdraw/`/`heartbeat/`);
 //! [`withdraw_cursor`]/[`heartbeat_cursor`] open a cursor that the caller
-//! advances/retreats and feeds to [`GuardianReader::read_dir`].
+//! advances/retreats and feeds to [`GuardianReader::read_logs_in_dir`].
 
 use crate::s3_client::GuardianS3Client;
 use crate::s3_client::HistoryCheck;
@@ -47,7 +47,7 @@ mod limiter_recovery;
 
 /// Open an hour-scoped cursor at `start` over the `withdraw/` stream. Advance/
 /// retreat with [`S3HourScopedDirectory::next_dir`]/`prev_dir`, gate on
-/// `write_completion_time`, and read via [`GuardianReader::read_dir`].
+/// `write_completion_time`, and read via [`GuardianReader::read_logs_in_dir`].
 pub fn withdraw_cursor(start: UnixSeconds) -> S3HourScopedDirectory {
     S3HourScopedDirectory::new(S3_DIR_WITHDRAW, start)
 }
@@ -123,7 +123,7 @@ impl GuardianReader {
     /// signing pubkey via the cache. Batch readers can straddle upgrades, so
     /// callers that need current-only semantics must inspect each returned
     /// record's build PCRs with [`Self::require_current_build`].
-    pub async fn read_dir(
+    pub async fn read_logs_in_dir(
         &mut self,
         dir: &S3HourScopedDirectory,
     ) -> anyhow::Result<Vec<VerifiedLogRecord>> {
@@ -172,7 +172,7 @@ impl GuardianReader {
     ///
     /// `kp-shares/` is read independently so later KP cert rotations can advance
     /// `cert_seq` without rewriting the `ceremony/` instance.
-    async fn read_latest_ceremony(
+    async fn read_latest_ceremony_log(
         &mut self,
         build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<CeremonyLogMessage>> {
@@ -204,7 +204,7 @@ impl GuardianReader {
     /// expected to expire, and their integrity is the enclave signature checked
     /// below — not S3 immutability — so the immutable-log lock assertion in
     /// `get_log_record` doesn't apply.
-    async fn read_latest_kp_share_state(
+    async fn read_latest_kp_share_state_log(
         &mut self,
         sharing_seq: u64,
         build_policy: BuildPolicy,
@@ -245,16 +245,16 @@ impl GuardianReader {
     /// `sharing_seq`. `None` means no ceremony has been logged. Once a ceremony
     /// exists, its matching KP share state must also exist: ceremony writers
     /// publish `kp-shares/` before `ceremony/`.
-    pub async fn read_latest_ceremony_and_kp_share_state(
+    pub async fn read_latest_ceremony_state(
         &mut self,
         build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<CeremonyState>> {
-        let Some(ceremony) = self.read_latest_ceremony(build_policy).await? else {
+        let Some(ceremony) = self.read_latest_ceremony_log(build_policy).await? else {
             return Ok(None);
         };
         let sharing_seq = ceremony.sharing_seq();
         let kp_share_state = self
-            .read_latest_kp_share_state(sharing_seq, build_policy)
+            .read_latest_kp_share_state_log(sharing_seq, build_policy)
             .await?
             .with_context(|| {
                 format!("no kp-shares log found for latest ceremony sharing_seq {sharing_seq}")
@@ -275,7 +275,7 @@ impl GuardianReader {
             return Ok(Some(committee));
         }
         Ok(self
-            .read_genesis(build_policy)
+            .read_genesis_log(build_policy)
             .await?
             .map(|genesis| genesis.committee))
     }
@@ -313,7 +313,7 @@ impl GuardianReader {
 
     /// Fixed genesis record from `genesis/record.json`. `None` means the
     /// operator-trusted bootstrap record has not been written yet.
-    async fn read_genesis(
+    async fn read_genesis_log(
         &mut self,
         build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<GenesisLogMessage>> {

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -19,6 +19,8 @@ use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
+use hashi_types::guardian::CeremonyLogMessage;
+use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GenesisLogMessage;
 use hashi_types::guardian::GuardianInfo;
@@ -63,17 +65,6 @@ pub enum BuildPolicy {
     /// Accept either the configured current build or an explicitly allowlisted
     /// previous build. This is for historical log reads, not live-session checks.
     AnyAllowlisted,
-}
-
-/// The latest ceremony record paired with the latest KP share state for that
-/// ceremony's secret-sharing instance.
-#[derive(Clone, Debug, PartialEq)]
-pub struct CeremonyAndKpShareState {
-    pub ceremony_session_id: SessionID,
-    pub kp_share_session_id: SessionID,
-    pub secret_sharing_instance: SecretSharingInstance,
-    pub btc_master_pubkey: BitcoinPubkey,
-    pub kp_share_state: KpShareStateLogMessage,
 }
 
 impl BuildPolicy {
@@ -187,6 +178,18 @@ impl GuardianReader {
         &mut self,
         build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<(SessionID, SecretSharingInstance, BitcoinPubkey)>> {
+        let Some((session_id, message)) = self.read_latest_ceremony_message(build_policy).await?
+        else {
+            return Ok(None);
+        };
+        let (instance, btc_master_pubkey) = message.into_instance_and_pubkey();
+        Ok(Some((session_id, instance, btc_master_pubkey)))
+    }
+
+    async fn read_latest_ceremony_message(
+        &mut self,
+        build_policy: BuildPolicy,
+    ) -> anyhow::Result<Option<(SessionID, CeremonyLogMessage)>> {
         let keys = self
             .s3
             .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_CEREMONY))
@@ -203,7 +206,7 @@ impl GuardianReader {
         &mut self,
         key: &str,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<(SessionID, SecretSharingInstance, BitcoinPubkey)> {
+    ) -> anyhow::Result<(SessionID, CeremonyLogMessage)> {
         let record = self.s3.get_log_record(key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         let session_id = record.session_id.clone();
@@ -212,8 +215,7 @@ impl GuardianReader {
         let LogMessage::V1(LogMessageV1::Ceremony(msg)) = record.message else {
             anyhow::bail!("expected a ceremony log at {key}");
         };
-        let (instance, btc_master_pubkey) = (*msg).into_instance_and_pubkey();
-        Ok((session_id, instance, btc_master_pubkey))
+        Ok((session_id, *msg))
     }
 
     /// Read + verify the latest encrypted KP share state for `sharing_seq`.
@@ -268,27 +270,18 @@ impl GuardianReader {
     pub async fn read_latest_ceremony_and_kp_share_state(
         &mut self,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<CeremonyAndKpShareState>> {
-        let Some((ceremony_session_id, secret_sharing_instance, btc_master_pubkey)) =
-            self.read_latest_ceremony(build_policy).await?
-        else {
+    ) -> anyhow::Result<Option<CeremonyState>> {
+        let Some((_, ceremony)) = self.read_latest_ceremony_message(build_policy).await? else {
             return Ok(None);
         };
-        let sharing_seq = secret_sharing_instance.sharing_seq();
-        let (kp_share_session_id, kp_share_state) = self
+        let sharing_seq = ceremony.sharing_seq();
+        let (_, kp_share_state) = self
             .read_latest_kp_share_state(sharing_seq, build_policy)
             .await?
             .with_context(|| {
                 format!("no kp-shares log found for latest ceremony sharing_seq {sharing_seq}")
             })?;
-
-        Ok(Some(CeremonyAndKpShareState {
-            ceremony_session_id,
-            kp_share_session_id,
-            secret_sharing_instance,
-            btc_master_pubkey,
-            kp_share_state,
-        }))
+        Ok(Some(CeremonyState::new(ceremony, kp_share_state)?))
     }
 
     /// Latest serving committee, preferring `committee-update/` and falling back

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -66,6 +66,17 @@ pub enum BuildPolicy {
     AnyAllowlisted,
 }
 
+/// The latest ceremony record paired with the latest KP share state for that
+/// ceremony's secret-sharing instance.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CeremonyAndKpShareState {
+    pub ceremony_session_id: SessionID,
+    pub kp_share_session_id: SessionID,
+    pub secret_sharing_instance: SecretSharingInstance,
+    pub btc_master_pubkey: BitcoinPubkey,
+    pub kp_share_state: KpShareStateLogMessage,
+}
+
 impl BuildPolicy {
     fn enforce(self, allowlist: &PcrAllowlist, build_pcrs: &BuildPcrs) -> GuardianResult<()> {
         match self {
@@ -166,24 +177,13 @@ impl GuardianReader {
         Ok(self.get_session_info(session_id, build_policy).await?.info)
     }
 
-    /// The latest secret-sharing instance from `ceremony/` — the max-`sharing_seq`
-    /// (lex-last) entry, attestation- and signature-verified. `None` if no ceremony
-    /// has been logged yet. Written from initial setup onward, so present whenever a
-    /// key exists.
-    pub async fn read_latest_ceremony_instance(
-        &mut self,
-        build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<SecretSharingInstance>> {
-        Ok(self
-            .read_latest_ceremony(build_policy)
-            .await?
-            .map(|(_, instance, _)| instance))
-    }
-
-    /// Like [`Self::read_latest_ceremony_instance`], but also returns the writing
-    /// session id and BTC master pubkey. `kp-shares/` is read independently so
-    /// later KP cert rotations can advance `cert_seq` without rewriting the
-    /// `ceremony/` instance.
+    /// The latest ceremony from `ceremony/` — the max-`sharing_seq` (lex-last)
+    /// entry, attestation- and signature-verified. Returns its writing session,
+    /// secret-sharing instance, and BTC master pubkey. `None` if no ceremony has
+    /// been logged yet.
+    ///
+    /// `kp-shares/` is read independently so later KP cert rotations can advance
+    /// `cert_seq` without rewriting the `ceremony/` instance.
     pub async fn read_latest_ceremony(
         &mut self,
         build_policy: BuildPolicy,
@@ -260,6 +260,36 @@ impl GuardianReader {
             );
         }
         Ok(Some((session_id, *msg)))
+    }
+
+    /// Read the latest ceremony together with the latest KP share state for its
+    /// `sharing_seq`. `None` means no ceremony has been logged. Once a ceremony
+    /// exists, its matching KP share state must also exist: ceremony writers
+    /// publish `kp-shares/` before `ceremony/`.
+    pub async fn read_latest_ceremony_and_kp_share_state(
+        &mut self,
+        build_policy: BuildPolicy,
+    ) -> anyhow::Result<Option<CeremonyAndKpShareState>> {
+        let Some((ceremony_session_id, secret_sharing_instance, btc_master_pubkey)) =
+            self.read_latest_ceremony(build_policy).await?
+        else {
+            return Ok(None);
+        };
+        let sharing_seq = secret_sharing_instance.sharing_seq();
+        let (kp_share_session_id, kp_share_state) = self
+            .read_latest_kp_share_state(sharing_seq, build_policy)
+            .await?
+            .with_context(|| {
+                format!("no kp-shares log found for latest ceremony sharing_seq {sharing_seq}")
+            })?;
+
+        Ok(Some(CeremonyAndKpShareState {
+            ceremony_session_id,
+            kp_share_session_id,
+            secret_sharing_instance,
+            btc_master_pubkey,
+            kp_share_state,
+        }))
     }
 
     /// Latest serving committee, preferring `committee-update/` and falling back

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -40,6 +40,7 @@ use hashi_types::guardian::S3_DIR_HEARTBEAT;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
 use hashi_types::move_types::Committee;
 use std::collections::HashMap;
+use tracing::info;
 
 mod heartbeat_checks;
 mod limiter_recovery;
@@ -186,9 +187,11 @@ impl GuardianReader {
         let record = self.cache.verify_record(&self.s3, record).await?;
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy("ceremony log", build_policy, &build_pcrs)?;
+        let session_id = record.session_id;
         let LogMessage::V1(LogMessageV1::Ceremony(msg)) = record.message else {
             anyhow::bail!("expected a ceremony log at {key}");
         };
+        log_verified_read(&key, &session_id);
         Ok(Some(*msg))
     }
 
@@ -223,6 +226,7 @@ impl GuardianReader {
         let record = self.cache.verify_record(&self.s3, record).await?;
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy("kp-shares log", build_policy, &build_pcrs)?;
+        let session_id = record.session_id;
         let LogMessage::V1(LogMessageV1::KpShareState(msg)) = record.message else {
             anyhow::bail!("expected a kp-shares log at {key}");
         };
@@ -233,6 +237,7 @@ impl GuardianReader {
                 sharing_seq
             );
         }
+        log_verified_read(&key, &session_id);
         Ok(Some(*msg))
     }
 
@@ -292,15 +297,18 @@ impl GuardianReader {
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy("committee-update log", build_policy, &record.build_pcrs)?;
+        let session_id = record.session_id;
         let LogMessage::V1(LogMessageV1::CommitteeUpdate(msg)) = record.message else {
             anyhow::bail!("expected a committee-update log at {key}");
         };
-        match *msg {
-            CommitteeUpdateLogMessage::Success { new_committee, .. } => Ok(Some(new_committee)),
+        let committee = match *msg {
+            CommitteeUpdateLogMessage::Success { new_committee, .. } => new_committee,
             CommitteeUpdateLogMessage::Failure { .. } => {
                 anyhow::bail!("lex-last non-failure key resolved to a Failure log at {key}")
             }
-        }
+        };
+        log_verified_read(&key, &session_id);
+        Ok(Some(committee))
     }
 
     /// Fixed genesis record from `genesis/record.json`. `None` means the
@@ -323,11 +331,17 @@ impl GuardianReader {
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy("genesis log", build_policy, &record.build_pcrs)?;
+        let session_id = record.session_id;
         let LogMessage::V1(LogMessageV1::Genesis(msg)) = record.message else {
             anyhow::bail!("expected a genesis log at {key}");
         };
+        log_verified_read(&key, &session_id);
         Ok(Some(*msg))
     }
+}
+
+fn log_verified_read(key: &str, session_id: &SessionID) {
+    info!("Successfully read {key} from session {session_id}.");
 }
 
 /// Per-session [`VerifiedSessionInfo`] cache, internal to [`GuardianReader`]. The first

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -171,7 +171,7 @@ impl GuardianReader {
     ///
     /// `kp-shares/` is read independently so later KP cert rotations can advance
     /// `cert_seq` without rewriting the `ceremony/` instance.
-    pub async fn read_latest_ceremony(
+    async fn read_latest_ceremony(
         &mut self,
         build_policy: BuildPolicy,
     ) -> anyhow::Result<Option<CeremonyLogMessage>> {
@@ -201,11 +201,11 @@ impl GuardianReader {
     /// expected to expire, and their integrity is the enclave signature checked
     /// below — not S3 immutability — so the immutable-log lock assertion in
     /// `get_log_record` doesn't apply.
-    pub async fn read_latest_kp_share_state(
+    async fn read_latest_kp_share_state(
         &mut self,
         sharing_seq: u64,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<(SessionID, KpShareStateLogMessage)>> {
+    ) -> anyhow::Result<Option<KpShareStateLogMessage>> {
         let prefix = KpShareStateLogMessage::object_key_dir(sharing_seq);
         let keys = self
             .s3
@@ -221,7 +221,6 @@ impl GuardianReader {
             .get_log_record_inner(&key, LockCheck::Skipped, HistoryCheck::AlreadyChecked)
             .await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        let session_id = record.session_id.clone();
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy("kp-shares log", build_policy, &build_pcrs)?;
         let LogMessage::V1(LogMessageV1::KpShareState(msg)) = record.message else {
@@ -234,7 +233,7 @@ impl GuardianReader {
                 sharing_seq
             );
         }
-        Ok(Some((session_id, *msg)))
+        Ok(Some(*msg))
     }
 
     /// Read the latest ceremony together with the latest KP share state for its
@@ -249,7 +248,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let sharing_seq = ceremony.sharing_seq();
-        let (_, kp_share_state) = self
+        let kp_share_state = self
             .read_latest_kp_share_state(sharing_seq, build_policy)
             .await?
             .with_context(|| {

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -23,7 +23,7 @@ impl GuardianReader {
         &mut self,
         live_session: &str,
     ) -> anyhow::Result<()> {
-        let recent_heartbeats = self.read_recent_heartbeats().await?;
+        let recent_heartbeats = self.read_recent_heartbeat_logs().await?;
         let summary = summarize_heartbeats_by_session(recent_heartbeats)?;
         let now = now_timestamp_secs();
 
@@ -49,14 +49,14 @@ impl GuardianReader {
         Ok(())
     }
 
-    async fn read_recent_heartbeats(&mut self) -> anyhow::Result<Vec<VerifiedLogRecord>> {
+    async fn read_recent_heartbeat_logs(&mut self) -> anyhow::Result<Vec<VerifiedLogRecord>> {
         // Read from the previous, current, and next hour-scoped prefixes to
         // cover clock-boundary cases and moderate clock skew.
         let one_hour_ago = now_timestamp_secs().saturating_sub(60 * 60);
         let mut cursor = heartbeat_cursor(one_hour_ago);
         let mut logs = Vec::new();
         for _ in 0..3 {
-            logs.extend(self.read_dir(&cursor).await?);
+            logs.extend(self.read_logs_in_dir(&cursor).await?);
             cursor = cursor.next_dir();
         }
         Ok(logs)

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -57,9 +57,9 @@ impl GuardianReader {
         // Read the found bucket + one bucket back, then take max-seq across
         // both. The peek-back defends against sub-hour clock skew that may have
         // placed a higher-seq log in the prior hour bucket.
-        let hit = bucket_max_post_state(self.read_dir(&cursor).await?);
+        let hit = bucket_max_post_state(self.read_logs_in_dir(&cursor).await?);
         cursor = cursor.prev_dir();
-        let peek = bucket_max_post_state(self.read_dir(&cursor).await?);
+        let peek = bucket_max_post_state(self.read_logs_in_dir(&cursor).await?);
         let recovered_state = [hit, peek]
             .into_iter()
             .flatten()

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -13,6 +13,7 @@ use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::bitcoin::HashiMasterG;
 use hashi_types::guardian::*;
 use rand::RngCore;
+use std::num::NonZeroU16;
 use std::sync::Arc;
 
 /// Mock S3 logger that returns success for every PutObject call.
@@ -160,12 +161,12 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
 }
 
 /// Args for arming a withdraw-mode test enclave. `config` is the stable
-/// operator-init config; `secret_sharing_instance` mirrors the ceremony snapshot
-/// that production `operator_init` reads from S3.
+/// operator-init config; `ceremony_state` mirrors the snapshot that production
+/// `operator_init` reads from S3.
 pub struct OperatorInitTestArgs {
     pub s3_logger: GuardianS3Client,
     pub config: InitConfig,
-    pub secret_sharing_instance: SecretSharingInstance,
+    pub ceremony_state: CeremonyState,
 }
 
 const TEST_N: usize = 5;
@@ -179,12 +180,36 @@ fn dummy_secret_sharing_instance() -> SecretSharingInstance {
     SecretSharingInstance::new(commitments, TEST_N, TEST_T, 0).unwrap()
 }
 
+fn dummy_kp_encrypted_shares() -> KPEncryptedShares {
+    KPEncryptedShares::new(
+        (1..=TEST_N)
+            .map(|i| KPEncryptedShare {
+                id: NonZeroU16::new(i as u16).unwrap(),
+                recipient_fingerprint: format!("DUMMY FINGERPRINT {i}"),
+                armored_ciphertext: "dummy".into(),
+            })
+            .collect(),
+    )
+    .unwrap()
+}
+
+fn dummy_ceremony_state() -> CeremonyState {
+    CeremonyState {
+        secret_sharing_instance: dummy_secret_sharing_instance(),
+        btc_master_pubkey: crypto::k256_sk_to_btc_xonly_pubkey(
+            &k256::SecretKey::from_slice(&[7u8; 32]).unwrap(),
+        ),
+        cert_seq: 0,
+        encrypted_shares: dummy_kp_encrypted_shares(),
+    }
+}
+
 impl Default for OperatorInitTestArgs {
     fn default() -> Self {
         Self {
             s3_logger: mock_logger(),
             config: InitConfig::mock_for_testing(None),
-            secret_sharing_instance: dummy_secret_sharing_instance(),
+            ceremony_state: dummy_ceremony_state(),
         }
     }
 }
@@ -197,13 +222,18 @@ impl OperatorInitTestArgs {
 
     /// Set the ceremony snapshot to a different secret-sharing instance.
     pub fn with_commitments(mut self, commitments: ShareCommitments) -> Self {
-        self.secret_sharing_instance =
+        self.ceremony_state.secret_sharing_instance =
             SecretSharingInstance::new(commitments, TEST_N, TEST_T, 0).unwrap();
         self
     }
 
     pub fn with_s3_logger(mut self, s3_logger: GuardianS3Client) -> Self {
         self.s3_logger = s3_logger;
+        self
+    }
+
+    pub fn with_kp_encrypted_shares(mut self, shares: KPEncryptedShares) -> Self {
+        self.ceremony_state.encrypted_shares = shares;
         self
     }
 }
@@ -240,7 +270,7 @@ impl Enclave {
     /// withdraw-mode commit). Lets a harness defer operator-init until DKG output exists.
     pub fn install_operator_init_for_testing(&self, args: OperatorInitTestArgs) {
         self.config.set_s3_logger(args.s3_logger).unwrap();
-        crate::operator_init::InitInstall::from_parts(args.config, args.secret_sharing_instance)
+        crate::operator_init::InitInstall::from_parts(args.config, args.ceremony_state)
             .install_into(self);
         self.advance_lifecycle_into(WithdrawStage::OperatorInitialized.into())
             .expect("operator init test setup should advance lifecycle");

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -85,7 +85,7 @@ impl GuardianWithdrawalsPoller {
             return Ok(PollOutcome::CursorUnmoved);
         }
 
-        let verified_logs = self.reader.read_dir(&self.cursor).await?;
+        let verified_logs = self.reader.read_logs_in_dir(&self.cursor).await?;
         // Withdrawal polling may replay historical buckets during an upgrade, so
         // this caller accepts any record whose session build verifies against the
         // configured allowlist. Add a cursor/cutoff policy here if tailing must

--- a/crates/hashi-types/src/guardian/log/ceremony_state.rs
+++ b/crates/hashi-types/src/guardian/log/ceremony_state.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Combined ceremony and KP share state derived from guardian log messages.
+
+use super::message::CeremonyLogMessage;
+use super::message::KpShareStateLogMessage;
+use crate::bitcoin::BitcoinPubkey;
+use crate::guardian::GuardianError;
+use crate::guardian::GuardianResult;
+use crate::guardian::KPEncryptedShares;
+use crate::guardian::SecretSharingInstance;
+
+/// The current ceremony result together with its latest encrypted KP share state.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CeremonyState {
+    pub secret_sharing_instance: SecretSharingInstance,
+    pub btc_master_pubkey: BitcoinPubkey,
+    pub cert_seq: u64,
+    pub encrypted_shares: KPEncryptedShares,
+}
+
+impl CeremonyState {
+    /// Combine a ceremony log message with the KP share-state message for its
+    /// resulting secret-sharing instance.
+    pub fn new(
+        ceremony: CeremonyLogMessage,
+        kp_share_state: KpShareStateLogMessage,
+    ) -> GuardianResult<Self> {
+        let (secret_sharing_instance, btc_master_pubkey) = ceremony.into_instance_and_pubkey();
+        if kp_share_state.sharing_seq != secret_sharing_instance.sharing_seq() {
+            return Err(GuardianError::InternalError(format!(
+                "kp-shares sharing_seq ({}) differs from ceremony sharing_seq ({})",
+                kp_share_state.sharing_seq,
+                secret_sharing_instance.sharing_seq()
+            )));
+        }
+        Ok(Self {
+            secret_sharing_instance,
+            btc_master_pubkey,
+            cert_seq: kp_share_state.cert_seq,
+            encrypted_shares: kp_share_state.encrypted_shares,
+        })
+    }
+}

--- a/crates/hashi-types/src/guardian/log/ceremony_state.rs
+++ b/crates/hashi-types/src/guardian/log/ceremony_state.rs
@@ -60,3 +60,24 @@ impl From<SetupNewKeyResponse> for CeremonyState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::guardian::GuardianSigned;
+
+    #[test]
+    fn new_rejects_mismatched_sharing_seq() {
+        let response = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing().data;
+        let sharing_seq = response.secret_sharing_instance.sharing_seq();
+        let err = CeremonyState::new(
+            CeremonyLogMessage::NewKey {
+                instance: response.secret_sharing_instance,
+                btc_master_pubkey: response.btc_master_pubkey,
+            },
+            KpShareStateLogMessage::new(sharing_seq + 1, 0, response.encrypted_shares),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("kp-shares sharing_seq"), "{err}");
+    }
+}

--- a/crates/hashi-types/src/guardian/log/ceremony_state.rs
+++ b/crates/hashi-types/src/guardian/log/ceremony_state.rs
@@ -10,6 +10,7 @@ use crate::guardian::GuardianError;
 use crate::guardian::GuardianResult;
 use crate::guardian::KPEncryptedShares;
 use crate::guardian::SecretSharingInstance;
+use crate::guardian::SetupNewKeyResponse;
 
 /// The current ceremony result together with its latest encrypted KP share state.
 #[derive(Clone, Debug, PartialEq)]
@@ -41,5 +42,21 @@ impl CeremonyState {
             cert_seq: kp_share_state.cert_seq,
             encrypted_shares: kp_share_state.encrypted_shares,
         })
+    }
+}
+
+impl From<SetupNewKeyResponse> for CeremonyState {
+    fn from(response: SetupNewKeyResponse) -> Self {
+        let SetupNewKeyResponse {
+            encrypted_shares,
+            secret_sharing_instance,
+            btc_master_pubkey,
+        } = response;
+        Self {
+            secret_sharing_instance,
+            btc_master_pubkey,
+            cert_seq: 0,
+            encrypted_shares,
+        }
     }
 }

--- a/crates/hashi-types/src/guardian/log/ceremony_state.rs
+++ b/crates/hashi-types/src/guardian/log/ceremony_state.rs
@@ -36,12 +36,54 @@ impl CeremonyState {
                 secret_sharing_instance.sharing_seq()
             )));
         }
+        Self::from_parts(
+            secret_sharing_instance,
+            btc_master_pubkey,
+            kp_share_state.cert_seq,
+            kp_share_state.encrypted_shares,
+        )
+    }
+
+    fn from_parts(
+        secret_sharing_instance: SecretSharingInstance,
+        btc_master_pubkey: BitcoinPubkey,
+        cert_seq: u64,
+        encrypted_shares: KPEncryptedShares,
+    ) -> GuardianResult<Self> {
+        if encrypted_shares.len() != secret_sharing_instance.num_shares() {
+            return Err(GuardianError::InternalError(format!(
+                "encrypted share count ({}) differs from ceremony num_shares ({})",
+                encrypted_shares.len(),
+                secret_sharing_instance.num_shares()
+            )));
+        }
         Ok(Self {
             secret_sharing_instance,
             btc_master_pubkey,
-            cert_seq: kp_share_state.cert_seq,
-            encrypted_shares: kp_share_state.encrypted_shares,
+            cert_seq,
+            encrypted_shares,
         })
+    }
+
+    /// Confirm the ceremony uses the expected secret-sharing parameters.
+    pub fn validate_sharing_params(
+        &self,
+        expected_n: usize,
+        expected_t: usize,
+    ) -> GuardianResult<()> {
+        if self.secret_sharing_instance.num_shares() != expected_n {
+            return Err(GuardianError::InvalidInputs(format!(
+                "ceremony num_shares ({}) differs from expected ({expected_n})",
+                self.secret_sharing_instance.num_shares()
+            )));
+        }
+        if self.secret_sharing_instance.threshold() != expected_t {
+            return Err(GuardianError::InvalidInputs(format!(
+                "ceremony threshold ({}) differs from expected ({expected_t})",
+                self.secret_sharing_instance.threshold()
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -52,12 +94,13 @@ impl From<SetupNewKeyResponse> for CeremonyState {
             secret_sharing_instance,
             btc_master_pubkey,
         } = response;
-        Self {
+        Self::from_parts(
             secret_sharing_instance,
             btc_master_pubkey,
-            cert_seq: 0,
+            0,
             encrypted_shares,
-        }
+        )
+        .expect("SetupNewKeyResponse must contain one encrypted share per participant")
     }
 }
 
@@ -79,5 +122,20 @@ mod tests {
         )
         .unwrap_err();
         assert!(format!("{err}").contains("kp-shares sharing_seq"), "{err}");
+    }
+
+    #[test]
+    fn new_rejects_mismatched_share_count() {
+        let response = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing().data;
+        let sharing_seq = response.secret_sharing_instance.sharing_seq();
+        let err = CeremonyState::new(
+            CeremonyLogMessage::NewKey {
+                instance: response.secret_sharing_instance,
+                btc_master_pubkey: response.btc_master_pubkey,
+            },
+            KpShareStateLogMessage::new(sharing_seq, 0, KPEncryptedShares::new(vec![]).unwrap()),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("encrypted share count"), "{err}");
     }
 }

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -208,6 +208,34 @@ pub enum CeremonyLogMessage {
 }
 
 impl CeremonyLogMessage {
+    /// Consume the ceremony result. `NewKey` yields its initial instance;
+    /// `Rotate` yields the new instance after verifying that it advances exactly
+    /// one `sharing_seq` from the consumed instance.
+    pub fn into_instance_and_pubkey(self) -> (SecretSharingInstance, BitcoinPubkey) {
+        match self {
+            Self::NewKey {
+                instance,
+                btc_master_pubkey,
+            } => (instance, btc_master_pubkey),
+            Self::Rotate {
+                old_instance,
+                new_instance,
+                btc_master_pubkey,
+            } => {
+                let expected = old_instance
+                    .sharing_seq()
+                    .checked_add(1)
+                    .expect("Rotate old sharing_seq must not be u64::MAX");
+                assert_eq!(
+                    new_instance.sharing_seq(),
+                    expected,
+                    "Rotate must advance sharing_seq by exactly one"
+                );
+                (new_instance, btc_master_pubkey)
+            }
+        }
+    }
+
     /// The resulting instance's `sharing_seq` — used as the `ceremony/` object key.
     pub fn sharing_seq(&self) -> u64 {
         match self {

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -28,6 +28,7 @@ use crate::committee::CommitteeSignature;
 use crate::guardian::GuardianError;
 use crate::guardian::GuardianInfo;
 use crate::guardian::GuardianPubKey;
+use crate::guardian::GuardianResult;
 use crate::guardian::KPEncryptedShares;
 use crate::guardian::LimiterState;
 use crate::guardian::NitroAttestation;
@@ -253,6 +254,39 @@ impl CeremonyLogMessage {
 
     fn object_key_pattern(&self, session_id: &str) -> ObjectKeyPattern {
         ObjectKeyPattern::Fixed(self.object_key(session_id))
+    }
+}
+
+/// The current ceremony result together with its latest encrypted KP share state.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CeremonyState {
+    pub secret_sharing_instance: SecretSharingInstance,
+    pub btc_master_pubkey: BitcoinPubkey,
+    pub cert_seq: u64,
+    pub encrypted_shares: KPEncryptedShares,
+}
+
+impl CeremonyState {
+    /// Combine a ceremony log message with the KP share-state message for its
+    /// resulting secret-sharing instance.
+    pub fn new(
+        ceremony: CeremonyLogMessage,
+        kp_share_state: KpShareStateLogMessage,
+    ) -> GuardianResult<Self> {
+        let (secret_sharing_instance, btc_master_pubkey) = ceremony.into_instance_and_pubkey();
+        if kp_share_state.sharing_seq != secret_sharing_instance.sharing_seq() {
+            return Err(GuardianError::InvalidInputs(format!(
+                "kp-shares sharing_seq ({}) differs from ceremony sharing_seq ({})",
+                kp_share_state.sharing_seq,
+                secret_sharing_instance.sharing_seq()
+            )));
+        }
+        Ok(Self {
+            secret_sharing_instance,
+            btc_master_pubkey,
+            cert_seq: kp_share_state.cert_seq,
+            encrypted_shares: kp_share_state.encrypted_shares,
+        })
     }
 }
 

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -28,7 +28,6 @@ use crate::committee::CommitteeSignature;
 use crate::guardian::GuardianError;
 use crate::guardian::GuardianInfo;
 use crate::guardian::GuardianPubKey;
-use crate::guardian::GuardianResult;
 use crate::guardian::KPEncryptedShares;
 use crate::guardian::LimiterState;
 use crate::guardian::NitroAttestation;
@@ -254,39 +253,6 @@ impl CeremonyLogMessage {
 
     fn object_key_pattern(&self, session_id: &str) -> ObjectKeyPattern {
         ObjectKeyPattern::Fixed(self.object_key(session_id))
-    }
-}
-
-/// The current ceremony result together with its latest encrypted KP share state.
-#[derive(Clone, Debug, PartialEq)]
-pub struct CeremonyState {
-    pub secret_sharing_instance: SecretSharingInstance,
-    pub btc_master_pubkey: BitcoinPubkey,
-    pub cert_seq: u64,
-    pub encrypted_shares: KPEncryptedShares,
-}
-
-impl CeremonyState {
-    /// Combine a ceremony log message with the KP share-state message for its
-    /// resulting secret-sharing instance.
-    pub fn new(
-        ceremony: CeremonyLogMessage,
-        kp_share_state: KpShareStateLogMessage,
-    ) -> GuardianResult<Self> {
-        let (secret_sharing_instance, btc_master_pubkey) = ceremony.into_instance_and_pubkey();
-        if kp_share_state.sharing_seq != secret_sharing_instance.sharing_seq() {
-            return Err(GuardianError::InvalidInputs(format!(
-                "kp-shares sharing_seq ({}) differs from ceremony sharing_seq ({})",
-                kp_share_state.sharing_seq,
-                secret_sharing_instance.sharing_seq()
-            )));
-        }
-        Ok(Self {
-            secret_sharing_instance,
-            btc_master_pubkey,
-            cert_seq: kp_share_state.cert_seq,
-            encrypted_shares: kp_share_state.encrypted_shares,
-        })
     }
 }
 

--- a/crates/hashi-types/src/guardian/log/mod.rs
+++ b/crates/hashi-types/src/guardian/log/mod.rs
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Guardian S3 logs. `message` holds the `LogMessage` family the enclave emits;
-//! `envelope` holds the `LogRecord` wrapper written to S3 and its keying/signing.
+//! `envelope` holds the `LogRecord` wrapper written to S3 and its keying/signing;
+//! `ceremony_state` combines the ceremony and KP-share messages for readers.
 //! The S3 layout constants (stream prefixes + object-lock durations) live here so
 //! the whole key/lock scheme reads from one place. See
 //! `crates/hashi-guardian/README.md` for the canonical key layout.
 
+pub mod ceremony_state;
 pub mod envelope;
 pub mod message;
 
+pub use ceremony_state::*;
 pub use envelope::*;
 pub use message::*;
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -165,8 +165,7 @@ pub struct InitConfig {
 pub struct ActivationState {
     /// Binds the live activation state to the stable arming config.
     config_hash: [u8; 32],
-    /// Secret-sharing instance armed during OI/PI. Activation rejects if the
-    /// latest ceremony instance no longer matches it.
+    /// Secret-sharing instance pinned during OI and retained through activation.
     secret_sharing_instance: SecretSharingInstance,
     /// Current Hashi committee
     committee: HashiCommittee,

--- a/design/docs/guardian.mdx
+++ b/design/docs/guardian.mdx
@@ -89,8 +89,8 @@ sequenceDiagram
     Operator->>Operator: Gather bucket plus limiter config plus PCR allowlist plus network
     Operator->>Operator: Build InitConfig
     Operator->>Guardian: OperatorInit(S3 config, InitConfig)
-    Guardian->>S3: Read latest ceremony log
-    Guardian->>Guardian: Snapshot sharing instance for this arming
+    Guardian->>S3: Read latest ceremony and KP-share state
+    Guardian->>Guardian: Snapshot CeremonyState for this arming
     Guardian->>S3: log(init GuardianInfo(config_hash, sharing instance))
     Guardian->>S3: start heartbeat stream from OI onward
 
@@ -130,13 +130,12 @@ sequenceDiagram
     participant S3
     participant Guardian as Guardian enclave
 
-    Operator->>S3: Download ceremony instance plus committee/genesis plus limiter post-state
+    Operator->>Guardian: Read pinned ceremony instance from GuardianInfo
+    Operator->>S3: Download committee/genesis plus limiter post-state
     Operator->>Operator: Compute expected_state_hash
     Operator->>Guardian: OperatorActivate(expected_state_hash)
 
     Guardian->>S3: Confirm all other sessions heartbeat-quiet for QUIET_PERIOD
-    Guardian->>S3: Read latest ceremony log
-    Guardian->>Guardian: Refuse if latest ceremony instance differs from arming snapshot
     Guardian->>S3: Read latest committee-update or genesis record
     Guardian->>S3: Recover limiter state from max-seq success or genesis
     Guardian->>Guardian: Derive ActivationState and state_hash


### PR DESCRIPTION
This adds a flat, session-free `CeremonyState` built from the ceremony and KP-share log messages or from a live setup response. `GuardianReader` can return the latest ceremony together with its latest KP-share state, rejecting a ceremony without corresponding shares. Verified point reads log the selected object key and writing session for traceability.

Withdraw OI reads and stores the complete state once, and later init phases rely on that pinned snapshot without rereading ceremony or KP-share logs. Provisioning and roster consumers use the same combined reader. Validated with `make fmt`; broader checks are left to CI per repository guidance.