### PR TITLE
[onchain] Poll the config snapshot onchain until final_publish

### DIFF
--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -178,6 +178,26 @@ impl HashiNodeHandle {
         }
     }
 
+    pub(crate) async fn wait_for_guardian_client(
+        &self,
+        timeout: std::time::Duration,
+    ) -> Result<()> {
+        tokio::time::timeout(timeout, self.wait_for_guardian_client_inner())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!("guardian client resolution timed out after {:?}", timeout)
+            })
+    }
+
+    async fn wait_for_guardian_client_inner(&self) {
+        loop {
+            if self.hashi().guardian_client().is_some() {
+                return;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
     pub fn current_epoch(&self) -> Option<u64> {
         self.hashi()
             .onchain_state_opt()

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -480,6 +480,9 @@ impl HashiNetworkBuilder {
             // the guardian client lazily from the on-chain guardian_url set
             // by the launch tx, so every e2e run exercises the
             // guardian-set-up-last path.
+            // Fast config poll so the guardian gate in `build()` isn't
+            // waiting out the 5-minute default.
+            config.onchain_config_poll_interval_ms = Some(5_000);
             config.hashi_ids = Some(hashi_ids);
             config.validator_address = Some(*validator_address);
             config.operator_private_key = Some(private_key.to_pem()?);

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -348,6 +348,26 @@ impl TestNetworksBuilder {
 
         tracing::info!("rpc url: {}", test_networks.sui_network().rpc_url);
 
+        // The launch tx writes guardian_url into the config with no event, so
+        // nodes that booted pre-launch only see it via the watcher's periodic
+        // config poll. Gate on it BEFORE the override proposals below: their
+        // ProposalExecuted events also refresh the config and would mask a
+        // broken poll path (which is how the testnet launch outage slipped by).
+        // Genesis end_reconfig losers rescrape and heal incidentally too, so
+        // only the race winner actually exercises the poll here.
+        if nodes_started {
+            futures::future::try_join_all(
+                test_networks
+                    .hashi_network
+                    .nodes()
+                    .iter()
+                    .filter(|node| node.is_running())
+                    .map(|node| node.wait_for_guardian_client(std::time::Duration::from_secs(60))),
+            )
+            .await?;
+            tracing::info!("running hashi nodes resolved the guardian client from on-chain config");
+        }
+
         if nodes_started && !self.onchain_config_overrides.is_empty() {
             apply_onchain_config_overrides(&mut test_networks, &self.onchain_config_overrides)
                 .await?;

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -348,13 +348,10 @@ impl TestNetworksBuilder {
 
         tracing::info!("rpc url: {}", test_networks.sui_network().rpc_url);
 
-        // The launch tx writes guardian_url into the config with no event, so
-        // nodes that booted pre-launch only see it via the watcher's periodic
-        // config poll. Gate on it BEFORE the override proposals below: their
-        // ProposalExecuted events also refresh the config and would mask a
-        // broken poll path (which is how the testnet launch outage slipped by).
-        // Genesis end_reconfig losers rescrape and heal incidentally too, so
-        // only the race winner actually exercises the poll here.
+        // The launch tx writes guardian_url with no event; nodes booted
+        // pre-launch learn it only via the watcher's config poll. Gate BEFORE
+        // the override proposals — their config refresh would mask a broken
+        // poll (genesis end_reconfig losers rescrape and heal incidentally).
         if nodes_started {
             futures::future::try_join_all(
                 test_networks
@@ -1400,7 +1397,7 @@ mod tests {
         let ids = test_networks.hashi_network().ids();
 
         let (state, _service) =
-            hashi::onchain::OnchainState::new(sui_rpc_url, ids, None, None, None).await?;
+            hashi::onchain::OnchainState::new(sui_rpc_url, ids, None, None, None, None).await?;
 
         assert_eq!(state.state().hashi().committees.committees().len(), 1);
         assert_eq!(state.state().hashi().committees.members().len(), 1);

--- a/crates/e2e-tests/src/main.rs
+++ b/crates/e2e-tests/src/main.rs
@@ -856,7 +856,7 @@ async fn cmd_deposit(amount: u64, recipient: Option<&str>, data_dir: &Path) -> R
 
     // Fetch MPC public key from on-chain state
     let (onchain_state, _service) =
-        hashi::onchain::OnchainState::new(&state.sui_rpc_url, hashi_ids, None, None, None)
+        hashi::onchain::OnchainState::new(&state.sui_rpc_url, hashi_ids, None, None, None, None)
             .await
             .context("Failed to read on-chain state")?;
 

--- a/crates/hashi-guardian-init/src/config.rs
+++ b/crates/hashi-guardian-init/src/config.rs
@@ -104,9 +104,10 @@ impl<'de> Deserialize<'de> for HashiOnchainConfig {
 
 impl HashiOnchainConfig {
     pub async fn onchain_state(&self) -> anyhow::Result<OnchainState> {
-        let (state, _watcher) = OnchainState::new(&self.sui_rpc, self.hashi_ids, None, None, None)
-            .await
-            .with_context(|| format!("failed to connect to Sui RPC at {}", self.sui_rpc))?;
+        let (state, _watcher) =
+            OnchainState::new(&self.sui_rpc, self.hashi_ids, None, None, None, None)
+                .await
+                .with_context(|| format!("failed to connect to Sui RPC at {}", self.sui_rpc))?;
         Ok(state)
     }
 }

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -199,7 +199,7 @@ pub struct Versioning {
 }
 
 /// Rust version of the Move sui::package::UpgradeCap type.
-#[derive(Debug, serde_derive::Deserialize)]
+#[derive(Debug, PartialEq, serde_derive::Deserialize)]
 pub struct UpgradeCap {
     pub id: Address,
     pub package: Address,

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -126,6 +126,7 @@ impl HashiClient {
             None,
             Some(crate::config::DEFAULT_GRPC_MAX_DECODING_MESSAGE_SIZE),
             None,
+            None,
         )
         .await
         .context("Failed to initialize on-chain state")?;

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -1328,7 +1328,7 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
     // Pre-flight: read the launch state and who would form the initial
     // committee. No hard failures yet — status mode reports every state.
     let (onchain, _watcher) =
-        crate::onchain::OnchainState::new(&opts.sui_rpc_url, ids, None, None, None).await?;
+        crate::onchain::OnchainState::new(&opts.sui_rpc_url, ids, None, None, None, None).await?;
     let (launched, roster): (bool, Vec<(sui_sdk_types::Address, bool)>) = {
         let state = onchain.state();
         (

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -14,6 +14,7 @@ use crate::constants::SUI_MAINNET_CHAIN_ID;
 
 const DEFAULT_WITHDRAWAL_SIGNING_CONCURRENCY: usize = 25;
 const DEFAULT_MPC_SIGNING_CHUNK_SIZE: usize = 64;
+pub(crate) const DEFAULT_ONCHAIN_CONFIG_POLL_INTERVAL_MS: u64 = 300_000;
 /// Tonic's 4 MiB default is too small to scrape a large on-chain state or
 /// receive large MPC round messages.
 pub(crate) const DEFAULT_GRPC_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
@@ -205,6 +206,14 @@ pub struct Config {
     /// Defaults to 3.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_fee_conf_target: Option<u16>,
+
+    /// Interval (ms) between watcher polls of the on-chain Hashi config —
+    /// the safety net for config writes that emit no event (`finish_publish`
+    /// sets `guardian_url` and the guardian BTC key directly).
+    ///
+    /// Defaults to 300,000 ms (5 minutes).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub onchain_config_poll_interval_ms: Option<u64>,
 
     /// Test-only: corrupt AVSS shares sent to this address, triggering the
     /// complaint recovery flow. Must not be set on mainnet or testnet.
@@ -407,6 +416,13 @@ impl Config {
 
     pub fn withdrawal_batching_delay_ms(&self) -> u64 {
         self.withdrawal_batching_delay_ms.unwrap_or(300_000)
+    }
+
+    pub fn onchain_config_poll_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(
+            self.onchain_config_poll_interval_ms
+                .unwrap_or(DEFAULT_ONCHAIN_CONFIG_POLL_INTERVAL_MS),
+        )
     }
 
     pub fn withdrawal_max_batch_size(&self) -> usize {

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -207,9 +207,10 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_fee_conf_target: Option<u16>,
 
-    /// Interval (ms) between watcher polls of the on-chain Hashi config —
-    /// the safety net for config writes that emit no event (`finish_publish`
-    /// sets `guardian_url` and the guardian BTC key directly).
+    /// Interval (ms) between watcher polls of the on-chain Hashi config while
+    /// the launch is pending — the safety net for `finish_publish`, which sets
+    /// `guardian_url` and the guardian BTC key with no event. Polling stops
+    /// once both are on-chain.
     ///
     /// Defaults to 300,000 ms (5 minutes).
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -312,6 +312,7 @@ impl Hashi {
             self.config.tls_private_key().ok(),
             Some(self.config.grpc_max_decoding_message_size()),
             Some(self.metrics.clone()),
+            Some(self.config.onchain_config_poll_interval()),
         )
         .await?;
         self.onchain_state

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -103,6 +103,8 @@ struct Inner {
     /// Pinged by the watcher after a reconnect rescrape, so the reconcile
     /// loop can re-align the local limiter immediately.
     guardian_reconcile_notify: Arc<tokio::sync::Notify>,
+    /// Cadence of the watcher's on-chain config poll.
+    config_poll_interval: std::time::Duration,
 }
 
 #[derive(Debug)]
@@ -127,6 +129,7 @@ impl OnchainState {
         tls_private_key: Option<ed25519_dalek::SigningKey>,
         grpc_max_decoding_message_size: Option<usize>,
         metrics: Option<Arc<crate::metrics::Metrics>>,
+        config_poll_interval: Option<std::time::Duration>,
     ) -> Result<(Self, Service)> {
         let mut client = Client::new(sui_rpc_url)?;
         // The scrape client reads the full on-chain state (the largest
@@ -165,6 +168,9 @@ impl OnchainState {
             metrics: metrics.clone(),
             local_limiter: OnceLock::new(),
             guardian_reconcile_notify: Arc::new(tokio::sync::Notify::new()),
+            config_poll_interval: config_poll_interval.unwrap_or(std::time::Duration::from_millis(
+                crate::config::DEFAULT_ONCHAIN_CONFIG_POLL_INTERVAL_MS,
+            )),
         }
         .pipe(Arc::new)
         .pipe(Self);
@@ -186,6 +192,10 @@ impl OnchainState {
 
     pub(crate) fn grpc_max_decoding_message_size(&self) -> Option<usize> {
         self.0.grpc_max_decoding_message_size
+    }
+
+    pub(crate) fn config_poll_interval(&self) -> std::time::Duration {
+        self.0.config_poll_interval
     }
 
     fn notify(&self, notification: Notification) {

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -525,7 +525,7 @@ impl ProposalType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Config {
     pub config: BTreeMap<String, ConfigValue>,
     pub enabled_versions: BTreeSet<u64>,

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -37,12 +37,6 @@ use crate::withdrawals::withdrawal_limiter_consumption_amount;
 /// server silently stopped sending checkpoints.
 const CHECKPOINT_STREAM_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
-/// Re-poll the on-chain config this often. Config writes normally reach the
-/// snapshot via `ProposalExecuted` events, but `finish_publish` mutates the
-/// config directly with no event — a node booted pre-launch would otherwise
-/// never see `guardian_url`/`guardian_btc_public_key` land.
-const CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
-
 #[tracing::instrument(name = "watcher", skip_all)]
 pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<Arc<Metrics>>) {
     let subscription_read_mask = FieldMask::from_paths([
@@ -183,7 +177,7 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
 
             handle_events(&mut client, &state, timestamp_ms, &events).await;
 
-            if last_config_refresh.elapsed() >= CONFIG_REFRESH_INTERVAL {
+            if last_config_refresh.elapsed() >= state.config_poll_interval() {
                 refresh_config_if_changed(&client, &state).await;
                 last_config_refresh = std::time::Instant::now();
             }
@@ -207,9 +201,8 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
     }
 }
 
-/// Re-fetch the Hashi config and swap it into the snapshot if it changed.
 /// Runs on the watcher task, so it can't race the event-driven config
-/// refresh. Bounded so a wedged connection can't hang the checkpoint loop.
+/// refresh; bounded so a wedged connection can't hang the checkpoint loop.
 async fn refresh_config_if_changed(client: &Client, state: &OnchainState) {
     let scrape = super::scrape_hashi_config(client.clone(), state.hashi_id());
     let config = match tokio::time::timeout(Duration::from_secs(10), scrape).await {

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -177,7 +177,9 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
 
             handle_events(&mut client, &state, timestamp_ms, &events).await;
 
-            if last_config_refresh.elapsed() >= state.config_poll_interval() {
+            if last_config_refresh.elapsed() >= state.config_poll_interval()
+                && launch_pending(&state)
+            {
                 refresh_config_if_changed(&client, &state).await;
                 last_config_refresh = std::time::Instant::now();
             }
@@ -199,6 +201,15 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
         tracing::warn!("checkpoint stream ended; reconnecting Sui client and rescraping");
         rescrape_state = true;
     }
+}
+
+/// The poll only exists to catch `finish_publish` (guardian url + BTC key,
+/// written with no event); every other config write emits `ProposalExecuted`.
+/// Once both fields are in the snapshot the launch has landed: stop polling.
+fn launch_pending(state: &OnchainState) -> bool {
+    let state = state.state();
+    let config = &state.hashi().config;
+    config.guardian_url().is_none() || config.guardian_btc_public_key().is_none()
 }
 
 /// Runs on the watcher task, so it can't race the event-driven config

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -37,6 +37,12 @@ use crate::withdrawals::withdrawal_limiter_consumption_amount;
 /// server silently stopped sending checkpoints.
 const CHECKPOINT_STREAM_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
+/// Re-poll the on-chain config this often. Config writes normally reach the
+/// snapshot via `ProposalExecuted` events, but `finish_publish` mutates the
+/// config directly with no event — a node booted pre-launch would otherwise
+/// never see `guardian_url`/`guardian_btc_public_key` land.
+const CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+
 #[tracing::instrument(name = "watcher", skip_all)]
 pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<Arc<Metrics>>) {
     let subscription_read_mask = FieldMask::from_paths([
@@ -58,6 +64,8 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
     ]);
 
     let mut rescrape_state = false;
+    // Boot scrape just populated the snapshot; start the poll clock from here.
+    let mut last_config_refresh = std::time::Instant::now();
 
     loop {
         // Reconnect with a fresh client each iteration. Re-subscribing on the
@@ -122,6 +130,7 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
 
             // Rescrape gapped the event-driven limiter; trigger an eager reconcile.
             state.request_limiter_reconcile();
+            last_config_refresh = std::time::Instant::now();
         }
 
         while let Ok(Some(item)) =
@@ -174,6 +183,11 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
 
             handle_events(&mut client, &state, timestamp_ms, &events).await;
 
+            if last_config_refresh.elapsed() >= CONFIG_REFRESH_INTERVAL {
+                refresh_config_if_changed(&client, &state).await;
+                last_config_refresh = std::time::Instant::now();
+            }
+
             // Finally update the latest checkpoint info
             state.update_latest_checkpoint_info(CheckpointInfo {
                 height: ckpt,
@@ -190,6 +204,29 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
         // re-subscribe, and rescrape to recover any gap we missed.
         tracing::warn!("checkpoint stream ended; reconnecting Sui client and rescraping");
         rescrape_state = true;
+    }
+}
+
+/// Re-fetch the Hashi config and swap it into the snapshot if it changed.
+/// Runs on the watcher task, so it can't race the event-driven config
+/// refresh. Bounded so a wedged connection can't hang the checkpoint loop.
+async fn refresh_config_if_changed(client: &Client, state: &OnchainState) {
+    let scrape = super::scrape_hashi_config(client.clone(), state.hashi_id());
+    let config = match tokio::time::timeout(Duration::from_secs(10), scrape).await {
+        Ok(Ok(config)) => config,
+        Ok(Err(e)) => {
+            tracing::warn!("error polling on-chain config: {e}");
+            return;
+        }
+        Err(_) => {
+            tracing::warn!("timed out polling on-chain config");
+            return;
+        }
+    };
+    let mut state = state.state_mut();
+    if state.hashi.config != config {
+        state.hashi.config = config;
+        tracing::info!("on-chain config changed; snapshot refreshed by periodic poll");
     }
 }
 

--- a/crates/internal-tools/src/main.rs
+++ b/crates/internal-tools/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
             println!("Connecting to Sui RPC: {sui_rpc}");
             println!("Chain ID: {chain_id}");
             let (onchain_state, _watcher) =
-                OnchainState::new(sui_rpc, cfg.hashi_ids(), None, None, None)
+                OnchainState::new(sui_rpc, cfg.hashi_ids(), None, None, None, None)
                     .await
                     .context("failed to connect to Sui RPC")?;
             key_recovery::run(args, &onchain_state, chain_id).await


### PR DESCRIPTION
## Changes

- `watcher.rs`: while the launch is pending, poll the Hashi config and swap it into the snapshot when it changed.
  - Once `guardian_url` and the BTC key are both on-chain the poll retires. 
  - Bounded (10s) so a wedged connection can't hang the checkpoint loop.
- `config.rs`: new `onchain_config_poll_interval_ms` node-config knob for the pending-launch poll, default 5 minutes.
- Derive `PartialEq` on `Config` / `UpgradeCap` for the change check.
