### PR TITLE
Fix the leader's spent-UTXO cleanup resubmitting cleaned sets forever

### DIFF
--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -169,10 +169,11 @@ impl LeaderService {
     }
 
     /// If a cleanup scan is due and no task is in-flight, spawn a background
-    /// task that refreshes the UTXO-pool mirror from chain, scans it for
-    /// spent-but-uncleaned records, and cleans them. The scan is armed at
-    /// boot (crash-between-confirm-and-cleanup recovery), whenever a
-    /// withdrawal confirms on Sui, and after a task that did work or failed.
+    /// task that scrapes a task-local snapshot of the on-chain UTXO records,
+    /// scans it for spent-but-uncleaned entries, and cleans them. The scan
+    /// is armed at boot (crash-between-confirm-and-cleanup recovery),
+    /// whenever a withdrawal confirms on Sui, and after a task that did
+    /// work or failed.
     pub(super) fn check_cleanup_spent_utxos(&mut self, checkpoint_timestamp_ms: u64) {
         if self.utxo_cleanup_gc_task.is_some() {
             debug!("UTXO cleanup GC task already in-flight, skipping");
@@ -217,8 +218,11 @@ impl LeaderService {
             utxo_count = utxo_ids.len(),
             "Cleaning up spent UTXO(s) pending cleanup",
         );
-        let mut executor = SuiTxExecutor::from_hashi(inner)?;
-        executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
+        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        let landed_at = executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
+        // Floor the next scrape past this cleanup's checkpoint so a lagging
+        // read can't re-show (and re-pay for) the records it just removed.
+        inner.onchain_state().raise_utxo_scrape_floor(landed_at);
         info!(
             utxo_count = utxo_ids.len(),
             "Successfully cleaned up spent UTXOs",
@@ -340,8 +344,8 @@ impl LeaderService {
 /// Capped at [`MAX_UTXO_CLEANUPS_PER_GC`]; the remainder is picked up by a
 /// later scan.
 ///
-/// This is the pure-data core of [`LeaderService::discover_orphaned_utxo_cleanups`],
-/// extracted so it can be unit-tested without constructing a full `LeaderService`.
+/// Pure-data core of the cleanup task's scan over its scraped snapshot,
+/// extracted so it can be unit-tested without RPC or a full `LeaderService`.
 fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>) -> Vec<UtxoId> {
     utxo_records
         .iter()

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -34,6 +34,33 @@ const PROPOSAL_DELETE_DELAY_MS: u64 = 1000 * 60 * 60 * 24; // 1 day
 // Mirrors `MAX_DEPOSIT_REQUEST_DELETIONS_PER_GC`.
 const MAX_PROPOSAL_DELETIONS_PER_GC: usize = 500;
 
+// Cap the orphan scan so one cleanup task stays bounded; a larger backlog
+// drains over successive checkpoints. Mirrors the two caps above.
+const MAX_UTXO_CLEANUPS_PER_GC: usize = 500;
+
+/// Failure kind for the UTXO cleanup GC. `max_retries` is unbounded: this is
+/// a singleton maintenance task that must never permanently give up (a
+/// drained gas wallet can heal by top-up), so it backs off to `max_delay_ms`
+/// instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum UtxoCleanupErrorKind {
+    Failed,
+}
+
+impl crate::leader::retry::RetryPolicy for UtxoCleanupErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        5_000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        5 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
+    }
+}
+
 impl LeaderService {
     /// Check for and delete expired deposit requests.
     /// Deposit requests are sorted by timestamp and deleted if they are older than
@@ -150,9 +177,14 @@ impl LeaderService {
     /// scans on-chain state for orphaned locked UTXOs whose withdrawal has
     /// already been confirmed (handles the crash-between-confirm-and-cleanup
     /// case).
-    pub(super) fn check_cleanup_spent_utxos(&mut self) {
+    pub(super) fn check_cleanup_spent_utxos(&mut self, checkpoint_timestamp_ms: u64) {
         if self.utxo_cleanup_gc_task.is_some() {
             debug!("UTXO cleanup GC task already in-flight, skipping");
+            return;
+        }
+
+        if self.utxo_cleanup_retry.should_skip(checkpoint_timestamp_ms) {
+            debug!("UTXO cleanup GC in backoff, skipping");
             return;
         }
 
@@ -201,10 +233,16 @@ impl LeaderService {
         inner: Arc<crate::Hashi>,
         cleanup: PendingUtxoCleanup,
     ) -> anyhow::Result<()> {
-        let mut executor = SuiTxExecutor::from_hashi(inner)?;
+        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
         executor
             .execute_cleanup_spent_utxos(&cleanup.utxo_ids)
             .await?;
+        // The Move call emits no event, so the watcher can't prune these
+        // records; without this the orphan scan rediscovers the same set and
+        // re-cleans it as a paid no-op forever.
+        inner
+            .onchain_state()
+            .remove_cleaned_utxo_records(&cleanup.utxo_ids);
         info!(
             utxo_count = cleanup.utxo_ids.len(),
             "Successfully cleaned up spent UTXOs",
@@ -323,6 +361,8 @@ impl LeaderService {
 
 /// Return UTXO IDs whose `spent_epoch` is set — these are spent UTXOs
 /// still present in `utxo_records` that need to be cleaned up on-chain.
+/// Capped at [`MAX_UTXO_CLEANUPS_PER_GC`]; the remainder is picked up by a
+/// later scan.
 ///
 /// This is the pure-data core of [`LeaderService::discover_orphaned_utxo_cleanups`],
 /// extracted so it can be unit-tested without constructing a full `LeaderService`.
@@ -331,6 +371,7 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
         .iter()
         .filter(|(_, record)| record.spent_epoch.is_some())
         .map(|(id, _)| *id)
+        .take(MAX_UTXO_CLEANUPS_PER_GC)
         .collect()
 }
 
@@ -417,5 +458,15 @@ mod tests {
 
         let result = find_spent_utxos_pending_cleanup(&utxo_records);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_is_capped_per_gc() {
+        let utxo_records: BTreeMap<UtxoId, UtxoRecord> = (0..MAX_UTXO_CLEANUPS_PER_GC as u32 + 7)
+            .map(|i| (utxo_id((i % 251) as u8, i), record(Some(1))))
+            .collect();
+
+        let result = find_spent_utxos_pending_cleanup(&utxo_records);
+        assert_eq!(result.len(), MAX_UTXO_CLEANUPS_PER_GC);
     }
 }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -207,8 +207,8 @@ impl LeaderService {
     /// paid on-chain no-ops. The mirror itself is left untouched; the
     /// watcher task is its sole writer.
     async fn cleanup_spent_utxos(inner: Arc<crate::Hashi>) -> anyhow::Result<usize> {
-        let pool = inner.onchain_state().scrape_utxo_pool_snapshot().await?;
-        let utxo_ids = find_spent_utxos_pending_cleanup(pool.utxo_records());
+        let utxo_records = inner.onchain_state().scrape_utxo_records_snapshot().await?;
+        let utxo_ids = find_spent_utxos_pending_cleanup(&utxo_records);
         if utxo_ids.is_empty() {
             return Ok(0);
         }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -18,10 +18,6 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 
-pub(super) struct PendingUtxoCleanup {
-    pub(super) utxo_ids: Vec<UtxoId>,
-}
-
 const MAX_DEPOSIT_REQUEST_AGE_MS: u64 = 1000 * 60 * 60 * 24; // 1 day
 const DEPOSIT_REQUEST_DELETE_DELAY_MS: u64 = 1000 * 60; // 1 minute
 const MAX_DEPOSIT_REQUEST_DELETIONS_PER_GC: usize = 500;
@@ -172,14 +168,18 @@ impl LeaderService {
         })));
     }
 
-    /// If there are pending UTXO cleanups and no task in-flight, spawn a
-    /// background task to process the next one. When the queue is empty,
-    /// scans on-chain state for orphaned locked UTXOs whose withdrawal has
-    /// already been confirmed (handles the crash-between-confirm-and-cleanup
-    /// case).
+    /// If a cleanup scan is due and no task is in-flight, spawn a background
+    /// task that refreshes the UTXO-pool mirror from chain, scans it for
+    /// spent-but-uncleaned records, and cleans them. The scan is armed at
+    /// boot (crash-between-confirm-and-cleanup recovery), whenever a
+    /// withdrawal confirms on Sui, and after a task that did work or failed.
     pub(super) fn check_cleanup_spent_utxos(&mut self, checkpoint_timestamp_ms: u64) {
         if self.utxo_cleanup_gc_task.is_some() {
             debug!("UTXO cleanup GC task already in-flight, skipping");
+            return;
+        }
+
+        if !self.utxo_cleanup_scan_needed {
             return;
         }
 
@@ -188,66 +188,48 @@ impl LeaderService {
             return;
         }
 
-        if self.pending_utxo_cleanups.is_empty() && self.utxo_cleanup_scan_needed {
-            self.discover_orphaned_utxo_cleanups();
-            if self.pending_utxo_cleanups.is_empty() {
-                self.utxo_cleanup_scan_needed = false;
-            }
-        }
-
-        let Some(cleanup) = self.pending_utxo_cleanups.pop_front() else {
-            return;
-        };
-
-        info!(
-            utxo_count = cleanup.utxo_ids.len(),
-            "Scheduling UTXO cleanup for spent UTXOs",
-        );
-
+        self.utxo_cleanup_scan_needed = false;
         let inner = self.inner.clone();
         self.utxo_cleanup_gc_task = Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
-            Self::cleanup_spent_utxos(inner, cleanup).await
+            Self::cleanup_spent_utxos(inner).await
         })));
     }
 
-    /// Scan local state for UTXOs with `spent_epoch` set — they have been
-    /// spent but their cleanup never ran (e.g. leader crashed).
-    fn discover_orphaned_utxo_cleanups(&mut self) {
-        let state = self.inner.onchain_state().state();
-        let utxo_records = state.hashi().utxo_pool.utxo_records();
+    /// Refresh the UTXO-pool mirror from chain, then clean every record the
+    /// refreshed mirror still shows as spent-but-uncleaned. Returns how many
+    /// UTXOs were cleaned so the caller can decide whether to re-arm the
+    /// scan (more work may exist past the per-GC cap).
+    ///
+    /// The refresh is what makes the tx worth paying for: the mirror
+    /// overstates pending cleanups whenever another leader cleaned records
+    /// (their prune is local to them), and submitting from a stale mirror
+    /// re-cleans those records as paid on-chain no-ops.
+    async fn cleanup_spent_utxos(inner: Arc<crate::Hashi>) -> anyhow::Result<usize> {
+        inner.onchain_state().refresh_utxo_pool().await?;
 
-        let orphaned_ids = find_spent_utxos_pending_cleanup(utxo_records);
-
-        if !orphaned_ids.is_empty() {
-            info!(
-                "Discovered {} spent UTXO(s) pending cleanup",
-                orphaned_ids.len(),
-            );
-            self.pending_utxo_cleanups.push_back(PendingUtxoCleanup {
-                utxo_ids: orphaned_ids,
-            });
+        let utxo_ids = {
+            let state = inner.onchain_state().state();
+            find_spent_utxos_pending_cleanup(state.hashi().utxo_pool.utxo_records())
+        };
+        if utxo_ids.is_empty() {
+            return Ok(0);
         }
-    }
 
-    async fn cleanup_spent_utxos(
-        inner: Arc<crate::Hashi>,
-        cleanup: PendingUtxoCleanup,
-    ) -> anyhow::Result<()> {
-        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
-        executor
-            .execute_cleanup_spent_utxos(&cleanup.utxo_ids)
-            .await?;
-        // The Move call emits no event, so the watcher can't prune these
-        // records; without this the orphan scan rediscovers the same set and
-        // re-cleans it as a paid no-op forever.
-        inner
-            .onchain_state()
-            .remove_cleaned_utxo_records(&cleanup.utxo_ids);
         info!(
-            utxo_count = cleanup.utxo_ids.len(),
+            utxo_count = utxo_ids.len(),
+            "Cleaning up spent UTXO(s) pending cleanup",
+        );
+        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
+        // The Move call emits no event, so the watcher can't prune these
+        // records; apply the cleanup to the local mirror here so the next
+        // scan doesn't rediscover and re-pay for the same set.
+        inner.onchain_state().remove_cleaned_utxo_records(&utxo_ids);
+        info!(
+            utxo_count = utxo_ids.len(),
             "Successfully cleaned up spent UTXOs",
         );
-        Ok(())
+        Ok(utxo_ids.len())
     }
 
     async fn delete_expired_proposals(

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -195,22 +195,20 @@ impl LeaderService {
         })));
     }
 
