### PR TITLE
docs: Add a systemd unit for running the standalone binary

### DIFF
--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -662,6 +662,45 @@ hashi server [--config <path>]
 
 Run the Hashi validator daemon. Uses the validator config.
 
+**Running as a standalone service (systemd).** Operators who run the binary directly rather than a container can manage it with systemd. Install the verified binary at `/usr/local/bin/hashi` (confirm its sha256 first, see [1.3](#13-software-dependencies)), place your config at `/etc/hashi/validator.toml`, and run the daemon under a dedicated unprivileged user:
+
+```ini
+# /etc/systemd/system/hashi.service
+[Unit]
+Description=Hashi validator node
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=hashi
+Group=hashi
+ExecStart=/usr/local/bin/hashi server --config /etc/hashi/validator.toml
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+# The node binds to :443 by default (the listen-address field). This grants the
+# non-root process the one privileged-port capability it needs. Drop this line if
+# you set listen-address to a port at or above 1024 and front it with a proxy.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable it, start it, and follow the logs:
+
+```bash
+sudo systemctl enable --now hashi
+journalctl -u hashi -f
+```
+
+Notes:
+
+- The `hashi` user needs read access to the config and key files (keep key files `chmod 600`) and write access to the `db` path, which must be on persistent storage.
+- The node writes structured JSON logs to stdout, so journald captures everything and there is no separate log file to rotate.
+- This is an alternative to containerizing the process (see [1.1](#11-resources)), not an addition. Run one or the other.
+
 ### 6.3 Register
 
 ```bash

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -71,19 +71,19 @@ See [1.4](#14-sui-rpc) and [1.5](#15-bitcoin-node) for details.
 
 ### 1.3 Software dependencies
 
-**Hashi binary.** Build the Linux x86-64 binary with the deterministic Docker build. It compiles in a pinned, reproducible environment, extracts the binary, and writes its sha256:
+**Hashi binary.** Build the Linux x86-64 binary with the deterministic Docker build. It compiles in a pinned, reproducible environment, extracts the binary to `out/hashi`, and prints its sha256:
 
 ```bash
-# Reproducible build (requires Docker); writes out/hashi and out/hashi.sha256
+# Reproducible build (requires Docker); writes out/hashi and prints its sha256
 bash docker/hashi/build.sh --no-cache
 ```
 
 > **Which source ref to build.** Check out the ref for your target network **before** running the build. The script builds whatever is in your working tree. The repository does not currently carry release tags, and the binary reports a version derived from the git revision at build time rather than from a tag or a `VERSION` file, so the runbook cannot name the ref for you. **Confirm the current Testnet ref with the Hashi team** and build from that. Whatever ref you use, verify the result against the published sha256 below.
 
-The build pins its base images, sets `SOURCE_DATE_EPOCH=0`, links statically, and compiles `--frozen` with networking disabled, so it is bit-for-bit reproducible. CI confirms the same binary hash across runners. Each release publishes the sha256 of these deterministic binaries, so you can reproduce the build yourself and confirm your binary matches the published checksum:
+The build pins its base images, sets `SOURCE_DATE_EPOCH=0`, links statically, and compiles `--frozen` with networking disabled, so it is bit-for-bit reproducible. CI confirms the same binary hash across runners. Each release publishes the sha256 of these deterministic binaries, so you can reproduce the build yourself and confirm your binary matches the published checksum. Compute the sha256 of your build and compare it against the published value:
 
 ```bash
-sha256sum -c out/hashi.sha256
+sha256sum out/hashi
 ```
 
 **Backup tooling.** Node backups are **OpenPGP** (Sequoia). To generate a backup key and decrypt backups you need an OpenPGP toolchain:
@@ -688,9 +688,10 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 WantedBy=multi-user.target
 ```
 
-Enable it, start it, and follow the logs:
+Reload systemd so it picks up the new or changed unit, enable and start it, then follow the logs:
 
 ```bash
+sudo systemctl daemon-reload
 sudo systemctl enable --now hashi
 journalctl -u hashi -f
 ```
@@ -698,7 +699,7 @@ journalctl -u hashi -f
 Notes:
 
 - The `hashi` user needs read access to the config and key files (keep key files `chmod 600`) and write access to the `db` path, which must be on persistent storage.
-- The node writes structured JSON logs to stdout, so journald captures everything and there is no separate log file to rotate.
+- The node writes structured JSON logs to stderr, so journald captures everything and there is no separate log file to rotate.
 - This is an alternative to containerizing the process (see [1.1](#11-resources)), not an addition. Run one or the other.
 
 ### 6.3 Register


### PR DESCRIPTION
Bare-metal operators (running the binary directly, not the container) asked for a setup guide. The runbook is already binary-first — the run command is `hashi server --config validator.toml` and all the config/keys/ports guidance is container-agnostic — but it had **no service-management example**, which is the actual gap they hit.

Adds a **Running as a standalone service (systemd)** block under §6.2 Server with a ready-to-use unit file:
- dedicated unprivileged `hashi` user
- `Restart=on-failure` + `RestartSec`
- `AmbientCapabilities=CAP_NET_BIND_SERVICE` so a non-root process can bind the default `:443` `listen-address` (with a note to drop it if fronting a proxy on a high port)
- `enable --now` + `journalctl -u hashi -f`
- notes on key-file permissions, the persistent `db` path, journald JSON logging, and that this is an alternative to containerizing (§1.1), not an addition

Placed inside §6.2 to avoid renumbering §6.3–6.9. Verified: no style-guide violations (no em dashes / `e.g.` / `on-chain` / italics), anchors resolve, code fences balanced.