### PR TITLE
watcher: Rescrape the full chain state every 10 minutes

### DIFF
--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -37,6 +37,12 @@ use crate::withdrawals::withdrawal_limiter_consumption_amount;
 /// server silently stopped sending checkpoints.
 const CHECKPOINT_STREAM_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
+/// How often to unconditionally rescrape the full on-chain state. The event
+/// stream can drift from chain state (e.g. writes that emit no event, such as
+/// `cleanup_spent_utxos`); a periodic rescrape bounds how long any such drift
+/// can persist.
+const PERIODIC_RESCRAPE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
 #[tracing::instrument(name = "watcher", skip_all)]
 pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<Arc<Metrics>>) {
     let subscription_read_mask = FieldMask::from_paths([
@@ -58,8 +64,9 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
     ]);
 
     let mut rescrape_state = false;
-    // Boot scrape just populated the snapshot; start the poll clock from here.
+    // Boot scrape just populated the snapshot; start the poll clocks from here.
     let mut last_config_refresh = std::time::Instant::now();
+    let mut last_rescrape = std::time::Instant::now();
 
     loop {
         // Reconnect with a fresh client each iteration. Re-subscribing on the
@@ -101,30 +108,13 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
 
         // Rescrape the chain state in the event our subscription broke
         if rescrape_state {
-            match super::scrape_hashi(
-                client.clone(),
-                state.hashi_id(),
-                state.package_id_original(),
-            )
-            .await
-            {
-                Ok((checkpoint_info, hashi)) => {
-                    state.replace_hashi_state(hashi);
-                    state.update_latest_checkpoint_info(checkpoint_info);
-                    if let Some(metrics) = &metrics {
-                        metrics.update_onchain_state(&state);
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("error trying to rescrape hashi's state: {e}");
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    continue;
-                }
+            if let Err(e) = rescrape_hashi_state(&client, &state, metrics.as_ref()).await {
+                tracing::warn!("error trying to rescrape hashi's state: {e}");
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
             }
-
-            // Rescrape gapped the event-driven limiter; trigger an eager reconcile.
-            state.request_limiter_reconcile();
             last_config_refresh = std::time::Instant::now();
+            last_rescrape = std::time::Instant::now();
         }
 
         while let Ok(Some(item)) =
@@ -194,6 +184,20 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
             if let Some(metrics) = &metrics {
                 metrics.update_onchain_state(&state);
             }
+
+            // Unconditional periodic rescrape. Runs on the watcher task, so
+            // it can't race event application; any checkpoints the scrape
+            // already included are replayed by the stream afterward, which
+            // re-applies them as no-ops. On failure, just wait for the next
+            // interval — the reconnect rescrape still guards correctness.
+            if last_rescrape.elapsed() >= PERIODIC_RESCRAPE_INTERVAL {
+                if let Err(e) = rescrape_hashi_state(&client, &state, metrics.as_ref()).await {
+                    tracing::warn!("periodic rescrape of hashi's state failed: {e}");
+                } else {
+                    last_config_refresh = std::time::Instant::now();
+                }
+                last_rescrape = std::time::Instant::now();
+            }
         }
 
         // The stream stalled, errored, or closed. Loop to rebuild the client,
@@ -201,6 +205,30 @@ pub async fn watcher(sui_rpc_url: String, state: OnchainState, metrics: Option<A
         tracing::warn!("checkpoint stream ended; reconnecting Sui client and rescraping");
         rescrape_state = true;
     }
+}
+
+/// Scrape the full on-chain state and install it as the new snapshot. Used
+/// both after a reconnect (to recover any gap the stream missed) and on the
+/// periodic rescrape interval (to heal drift from eventless writes).
+async fn rescrape_hashi_state(
+    client: &Client,
+    state: &OnchainState,
+    metrics: Option<&Arc<Metrics>>,
+) -> anyhow::Result<()> {
+    let (checkpoint_info, hashi) = super::scrape_hashi(
+        client.clone(),
+        state.hashi_id(),
+        state.package_id_original(),
+    )
+    .await?;
+    state.replace_hashi_state(hashi);
+    state.update_latest_checkpoint_info(checkpoint_info);
+    if let Some(metrics) = metrics {
+        metrics.update_onchain_state(state);
+    }
+    // Rescrape gapped the event-driven limiter; trigger an eager reconcile.
+    state.request_limiter_reconcile();
+    Ok(())
 }
 
 /// The poll only exists to catch `finish_publish` (guardian url + BTC key,


### PR DESCRIPTION
Previously, the watcher only rescraped on-chain state after a reconnect, so the local mirror could drift indefinitely from chain state for writes that emit no event (such as withdraw::cleanup_spent_utxos, whose stale mirror entries caused the recent gas-drain incident).

With this commit, the watcher unconditionally rescrapes the full state every 10 minutes. The rescrape runs on the watcher task itself, so it is serialized with event application and cannot race the checkpoint stream; any checkpoints the scrape already included simply replay as no-ops. The reconnect-rescrape body is extracted into a shared rescrape_hashi_state helper, and a successful periodic rescrape also resets the config-poll clock since the full scrape includes config. A failed periodic rescrape only warns and waits for the next interval, as the reconnect rescrape still guards correctness.