### PR TITLE
Emit UtxoCleaned from cleanup_spent so every node prunes its mirror

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -841,6 +841,7 @@ pub enum HashiEvent {
     WithdrawalPresigsReassigned(WithdrawalPresigsReassigned),
     WithdrawalConfirmed(WithdrawalConfirmed),
     UtxoSpent(UtxoSpent),
+    UtxoCleaned(UtxoCleaned),
     ReconfigStarted(ReconfigStarted),
     ReconfigEnded(ReconfigEnded),
 }
@@ -890,6 +891,7 @@ impl HashiEvent {
             }
             WithdrawalConfirmed::MODULE_NAME => WithdrawalConfirmed::from_bcs(bcs.value())?.into(),
             UtxoSpent::MODULE_NAME => UtxoSpent::from_bcs(bcs.value())?.into(),
+            UtxoCleaned::MODULE_NAME => UtxoCleaned::from_bcs(bcs.value())?.into(),
             ReconfigStarted::MODULE_NAME => ReconfigStarted::from_bcs(bcs.value())?.into(),
             ReconfigEnded::MODULE_NAME => ReconfigEnded::from_bcs(bcs.value())?.into(),
             PackageUpgraded::MODULE_NAME => PackageUpgraded::from_bcs(bcs.value())?.into(),
@@ -1425,6 +1427,23 @@ pub struct UtxoSpent {
 impl MoveType for UtxoSpent {
     const MODULE: &'static str = "utxo_pool";
     const NAME: &'static str = "UtxoSpent";
+}
+
+#[derive(Debug, serde_derive::Deserialize)]
+pub struct UtxoCleaned {
+    pub utxo_id: UtxoId,
+    pub spent_epoch: u64,
+}
+
+impl MoveType for UtxoCleaned {
+    const MODULE: &'static str = "utxo_pool";
+    const NAME: &'static str = "UtxoCleaned";
+}
+
+impl From<UtxoCleaned> for HashiEvent {
+    fn from(value: UtxoCleaned) -> Self {
+        Self::UtxoCleaned(value)
+    }
 }
 
 impl From<UtxoSpent> for HashiEvent {

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -34,6 +34,33 @@ const PROPOSAL_DELETE_DELAY_MS: u64 = 1000 * 60 * 60 * 24; // 1 day
 // Mirrors `MAX_DEPOSIT_REQUEST_DELETIONS_PER_GC`.
 const MAX_PROPOSAL_DELETIONS_PER_GC: usize = 500;
 
+// Cap the orphan scan so one cleanup task stays bounded; a larger backlog
+// drains over successive checkpoints. Mirrors the two caps above.
+const MAX_UTXO_CLEANUPS_PER_GC: usize = 500;
+
+/// Failure kind for the UTXO cleanup GC. `max_retries` is unbounded: this is
+/// a singleton maintenance task that must never permanently give up (a
+/// drained gas wallet can heal by top-up), so it backs off to `max_delay_ms`
+/// instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum UtxoCleanupErrorKind {
+    Failed,
+}
+
+impl crate::leader::retry::RetryPolicy for UtxoCleanupErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        5_000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        5 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
+    }
+}
+
 impl LeaderService {
     /// Check for and delete expired deposit requests.
     /// Deposit requests are sorted by timestamp and deleted if they are older than
@@ -150,9 +177,14 @@ impl LeaderService {
     /// scans on-chain state for orphaned locked UTXOs whose withdrawal has
     /// already been confirmed (handles the crash-between-confirm-and-cleanup
     /// case).
-    pub(super) fn check_cleanup_spent_utxos(&mut self) {
+    pub(super) fn check_cleanup_spent_utxos(&mut self, checkpoint_timestamp_ms: u64) {
         if self.utxo_cleanup_gc_task.is_some() {
             debug!("UTXO cleanup GC task already in-flight, skipping");
+            return;
+        }
+
+        if self.utxo_cleanup_retry.should_skip(checkpoint_timestamp_ms) {
+            debug!("UTXO cleanup GC in backoff, skipping");
             return;
         }
 
@@ -201,10 +233,16 @@ impl LeaderService {
         inner: Arc<crate::Hashi>,
         cleanup: PendingUtxoCleanup,
     ) -> anyhow::Result<()> {
-        let mut executor = SuiTxExecutor::from_hashi(inner)?;
+        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
         executor
             .execute_cleanup_spent_utxos(&cleanup.utxo_ids)
             .await?;
+        // The Move call emits no event, so the watcher can't prune these
+        // records; without this the orphan scan rediscovers the same set and
+        // re-cleans it as a paid no-op forever.
+        inner
+            .onchain_state()
+            .remove_cleaned_utxo_records(&cleanup.utxo_ids);
         info!(
             utxo_count = cleanup.utxo_ids.len(),
             "Successfully cleaned up spent UTXOs",
@@ -323,6 +361,8 @@ impl LeaderService {
 
 /// Return UTXO IDs whose `spent_epoch` is set — these are spent UTXOs
 /// still present in `utxo_records` that need to be cleaned up on-chain.
+/// Capped at [`MAX_UTXO_CLEANUPS_PER_GC`]; the remainder is picked up by a
+/// later scan.
 ///
 /// This is the pure-data core of [`LeaderService::discover_orphaned_utxo_cleanups`],
 /// extracted so it can be unit-tested without constructing a full `LeaderService`.
@@ -331,6 +371,7 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
         .iter()
         .filter(|(_, record)| record.spent_epoch.is_some())
         .map(|(id, _)| *id)
+        .take(MAX_UTXO_CLEANUPS_PER_GC)
         .collect()
 }
 
@@ -417,5 +458,15 @@ mod tests {
 
         let result = find_spent_utxos_pending_cleanup(&utxo_records);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_is_capped_per_gc() {
+        let utxo_records: BTreeMap<UtxoId, UtxoRecord> = (0..MAX_UTXO_CLEANUPS_PER_GC as u32 + 7)
+            .map(|i| (utxo_id((i % 251) as u8, i), record(Some(1))))
+            .collect();
+
+        let result = find_spent_utxos_pending_cleanup(&utxo_records);
+        assert_eq!(result.len(), MAX_UTXO_CLEANUPS_PER_GC);
     }
 }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -18,10 +18,6 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 
-pub(super) struct PendingUtxoCleanup {
-    pub(super) utxo_ids: Vec<UtxoId>,
-}
-
 const MAX_DEPOSIT_REQUEST_AGE_MS: u64 = 1000 * 60 * 60 * 24; // 1 day
 const DEPOSIT_REQUEST_DELETE_DELAY_MS: u64 = 1000 * 60; // 1 minute
 const MAX_DEPOSIT_REQUEST_DELETIONS_PER_GC: usize = 500;
@@ -172,14 +168,18 @@ impl LeaderService {
         })));
     }
 
-    /// If there are pending UTXO cleanups and no task in-flight, spawn a
-    /// background task to process the next one. When the queue is empty,
-    /// scans on-chain state for orphaned locked UTXOs whose withdrawal has
-    /// already been confirmed (handles the crash-between-confirm-and-cleanup
-    /// case).
+    /// If a cleanup scan is due and no task is in-flight, spawn a background
+    /// task that refreshes the UTXO-pool mirror from chain, scans it for
+    /// spent-but-uncleaned records, and cleans them. The scan is armed at
+    /// boot (crash-between-confirm-and-cleanup recovery), whenever a
+    /// withdrawal confirms on Sui, and after a task that did work or failed.
     pub(super) fn check_cleanup_spent_utxos(&mut self, checkpoint_timestamp_ms: u64) {
         if self.utxo_cleanup_gc_task.is_some() {
             debug!("UTXO cleanup GC task already in-flight, skipping");
+            return;
+        }
+
+        if !self.utxo_cleanup_scan_needed {
             return;
         }
 
@@ -188,66 +188,48 @@ impl LeaderService {
             return;
         }
 
-        if self.pending_utxo_cleanups.is_empty() && self.utxo_cleanup_scan_needed {
-            self.discover_orphaned_utxo_cleanups();
-            if self.pending_utxo_cleanups.is_empty() {
-                self.utxo_cleanup_scan_needed = false;
-            }
-        }
-
-        let Some(cleanup) = self.pending_utxo_cleanups.pop_front() else {
-            return;
-        };
-
-        info!(
-            utxo_count = cleanup.utxo_ids.len(),
-            "Scheduling UTXO cleanup for spent UTXOs",
-        );
-
+        self.utxo_cleanup_scan_needed = false;
         let inner = self.inner.clone();
         self.utxo_cleanup_gc_task = Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
-            Self::cleanup_spent_utxos(inner, cleanup).await
+            Self::cleanup_spent_utxos(inner).await
         })));
     }
 
