### PR TITLE
[Guardian] Make mutating RPCs cancellation-safe

### DIFF
--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -21,9 +21,6 @@ pub async fn rotate_kps(
 ) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
     info!("/rotate_kps - Received request.");
 
-    // Serialize the whole ceremony. The exact lifecycle check prevents setup
-    // and rotation from interleaving and rejects another ceremony afterward.
-    let _guard = enclave.control_lock.lock().await;
     enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
 
     let (encrypted_old_shares, old_instance, state) = request.into_parts();

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -19,9 +19,6 @@ pub async fn setup_new_key(
 ) -> GuardianResult<GuardianSigned<SetupNewKeyResponse>> {
     info!("/setup_new_key - Received request.");
 
-    // Serialize the whole ceremony. The exact lifecycle check prevents setup
-    // and rotation from interleaving and rejects another ceremony afterward.
-    let _guard = enclave.control_lock.lock().await;
     enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
 
     let params = request.params();

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -21,6 +21,7 @@ use hashi_types::guardian::GuardianError::Unavailable;
 use hashi_types::guardian::*;
 use hpke::Serializable;
 use serde::Serialize;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::RwLock;
@@ -40,11 +41,9 @@ pub struct Enclave {
     pub state: EnclaveState,
     /// Temporary state retained until operator activation commits.
     temporary_init_state: RwLock<Option<TemporaryInitState>>,
-    /// Serializes lifecycle and control-plane transitions so concurrent callers
-    /// cannot race a check-then-set. Held across each handler.
-    /// TODO: Ensure this lock is not released if the RPC is cancelled while a
-    /// detached state mutation is still being persisted.
-    pub control_lock: tokio::sync::Mutex<()>,
+    /// Serializes lifecycle and control-plane transitions so concurrent
+    /// operations cannot race a check-then-set.
+    control_lock: tokio::sync::Mutex<()>,
 }
 
 /// Configuration set during initialization (immutable after set)
@@ -85,7 +84,7 @@ pub struct EnclaveState {
 /// Inputs needed only between operator initialization and activation.
 /// The enclave drops this entire capability when activation commits.
 #[derive(Clone)]
-pub(crate) struct TemporaryInitState {
+pub struct TemporaryInitState {
     pub ceremony_state: CeremonyState,
     pub genesis_state: Option<GenesisState>,
     pub config_hash: [u8; 32],
@@ -303,7 +302,7 @@ impl EnclaveState {
 
 impl Enclave {
     // ========================================================================
-    // Construction & Lifecycle
+    // Construction
     // ========================================================================
 
     pub fn new(
@@ -325,6 +324,56 @@ impl Enclave {
             control_lock: tokio::sync::Mutex::new(()),
         }
     }
+
+    // ========================================================================
+    // Task Spawning
+    // ========================================================================
+
+    /// Spawn a root-owned Tokio task so caller cancellation only detaches the
+    /// waiter and does not cancel accepted work. Use this when the task needs
+    /// no serialization or owns a narrower lock for the state it mutates.
+    /// E.g., used in `standard_withdrawal` that owns a separate serialization lock inside.
+    pub async fn spawn_task<Input, Output, Task, Fut>(
+        self: Arc<Self>,
+        input: Input,
+        task: Task,
+    ) -> GuardianResult<Output>
+    where
+        Input: Send + 'static,
+        Output: Send + 'static,
+        Task: FnOnce(Arc<Self>, Input) -> Fut + Send + 'static,
+        Fut: Future<Output = GuardianResult<Output>> + Send + 'static,
+    {
+        tokio::spawn(async move { task(self, input).await })
+            .await
+            .expect("guardian task failed")
+    }
+
+    /// Spawn a root-owned Tokio task that holds the control lock while running.
+    /// Use this for lifecycle and control-plane transitions whose shared-state
+    /// checks and mutations must not interleave with another control task.
+    pub async fn spawn_control_task<Input, Output, Task, Fut>(
+        self: Arc<Self>,
+        input: Input,
+        task: Task,
+    ) -> GuardianResult<Output>
+    where
+        Input: Send + 'static,
+        Output: Send + 'static,
+        Task: FnOnce(Arc<Self>, Input) -> Fut + Send + 'static,
+        Fut: Future<Output = GuardianResult<Output>> + Send + 'static,
+    {
+        self.spawn_task(input, move |enclave, input| async move {
+            let task_enclave = enclave.clone();
+            let _guard = enclave.control_lock.lock().await;
+            task(task_enclave, input).await
+        })
+        .await
+    }
+
+    // ========================================================================
+    // Lifecycle
+    // ========================================================================
 
     /// Which flows this enclave serves (fixed at boot).
     pub fn mode(&self) -> EnclaveMode {
@@ -577,7 +626,7 @@ impl Enclave {
     /// Keep this as the only accessor for `TemporaryInitState`. Its readers are
     /// restricted to provisioner initialization, operator activation, and
     /// status reporting; active request handlers must not depend on it.
-    pub(crate) fn temporary_init_state(&self) -> GuardianResult<TemporaryInitState> {
+    pub fn temporary_init_state(&self) -> GuardianResult<TemporaryInitState> {
         self.temporary_init_state
             .read()
             .expect("temporary initialization lock poisoned")
@@ -586,7 +635,7 @@ impl Enclave {
     }
 
     /// Operator initialization is the sole installer of temporary state.
-    pub(crate) fn set_temporary_init_state(&self, state: TemporaryInitState) -> GuardianResult<()> {
+    pub fn set_temporary_init_state(&self, state: TemporaryInitState) -> GuardianResult<()> {
         let mut slot = self
             .temporary_init_state
             .write()
@@ -607,7 +656,7 @@ impl Enclave {
             .is_some()
     }
 
-    pub(crate) fn clear_temporary_init_state(&self) {
+    pub fn clear_temporary_init_state(&self) {
         self.temporary_init_state
             .write()
             .expect("temporary initialization lock poisoned")
@@ -621,7 +670,7 @@ impl Enclave {
 
     /// Construct a verified reader with the enclave's fixed S3 client and PCR
     /// allowlist. Each operation gets a fresh, operation-scoped session cache.
-    pub(crate) fn new_guardian_reader(&self) -> GuardianResult<GuardianReader> {
+    pub fn new_guardian_reader(&self) -> GuardianResult<GuardianReader> {
         let s3 = self.config.s3_logger()?.clone();
         let pcr_allowlist = self
             .config
@@ -640,7 +689,7 @@ impl Enclave {
             .ok_or_else(|| InvalidInputs("Limiter config is uninitialized".into()))
     }
 
-    pub(crate) fn install_config(
+    pub fn install_config(
         &self,
         network: Network,
         hashi_btc_master_pubkey: HashiMasterG,

--- a/crates/hashi-guardian/src/lib.rs
+++ b/crates/hashi-guardian/src/lib.rs
@@ -27,6 +27,7 @@ pub mod operator_init;
 pub mod rpc;
 pub mod s3_client; // used by the monitor
 pub mod s3_reader; // verified read layer; used by the monitor + init tooling
+pub mod task_spawner;
 pub mod withdraw_mode;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -20,13 +20,13 @@ use tracing::info;
 use GuardianError::*;
 
 /// Complete operator-init state ready for its fail-stop commit.
-pub(crate) struct OIInstall {
+pub struct OIInstall {
     logger: GuardianS3Client,
     withdraw_mode: Option<OIWithdrawModeInstall>,
 }
 
 /// Withdraw-mode arming state built from `InitConfig` and the ceremony logs.
-pub(crate) struct OIWithdrawModeInstall {
+pub struct OIWithdrawModeInstall {
     init_config: InitConfig,
     ceremony_state: CeremonyState,
     genesis_state: Option<GenesisState>,
@@ -42,7 +42,7 @@ impl OIInstall {
 }
 
 impl OIWithdrawModeInstall {
-    pub(crate) fn from_parts(
+    pub fn from_parts(
         init_config: InitConfig,
         ceremony_state: CeremonyState,
         genesis_state: Option<GenesisState>,
@@ -56,7 +56,7 @@ impl OIWithdrawModeInstall {
 
     /// Build the arming bundle from the stable config and S3-derived ceremony +
     /// KP share state.
-    pub(crate) async fn from_config(
+    pub async fn from_config(
         logger: &GuardianS3Client,
         config: InitConfig,
         genesis_state: Option<GenesisState>,
@@ -74,7 +74,7 @@ impl OIWithdrawModeInstall {
 
     /// Install the bundle onto a fresh enclave. Infallible by design (see the
     /// `operator_init` invariant): every set runs once on a fresh enclave.
-    pub(crate) fn install_into(self, enclave: &Enclave) {
+    pub fn install_into(self, enclave: &Enclave) {
         let config_hash = self.init_config.digest();
         let (limiter_config, hashi_btc_master_pubkey, pcr_allowlist, network) =
             self.init_config.into_parts();
@@ -123,14 +123,13 @@ impl OIWithdrawModeInstall {
 /// untouched and retryable. The mutation then happens entirely in
 /// `commit_operator_init`, which returns `()` — it cannot report an error, so a
 /// half-mutated enclave is never observed via an `Err`.
+/// Validate and commit operator initialization under the cancellation-safe
+/// control lock so concurrent callers cannot race the check-then-commit.
 pub async fn operator_init(
     enclave: Arc<Enclave>,
     request: OperatorInitRequest,
 ) -> GuardianResult<()> {
     info!("/operator_init - Received request.");
-
-    // Serialize so concurrent callers can't race the check-then-commit below.
-    let _guard = enclave.control_lock.lock().await;
 
     let uninitialized = match enclave.mode() {
         EnclaveMode::Ceremony => CeremonyStage::Uninitialized.into(),

--- a/crates/hashi-guardian/src/rpc.rs
+++ b/crates/hashi-guardian/src/rpc.rs
@@ -1,15 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ceremony_mode::rotate;
-use crate::ceremony_mode::setup;
 use crate::info;
-use crate::operator_init;
-use crate::withdraw_mode::committee_update;
-use crate::withdraw_mode::operator_activate;
-use crate::withdraw_mode::provisioner_init;
-use crate::withdraw_mode::provisioner_rotate_cert;
-use crate::withdraw_mode::standard_withdrawal;
+use crate::task_spawner;
 use crate::Enclave;
 use hashi_types::guardian::proto_conversions;
 use hashi_types::guardian::AddressValidation;
@@ -68,7 +61,7 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
     ) -> anyhow::Result<Response<proto::SignedSetupNewKeyResponse>, Status> {
         let domain_req: SetupNewKeyRequest = request.into_inner().try_into().map_err(to_status)?;
 
-        let signed = setup::setup_new_key(self.enclave.clone(), domain_req)
+        let signed = task_spawner::setup_new_key(self.enclave.clone(), domain_req)
             .await
             .map_err(to_status)?;
 
@@ -83,7 +76,7 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
     ) -> Result<Response<proto::SignedRotateKpsResponse>, Status> {
         let domain_req: RotateKpsRequest = request.into_inner().try_into().map_err(to_status)?;
 
-        let signed = rotate::rotate_kps(self.enclave.clone(), domain_req)
+        let signed = task_spawner::rotate_kps(self.enclave.clone(), domain_req)
             .await
             .map_err(to_status)?;
 
@@ -99,7 +92,7 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
     ) -> Result<Response<proto::OperatorInitResponse>, Status> {
         let domain_req: OperatorInitRequest = request.into_inner().try_into().map_err(to_status)?;
 
-        operator_init::operator_init(self.enclave.clone(), domain_req)
+        task_spawner::operator_init(self.enclave.clone(), domain_req)
             .await
             .map_err(to_status)?;
 
@@ -112,7 +105,7 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
     ) -> Result<Response<proto::ProvisionerInitResponse>, Status> {
         let domain_req = request.into_inner().try_into().map_err(to_status)?;
 
-        provisioner_init::provisioner_init(self.enclave.clone(), domain_req)
+        task_spawner::provisioner_init(self.enclave.clone(), domain_req)
             .await
             .map_err(to_status)?;
 
@@ -125,10 +118,9 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
     ) -> Result<Response<proto::SignedProvisionerRotateCertResponse>, Status> {
         let domain_req: KpSigned<ProvisionerRotateCertRequest> =
             request.into_inner().try_into().map_err(to_status)?;
-        let signed =
-            provisioner_rotate_cert::provisioner_rotate_cert(self.enclave.clone(), domain_req)
-                .await
-                .map_err(to_status)?;
+        let signed = task_spawner::provisioner_rotate_cert(self.enclave.clone(), domain_req)
+            .await
+            .map_err(to_status)?;
 
         Ok(Response::new(
             proto_conversions::provisioner_rotate_cert_response_signed_to_pb(signed),
@@ -142,7 +134,7 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
         let domain_req: OperatorActivateRequest =
             request.into_inner().try_into().map_err(to_status)?;
 
-        operator_activate::operator_activate(self.enclave.clone(), domain_req)
+        task_spawner::operator_activate(self.enclave.clone(), domain_req)
             .await
             .map_err(to_status)?;
 
@@ -164,10 +156,9 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
                 .map_err(to_status)?;
 
         // core withdraw call
-        let response =
-            standard_withdrawal::standard_withdrawal(self.enclave.clone(), validated_req)
-                .await
-                .map_err(to_status)?;
+        let response = task_spawner::standard_withdrawal(self.enclave.clone(), validated_req)
+            .await
+            .map_err(to_status)?;
 
         // domain to proto
         let resp_pb = proto_conversions::standard_withdrawal_response_signed_to_pb(response);
@@ -180,10 +171,9 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
     ) -> Result<Response<proto::UpdateCommitteeResponse>, Status> {
         let signed = HashiSigned::<CommitteeTransitionRequest>::try_from(request.into_inner())
             .map_err(to_status)?;
-        let current_committee_epoch =
-            committee_update::update_committee(self.enclave.clone(), signed)
-                .await
-                .map_err(to_status)?;
+        let current_committee_epoch = task_spawner::update_committee(self.enclave.clone(), signed)
+            .await
+            .map_err(to_status)?;
 
         Ok(Response::new(proto::UpdateCommitteeResponse {
             current_committee_epoch: Some(current_committee_epoch),
@@ -202,7 +192,7 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
             .collect::<Result<Vec<_>, _>>()
             .map_err(to_status)?;
         let current_committee_epoch =
-            committee_update::update_committee_chain(self.enclave.clone(), transitions)
+            task_spawner::update_committee_chain(self.enclave.clone(), transitions)
                 .await
                 .map_err(to_status)?;
 

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -113,21 +113,15 @@ impl GuardianS3Client {
         self.write_at_key(&key, &log, object_lock_duration).await
     }
 
-    /// Retry an immutable log write through the grace period, then abort. The
-    /// worker is detached so caller cancellation cannot abandon an in-flight PUT.
+    /// Retry an immutable log write through the grace period, then abort.
+    /// State-changing RPCs call this from their root-owned task.
     pub async fn write_log_record_or_abort(&self, log: LogRecord) -> GuardianResult<()> {
-        let writer = self.clone();
-        tokio::spawn(async move {
-            writer
-                .write_log_record_or_abort_inner(
-                    log,
-                    MAX_S3_WRITE_FAILURE_INTERVAL,
-                    S3_WRITE_RETRY_INTERVAL,
-                )
-                .await
-        })
+        self.write_log_record_or_abort_inner(
+            log,
+            MAX_S3_WRITE_FAILURE_INTERVAL,
+            S3_WRITE_RETRY_INTERVAL,
+        )
         .await
-        .expect("S3 log writer task failed")
     }
 
     async fn write_log_record_or_abort_inner(

--- a/crates/hashi-guardian/src/task_spawner.rs
+++ b/crates/hashi-guardian/src/task_spawner.rs
@@ -1,0 +1,240 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cancellation-safe task spawning for state-changing guardian RPCs.
+//!
+//! Transport conversion stays in `rpc`; endpoint modules contain domain logic.
+//! This module routes each mutation through the enclave's appropriate
+//! cancellation-safe execution policy.
+//!
+//! Control-plane mutations use `spawn_control_task` because they share enclave
+//! lifecycle and configuration state. Standard withdrawal uses `spawn_task`
+//! because its limiter guard is the narrower serialization boundary: requests
+//! may validate concurrently, but limiter mutation through durable logging is
+//! still exclusive.
+
+use crate::ceremony_mode::rotate;
+use crate::ceremony_mode::setup;
+use crate::operator_init as operator_init_domain;
+use crate::withdraw_mode::committee_update;
+use crate::withdraw_mode::operator_activate as operator_activate_domain;
+use crate::withdraw_mode::provisioner_init as provisioner_init_domain;
+use crate::withdraw_mode::provisioner_rotate_cert as provisioner_rotate_cert_domain;
+use crate::withdraw_mode::standard_withdrawal as standard_withdrawal_domain;
+use crate::Enclave;
+use hashi_types::guardian::CommitteeTransitionRequest;
+use hashi_types::guardian::GuardianResult;
+use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::HashiSigned;
+use hashi_types::guardian::KpSigned;
+use hashi_types::guardian::OperatorActivateRequest;
+use hashi_types::guardian::OperatorInitRequest;
+use hashi_types::guardian::ProvisionerInitRequest;
+use hashi_types::guardian::ProvisionerRotateCertRequest;
+use hashi_types::guardian::ProvisionerRotateCertResponse;
+use hashi_types::guardian::RotateKpsRequest;
+use hashi_types::guardian::RotateKpsResponse;
+use hashi_types::guardian::SetupNewKeyRequest;
+use hashi_types::guardian::SetupNewKeyResponse;
+use hashi_types::guardian::StandardWithdrawalRequest;
+use hashi_types::guardian::StandardWithdrawalResponse;
+use std::sync::Arc;
+
+pub async fn setup_new_key(
+    enclave: Arc<Enclave>,
+    request: SetupNewKeyRequest,
+) -> GuardianResult<GuardianSigned<SetupNewKeyResponse>> {
+    enclave
+        .spawn_control_task(request, setup::setup_new_key)
+        .await
+}
+
+pub async fn rotate_kps(
+    enclave: Arc<Enclave>,
+    request: RotateKpsRequest,
+) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
+    enclave
+        .spawn_control_task(request, rotate::rotate_kps)
+        .await
+}
+
+pub async fn operator_init(
+    enclave: Arc<Enclave>,
+    request: OperatorInitRequest,
+) -> GuardianResult<()> {
+    enclave
+        .spawn_control_task(request, operator_init_domain::operator_init)
+        .await
+}
+
+pub async fn provisioner_init(
+    enclave: Arc<Enclave>,
+    request: ProvisionerInitRequest,
+) -> GuardianResult<()> {
+    enclave
+        .spawn_control_task(request, provisioner_init_domain::provisioner_init)
+        .await
+}
+
+pub async fn operator_activate(
+    enclave: Arc<Enclave>,
+    request: OperatorActivateRequest,
+) -> GuardianResult<()> {
+    enclave
+        .spawn_control_task(request, operator_activate_domain::operator_activate)
+        .await
+}
+
+pub async fn provisioner_rotate_cert(
+    enclave: Arc<Enclave>,
+    signed_request: KpSigned<ProvisionerRotateCertRequest>,
+) -> GuardianResult<GuardianSigned<ProvisionerRotateCertResponse>> {
+    enclave
+        .spawn_control_task(
+            signed_request,
+            provisioner_rotate_cert_domain::provisioner_rotate_cert,
+        )
+        .await
+}
+
+pub async fn standard_withdrawal(
+    enclave: Arc<Enclave>,
+    request: HashiSigned<StandardWithdrawalRequest>,
+) -> GuardianResult<GuardianSigned<StandardWithdrawalResponse>> {
+    enclave
+        .spawn_task(request, standard_withdrawal_domain::standard_withdrawal)
+        .await
+}
+
+pub async fn update_committee(
+    enclave: Arc<Enclave>,
+    signed: HashiSigned<CommitteeTransitionRequest>,
+) -> GuardianResult<u64> {
+    enclave
+        .spawn_control_task(signed, committee_update::update_committee)
+        .await
+}
+
+pub async fn update_committee_chain(
+    enclave: Arc<Enclave>,
+    transitions: Vec<HashiSigned<CommitteeTransitionRequest>>,
+) -> GuardianResult<u64> {
+    enclave
+        .spawn_control_task(transitions, committee_update::update_committee_chain)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hashi_types::guardian::EnclaveMode;
+    use hashi_types::guardian::GuardianEncKeyPair;
+    use hashi_types::guardian::GuardianSignKeyPair;
+    use std::time::Duration;
+    use tokio::sync::oneshot;
+
+    /// A task body that reports when it starts, waits for the test to let it
+    /// continue, then reports completion.
+    struct PausedTask {
+        started: oneshot::Sender<()>,
+        resume: oneshot::Receiver<()>,
+        finished: oneshot::Sender<()>,
+    }
+
+    fn test_enclave() -> Arc<Enclave> {
+        Arc::new(Enclave::new(
+            GuardianSignKeyPair::new(rand::thread_rng()),
+            GuardianEncKeyPair::random(&mut rand::thread_rng()),
+            EnclaveMode::Withdraw,
+        ))
+    }
+
+    async fn pause_after_start(_enclave: Arc<Enclave>, task: PausedTask) -> GuardianResult<()> {
+        task.started.send(()).unwrap();
+        task.resume.await.unwrap();
+        task.finished.send(()).unwrap();
+        Ok(())
+    }
+
+    async fn signal_started(
+        _enclave: Arc<Enclave>,
+        started: oneshot::Sender<()>,
+    ) -> GuardianResult<()> {
+        started.send(()).unwrap();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn root_owned_task_survives_caller_cancellation() {
+        let (started_tx, started_rx) = oneshot::channel();
+        let (resume_tx, resume_rx) = oneshot::channel();
+        let (finished_tx, finished_rx) = oneshot::channel();
+
+        // This outer task represents the Tonic RPC handler awaiting the
+        // independently spawned guardian task.
+        let caller = tokio::spawn(test_enclave().spawn_task(
+            PausedTask {
+                started: started_tx,
+                resume: resume_rx,
+                finished: finished_tx,
+            },
+            pause_after_start,
+        ));
+        // Ensure the guardian accepted and started the task before simulating
+        // the client disconnect.
+        started_rx.await.unwrap();
+
+        // Cancelling the RPC handler drops only its waiter. The guardian task
+        // spawned by `spawn_task` must continue independently.
+        caller.abort();
+        assert!(caller.await.unwrap_err().is_cancelled());
+
+        // Allow the guardian task to finish and prove that caller cancellation
+        // did not cancel it.
+        resume_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), finished_rx)
+            .await
+            .expect("root-owned task should finish")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn control_tasks_are_serialized() {
+        let enclave = test_enclave();
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (first_resume_tx, first_resume_rx) = oneshot::channel();
+        let (first_finished_tx, first_finished_rx) = oneshot::channel();
+
+        // The first task acquires the control lock, then pauses while holding it.
+        let first = tokio::spawn(enclave.clone().spawn_control_task(
+            PausedTask {
+                started: first_started_tx,
+                resume: first_resume_rx,
+                finished: first_finished_tx,
+            },
+            pause_after_start,
+        ));
+        first_started_rx.await.unwrap();
+
+        // A second control task is accepted and spawned, but must wait for the
+        // first task to release the control lock.
+        let (second_started_tx, mut second_started_rx) = oneshot::channel();
+        let second = tokio::spawn(enclave.spawn_control_task(second_started_tx, signal_started));
+        // Yield this test task to give Tokio an opportunity to poll the second
+        // task and let it reach the control lock. This is a scheduling hint,
+        // not proof that the second task reached the lock-waiting point.
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            second_started_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+
+        // Finishing the first task releases the lock, after which the second
+        // task may enter and signal that it started.
+        first_resume_tx.send(()).unwrap();
+        first_finished_rx.await.unwrap();
+        second_started_rx.await.unwrap();
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+    }
+}

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -47,14 +47,12 @@ pub type CapturedPuts = Arc<std::sync::Mutex<Vec<(String, Vec<u8>)>>>;
 
 /// Mock OpenPGP secret keys keyed by the corresponding public-cert fingerprint.
 #[cfg(test)]
-pub(crate) type MockKpSecretKeys = BTreeMap<String, String>;
+pub type MockKpSecretKeys = BTreeMap<String, String>;
 
 /// Build a one-certificate-per-KP roster while retaining the matching secret
 /// keys so tests can prove the returned armored shares are decryptable.
 #[cfg(test)]
-pub(crate) fn mock_kp_certs_roster_with_secrets(
-    num_kps: usize,
-) -> (KpCertsRoster, MockKpSecretKeys) {
+pub fn mock_kp_certs_roster_with_secrets(num_kps: usize) -> (KpCertsRoster, MockKpSecretKeys) {
     let mut secret_keys = MockKpSecretKeys::new();
     let cert_sets = (0..num_kps)
         .map(|_| {
@@ -78,7 +76,7 @@ pub(crate) fn mock_kp_certs_roster_with_secrets(
 /// If a share has multiple recipient certs, all ciphertexts must decrypt to the
 /// same scalar.
 #[cfg(test)]
-pub(crate) fn decrypt_kp_shares(
+pub fn decrypt_kp_shares(
     encrypted_shares: &KPEncryptedSharesRoster,
     secret_keys: &MockKpSecretKeys,
 ) -> Vec<Share> {

--- a/crates/hashi-guardian/src/withdraw_mode/committee_update.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/committee_update.rs
@@ -25,9 +25,6 @@ pub async fn update_committee(
     enclave: Arc<Enclave>,
     signed: HashiSigned<CommitteeTransitionRequest>,
 ) -> GuardianResult<u64> {
-    // Serialize so a stalled call can't roll the committee backwards.
-    let _guard = enclave.control_lock.lock().await;
-
     if !enclave.is_fully_initialized() {
         return Err(EnclaveUninitialized);
     }

--- a/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
@@ -101,8 +101,6 @@ pub async fn operator_activate(
 ) -> GuardianResult<()> {
     info!("/operator_activate - Received request.");
 
-    let _guard = enclave.control_lock.lock().await;
-
     enclave.require_lifecycle(WithdrawStage::ProvisionerInitialized.into())?;
     info!("Lifecycle stage validated.");
 

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -93,9 +93,6 @@ pub async fn provisioner_init(
 ) -> GuardianResult<()> {
     info!("/provisioner_init - Received request.");
 
-    // Serialize so concurrent callers can't race the check-then-finalize below.
-    let _guard = enclave.control_lock.lock().await;
-
     enclave.require_lifecycle(WithdrawStage::OperatorInitialized.into())?;
     info!("Lifecycle stage validated.");
 

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -29,9 +29,6 @@ pub async fn provisioner_rotate_cert(
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
     let request = signed_request.verify()?;
 
-    // Serialize the read-latest-state + append-next-state sequence.
-    let _guard = enclave.control_lock.lock().await;
-
     if !enclave.is_fully_initialized() {
         return Err(InvalidInputs(
             "provisioner_rotate_cert requires operator_activate complete".into(),

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -44,8 +44,9 @@ pub async fn standard_withdrawal(
                 response: response.clone(),
                 post_state,
             };
-            log_withdrawal_success(enclave.clone(), wid, msg, limiter_guard).await?;
-            // <-- Limiter guard drops upon log_withdrawal_success return. Next withdrawal can begin.
+            log_withdrawal_success(enclave.as_ref(), wid, msg, limiter_guard).await?;
+            // The limiter guard is retained through the durable log and released
+            // when `log_withdrawal_success` returns. The next withdrawal may now begin.
             Ok(enclave.sign(response))
         }
         Err(withdraw_err) => {
@@ -130,24 +131,19 @@ async fn normal_withdrawal_inner(
 }
 
 async fn log_withdrawal_success(
-    enclave: Arc<Enclave>,
+    enclave: &Enclave,
     wid: WithdrawalID,
     msg: WithdrawalLogMessage,
     limiter_guard: OwnedMutexGuard<RateLimiter>,
 ) -> GuardianResult<()> {
-    // The task owns the limiter guard and continues if the RPC future is cancelled.
-    // In production, exhausting the write grace period panics and the process-wide
-    // panic hook aborts the enclave.
-    tokio::spawn(async move {
-        enclave
-            .log_withdraw(msg)
-            .await
-            .expect("withdrawal log write failed");
-        info!("Withdrawal {} logged.", wid);
-        drop(limiter_guard);
-    })
-    .await
-    .expect("withdrawal log task failed");
+    enclave
+        .log_withdraw(msg)
+        .await
+        .expect("withdrawal log write failed");
+    info!("Withdrawal {} logged.", wid);
+    // Rust would drop this guard at function exit; the explicit drop documents
+    // that the next withdrawal may enter only after this one is durably logged.
+    drop(limiter_guard);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- add a `task_spawner` boundary for every state-changing Guardian RPC
- centralize Tokio task ownership in `Enclave::spawn_task`, so accepted work survives caller cancellation
- compose `spawn_control_task` with a private control lock for lifecycle and control-plane transitions
- keep standard withdrawal on `spawn_task`, using its limiter guard as the narrower serialization boundary
- remove nested task spawning from S3 retry and withdrawal logging helpers
- preserve standard-withdrawal validation, limiter, signing, logging, and response ordering
- test caller cancellation survival and control-task serialization, with comments explaining the simulated RPC behavior

## Verification

- `make fmt`
- CI
