### PR TITLE
Add a hashi_sui_balance metric for the operator gas wallet

### DIFF
--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -837,6 +837,7 @@ impl Hashi {
         let backup_service = backup_service.start();
         let mpc_service = mpc_service.start();
         let guardian_bootstrap_service = self.clone().start_guardian_bootstrap();
+        let sui_balance_service = self.clone().start_sui_balance_metric();
 
         let service = Service::new()
             .merge(onchain_service)
@@ -845,7 +846,8 @@ impl Hashi {
             .merge(leader_service)
             .merge(backup_service)
             .merge(mpc_service)
-            .merge(guardian_bootstrap_service);
+            .merge(guardian_bootstrap_service)
+            .merge(sui_balance_service);
 
         Ok(service)
     }
@@ -1035,6 +1037,47 @@ impl Hashi {
                 "Local guardian limiter bucket reconciled after watcher rescrape",
             );
         }
+    }
+
+    /// Poll the operator gas wallet's total SUI balance (owned coins plus
+    /// address balance — `sui client gas` misses the latter) into
+    /// `hashi_sui_balance`, so operators can alert on drain before
+    /// transactions start failing gas selection.
+    fn start_sui_balance_metric(self: Arc<Self>) -> Service {
+        const BALANCE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+        Service::new().spawn_aborting(async move {
+            let owner = match self.config.operator_private_key() {
+                Ok(key) => key.verifying_key().derive_address().to_string(),
+                Err(e) => {
+                    tracing::info!("SUI balance metric disabled; operator key unavailable: {e}");
+                    return Ok(());
+                }
+            };
+            let request = {
+                let mut request = sui_rpc::proto::sui::rpc::v2::GetBalanceRequest::default();
+                request.owner = Some(owner);
+                request.coin_type = Some("0x2::sui::SUI".to_string());
+                request
+            };
+            let mut client = self.onchain_state().client();
+            let mut interval = tokio::time::interval(BALANCE_POLL_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                match client.state_client().get_balance(request.clone()).await {
+                    Ok(response) => {
+                        if let Some(balance) =
+                            response.into_inner().balance.and_then(|b| b.balance)
+                        {
+                            self.metrics
+                                .sui_balance
+                                .set(balance.min(i64::MAX as u64) as i64);
+                        }
+                    }
+                    Err(e) => tracing::debug!("failed to fetch operator SUI balance: {e}"),
+                }
+            }
+        })
     }
 
     fn start_guardian_bootstrap(self: Arc<Self>) -> Service {

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -1046,19 +1046,20 @@ impl Hashi {
     fn start_sui_balance_metric(self: Arc<Self>) -> Service {
         const BALANCE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
         Service::new().spawn_aborting(async move {
+            // -1 = never sampled; keeps a `0 <= balance < threshold` alert
+            // from firing on nodes where this poller is disabled or has not
+            // yet succeeded (the gauge would otherwise read a false 0).
+            self.metrics.sui_balance.set(-1);
             let owner = match self.config.operator_private_key() {
-                Ok(key) => key.verifying_key().derive_address().to_string(),
+                Ok(key) => key.verifying_key().derive_address(),
                 Err(e) => {
                     tracing::info!("SUI balance metric disabled; operator key unavailable: {e}");
                     return Ok(());
                 }
             };
-            let request = {
-                let mut request = sui_rpc::proto::sui::rpc::v2::GetBalanceRequest::default();
-                request.owner = Some(owner);
-                request.coin_type = Some("0x2::sui::SUI".to_string());
-                request
-            };
+            let request = sui_rpc::proto::sui::rpc::v2::GetBalanceRequest::default()
+                .with_owner(owner)
+                .with_coin_type(sui_sdk_types::StructTag::sui());
             let mut client = self.onchain_state().client();
             let mut interval = tokio::time::interval(BALANCE_POLL_INTERVAL);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -1067,8 +1067,7 @@ impl Hashi {
                 interval.tick().await;
                 match client.state_client().get_balance(request.clone()).await {
                     Ok(response) => {
-                        if let Some(balance) =
-                            response.into_inner().balance.and_then(|b| b.balance)
+                        if let Some(balance) = response.into_inner().balance.and_then(|b| b.balance)
                         {
                             self.metrics
                                 .sui_balance

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -96,6 +96,7 @@ pub struct Metrics {
     pub withdrawals_finalized_total: IntCounter,
     pub presig_pool_remaining: IntGauge,
     pub sui_tx_submissions_total: IntCounterVec,
+    pub sui_balance: IntGauge,
 
     pub is_leader: IntGauge,
     pub leader_retries_total: IntCounterVec,
@@ -615,6 +616,13 @@ impl Metrics {
                 "hashi_sui_tx_submissions_total",
                 "Total Sui transaction submissions by operation and outcome",
                 &["operation", "status"],
+                registry,
+            )
+            .unwrap(),
+            sui_balance: register_int_gauge_with_registry!(
+                "hashi_sui_balance",
+                "Operator gas wallet SUI balance in MIST, totaled across owned \
+                 coins and the address balance",
                 registry,
             )
             .unwrap(),

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -832,6 +832,7 @@ Notes:
 | `hashi_mpc_sign_failures_total` | counter | MPC signing failures. Investigate if increasing. |
 | `hashi_mpc_reconfig_total_duration_seconds` | histogram | DKG/rotation duration. |
 | `hashi_sui_tx_submissions_total` | counter | Sui tx submissions (by operation, status). |
+| `hashi_sui_balance` | gauge | Operator gas wallet SUI balance in MIST (owned coins + address balance). |
 | `hashi_leader_retries_total` | counter | Leader operation retries (by operation, error kind). |
 
 ### 8.4 Suggested alerts
@@ -843,6 +844,7 @@ Notes:
 | `hashi_kyoto_synced == 0` for > 5 min | Warning | Light client lost sync. Check Bitcoin RPC and P2P connectivity. |
 | `hashi_kyoto_connected_peers == 0` | Warning | No Bitcoin P2P peers. Check `bitcoin-trusted-peers` and reachability. |
 | `hashi_mpc_sign_failures_total` increasing | Warning | Investigate MPC protocol errors in logs. |
+| `hashi_sui_balance < 1e9` (1 SUI) | Warning | Gas wallet running low; the node stops landing Sui transactions when it empties. Top up the operator address. |
 | `up == 0` (Prometheus target down) | Critical | Node is down. Restart and check logs. |
 
 > **Coming soon:** A metrics **push** service for centralized collection. Details follow once it lands.

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -832,7 +832,7 @@ Notes:
 | `hashi_mpc_sign_failures_total` | counter | MPC signing failures. Investigate if increasing. |
 | `hashi_mpc_reconfig_total_duration_seconds` | histogram | DKG/rotation duration. |
 | `hashi_sui_tx_submissions_total` | counter | Sui tx submissions (by operation, status). |
-| `hashi_sui_balance` | gauge | Operator gas wallet SUI balance in MIST (owned coins + address balance). |
+| `hashi_sui_balance` | gauge | Operator gas wallet SUI balance in MIST (owned coins + address balance). `-1` until the first successful sample. |
 | `hashi_leader_retries_total` | counter | Leader operation retries (by operation, error kind). |
 
 ### 8.4 Suggested alerts
@@ -844,7 +844,7 @@ Notes:
 | `hashi_kyoto_synced == 0` for > 5 min | Warning | Light client lost sync. Check Bitcoin RPC and P2P connectivity. |
 | `hashi_kyoto_connected_peers == 0` | Warning | No Bitcoin P2P peers. Check `bitcoin-trusted-peers` and reachability. |
 | `hashi_mpc_sign_failures_total` increasing | Warning | Investigate MPC protocol errors in logs. |
-| `hashi_sui_balance < 1e9` (1 SUI) | Warning | Gas wallet running low; the node stops landing Sui transactions when it empties. Top up the operator address. |
+| `hashi_sui_balance < 1e9 and hashi_sui_balance >= 0` (below 1 SUI) | Warning | Gas wallet running low; the node stops landing Sui transactions when it empties. Top up the operator address. (`-1` means not yet sampled, not empty.) |
 | `up == 0` (Prometheus target down) | Critical | Node is down. Restart and check logs. |
 
 > **Coming soon:** A metrics **push** service for centralized collection. Details follow once it lands.


### PR DESCRIPTION
## Summary

Requested by a validator during the GC gas-drain incident (#842): the gas wallet drained with zero observability, and `sui client gas` reads empty even for a funded wallet because the node sweeps coins into the Sui **address balance** at startup.

## Changes

- New service in `lib.rs` polls `StateService/GetBalance` every 60s for the operator address (the response's `balance` field totals owned coins **plus** address balance) and sets `hashi_sui_balance` (MIST).
- If no operator key is configured, the service logs and exits cleanly.
- Runbook: metric table row + suggested alert (`hashi_sui_balance < 1e9`), since the same wallet signs deposit approvals, withdrawal certs, and MPC/reconfig txs — an empty wallet means dead leadership windows.