-    /// Scan local state for UTXOs with `spent_epoch` set — they have been
-    /// spent but their cleanup never ran (e.g. leader crashed).
-    fn discover_orphaned_utxo_cleanups(&mut self) {
-        let state = self.inner.onchain_state().state();
-        let utxo_records = state.hashi().utxo_pool.utxo_records();
+    /// Refresh the UTXO-pool mirror from chain, then clean every record the
+    /// refreshed mirror still shows as spent-but-uncleaned. Returns how many
+    /// UTXOs were cleaned so the caller can decide whether to re-arm the
+    /// scan (more work may exist past the per-GC cap).
+    ///
+    /// The refresh is what makes the tx worth paying for: the mirror
+    /// overstates pending cleanups whenever another leader cleaned records
+    /// (their prune is local to them), and submitting from a stale mirror
+    /// re-cleans those records as paid on-chain no-ops.
+    async fn cleanup_spent_utxos(inner: Arc<crate::Hashi>) -> anyhow::Result<usize> {
+        inner.onchain_state().refresh_utxo_pool().await?;
 
-        let orphaned_ids = find_spent_utxos_pending_cleanup(utxo_records);
-
-        if !orphaned_ids.is_empty() {
-            info!(
-                "Discovered {} spent UTXO(s) pending cleanup",
-                orphaned_ids.len(),
-            );
-            self.pending_utxo_cleanups.push_back(PendingUtxoCleanup {
-                utxo_ids: orphaned_ids,
-            });
+        let utxo_ids = {
+            let state = inner.onchain_state().state();
+            find_spent_utxos_pending_cleanup(state.hashi().utxo_pool.utxo_records())
+        };
+        if utxo_ids.is_empty() {
+            return Ok(0);
         }
-    }
 
-    async fn cleanup_spent_utxos(
-        inner: Arc<crate::Hashi>,
-        cleanup: PendingUtxoCleanup,
-    ) -> anyhow::Result<()> {
-        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
-        executor
-            .execute_cleanup_spent_utxos(&cleanup.utxo_ids)
-            .await?;
-        // The Move call emits no event, so the watcher can't prune these
-        // records; without this the orphan scan rediscovers the same set and
-        // re-cleans it as a paid no-op forever.
-        inner
-            .onchain_state()
-            .remove_cleaned_utxo_records(&cleanup.utxo_ids);
         info!(
-            utxo_count = cleanup.utxo_ids.len(),
+            utxo_count = utxo_ids.len(),
+            "Cleaning up spent UTXO(s) pending cleanup",
+        );
+        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
+        // The Move call emits no event, so the watcher can't prune these
+        // records; apply the cleanup to the local mirror here so the next
+        // scan doesn't rediscover and re-pay for the same set.
+        inner.onchain_state().remove_cleaned_utxo_records(&utxo_ids);
+        info!(
+            utxo_count = utxo_ids.len(),
             "Successfully cleaned up spent UTXOs",
         );
-        Ok(())
+        Ok(utxo_ids.len())
     }
 
     async fn delete_expired_proposals(

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -195,22 +195,20 @@ impl LeaderService {
         })));
     }
 
-    /// Refresh the UTXO-pool mirror from chain, then clean every record the
-    /// refreshed mirror still shows as spent-but-uncleaned. Returns how many
+    /// Scrape a fresh task-local snapshot of the on-chain UTXO pool, then
+    /// clean every record it shows as spent-but-uncleaned. Returns how many
     /// UTXOs were cleaned so the caller can decide whether to re-arm the
     /// scan (more work may exist past the per-GC cap).
     ///