-    /// Refresh the UTXO-pool mirror from chain, then clean every record the
-    /// refreshed mirror still shows as spent-but-uncleaned. Returns how many
+    /// Scrape a fresh task-local snapshot of the on-chain UTXO pool, then
+    /// clean every record it shows as spent-but-uncleaned. Returns how many
     /// UTXOs were cleaned so the caller can decide whether to re-arm the
     /// scan (more work may exist past the per-GC cap).
     ///
-    /// The refresh is what makes the tx worth paying for: the mirror
-    /// overstates pending cleanups whenever another leader cleaned records
-    /// (their prune is local to them), and submitting from a stale mirror
-    /// re-cleans those records as paid on-chain no-ops.
+    /// Deciding from a fresh chain read — never from the shared mirror — is
+    /// what makes the tx worth paying for: the mirror overstates pending
+    /// cleanups whenever another leader cleaned records (`cleanup_spent`
+    /// emits no event), and submitting from it re-cleans those records as
+    /// paid on-chain no-ops. The mirror itself is left untouched; the
+    /// watcher task is its sole writer.
     async fn cleanup_spent_utxos(inner: Arc<crate::Hashi>) -> anyhow::Result<usize> {
-        inner.onchain_state().refresh_utxo_pool().await?;
-
-        let utxo_ids = {
-            let state = inner.onchain_state().state();
-            find_spent_utxos_pending_cleanup(state.hashi().utxo_pool.utxo_records())
-        };
+        let pool = inner.onchain_state().scrape_utxo_pool_snapshot().await?;
+        let utxo_ids = find_spent_utxos_pending_cleanup(pool.utxo_records());
         if utxo_ids.is_empty() {
             return Ok(0);
         }
@@ -219,12 +217,8 @@ impl LeaderService {
             utxo_count = utxo_ids.len(),
             "Cleaning up spent UTXO(s) pending cleanup",
         );
-        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        let mut executor = SuiTxExecutor::from_hashi(inner)?;
         executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
-        // The Move call emits no event, so the watcher can't prune these
-        // records; apply the cleanup to the local mirror here so the next
-        // scan doesn't rediscover and re-pay for the same set.
-        inner.onchain_state().remove_cleaned_utxo_records(&utxo_ids);
         info!(
             utxo_count = utxo_ids.len(),
             "Successfully cleaned up spent UTXOs",

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -29,7 +29,6 @@ use futures::future::OptionFuture;
 use hashi_types::committee::MemberSignature;
 use hashi_types::proto::bridge_service_client::BridgeServiceClient;
 use std::collections::HashSet;
-use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -104,12 +103,12 @@ pub(crate) struct LeaderService {
     // Singleton task that deletes stale governance proposals.
     proposal_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
 
-    // UTXO cleanup requests discovered after withdrawals are confirmed on Sui.
-    pending_utxo_cleanups: VecDeque<garbage_collection::PendingUtxoCleanup>,
-    // Singleton task that cleans up spent withdrawal input UTXOs on-chain.
-    utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    // Singleton task that cleans up spent withdrawal input UTXOs on-chain;
+    // resolves to how many UTXOs it cleaned.
+    utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<usize>>>,
     utxo_cleanup_retry: GlobalRetryTracker<garbage_collection::UtxoCleanupErrorKind>,
-    // Forces a fresh scan for UTXO cleanup work after cleanup state changes.
+    // Arms the cleanup scan: set at boot (crash recovery), when a withdrawal
+    // confirms on Sui, and after a cleanup task that did work or failed.
     utxo_cleanup_scan_needed: bool,
 
     // Singleton task that reconciles the guardian committee with the on-chain committee.
@@ -147,7 +146,6 @@ impl LeaderService {
             approved_deposit_retry_tracker: RetryTracker::new(),
             deposit_gc_task: None,
             proposal_gc_task: None,
-            pending_utxo_cleanups: VecDeque::new(),
             utxo_cleanup_gc_task: None,
             utxo_cleanup_retry: GlobalRetryTracker::new(),
             utxo_cleanup_scan_needed: true,
@@ -304,19 +302,28 @@ impl LeaderService {
                 }
                 Some(result) = OptionFuture::from(self.utxo_cleanup_gc_task.as_mut()) => {
                     self.utxo_cleanup_gc_task = None;
-                    match &result {
-                        Ok(Ok(())) => self.utxo_cleanup_retry.clear(),
-                        _ => self.utxo_cleanup_retry.record_failure(
-                            garbage_collection::UtxoCleanupErrorKind::Failed,
-                            checkpoint_rx.borrow().timestamp_ms,
-                        ),
-                    }
-                    Self::log_task_result("utxo_cleanup_gc", result);
-                    // Re-arm the scan and leave rescheduling to the
-                    // leader-gated checkpoint arm: respawning here ran
+                    // Re-arm the scan when the task did work (more may exist
+                    // past the per-GC cap, or new spends raced in) or failed
+                    // (retry after backoff); a barren scan stays disarmed
+                    // until a withdrawal confirms. Rescheduling is left to
+                    // the leader-gated checkpoint arm: respawning here ran
                     // ungated (leader or not) with no backoff, which kept a
                     // node resubmitting cleanups indefinitely.
-                    self.utxo_cleanup_scan_needed = true;
+                    match &result {
+                        Ok(Ok(0)) => self.utxo_cleanup_retry.clear(),
+                        Ok(Ok(_)) => {
+                            self.utxo_cleanup_retry.clear();
+                            self.utxo_cleanup_scan_needed = true;
+                        }
+                        _ => {
+                            self.utxo_cleanup_retry.record_failure(
+                                garbage_collection::UtxoCleanupErrorKind::Failed,
+                                checkpoint_rx.borrow().timestamp_ms,
+                            );
+                            self.utxo_cleanup_scan_needed = true;
+                        }
+                    }
+                    Self::log_task_result("utxo_cleanup_gc", result);
                 }
                 Some(result) = OptionFuture::from(self.guardian_committee_reconcile_task.as_mut()) => {
                     self.guardian_committee_reconcile_task = None;
@@ -333,9 +340,9 @@ impl LeaderService {
         }
     }
 
-    fn log_task_result(label: &str, result: Result<anyhow::Result<()>, tokio::task::JoinError>) {
+    fn log_task_result<T>(label: &str, result: Result<anyhow::Result<T>, tokio::task::JoinError>) {
         match result {
-            Ok(Ok(())) => {}
+            Ok(Ok(_)) => {}
             Ok(Err(err)) => error!("{label} task failed: {err:#?}"),
             Err(err) if err.is_panic() => error!("{label} task panicked: {err}"),
             Err(err) => error!("{label} task failed to join: {err}"),

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -108,6 +108,7 @@ pub(crate) struct LeaderService {
     pending_utxo_cleanups: VecDeque<garbage_collection::PendingUtxoCleanup>,
     // Singleton task that cleans up spent withdrawal input UTXOs on-chain.
     utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    utxo_cleanup_retry: GlobalRetryTracker<garbage_collection::UtxoCleanupErrorKind>,
     // Forces a fresh scan for UTXO cleanup work after cleanup state changes.
     utxo_cleanup_scan_needed: bool,
 
@@ -148,6 +149,7 @@ impl LeaderService {
             proposal_gc_task: None,
             pending_utxo_cleanups: VecDeque::new(),
             utxo_cleanup_gc_task: None,
+            utxo_cleanup_retry: GlobalRetryTracker::new(),
             utxo_cleanup_scan_needed: true,
             guardian_committee_reconcile_task: None,
             last_guardian_reconcile_epoch: None,
@@ -243,7 +245,7 @@ impl LeaderService {
                     self.process_signed_withdrawal_txns();
                     self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
                     self.check_delete_proposals(checkpoint_timestamp_ms);
-                    self.check_cleanup_spent_utxos();
+                    self.check_cleanup_spent_utxos(checkpoint_timestamp_ms);
                     self.process_stale_unapproved_deposits_if_new_epoch();
                     self.process_approved_deposit_requests();
                 }
@@ -302,9 +304,19 @@ impl LeaderService {
                 }
                 Some(result) = OptionFuture::from(self.utxo_cleanup_gc_task.as_mut()) => {
                     self.utxo_cleanup_gc_task = None;
+                    match &result {
+                        Ok(Ok(())) => self.utxo_cleanup_retry.clear(),
+                        _ => self.utxo_cleanup_retry.record_failure(
+                            garbage_collection::UtxoCleanupErrorKind::Failed,
+                            checkpoint_rx.borrow().timestamp_ms,
+                        ),
+                    }
                     Self::log_task_result("utxo_cleanup_gc", result);
+                    // Re-arm the scan and leave rescheduling to the
+                    // leader-gated checkpoint arm: respawning here ran
+                    // ungated (leader or not) with no backoff, which kept a
+                    // node resubmitting cleanups indefinitely.
                     self.utxo_cleanup_scan_needed = true;
-                    self.check_cleanup_spent_utxos();
                 }
                 Some(result) = OptionFuture::from(self.guardian_committee_reconcile_task.as_mut()) => {
                     self.guardian_committee_reconcile_task = None;

--- a/crates/hashi/src/leader/withdrawal_transactions.rs
+++ b/crates/hashi/src/leader/withdrawal_transactions.rs
@@ -6,8 +6,6 @@ use super::LeaderService;
 use super::parse_member_signature;
 use crate::Hashi;
 use crate::btc_monitor::monitor::TxStatus;
-use crate::leader::garbage_collection::PendingUtxoCleanup;
-use crate::onchain::types::UtxoId;
 use crate::onchain::types::WithdrawalTransaction;
 use crate::sui_tx_executor::SuiTxExecutor;
 use crate::withdrawals::MpcInputSignaturesMessage;
@@ -40,7 +38,7 @@ use tracing::trace;
 use tracing::warn;
 
 pub(super) enum WithdrawalBroadcastOutcome {
-    ConfirmedOnSui { utxo_ids: Vec<UtxoId> },
+    ConfirmedOnSui,
     WaitForNextBitcoinBlock,
 }
 
@@ -1048,11 +1046,14 @@ impl LeaderService {
         result: WithdrawalBroadcastResult,
     ) -> anyhow::Result<()> {
         match result {
-            Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui { utxo_ids }) => {
+            Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui) => {
                 self.withdrawal_broadcast_retry_tracker
                     .clear(&withdrawal_id);
-                self.pending_utxo_cleanups
-                    .push_back(PendingUtxoCleanup { utxo_ids });
+                // The confirm tx marked the input UTXOs spent on-chain; arm
+                // the cleanup scan rather than queueing the ids — the scan
+                // re-reads on-chain state before paying for a cleanup, which
+                // keeps stale or duplicated ids from becoming no-op txs.
+                self.utxo_cleanup_scan_needed = true;
             }
             Ok(WithdrawalBroadcastOutcome::WaitForNextBitcoinBlock) => {
                 self.withdrawal_broadcast_retry_tracker
@@ -1107,7 +1108,6 @@ impl LeaderService {
                     confirmations,
                     "Withdrawal tx confirmed, proceeding to on-chain confirmation"
                 );
-                let utxo_ids: Vec<UtxoId> = txn.inputs.iter().map(|u| u.id).collect();
                 Self::confirm_withdrawal_on_sui(&inner, &txn)
                     .await
                     .map_err(|e| {
@@ -1116,7 +1116,7 @@ impl LeaderService {
                             e,
                         )
                     })?;
-                return Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui { utxo_ids });
+                return Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui);
             }
             Ok(TxStatus::Confirmed { confirmations }) => {
                 debug!(

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -212,6 +212,14 @@ impl OnchainState {
         self.0.state.write().unwrap()
     }
 
+    /// Prune UTXO records that a cleanup transaction has removed on-chain.
+    /// `cleanup_spent_utxos` emits no event the watcher could react to, so
+    /// the leader that executed the cleanup applies its effect to the local
+    /// mirror through this call.
+    pub(crate) fn remove_cleaned_utxo_records(&self, utxo_ids: &[types::UtxoId]) {
+        self.state_mut().hashi.utxo_pool.remove_cleaned(utxo_ids);
+    }
+
     pub fn subscribe_checkpoint(&self) -> watch::Receiver<CheckpointInfo> {
         self.0.checkpoint.subscribe()
     }

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -212,28 +212,33 @@ impl OnchainState {
         self.0.state.write().unwrap()
     }
 
-    /// Prune UTXO records that a cleanup transaction has removed on-chain.
-    /// `cleanup_spent_utxos` emits no event the watcher could react to, so
-    /// the leader that executed the cleanup applies its effect to the local
-    /// mirror through this call.
-    pub(crate) fn remove_cleaned_utxo_records(&self, utxo_ids: &[types::UtxoId]) {
-        self.state_mut().hashi.utxo_pool.remove_cleaned(utxo_ids);
-    }
-
-    /// Re-scrape the on-chain UTXO pool into the local mirror. The cleanup
-    /// GC calls this before submitting an orphan-scan batch: the mirror can
-    /// overstate pending cleanups (another leader's cleanup emits no event
-    /// the watcher could apply), and every overstated id becomes a paid
-    /// on-chain no-op. One table scan here is cheaper than paying to
-    /// re-clean records that are already gone.
-    pub(crate) async fn refresh_utxo_pool(&self) -> Result<()> {
+    /// Scrape the on-chain UTXO pool into a task-local snapshot for the
+    /// cleanup GC's use. Deliberately does NOT touch the shared mirror: the
+    /// watcher task is its sole writer, and installing an out-of-band
+    /// snapshot could revert mutations the watcher already applied from
+    /// newer checkpoints (e.g. a `spent_by` lock, whose loss would let coin
+    /// selection re-pick a locked input and pay for an aborted tx).
+    ///
+    /// The GC scans this snapshot instead of the mirror because the mirror
+    /// can overstate pending cleanups (`cleanup_spent_utxos` emits no event
+    /// the watcher could apply, so another leader's cleanup is invisible),
+    /// and every overstated id becomes a paid on-chain no-op. Errors if the
+    /// read is older than the watcher's checkpoint cursor (e.g. a
+    /// load-balanced endpoint serving a lagging fullnode) — the caller
+    /// should back off and retry rather than act on stale data.
+    pub(crate) async fn scrape_utxo_pool_snapshot(&self) -> Result<types::UtxoPool> {
         let client = self.client();
-        let bitcoin_state =
+        let (scrape_height, bitcoin_state) =
             fetch_bitcoin_state(client.clone(), self.hashi_id(), self.package_id_original())
                 .await?;
-        let utxo_pool = scrape_utxo_pool(client, bitcoin_state.utxo_pool).await?;
-        self.state_mut().hashi.utxo_pool = utxo_pool;
-        Ok(())
+        let watcher_height = self.latest_checkpoint_height();
+        if scrape_height < watcher_height {
+            anyhow::bail!(
+                "stale UTXO pool read: scrape at checkpoint {scrape_height} is behind the \
+                 watcher's cursor {watcher_height}"
+            );
+        }
+        scrape_utxo_pool(client, bitcoin_state.utxo_pool).await
     }
 
     pub fn subscribe_checkpoint(&self) -> watch::Receiver<CheckpointInfo> {
@@ -777,11 +782,13 @@ async fn scrape_package_versions(
 }
 
 /// Fetch the `BitcoinState` dynamic field hanging off the Hashi object.
+/// Returns the checkpoint height the response was served at alongside the
+/// state, so callers can judge the read's freshness.
 async fn fetch_bitcoin_state(
     mut client: Client,
     hashi_object_id: Address,
     package_id: Address,
-) -> Result<move_types::BitcoinState> {
+) -> Result<(u64, move_types::BitcoinState)> {
     let bitcoin_state_key = move_types::BitcoinStateKey { dummy_field: false };
     let bitcoin_state_key_type = TypeTag::Struct(Box::new(StructTag::new(
         package_id,
@@ -801,6 +808,9 @@ async fn fetch_bitcoin_state(
             ])),
         )
         .await?;
+    let checkpoint_height = bitcoin_state_response
+        .checkpoint_height()
+        .ok_or_else(|| anyhow!("response missing X_SUI_CHECKPOINT_HEIGHT header"))?;
     let bitcoin_state_field: move_types::Field<
         move_types::BitcoinStateKey,
         move_types::BitcoinState,
@@ -810,7 +820,7 @@ async fn fetch_bitcoin_state(
         .contents()
         .deserialize()
         .map_err(|e| anyhow!("failed to deserialize BitcoinState: {e}"))?;
-    Ok(bitcoin_state_field.value)
+    Ok((checkpoint_height, bitcoin_state_field.value))
 }
 
 async fn scrape_hashi(
@@ -852,7 +862,7 @@ async fn scrape_hashi(
         num_consumed_presigs,
     } = response.get_ref().object().contents().deserialize()?;
 
-    let bitcoin_state = fetch_bitcoin_state(client.clone(), id, package_id).await?;
+    let (_, bitcoin_state) = fetch_bitcoin_state(client.clone(), id, package_id).await?;
 
     let (
         member_info,

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -251,6 +251,11 @@ impl OnchainState {
         let utxo_records_id = bitcoin_state.utxo_pool.utxo_records.id;
         let mut records = BTreeMap::new();
         let mut page_token: Option<bytes::Bytes> = None;
+        // Monotonic floor over every height observed in this scrape,
+        // seeded by the wrapper read: heights must never move backward
+        // across responses, or a page could miss a cleanup that an
+        // earlier response's serving node had already seen.
+        let mut min_height = scrape_height;
         loop {
             let mut request = ListDynamicFieldsRequest::default()
                 .with_parent(utxo_records_id)
@@ -269,15 +274,18 @@ impl OnchainState {
             let page_height = response
                 .checkpoint_height()
                 .ok_or_else(|| anyhow!("response missing X_SUI_CHECKPOINT_HEIGHT header"))?;
-            // Re-sample the cursor: it advances while we paginate, and a
-            // page must not predate anything this node has already seen.
-            let watcher_height = self.latest_checkpoint_height();
-            if page_height < watcher_height {
+            // Re-sample the cursor (it advances while we paginate) and
+            // fold it into the floor: a page must not predate anything
+            // this node — or any earlier response in this scrape — has
+            // already seen.
+            min_height = min_height.max(self.latest_checkpoint_height());
+            if page_height < min_height {
                 anyhow::bail!(
-                    "stale UTXO pool read: page at checkpoint {page_height} is behind the \
-                     watcher's cursor {watcher_height}"
+                    "stale UTXO pool read: page at checkpoint {page_height} is behind \
+                     checkpoint {min_height} already observed by this scrape"
                 );
             }
+            min_height = page_height;
             let page = response.into_inner();
             for field in &page.dynamic_fields {
                 let record: types::UtxoRecord = field

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -103,6 +103,10 @@ struct Inner {
     /// Pinged by the watcher after a reconnect rescrape, so the reconcile
     /// loop can re-align the local limiter immediately.
     guardian_reconcile_notify: Arc<tokio::sync::Notify>,
+    /// Checkpoint floor for cleanup-GC scrapes: raised to the checkpoint of
+    /// each landed cleanup tx so the next scrape cannot be served state
+    /// from before it (the watcher cursor alone may lag that checkpoint).
+    utxo_scrape_floor: std::sync::atomic::AtomicU64,
     /// Cadence of the watcher's on-chain config poll.
     config_poll_interval: std::time::Duration,
 }
@@ -171,6 +175,7 @@ impl OnchainState {
             config_poll_interval: config_poll_interval.unwrap_or(std::time::Duration::from_millis(
                 crate::config::DEFAULT_ONCHAIN_CONFIG_POLL_INTERVAL_MS,
             )),
+            utxo_scrape_floor: std::sync::atomic::AtomicU64::new(0),
         }
         .pipe(Arc::new)
         .pipe(Self);
@@ -233,6 +238,15 @@ impl OnchainState {
     /// in a lagging fullnode) errors out so the caller backs off and
     /// retries rather than paying to re-clean records a fresh page would
     /// have shown as already gone.
+    /// Raise the cleanup-scrape freshness floor to `checkpoint` (monotonic).
+    /// Called after a cleanup tx lands so the next scrape cannot be served
+    /// pre-cleanup state and re-pay for records the tx already removed.
+    pub(crate) fn raise_utxo_scrape_floor(&self, checkpoint: u64) {
+        self.0
+            .utxo_scrape_floor
+            .fetch_max(checkpoint, std::sync::atomic::Ordering::Relaxed);
+    }
+
     pub(crate) async fn scrape_utxo_records_snapshot(
         &self,
     ) -> Result<BTreeMap<types::UtxoId, types::UtxoRecord>> {
@@ -240,11 +254,15 @@ impl OnchainState {
         let (scrape_height, bitcoin_state) =
             fetch_bitcoin_state(client.clone(), self.hashi_id(), self.package_id_original())
                 .await?;
-        let watcher_height = self.latest_checkpoint_height();
-        if scrape_height < watcher_height {
+        let floor = self
+            .0
+            .utxo_scrape_floor
+            .load(std::sync::atomic::Ordering::Relaxed)
+            .max(self.latest_checkpoint_height());
+        if scrape_height < floor {
             anyhow::bail!(
                 "stale UTXO pool read: scrape at checkpoint {scrape_height} is behind the \
-                 watcher's cursor {watcher_height}"
+                 freshness floor {floor}"
             );
         }
 
@@ -252,17 +270,24 @@ impl OnchainState {
         let mut records = BTreeMap::new();
         let mut page_token: Option<bytes::Bytes> = None;
         // Monotonic floor over every height observed in this scrape,
-        // seeded by the wrapper read: heights must never move backward
-        // across responses, or a page could miss a cleanup that an
-        // earlier response's serving node had already seen.
+        // seeded by the wrapper read (already >= the persistent floor):
+        // heights must never move backward across responses, or a page
+        // could miss a cleanup that an earlier response's serving node had
+        // already seen.
         let mut min_height = scrape_height;
         loop {
             let mut request = ListDynamicFieldsRequest::default()
                 .with_parent(utxo_records_id)
                 .with_page_size(SCRAPE_PAGE_SIZE)
-                .with_read_mask(FieldMask::from_paths([DynamicField::path_builder()
-                    .value()
-                    .finish()]));
+                .with_read_mask(FieldMask::from_paths([
+                    // `name` is load-bearing even though we only read
+                    // `value`: the fullnode's `should_load_field` does not
+                    // recognize a value-only mask and would return fields
+                    // with `value` unset (main's scrape_utxo_records
+                    // requests both for the same reason).
+                    DynamicField::path_builder().name().finish(),
+                    DynamicField::path_builder().value().finish(),
+                ]));
             if let Some(token) = page_token.take() {
                 request = request.with_page_token(token);
             }
@@ -281,8 +306,8 @@ impl OnchainState {
             min_height = min_height.max(self.latest_checkpoint_height());
             if page_height < min_height {
                 anyhow::bail!(
-                    "stale UTXO pool read: page at checkpoint {page_height} is behind \
-                     checkpoint {min_height} already observed by this scrape"
+                    "stale UTXO pool read: page at checkpoint {page_height} is behind the \
+                     freshness floor {min_height}"
                 );
             }
             min_height = page_height;

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -212,21 +212,30 @@ impl OnchainState {
         self.0.state.write().unwrap()
     }
 
-    /// Scrape the on-chain UTXO pool into a task-local snapshot for the
-    /// cleanup GC's use. Deliberately does NOT touch the shared mirror: the
-    /// watcher task is its sole writer, and installing an out-of-band
-    /// snapshot could revert mutations the watcher already applied from
-    /// newer checkpoints (e.g. a `spent_by` lock, whose loss would let coin
-    /// selection re-pick a locked input and pay for an aborted tx).
+    /// Scrape the on-chain `utxo_records` table into a task-local snapshot
+    /// for the cleanup GC's use. Deliberately does NOT touch the shared
+    /// mirror: the watcher task is its sole writer, and installing an
+    /// out-of-band snapshot could revert mutations the watcher already
+    /// applied from newer checkpoints (e.g. a `spent_by` lock, whose loss
+    /// would let coin selection re-pick a locked input and pay for an
+    /// aborted tx).
     ///
     /// The GC scans this snapshot instead of the mirror because the mirror
     /// can overstate pending cleanups (`cleanup_spent_utxos` emits no event
     /// the watcher could apply, so another leader's cleanup is invisible),
-    /// and every overstated id becomes a paid on-chain no-op. Errors if the
-    /// read is older than the watcher's checkpoint cursor (e.g. a
-    /// load-balanced endpoint serving a lagging fullnode) — the caller
-    /// should back off and retry rather than act on stale data.
-    pub(crate) async fn scrape_utxo_pool_snapshot(&self) -> Result<types::UtxoPool> {
+    /// and every overstated id becomes a paid on-chain no-op. Only
+    /// `utxo_records` is fetched — cleanup never consults the ever-growing
+    /// `spent_utxos` tombstone history.
+    ///
+    /// Every response — the `BitcoinState` wrapper AND each pagination page
+    /// — must be at or past the watcher's checkpoint cursor, re-sampled per
+    /// page; a page served behind it (e.g. a load-balanced endpoint mixing
+    /// in a lagging fullnode) errors out so the caller backs off and
+    /// retries rather than paying to re-clean records a fresh page would
+    /// have shown as already gone.
+    pub(crate) async fn scrape_utxo_records_snapshot(
+        &self,
+    ) -> Result<BTreeMap<types::UtxoId, types::UtxoRecord>> {
         let client = self.client();
         let (scrape_height, bitcoin_state) =
             fetch_bitcoin_state(client.clone(), self.hashi_id(), self.package_id_original())
@@ -238,7 +247,51 @@ impl OnchainState {
                  watcher's cursor {watcher_height}"
             );
         }
-        scrape_utxo_pool(client, bitcoin_state.utxo_pool).await
+
+        let utxo_records_id = bitcoin_state.utxo_pool.utxo_records.id;
+        let mut records = BTreeMap::new();
+        let mut page_token: Option<bytes::Bytes> = None;
+        loop {
+            let mut request = ListDynamicFieldsRequest::default()
+                .with_parent(utxo_records_id)
+                .with_page_size(SCRAPE_PAGE_SIZE)
+                .with_read_mask(FieldMask::from_paths([DynamicField::path_builder()
+                    .value()
+                    .finish()]));
+            if let Some(token) = page_token.take() {
+                request = request.with_page_token(token);
+            }
+            let response = client
+                .clone()
+                .state_client()
+                .list_dynamic_fields(request)
+                .await?;
+            let page_height = response
+                .checkpoint_height()
+                .ok_or_else(|| anyhow!("response missing X_SUI_CHECKPOINT_HEIGHT header"))?;
+            // Re-sample the cursor: it advances while we paginate, and a
+            // page must not predate anything this node has already seen.
+            let watcher_height = self.latest_checkpoint_height();
+            if page_height < watcher_height {
+                anyhow::bail!(
+                    "stale UTXO pool read: page at checkpoint {page_height} is behind the \
+                     watcher's cursor {watcher_height}"
+                );
+            }
+            let page = response.into_inner();
+            for field in &page.dynamic_fields {
+                let record: types::UtxoRecord = field
+                    .value()
+                    .deserialize()
+                    .map_err(|e| anyhow!("failed to deserialize UtxoRecord: {e}"))?;
+                records.insert(record.utxo.id, record);
+            }
+            match page.next_page_token {
+                Some(token) => page_token = Some(token),
+                None => break,
+            }
+        }
+        Ok(records)
     }
 
     pub fn subscribe_checkpoint(&self) -> watch::Receiver<CheckpointInfo> {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -220,6 +220,22 @@ impl OnchainState {
         self.state_mut().hashi.utxo_pool.remove_cleaned(utxo_ids);
     }
 
+    /// Re-scrape the on-chain UTXO pool into the local mirror. The cleanup
+    /// GC calls this before submitting an orphan-scan batch: the mirror can
+    /// overstate pending cleanups (another leader's cleanup emits no event
+    /// the watcher could apply), and every overstated id becomes a paid
+    /// on-chain no-op. One table scan here is cheaper than paying to
+    /// re-clean records that are already gone.
+    pub(crate) async fn refresh_utxo_pool(&self) -> Result<()> {
+        let client = self.client();
+        let bitcoin_state =
+            fetch_bitcoin_state(client.clone(), self.hashi_id(), self.package_id_original())
+                .await?;
+        let utxo_pool = scrape_utxo_pool(client, bitcoin_state.utxo_pool).await?;
+        self.state_mut().hashi.utxo_pool = utxo_pool;
+        Ok(())
+    }
+
     pub fn subscribe_checkpoint(&self) -> watch::Receiver<CheckpointInfo> {
         self.0.checkpoint.subscribe()
     }
@@ -760,6 +776,43 @@ async fn scrape_package_versions(
     Ok(package_versions)
 }
 
+/// Fetch the `BitcoinState` dynamic field hanging off the Hashi object.
+async fn fetch_bitcoin_state(
+    mut client: Client,
+    hashi_object_id: Address,
+    package_id: Address,
+) -> Result<move_types::BitcoinState> {
+    let bitcoin_state_key = move_types::BitcoinStateKey { dummy_field: false };
+    let bitcoin_state_key_type = TypeTag::Struct(Box::new(StructTag::new(
+        package_id,
+        Identifier::from_static("bitcoin_state"),
+        Identifier::from_static("BitcoinStateKey"),
+        vec![],
+    )));
+    let bitcoin_state_field_id = hashi_object_id.derive_dynamic_child_id(
+        &bitcoin_state_key_type,
+        &bitcoin_state_key.to_bcs().unwrap(),
+    );
+    let bitcoin_state_response = client
+        .ledger_client()
+        .get_object(
+            GetObjectRequest::new(&bitcoin_state_field_id).with_read_mask(FieldMask::from_paths([
+                Object::path_builder().contents().finish(),
+            ])),
+        )
+        .await?;
+    let bitcoin_state_field: move_types::Field<
+        move_types::BitcoinStateKey,
+        move_types::BitcoinState,
+    > = bitcoin_state_response
+        .into_inner()
+        .object()
+        .contents()
+        .deserialize()
+        .map_err(|e| anyhow!("failed to deserialize BitcoinState: {e}"))?;
+    Ok(bitcoin_state_field.value)
+}
+
 async fn scrape_hashi(
     mut client: Client,
     hashi_object_id: Address,
@@ -799,36 +852,7 @@ async fn scrape_hashi(
         num_consumed_presigs,
     } = response.get_ref().object().contents().deserialize()?;
 
-    // Fetch BitcoinState from dynamic field on Hashi
-    let bitcoin_state_key = move_types::BitcoinStateKey { dummy_field: false };
-    let bitcoin_state_key_type = TypeTag::Struct(Box::new(StructTag::new(
-        package_id,
-        Identifier::from_static("bitcoin_state"),
-        Identifier::from_static("BitcoinStateKey"),
-        vec![],
-    )));
-    let bitcoin_state_field_id = id.derive_dynamic_child_id(
-        &bitcoin_state_key_type,
-        &bitcoin_state_key.to_bcs().unwrap(),
-    );
-    let bitcoin_state_response = client
-        .ledger_client()
-        .get_object(
-            GetObjectRequest::new(&bitcoin_state_field_id).with_read_mask(FieldMask::from_paths([
-                Object::path_builder().contents().finish(),
-            ])),
-        )
-        .await?;
-    let bitcoin_state_field: move_types::Field<
-        move_types::BitcoinStateKey,
-        move_types::BitcoinState,
-    > = bitcoin_state_response
-        .into_inner()
-        .object()
-        .contents()
-        .deserialize()
-        .map_err(|e| anyhow!("failed to deserialize BitcoinState: {e}"))?;
-    let bitcoin_state = bitcoin_state_field.value;
+    let bitcoin_state = fetch_bitcoin_state(client.clone(), id, package_id).await?;
 
     let (
         member_info,

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -752,21 +752,6 @@ impl UtxoPool {
     pub fn spent_utxos(&self) -> &BTreeMap<UtxoId, u64> {
         &self.spent_utxos
     }
-
-    /// Apply a successful on-chain `cleanup_spent_utxos` to the local mirror:
-    /// drop the records and tombstone them in `spent_utxos`. The Move call
-    /// emits no event, so the executor that lands the cleanup must apply it
-    /// here — a stale record would be rediscovered by the orphan scan and
-    /// re-cleaned as a paid no-op forever.
-    pub(crate) fn remove_cleaned(&mut self, utxo_ids: &[UtxoId]) {
-        for id in utxo_ids {
-            if let Some(record) = self.utxo_records.remove(id)
-                && let Some(epoch) = record.spent_epoch
-            {
-                self.spent_utxos.insert(*id, epoch);
-            }
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -911,61 +896,5 @@ mod tests {
     fn previous_committee_for_target_returns_none_when_no_earlier_committee() {
         let set = set_with(3, None, &[3]);
         assert_eq!(set.previous_committee_for_target(3).map(|(e, _)| e), None);
-    }
-
-    fn test_utxo_id(byte: u8) -> UtxoId {
-        let mut bytes = [0u8; 32];
-        bytes[0] = byte;
-        UtxoId {
-            txid: hashi_types::bitcoin_txid::BitcoinTxid::new(bytes),
-            vout: 0,
-        }
-    }
-
-    fn test_utxo_record(spent_epoch: Option<u64>) -> UtxoRecord {
-        UtxoRecord {
-            utxo: Utxo {
-                id: test_utxo_id(0),
-                amount: 1_000,
-                derivation_path: None,
-            },
-            produced_by: None,
-            spent_by: None,
-            spent_epoch,
-        }
-    }
-
-    fn utxo_pool(records: Vec<(UtxoId, UtxoRecord)>) -> UtxoPool {
-        UtxoPool {
-            utxo_records_id: Address::new([0u8; 32]),
-            utxo_records: records.into_iter().collect(),
-            spent_utxos_id: Address::new([0u8; 32]),
-            spent_utxos: BTreeMap::new(),
-        }
-    }
-
-    #[test]
-    fn remove_cleaned_drops_records_and_tombstones_them() {
-        let mut pool = utxo_pool(vec![
-            (test_utxo_id(1), test_utxo_record(Some(7))),
-            (test_utxo_id(2), test_utxo_record(None)),
-        ]);
-
-        pool.remove_cleaned(&[test_utxo_id(1)]);
-
-        assert!(!pool.utxo_records.contains_key(&test_utxo_id(1)));
-        assert!(pool.utxo_records.contains_key(&test_utxo_id(2)));
-        assert_eq!(pool.spent_utxos.get(&test_utxo_id(1)), Some(&7));
-    }
-
-    #[test]
-    fn remove_cleaned_is_idempotent_for_absent_records() {
-        let mut pool = utxo_pool(vec![(test_utxo_id(1), test_utxo_record(Some(3)))]);
-
-        pool.remove_cleaned(&[test_utxo_id(1)]);
-        pool.remove_cleaned(&[test_utxo_id(1), test_utxo_id(9)]);
-
-        assert!(pool.utxo_records.is_empty());
-        assert_eq!(pool.spent_utxos.len(), 1);
     }
 }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -752,6 +752,21 @@ impl UtxoPool {
     pub fn spent_utxos(&self) -> &BTreeMap<UtxoId, u64> {
         &self.spent_utxos
     }
+
+    /// Apply a successful on-chain `cleanup_spent_utxos` to the local mirror:
+    /// drop the records and tombstone them in `spent_utxos`. The Move call
+    /// emits no event, so the executor that lands the cleanup must apply it
+    /// here — a stale record would be rediscovered by the orphan scan and
+    /// re-cleaned as a paid no-op forever.
+    pub(crate) fn remove_cleaned(&mut self, utxo_ids: &[UtxoId]) {
+        for id in utxo_ids {
+            if let Some(record) = self.utxo_records.remove(id)
+                && let Some(epoch) = record.spent_epoch
+            {
+                self.spent_utxos.insert(*id, epoch);
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -896,5 +911,61 @@ mod tests {
     fn previous_committee_for_target_returns_none_when_no_earlier_committee() {
         let set = set_with(3, None, &[3]);
         assert_eq!(set.previous_committee_for_target(3).map(|(e, _)| e), None);
+    }
+
+    fn test_utxo_id(byte: u8) -> UtxoId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = byte;
+        UtxoId {
+            txid: hashi_types::bitcoin_txid::BitcoinTxid::new(bytes),
+            vout: 0,
+        }
+    }
+
+    fn test_utxo_record(spent_epoch: Option<u64>) -> UtxoRecord {
+        UtxoRecord {
+            utxo: Utxo {
+                id: test_utxo_id(0),
+                amount: 1_000,
+                derivation_path: None,
+            },
+            produced_by: None,
+            spent_by: None,
+            spent_epoch,
+        }
+    }
+
+    fn utxo_pool(records: Vec<(UtxoId, UtxoRecord)>) -> UtxoPool {
+        UtxoPool {
+            utxo_records_id: Address::new([0u8; 32]),
+            utxo_records: records.into_iter().collect(),
+            spent_utxos_id: Address::new([0u8; 32]),
+            spent_utxos: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn remove_cleaned_drops_records_and_tombstones_them() {
+        let mut pool = utxo_pool(vec![
+            (test_utxo_id(1), test_utxo_record(Some(7))),
+            (test_utxo_id(2), test_utxo_record(None)),
+        ]);
+
+        pool.remove_cleaned(&[test_utxo_id(1)]);
+
+        assert!(!pool.utxo_records.contains_key(&test_utxo_id(1)));
+        assert!(pool.utxo_records.contains_key(&test_utxo_id(2)));
+        assert_eq!(pool.spent_utxos.get(&test_utxo_id(1)), Some(&7));
+    }
+
+    #[test]
+    fn remove_cleaned_is_idempotent_for_absent_records() {
+        let mut pool = utxo_pool(vec![(test_utxo_id(1), test_utxo_record(Some(3)))]);
+
+        pool.remove_cleaned(&[test_utxo_id(1)]);
+        pool.remove_cleaned(&[test_utxo_id(1), test_utxo_id(9)]);
+
+        assert!(pool.utxo_records.is_empty());
+        assert_eq!(pool.spent_utxos.len(), 1);
     }
 }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -685,8 +685,12 @@ async fn handle_events(
                     // Promote the change UTXOs from pending to confirmed by
                     // clearing `produced_by`. The UTXOs were already inserted at
                     // commit time; input UTXOs are marked spent via UtxoSpent
-                    // and pruned from the mirror when the leader's cleanup
-                    // transaction lands.
+                    // and their records then stay in the mirror until a full
+                    // rescrape (reconnect or restart) — nothing prunes them.
+                    // The cleanup GC deliberately decides from a fresh chain
+                    // snapshot rather than these records, so the staleness is
+                    // cosmetic (spent_by stays set, excluding them from coin
+                    // selection).
                     for change_utxo_id in &event.change_utxo_ids {
                         if let Some(record) =
                             state.hashi.utxo_pool.utxo_records.get_mut(change_utxo_id)

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -684,7 +684,9 @@ async fn handle_events(
 
                     // Promote the change UTXOs from pending to confirmed by
                     // clearing `produced_by`. The UTXOs were already inserted at
-                    // commit time; input UTXOs are removed via UtxoSpent.
+                    // commit time; input UTXOs are marked spent via UtxoSpent
+                    // and pruned from the mirror when the leader's cleanup
+                    // transaction lands.
                     for change_utxo_id in &event.change_utxo_ids {
                         if let Some(record) =
                             state.hashi.utxo_pool.utxo_records.get_mut(change_utxo_id)

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1611,9 +1611,15 @@ impl SuiTxExecutor {
         skip_all,
         fields(utxo_count = utxo_ids.len()),
     )]
-    pub async fn execute_cleanup_spent_utxos(&mut self, utxo_ids: &[UtxoId]) -> anyhow::Result<()> {
+    /// Returns the highest checkpoint the cleanup transactions landed in,
+    /// so the caller can floor subsequent freshness checks past them.
+    pub async fn execute_cleanup_spent_utxos(
+        &mut self,
+        utxo_ids: &[UtxoId],
+    ) -> anyhow::Result<u64> {
         const MAX_PER_TX: usize = 400;
 
+        let mut max_checkpoint = 0;
         for chunk in utxo_ids.chunks(MAX_PER_TX) {
             let mut builder = TransactionBuilder::new();
             let hashi_arg = builder.object(
@@ -1663,8 +1669,12 @@ impl SuiTxExecutor {
                     response.transaction().effects().status()
                 );
             }
+            let checkpoint = response.transaction().checkpoint_opt().ok_or_else(|| {
+                anyhow::anyhow!("cleanup_spent_utxos response missing checkpoint")
+            })?;
+            max_checkpoint = max_checkpoint.max(checkpoint);
         }
-        Ok(())
+        Ok(max_checkpoint)
     }
 }
 


### PR DESCRIPTION
## Summary

Root-cause fix for the 7/17 gas-drain incident: at least four validators were each burning ~10 SUI/hour submitting successful **no-op** `withdraw::cleanup_spent_utxos` transactions in a tight loop (~45 tx/min, 16k txs/day from one address, 34 SUI/day).

## Root cause

Three-layer interaction:
1. `utxo_pool::cleanup_spent` emits no event, so a successful cleanup is invisible to the watcher.
2. The watcher never removes entries from the local `utxo_records` mirror (a comment claimed `UtxoSpent` removes them; it only marks them).
3. The leader's task-completion arm respawned the cleanup unconditionally — ungated by leadership, no backoff. First real cleanup succeeds → mirror still shows the records → scan rediscovers the same set → resubmit as a paid no-op, at transaction round-trip speed, forever.

## Fix — final design

One principle: **never pay for a cleanup the chain doesn't currently show as needed, and never write the shared mirror from outside the watcher.**

- The GC task builds a **task-local snapshot** of the on-chain `utxo_records` table (`scrape_utxo_records_snapshot`) — only that table, not the unbounded `spent_utxos` history — scans it for spent-but-uncleaned records (500/GC cap), submits, and returns the count. **The shared mirror is never written**; the watcher remains its sole writer.
- **Freshness is enforced on every response**: the `BitcoinState` wrapper read and each manually-paginated `ListDynamicFields` page must be at or past a monotonic height floor (seeded from the wrapper's `X_SUI_CHECKPOINT_HEIGHT`, folded with the re-sampled watcher cursor per page, raised by each accepted page). Any backward height bails into backoff — heights can only move forward through a scrape.
- **Scheduling**: spawn only from the leader-gated checkpoint arm, gated by an armed-scan flag (armed at boot, on withdrawal ConfirmedOnSui, and after a task that did work or failed), single-flight, with exponential failure backoff (5s → 5min cap, never giving up permanently — a drained wallet heals by top-up). A barren scan disarms until the next withdrawal confirms.

## Verification

- Adversarially reviewed across four passes (state-machine exhaustion, rotation races, failure-path cadence, mixed-fleet deployment): no unbounded gas or RPC path exists; every re-arm leads to a fresh chain read whose empty result disarms. Residuals are bounded: ≤2 no-op txs (~7.4 mSUI) per rotation/boot race episode; failure loops are gas-free (dry-run precedes signing).
- Unit tests cover the scan filter and cap; 74 utxo tests + clippy + fmt green.
- Known follow-up: no e2e exercises the leader GC loop end-to-end (pre-existing gap).

## Deployment

Ships alone against the current package (no Move changes). The fix is **per-process**: every validator must upgrade **and restart** — an unrestarted node keeps draining ~10 SUI/hr once it has held leadership after a withdrawal wave. Restart before topping up gas wallets (for upgraded nodes, top-up order is irrelevant). Serve validator RPC from a height-consistent source; the log signatures to alert on are repeated `Cleaning up spent UTXO(s) pending cleanup` with non-decreasing counts and repeated `stale UTXO pool read` errors.