### PR TITLE
[Guardian] Isolate and revoke temporary initialization state

### DIFF
--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -187,7 +187,6 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         post,
         &session_id,
         signing_pub_key,
-        standby.config_hash,
         standby.enclave_btc_pubkey,
         committee_epoch,
         limiter_state,
@@ -372,7 +371,6 @@ fn verify_activated_info(
     post: VerifiedGuardianInfo,
     expected_session_id: &str,
     expected_signing_key: hashi_types::guardian::GuardianPubKey,
-    expected_config_hash: [u8; 32],
     expected_enclave_btc_pubkey: hashi_types::bitcoin::BitcoinPubkey,
     expected_committee_epoch: u64,
     expected_limiter_state: hashi_types::guardian::LimiterState,
@@ -390,10 +388,6 @@ fn verify_activated_info(
     ensure!(
         post.info.lifecycle == WithdrawStage::Activated.into(),
         "guardian is not an activated withdraw enclave"
-    );
-    ensure!(
-        post.info.config_hash == Some(expected_config_hash),
-        "Guardian config_hash changed during operator activation"
     );
     ensure!(
         post.info.enclave_btc_pubkey == Some(expected_enclave_btc_pubkey),

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Core enclave types: `Enclave` holds all guardian state (immutable config
-//! set during operator/provisioner-init, mutable runtime state, and
-//! initialization state). Lives in the library so external crates
+//! Core enclave types: `Enclave` holds all guardian state (durable config,
+//! mutable runtime state, and temporary initialization state). Lives in the
+//! library so external crates
 //! (integration test harnesses, ops tooling) can construct and drive an
 //! enclave without going through `main`.
 
@@ -29,6 +29,7 @@ use tokio::sync::OwnedMutexGuard;
 use tracing::info;
 
 use crate::s3_client::GuardianS3Client;
+use crate::s3_reader::GuardianReader;
 use hashi_types::committee::Committee as HashiCommittee;
 
 /// Enclave's config & state
@@ -37,8 +38,8 @@ pub struct Enclave {
     pub config: EnclaveConfig,
     /// Mutable state
     pub state: EnclaveState,
-    /// State produced or consumed by initialization flows.
-    init_state: InitializationState,
+    /// Temporary state retained until operator activation commits.
+    temporary_init_state: RwLock<Option<TemporaryInitState>>,
     /// Serializes lifecycle and control-plane transitions so concurrent callers
     /// cannot race a check-then-set. Held across each handler.
     /// TODO: Ensure this lock is not released if the RPC is cancelled while a
@@ -48,8 +49,10 @@ pub struct Enclave {
 
 /// Configuration set during initialization (immutable after set)
 pub struct EnclaveConfig {
-    /// Ephemeral keypair (set on boot)
-    eph_keys: EphemeralKeyPairs,
+    /// Ephemeral signing keypair generated at boot.
+    signing_keys: GuardianSignKeyPair,
+    /// Ephemeral encryption keypair generated at boot.
+    encryption_keys: GuardianEncKeyPair,
     /// S3 client & config (set in operator_init)
     s3_logger: OnceLock<GuardianS3Client>,
     /// Enclave BTC private key (set in provisioner_init)
@@ -60,6 +63,11 @@ pub struct EnclaveConfig {
     /// 2-of-2 child-key derivation matches the MPC's signing protocol.
     /// Set in operator_init.
     hashi_btc_master_pubkey: OnceLock<HashiMasterG>,
+    /// Guardian build PCR pins used to verify attested guardian sessions.
+    pcr_allowlist: OnceLock<PcrAllowlist>,
+    /// Operator-supplied limiter configuration.
+    /// Note: This struct is duplicated in two places: `RateLimiter` stores a copy after activation.
+    limiter_config: OnceLock<LimiterConfig>,
 }
 
 /// Mutable state that changes during operation.
@@ -74,51 +82,30 @@ pub struct EnclaveState {
     rate_limiter: OnceLock<Arc<tokio::sync::Mutex<RateLimiter>>>,
 }
 
-/// State produced or consumed by initialization flows.
-#[derive(Default)]
-struct InitializationState {
-    /// Withdraw-mode input: stable configuration installed by `operator_init`.
-    init_config: OnceLock<InitConfig>,
-    /// Withdraw-mode input: the ceremony instance and its share-to-KP assignment,
-    /// installed by `operator_init` for `provisioner_init` validation.
-    ceremony_state: RwLock<Option<CeremonyState>>,
-    /// Optional first-deploy state pinned during OI and retained through PI
-    /// until activation clears initialization state.
-    genesis_state: RwLock<Option<GenesisState>>,
-}
-
-impl InitializationState {
-    /// Drop withdraw-mode inputs that may become stale once the enclave is active.
-    /// Stable config and ceremony-mode output remain available.
-    fn clear(&self) {
-        self.ceremony_state
-            .write()
-            .expect("ceremony state lock poisoned")
-            .take()
-            .expect("ceremony state must exist before activation");
-        self.genesis_state
-            .write()
-            .expect("genesis state lock poisoned")
-            .take();
-    }
-}
-
-pub struct EphemeralKeyPairs {
-    pub signing_keys: GuardianSignKeyPair,
-    pub encryption_keys: GuardianEncKeyPair,
+/// Inputs needed only between operator initialization and activation.
+/// The enclave drops this entire capability when activation commits.
+#[derive(Clone)]
+pub(crate) struct TemporaryInitState {
+    pub ceremony_state: CeremonyState,
+    pub genesis_state: Option<GenesisState>,
+    pub config_hash: [u8; 32],
 }
 
 impl EnclaveConfig {
+    // ========================================================================
+    // Construction
+    // ========================================================================
+
     pub fn new(signing_keys: GuardianSignKeyPair, encryption_keys: GuardianEncKeyPair) -> Self {
         EnclaveConfig {
-            eph_keys: EphemeralKeyPairs {
-                signing_keys,
-                encryption_keys,
-            },
+            signing_keys,
+            encryption_keys,
             s3_logger: OnceLock::new(),
             enclave_btc_keypair: OnceLock::new(),
             btc_network: OnceLock::new(),
             hashi_btc_master_pubkey: OnceLock::new(),
+            pcr_allowlist: OnceLock::new(),
+            limiter_config: OnceLock::new(),
         }
     }
 
@@ -131,12 +118,6 @@ impl EnclaveConfig {
             .get()
             .copied()
             .ok_or(InvalidInputs("Network is uninitialized".into()))
-    }
-
-    pub fn set_bitcoin_network(&self, network: Network) -> GuardianResult<()> {
-        self.btc_network
-            .set(network)
-            .map_err(|_| InvalidInputs("Network is already initialized".into()))
     }
 
     pub fn set_btc_keypair(&self, keypair: Keypair) -> GuardianResult<()> {
@@ -152,12 +133,6 @@ impl EnclaveConfig {
             .get()
             .map(|kp| kp.x_only_public_key().0)
             .ok_or(InvalidInputs("Bitcoin key is not initialized".into()))
-    }
-
-    pub fn set_hashi_btc_pk(&self, pk: HashiMasterG) -> GuardianResult<()> {
-        self.hashi_btc_master_pubkey
-            .set(pk)
-            .map_err(|_| InvalidInputs("Hashi BTC key is already set".into()))
     }
 
     /// Sign a BTC tx. Returns an Err if enclave btc keypair or hashi btc pk is not set.
@@ -176,6 +151,10 @@ impl EnclaveConfig {
         Ok((txid, sign_btc_tx(&messages, enclave_keypair)))
     }
 
+    pub fn is_enclave_btc_keypair_set(&self) -> bool {
+        self.enclave_btc_keypair.get().is_some()
+    }
+
     // ========================================================================
     // S3 Logger
     // ========================================================================
@@ -191,13 +170,13 @@ impl EnclaveConfig {
             .set(logger)
             .map_err(|_| InvalidInputs("S3 logger already set".into()))
     }
-
-    pub fn is_enclave_btc_keypair_set(&self) -> bool {
-        self.enclave_btc_keypair.get().is_some()
-    }
 }
 
 impl EnclaveState {
+    // ========================================================================
+    // Activation State Installation
+    // ========================================================================
+
     /// Install the activation-derived committee + rate limiter. Called from operator_activate.
     pub fn init(&self, committee: HashiCommittee, rate_limiter: RateLimiter) -> GuardianResult<()> {
         self.set_committee(committee)?;
@@ -320,17 +299,11 @@ impl EnclaveState {
     pub async fn limiter_state(&self) -> Option<LimiterState> {
         Some(*self.lock_limiter().await.ok()?.state())
     }
-
-    /// Return the limiter config for status reporting, or `None` if the limiter
-    /// is uninitialized or remains locked through the acquisition deadline.
-    pub async fn limiter_config(&self) -> Option<LimiterConfig> {
-        Some(*self.lock_limiter().await.ok()?.config())
-    }
 }
 
 impl Enclave {
     // ========================================================================
-    // Construction & Initialization Status
+    // Construction & Lifecycle
     // ========================================================================
 
     pub fn new(
@@ -348,7 +321,7 @@ impl Enclave {
                 committee: RwLock::new(None),
                 rate_limiter: OnceLock::new(),
             },
-            init_state: InitializationState::default(),
+            temporary_init_state: RwLock::new(None),
             control_lock: tokio::sync::Mutex::new(()),
         }
     }
@@ -415,10 +388,12 @@ impl Enclave {
             // The lifecycle itself is the completion state.
             EnclaveLifecycle::Ceremony(CeremonyStage::Completed) => return,
             EnclaveLifecycle::Withdraw(WithdrawStage::ProvisionerInitialized) => {
-                self.config.is_enclave_btc_keypair_set()
+                self.config.is_enclave_btc_keypair_set() && self.temporary_init_state_is_available()
             }
             EnclaveLifecycle::Withdraw(WithdrawStage::Activated) => {
-                self.state.has_committee() && self.state.rate_limiter.get().is_some()
+                self.state.has_committee()
+                    && self.state.rate_limiter.get().is_some()
+                    && !self.temporary_init_state_is_available()
             }
         };
         assert!(
@@ -435,16 +410,12 @@ impl Enclave {
         }
         match mode {
             EnclaveMode::Ceremony => true,
-            // Withdraw enclaves additionally install the stable InitConfig.
+            // Withdraw enclaves additionally install their stable configuration.
             EnclaveMode::Withdraw => {
                 self.config.btc_network.get().is_some()
-                    && self.init_state.init_config.get().is_some()
-                    && self
-                        .init_state
-                        .ceremony_state
-                        .read()
-                        .expect("ceremony state lock poisoned")
-                        .is_some()
+                    && self.config.pcr_allowlist.get().is_some()
+                    && self.config.limiter_config.get().is_some()
+                    && self.temporary_init_state_is_available()
                     && self.config.hashi_btc_master_pubkey.get().is_some()
             }
         }
@@ -460,21 +431,21 @@ impl Enclave {
 
     /// Get the enclave's encryption secret key
     pub fn encryption_secret_key(&self) -> &EncSecKey {
-        self.config.eph_keys.encryption_keys.secret_key()
+        self.config.encryption_keys.secret_key()
     }
 
     /// Get the enclave's encryption public key
     pub fn encryption_public_key(&self) -> &EncPubKey {
-        self.config.eph_keys.encryption_keys.public_key()
+        self.config.encryption_keys.public_key()
     }
 
     /// Get the enclave's verification key
     pub fn signing_pubkey(&self) -> GuardianPubKey {
-        self.config.eph_keys.signing_keys.verification_key()
+        self.config.signing_keys.verification_key()
     }
 
     pub fn sign<T: Serialize + SigningIntent>(&self, data: T) -> GuardianSigned<T> {
-        let kp = &self.config.eph_keys.signing_keys;
+        let kp = &self.config.signing_keys;
         let timestamp = now_timestamp_ms();
         GuardianSigned::new(data, kp, timestamp)
     }
@@ -502,26 +473,28 @@ impl Enclave {
     }
 
     pub async fn info(&self) -> GuardianInfo {
+        let temporary_init_state = self.temporary_init_state().ok();
         GuardianInfo {
             lifecycle: self.lifecycle(),
-            secret_sharing_instance: self.secret_sharing_instance().ok(),
+            secret_sharing_instance: temporary_init_state
+                .as_ref()
+                .map(|state| state.ceremony_state.secret_sharing_instance.clone()),
             bucket_info: self
                 .config
                 .s3_logger()
                 .ok()
                 .map(|l| l.bucket_info().clone()),
             encryption_pubkey: self.encryption_public_key().to_bytes().to_vec(),
-            config_hash: self.config_hash(),
-            genesis_state_hash: self.genesis_state_hash(),
+            config_hash: temporary_init_state.as_ref().map(|state| state.config_hash),
+            genesis_state_hash: temporary_init_state
+                .as_ref()
+                .and_then(|state| state.genesis_state.as_ref().map(GenesisState::digest)),
             untrusted_git_revision: self.reported_git_revision(),
             enclave_btc_pubkey: self.config.enclave_btc_pubkey().ok(),
             limiter_state: self.state.limiter_state().await,
-            limiter_config: match self.state.limiter_config().await {
-                Some(config) => Some(config),
-                None => self.init_config().map(|config| *config.limiter_config()),
-            },
+            limiter_config: self.limiter_config().ok(),
             current_committee_epoch: self.state.get_committee().ok().map(|c| c.epoch()),
-            mpc_master_g: self.config.hashi_btc_master_pubkey.get().cloned(),
+            mpc_master_g: self.config.hashi_btc_master_pubkey.get().copied(),
         }
     }
 
@@ -535,21 +508,13 @@ impl Enclave {
     }
 
     async fn write_log(&self, message: LogMessage) -> GuardianResult<()> {
-        let log = LogRecord::new(
-            self.s3_session_id(),
-            message,
-            &self.config.eph_keys.signing_keys,
-        );
+        let log = LogRecord::new(self.s3_session_id(), message, &self.config.signing_keys);
 
         self.config.s3_logger()?.write_log_record(log).await
     }
 
     async fn write_log_or_abort(&self, message: LogMessage) -> GuardianResult<()> {
-        let log = LogRecord::new(
-            self.s3_session_id(),
-            message,
-            &self.config.eph_keys.signing_keys,
-        );
+        let log = LogRecord::new(self.s3_session_id(), message, &self.config.signing_keys);
 
         self.config
             .s3_logger()?
@@ -604,79 +569,99 @@ impl Enclave {
     }
 
     // ========================================================================
-    // Initialization state
+    // Temporary Initialization State
     // ========================================================================
 
-    // TODO: This accessor is valid only before operator activation. Activation
-    // clears `ceremony_state`, so calls in the Activated lifecycle always fail.
-    // Remove it when lifecycle-specific state owns the initialization data.
-    pub fn secret_sharing_instance(&self) -> GuardianResult<SecretSharingInstance> {
-        Ok(self.ceremony_state()?.secret_sharing_instance)
-    }
-
-    pub fn ceremony_state(&self) -> GuardianResult<CeremonyState> {
-        self.init_state
-            .ceremony_state
+    /// Return an owned initialization snapshot. Activation takes the stored
+    /// value, so this capability is unavailable once the enclave is active.
+    /// Keep this as the only accessor for `TemporaryInitState`. Its readers are
+    /// restricted to provisioner initialization, operator activation, and
+    /// status reporting; active request handlers must not depend on it.
+    pub(crate) fn temporary_init_state(&self) -> GuardianResult<TemporaryInitState> {
+        self.temporary_init_state
             .read()
-            .expect("ceremony state lock poisoned")
+            .expect("temporary initialization lock poisoned")
             .clone()
-            .ok_or(InvalidInputs("Ceremony state not set".into()))
+            .ok_or_else(|| InvalidInputs("Temporary initialization state not set".into()))
     }
 
-    pub fn set_ceremony_state(&self, state: CeremonyState) -> GuardianResult<()> {
+    /// Operator initialization is the sole installer of temporary state.
+    pub(crate) fn set_temporary_init_state(&self, state: TemporaryInitState) -> GuardianResult<()> {
         let mut slot = self
-            .init_state
-            .ceremony_state
+            .temporary_init_state
             .write()
-            .expect("ceremony state lock poisoned");
+            .expect("temporary initialization lock poisoned");
         if slot.is_some() {
-            return Err(InvalidInputs("Ceremony state already set".into()));
+            return Err(InvalidInputs(
+                "Temporary initialization state already set".into(),
+            ));
         }
         *slot = Some(state);
         Ok(())
     }
 
-    pub fn genesis_state(&self) -> Option<GenesisState> {
-        self.init_state
-            .genesis_state
+    fn temporary_init_state_is_available(&self) -> bool {
+        self.temporary_init_state
             .read()
-            .expect("genesis state lock poisoned")
-            .clone()
+            .expect("temporary initialization lock poisoned")
+            .is_some()
     }
 
-    pub fn set_genesis_state(&self, state: GenesisState) -> GuardianResult<()> {
-        let mut slot = self
-            .init_state
-            .genesis_state
+    pub(crate) fn clear_temporary_init_state(&self) {
+        self.temporary_init_state
             .write()
-            .expect("genesis state lock poisoned");
-        if slot.is_some() {
-            return Err(InvalidInputs("Genesis state already set".into()));
-        }
-        *slot = Some(state);
-        Ok(())
+            .expect("temporary initialization lock poisoned")
+            .take()
+            .expect("temporary initialization state must exist before activation");
     }
 
-    pub fn genesis_state_hash(&self) -> Option<[u8; 32]> {
-        self.genesis_state().as_ref().map(GenesisState::digest)
+    // ========================================================================
+    // Enclave Configuration
+    // ========================================================================
+
+    /// Construct a verified reader with the enclave's fixed S3 client and PCR
+    /// allowlist. Each operation gets a fresh, operation-scoped session cache.
+    pub(crate) fn new_guardian_reader(&self) -> GuardianResult<GuardianReader> {
+        let s3 = self.config.s3_logger()?.clone();
+        let pcr_allowlist = self
+            .config
+            .pcr_allowlist
+            .get()
+            .cloned()
+            .ok_or_else(|| InvalidInputs("PCR allowlist is uninitialized".into()))?;
+        Ok(GuardianReader::from_s3_client(s3, pcr_allowlist))
     }
 
-    pub fn clear_initialization_state(&self) {
-        self.init_state.clear();
+    pub fn limiter_config(&self) -> GuardianResult<LimiterConfig> {
+        self.config
+            .limiter_config
+            .get()
+            .copied()
+            .ok_or_else(|| InvalidInputs("Limiter config is uninitialized".into()))
     }
 
-    pub fn init_config(&self) -> Option<&InitConfig> {
-        self.init_state.init_config.get()
-    }
-
-    pub fn set_init_config(&self, config: InitConfig) -> GuardianResult<()> {
-        self.init_state
-            .init_config
-            .set(config)
-            .map_err(|_| InvalidInputs("Init config already set".into()))
-    }
-
-    pub fn config_hash(&self) -> Option<[u8; 32]> {
-        self.init_config().map(InitConfig::digest)
+    pub(crate) fn install_config(
+        &self,
+        network: Network,
+        hashi_btc_master_pubkey: HashiMasterG,
+        pcr_allowlist: PcrAllowlist,
+        limiter_config: LimiterConfig,
+    ) -> GuardianResult<()> {
+        self.config
+            .btc_network
+            .set(network)
+            .map_err(|_| InvalidInputs("Network is already initialized".into()))?;
+        self.config
+            .hashi_btc_master_pubkey
+            .set(hashi_btc_master_pubkey)
+            .map_err(|_| InvalidInputs("Hashi BTC key is already initialized".into()))?;
+        self.config
+            .pcr_allowlist
+            .set(pcr_allowlist)
+            .map_err(|_| InvalidInputs("PCR allowlist is already initialized".into()))?;
+        self.config
+            .limiter_config
+            .set(limiter_config)
+            .map_err(|_| InvalidInputs("Limiter config is already initialized".into()))
     }
 }

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -7,6 +7,7 @@
 //! `withdraw::provisioner_init`.
 
 use crate::attestation::get_attestation;
+use crate::enclave::TemporaryInitState;
 use crate::s3_reader::BuildPolicy;
 use crate::s3_reader::GuardianReader;
 use crate::Enclave;
@@ -74,14 +75,9 @@ impl OIWithdrawModeInstall {
     /// Install the bundle onto a fresh enclave. Infallible by design (see the
     /// `operator_init` invariant): every set runs once on a fresh enclave.
     pub(crate) fn install_into(self, enclave: &Enclave) {
-        let network = self.init_config.network();
-        let hashi_btc_master_pubkey = self.init_config.hashi_btc_master_pubkey();
-
-        info!("Setting Bitcoin network to {:?}.", network);
-        enclave
-            .config
-            .set_bitcoin_network(network)
-            .expect("Unable to set network");
+        let config_hash = self.init_config.digest();
+        let (limiter_config, hashi_btc_master_pubkey, pcr_allowlist, network) =
+            self.init_config.into_parts();
 
         info!(
             "Setting secret-sharing instance: n={}, t={}, {} commitments.",
@@ -92,30 +88,29 @@ impl OIWithdrawModeInstall {
                 .commitments()
                 .len()
         );
-        enclave
-            .set_ceremony_state(self.ceremony_state)
-            .expect("Unable to set ceremony state");
-
-        if let Some(genesis_state) = self.genesis_state {
+        if let Some(genesis_state) = &self.genesis_state {
             info!(
                 genesis_state_hash = hex::encode(genesis_state.digest()),
                 "Storing genesis state."
             );
-            enclave
-                .set_genesis_state(genesis_state)
-                .expect("Unable to set genesis state");
         }
-
-        info!("Setting init config.");
         enclave
-            .set_init_config(self.init_config)
-            .expect("Unable to set init config");
+            .set_temporary_init_state(TemporaryInitState {
+                ceremony_state: self.ceremony_state,
+                genesis_state: self.genesis_state,
+                config_hash,
+            })
+            .expect("Unable to set temporary initialization state");
 
-        info!("Setting Hashi BTC master pubkey.");
+        info!(?network, "Setting enclave configuration.");
         enclave
-            .config
-            .set_hashi_btc_pk(hashi_btc_master_pubkey)
-            .expect("Unable to set hashi BTC master pubkey");
+            .install_config(
+                network,
+                hashi_btc_master_pubkey,
+                pcr_allowlist,
+                limiter_config,
+            )
+            .expect("Unable to set enclave configuration");
     }
 }
 
@@ -205,6 +200,9 @@ async fn commit_operator_init(enclave: &Enclave, install: OIInstall) {
     // 2) Share commitments help KPs confirm that the right private key will be constructed.
     // This pre-transition snapshot reports `Uninitialized`; successfully
     // writing it completes operator initialization.
+    // TODO(testnet-wipe): Replace the full GuardianInfo snapshot with a
+    // purpose-built OI payload containing only the data readers and KPs need;
+    // the evolving status response should not define the durable log schema.
     enclave
         .log_init(OIGuardianInfo(Box::new(enclave.info().await)))
         .await

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -351,7 +351,7 @@ pub fn activate_enclave_for_testing(
     let rate_limiter = RateLimiter::new(limiter_config, limiter_state)?;
 
     enclave.state.init(committee, rate_limiter)?;
-    enclave.clear_initialization_state();
+    enclave.clear_temporary_init_state();
     enclave.advance_lifecycle_into(WithdrawStage::Activated.into())?;
     Ok(())
 }
@@ -376,6 +376,6 @@ pub async fn create_fully_initialized_enclave(args: FullyInitializedArgs) -> Arc
         .expect("activate_enclave_for_testing should succeed on a fresh enclave");
 
     assert!(enclave.is_fully_initialized());
-    assert!(enclave.secret_sharing_instance().is_err());
+    assert!(enclave.temporary_init_state().is_err());
     enclave
 }

--- a/crates/hashi-guardian/src/withdraw_mode/genesis.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/genesis.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::s3_reader::BuildPolicy;
-use crate::s3_reader::GuardianReader;
 use crate::Enclave;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianResult;
@@ -10,12 +9,7 @@ use hashi_types::guardian::GuardianResult;
 /// Preserve the existing genesis guard: a first-deploy PI may write genesis only
 /// while no serving committee exists in `committee-update/` or `genesis/`.
 pub(super) async fn ensure_no_serving_committee(enclave: &Enclave) -> GuardianResult<()> {
-    let init_config = enclave
-        .init_config()
-        .ok_or_else(|| InvalidInputs("InitConfig not set".into()))?
-        .clone();
-    let logger = enclave.config.s3_logger()?.clone();
-    let mut reader = GuardianReader::from_s3_client(logger, init_config.pcr_allowlist().clone());
+    let mut reader = enclave.new_guardian_reader()?;
 
     if reader
         .read_latest_committee(BuildPolicy::AnyAllowlisted)

--- a/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
@@ -6,7 +6,6 @@
 //! operator-pinned `ActivationState` hash.
 
 use crate::s3_reader::BuildPolicy;
-use crate::s3_reader::GuardianReader;
 use crate::Enclave;
 use hashi_types::guardian::ActivationState;
 use hashi_types::guardian::GuardianError;
@@ -37,23 +36,14 @@ impl OAInstall {
         enclave: &Enclave,
         request: OperatorActivateRequest,
     ) -> GuardianResult<Self> {
-        let init_config = enclave
-            .init_config()
-            .ok_or_else(|| InvalidInputs("InitConfig not set".into()))?
-            .clone();
-        let config_hash = enclave
-            .config_hash()
-            .ok_or_else(|| InvalidInputs("config_hash not set".into()))?;
-        let armed_instance = enclave
-            .secret_sharing_instance()
-            .map_err(|_| InvalidInputs("secret-sharing instance not set".into()))?;
+        let limiter_config = enclave.limiter_config()?;
+        let initialization = enclave
+            .temporary_init_state()
+            .map_err(|_| InvalidInputs("temporary initialization state not set".into()))?;
+        let config_hash = initialization.config_hash;
+        let armed_instance = initialization.ceremony_state.secret_sharing_instance;
 
-        let s3 = enclave
-            .config
-            .s3_logger()
-            .map_err(|_| InvalidInputs("S3 logger not set".into()))?
-            .clone();
-        let mut reader = GuardianReader::from_s3_client(s3, init_config.pcr_allowlist().clone());
+        let mut reader = enclave.new_guardian_reader()?;
 
         reader
             .ensure_session_live_and_others_quiet(&enclave.s3_session_id())
@@ -69,10 +59,10 @@ impl OAInstall {
             .map_err(|e| InvalidInputs(format!("invalid serving committee: {e}")))?;
 
         let limiter_state = reader
-            .recover_limiter_state(init_config.limiter_config())
+            .recover_limiter_state(&limiter_config)
             .await
             .map_err(|e| InvalidInputs(format!("recover limiter state: {e}")))?;
-        let rate_limiter = RateLimiter::new(*init_config.limiter_config(), limiter_state)?;
+        let rate_limiter = RateLimiter::new(limiter_config, limiter_state)?;
         let sharing_seq = armed_instance.sharing_seq();
         let committee_epoch = committee.epoch();
 
@@ -142,7 +132,7 @@ async fn commit_operator_activate(enclave: &Enclave, install: OAInstall) {
         .await
         .expect("Unable to log operator activation");
 
-    enclave.clear_initialization_state();
+    enclave.clear_temporary_init_state();
 
     enclave
         .advance_lifecycle_into(WithdrawStage::Activated.into())

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -31,17 +31,16 @@ impl PIInstall {
         enclave: &Enclave,
         request: ProvisionerInitRequest,
     ) -> GuardianResult<Self> {
-        let ceremony_state = enclave
-            .ceremony_state()
-            .expect("ceremony state should be set after operator_init");
+        let initialization = enclave
+            .temporary_init_state()
+            .expect("temporary initialization state should be set after operator_init");
+        let ceremony_state = &initialization.ceremony_state;
         let instance = &ceremony_state.secret_sharing_instance;
         let threshold = instance.threshold();
         let sharing_seq = instance.sharing_seq();
-        let config_hash = enclave
-            .config_hash()
-            .expect("withdraw-mode operator_init installs the config_hash");
+        let config_hash = initialization.config_hash;
         let session_id = enclave.s3_session_id();
-        let genesis_state = enclave.genesis_state();
+        let genesis_state = initialization.genesis_state.clone();
         let genesis_state_hash = genesis_state.as_ref().map(GenesisState::digest);
 
         let encrypted_shares = verify_signed_submissions(
@@ -280,6 +279,13 @@ mod tests {
     }
 
     impl TestContext {
+        fn config_hash(&self) -> [u8; 32] {
+            self.enclave
+                .temporary_init_state()
+                .expect("test enclave should retain temporary initialization state")
+                .config_hash
+        }
+
         fn signed_submission(
             &self,
             share: &Share,
@@ -292,7 +298,12 @@ mod tests {
                 &self.kp_keys[signer_index],
                 expected_session_id,
                 expected_config_hash,
-                self.enclave.genesis_state_hash(),
+                self.enclave
+                    .temporary_init_state()
+                    .expect("test enclave should retain temporary initialization state")
+                    .genesis_state
+                    .as_ref()
+                    .map(GenesisState::digest),
             )
         }
 
@@ -308,7 +319,12 @@ mod tests {
                 signer,
                 expected_session_id,
                 expected_config_hash,
-                self.enclave.genesis_state_hash(),
+                self.enclave
+                    .temporary_init_state()
+                    .expect("test enclave should retain temporary initialization state")
+                    .genesis_state
+                    .as_ref()
+                    .map(GenesisState::digest),
             )
         }
 
@@ -355,7 +371,7 @@ mod tests {
 
         fn request(&self, shares: &[Share]) -> ProvisionerInitRequest {
             let session_id = self.enclave.s3_session_id();
-            let config_hash = self.enclave.config_hash().unwrap();
+            let config_hash = self.config_hash();
             let submissions = shares
                 .iter()
                 .map(|share| {
@@ -400,7 +416,7 @@ mod tests {
             &ctx.shares[0],
             &ctx.alternate_first_kp_key,
             ctx.enclave.s3_session_id(),
-            ctx.enclave.config_hash().unwrap(),
+            ctx.config_hash(),
         )];
         submissions.extend(ctx.request(&ctx.shares[1..TEST_T]).0);
 
@@ -487,7 +503,7 @@ mod tests {
                     share,
                     usize::from(share.id.get() - 1),
                     ctx.enclave.s3_session_id(),
-                    ctx.enclave.config_hash().unwrap(),
+                    ctx.config_hash(),
                     Some([0xAB; 32]),
                 )
             })
@@ -502,7 +518,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_mismatched_session() {
         let ctx = setup().await;
-        let config_hash = ctx.enclave.config_hash().unwrap();
+        let config_hash = ctx.config_hash();
         let submissions = ctx.shares[..TEST_T]
             .iter()
             .map(|share| {
@@ -541,7 +557,7 @@ mod tests {
             &ctx.shares[0],
             1,
             ctx.enclave.s3_session_id(),
-            ctx.enclave.config_hash().unwrap(),
+            ctx.config_hash(),
         );
         let err = ctx
             .provision(ProvisionerInitRequest(submissions))
@@ -561,7 +577,7 @@ mod tests {
             &bogus_share,
             0,
             ctx.enclave.s3_session_id(),
-            ctx.enclave.config_hash().unwrap(),
+            ctx.config_hash(),
         )];
         submissions.extend(ctx.request(&ctx.shares[1..TEST_T]).0);
         let err = ctx
@@ -578,7 +594,7 @@ mod tests {
             &ctx.shares[0],
             0,
             ctx.enclave.s3_session_id(),
-            ctx.enclave.config_hash().unwrap(),
+            ctx.config_hash(),
         );
         let err = ctx
             .provision(ProvisionerInitRequest(vec![
@@ -588,7 +604,7 @@ mod tests {
                     &ctx.shares[1],
                     1,
                     ctx.enclave.s3_session_id(),
-                    ctx.enclave.config_hash().unwrap(),
+                    ctx.config_hash(),
                 ),
             ]))
             .await

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -8,7 +8,6 @@
 use std::sync::Arc;
 
 use crate::s3_reader::BuildPolicy;
-use crate::s3_reader::GuardianReader;
 use crate::Enclave;
 use hashi_types::guardian::crypto::decrypt_share;
 use hashi_types::guardian::crypto::encrypt_share_for_provisioner;
@@ -53,15 +52,7 @@ pub async fn provisioner_rotate_cert(
     let new_recipient_fingerprint = request.new_recipient_fingerprint();
     let encrypted_share = request.encrypted_share().clone();
 
-    let init_config = enclave
-        .init_config()
-        .ok_or_else(|| InvalidInputs("InitConfig not set".into()))?;
-    let s3 = enclave
-        .config
-        .s3_logger()
-        .map_err(|_| InvalidInputs("S3 logger not set".into()))?
-        .clone();
-    let mut reader = GuardianReader::from_s3_client(s3, init_config.pcr_allowlist().clone());
+    let mut reader = enclave.new_guardian_reader()?;
 
     let latest_state = reader
         .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -95,6 +95,8 @@ pub enum LogMessageV1 {
 
 /// Current log schema emitted by the guardian enclave.
 /// Uses an enum discriminator for automatic domain separation between variants.
+// TODO(testnet-wipe): Collapse the V1/V2 compatibility layer into a single log
+// schema once existing testnet records no longer need to be read.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum LogMessageV2 {
     Heartbeat(HeartbeatLogMessage),


### PR DESCRIPTION
Groups ceremony state, optional genesis state, and the initialization config hash into one temporary initialization capability. Operator initialization installs the bundle, provisioner initialization and operator activation consume an owned snapshot, and activation removes the entire capability after its durable log commits.

Durable values needed by an active enclave remain directly in EnclaveConfig. This removes broad initialization accessors (e.g., `get_secret_sharing_instance()`) while preserving the existing S3 log schema and lifecycle ordering.