### PR TITLE
feat: report server version from GetServiceInfo

### DIFF
--- a/crates/hashi/src/grpc/bridge_service.rs
+++ b/crates/hashi/src/grpc/bridge_service.rs
@@ -50,7 +50,10 @@ impl BridgeService for HttpService {
         &self,
         _request: Request<GetServiceInfoRequest>,
     ) -> Result<Response<GetServiceInfoResponse>, Status> {
-        Ok(Response::new(GetServiceInfoResponse::default()))
+        Ok(Response::new(GetServiceInfoResponse {
+            server: Some(self.inner.server_version.to_string()),
+            ..Default::default()
+        }))
     }
 
     /// Validate and sign a confirmation of a bitcoin deposit request.

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -1456,7 +1456,8 @@ mod test {
         config.db = Some(tmpdir.path().into());
         let tls_public_key = config.tls_public_key().unwrap();
 
-        let hashi = Hashi::new(server_version, None, config).unwrap();
+        let registry = prometheus::Registry::new();
+        let hashi = Hashi::new_with_registry(server_version, None, config, &registry).unwrap();
 
         let (local_addr, _http_service) = crate::grpc::HttpService::new(hashi).start().await;
 
@@ -1467,10 +1468,19 @@ mod test {
         let client_auth_server = Client::new(&address, client_tls_config).unwrap();
         let client_no_auth = Client::new_no_auth(&address).unwrap();
 
-        let resp = client_auth_server.get_service_info().await.unwrap();
-        dbg!(resp);
-        let resp = client_no_auth.get_service_info().await.unwrap();
-        dbg!(resp);
+        let resp = client_auth_server
+            .get_service_info()
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.server.as_deref(), Some("unknown/unknown"));
+
+        let resp = client_no_auth
+            .get_service_info()
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.server.as_deref(), Some("unknown/unknown"));
 
         //         loop {
         //             let resp = client


### PR DESCRIPTION
## Summary
- populate the existing `GetServiceInfoResponse.server` field from `ServerVersion`
- verify both authenticated and unauthenticated clients receive the version
- isolate the TLS integration test with a fresh Prometheus registry

## Motivation
The proto documents `server` as the service software version, but the implementation currently returns `GetServiceInfoResponse::default()`. Network-wide operator dashboards therefore cannot identify outdated Hashi nodes even though the public API already reserves this field.

Returning the binary version (including the build revision supplied by `bin_version`) enables operators to see version distribution and upgrade lag without exposing private metrics.

## Test plan
- `cargo test -p hashi tls -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo test -p hashi --lib` — 469 passed