-    /// The refresh is what makes the tx worth paying for: the mirror
-    /// overstates pending cleanups whenever another leader cleaned records
-    /// (their prune is local to them), and submitting from a stale mirror
-    /// re-cleans those records as paid on-chain no-ops.
+    /// Deciding from a fresh chain read — never from the shared mirror — is
+    /// what makes the tx worth paying for: the mirror overstates pending
+    /// cleanups whenever another leader cleaned records (`cleanup_spent`
+    /// emits no event), and submitting from it re-cleans those records as
+    /// paid on-chain no-ops. The mirror itself is left untouched; the
+    /// watcher task is its sole writer.
     async fn cleanup_spent_utxos(inner: Arc<crate::Hashi>) -> anyhow::Result<usize> {
-        inner.onchain_state().refresh_utxo_pool().await?;
-
-        let utxo_ids = {
-            let state = inner.onchain_state().state();
-            find_spent_utxos_pending_cleanup(state.hashi().utxo_pool.utxo_records())
-        };
+        let pool = inner.onchain_state().scrape_utxo_pool_snapshot().await?;
+        let utxo_ids = find_spent_utxos_pending_cleanup(pool.utxo_records());
         if utxo_ids.is_empty() {
             return Ok(0);
         }
@@ -219,12 +217,8 @@ impl LeaderService {
             utxo_count = utxo_ids.len(),
             "Cleaning up spent UTXO(s) pending cleanup",
         );
-        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        let mut executor = SuiTxExecutor::from_hashi(inner)?;
         executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
-        // The Move call emits no event, so the watcher can't prune these
-        // records; apply the cleanup to the local mirror here so the next
-        // scan doesn't rediscover and re-pay for the same set.
-        inner.onchain_state().remove_cleaned_utxo_records(&utxo_ids);
         info!(
             utxo_count = utxo_ids.len(),
             "Successfully cleaned up spent UTXOs",

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -29,7 +29,6 @@ use futures::future::OptionFuture;
 use hashi_types::committee::MemberSignature;
 use hashi_types::proto::bridge_service_client::BridgeServiceClient;
 use std::collections::HashSet;
-use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -104,12 +103,12 @@ pub(crate) struct LeaderService {
     // Singleton task that deletes stale governance proposals.
     proposal_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
 
-    // UTXO cleanup requests discovered after withdrawals are confirmed on Sui.
-    pending_utxo_cleanups: VecDeque<garbage_collection::PendingUtxoCleanup>,
-    // Singleton task that cleans up spent withdrawal input UTXOs on-chain.
-    utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    // Singleton task that cleans up spent withdrawal input UTXOs on-chain;
+    // resolves to how many UTXOs it cleaned.
+    utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<usize>>>,
     utxo_cleanup_retry: GlobalRetryTracker<garbage_collection::UtxoCleanupErrorKind>,
-    // Forces a fresh scan for UTXO cleanup work after cleanup state changes.
+    // Arms the cleanup scan: set at boot (crash recovery), when a withdrawal
+    // confirms on Sui, and after a cleanup task that did work or failed.
     utxo_cleanup_scan_needed: bool,
 
     // Singleton task that reconciles the guardian committee with the on-chain committee.
@@ -147,7 +146,6 @@ impl LeaderService {
             approved_deposit_retry_tracker: RetryTracker::new(),
             deposit_gc_task: None,
             proposal_gc_task: None,
-            pending_utxo_cleanups: VecDeque::new(),
             utxo_cleanup_gc_task: None,
             utxo_cleanup_retry: GlobalRetryTracker::new(),
             utxo_cleanup_scan_needed: true,
@@ -304,19 +302,28 @@ impl LeaderService {
                 }
                 Some(result) = OptionFuture::from(self.utxo_cleanup_gc_task.as_mut()) => {
                     self.utxo_cleanup_gc_task = None;
-                    match &result {
-                        Ok(Ok(())) => self.utxo_cleanup_retry.clear(),
-                        _ => self.utxo_cleanup_retry.record_failure(
-                            garbage_collection::UtxoCleanupErrorKind::Failed,
-                            checkpoint_rx.borrow().timestamp_ms,
-                        ),
-                    }
-                    Self::log_task_result("utxo_cleanup_gc", result);
-                    // Re-arm the scan and leave rescheduling to the
-                    // leader-gated checkpoint arm: respawning here ran
+                    // Re-arm the scan when the task did work (more may exist
+                    // past the per-GC cap, or new spends raced in) or failed
+                    // (retry after backoff); a barren scan stays disarmed
+                    // until a withdrawal confirms. Rescheduling is left to
+                    // the leader-gated checkpoint arm: respawning here ran
                     // ungated (leader or not) with no backoff, which kept a
                     // node resubmitting cleanups indefinitely.
-                    self.utxo_cleanup_scan_needed = true;
+                    match &result {
+                        Ok(Ok(0)) => self.utxo_cleanup_retry.clear(),
+                        Ok(Ok(_)) => {
+                            self.utxo_cleanup_retry.clear();
+                            self.utxo_cleanup_scan_needed = true;
+                        }
+                        _ => {
+                            self.utxo_cleanup_retry.record_failure(
+                                garbage_collection::UtxoCleanupErrorKind::Failed,
+                                checkpoint_rx.borrow().timestamp_ms,
+                            );
+                            self.utxo_cleanup_scan_needed = true;
+                        }
+                    }
+                    Self::log_task_result("utxo_cleanup_gc", result);
                 }
                 Some(result) = OptionFuture::from(self.guardian_committee_reconcile_task.as_mut()) => {
                     self.guardian_committee_reconcile_task = None;
@@ -333,9 +340,9 @@ impl LeaderService {
         }
     }
 
-    fn log_task_result(label: &str, result: Result<anyhow::Result<()>, tokio::task::JoinError>) {
+    fn log_task_result<T>(label: &str, result: Result<anyhow::Result<T>, tokio::task::JoinError>) {
         match result {
-            Ok(Ok(())) => {}
+            Ok(Ok(_)) => {}
             Ok(Err(err)) => error!("{label} task failed: {err:#?}"),
             Err(err) if err.is_panic() => error!("{label} task panicked: {err}"),
             Err(err) => error!("{label} task failed to join: {err}"),

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -108,6 +108,7 @@ pub(crate) struct LeaderService {
     pending_utxo_cleanups: VecDeque<garbage_collection::PendingUtxoCleanup>,
     // Singleton task that cleans up spent withdrawal input UTXOs on-chain.
     utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
+    utxo_cleanup_retry: GlobalRetryTracker<garbage_collection::UtxoCleanupErrorKind>,
     // Forces a fresh scan for UTXO cleanup work after cleanup state changes.
     utxo_cleanup_scan_needed: bool,
 
@@ -148,6 +149,7 @@ impl LeaderService {
             proposal_gc_task: None,
             pending_utxo_cleanups: VecDeque::new(),
             utxo_cleanup_gc_task: None,
+            utxo_cleanup_retry: GlobalRetryTracker::new(),
             utxo_cleanup_scan_needed: true,
             guardian_committee_reconcile_task: None,
             last_guardian_reconcile_epoch: None,
@@ -243,7 +245,7 @@ impl LeaderService {
                     self.process_signed_withdrawal_txns();
                     self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
                     self.check_delete_proposals(checkpoint_timestamp_ms);
-                    self.check_cleanup_spent_utxos();
+                    self.check_cleanup_spent_utxos(checkpoint_timestamp_ms);
                     self.process_stale_unapproved_deposits_if_new_epoch();
                     self.process_approved_deposit_requests();
                 }
@@ -302,9 +304,19 @@ impl LeaderService {
                 }
                 Some(result) = OptionFuture::from(self.utxo_cleanup_gc_task.as_mut()) => {
                     self.utxo_cleanup_gc_task = None;
+                    match &result {
+                        Ok(Ok(())) => self.utxo_cleanup_retry.clear(),
+                        _ => self.utxo_cleanup_retry.record_failure(
+                            garbage_collection::UtxoCleanupErrorKind::Failed,
+                            checkpoint_rx.borrow().timestamp_ms,
+                        ),
+                    }
                     Self::log_task_result("utxo_cleanup_gc", result);
+                    // Re-arm the scan and leave rescheduling to the
+                    // leader-gated checkpoint arm: respawning here ran
+                    // ungated (leader or not) with no backoff, which kept a
+                    // node resubmitting cleanups indefinitely.
                     self.utxo_cleanup_scan_needed = true;
-                    self.check_cleanup_spent_utxos();
                 }
                 Some(result) = OptionFuture::from(self.guardian_committee_reconcile_task.as_mut()) => {
                     self.guardian_committee_reconcile_task = None;

--- a/crates/hashi/src/leader/withdrawal_transactions.rs
+++ b/crates/hashi/src/leader/withdrawal_transactions.rs
@@ -6,8 +6,6 @@ use super::LeaderService;
 use super::parse_member_signature;
 use crate::Hashi;
 use crate::btc_monitor::monitor::TxStatus;
-use crate::leader::garbage_collection::PendingUtxoCleanup;
-use crate::onchain::types::UtxoId;
 use crate::onchain::types::WithdrawalTransaction;
 use crate::sui_tx_executor::SuiTxExecutor;
 use crate::withdrawals::MpcInputSignaturesMessage;
@@ -40,7 +38,7 @@ use tracing::trace;
 use tracing::warn;
 
 pub(super) enum WithdrawalBroadcastOutcome {
-    ConfirmedOnSui { utxo_ids: Vec<UtxoId> },
+    ConfirmedOnSui,
     WaitForNextBitcoinBlock,
 }
 
@@ -1048,11 +1046,14 @@ impl LeaderService {
         result: WithdrawalBroadcastResult,
     ) -> anyhow::Result<()> {
         match result {
-            Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui { utxo_ids }) => {
+            Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui) => {
                 self.withdrawal_broadcast_retry_tracker
                     .clear(&withdrawal_id);
-                self.pending_utxo_cleanups
-                    .push_back(PendingUtxoCleanup { utxo_ids });
+                // The confirm tx marked the input UTXOs spent on-chain; arm
+                // the cleanup scan rather than queueing the ids — the scan
+                // re-reads on-chain state before paying for a cleanup, which
+                // keeps stale or duplicated ids from becoming no-op txs.
+                self.utxo_cleanup_scan_needed = true;
             }
             Ok(WithdrawalBroadcastOutcome::WaitForNextBitcoinBlock) => {
                 self.withdrawal_broadcast_retry_tracker
@@ -1107,7 +1108,6 @@ impl LeaderService {
                     confirmations,
                     "Withdrawal tx confirmed, proceeding to on-chain confirmation"
                 );
-                let utxo_ids: Vec<UtxoId> = txn.inputs.iter().map(|u| u.id).collect();
                 Self::confirm_withdrawal_on_sui(&inner, &txn)
                     .await
                     .map_err(|e| {
@@ -1116,7 +1116,7 @@ impl LeaderService {
                             e,
                         )
                     })?;
-                return Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui { utxo_ids });
+                return Ok(WithdrawalBroadcastOutcome::ConfirmedOnSui);
             }
             Ok(TxStatus::Confirmed { confirmations }) => {
                 debug!(

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -212,6 +212,14 @@ impl OnchainState {
         self.0.state.write().unwrap()
     }
 
+    /// Prune UTXO records that a cleanup transaction has removed on-chain.
+    /// `cleanup_spent_utxos` emits no event the watcher could react to, so
+    /// the leader that executed the cleanup applies its effect to the local
+    /// mirror through this call.
+    pub(crate) fn remove_cleaned_utxo_records(&self, utxo_ids: &[types::UtxoId]) {
+        self.state_mut().hashi.utxo_pool.remove_cleaned(utxo_ids);
+    }
+
     pub fn subscribe_checkpoint(&self) -> watch::Receiver<CheckpointInfo> {
         self.0.checkpoint.subscribe()
     }

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -212,28 +212,33 @@ impl OnchainState {
         self.0.state.write().unwrap()
     }
 
-    /// Prune UTXO records that a cleanup transaction has removed on-chain.
-    /// `cleanup_spent_utxos` emits no event the watcher could react to, so
-    /// the leader that executed the cleanup applies its effect to the local
-    /// mirror through this call.
-    pub(crate) fn remove_cleaned_utxo_records(&self, utxo_ids: &[types::UtxoId]) {
-        self.state_mut().hashi.utxo_pool.remove_cleaned(utxo_ids);
-    }
-
-    /// Re-scrape the on-chain UTXO pool into the local mirror. The cleanup
-    /// GC calls this before submitting an orphan-scan batch: the mirror can
-    /// overstate pending cleanups (another leader's cleanup emits no event
-    /// the watcher could apply), and every overstated id becomes a paid
-    /// on-chain no-op. One table scan here is cheaper than paying to
-    /// re-clean records that are already gone.
-    pub(crate) async fn refresh_utxo_pool(&self) -> Result<()> {
+    /// Scrape the on-chain UTXO pool into a task-local snapshot for the
+    /// cleanup GC's use. Deliberately does NOT touch the shared mirror: the
+    /// watcher task is its sole writer, and installing an out-of-band
+    /// snapshot could revert mutations the watcher already applied from
+    /// newer checkpoints (e.g. a `spent_by` lock, whose loss would let coin
+    /// selection re-pick a locked input and pay for an aborted tx).
+    ///
+    /// The GC scans this snapshot instead of the mirror because the mirror
+    /// can overstate pending cleanups (`cleanup_spent_utxos` emits no event
+    /// the watcher could apply, so another leader's cleanup is invisible),
+    /// and every overstated id becomes a paid on-chain no-op. Errors if the
+    /// read is older than the watcher's checkpoint cursor (e.g. a
+    /// load-balanced endpoint serving a lagging fullnode) — the caller
+    /// should back off and retry rather than act on stale data.
+    pub(crate) async fn scrape_utxo_pool_snapshot(&self) -> Result<types::UtxoPool> {
         let client = self.client();
-        let bitcoin_state =
+        let (scrape_height, bitcoin_state) =
             fetch_bitcoin_state(client.clone(), self.hashi_id(), self.package_id_original())
                 .await?;
-        let utxo_pool = scrape_utxo_pool(client, bitcoin_state.utxo_pool).await?;
-        self.state_mut().hashi.utxo_pool = utxo_pool;
-        Ok(())
+        let watcher_height = self.latest_checkpoint_height();
+        if scrape_height < watcher_height {
+            anyhow::bail!(
+                "stale UTXO pool read: scrape at checkpoint {scrape_height} is behind the \
+                 watcher's cursor {watcher_height}"
+            );
+        }
+        scrape_utxo_pool(client, bitcoin_state.utxo_pool).await
     }
 
     pub fn subscribe_checkpoint(&self) -> watch::Receiver<CheckpointInfo> {
@@ -777,11 +782,13 @@ async fn scrape_package_versions(
 }
 
 /// Fetch the `BitcoinState` dynamic field hanging off the Hashi object.
+/// Returns the checkpoint height the response was served at alongside the
+/// state, so callers can judge the read's freshness.
 async fn fetch_bitcoin_state(
     mut client: Client,
     hashi_object_id: Address,
     package_id: Address,
-) -> Result<move_types::BitcoinState> {
+) -> Result<(u64, move_types::BitcoinState)> {
     let bitcoin_state_key = move_types::BitcoinStateKey { dummy_field: false };
     let bitcoin_state_key_type = TypeTag::Struct(Box::new(StructTag::new(
         package_id,
@@ -801,6 +808,9 @@ async fn fetch_bitcoin_state(
             ])),
         )
         .await?;
+    let checkpoint_height = bitcoin_state_response
+        .checkpoint_height()
+        .ok_or_else(|| anyhow!("response missing X_SUI_CHECKPOINT_HEIGHT header"))?;
     let bitcoin_state_field: move_types::Field<
         move_types::BitcoinStateKey,
         move_types::BitcoinState,
@@ -810,7 +820,7 @@ async fn fetch_bitcoin_state(
         .contents()
         .deserialize()
         .map_err(|e| anyhow!("failed to deserialize BitcoinState: {e}"))?;
-    Ok(bitcoin_state_field.value)
+    Ok((checkpoint_height, bitcoin_state_field.value))
 }
 
 async fn scrape_hashi(
@@ -852,7 +862,7 @@ async fn scrape_hashi(
         num_consumed_presigs,
     } = response.get_ref().object().contents().deserialize()?;
 
-    let bitcoin_state = fetch_bitcoin_state(client.clone(), id, package_id).await?;
+    let (_, bitcoin_state) = fetch_bitcoin_state(client.clone(), id, package_id).await?;
 
     let (
         member_info,

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -220,6 +220,22 @@ impl OnchainState {
         self.state_mut().hashi.utxo_pool.remove_cleaned(utxo_ids);
     }
 
+    /// Re-scrape the on-chain UTXO pool into the local mirror. The cleanup
+    /// GC calls this before submitting an orphan-scan batch: the mirror can
+    /// overstate pending cleanups (another leader's cleanup emits no event
+    /// the watcher could apply), and every overstated id becomes a paid
+    /// on-chain no-op. One table scan here is cheaper than paying to
+    /// re-clean records that are already gone.
+    pub(crate) async fn refresh_utxo_pool(&self) -> Result<()> {
+        let client = self.client();
+        let bitcoin_state =
+            fetch_bitcoin_state(client.clone(), self.hashi_id(), self.package_id_original())
+                .await?;
+        let utxo_pool = scrape_utxo_pool(client, bitcoin_state.utxo_pool).await?;
+        self.state_mut().hashi.utxo_pool = utxo_pool;
+        Ok(())
+    }
+
     pub fn subscribe_checkpoint(&self) -> watch::Receiver<CheckpointInfo> {
         self.0.checkpoint.subscribe()
     }
@@ -760,6 +776,43 @@ async fn scrape_package_versions(
     Ok(package_versions)
 }
 
+/// Fetch the `BitcoinState` dynamic field hanging off the Hashi object.
+async fn fetch_bitcoin_state(
+    mut client: Client,
+    hashi_object_id: Address,
+    package_id: Address,
+) -> Result<move_types::BitcoinState> {
+    let bitcoin_state_key = move_types::BitcoinStateKey { dummy_field: false };
+    let bitcoin_state_key_type = TypeTag::Struct(Box::new(StructTag::new(
+        package_id,
+        Identifier::from_static("bitcoin_state"),
+        Identifier::from_static("BitcoinStateKey"),
+        vec![],
+    )));
+    let bitcoin_state_field_id = hashi_object_id.derive_dynamic_child_id(
+        &bitcoin_state_key_type,
+        &bitcoin_state_key.to_bcs().unwrap(),
+    );
+    let bitcoin_state_response = client
+        .ledger_client()
+        .get_object(
+            GetObjectRequest::new(&bitcoin_state_field_id).with_read_mask(FieldMask::from_paths([
+                Object::path_builder().contents().finish(),
+            ])),
+        )
+        .await?;
+    let bitcoin_state_field: move_types::Field<
+        move_types::BitcoinStateKey,
+        move_types::BitcoinState,
+    > = bitcoin_state_response
+        .into_inner()
+        .object()
+        .contents()
+        .deserialize()
+        .map_err(|e| anyhow!("failed to deserialize BitcoinState: {e}"))?;
+    Ok(bitcoin_state_field.value)
+}
+
 async fn scrape_hashi(
     mut client: Client,
     hashi_object_id: Address,
@@ -799,36 +852,7 @@ async fn scrape_hashi(
         num_consumed_presigs,
     } = response.get_ref().object().contents().deserialize()?;
 
-    // Fetch BitcoinState from dynamic field on Hashi
-    let bitcoin_state_key = move_types::BitcoinStateKey { dummy_field: false };
-    let bitcoin_state_key_type = TypeTag::Struct(Box::new(StructTag::new(
-        package_id,
-        Identifier::from_static("bitcoin_state"),
-        Identifier::from_static("BitcoinStateKey"),
-        vec![],
-    )));
-    let bitcoin_state_field_id = id.derive_dynamic_child_id(
-        &bitcoin_state_key_type,
-        &bitcoin_state_key.to_bcs().unwrap(),
-    );
-    let bitcoin_state_response = client
-        .ledger_client()
-        .get_object(
-            GetObjectRequest::new(&bitcoin_state_field_id).with_read_mask(FieldMask::from_paths([
-                Object::path_builder().contents().finish(),
-            ])),
-        )
-        .await?;
-    let bitcoin_state_field: move_types::Field<
-        move_types::BitcoinStateKey,
-        move_types::BitcoinState,
-    > = bitcoin_state_response
-        .into_inner()
-        .object()
-        .contents()
-        .deserialize()
-        .map_err(|e| anyhow!("failed to deserialize BitcoinState: {e}"))?;
-    let bitcoin_state = bitcoin_state_field.value;
+    let bitcoin_state = fetch_bitcoin_state(client.clone(), id, package_id).await?;
 
     let (
         member_info,

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -752,21 +752,6 @@ impl UtxoPool {
     pub fn spent_utxos(&self) -> &BTreeMap<UtxoId, u64> {
         &self.spent_utxos
     }
-
-    /// Apply a successful on-chain `cleanup_spent_utxos` to the local mirror:
-    /// drop the records and tombstone them in `spent_utxos`. The Move call
-    /// emits no event, so the executor that lands the cleanup must apply it
-    /// here — a stale record would be rediscovered by the orphan scan and
-    /// re-cleaned as a paid no-op forever.
-    pub(crate) fn remove_cleaned(&mut self, utxo_ids: &[UtxoId]) {
-        for id in utxo_ids {
-            if let Some(record) = self.utxo_records.remove(id)
-                && let Some(epoch) = record.spent_epoch
-            {
-                self.spent_utxos.insert(*id, epoch);
-            }
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -911,61 +896,5 @@ mod tests {
     fn previous_committee_for_target_returns_none_when_no_earlier_committee() {
         let set = set_with(3, None, &[3]);
         assert_eq!(set.previous_committee_for_target(3).map(|(e, _)| e), None);
-    }
-
-    fn test_utxo_id(byte: u8) -> UtxoId {
-        let mut bytes = [0u8; 32];
-        bytes[0] = byte;
-        UtxoId {
-            txid: hashi_types::bitcoin_txid::BitcoinTxid::new(bytes),
-            vout: 0,
-        }
-    }
-
-    fn test_utxo_record(spent_epoch: Option<u64>) -> UtxoRecord {
-        UtxoRecord {
-            utxo: Utxo {
-                id: test_utxo_id(0),
-                amount: 1_000,
-                derivation_path: None,
-            },
-            produced_by: None,
-            spent_by: None,
-            spent_epoch,
-        }
-    }
-
-    fn utxo_pool(records: Vec<(UtxoId, UtxoRecord)>) -> UtxoPool {
-        UtxoPool {
-            utxo_records_id: Address::new([0u8; 32]),
-            utxo_records: records.into_iter().collect(),
-            spent_utxos_id: Address::new([0u8; 32]),
-            spent_utxos: BTreeMap::new(),
-        }
-    }
-
-    #[test]
-    fn remove_cleaned_drops_records_and_tombstones_them() {
-        let mut pool = utxo_pool(vec![
-            (test_utxo_id(1), test_utxo_record(Some(7))),
-            (test_utxo_id(2), test_utxo_record(None)),
-        ]);
-
-        pool.remove_cleaned(&[test_utxo_id(1)]);
-
-        assert!(!pool.utxo_records.contains_key(&test_utxo_id(1)));
-        assert!(pool.utxo_records.contains_key(&test_utxo_id(2)));
-        assert_eq!(pool.spent_utxos.get(&test_utxo_id(1)), Some(&7));
-    }
-
-    #[test]
-    fn remove_cleaned_is_idempotent_for_absent_records() {
-        let mut pool = utxo_pool(vec![(test_utxo_id(1), test_utxo_record(Some(3)))]);
-
-        pool.remove_cleaned(&[test_utxo_id(1)]);
-        pool.remove_cleaned(&[test_utxo_id(1), test_utxo_id(9)]);
-
-        assert!(pool.utxo_records.is_empty());
-        assert_eq!(pool.spent_utxos.len(), 1);
     }
 }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -752,6 +752,21 @@ impl UtxoPool {
     pub fn spent_utxos(&self) -> &BTreeMap<UtxoId, u64> {
         &self.spent_utxos
     }
+
+    /// Apply a successful on-chain `cleanup_spent_utxos` to the local mirror:
+    /// drop the records and tombstone them in `spent_utxos`. The Move call
+    /// emits no event, so the executor that lands the cleanup must apply it
+    /// here — a stale record would be rediscovered by the orphan scan and
+    /// re-cleaned as a paid no-op forever.
+    pub(crate) fn remove_cleaned(&mut self, utxo_ids: &[UtxoId]) {
+        for id in utxo_ids {
+            if let Some(record) = self.utxo_records.remove(id)
+                && let Some(epoch) = record.spent_epoch
+            {
+                self.spent_utxos.insert(*id, epoch);
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -896,5 +911,61 @@ mod tests {
     fn previous_committee_for_target_returns_none_when_no_earlier_committee() {
         let set = set_with(3, None, &[3]);
         assert_eq!(set.previous_committee_for_target(3).map(|(e, _)| e), None);
+    }
+
+    fn test_utxo_id(byte: u8) -> UtxoId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = byte;
+        UtxoId {
+            txid: hashi_types::bitcoin_txid::BitcoinTxid::new(bytes),
+            vout: 0,
+        }
+    }
+
+    fn test_utxo_record(spent_epoch: Option<u64>) -> UtxoRecord {
+        UtxoRecord {
+            utxo: Utxo {
+                id: test_utxo_id(0),
+                amount: 1_000,
+                derivation_path: None,
+            },
+            produced_by: None,
+            spent_by: None,
+            spent_epoch,
+        }
+    }
+
+    fn utxo_pool(records: Vec<(UtxoId, UtxoRecord)>) -> UtxoPool {
+        UtxoPool {
+            utxo_records_id: Address::new([0u8; 32]),
+            utxo_records: records.into_iter().collect(),
+            spent_utxos_id: Address::new([0u8; 32]),
+            spent_utxos: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn remove_cleaned_drops_records_and_tombstones_them() {
+        let mut pool = utxo_pool(vec![
+            (test_utxo_id(1), test_utxo_record(Some(7))),
+            (test_utxo_id(2), test_utxo_record(None)),
+        ]);
+
+        pool.remove_cleaned(&[test_utxo_id(1)]);
+
+        assert!(!pool.utxo_records.contains_key(&test_utxo_id(1)));
+        assert!(pool.utxo_records.contains_key(&test_utxo_id(2)));
+        assert_eq!(pool.spent_utxos.get(&test_utxo_id(1)), Some(&7));
+    }
+
+    #[test]
+    fn remove_cleaned_is_idempotent_for_absent_records() {
+        let mut pool = utxo_pool(vec![(test_utxo_id(1), test_utxo_record(Some(3)))]);
+
+        pool.remove_cleaned(&[test_utxo_id(1)]);
+        pool.remove_cleaned(&[test_utxo_id(1), test_utxo_id(9)]);
+
+        assert!(pool.utxo_records.is_empty());
+        assert_eq!(pool.spent_utxos.len(), 1);
     }
 }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -752,6 +752,17 @@ impl UtxoPool {
     pub fn spent_utxos(&self) -> &BTreeMap<UtxoId, u64> {
         &self.spent_utxos
     }
+
+    /// Apply a `UtxoCleaned` event to the local mirror: drop the record and
+    /// tombstone it in `spent_utxos`. The tombstone epoch comes from the
+    /// event — the on-chain cleanup is authoritative even when the local
+    /// record is missing or was never marked spent (e.g. a missed
+    /// `UtxoSpent`). This is the mirror's only cleanup-hygiene path; the
+    /// GC decides from a task-local chain snapshot and never writes here.
+    pub(crate) fn apply_cleaned(&mut self, utxo_id: UtxoId, spent_epoch: u64) {
+        self.utxo_records.remove(&utxo_id);
+        self.spent_utxos.insert(utxo_id, spent_epoch);
+    }
 }
 
 #[derive(Debug)]
@@ -896,5 +907,64 @@ mod tests {
     fn previous_committee_for_target_returns_none_when_no_earlier_committee() {
         let set = set_with(3, None, &[3]);
         assert_eq!(set.previous_committee_for_target(3).map(|(e, _)| e), None);
+    }
+
+    fn test_utxo_id(byte: u8) -> UtxoId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = byte;
+        UtxoId {
+            txid: hashi_types::bitcoin_txid::BitcoinTxid::new(bytes),
+            vout: 0,
+        }
+    }
+
+    fn test_utxo_record(spent_epoch: Option<u64>) -> UtxoRecord {
+        UtxoRecord {
+            utxo: Utxo {
+                id: test_utxo_id(0),
+                amount: 1_000,
+                derivation_path: None,
+            },
+            produced_by: None,
+            spent_by: None,
+            spent_epoch,
+        }
+    }
+
+    fn utxo_pool(records: Vec<(UtxoId, UtxoRecord)>) -> UtxoPool {
+        UtxoPool {
+            utxo_records_id: Address::new([0u8; 32]),
+            utxo_records: records.into_iter().collect(),
+            spent_utxos_id: Address::new([0u8; 32]),
+            spent_utxos: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn apply_cleaned_drops_record_and_tombstones_it() {
+        let mut pool = utxo_pool(vec![
+            (test_utxo_id(1), test_utxo_record(Some(7))),
+            (test_utxo_id(2), test_utxo_record(None)),
+        ]);
+
+        pool.apply_cleaned(test_utxo_id(1), 7);
+
+        assert!(!pool.utxo_records.contains_key(&test_utxo_id(1)));
+        assert!(pool.utxo_records.contains_key(&test_utxo_id(2)));
+        assert_eq!(pool.spent_utxos.get(&test_utxo_id(1)), Some(&7));
+    }
+
+    #[test]
+    fn apply_cleaned_tombstones_even_without_local_spent_mark() {
+        let mut pool = utxo_pool(vec![(test_utxo_id(1), test_utxo_record(None))]);
+
+        // Local record never saw UtxoSpent; the event's epoch still lands.
+        pool.apply_cleaned(test_utxo_id(1), 9);
+        // Record entirely absent locally: tombstone alone is applied.
+        pool.apply_cleaned(test_utxo_id(2), 4);
+
+        assert!(pool.utxo_records.is_empty());
+        assert_eq!(pool.spent_utxos.get(&test_utxo_id(1)), Some(&9));
+        assert_eq!(pool.spent_utxos.get(&test_utxo_id(2)), Some(&4));
     }
 }

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -684,7 +684,9 @@ async fn handle_events(
 
                     // Promote the change UTXOs from pending to confirmed by
                     // clearing `produced_by`. The UTXOs were already inserted at
-                    // commit time; input UTXOs are removed via UtxoSpent.
+                    // commit time; input UTXOs are marked spent via UtxoSpent
+                    // and pruned from the mirror when the leader's cleanup
+                    // transaction lands.
                     for change_utxo_id in &event.change_utxo_ids {
                         if let Some(record) =
                             state.hashi.utxo_pool.utxo_records.get_mut(change_utxo_id)

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -742,14 +742,15 @@ async fn handle_events(
                     .insert(utxo_spent_event.utxo_id, utxo_spent_event.spent_epoch);
             }
             HashiEvent::UtxoCleaned(utxo_cleaned_event) => {
-                // Prune the cleaned record so every node's orphan scanner —
+                // Prune the cleaned record so every node's cleanup scanner —
                 // not just the leader that executed the cleanup — stops
-                // rediscovering it.
-                state
-                    .state_mut()
-                    .hashi
-                    .utxo_pool
-                    .remove_cleaned(&[utxo_cleaned_event.utxo_id]);
+                // rediscovering it. The event's epoch is authoritative, so
+                // the tombstone lands even if the local record was missing
+                // or never marked spent.
+                state.state_mut().hashi.utxo_pool.apply_cleaned(
+                    utxo_cleaned_event.utxo_id,
+                    utxo_cleaned_event.spent_epoch,
+                );
             }
             HashiEvent::ReconfigStarted(start_reconfig_event) => {
                 let epoch = start_reconfig_event.epoch;

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -741,6 +741,16 @@ async fn handle_events(
                     .spent_utxos
                     .insert(utxo_spent_event.utxo_id, utxo_spent_event.spent_epoch);
             }
+            HashiEvent::UtxoCleaned(utxo_cleaned_event) => {
+                // Prune the cleaned record so every node's orphan scanner —
+                // not just the leader that executed the cleanup — stops
+                // rediscovering it.
+                state
+                    .state_mut()
+                    .hashi
+                    .utxo_pool
+                    .remove_cleaned(&[utxo_cleaned_event.utxo_id]);
+            }
             HashiEvent::ReconfigStarted(start_reconfig_event) => {
                 let epoch = start_reconfig_event.epoch;
                 // Fetch new committee

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -747,10 +747,11 @@ async fn handle_events(
                 // rediscovering it. The event's epoch is authoritative, so
                 // the tombstone lands even if the local record was missing
                 // or never marked spent.
-                state.state_mut().hashi.utxo_pool.apply_cleaned(
-                    utxo_cleaned_event.utxo_id,
-                    utxo_cleaned_event.spent_epoch,
-                );
+                state
+                    .state_mut()
+                    .hashi
+                    .utxo_pool
+                    .apply_cleaned(utxo_cleaned_event.utxo_id, utxo_cleaned_event.spent_epoch);
             }
             HashiEvent::ReconfigStarted(start_reconfig_event) => {
                 let epoch = start_reconfig_event.epoch;

--- a/packages/hashi/sources/btc/utxo_pool.move
+++ b/packages/hashi/sources/btc/utxo_pool.move
@@ -55,6 +55,14 @@ public struct UtxoSpent has copy, drop {
     spent_epoch: u64,
 }
 
+/// Emitted when `cleanup_spent` removes a spent UTXO's record. Nodes prune
+/// their local `utxo_records` mirror on this event; without it only the
+/// leader that executed the cleanup learns the record is gone.
+public struct UtxoCleaned has copy, drop {
+    utxo_id: UtxoId,
+    spent_epoch: u64,
+}
+
 // ~~~~~~~ Package Functions ~~~~~~~
 
 public(package) fun create(ctx: &mut TxContext): UtxoPool {
@@ -151,10 +159,16 @@ public(package) fun cleanup_spent(self: &mut UtxoPool, utxo_id: UtxoId) {
         let epoch = spent_epoch.destroy_some();
         utxo.delete();
         self.spent_utxos.add(utxo_id, epoch);
+        sui::event::emit(UtxoCleaned { utxo_id, spent_epoch: epoch });
     };
 }
 
 // ~~~~~~~ Test Helpers ~~~~~~~
+
+#[test_only]
+public(package) fun utxo_cleaned_fields(event: &UtxoCleaned): (UtxoId, u64) {
+    (event.utxo_id, event.spent_epoch)
+}
 
 #[test_only]
 public(package) fun has_active_record(self: &UtxoPool, utxo_id: UtxoId): bool {

--- a/packages/hashi/tests/utxo_spent_tests.move
+++ b/packages/hashi/tests/utxo_spent_tests.move
@@ -99,6 +99,54 @@ fun test_insert_active_rejects_spent_utxo() {
     std::unit_test::destroy(hashi);
 }
 
+// ======== cleanup_spent emits UtxoCleaned ========
+
+/// A real cleanup emits exactly one UtxoCleaned event carrying the spent
+/// epoch; node watchers prune their local mirror on it.
+#[test]
+fun test_cleanup_spent_emits_event() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    let utxo_id = hashi::utxo::utxo_id(@0xCAFE, 0);
+    let utxo = hashi::utxo::utxo(utxo_id, 50_000, option::none());
+
+    hashi.bitcoin_mut().utxo_pool_mut().insert_active(utxo);
+    hashi.bitcoin_mut().utxo_pool_mut().mark_spent(utxo_id, 7);
+    hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
+
+    let events = sui::event::events_by_type<utxo_pool::UtxoCleaned>();
+    assert!(events.length() == 1);
+    let (event_utxo_id, event_epoch) = utxo_pool::utxo_cleaned_fields(&events[0]);
+    assert!(event_utxo_id == utxo_id);
+    assert!(event_epoch == 7);
+
+    std::unit_test::destroy(hashi);
+}
+
+/// A no-op cleanup (record already gone) must not emit UtxoCleaned.
+#[test]
+fun test_cleanup_spent_noop_emits_no_event() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    let utxo_id = hashi::utxo::utxo_id(@0xCAFE, 0);
+    let utxo = hashi::utxo::utxo(utxo_id, 50_000, option::none());
+
+    hashi.bitcoin_mut().utxo_pool_mut().insert_active(utxo);
+    hashi.bitcoin_mut().utxo_pool_mut().mark_spent(utxo_id, 0);
+    hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
+    // Second cleanup is a no-op and must stay silent.
+    hashi.bitcoin_mut().utxo_pool_mut().cleanup_spent(utxo_id);
+
+    let events = sui::event::events_by_type<utxo_pool::UtxoCleaned>();
+    assert!(events.length() == 1);
+
+    std::unit_test::destroy(hashi);
+}
+
 // ======== cleanup_spent is idempotent ========
 
 /// A second cleanup_spent call for the same UTXO is a no-op (must not abort).


### PR DESCRIPTION
## Summary

Stacked on #842. The base fix prunes the local `utxo_records` mirror only on the **leader that executed** the cleanup transaction. Every other validator's mirror keeps the stale records, so each would fire one redundant (idempotent, paid) cleanup on its first leadership turn after any withdrawal wave.

## Changes

- `utxo_pool.move`: emit `UtxoCleaned { utxo_id, spent_epoch }` from the real-cleanup branch of `cleanup_spent`. The no-op branch stays silent, so replayed cleanups emit nothing.
- `hashi-types`: `UtxoCleaned` struct + `HashiEvent` variant + parse arm (module `utxo_pool`, mirrors `UtxoSpent`).
- Watcher: on `UtxoCleaned`, prune via the same `UtxoPool::remove_cleaned` helper (no-ops on the leader that already pruned directly).

## Tests

Move tests in `tests/utxo_spent_tests.move`: a real cleanup emits exactly one event with the right fields; a no-op cleanup emits none.

## Deployment

Takes effect with the next testnet package upgrade. Mixed-version windows are safe in both directions: new binaries against the old package simply see no event (base-PR behavior), and old binaries against the new package ignore unknown events in `HashiEvent::try_parse`.