### PR TITLE
[Guardian] Cleanup and test hardening

### DIFF
--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -210,30 +210,22 @@ pub async fn run(
         "ProvisionerRotateCert response changed ciphertexts other than the requested certificate"
     );
 
-    // TODO: Read and verify the exact (sharing_seq, response.cert_seq, session_id)
-    // kp-shares snapshot. Reading the global latest state can report a false
-    // failure if another certificate rotation commits before this post-check.
     let updated_state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
-        .await?
-        .context("no ceremony log found after certificate rotation")?;
-    anyhow::ensure!(
-        updated_state.secret_sharing_instance == state.secret_sharing_instance,
-        "latest ceremony changed while rotating the KP certificate"
-    );
-    anyhow::ensure!(
-        updated_state.cert_seq == response.cert_seq,
-        "latest kp-shares cert_seq {} does not match ProvisionerRotateCert response {}",
-        updated_state.cert_seq,
-        response.cert_seq
-    );
+        .read_kp_share_state_log(
+            &session_id,
+            sharing_seq,
+            response.cert_seq,
+            BuildPolicy::Current,
+        )
+        .await
+        .context("read the certificate-rotation kp-shares snapshot")?;
     updated_state
         .encrypted_shares
         .verify_recipients(&expected_certs_roster)
-        .context("verify updated kp-shares state against the rotated certificate roster")?;
+        .context("verify persisted kp-shares snapshot against the rotated certificate roster")?;
     anyhow::ensure!(
         updated_state.encrypted_shares == expected_encrypted_shares,
-        "updated kp-shares state changed entries other than the requested certificate rotation"
+        "persisted kp-shares snapshot changed entries other than the requested certificate rotation"
     );
 
     println!(

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -35,11 +35,11 @@ use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::bitcoin::BitcoinSignature;
 use hashi_types::bitcoin::HashiMasterG;
 use hashi_types::bitcoin::BTC_LIB;
-use hashi_types::guardian::proto_conversions::pb_to_signed_standard_withdrawal_request_wire;
 use hashi_types::guardian::AddressValidation;
 use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::HashiSigned;
+use hashi_types::guardian::SignedStandardWithdrawalRequestWire;
 use hashi_types::guardian::StandardWithdrawalRequest;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::proto;
@@ -252,7 +252,7 @@ fn verify_recorded_signatures(
     master_g: &HashiMasterG,
     network: Network,
 ) -> anyhow::Result<()> {
-    let wire = pb_to_signed_standard_withdrawal_request_wire(request.clone())
+    let wire = SignedStandardWithdrawalRequestWire::try_from(request.clone())
         .map_err(|e| anyhow::anyhow!("parse request: {e:?}"))?;
     let signed = HashiSigned::<StandardWithdrawalRequest>::validate_addr(wire, network)
         .map_err(|e| anyhow::anyhow!("validate request: {e:?}"))?;

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -130,7 +130,10 @@ async fn finalize_rotation(
 mod tests {
     use super::*;
     use crate::mock_logger_capturing;
+    use crate::test_utils::decrypt_kp_shares;
+    use crate::test_utils::mock_kp_certs_roster_with_secrets;
     use crate::test_utils::CapturedPuts;
+    use crate::test_utils::MockKpSecretKeys;
     use hashi_types::guardian::crypto::split_secret;
     use hashi_types::guardian::test_utils::mock_kp_certs_roster;
     use hashi_types::guardian::GuardianError::InvalidInputs;
@@ -166,6 +169,17 @@ mod tests {
 
     fn build_state() -> RotateKpsState {
         RotateKpsState::new(mock_kp_certs_roster(TEST_N), TEST_N, TEST_T).unwrap()
+    }
+
+    fn build_state_with_secrets(
+        num_shares: usize,
+        threshold: usize,
+    ) -> (RotateKpsState, MockKpSecretKeys) {
+        let (roster, secret_keys) = mock_kp_certs_roster_with_secrets(num_shares);
+        (
+            RotateKpsState::new(roster, num_shares, threshold).unwrap(),
+            secret_keys,
+        )
     }
 
     /// Bundle one submission per share, all bound to `state.digest()` as AAD —
@@ -205,13 +219,10 @@ mod tests {
     /// Assert the rotation returned `new_n` PGP-armored shares and produced
     /// exactly one `ceremony/` log at `sharing_seq = 1` carrying the instance
     /// only (no ciphertexts).
-    ///
-    /// TODO: strengthen this (and setup_new_key's test) to decrypt the armored
-    /// shares with the new KPs' PGP secret keys and verify they reconstruct the
-    /// original BTC key, once a PGP-decrypt test helper exists.
     fn assert_rotation_output(
         captures: &CapturedPuts,
         response_shares: &KPEncryptedSharesRoster,
+        secret_keys: &MockKpSecretKeys,
         new_n: usize,
         new_t: usize,
     ) {
@@ -250,7 +261,7 @@ mod tests {
         let CeremonyLogMessage::Rotate {
             old_instance,
             new_instance,
-            btc_master_pubkey: _,
+            btc_master_pubkey,
         } = *ceremony
         else {
             panic!("expected Rotate variant");
@@ -262,6 +273,20 @@ mod tests {
         assert_eq!(new_instance.sharing_seq(), 1);
         assert_eq!(new_instance.num_shares(), new_n);
         assert_eq!(new_instance.threshold(), new_t);
+
+        let decrypted_shares = decrypt_kp_shares(response_shares, secret_keys);
+        for share in &decrypted_shares {
+            new_instance
+                .commitments()
+                .verify_share(share)
+                .expect("decrypted rotation share should match its commitment");
+        }
+        let reconstructed = combine_shares(&decrypted_shares[..new_t], new_t).unwrap();
+        assert_eq!(
+            k256_sk_to_btc_xonly_pubkey(&reconstructed),
+            btc_master_pubkey,
+            "threshold decrypted rotation shares should reconstruct the original key"
+        );
 
         // The new shares are persisted to kp-shares/ keyed by the new sharing_seq
         // and initial cert_seq=0.
@@ -288,19 +313,20 @@ mod tests {
     #[tokio::test]
     async fn happy_path_threshold_reached() {
         let (shares, old_instance, captures, enclave) = setup_rotation_enclave().await;
-        let req = build_request(&shares[..TEST_T], &enclave, &old_instance, build_state());
+        let (state, secret_keys) = build_state_with_secrets(TEST_N, TEST_T);
+        let req = build_request(&shares[..TEST_T], &enclave, &old_instance, state);
         let response_shares = rotate_and_verify(&enclave, req).await;
-        assert_rotation_output(&captures, &response_shares, TEST_N, TEST_T);
+        assert_rotation_output(&captures, &response_shares, &secret_keys, TEST_N, TEST_T);
     }
 
     #[tokio::test]
     async fn happy_path_asymmetric_n_t() {
         // Old (n=5, t=3); rotate to new (n=3, t=2).
         let (shares, old_instance, captures, enclave) = setup_rotation_enclave().await;
-        let state = RotateKpsState::new(mock_kp_certs_roster(3), 3, 2).unwrap();
+        let (state, secret_keys) = build_state_with_secrets(3, 2);
         let req = build_request(&shares[..TEST_T], &enclave, &old_instance, state);
         let response_shares = rotate_and_verify(&enclave, req).await;
-        assert_rotation_output(&captures, &response_shares, 3, 2);
+        assert_rotation_output(&captures, &response_shares, &secret_keys, 3, 2);
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -307,6 +307,7 @@ mod tests {
         };
         assert_eq!(shares.sharing_seq, 1);
         assert_eq!(shares.cert_seq, 0);
+        assert_eq!(shares.encrypted_shares, *response_shares);
         assert_eq!(shares.encrypted_shares.share_count(), new_n);
     }
 

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -97,7 +97,9 @@ pub async fn setup_new_key(
 mod tests {
     use super::*;
     use crate::mock_logger_capturing;
-    use hashi_types::guardian::test_utils::mock_kp_certs_roster;
+    use crate::test_utils::decrypt_kp_shares;
+    use crate::test_utils::mock_kp_certs_roster_with_secrets;
+    use hashi_types::guardian::crypto::combine_shares;
     use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;
@@ -105,8 +107,12 @@ mod tests {
     const TEST_N: usize = 5;
     const TEST_T: usize = 3;
 
-    fn mock_setup_new_key_request() -> SetupNewKeyRequest {
-        SetupNewKeyRequest::new(mock_kp_certs_roster(TEST_N), TEST_N, TEST_T).unwrap()
+    fn mock_setup_new_key_request() -> (SetupNewKeyRequest, crate::test_utils::MockKpSecretKeys) {
+        let (roster, secret_keys) = mock_kp_certs_roster_with_secrets(TEST_N);
+        (
+            SetupNewKeyRequest::new(roster, TEST_N, TEST_T).unwrap(),
+            secret_keys,
+        )
     }
 
     #[tokio::test]
@@ -114,7 +120,7 @@ mod tests {
         let (logger, captures) = mock_logger_capturing();
         let enclave = Enclave::create_operator_initialized_ceremony(logger);
         let verification_key = &enclave.signing_pubkey();
-        let request = mock_setup_new_key_request();
+        let (request, secret_keys) = mock_setup_new_key_request();
         let resp = setup_new_key(enclave.clone(), request).await.unwrap();
         let validated_resp = resp.verify(verification_key).unwrap();
         assert_eq!(enclave.lifecycle(), CeremonyStage::Completed.into());
@@ -128,11 +134,20 @@ mod tests {
             validated_resp.secret_sharing_instance.commitments().len(),
             TEST_N
         );
-        for enc_share in validated_resp.encrypted_shares.iter() {
-            for ciphertext in enc_share.ciphertexts_by_fingerprint.values() {
-                assert!(ciphertext.starts_with("-----BEGIN PGP MESSAGE-----"));
-            }
+        let decrypted_shares = decrypt_kp_shares(&validated_resp.encrypted_shares, &secret_keys);
+        for share in &decrypted_shares {
+            validated_resp
+                .secret_sharing_instance
+                .commitments()
+                .verify_share(share)
+                .expect("decrypted setup share should match its commitment");
         }
+        let reconstructed = combine_shares(&decrypted_shares[..TEST_T], TEST_T).unwrap();
+        assert_eq!(
+            k256_sk_to_btc_xonly_pubkey(&reconstructed),
+            validated_resp.btc_master_pubkey,
+            "threshold decrypted setup shares should reconstruct the ceremony key"
+        );
 
         // The ceremony log records the instance only — no ciphertexts.
         let captured = captures.lock().unwrap();

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -175,6 +175,7 @@ mod tests {
         else {
             panic!("expected NewKey variant");
         };
+        assert_eq!(instance, validated_resp.secret_sharing_instance);
         assert_eq!(instance.sharing_seq(), 0);
         assert_eq!(instance.num_shares(), TEST_N);
         assert_eq!(instance.threshold(), TEST_T);
@@ -205,6 +206,7 @@ mod tests {
         };
         assert_eq!(shares.sharing_seq, 0);
         assert_eq!(shares.cert_seq, 0);
+        assert_eq!(shares.encrypted_shares, validated_resp.encrypted_shares);
         assert_eq!(shares.encrypted_shares.share_count(), TEST_N);
         assert!(std::str::from_utf8(shares_body)
             .unwrap()

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -220,17 +220,18 @@ async fn commit_operator_init(enclave: &Enclave, install: OIInstall) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::CapturedPuts;
 
     /// Run commit_operator_init on a fresh enclave for the given mode (withdraw =>
     /// carries the InitConfig install bundle; ceremony => none).
-    async fn commit_for_mode(mode: EnclaveMode) -> Arc<Enclave> {
+    async fn commit_for_mode(mode: EnclaveMode) -> (Arc<Enclave>, CapturedPuts) {
         let enclave = Arc::new(Enclave::new(
             GuardianSignKeyPair::new(rand::thread_rng()),
             GuardianEncKeyPair::random(&mut rand::thread_rng()),
             mode,
         ));
 
-        let logger = crate::test_utils::mock_logger();
+        let (logger, captures) = crate::test_utils::mock_logger_capturing();
         let install = match mode {
             EnclaveMode::Withdraw => {
                 let config = InitConfig::mock_for_testing(None);
@@ -248,24 +249,60 @@ mod tests {
         };
 
         commit_operator_init(&enclave, install).await;
-        enclave
+        (enclave, captures)
+    }
+
+    fn assert_operator_init_logs(
+        enclave: &Enclave,
+        captures: &CapturedPuts,
+        expected_lifecycle: EnclaveLifecycle,
+    ) {
+        let captured = captures.lock().unwrap();
+        assert_eq!(captured.len(), 2, "operator init should write two records");
+        let session_id = enclave.s3_session_id();
+        assert_eq!(
+            captured[0].0,
+            InitLogMessage::attestation_object_key(&session_id)
+        );
+        assert_eq!(
+            captured[1].0,
+            InitLogMessage::guardian_info_object_key(&session_id)
+        );
+
+        let attestation: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
+        assert!(matches!(
+            attestation.message,
+            VersionedLogMessage::V2(LogMessage::Init(message))
+                if matches!(*message, OIAttestationUnsigned { .. })
+        ));
+
+        let guardian_info: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
+        let VersionedLogMessage::V2(LogMessage::Init(message)) = guardian_info.message else {
+            panic!("expected V2 init record");
+        };
+        let OIGuardianInfo(info) = *message else {
+            panic!("expected operator-init GuardianInfo record");
+        };
+        assert_eq!(info.lifecycle, expected_lifecycle);
     }
 
     #[tokio::test]
     async fn commit_marks_operator_init_complete_withdraw_mode() {
-        let enclave = commit_for_mode(EnclaveMode::Withdraw).await;
+        let (enclave, captures) = commit_for_mode(EnclaveMode::Withdraw).await;
         assert_eq!(
             enclave.lifecycle(),
             WithdrawStage::OperatorInitialized.into()
         );
+        assert_operator_init_logs(&enclave, &captures, WithdrawStage::Uninitialized.into());
     }
 
     #[tokio::test]
     async fn commit_marks_operator_init_complete_ceremony_mode() {
-        let enclave = commit_for_mode(EnclaveMode::Ceremony).await;
+        let (enclave, captures) = commit_for_mode(EnclaveMode::Ceremony).await;
         assert_eq!(
             enclave.lifecycle(),
             CeremonyStage::OperatorInitialized.into()
         );
+        assert_operator_init_logs(&enclave, &captures, CeremonyStage::Uninitialized.into());
     }
 }

--- a/crates/hashi-guardian/src/rpc.rs
+++ b/crates/hashi-guardian/src/rpc.rs
@@ -12,9 +12,8 @@ use crate::withdraw_mode::provisioner_rotate_cert;
 use crate::withdraw_mode::standard_withdrawal;
 use crate::Enclave;
 use hashi_types::guardian::proto_conversions;
-use hashi_types::guardian::proto_conversions::pb_to_signed_committee_transition;
-use hashi_types::guardian::proto_conversions::pb_to_signed_standard_withdrawal_request_wire;
 use hashi_types::guardian::AddressValidation;
+use hashi_types::guardian::CommitteeTransitionRequest;
 use hashi_types::guardian::GuardianError;
 use hashi_types::guardian::GuardianError::*;
 use hashi_types::guardian::HashiSigned;
@@ -24,6 +23,7 @@ use hashi_types::guardian::OperatorInitRequest;
 use hashi_types::guardian::ProvisionerRotateCertRequest;
 use hashi_types::guardian::RotateKpsRequest;
 use hashi_types::guardian::SetupNewKeyRequest;
+use hashi_types::guardian::SignedStandardWithdrawalRequestWire;
 use hashi_types::guardian::StandardWithdrawalRequest;
 use hashi_types::proto;
 use std::sync::Arc;
@@ -154,7 +154,7 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
         request: Request<proto::SignedStandardWithdrawalRequest>,
     ) -> Result<Response<proto::SignedStandardWithdrawalResponse>, Status> {
         // proto to domain
-        let domain_req = pb_to_signed_standard_withdrawal_request_wire(request.into_inner())
+        let domain_req = SignedStandardWithdrawalRequestWire::try_from(request.into_inner())
             .map_err(to_status)?;
 
         // validate address with network
@@ -178,7 +178,8 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
         &self,
         request: Request<proto::SignedCommitteeTransition>,
     ) -> Result<Response<proto::UpdateCommitteeResponse>, Status> {
-        let signed = pb_to_signed_committee_transition(request.into_inner()).map_err(to_status)?;
+        let signed = HashiSigned::<CommitteeTransitionRequest>::try_from(request.into_inner())
+            .map_err(to_status)?;
         let current_committee_epoch =
             committee_update::update_committee(self.enclave.clone(), signed)
                 .await
@@ -197,7 +198,7 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
             .into_inner()
             .transitions
             .into_iter()
-            .map(pb_to_signed_committee_transition)
+            .map(HashiSigned::<CommitteeTransitionRequest>::try_from)
             .collect::<Result<Vec<_>, _>>()
             .map_err(to_status)?;
         let current_committee_epoch =

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -216,19 +216,11 @@ impl GuardianReader {
         let Some(key) = keys.into_iter().max() else {
             return Ok(None);
         };
-        // The prefix history was checked above. KP-share locks are short-lived
-        // and expected to expire, so integrity comes from the signature below.
-        let record = self
-            .s3
-            .get_log_record_inner(&key, LockCheck::Skipped, HistoryCheck::AlreadyChecked)
+        // The enclosing prefix's version history was checked while listing the
+        // candidate keys above, so the selected key does not need another check.
+        let msg = self
+            .read_kp_share_state_log_at_key(&key, build_policy, HistoryCheck::AlreadyChecked)
             .await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        let build_pcrs = record.build_pcrs.clone();
-        self.enforce_build_policy("kp-shares log", build_policy, &build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::KpShareState(msg) = record.message else {
-            anyhow::bail!("expected a kp-shares log at {key}");
-        };
         if msg.sharing_seq != sharing_seq {
             anyhow::bail!(
                 "sharing_seq mismatch: {} != {}",
@@ -236,8 +228,49 @@ impl GuardianReader {
                 sharing_seq
             );
         }
-        log_verified_read(&key, &session_id);
-        Ok(Some(*msg))
+        Ok(Some(msg))
+    }
+
+    /// Read and verify one exact encrypted KP-share snapshot.
+    ///
+    /// The object key binds the writing guardian session and the two sequence
+    /// numbers. This lets callers verify the snapshot produced by one request
+    /// even if a later request has already advanced the latest state.
+    pub async fn read_kp_share_state_log(
+        &mut self,
+        session_id: &SessionID,
+        sharing_seq: u64,
+        cert_seq: u64,
+        build_policy: BuildPolicy,
+    ) -> anyhow::Result<KpShareStateLogMessage> {
+        let key = KpShareStateLogMessage::object_key(session_id, sharing_seq, cert_seq);
+        // Unlike the latest-state path, this direct read has not already
+        // checked an enclosing prefix, so validate this exact key's history.
+        self.read_kp_share_state_log_at_key(&key, build_policy, HistoryCheck::Required)
+            .await
+    }
+
+    /// Shared verification path for both latest and exact KP-share reads.
+    async fn read_kp_share_state_log_at_key(
+        &mut self,
+        key: &str,
+        build_policy: BuildPolicy,
+        history_check: HistoryCheck,
+    ) -> anyhow::Result<KpShareStateLogMessage> {
+        // KP-share locks are short-lived and expected to expire. Their contents
+        // remain authenticatable through the enclave signature verified below.
+        let record = self
+            .s3
+            .get_log_record_inner(key, LockCheck::Skipped, history_check)
+            .await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
+        self.enforce_build_policy("kp-shares log", build_policy, &record.build_pcrs)?;
+        let session_id = record.session_id;
+        let LogMessage::KpShareState(msg) = record.message else {
+            anyhow::bail!("expected a kp-shares log at {key}");
+        };
+        log_verified_read(key, &session_id);
+        Ok(*msg)
     }
 
     /// Read the latest ceremony together with the latest KP share state for its

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -49,6 +49,8 @@ impl GuardianReader {
         limiter_config: &LimiterConfig,
     ) -> anyhow::Result<LimiterState> {
         let Some(mut cursor) = find_latest_success_bucket(self.s3()).await? else {
+            // The search covers the complete S3 withdrawal history, so this
+            // branch is reachable only if no withdrawal has ever succeeded.
             info!("no successful withdrawal logs found; using genesis limiter state");
             return Ok(LimiterState::genesis(limiter_config));
         };

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -12,7 +12,19 @@ use bitcoin::Network;
 use hashi_types::bitcoin::BitcoinPubkey;
 use hashi_types::bitcoin::HashiMasterG;
 use hashi_types::guardian::*;
+#[cfg(test)]
+use hashi_types::pgp::decrypt_with_secret_key;
+#[cfg(test)]
+use hashi_types::pgp::PgpPublicCert;
+#[cfg(test)]
+use k256::elliptic_curve::ScalarPrimitive;
+#[cfg(test)]
+use k256::Secp256k1 as K256Secp256k1;
 use rand::RngCore;
+#[cfg(test)]
+use std::collections::BTreeMap;
+#[cfg(test)]
+use std::io::Read;
 use std::num::NonZeroU16;
 use std::sync::Arc;
 
@@ -33,14 +45,83 @@ pub fn mock_logger() -> GuardianS3Client {
 /// Captured `(key, body)` pairs from a `mock_logger_capturing()` logger.
 pub type CapturedPuts = Arc<std::sync::Mutex<Vec<(String, Vec<u8>)>>>;
 
+/// Mock OpenPGP secret keys keyed by the corresponding public-cert fingerprint.
+#[cfg(test)]
+pub(crate) type MockKpSecretKeys = BTreeMap<String, String>;
+
+/// Build a one-certificate-per-KP roster while retaining the matching secret
+/// keys so tests can prove the returned armored shares are decryptable.
+#[cfg(test)]
+pub(crate) fn mock_kp_certs_roster_with_secrets(
+    num_kps: usize,
+) -> (KpCertsRoster, MockKpSecretKeys) {
+    let mut secret_keys = MockKpSecretKeys::new();
+    let cert_sets = (0..num_kps)
+        .map(|_| {
+            let (public, secret) = hashi_types::pgp::test_utils::mock_pgp_keypair();
+            let cert = PgpPublicCert::new(public).expect("mock public cert should parse");
+            let fingerprint = cert.fingerprint().to_hex();
+            assert!(
+                secret_keys.insert(fingerprint, secret).is_none(),
+                "mock PGP fingerprints should be unique"
+            );
+            KpCerts::new(vec![cert]).expect("one mock cert forms a valid KP cert set")
+        })
+        .collect();
+    (
+        KpCertsRoster::new(cert_sets).expect("mock cert sets form a valid roster"),
+        secret_keys,
+    )
+}
+
+/// Decrypt every ciphertext in a KP-share roster and return one share per ID.
+/// If a share has multiple recipient certs, all ciphertexts must decrypt to the
+/// same scalar.
+#[cfg(test)]
+pub(crate) fn decrypt_kp_shares(
+    encrypted_shares: &KPEncryptedSharesRoster,
+    secret_keys: &MockKpSecretKeys,
+) -> Vec<Share> {
+    encrypted_shares
+        .iter()
+        .map(|encrypted_share| {
+            let mut share_value = None;
+            for (fingerprint, ciphertext) in &encrypted_share.ciphertexts_by_fingerprint {
+                let secret_key = secret_keys
+                    .get(fingerprint)
+                    .expect("every ciphertext should have a matching mock secret key");
+                let mut decryptor = decrypt_with_secret_key(
+                    std::io::Cursor::new(ciphertext.clone().into_bytes()),
+                    secret_key.as_bytes(),
+                )
+                .expect("mock KP should decrypt its armored share");
+                let mut plaintext = Vec::new();
+                decryptor
+                    .read_to_end(&mut plaintext)
+                    .expect("decrypted share should be readable");
+                let value = ScalarPrimitive::<K256Secp256k1>::from_slice(&plaintext)
+                    .map(k256::Scalar::from)
+                    .expect("decrypted share should be a valid scalar");
+                if let Some(expected) = share_value {
+                    assert_eq!(
+                        value, expected,
+                        "all recipients must receive the same share"
+                    );
+                } else {
+                    share_value = Some(value);
+                }
+            }
+            Share {
+                id: encrypted_share.id,
+                value: share_value.expect("each encrypted share should have a recipient"),
+            }
+        })
+        .collect()
+}
+
 /// Mock S3 logger that captures every PutObject's (key, body) into the returned
 /// Vec. Lets tests assert on what was written. Body is captured via `match_requests`
 /// (same Mutex side-channel trick as `mock_logger_with_layout`).
-///
-/// TODO: retrofit `setup_new_key`, `operator_init`/`provisioner_init`,
-/// `withdraw`, and `heartbeat` tests to use this — they currently rely on
-/// in-process side effects and the response payload, leaving the on-S3 log
-/// shape unverified.
 pub fn mock_logger_capturing() -> (GuardianS3Client, CapturedPuts) {
     use aws_sdk_s3::operation::put_object::PutObjectOutput;
     use aws_sdk_s3::Client;

--- a/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
@@ -63,6 +63,10 @@ impl HeartbeatWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::OperatorInitTestArgs;
+    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogRecord;
+    use hashi_types::guardian::VersionedLogMessage;
 
     #[tokio::test]
     async fn heartbeat_is_a_noop_before_operator_init() {
@@ -73,9 +77,22 @@ mod tests {
 
     #[tokio::test]
     async fn heartbeat_advances_after_durable_write() {
-        let enclave = Enclave::create_operator_initialized_with(Default::default()).await;
+        let (logger, captures) = crate::test_utils::mock_logger_capturing();
+        let enclave = Enclave::create_operator_initialized_with(
+            OperatorInitTestArgs::default().with_s3_logger(logger),
+        )
+        .await;
         let mut writer = HeartbeatWriter::new(enclave);
         writer.tick().await.unwrap();
         assert_eq!(writer.next_seq, 1);
+
+        let captured = captures.lock().unwrap();
+        assert_eq!(captured.len(), 1, "heartbeat tick should write one record");
+        let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
+        assert_eq!(captured[0].0, record.object_key());
+        let VersionedLogMessage::V2(LogMessage::Heartbeat(message)) = record.message else {
+            panic!("expected V2 heartbeat record");
+        };
+        assert_eq!(message.seq, 0);
     }
 }

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -219,6 +219,7 @@ mod tests {
     struct TestContext {
         shares: Vec<Share>,
         enclave: Arc<Enclave>,
+        captures: crate::test_utils::CapturedPuts,
         kp_keys: Vec<(PgpPublicCert, String)>,
         alternate_first_kp_key: (PgpPublicCert, String),
     }
@@ -264,8 +265,10 @@ mod tests {
                 .collect(),
         )
         .unwrap();
+        let (logger, captures) = crate::test_utils::mock_logger_capturing();
         let enclave = Enclave::create_operator_initialized_with(
             OperatorInitTestArgs::default()
+                .with_s3_logger(logger)
                 .with_commitments(share_commitments)
                 .with_kp_encrypted_shares(kp_encrypted_shares),
         )
@@ -273,6 +276,7 @@ mod tests {
         TestContext {
             shares,
             enclave,
+            captures,
             kp_keys,
             alternate_first_kp_key,
         }
@@ -407,6 +411,41 @@ mod tests {
             "provisioner init complete"
         );
         assert!(!ctx.enclave.is_fully_initialized(), "not active before OA");
+
+        let captured = ctx.captures.lock().unwrap();
+        assert_eq!(
+            captured.len(),
+            1,
+            "provisioner init should write one record"
+        );
+        let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
+        let VersionedLogMessage::V2(LogMessage::Init(message)) = record.message else {
+            panic!("expected V2 init record");
+        };
+        assert_eq!(
+            captured[0].0,
+            message.object_key(&ctx.enclave.s3_session_id())
+        );
+        let PIEnclaveFullyInitialized {
+            sharing_seq,
+            share_ids,
+            enclave_btc_pubkey,
+        } = *message
+        else {
+            panic!("expected provisioner-init completion record");
+        };
+        assert_eq!(sharing_seq, 0);
+        assert_eq!(
+            share_ids,
+            ctx.shares[..TEST_T]
+                .iter()
+                .map(|share| share.id)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            enclave_btc_pubkey,
+            ctx.enclave.config.enclave_btc_pubkey().unwrap()
+        );
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -180,7 +180,10 @@ mod tests {
     use hashi_types::guardian::InitConfig;
     use hashi_types::guardian::LimiterConfig;
     use hashi_types::guardian::LimiterState;
+    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;
+    use hashi_types::guardian::VersionedLogMessage;
     use hashi_types::guardian::WithdrawStage;
 
     /// Sets up an enclave with a single committee and token bucket limiter.
@@ -188,7 +191,7 @@ mod tests {
         network: Network,
         committee: HashiCommittee,
         max_bucket_capacity_sats: u64,
-    ) -> Arc<Enclave> {
+    ) -> (Arc<Enclave>, crate::test_utils::CapturedPuts) {
         let hashi_kp = create_btc_keypair_for_test(&[6u8; 32]);
         let hashi_btc_master_pubkey =
             hashi_master_g_from_btc_xonly_for_test(&hashi_kp.x_only_public_key().0);
@@ -204,8 +207,11 @@ mod tests {
 
         // operator_init installs standby config; test activation installs the
         // committee and limiter before withdrawals.
+        let (logger, captures) = crate::test_utils::mock_logger_capturing();
         let enclave = Enclave::create_operator_initialized_with(
-            OperatorInitTestArgs::default().with_config(config),
+            OperatorInitTestArgs::default()
+                .with_s3_logger(logger)
+                .with_config(config),
         )
         .await;
 
@@ -222,7 +228,7 @@ mod tests {
             .expect("activate_enclave_for_testing should succeed on a fresh enclave");
 
         assert!(enclave.is_fully_initialized());
-        enclave
+        (enclave, captures)
     }
 
     #[tokio::test]
@@ -243,7 +249,7 @@ mod tests {
             .gross_outflow_amount()
             .to_sat();
         // Set request amount as the max bucket capacity
-        let enclave =
+        let (enclave, _captures) =
             setup_fully_initialized_enclave(Network::Regtest, committee, amount_sats).await;
 
         let result = normal_withdrawal_inner(enclave, signed_request).await;
@@ -260,7 +266,7 @@ mod tests {
         );
         let amount_sats = req1.message().utxos().gross_outflow_amount().to_sat();
         // Bucket capacity == one withdrawal, so second will be rejected.
-        let enclave =
+        let (enclave, captures) =
             setup_fully_initialized_enclave(Network::Regtest, committee, amount_sats).await;
 
         let first = standard_withdrawal(enclave.clone(), req1).await;
@@ -278,5 +284,44 @@ mod tests {
             second.unwrap_err(),
             GuardianError::RateLimitExceeded
         ));
+
+        let captured = captures.lock().unwrap();
+        assert_eq!(
+            captured.len(),
+            2,
+            "both withdrawal outcomes should be logged"
+        );
+        let success: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
+        assert_eq!(captured[0].0, success.object_key());
+        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = success.message else {
+            panic!("expected V2 withdrawal record");
+        };
+        let WithdrawalLogMessage::Success {
+            request_data,
+            post_state,
+            ..
+        } = *message
+        else {
+            panic!("expected successful withdrawal record");
+        };
+        assert_eq!(request_data.seq, 0);
+        assert_eq!(post_state.next_seq, 1);
+        assert_eq!(post_state.num_tokens_available, 0);
+
+        let failure: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
+        assert_eq!(captured[1].0, failure.object_key());
+        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = failure.message else {
+            panic!("expected V2 withdrawal record");
+        };
+        let WithdrawalLogMessage::Failure {
+            request_data,
+            error,
+            ..
+        } = *message
+        else {
+            panic!("expected failed withdrawal record");
+        };
+        assert_eq!(request_data.seq, 1);
+        assert_eq!(error, GuardianError::RateLimitExceeded);
     }
 }

--- a/crates/hashi-types/src/guardian/limiter.rs
+++ b/crates/hashi-types/src/guardian/limiter.rs
@@ -32,11 +32,6 @@ pub struct LimiterState {
 impl LimiterState {
     /// Genesis state for a freshly bootstrapped enclave: a full bucket, no
     /// consumes yet, no refill timestamp.
-    ///
-    /// TODO: if the provisioner-init rotation path falls back here (no Success
-    /// logs in the prior enclave's walk-back window), `next_seq = 0` may not
-    /// match Hashi's current seq counter. Recover the real seq from a
-    /// separate source instead of falling back to 0.
     pub fn genesis(config: &super::LimiterConfig) -> Self {
         Self {
             num_tokens_available: config.max_bucket_capacity,

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -137,8 +137,6 @@ pub struct GuardianInfo {
         with = "crate::guardian::serde_utils::option_hex_32"
     )]
     pub genesis_state_hash: Option<[u8; 32]>,
-    // TODO: report the full committee too, so its membership is directly
-    // verifiable from GuardianInfo; it's large, though.
 }
 
 // ---------------------------------------
@@ -216,8 +214,6 @@ pub struct StandardWithdrawalRequest {
     /// Timestamp in unix seconds (used for rate limiting)
     timestamp_secs: u64,
     /// Monotonic sequence number for ordering
-    /// TODO: rename to `withdraw_seq` (and `LimiterState.next_seq` →
-    /// `next_withdraw_seq`) to disambiguate from `SecretSharingInstance.sharing_seq`.
     seq: u64,
 }
 
@@ -268,8 +264,6 @@ pub struct SetupNewKeyResponse {
 /// rotation target `state`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RotateKpsRequest {
-    // TODO: Use the same unique-id wrapper as ProvisionerInitRequest once we
-    // centralize validation for submitted guardian share batches.
     encrypted_old_shares: Vec<GuardianEncryptedShare>,
     old_instance: SecretSharingInstance,
     state: RotateKpsState,

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -81,30 +81,39 @@ use crate::move_types::Config;
 //      Proto -> Domain (deserialization)
 // --------------------------------------------
 
-fn pb_to_kp_encrypted_shares(pb: pb::SingleKpEncryptedShares) -> GuardianResult<KPEncryptedShares> {
-    Ok(KPEncryptedShares {
-        id: pb_to_share_id(pb.id)?,
-        ciphertexts_by_fingerprint: pb.ciphertexts.into_iter().collect(),
-    })
+impl TryFrom<pb::SingleKpEncryptedShares> for KPEncryptedShares {
+    type Error = GuardianError;
+
+    fn try_from(pb: pb::SingleKpEncryptedShares) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: pb_to_share_id(pb.id)?,
+            ciphertexts_by_fingerprint: pb.ciphertexts.into_iter().collect(),
+        })
+    }
 }
 
-fn pb_to_kp_cert_set(pb: pb::KpPgpCertSet) -> GuardianResult<KpCerts> {
-    let certs = pb
-        .pgp_certs
-        .iter()
-        .cloned()
-        .map(|cert| PgpPublicCert::new(cert).map_err(|e| InvalidInputs(e.to_string())))
-        .collect::<GuardianResult<Vec<_>>>()?;
-    KpCerts::new(certs)
+impl TryFrom<pb::KpPgpCertSet> for KpCerts {
+    type Error = GuardianError;
+
+    fn try_from(pb: pb::KpPgpCertSet) -> Result<Self, Self::Error> {
+        let certs = pb
+            .pgp_certs
+            .into_iter()
+            .map(|cert| PgpPublicCert::new(cert).map_err(|e| InvalidInputs(e.to_string())))
+            .collect::<GuardianResult<Vec<_>>>()?;
+        Self::new(certs)
+    }
 }
 
-pub fn pb_to_guardian_encrypted_share(
-    pb: pb::GuardianEncryptedShare,
-) -> GuardianResult<GuardianEncryptedShare> {
-    Ok(GuardianEncryptedShare {
-        id: pb_to_share_id(pb.id)?,
-        ciphertext: pb_to_ciphertext(pb.ciphertext)?,
-    })
+impl TryFrom<pb::GuardianEncryptedShare> for GuardianEncryptedShare {
+    type Error = GuardianError;
+
+    fn try_from(pb: pb::GuardianEncryptedShare) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: pb_to_share_id(pb.id)?,
+            ciphertext: Ciphertext::try_from(pb.ciphertext.ok_or_else(|| missing("ciphertext"))?)?,
+        })
+    }
 }
 
 impl TryFrom<pb::SetupNewKeyRequest> for SetupNewKeyRequest {
@@ -113,9 +122,8 @@ impl TryFrom<pb::SetupNewKeyRequest> for SetupNewKeyRequest {
     fn try_from(req: pb::SetupNewKeyRequest) -> Result<Self, Self::Error> {
         let cert_sets = req
             .key_provisioner_pgp_cert_sets
-            .iter()
-            .cloned()
-            .map(pb_to_kp_cert_set)
+            .into_iter()
+            .map(KpCerts::try_from)
             .collect::<GuardianResult<Vec<_>>>()?;
 
         let num_shares = req.num_shares.ok_or_else(|| missing("num_shares"))? as usize;
@@ -139,11 +147,11 @@ impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSigned<SetupNewKeyRespon
         let encrypted_shares = data
             .encrypted_shares
             .into_iter()
-            .map(pb_to_kp_encrypted_shares)
+            .map(KPEncryptedShares::try_from)
             .collect::<GuardianResult<Vec<_>>>()?;
         let encrypted_shares = KPEncryptedSharesRoster::new(encrypted_shares)?;
 
-        let secret_sharing_instance = pb_to_secret_sharing_instance(
+        let secret_sharing_instance = SecretSharingInstance::try_from(
             data.secret_sharing_instance
                 .ok_or_else(|| missing("secret_sharing_instance"))?,
         )?;
@@ -169,14 +177,15 @@ impl TryFrom<pb::OperatorInitRequest> for OperatorInitRequest {
     type Error = GuardianError;
 
     fn try_from(req: pb::OperatorInitRequest) -> Result<Self, Self::Error> {
-        let s3_config = pb_to_s3_config(req.s3_config.ok_or_else(|| missing("s3_config"))?)?;
+        let s3_config =
+            super::S3Config::try_from(req.s3_config.ok_or_else(|| missing("s3_config"))?)?;
         let genesis_state = req
             .genesis_state
             .map(|state| {
                 let committee = state.committee.ok_or_else(|| missing("committee"))?;
-                Ok(GenesisState::from_move_committee(pb_to_move_committee(
-                    committee,
-                )?))
+                Ok(GenesisState::from_move_committee(
+                    crate::move_types::Committee::try_from(committee)?,
+                ))
             })
             .transpose()?;
         // `init_config` present ⇔ withdraw mode; absent ⇔ ceremony (S3 only).
@@ -209,14 +218,16 @@ impl TryFrom<pb::OperatorActivateRequest> for OperatorActivateRequest {
     }
 }
 
-pub fn pb_to_secret_sharing_instance(
-    pb: pb::SecretSharingInstance,
-) -> GuardianResult<SecretSharingInstance> {
-    let commitments = pb_share_commitments_to_domain(&pb.commitments)?;
-    let num_shares = pb.num_shares.ok_or_else(|| missing("num_shares"))? as usize;
-    let threshold = pb.threshold.ok_or_else(|| missing("threshold"))? as usize;
-    let sharing_seq = pb.sharing_seq.ok_or_else(|| missing("sharing_seq"))?;
-    SecretSharingInstance::new(commitments, num_shares, threshold, sharing_seq)
+impl TryFrom<pb::SecretSharingInstance> for SecretSharingInstance {
+    type Error = GuardianError;
+
+    fn try_from(pb: pb::SecretSharingInstance) -> Result<Self, Self::Error> {
+        let commitments = ShareCommitments::try_from(pb.commitments)?;
+        let num_shares = pb.num_shares.ok_or_else(|| missing("num_shares"))? as usize;
+        let threshold = pb.threshold.ok_or_else(|| missing("threshold"))? as usize;
+        let sharing_seq = pb.sharing_seq.ok_or_else(|| missing("sharing_seq"))?;
+        Self::new(commitments, num_shares, threshold, sharing_seq)
+    }
 }
 
 pub fn secret_sharing_instance_to_pb(
@@ -274,7 +285,7 @@ impl TryFrom<pb::SignedSingleProvisionerInitRequest> for KpSigned<SingleProvisio
                 })
             })
             .transpose()?;
-        let encrypted_share = pb_to_guardian_encrypted_share(
+        let encrypted_share = GuardianEncryptedShare::try_from(
             req.encrypted_share
                 .ok_or_else(|| missing("encrypted_share"))?,
         )?;
@@ -316,7 +327,7 @@ impl TryFrom<pb::SignedProvisionerRotateCertRequest> for KpSigned<ProvisionerRot
 
         let new_kp_pgp_cert = PgpPublicCert::new(req.new_kp_pgp_cert)
             .map_err(|e| InvalidInputs(format!("invalid new_kp_pgp_cert: {e}")))?;
-        let encrypted_share = pb_to_guardian_encrypted_share(
+        let encrypted_share = GuardianEncryptedShare::try_from(
             req.encrypted_share
                 .ok_or_else(|| missing("encrypted_share"))?,
         )?;
@@ -345,7 +356,7 @@ impl TryFrom<pb::RotateKpsRequest> for RotateKpsRequest {
         let encrypted_old_shares = req
             .encrypted_old_shares
             .into_iter()
-            .map(pb_to_guardian_encrypted_share)
+            .map(GuardianEncryptedShare::try_from)
             .collect::<GuardianResult<Vec<_>>>()?;
 
         let new_num_shares = req
@@ -356,7 +367,7 @@ impl TryFrom<pb::RotateKpsRequest> for RotateKpsRequest {
         let new_kp_pgp_cert_sets = req
             .new_kp_pgp_cert_sets
             .into_iter()
-            .map(pb_to_kp_cert_set)
+            .map(KpCerts::try_from)
             .collect::<GuardianResult<Vec<_>>>()?;
         let state = RotateKpsState::new(
             KpCertsRoster::new(new_kp_pgp_cert_sets)?,
@@ -364,7 +375,7 @@ impl TryFrom<pb::RotateKpsRequest> for RotateKpsRequest {
             new_threshold,
         )?;
 
-        let old_instance = pb_to_secret_sharing_instance(
+        let old_instance = SecretSharingInstance::try_from(
             req.old_instance.ok_or_else(|| missing("old_instance"))?,
         )?;
 
@@ -388,7 +399,7 @@ impl TryFrom<pb::SignedRotateKpsResponse> for GuardianSigned<RotateKpsResponse> 
         let encrypted_shares = data
             .encrypted_shares
             .into_iter()
-            .map(pb_to_kp_encrypted_shares)
+            .map(KPEncryptedShares::try_from)
             .collect::<GuardianResult<Vec<_>>>()?;
         let encrypted_shares = KPEncryptedSharesRoster::new(encrypted_shares)?;
 
@@ -412,7 +423,7 @@ impl TryFrom<pb::SignedProvisionerRotateCertResponse>
         let signature = GuardianSignature::try_from(signature_bytes.as_ref())
             .map_err(|e| InvalidInputs(format!("invalid signature: {e}")))?;
         let timestamp_ms = resp.timestamp_ms.ok_or_else(|| missing("timestamp_ms"))?;
-        let encrypted_shares = pb_to_kp_encrypted_shares(
+        let encrypted_shares = KPEncryptedShares::try_from(
             resp.encrypted_shares
                 .ok_or_else(|| missing("encrypted_shares"))?,
         )?;
@@ -465,7 +476,7 @@ impl TryFrom<pb::InitConfig> for InitConfig {
         let limiter_config_pb = config_pb
             .limiter_config
             .ok_or_else(|| missing("limiter_config"))?;
-        let limiter_config = pb_to_limiter_config(limiter_config_pb)?;
+        let limiter_config = LimiterConfig::try_from(limiter_config_pb)?;
 
         let master_pk_bytes = config_pb
             .hashi_btc_master_pubkey
@@ -510,7 +521,7 @@ impl TryFrom<pb::GetGuardianInfoResponse> for GetGuardianInfoResponse {
             .map_err(|e| InvalidInputs(format!("invalid signing_pub_key: {e}")))?;
 
         let signed_info_pb = resp.signed_info.ok_or_else(|| missing("signed_info"))?;
-        let signed_info = pb_to_signed_guardian_info(signed_info_pb)?;
+        let signed_info = GuardianSigned::<GuardianInfo>::try_from(signed_info_pb)?;
 
         Ok(GetGuardianInfoResponse::new(
             NitroAttestation::new(attestation.to_vec()),
@@ -520,39 +531,36 @@ impl TryFrom<pb::GetGuardianInfoResponse> for GetGuardianInfoResponse {
     }
 }
 
-// TODO: Replace with TryFrom<> after moving it to hashi-types.
-pub fn pb_to_signed_standard_withdrawal_request_wire(
-    req: pb::SignedStandardWithdrawalRequest,
-) -> GuardianResult<SignedStandardWithdrawalRequestWire> {
-    let data = req.data.ok_or_else(|| missing("data"))?;
-    let committee_signature_pb = req
-        .committee_signature
-        .ok_or_else(|| missing("committee_signature"))?;
-    let (epoch, signature, bitmap) = pb_to_committee_signature(committee_signature_pb)?;
+impl TryFrom<pb::SignedStandardWithdrawalRequest> for SignedStandardWithdrawalRequestWire {
+    type Error = GuardianError;
 
-    let wid_bytes = data.wid.ok_or_else(|| missing("wid"))?;
-    let wid = super::WithdrawalID::from_bytes(wid_bytes.as_ref())
-        .map_err(|_| InvalidInputs(format!("wid must be 32 bytes, got {}", wid_bytes.len())))?;
-    let utxos_pb = data.utxos.ok_or_else(|| missing("utxos"))?;
-    let utxos_wire = pb_to_tx_utxos_wire(utxos_pb)?;
-    let timestamp_secs = data
-        .timestamp_secs
-        .ok_or_else(|| missing("timestamp_secs"))?;
-    let seq = data.seq.ok_or_else(|| missing("seq"))?;
+    fn try_from(req: pb::SignedStandardWithdrawalRequest) -> Result<Self, Self::Error> {
+        let data = req.data.ok_or_else(|| missing("data"))?;
+        let committee_signature_pb = req
+            .committee_signature
+            .ok_or_else(|| missing("committee_signature"))?;
+        let signature = CommitteeSignature::try_from(committee_signature_pb)?;
 
-    Ok(SignedStandardWithdrawalRequestWire {
-        data: StandardWithdrawalRequestWire {
-            wid,
-            utxos: utxos_wire,
-            timestamp_secs,
-            seq,
-        },
-        signature: CommitteeSignature {
-            epoch,
+        let wid_bytes = data.wid.ok_or_else(|| missing("wid"))?;
+        let wid = super::WithdrawalID::from_bytes(wid_bytes.as_ref())
+            .map_err(|_| InvalidInputs(format!("wid must be 32 bytes, got {}", wid_bytes.len())))?;
+        let utxos_pb = data.utxos.ok_or_else(|| missing("utxos"))?;
+        let utxos_wire = TxUTXOsWire::try_from(utxos_pb)?;
+        let timestamp_secs = data
+            .timestamp_secs
+            .ok_or_else(|| missing("timestamp_secs"))?;
+        let seq = data.seq.ok_or_else(|| missing("seq"))?;
+
+        Ok(Self {
+            data: StandardWithdrawalRequestWire {
+                wid,
+                utxos: utxos_wire,
+                timestamp_secs,
+                seq,
+            },
             signature,
-            signers_bitmap: bitmap,
-        },
-    })
+        })
+    }
 }
 
 impl TryFrom<pb::SignedStandardWithdrawalResponse> for GuardianSigned<StandardWithdrawalResponse> {
@@ -833,41 +841,53 @@ fn missing(field: &str) -> GuardianError {
     InvalidInputs(format!("missing {field}"))
 }
 
-fn pb_to_committee_signature(s: pb::CommitteeSignature) -> GuardianResult<(u64, Vec<u8>, Vec<u8>)> {
-    let epoch = s.epoch.ok_or_else(|| missing("epoch"))?;
-    let signature_bytes = s.signature.ok_or_else(|| missing("signature"))?;
-    let signer_bitmap_bytes = s.bitmap.ok_or_else(|| missing("signer_bitmap"))?;
+impl TryFrom<pb::CommitteeSignature> for CommitteeSignature {
+    type Error = GuardianError;
 
-    Ok((
-        epoch,
-        signature_bytes.to_vec(),
-        signer_bitmap_bytes.to_vec(),
-    ))
-}
-
-pub fn pb_share_commitments_to_domain(
-    commitments: &[pb::GuardianShareCommitment],
-) -> GuardianResult<ShareCommitments> {
-    let commitments = commitments
-        .iter()
-        .map(|c| {
-            let digest_hex = c.digest_hex.clone().ok_or_else(|| missing("digest_hex"))?;
-            let digest = hex::decode(&digest_hex)
-                .map_err(|e| InvalidInputs(format!("invalid digest_hex: {e}")))?;
-            Ok(ShareCommitment {
-                id: pb_to_share_id(c.id)?,
-                digest,
-            })
+    fn try_from(s: pb::CommitteeSignature) -> Result<Self, Self::Error> {
+        Ok(Self {
+            epoch: s.epoch.ok_or_else(|| missing("epoch"))?,
+            signature: s.signature.ok_or_else(|| missing("signature"))?.to_vec(),
+            signers_bitmap: s.bitmap.ok_or_else(|| missing("signer_bitmap"))?.to_vec(),
         })
-        .collect::<GuardianResult<Vec<_>>>()?;
-
-    ShareCommitments::new(commitments)
+    }
 }
 
-fn pb_to_s3_bucket_info(info: pb::S3BucketInfo) -> GuardianResult<super::S3BucketInfo> {
-    let bucket = info.bucket.ok_or_else(|| missing("bucket"))?;
-    let region = info.region.ok_or_else(|| missing("region"))?;
-    Ok(super::S3BucketInfo { bucket, region })
+impl TryFrom<pb::GuardianShareCommitment> for ShareCommitment {
+    type Error = GuardianError;
+
+    fn try_from(commitment: pb::GuardianShareCommitment) -> Result<Self, Self::Error> {
+        let digest_hex = commitment.digest_hex.ok_or_else(|| missing("digest_hex"))?;
+        let digest = hex::decode(&digest_hex)
+            .map_err(|e| InvalidInputs(format!("invalid digest_hex: {e}")))?;
+        Ok(Self {
+            id: pb_to_share_id(commitment.id)?,
+            digest,
+        })
+    }
+}
+
+impl TryFrom<Vec<pb::GuardianShareCommitment>> for ShareCommitments {
+    type Error = GuardianError;
+
+    fn try_from(commitments: Vec<pb::GuardianShareCommitment>) -> Result<Self, Self::Error> {
+        let commitments = commitments
+            .into_iter()
+            .map(ShareCommitment::try_from)
+            .collect::<GuardianResult<Vec<_>>>()?;
+
+        Self::new(commitments)
+    }
+}
+
+impl TryFrom<pb::S3BucketInfo> for super::S3BucketInfo {
+    type Error = GuardianError;
+
+    fn try_from(info: pb::S3BucketInfo) -> Result<Self, Self::Error> {
+        let bucket = info.bucket.ok_or_else(|| missing("bucket"))?;
+        let region = info.region.ok_or_else(|| missing("region"))?;
+        Ok(Self { bucket, region })
+    }
 }
 
 fn s3_bucket_info_to_pb(info: super::S3BucketInfo) -> pb::S3BucketInfo {
@@ -877,13 +897,17 @@ fn s3_bucket_info_to_pb(info: super::S3BucketInfo) -> pb::S3BucketInfo {
     }
 }
 
-fn pb_to_ceremony_stage(stage: i32) -> GuardianResult<CeremonyStage> {
-    match pb::CeremonyStage::try_from(stage) {
-        Ok(pb::CeremonyStage::Uninitialized) => Ok(CeremonyStage::Uninitialized),
-        Ok(pb::CeremonyStage::OperatorInitialized) => Ok(CeremonyStage::OperatorInitialized),
-        Ok(pb::CeremonyStage::Completed) => Ok(CeremonyStage::Completed),
-        Ok(pb::CeremonyStage::Unspecified) | Err(_) => {
-            Err(InvalidInputs(format!("invalid ceremony stage: {stage}")))
+impl TryFrom<i32> for CeremonyStage {
+    type Error = GuardianError;
+
+    fn try_from(stage: i32) -> Result<Self, Self::Error> {
+        match pb::CeremonyStage::try_from(stage) {
+            Ok(pb::CeremonyStage::Uninitialized) => Ok(Self::Uninitialized),
+            Ok(pb::CeremonyStage::OperatorInitialized) => Ok(Self::OperatorInitialized),
+            Ok(pb::CeremonyStage::Completed) => Ok(Self::Completed),
+            Ok(pb::CeremonyStage::Unspecified) | Err(_) => {
+                Err(InvalidInputs(format!("invalid ceremony stage: {stage}")))
+            }
         }
     }
 }
@@ -896,14 +920,18 @@ fn ceremony_stage_to_pb(stage: CeremonyStage) -> i32 {
     }
 }
 
-fn pb_to_withdraw_stage(stage: i32) -> GuardianResult<WithdrawStage> {
-    match pb::WithdrawStage::try_from(stage) {
-        Ok(pb::WithdrawStage::Uninitialized) => Ok(WithdrawStage::Uninitialized),
-        Ok(pb::WithdrawStage::OperatorInitialized) => Ok(WithdrawStage::OperatorInitialized),
-        Ok(pb::WithdrawStage::ProvisionerInitialized) => Ok(WithdrawStage::ProvisionerInitialized),
-        Ok(pb::WithdrawStage::Activated) => Ok(WithdrawStage::Activated),
-        Ok(pb::WithdrawStage::Unspecified) | Err(_) => {
-            Err(InvalidInputs(format!("invalid withdraw stage: {stage}")))
+impl TryFrom<i32> for WithdrawStage {
+    type Error = GuardianError;
+
+    fn try_from(stage: i32) -> Result<Self, Self::Error> {
+        match pb::WithdrawStage::try_from(stage) {
+            Ok(pb::WithdrawStage::Uninitialized) => Ok(Self::Uninitialized),
+            Ok(pb::WithdrawStage::OperatorInitialized) => Ok(Self::OperatorInitialized),
+            Ok(pb::WithdrawStage::ProvisionerInitialized) => Ok(Self::ProvisionerInitialized),
+            Ok(pb::WithdrawStage::Activated) => Ok(Self::Activated),
+            Ok(pb::WithdrawStage::Unspecified) | Err(_) => {
+                Err(InvalidInputs(format!("invalid withdraw stage: {stage}")))
+            }
         }
     }
 }
@@ -917,80 +945,90 @@ fn withdraw_stage_to_pb(stage: WithdrawStage) -> i32 {
     }
 }
 
-fn pb_to_guardian_info_data(data: pb::GuardianInfoData) -> GuardianResult<GuardianInfo> {
-    let lifecycle = match data.lifecycle.ok_or_else(|| missing("lifecycle"))? {
-        pb::guardian_info_data::Lifecycle::Ceremony(stage) => {
-            EnclaveLifecycle::Ceremony(pb_to_ceremony_stage(stage)?)
-        }
-        pb::guardian_info_data::Lifecycle::Withdraw(stage) => {
-            EnclaveLifecycle::Withdraw(pb_to_withdraw_stage(stage)?)
-        }
-    };
-    let secret_sharing_instance = data
-        .secret_sharing_instance
-        .map(pb_to_secret_sharing_instance)
-        .transpose()?;
+impl TryFrom<pb::GuardianInfoData> for GuardianInfo {
+    type Error = GuardianError;
 
-    let bucket_info = data.bucket_info.map(pb_to_s3_bucket_info).transpose()?;
+    fn try_from(data: pb::GuardianInfoData) -> Result<Self, Self::Error> {
+        let lifecycle = match data.lifecycle.ok_or_else(|| missing("lifecycle"))? {
+            pb::guardian_info_data::Lifecycle::Ceremony(stage) => {
+                EnclaveLifecycle::Ceremony(CeremonyStage::try_from(stage)?)
+            }
+            pb::guardian_info_data::Lifecycle::Withdraw(stage) => {
+                EnclaveLifecycle::Withdraw(WithdrawStage::try_from(stage)?)
+            }
+        };
+        let secret_sharing_instance = data
+            .secret_sharing_instance
+            .map(SecretSharingInstance::try_from)
+            .transpose()?;
 
-    let encryption_pubkey = data
-        .encryption_pubkey
-        .ok_or_else(|| missing("encryption_pubkey"))?
-        .to_vec();
+        let bucket_info = data
+            .bucket_info
+            .map(super::S3BucketInfo::try_from)
+            .transpose()?;
 
-    let untrusted_git_revision = data
-        .untrusted_git_revision
-        .ok_or_else(|| missing("untrusted_git_revision"))?;
+        let encryption_pubkey = data
+            .encryption_pubkey
+            .ok_or_else(|| missing("encryption_pubkey"))?
+            .to_vec();
 
-    let config_hash = data
-        .config_hash
-        .map(|b| {
-            <[u8; 32]>::try_from(b.as_ref())
-                .map_err(|_| InvalidInputs("config_hash must be 32 bytes".into()))
+        let untrusted_git_revision = data
+            .untrusted_git_revision
+            .ok_or_else(|| missing("untrusted_git_revision"))?;
+
+        let config_hash = data
+            .config_hash
+            .map(|b| {
+                <[u8; 32]>::try_from(b.as_ref())
+                    .map_err(|_| InvalidInputs("config_hash must be 32 bytes".into()))
+            })
+            .transpose()?;
+
+        let genesis_state_hash = data
+            .genesis_state_hash
+            .map(|b| {
+                <[u8; 32]>::try_from(b.as_ref())
+                    .map_err(|_| InvalidInputs("genesis_state_hash must be 32 bytes".into()))
+            })
+            .transpose()?;
+
+        let enclave_btc_pubkey = data
+            .enclave_btc_pubkey
+            .map(|bytes| {
+                BitcoinPubkey::from_slice(bytes.as_ref())
+                    .map_err(|e| InvalidInputs(format!("invalid enclave_btc_pubkey: {e}")))
+            })
+            .transpose()?;
+
+        let limiter_state = data.limiter_state.map(LimiterState::try_from).transpose()?;
+        let limiter_config = data
+            .limiter_config
+            .map(LimiterConfig::try_from)
+            .transpose()?;
+
+        let mpc_master_g = data
+            .mpc_master_g
+            .map(|b| {
+                bcs::from_bytes(b.as_ref())
+                    .map_err(|e| InvalidInputs(format!("invalid mpc_master_g: {e}")))
+            })
+            .transpose()?;
+
+        Ok(Self {
+            lifecycle,
+            secret_sharing_instance,
+            bucket_info,
+            encryption_pubkey,
+            config_hash,
+            genesis_state_hash,
+            untrusted_git_revision,
+            enclave_btc_pubkey,
+            limiter_state,
+            limiter_config,
+            current_committee_epoch: data.current_committee_epoch,
+            mpc_master_g,
         })
-        .transpose()?;
-
-    let genesis_state_hash = data
-        .genesis_state_hash
-        .map(|b| {
-            <[u8; 32]>::try_from(b.as_ref())
-                .map_err(|_| InvalidInputs("genesis_state_hash must be 32 bytes".into()))
-        })
-        .transpose()?;
-
-    let enclave_btc_pubkey = data
-        .enclave_btc_pubkey
-        .map(|bytes| {
-            BitcoinPubkey::from_slice(bytes.as_ref())
-                .map_err(|e| InvalidInputs(format!("invalid enclave_btc_pubkey: {e}")))
-        })
-        .transpose()?;
-
-    let limiter_state = data.limiter_state.map(pb_to_limiter_state).transpose()?;
-    let limiter_config = data.limiter_config.map(pb_to_limiter_config).transpose()?;
-
-    let mpc_master_g = data
-        .mpc_master_g
-        .map(|b| {
-            bcs::from_bytes(b.as_ref())
-                .map_err(|e| InvalidInputs(format!("invalid mpc_master_g: {e}")))
-        })
-        .transpose()?;
-
-    Ok(GuardianInfo {
-        lifecycle,
-        secret_sharing_instance,
-        bucket_info,
-        encryption_pubkey,
-        config_hash,
-        genesis_state_hash,
-        untrusted_git_revision,
-        enclave_btc_pubkey,
-        limiter_state,
-        limiter_config,
-        current_committee_epoch: data.current_committee_epoch,
-        mpc_master_g,
-    })
+    }
 }
 
 fn guardian_info_data_to_pb(info: GuardianInfo) -> pb::GuardianInfoData {
@@ -1025,25 +1063,27 @@ fn guardian_info_data_to_pb(info: GuardianInfo) -> pb::GuardianInfoData {
     }
 }
 
-fn pb_to_signed_guardian_info(
-    s: pb::SignedGuardianInfo,
-) -> GuardianResult<GuardianSigned<GuardianInfo>> {
-    let data_pb = s.data.ok_or_else(|| missing("signed_info.data"))?;
-    let timestamp_ms = s
-        .timestamp_ms
-        .ok_or_else(|| missing("signed_info.timestamp_ms"))?;
-    let signature_bytes = s
-        .signature
-        .ok_or_else(|| missing("signed_info.signature"))?;
+impl TryFrom<pb::SignedGuardianInfo> for GuardianSigned<GuardianInfo> {
+    type Error = GuardianError;
 
-    let signature = GuardianSignature::try_from(signature_bytes.as_ref())
-        .map_err(|e| InvalidInputs(format!("invalid signed_info.signature: {e}")))?;
+    fn try_from(s: pb::SignedGuardianInfo) -> Result<Self, Self::Error> {
+        let data_pb = s.data.ok_or_else(|| missing("signed_info.data"))?;
+        let timestamp_ms = s
+            .timestamp_ms
+            .ok_or_else(|| missing("signed_info.timestamp_ms"))?;
+        let signature_bytes = s
+            .signature
+            .ok_or_else(|| missing("signed_info.signature"))?;
 
-    Ok(GuardianSigned {
-        data: pb_to_guardian_info_data(data_pb)?,
-        timestamp_ms,
-        signature,
-    })
+        let signature = GuardianSignature::try_from(signature_bytes.as_ref())
+            .map_err(|e| InvalidInputs(format!("invalid signed_info.signature: {e}")))?;
+
+        Ok(Self {
+            data: GuardianInfo::try_from(data_pb)?,
+            timestamp_ms,
+            signature,
+        })
+    }
 }
 
 fn signed_guardian_info_to_pb(s: GuardianSigned<GuardianInfo>) -> pb::SignedGuardianInfo {
@@ -1074,21 +1114,25 @@ fn share_id_to_pb(id: ShareID) -> pb::GuardianShareId {
     }
 }
 
-fn pb_to_s3_config(cfg: pb::S3Config) -> GuardianResult<super::S3Config> {
-    let access_key = cfg.access_key.ok_or_else(|| missing("access_key"))?;
-    let secret_key = cfg.secret_key.ok_or_else(|| missing("secret_key"))?;
-    let bucket_name = cfg.bucket_name.ok_or_else(|| missing("bucket_name"))?;
-    let region = cfg.region.ok_or_else(|| missing("region"))?;
+impl TryFrom<pb::S3Config> for super::S3Config {
+    type Error = GuardianError;
 
-    Ok(super::S3Config {
-        access_key: access_key.to_string(),
-        secret_key: secret_key.to_string(),
-        session_token: cfg.session_token.map(|token| token.to_string()),
-        bucket_info: super::S3BucketInfo {
-            bucket: bucket_name.to_string(),
-            region: region.to_string(),
-        },
-    })
+    fn try_from(cfg: pb::S3Config) -> Result<Self, Self::Error> {
+        let access_key = cfg.access_key.ok_or_else(|| missing("access_key"))?;
+        let secret_key = cfg.secret_key.ok_or_else(|| missing("secret_key"))?;
+        let bucket_name = cfg.bucket_name.ok_or_else(|| missing("bucket_name"))?;
+        let region = cfg.region.ok_or_else(|| missing("region"))?;
+
+        Ok(Self {
+            access_key,
+            secret_key,
+            session_token: cfg.session_token,
+            bucket_info: super::S3BucketInfo {
+                bucket: bucket_name,
+                region,
+            },
+        })
+    }
 }
 
 fn s3_config_to_pb(cfg: super::S3Config) -> pb::S3Config {
@@ -1121,21 +1165,23 @@ fn network_to_pb(n: super::Network) -> GuardianResult<i32> {
     }
 }
 
-fn pb_to_ciphertext(ciphertext_pb_opt: Option<pb::HpkeCiphertext>) -> GuardianResult<Ciphertext> {
-    let ciphertext_pb = ciphertext_pb_opt.ok_or_else(|| missing("ciphertext"))?;
+impl TryFrom<pb::HpkeCiphertext> for Ciphertext {
+    type Error = GuardianError;
 
-    let encapsulated_key = ciphertext_pb
-        .encapsulated_key
-        .ok_or_else(|| missing("encapsulated_key"))?;
+    fn try_from(ciphertext_pb: pb::HpkeCiphertext) -> Result<Self, Self::Error> {
+        let encapsulated_key = ciphertext_pb
+            .encapsulated_key
+            .ok_or_else(|| missing("encapsulated_key"))?;
 
-    let aes_ciphertext = ciphertext_pb
-        .aes_ciphertext
-        .ok_or_else(|| missing("aes_ciphertext"))?;
+        let aes_ciphertext = ciphertext_pb
+            .aes_ciphertext
+            .ok_or_else(|| missing("aes_ciphertext"))?;
 
-    Ok(Ciphertext {
-        encapsulated_key: encapsulated_key.to_vec(),
-        aes_ciphertext: aes_ciphertext.to_vec(),
-    })
+        Ok(Self {
+            encapsulated_key: encapsulated_key.to_vec(),
+            aes_ciphertext: aes_ciphertext.to_vec(),
+        })
+    }
 }
 
 fn ciphertext_to_pb(c: Ciphertext) -> pb::HpkeCiphertext {
@@ -1179,18 +1225,22 @@ pub fn setup_new_key_response_to_pb(r: SetupNewKeyResponse) -> pb::SetupNewKeyRe
     }
 }
 
-fn pb_to_limiter_config(cfg: pb::LimiterConfig) -> GuardianResult<LimiterConfig> {
-    let refill_rate = cfg
-        .refill_rate_sats_per_sec
-        .ok_or_else(|| missing("refill_rate_sats_per_sec"))?;
-    let max_bucket_capacity = cfg
-        .max_bucket_capacity_sats
-        .ok_or_else(|| missing("max_bucket_capacity_sats"))?;
+impl TryFrom<pb::LimiterConfig> for LimiterConfig {
+    type Error = GuardianError;
 
-    Ok(LimiterConfig {
-        refill_rate,
-        max_bucket_capacity,
-    })
+    fn try_from(cfg: pb::LimiterConfig) -> Result<Self, Self::Error> {
+        let refill_rate = cfg
+            .refill_rate_sats_per_sec
+            .ok_or_else(|| missing("refill_rate_sats_per_sec"))?;
+        let max_bucket_capacity = cfg
+            .max_bucket_capacity_sats
+            .ok_or_else(|| missing("max_bucket_capacity_sats"))?;
+
+        Ok(Self {
+            refill_rate,
+            max_bucket_capacity,
+        })
+    }
 }
 
 fn limiter_config_to_pb(cfg: LimiterConfig) -> pb::LimiterConfig {
@@ -1200,20 +1250,24 @@ fn limiter_config_to_pb(cfg: LimiterConfig) -> pb::LimiterConfig {
     }
 }
 
-fn pb_to_limiter_state(limiter: pb::LimiterState) -> GuardianResult<LimiterState> {
-    let num_tokens_available = limiter
-        .num_tokens_available_sats
-        .ok_or_else(|| missing("num_tokens_available_sats"))?;
-    let last_updated_at = limiter
-        .last_updated_at_secs
-        .ok_or_else(|| missing("last_updated_at_secs"))?;
-    let next_seq = limiter.next_seq.ok_or_else(|| missing("next_seq"))?;
+impl TryFrom<pb::LimiterState> for LimiterState {
+    type Error = GuardianError;
 
-    Ok(LimiterState {
-        num_tokens_available,
-        last_updated_at,
-        next_seq,
-    })
+    fn try_from(limiter: pb::LimiterState) -> Result<Self, Self::Error> {
+        let num_tokens_available = limiter
+            .num_tokens_available_sats
+            .ok_or_else(|| missing("num_tokens_available_sats"))?;
+        let last_updated_at = limiter
+            .last_updated_at_secs
+            .ok_or_else(|| missing("last_updated_at_secs"))?;
+        let next_seq = limiter.next_seq.ok_or_else(|| missing("next_seq"))?;
+
+        Ok(Self {
+            num_tokens_available,
+            last_updated_at,
+            next_seq,
+        })
+    }
 }
 
 fn limiter_state_to_pb(state: LimiterState) -> pb::LimiterState {
@@ -1224,128 +1278,149 @@ fn limiter_state_to_pb(state: LimiterState) -> pb::LimiterState {
     }
 }
 
-fn pb_to_hashi_committee(c: pb::Committee) -> GuardianResult<HashiCommittee> {
-    let epoch = c.epoch.ok_or_else(|| missing("epoch"))?;
+impl TryFrom<pb::Committee> for HashiCommittee {
+    type Error = GuardianError;
 
-    let members: Vec<HashiCommitteeMember> = c
-        .members
-        .into_iter()
-        .map(pb_to_hashi_committee_member)
-        .collect::<GuardianResult<Vec<_>>>()?;
+    fn try_from(c: pb::Committee) -> Result<Self, Self::Error> {
+        let epoch = c.epoch.ok_or_else(|| missing("epoch"))?;
 
-    let total_weight = c.total_weight.ok_or_else(|| missing("total_weight"))?;
+        let members: Vec<HashiCommitteeMember> = c
+            .members
+            .into_iter()
+            .map(HashiCommitteeMember::try_from)
+            .collect::<GuardianResult<Vec<_>>>()?;
 
-    // The pinned config is carried verbatim as BCS bytes so the committee's
-    // signed bytes survive the wire without reconstruction.
-    let config_bytes = c.config.ok_or_else(|| missing("config"))?;
-    let config: Config = bcs::from_bytes(&config_bytes)
-        .map_err(|e| InvalidInputs(format!("invalid config: {e}")))?;
-    let committee = HashiCommittee::with_config(members, epoch, config);
+        let total_weight = c.total_weight.ok_or_else(|| missing("total_weight"))?;
 
-    if committee.total_weight() != total_weight {
-        return Err(InvalidInputs(format!(
-            "invalid total_weight: expected {total_weight}, computed {}",
-            committee.total_weight()
-        )));
+        // The pinned config is carried verbatim as BCS bytes so the committee's
+        // signed bytes survive the wire without reconstruction.
+        let config_bytes = c.config.ok_or_else(|| missing("config"))?;
+        let config: Config = bcs::from_bytes(&config_bytes)
+            .map_err(|e| InvalidInputs(format!("invalid config: {e}")))?;
+        let committee = Self::with_config(members, epoch, config);
+
+        if committee.total_weight() != total_weight {
+            return Err(InvalidInputs(format!(
+                "invalid total_weight: expected {total_weight}, computed {}",
+                committee.total_weight()
+            )));
+        }
+
+        Ok(committee)
     }
-
-    Ok(committee)
 }
 
-fn pb_to_hashi_committee_member(m: pb::CommitteeMember) -> GuardianResult<HashiCommitteeMember> {
-    let address = m.address.ok_or_else(|| missing("address"))?;
-    let validator_address = sui_sdk_types::Address::from_str(&address)
-        .map_err(|e| InvalidInputs(format!("invalid address: {e}")))?;
+impl TryFrom<pb::CommitteeMember> for HashiCommitteeMember {
+    type Error = GuardianError;
 
-    let public_key = m.public_key.ok_or_else(|| missing("public_key"))?;
-    let encryption_public_key = m
-        .encryption_public_key
-        .ok_or_else(|| missing("encryption_public_key"))?;
+    fn try_from(m: pb::CommitteeMember) -> Result<Self, Self::Error> {
+        let address = m.address.ok_or_else(|| missing("address"))?;
+        let validator_address = sui_sdk_types::Address::from_str(&address)
+            .map_err(|e| InvalidInputs(format!("invalid address: {e}")))?;
 
-    let weight = m.weight.ok_or_else(|| missing("weight"))?;
+        let public_key = m.public_key.ok_or_else(|| missing("public_key"))?;
+        let encryption_public_key = m
+            .encryption_public_key
+            .ok_or_else(|| missing("encryption_public_key"))?;
 
-    let x = crate::move_types::CommitteeMember {
-        validator_address,
-        public_key: public_key.to_vec(),
-        encryption_public_key: encryption_public_key.to_vec(),
-        weight,
-    };
+        let weight = m.weight.ok_or_else(|| missing("weight"))?;
 
-    HashiCommitteeMember::try_from(x)
-        .map_err(|e| InvalidInputs(format!("invalid committee member: {e}")))
+        let member = crate::move_types::CommitteeMember {
+            validator_address,
+            public_key: public_key.to_vec(),
+            encryption_public_key: encryption_public_key.to_vec(),
+            weight,
+        };
+
+        Self::try_from(member).map_err(|e| InvalidInputs(format!("invalid committee member: {e}")))
+    }
 }
 
 // -----------------------------------------
 //    Standard Withdrawal Helper Functions
 // -----------------------------------------
 
-fn pb_to_tx_utxos_wire(utxos_pb: pb::TxUtxos) -> GuardianResult<TxUTXOsWire> {
-    let inputs = utxos_pb
-        .inputs
-        .into_iter()
-        .map(pb_to_input_utxo)
-        .collect::<GuardianResult<Vec<_>>>()?;
+impl TryFrom<pb::TxUtxos> for TxUTXOsWire {
+    type Error = GuardianError;
 
-    let outputs = utxos_pb
-        .outputs
-        .into_iter()
-        .map(pb_to_output_utxo_wire)
-        .collect::<GuardianResult<Vec<_>>>()?;
+    fn try_from(utxos_pb: pb::TxUtxos) -> Result<Self, Self::Error> {
+        let inputs = utxos_pb
+            .inputs
+            .into_iter()
+            .map(InputUTXO::try_from)
+            .collect::<GuardianResult<Vec<_>>>()?;
 
-    Ok(TxUTXOsWire { inputs, outputs })
+        let outputs = utxos_pb
+            .outputs
+            .into_iter()
+            .map(OutputUTXOWire::try_from)
+            .collect::<GuardianResult<Vec<_>>>()?;
+
+        Ok(Self { inputs, outputs })
+    }
 }
 
-fn pb_to_input_utxo(input_pb: pb::InputUtxo) -> GuardianResult<InputUTXO> {
-    let outpoint_pb = input_pb.outpoint.ok_or_else(|| missing("outpoint"))?;
-    let txid_bytes = outpoint_pb.txid.ok_or_else(|| missing("txid"))?;
-    let vout = outpoint_pb.vout.ok_or_else(|| missing("vout"))?;
+impl TryFrom<pb::InputUtxo> for InputUTXO {
+    type Error = GuardianError;
 
-    let txid = Txid::from_slice(txid_bytes.as_ref())
-        .map_err(|e| InvalidInputs(format!("invalid txid: {e}")))?;
-    let outpoint = OutPoint { txid, vout };
+    fn try_from(input_pb: pb::InputUtxo) -> Result<Self, Self::Error> {
+        let outpoint_pb = input_pb.outpoint.ok_or_else(|| missing("outpoint"))?;
+        let txid_bytes = outpoint_pb.txid.ok_or_else(|| missing("txid"))?;
+        let vout = outpoint_pb.vout.ok_or_else(|| missing("vout"))?;
 
-    let amount = input_pb.amount.ok_or_else(|| missing("amount"))?;
+        let txid = Txid::from_slice(txid_bytes.as_ref())
+            .map_err(|e| InvalidInputs(format!("invalid txid: {e}")))?;
+        let outpoint = OutPoint { txid, vout };
 
-    let path_bytes = input_pb
-        .derivation_path
-        .ok_or_else(|| missing("derivation_path"))?;
-    let derivation_path = DerivationPath::from_bytes(path_bytes.as_ref())
-        .map_err(|_| InvalidInputs("invalid derivation_path: expected 32 bytes".into()))?;
+        let amount = input_pb.amount.ok_or_else(|| missing("amount"))?;
 
-    Ok(InputUTXO::new(
-        outpoint,
-        Amount::from_sat(amount),
-        derivation_path,
-    ))
+        let path_bytes = input_pb
+            .derivation_path
+            .ok_or_else(|| missing("derivation_path"))?;
+        let derivation_path = DerivationPath::from_bytes(path_bytes.as_ref())
+            .map_err(|_| InvalidInputs("invalid derivation_path: expected 32 bytes".into()))?;
+
+        Ok(Self::new(
+            outpoint,
+            Amount::from_sat(amount),
+            derivation_path,
+        ))
+    }
 }
 
-fn pb_to_output_utxo_wire(output_pb: pb::OutputUtxo) -> GuardianResult<OutputUTXOWire> {
-    let output = output_pb.output.ok_or_else(|| missing("output"))?;
+impl TryFrom<pb::OutputUtxo> for OutputUTXOWire {
+    type Error = GuardianError;
 
-    match output {
-        pb::output_utxo::Output::External(ext) => {
-            let address_str = ext.address.ok_or_else(|| missing("address"))?;
-            let address = BitcoinAddress::<NetworkUnchecked>::from_str(&address_str)
-                .map_err(|e| InvalidInputs(format!("invalid address: {e}")))?;
-            let amount = ext.amount.ok_or_else(|| missing("amount"))?;
+    fn try_from(output_pb: pb::OutputUtxo) -> Result<Self, Self::Error> {
+        let output = output_pb.output.ok_or_else(|| missing("output"))?;
 
-            Ok(OutputUTXOWire::External(ExternalOutputUTXOWire {
-                address,
-                amount: Amount::from_sat(amount),
-            }))
-        }
-        pb::output_utxo::Output::Internal(int) => {
-            let path_bytes = int
-                .derivation_path
-                .ok_or_else(|| missing("derivation_path"))?;
-            let derivation_path = DerivationPath::from_bytes(path_bytes.as_ref())
-                .map_err(|_| InvalidInputs("invalid derivation_path: expected 32 bytes".into()))?;
-            let amount = int.amount.ok_or_else(|| missing("amount"))?;
+        match output {
+            pb::output_utxo::Output::External(ext) => {
+                let address_str = ext.address.ok_or_else(|| missing("address"))?;
+                let address = BitcoinAddress::<NetworkUnchecked>::from_str(&address_str)
+                    .map_err(|e| InvalidInputs(format!("invalid address: {e}")))?;
+                let amount = ext.amount.ok_or_else(|| missing("amount"))?;
 
-            Ok(OutputUTXOWire::Internal(InternalOutputUTXO::new(
-                derivation_path,
-                Amount::from_sat(amount),
-            )))
+                Ok(Self::External(ExternalOutputUTXOWire {
+                    address,
+                    amount: Amount::from_sat(amount),
+                }))
+            }
+            pb::output_utxo::Output::Internal(int) => {
+                let path_bytes = int
+                    .derivation_path
+                    .ok_or_else(|| missing("derivation_path"))?;
+                let derivation_path =
+                    DerivationPath::from_bytes(path_bytes.as_ref()).map_err(|_| {
+                        InvalidInputs("invalid derivation_path: expected 32 bytes".into())
+                    })?;
+                let amount = int.amount.ok_or_else(|| missing("amount"))?;
+
+                Ok(Self::Internal(InternalOutputUTXO::new(
+                    derivation_path,
+                    Amount::from_sat(amount),
+                )))
+            }
         }
     }
 }
@@ -1411,9 +1486,13 @@ fn output_utxo_wire_to_pb(output: OutputUTXOWire) -> pb::OutputUtxo {
 /// Decode the wire `Committee` into the BCS-stable `move_types::Committee`,
 /// going through `HashiCommittee` so member keys and `total_weight` are
 /// validated before we project back.
-fn pb_to_move_committee(c: pb::Committee) -> GuardianResult<crate::move_types::Committee> {
-    let hashi_committee = pb_to_hashi_committee(c)?;
-    Ok(crate::move_types::Committee::from(&hashi_committee))
+impl TryFrom<pb::Committee> for crate::move_types::Committee {
+    type Error = GuardianError;
+
+    fn try_from(c: pb::Committee) -> Result<Self, Self::Error> {
+        let hashi_committee = HashiCommittee::try_from(c)?;
+        Ok(Self::from(&hashi_committee))
+    }
 }
 
 fn move_committee_to_pb(c: &crate::move_types::Committee) -> pb::Committee {
@@ -1440,12 +1519,14 @@ pub fn committee_transition_to_pb(t: &CommitteeTransitionRequest) -> pb::Committ
     }
 }
 
-pub fn pb_to_committee_transition(
-    t: pb::CommitteeTransition,
-) -> GuardianResult<CommitteeTransitionRequest> {
-    let new_committee_pb = t.new_committee.ok_or_else(|| missing("new_committee"))?;
-    let new_committee = pb_to_move_committee(new_committee_pb)?;
-    Ok(CommitteeTransitionRequest { new_committee })
+impl TryFrom<pb::CommitteeTransition> for CommitteeTransitionRequest {
+    type Error = GuardianError;
+
+    fn try_from(t: pb::CommitteeTransition) -> Result<Self, Self::Error> {
+        let new_committee_pb = t.new_committee.ok_or_else(|| missing("new_committee"))?;
+        let new_committee = crate::move_types::Committee::try_from(new_committee_pb)?;
+        Ok(Self { new_committee })
+    }
 }
 
 pub fn signed_committee_transition_to_pb(
@@ -1461,19 +1542,26 @@ pub fn signed_committee_transition_to_pb(
     }
 }
 
-pub fn pb_to_signed_committee_transition(
-    req: pb::SignedCommitteeTransition,
-) -> GuardianResult<HashiSigned<CommitteeTransitionRequest>> {
-    let data_pb = req.data.ok_or_else(|| missing("data"))?;
-    let transition = pb_to_committee_transition(data_pb)?;
+impl TryFrom<pb::SignedCommitteeTransition> for HashiSigned<CommitteeTransitionRequest> {
+    type Error = GuardianError;
 
-    let committee_signature_pb = req
-        .committee_signature
-        .ok_or_else(|| missing("committee_signature"))?;
-    let (epoch, signature, bitmap) = pb_to_committee_signature(committee_signature_pb)?;
+    fn try_from(req: pb::SignedCommitteeTransition) -> Result<Self, Self::Error> {
+        let data_pb = req.data.ok_or_else(|| missing("data"))?;
+        let transition = CommitteeTransitionRequest::try_from(data_pb)?;
 
-    HashiSigned::<CommitteeTransitionRequest>::new(epoch, transition, &signature, &bitmap)
+        let committee_signature_pb = req
+            .committee_signature
+            .ok_or_else(|| missing("committee_signature"))?;
+        let signature = CommitteeSignature::try_from(committee_signature_pb)?;
+
+        Self::new(
+            signature.epoch,
+            transition,
+            &signature.signature,
+            &signature.signers_bitmap,
+        )
         .map_err(|e| InvalidInputs(format!("invalid signed committee transition: {e}")))
+    }
 }
 
 #[cfg(test)]
@@ -1512,7 +1600,7 @@ mod tests {
             mpc_master_g: None,
         };
         let pb = guardian_info_data_to_pb(info.clone());
-        let back = pb_to_guardian_info_data(pb).unwrap();
+        let back = GuardianInfo::try_from(pb).unwrap();
         assert_eq!(info, back);
         assert_eq!(back.enclave_btc_pubkey, Some(pk));
     }
@@ -1632,7 +1720,7 @@ mod tests {
         let signed_pb = signed_standard_withdrawal_request_to_pb(&signed_domain);
 
         // 3) Convert back from pb -> wire.
-        let signed_wire = pb_to_signed_standard_withdrawal_request_wire(signed_pb).unwrap();
+        let signed_wire = SignedStandardWithdrawalRequestWire::try_from(signed_pb).unwrap();
 
         // 4) Convert wire -> HashiSigned<StandardWithdrawalRequest> using AddressValidation.
         let signed_back =
@@ -1702,7 +1790,7 @@ mod tests {
         let signed = agg.finish().expect("threshold met");
 
         let pb = signed_committee_transition_to_pb(&signed);
-        let back = pb_to_signed_committee_transition(pb).expect("round-trip");
+        let back = HashiSigned::<CommitteeTransitionRequest>::try_from(pb).expect("round-trip");
         assert_eq!(signed.epoch(), back.epoch());
         assert_eq!(signed.signature_bytes(), back.signature_bytes());
         assert_eq!(signed.signers_bitmap_bytes(), back.signers_bitmap_bytes());


### PR DESCRIPTION
## Summary

- verify the exact `kp-shares` S3 snapshot written by a KP certificate rotation instead of reading globally latest state
- share the S3 fetch, version-history, signature, attestation, PCR, decoding, and read-logging path between exact and latest KP-share reads
- replace natural protobuf-to-domain conversion helpers with `TryFrom` implementations, retaining helpers only where Rust's orphan rules prevent the trait implementation
- remove stale guardian TODOs and document why limiter recovery reaches genesis only when no withdrawal has ever succeeded
- strengthen ceremony tests by decrypting returned KP shares, verifying their commitments, and reconstructing the advertised Bitcoin public key
- assert the exact signed S3 records emitted by operator/provisioner initialization, withdrawals, rate-limit failures, and heartbeats

The production behavior change is limited to binding KP certificate rotation to the exact S3 snapshot it just wrote; the remaining changes are cleanup and test hardening.

## Verification

- `make fmt`
- CI
