### PR TITLE
Emit LaunchCompleted from finish_publish; refresh config on version proposals

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -842,6 +842,7 @@ pub enum HashiEvent {
     WithdrawalConfirmed(WithdrawalConfirmed),
     UtxoSpent(UtxoSpent),
     UtxoCleaned(UtxoCleaned),
+    LaunchCompleted(LaunchCompleted),
     ReconfigStarted(ReconfigStarted),
     ReconfigEnded(ReconfigEnded),
 }
@@ -892,6 +893,7 @@ impl HashiEvent {
             WithdrawalConfirmed::MODULE_NAME => WithdrawalConfirmed::from_bcs(bcs.value())?.into(),
             UtxoSpent::MODULE_NAME => UtxoSpent::from_bcs(bcs.value())?.into(),
             UtxoCleaned::MODULE_NAME => UtxoCleaned::from_bcs(bcs.value())?.into(),
+            LaunchCompleted::MODULE_NAME => LaunchCompleted::from_bcs(bcs.value())?.into(),
             ReconfigStarted::MODULE_NAME => ReconfigStarted::from_bcs(bcs.value())?.into(),
             ReconfigEnded::MODULE_NAME => ReconfigEnded::from_bcs(bcs.value())?.into(),
             PackageUpgraded::MODULE_NAME => PackageUpgraded::from_bcs(bcs.value())?.into(),
@@ -1438,6 +1440,23 @@ pub struct UtxoCleaned {
 impl MoveType for UtxoCleaned {
     const MODULE: &'static str = "utxo_pool";
     const NAME: &'static str = "UtxoCleaned";
+}
+
+#[derive(Debug, serde_derive::Deserialize)]
+pub struct LaunchCompleted {
+    pub guardian_url: String,
+    pub guardian_btc_public_key: Vec<u8>,
+}
+
+impl MoveType for LaunchCompleted {
+    const MODULE: &'static str = "hashi";
+    const NAME: &'static str = "LaunchCompleted";
+}
+
+impl From<LaunchCompleted> for HashiEvent {
+    fn from(value: LaunchCompleted) -> Self {
+        Self::LaunchCompleted(value)
+    }
 }
 
 impl From<UtxoCleaned> for HashiEvent {

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -296,16 +296,23 @@ async fn handle_events(
                     }
                 }
 
-                // When an UpdateConfig or EmergencyPause proposal executes,
-                // the Hashi object's config field changes on-chain. Re-fetch
-                // the config from the Hashi object to keep the in-memory
-                // state current. (The event now carries the typed `data`,
-                // so this could be applied directly in the future.)
+                // When a proposal that mutates the Hashi object's config,
+                // enabled versions, or upgrade cap executes, re-fetch the
+                // config snapshot to keep the in-memory state current.
+                // EnableVersion/DisableVersion/Upgrade matter because
+                // `types::Config` also carries `enabled_versions` and
+                // `upgrade_cap`; without them a node keeps stale version
+                // gating until a stream reconnect. (The event now carries
+                // the typed `data`, so this could be applied directly in
+                // the future.)
                 if matches!(
                     parse_proposal_type_from_type_tag(&proposal_executed_event.proposal_type),
                     ProposalType::UpdateConfig
                         | ProposalType::EmergencyPause
                         | ProposalType::UpdateGuardian
+                        | ProposalType::EnableVersion
+                        | ProposalType::DisableVersion
+                        | ProposalType::Upgrade
                 ) {
                     match super::scrape_hashi_config(client.clone(), state.hashi_id()).await {
                         Ok(config) => {
@@ -752,6 +759,24 @@ async fn handle_events(
                     .hashi
                     .utxo_pool
                     .apply_cleaned(utxo_cleaned_event.utxo_id, utxo_cleaned_event.spent_epoch);
+            }
+            HashiEvent::LaunchCompleted(_) => {
+                // finish_publish writes guardian_url and the guardian BTC
+                // key directly into the config with no proposal event; this
+                // is the launch stall of 2026-07-16, where nodes booted
+                // pre-launch never learned either. Refresh the snapshot and
+                // kick the guardian reconcile so the BTC-key pin lands
+                // without waiting for an unrelated interaction.
+                match super::scrape_hashi_config(client.clone(), state.hashi_id()).await {
+                    Ok(config) => {
+                        state.state_mut().hashi.config = config;
+                        state.request_limiter_reconcile();
+                        tracing::info!("on-chain config refreshed after LaunchCompleted");
+                    }
+                    Err(e) => {
+                        tracing::warn!("failed to refresh config after LaunchCompleted: {e}")
+                    }
+                }
             }
             HashiEvent::ReconfigStarted(start_reconfig_event) => {
                 let epoch = start_reconfig_event.epoch;

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -65,6 +65,15 @@ public struct Hashi has key {
 // load-bearing component of every deposit address (2-of-2 taproot leaf)
 // and every withdrawal signature, so a deploy without them would produce
 // a non-functional bridge.
+/// Emitted once when `finish_publish` flips the launch switch. The config
+/// fields it writes (notably the guardian url and BTC key) land without a
+/// proposal event, so nodes listen for this to refresh their config
+/// snapshot instead of discovering the launch by polling.
+public struct LaunchCompleted has copy, drop {
+    guardian_url: String,
+    guardian_btc_public_key: vector<u8>,
+}
+
 entry fun finish_publish(
     self: &mut Hashi,
     upgrade_cap: sui::package::UpgradeCap,
@@ -109,6 +118,8 @@ entry fun finish_publish(
     let (treasury_cap, metadata_cap) = hashi::btc::create(coin_registry, ctx);
     self.treasury.register_treasury_cap(treasury_cap);
     self.treasury.register_metadata_cap(metadata_cap);
+
+    sui::event::emit(LaunchCompleted { guardian_url, guardian_btc_public_key });
 }
 
 // ~~~~~~~ Package Functions ~~~~~~~
@@ -306,6 +317,11 @@ public fun create_for_testing(
 /// Forwards to `finish_publish` so its guards can be exercised from
 /// `hashi::finish_publish_tests` (non-public entry functions are not
 /// callable from other modules).
+#[test_only]
+public fun launch_completed_fields(event: &LaunchCompleted): (String, vector<u8>) {
+    (event.guardian_url, event.guardian_btc_public_key)
+}
+
 public fun finish_publish_for_testing(
     self: &mut Hashi,
     upgrade_cap: sui::package::UpgradeCap,

--- a/packages/hashi/tests/finish_publish_tests.move
+++ b/packages/hashi/tests/finish_publish_tests.move
@@ -42,6 +42,35 @@ fun test_finish_publish_stores_upgrade_cap() {
 }
 
 #[test]
+/// The launch emits exactly one LaunchCompleted carrying the pinned
+/// guardian config; node watchers refresh their config snapshot on it.
+fun test_finish_publish_emits_launch_completed() {
+    let ctx = &mut test_utils::new_tx_context(PUBLISHER, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[PUBLISHER], ctx);
+    let mut registry = registry_for_testing();
+    let this_package_id = std::type_name::original_id<Hashi>().to_id();
+    let cap = sui::package::test_publish(this_package_id, ctx);
+
+    hashi.finish_publish_for_testing(
+        cap,
+        @0xb17c,
+        b"http://guardian.example:3000".to_string(),
+        guardian_btc_public_key(),
+        &mut registry,
+        ctx,
+    );
+
+    let events = sui::event::events_by_type<hashi::LaunchCompleted>();
+    assert!(events.length() == 1);
+    let (url, btc_key) = hashi::launch_completed_fields(&events[0]);
+    assert!(url == b"http://guardian.example:3000".to_string());
+    assert!(btc_key == guardian_btc_public_key());
+
+    std::unit_test::destroy(hashi);
+    std::unit_test::destroy(registry);
+}
+
+#[test]
 #[expected_failure(abort_code = hashi::EWrongUpgradeCap)]
 fun test_finish_publish_rejects_wrong_cap() {
     let ctx = &mut test_utils::new_tx_context(PUBLISHER, 0);


### PR DESCRIPTION
## Summary

Stacked on #843 (second in the package-upgrade batch — **not for the current binary release**; #842 ships alone now, this lands with the upcoming package upgrade).

Closes out the two config-staleness gaps from this week's incidents:

1. **`LaunchCompleted` event** — `finish_publish` writes `guardian_url` and the guardian BTC key directly into config with no event, which is the root cause of the 2026-07-16 launch stall (nodes booted pre-launch kept an empty snapshot, derived no deposit addresses, and terminally rejected every deposit). The event carries the pinned guardian fields; the watcher responds by re-fetching the config snapshot and kicking the guardian reconcile so the BTC-key pin lands immediately instead of waiting for an unrelated guardian interaction. The #839 launch poll stays as the fallback for pre-event packages.
2. **Version proposals refresh the snapshot** — the `ProposalExecuted` refresh arm covered only `UpdateConfig | EmergencyPause | UpdateGuardian`, but `types::Config` also carries `enabled_versions` and `upgrade_cap`: executing `EnableVersion`/`DisableVersion`/`Upgrade` left every stable-stream node with stale version gating until a reconnect. This half is pure watcher code and needs no package upgrade — those proposals already emit `ProposalExecuted`.

## Tests

- Move: `finish_publish` emits exactly one `LaunchCompleted` with the pinned fields (full Move suite: 151 passing).
- Mixed-version safety: identical to #843 — old binaries ignore the unknown event via the `try_parse` fallthrough; new binaries on the old package simply never see it and rely on the existing poll.

## Deployment

Rollout order: #842 binary now → package upgrade with #843 + this PR → the `EnableVersion` proposal that activates the new version is itself the first beneficiary of change 2.