### PR TITLE
[Guardian] Improve error classification

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -568,12 +568,7 @@ mod tests {
             .guardian_harness
             .as_ref()
             .expect("harness present after 2-of-2 cutover");
-        assert!(
-            harness
-                .enclave()
-                .require_fully_initialized("e2e_flow")
-                .is_ok()
-        );
+        assert!(harness.enclave().require_fully_initialized().is_ok());
 
         let deposit_amount_sats = 100_000u64;
         let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_amount_sats).await?;

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -568,7 +568,12 @@ mod tests {
             .guardian_harness
             .as_ref()
             .expect("harness present after 2-of-2 cutover");
-        assert!(harness.enclave().is_fully_initialized());
+        assert!(
+            harness
+                .enclave()
+                .require_fully_initialized("e2e_flow")
+                .is_ok()
+        );
 
         let deposit_amount_sats = 100_000u64;
         let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_amount_sats).await?;

--- a/crates/e2e-tests/src/guardian_harness.rs
+++ b/crates/e2e-tests/src/guardian_harness.rs
@@ -92,7 +92,9 @@ impl GuardianHarness {
             .map_err(|e| anyhow::anyhow!("activate guardian enclave: {e:?}"))?;
 
         anyhow::ensure!(
-            self.enclave.is_fully_initialized(),
+            self.enclave
+                .require_fully_initialized("guardian_harness::finalize")
+                .is_ok(),
             "guardian did not reach active state"
         );
         Ok(())

--- a/crates/e2e-tests/src/guardian_harness.rs
+++ b/crates/e2e-tests/src/guardian_harness.rs
@@ -92,9 +92,7 @@ impl GuardianHarness {
             .map_err(|e| anyhow::anyhow!("activate guardian enclave: {e:?}"))?;
 
         anyhow::ensure!(
-            self.enclave
-                .require_fully_initialized("guardian_harness::finalize")
-                .is_ok(),
+            self.enclave.require_fully_initialized().is_ok(),
             "guardian did not reach active state"
         );
         Ok(())

--- a/crates/hashi-guardian-init/src/guardian_info.rs
+++ b/crates/hashi-guardian-init/src/guardian_info.rs
@@ -25,7 +25,7 @@ pub async fn verified_live_guardian_info(
         .map_err(|e| anyhow!("decode GetGuardianInfoResponse: {e:?}"))?;
     info_resp
         .verify_live(current_build)
-        .map_err(|e| anyhow!("verify GuardianInfo attestation/signature: {e:?}"))
+        .map_err(|e| anyhow!("verify GuardianInfo attestation/signature: {e}"))
 }
 
 /// The OI log captures the final pre-transition snapshot. Apart from the

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -171,7 +171,7 @@ pub async fn run(
         .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
     let response = signed_response
         .verify(&signing_pub_key)
-        .map_err(|e| anyhow!("verify ProvisionerRotateCertResponse signature: {e:?}"))?;
+        .map_err(|e| anyhow!("verify ProvisionerRotateCertResponse signature: {e}"))?;
     let expected_cert_seq = old_cert_seq.checked_add(1).context("cert_seq overflow")?;
     anyhow::ensure!(
         response.cert_seq == expected_cert_seq,

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -180,7 +180,7 @@ pub async fn run(cfg: Config) -> Result<()> {
     //    and sanity-check the shape; keep the now-verified BTC master pubkey.
     let response = signed_resp
         .verify(&signing_pub_key)
-        .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e:?}"))?;
+        .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e}"))?;
     let live = CeremonyState::from(response);
     live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -46,7 +46,7 @@ fn verify_provisioner_rotate_cert_signature(
         .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
     signed_request
         .verify()
-        .map_err(|e| Status::unauthenticated(e.to_string()))?;
+        .map_err(|error| Status::unauthenticated(error.to_string()))?;
     Ok(())
 }
 

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -17,7 +17,6 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use hashi_types::guardian::GetGuardianInfoResponse;
-use hashi_types::guardian::GuardianError;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::SessionID;
 use hashi_types::guardian::SingleProvisionerInitRequest;
@@ -147,14 +146,7 @@ fn verify_kp_submission(
     }
     signed_request
         .verify_signature()
-        .map_err(kp_signature_error_status)
-}
-
-fn kp_signature_error_status(error: GuardianError) -> Status {
-    match error {
-        GuardianError::InvalidInputs(msg) => Status::unauthenticated(msg),
-        other => Status::unauthenticated(other.to_string()),
-    }
+        .map_err(|error| Status::unauthenticated(error.to_string()))
 }
 
 fn done() -> Response<proto::SingleProvisionerInitResponse> {

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -21,7 +21,7 @@ pub async fn rotate_kps(
 ) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
     info!("/rotate_kps - Received request.");
 
-    enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
+    enclave.require_lifecycle("rotate_kps", CeremonyStage::OperatorInitialized.into())?;
 
     let (encrypted_old_shares, old_instance, state) = request.into_parts();
     let old_t = old_instance.threshold();
@@ -134,6 +134,7 @@ mod tests {
     use hashi_types::guardian::crypto::split_secret;
     use hashi_types::guardian::test_utils::mock_kp_certs_roster;
     use hashi_types::guardian::GuardianError::InvalidInputs;
+    use hashi_types::guardian::GuardianError::LifecycleMismatch;
     use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;
@@ -338,7 +339,7 @@ mod tests {
         // A second call is rejected outright — no re-split.
         let req2 = build_request(&shares[..TEST_T], &enclave, &old_instance, build_state());
         let err = rotate_kps(enclave, req2).await.expect_err("should reject");
-        assert!(matches!(err, InvalidInputs(_)));
+        assert!(matches!(err, LifecycleMismatch { .. }));
 
         let captured = captures.lock().unwrap();
         let count = captured
@@ -478,6 +479,6 @@ mod tests {
         .unwrap();
         let req = RotateKpsRequest::new(submissions, old_instance, state);
         let err = rotate_kps(enclave, req).await.expect_err("should fail");
-        assert!(matches!(err, InvalidInputs(_)));
+        assert!(matches!(err, LifecycleMismatch { .. }));
     }
 }

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -21,7 +21,7 @@ pub async fn rotate_kps(
 ) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
     info!("/rotate_kps - Received request.");
 
-    enclave.require_lifecycle("rotate_kps", CeremonyStage::OperatorInitialized.into())?;
+    enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
 
     let (encrypted_old_shares, old_instance, state) = request.into_parts();
     let old_t = old_instance.threshold();

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -19,7 +19,7 @@ pub async fn setup_new_key(
 ) -> GuardianResult<GuardianSigned<SetupNewKeyResponse>> {
     info!("/setup_new_key - Received request.");
 
-    enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
+    enclave.require_lifecycle("setup_new_key", CeremonyStage::OperatorInitialized.into())?;
 
     let params = request.params();
     let n = params.num_shares();

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -19,7 +19,7 @@ pub async fn setup_new_key(
 ) -> GuardianResult<GuardianSigned<SetupNewKeyResponse>> {
     info!("/setup_new_key - Received request.");
 
-    enclave.require_lifecycle("setup_new_key", CeremonyStage::OperatorInitialized.into())?;
+    enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
 
     let params = request.params();
     let n = params.num_shares();

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -17,6 +17,7 @@ use hashi_types::bitcoin::HashiMasterG;
 use hashi_types::bitcoin::TxUTXOs;
 use hashi_types::guardian::GuardianError::InternalError;
 use hashi_types::guardian::GuardianError::InvalidInputs;
+use hashi_types::guardian::GuardianError::LifecycleMismatch;
 use hashi_types::guardian::GuardianError::Unavailable;
 use hashi_types::guardian::*;
 use hpke::Serializable;
@@ -388,13 +389,20 @@ impl Enclave {
             .expect("lifecycle lock poisoned")
     }
 
-    /// Require an exact mode and lifecycle stage.
-    pub fn require_lifecycle(&self, expected: EnclaveLifecycle) -> GuardianResult<()> {
+    /// Require an exact mode and lifecycle stage, naming the operation in any
+    /// resulting error.
+    pub fn require_lifecycle(
+        &self,
+        operation: &str,
+        expected: EnclaveLifecycle,
+    ) -> GuardianResult<()> {
         let actual = self.lifecycle();
         if actual != expected {
-            return Err(InvalidInputs(format!(
-                "expected enclave lifecycle {expected:?}, got {actual:?}"
-            )));
+            return Err(LifecycleMismatch {
+                operation: operation.into(),
+                expected,
+                actual,
+            });
         }
         Ok(())
     }
@@ -411,10 +419,11 @@ impl Enclave {
             .write()
             .expect("lifecycle lock poisoned");
         if *lifecycle != expected {
-            return Err(InvalidInputs(format!(
-                "expected enclave lifecycle {expected:?}, got {:?}",
-                *lifecycle
-            )));
+            return Err(LifecycleMismatch {
+                operation: "advance_lifecycle_into".into(),
+                expected,
+                actual: *lifecycle,
+            });
         }
         self.assert_state_installed_for(next);
         *lifecycle = next;
@@ -470,8 +479,10 @@ impl Enclave {
         }
     }
 
-    pub fn is_fully_initialized(&self) -> bool {
-        self.lifecycle() == WithdrawStage::Activated.into()
+    /// Require the activated withdraw lifecycle, naming the operation in any
+    /// resulting error.
+    pub fn require_fully_initialized(&self, operation: &str) -> GuardianResult<()> {
+        self.require_lifecycle(operation, WithdrawStage::Activated.into())
     }
 
     // ========================================================================

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -389,20 +389,11 @@ impl Enclave {
             .expect("lifecycle lock poisoned")
     }
 
-    /// Require an exact mode and lifecycle stage, naming the operation in any
-    /// resulting error.
-    pub fn require_lifecycle(
-        &self,
-        operation: &str,
-        expected: EnclaveLifecycle,
-    ) -> GuardianResult<()> {
+    /// Require an exact mode and lifecycle stage.
+    pub fn require_lifecycle(&self, expected: EnclaveLifecycle) -> GuardianResult<()> {
         let actual = self.lifecycle();
         if actual != expected {
-            return Err(LifecycleMismatch {
-                operation: operation.into(),
-                expected,
-                actual,
-            });
+            return Err(LifecycleMismatch { expected, actual });
         }
         Ok(())
     }
@@ -420,7 +411,6 @@ impl Enclave {
             .expect("lifecycle lock poisoned");
         if *lifecycle != expected {
             return Err(LifecycleMismatch {
-                operation: "advance_lifecycle_into".into(),
                 expected,
                 actual: *lifecycle,
             });
@@ -479,10 +469,9 @@ impl Enclave {
         }
     }
 
-    /// Require the activated withdraw lifecycle, naming the operation in any
-    /// resulting error.
-    pub fn require_fully_initialized(&self, operation: &str) -> GuardianResult<()> {
-        self.require_lifecycle(operation, WithdrawStage::Activated.into())
+    /// Require the activated withdraw lifecycle.
+    pub fn require_fully_initialized(&self) -> GuardianResult<()> {
+        self.require_lifecycle(WithdrawStage::Activated.into())
     }
 
     // ========================================================================

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -65,8 +65,7 @@ impl OIWithdrawModeInstall {
             GuardianReader::from_s3_client(logger.clone(), config.pcr_allowlist().clone());
         let ceremony_state = reader
             .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
-            .await
-            .map_err(|e| InvalidInputs(format!("read latest ceremony and KP share state: {e}")))?
+            .await?
             .ok_or_else(|| InvalidInputs("no ceremony log found for withdraw init".into()))?;
 
         Ok(Self::from_parts(config, ceremony_state, genesis_state))
@@ -135,7 +134,7 @@ pub async fn operator_init(
         EnclaveMode::Ceremony => CeremonyStage::Uninitialized.into(),
         EnclaveMode::Withdraw => WithdrawStage::Uninitialized.into(),
     };
-    enclave.require_lifecycle("operator_init", uninitialized)?;
+    enclave.require_lifecycle(uninitialized)?;
     info!("Lifecycle stage validated.");
 
     // ---- Validate & build: Nothing in this phase mutates enclave state, so any

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -135,7 +135,7 @@ pub async fn operator_init(
         EnclaveMode::Ceremony => CeremonyStage::Uninitialized.into(),
         EnclaveMode::Withdraw => WithdrawStage::Uninitialized.into(),
     };
-    enclave.require_lifecycle(uninitialized)?;
+    enclave.require_lifecycle("operator_init", uninitialized)?;
     info!("Lifecycle stage validated.");
 
     // ---- Validate & build: Nothing in this phase mutates enclave state, so any

--- a/crates/hashi-guardian/src/rpc.rs
+++ b/crates/hashi-guardian/src/rpc.rs
@@ -33,7 +33,7 @@ fn to_status(e: GuardianError) -> Status {
     match e {
         InvalidInputs(msg) => Status::invalid_argument(msg),
         Unauthenticated(msg) => Status::unauthenticated(msg),
-        GuardianBuildNotAccepted(msg) => Status::failed_precondition(msg),
+        BuildNotAllowlisted(msg) | BuildNotCurrent(msg) => Status::failed_precondition(msg),
         LifecycleMismatch {
             operation,
             expected,
@@ -41,11 +41,11 @@ fn to_status(e: GuardianError) -> Status {
         } => Status::failed_precondition(format!(
             "{operation} requires {expected:?}, but enclave is {actual:?}"
         )),
+        RateLimitExceeded => Status::resource_exhausted("Rate limit exceeded"),
+        S3Error(msg) => Status::internal(msg),
+        InvalidS3Log(msg) => Status::internal(msg),
         InternalError(msg) => Status::internal(msg),
         Unavailable(msg) => Status::unavailable(msg),
-        S3Error(msg) => Status::internal(msg),
-        InvalidGuardianLog(msg) => Status::internal(msg),
-        RateLimitExceeded => Status::resource_exhausted("Rate limit exceeded"),
     }
 }
 

--- a/crates/hashi-guardian/src/rpc.rs
+++ b/crates/hashi-guardian/src/rpc.rs
@@ -32,11 +32,17 @@ pub struct GuardianGrpc {
 fn to_status(e: GuardianError) -> Status {
     match e {
         InvalidInputs(msg) => Status::invalid_argument(msg),
+        LifecycleMismatch {
+            operation,
+            expected,
+            actual,
+        } => Status::failed_precondition(format!(
+            "{operation} requires {expected:?}, but enclave is {actual:?}"
+        )),
         InternalError(msg) => Status::internal(msg),
         Unavailable(msg) => Status::unavailable(msg),
         S3Error(msg) => Status::internal(msg),
-        EnclaveUninitialized => Status::failed_precondition("Enclave is not fully initialized"),
-        RateLimitExceeded => Status::internal("Rate limit exceeded"),
+        RateLimitExceeded => Status::resource_exhausted("Rate limit exceeded"),
     }
 }
 

--- a/crates/hashi-guardian/src/rpc.rs
+++ b/crates/hashi-guardian/src/rpc.rs
@@ -32,6 +32,8 @@ pub struct GuardianGrpc {
 fn to_status(e: GuardianError) -> Status {
     match e {
         InvalidInputs(msg) => Status::invalid_argument(msg),
+        Unauthenticated(msg) => Status::unauthenticated(msg),
+        GuardianBuildNotAccepted(msg) => Status::failed_precondition(msg),
         LifecycleMismatch {
             operation,
             expected,
@@ -42,6 +44,7 @@ fn to_status(e: GuardianError) -> Status {
         InternalError(msg) => Status::internal(msg),
         Unavailable(msg) => Status::unavailable(msg),
         S3Error(msg) => Status::internal(msg),
+        InvalidGuardianLog(msg) => Status::internal(msg),
         RateLimitExceeded => Status::resource_exhausted("Rate limit exceeded"),
     }
 }

--- a/crates/hashi-guardian/src/rpc.rs
+++ b/crates/hashi-guardian/src/rpc.rs
@@ -34,12 +34,14 @@ fn to_status(e: GuardianError) -> Status {
         InvalidInputs(msg) => Status::invalid_argument(msg),
         Unauthenticated(msg) => Status::unauthenticated(msg),
         BuildNotAllowlisted(msg) | BuildNotCurrent(msg) => Status::failed_precondition(msg),
-        LifecycleMismatch {
-            operation,
-            expected,
-            actual,
-        } => Status::failed_precondition(format!(
-            "{operation} requires {expected:?}, but enclave is {actual:?}"
+        LifecycleMismatch { expected, actual } => Status::failed_precondition(format!(
+            "expected enclave lifecycle {expected:?}, but enclave is {actual:?}"
+        )),
+        // Guardian reserves `Aborted` and `ResourceExhausted` exclusively for
+        // limiter sequence mismatches and rate limiting, respectively, so
+        // Hashi can classify them without parsing error messages.
+        LimiterSequenceMismatch { expected, actual } => Status::aborted(format!(
+            "limiter sequence mismatch: expected {expected}, got {actual}"
         )),
         RateLimitExceeded => Status::resource_exhausted("Rate limit exceeded"),
         S3Error(msg) => Status::internal(msg),

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -20,14 +20,11 @@ use aws_sdk_s3::types::ObjectLockEnabled;
 use aws_sdk_s3::types::ObjectLockMode;
 use aws_sdk_s3::Client as S3Client;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
-use hashi_types::guardian::GuardianError;
-use hashi_types::guardian::GuardianError::GuardianBuildNotAccepted;
-use hashi_types::guardian::GuardianError::InvalidGuardianLog;
+use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianError::S3Error;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::InitLogMessage;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::VerificationError;
 use hashi_types::guardian::VerifiedSessionInfo;
 use serde::Serialize;
 use tracing::info;
@@ -37,18 +34,6 @@ use tracing::warn;
 const MAX_RETRY_ATTEMPTS: u32 = 5;
 /// Delay between application-level retries of an immutable S3 log write.
 const S3_WRITE_RETRY_INTERVAL: Duration = Duration::from_secs(10);
-
-fn guardian_log_verification_error(
-    context: impl std::fmt::Display,
-    error: VerificationError,
-) -> GuardianError {
-    match error {
-        VerificationError::Invalid(message) => InvalidGuardianLog(format!("{context}: {message}")),
-        VerificationError::PcrMismatch(message) => {
-            GuardianBuildNotAccepted(format!("{context}: {message}"))
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct GuardianS3Client {
@@ -619,7 +604,7 @@ impl GuardianS3Client {
         })?;
 
         let record = serde_json::from_slice::<LogRecord>(&bytes.into_bytes()).map_err(|e| {
-            InvalidGuardianLog(format!(
+            InvalidS3Log(format!(
                 "Failed to deserialize object {} into target type: {}",
                 key, e
             ))
@@ -658,7 +643,7 @@ impl GuardianS3Client {
                 _ => None,
             })
             .ok_or_else(|| {
-                InvalidGuardianLog(format!("expected OIAttestationUnsigned at key {att_key}"))
+                InvalidS3Log(format!("expected OIAttestationUnsigned at key {att_key}"))
             })?;
 
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
@@ -671,9 +656,7 @@ impl GuardianS3Client {
                 InitLogMessage::OIGuardianInfo(info) => Some(*info),
                 _ => None,
             })
-            .ok_or_else(|| {
-                InvalidGuardianLog(format!("expected OIGuardianInfo at key {info_key}"))
-            })?;
+            .ok_or_else(|| InvalidS3Log(format!("expected OIGuardianInfo at key {info_key}")))?;
 
         // 3. Anchor the pubkey and pin PCR0 to the allowlist entry for the
         //    reported build. This replays a logged attestation whose short-lived
@@ -682,9 +665,7 @@ impl GuardianS3Client {
         let build_pcrs = allowlist.resolve(&info.untrusted_git_revision)?.clone();
         attestation
             .verify_replay(&signing_pubkey, &build_pcrs)
-            .map_err(|e| {
-                guardian_log_verification_error(format!("attestation at key {att_key}"), e)
-            })?;
+            .map_err(|e| InvalidS3Log(format!("attestation at key {att_key}: {e}")))?;
 
         Ok(VerifiedSessionInfo {
             signing_pubkey,

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -20,10 +20,14 @@ use aws_sdk_s3::types::ObjectLockEnabled;
 use aws_sdk_s3::types::ObjectLockMode;
 use aws_sdk_s3::Client as S3Client;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
+use hashi_types::guardian::GuardianError;
+use hashi_types::guardian::GuardianError::GuardianBuildNotAccepted;
+use hashi_types::guardian::GuardianError::InvalidGuardianLog;
 use hashi_types::guardian::GuardianError::S3Error;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::InitLogMessage;
 use hashi_types::guardian::PcrAllowlist;
+use hashi_types::guardian::VerificationError;
 use hashi_types::guardian::VerifiedSessionInfo;
 use serde::Serialize;
 use tracing::info;
@@ -33,6 +37,18 @@ use tracing::warn;
 const MAX_RETRY_ATTEMPTS: u32 = 5;
 /// Delay between application-level retries of an immutable S3 log write.
 const S3_WRITE_RETRY_INTERVAL: Duration = Duration::from_secs(10);
+
+fn guardian_log_verification_error(
+    context: impl std::fmt::Display,
+    error: VerificationError,
+) -> GuardianError {
+    match error {
+        VerificationError::Invalid(message) => InvalidGuardianLog(format!("{context}: {message}")),
+        VerificationError::PcrMismatch(message) => {
+            GuardianBuildNotAccepted(format!("{context}: {message}"))
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct GuardianS3Client {
@@ -603,7 +619,7 @@ impl GuardianS3Client {
         })?;
 
         let record = serde_json::from_slice::<LogRecord>(&bytes.into_bytes()).map_err(|e| {
-            S3Error(format!(
+            InvalidGuardianLog(format!(
                 "Failed to deserialize object {} into target type: {}",
                 key, e
             ))
@@ -641,7 +657,9 @@ impl GuardianS3Client {
                 } => Some((attestation, signing_public_key)),
                 _ => None,
             })
-            .ok_or_else(|| S3Error(format!("expected OIAttestationUnsigned at key {att_key}")))?;
+            .ok_or_else(|| {
+                InvalidGuardianLog(format!("expected OIAttestationUnsigned at key {att_key}"))
+            })?;
 
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
@@ -653,14 +671,20 @@ impl GuardianS3Client {
                 InitLogMessage::OIGuardianInfo(info) => Some(*info),
                 _ => None,
             })
-            .ok_or_else(|| S3Error(format!("expected OIGuardianInfo at key {info_key}")))?;
+            .ok_or_else(|| {
+                InvalidGuardianLog(format!("expected OIGuardianInfo at key {info_key}"))
+            })?;
 
         // 3. Anchor the pubkey and pin PCR0 to the allowlist entry for the
         //    reported build. This replays a logged attestation whose short-lived
         //    leaf cert has typically expired, so the chain is checked at the
         //    document's own signed timestamp, not now.
         let build_pcrs = allowlist.resolve(&info.untrusted_git_revision)?.clone();
-        attestation.verify_replay(&signing_pubkey, &build_pcrs)?;
+        attestation
+            .verify_replay(&signing_pubkey, &build_pcrs)
+            .map_err(|e| {
+                guardian_log_verification_error(format!("attestation at key {att_key}"), e)
+            })?;
 
         Ok(VerifiedSessionInfo {
             signing_pubkey,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -14,7 +14,6 @@
 use crate::s3_client::GuardianS3Client;
 use crate::s3_client::HistoryCheck;
 use crate::s3_client::LockCheck;
-use anyhow::Context;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
@@ -22,6 +21,7 @@ use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GenesisLogMessage;
+use hashi_types::guardian::GuardianError::InvalidGuardianLog;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::KpShareStateLogMessage;
@@ -83,11 +83,8 @@ pub struct GuardianReader {
 }
 
 impl GuardianReader {
-    pub async fn new(config: &S3Config, allowlist: PcrAllowlist) -> anyhow::Result<Self> {
-        let s3 = GuardianS3Client::new_checked(config)
-            .await
-            .map_err(|e| anyhow::anyhow!(e))
-            .context("failed to verify guardian S3 connectivity")?;
+    pub async fn new(config: &S3Config, allowlist: PcrAllowlist) -> GuardianResult<Self> {
+        let s3 = GuardianS3Client::new_checked(config).await?;
         Ok(Self::from_s3_client(s3, allowlist))
     }
 
@@ -109,13 +106,10 @@ impl GuardianReader {
 
     fn enforce_build_policy(
         &self,
-        context: &str,
         build_policy: BuildPolicy,
         build_pcrs: &BuildPcrs,
-    ) -> anyhow::Result<()> {
-        build_policy
-            .enforce(&self.cache.allowlist, build_pcrs)
-            .map_err(|e| anyhow::anyhow!("{context} PCR check: {e:?}"))
+    ) -> GuardianResult<()> {
+        build_policy.enforce(&self.cache.allowlist, build_pcrs)
     }
 
     /// Read and verify every record in `dir`, resolving each writing session's
@@ -125,12 +119,8 @@ impl GuardianReader {
     pub async fn read_logs_in_dir(
         &mut self,
         dir: &S3HourScopedDirectory,
-    ) -> anyhow::Result<Vec<VerifiedLogRecord>> {
-        let all_logs = self
-            .s3
-            .list_all_log_records_in_dir(dir)
-            .await
-            .with_context(|| format!("failed to list guardian logs in {dir}"))?;
+    ) -> GuardianResult<Vec<VerifiedLogRecord>> {
+        let all_logs = self.s3.list_all_log_records_in_dir(dir).await?;
 
         let mut out = Vec::with_capacity(all_logs.len());
         for log in all_logs {
@@ -146,13 +136,13 @@ impl GuardianReader {
         &mut self,
         session_id: &str,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<VerifiedSessionInfo> {
+    ) -> GuardianResult<VerifiedSessionInfo> {
         let session_info = self
             .cache
             .get_or_load_session_info(&self.s3, session_id)
             .await?
             .clone();
-        self.enforce_build_policy("session", build_policy, &session_info.build_pcrs)?;
+        self.enforce_build_policy(build_policy, &session_info.build_pcrs)?;
         Ok(session_info)
     }
 
@@ -161,7 +151,7 @@ impl GuardianReader {
         &mut self,
         session_id: &str,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<GuardianInfo> {
+    ) -> GuardianResult<GuardianInfo> {
         Ok(self.get_session_info(session_id, build_policy).await?.info)
     }
 
@@ -174,7 +164,7 @@ impl GuardianReader {
     async fn read_latest_ceremony_log(
         &mut self,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<CeremonyLogMessage>> {
+    ) -> GuardianResult<Option<CeremonyLogMessage>> {
         let keys = self
             .s3
             .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_CEREMONY))
@@ -185,10 +175,12 @@ impl GuardianReader {
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         let build_pcrs = record.build_pcrs.clone();
-        self.enforce_build_policy("ceremony log", build_policy, &build_pcrs)?;
+        self.enforce_build_policy(build_policy, &build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::Ceremony(msg) = record.message else {
-            anyhow::bail!("expected a ceremony log at {key}");
+            return Err(InvalidGuardianLog(format!(
+                "expected a ceremony log at {key}"
+            )));
         };
         log_verified_read(&key, &session_id);
         Ok(Some(*msg))
@@ -207,7 +199,7 @@ impl GuardianReader {
         &mut self,
         sharing_seq: u64,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<KpShareStateLogMessage>> {
+    ) -> GuardianResult<Option<KpShareStateLogMessage>> {
         let prefix = KpShareStateLogMessage::object_key_dir(sharing_seq);
         let keys = self
             .s3
@@ -222,11 +214,10 @@ impl GuardianReader {
             .read_kp_share_state_log_at_key(&key, build_policy, HistoryCheck::AlreadyChecked)
             .await?;
         if msg.sharing_seq != sharing_seq {
-            anyhow::bail!(
+            return Err(InvalidGuardianLog(format!(
                 "sharing_seq mismatch: {} != {}",
-                msg.sharing_seq,
-                sharing_seq
-            );
+                msg.sharing_seq, sharing_seq
+            )));
         }
         Ok(Some(msg))
     }
@@ -242,7 +233,7 @@ impl GuardianReader {
         sharing_seq: u64,
         cert_seq: u64,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<KpShareStateLogMessage> {
+    ) -> GuardianResult<KpShareStateLogMessage> {
         let key = KpShareStateLogMessage::object_key(session_id, sharing_seq, cert_seq);
         // Unlike the latest-state path, this direct read has not already
         // checked an enclosing prefix, so validate this exact key's history.
@@ -256,7 +247,7 @@ impl GuardianReader {
         key: &str,
         build_policy: BuildPolicy,
         history_check: HistoryCheck,
-    ) -> anyhow::Result<KpShareStateLogMessage> {
+    ) -> GuardianResult<KpShareStateLogMessage> {
         // KP-share locks are short-lived and expected to expire. Expiry permits
         // deletion but does not cause it; while an object remains, its contents
         // are authenticatable through the enclave signature verified below.
@@ -265,10 +256,12 @@ impl GuardianReader {
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy("kp-shares log", build_policy, &record.build_pcrs)?;
+        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::KpShareState(msg) = record.message else {
-            anyhow::bail!("expected a kp-shares log at {key}");
+            return Err(InvalidGuardianLog(format!(
+                "expected a kp-shares log at {key}"
+            )));
         };
         log_verified_read(key, &session_id);
         Ok(*msg)
@@ -281,7 +274,7 @@ impl GuardianReader {
     pub async fn read_latest_ceremony_state(
         &mut self,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<CeremonyState>> {
+    ) -> GuardianResult<Option<CeremonyState>> {
         let Some(ceremony) = self.read_latest_ceremony_log(build_policy).await? else {
             return Ok(None);
         };
@@ -289,8 +282,10 @@ impl GuardianReader {
         let kp_share_state = self
             .read_latest_kp_share_state_log(sharing_seq, build_policy)
             .await?
-            .with_context(|| {
-                format!("no kp-shares log found for latest ceremony sharing_seq {sharing_seq}")
+            .ok_or_else(|| {
+                InvalidGuardianLog(format!(
+                    "no kp-shares log found for latest ceremony sharing_seq {sharing_seq}"
+                ))
             })?;
         Ok(Some(CeremonyState::new(ceremony, kp_share_state).expect(
             "ceremony and KP share state must have a consistent shape",
@@ -303,7 +298,7 @@ impl GuardianReader {
     pub async fn read_latest_committee(
         &mut self,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<Committee>> {
+    ) -> GuardianResult<Option<Committee>> {
         if let Some(committee) = self.read_latest_committee_update(build_policy).await? {
             return Ok(Some(committee));
         }
@@ -319,7 +314,7 @@ impl GuardianReader {
     async fn read_latest_committee_update(
         &mut self,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<Committee>> {
+    ) -> GuardianResult<Option<Committee>> {
         let keys = self
             .s3
             .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE))
@@ -329,15 +324,19 @@ impl GuardianReader {
         };
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy("committee-update log", build_policy, &record.build_pcrs)?;
+        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::CommitteeUpdate(msg) = record.message else {
-            anyhow::bail!("expected a committee-update log at {key}");
+            return Err(InvalidGuardianLog(format!(
+                "expected a committee-update log at {key}"
+            )));
         };
         let committee = match *msg {
             CommitteeUpdateLogMessage::Success { new_committee, .. } => new_committee,
             CommitteeUpdateLogMessage::Failure { .. } => {
-                anyhow::bail!("lex-last non-failure key resolved to a Failure log at {key}")
+                return Err(InvalidGuardianLog(format!(
+                    "lex-last non-failure key resolved to a Failure log at {key}"
+                )));
             }
         };
         log_verified_read(&key, &session_id);
@@ -349,7 +348,7 @@ impl GuardianReader {
     async fn read_genesis_log(
         &mut self,
         build_policy: BuildPolicy,
-    ) -> anyhow::Result<Option<GenesisLogMessage>> {
+    ) -> GuardianResult<Option<GenesisLogMessage>> {
         let key = GenesisLogMessage::object_key();
         let keys = self
             .s3
@@ -359,14 +358,18 @@ impl GuardianReader {
             return Ok(None);
         }
         if keys != [key.clone()] {
-            anyhow::bail!("expected exactly one genesis record at {key}, found {keys:?}");
+            return Err(InvalidGuardianLog(format!(
+                "expected exactly one genesis record at {key}, found {keys:?}"
+            )));
         }
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy("genesis log", build_policy, &record.build_pcrs)?;
+        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::Genesis(msg) = record.message else {
-            anyhow::bail!("expected a genesis log at {key}");
+            return Err(InvalidGuardianLog(format!(
+                "expected a genesis log at {key}"
+            )));
         };
         log_verified_read(&key, &session_id);
         Ok(Some(*msg))
@@ -399,7 +402,7 @@ impl GuardianSessionCache {
         &mut self,
         s3: &GuardianS3Client,
         session_id: &str,
-    ) -> anyhow::Result<&VerifiedSessionInfo> {
+    ) -> GuardianResult<&VerifiedSessionInfo> {
         if !self.sessions.contains_key(session_id) {
             let session_info = s3
                 .get_verified_session_info(session_id, &self.allowlist)
@@ -414,22 +417,18 @@ impl GuardianSessionCache {
         &mut self,
         s3: &GuardianS3Client,
         record: LogRecord,
-    ) -> anyhow::Result<VerifiedLogRecord> {
+    ) -> GuardianResult<VerifiedLogRecord> {
         let object_key = record.object_key.clone();
         let session_id = record.session_id.clone();
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        record
-            .verify(&session_info.signing_pubkey)
-            .map(|(session_id, timestamp_ms, message)| {
-                VerifiedLogRecord::new(
-                    object_key,
-                    session_id,
-                    timestamp_ms,
-                    message,
-                    session_info.build_pcrs.clone(),
-                )
-            })
-            .with_context(|| "failed to verify guardian enclave signature")
+        let (session_id, timestamp_ms, message) = record.verify(&session_info.signing_pubkey)?;
+        Ok(VerifiedLogRecord::new(
+            object_key,
+            session_id,
+            timestamp_ms,
+            message,
+            session_info.build_pcrs.clone(),
+        ))
     }
 }
 

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -21,7 +21,7 @@ use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GenesisLogMessage;
-use hashi_types::guardian::GuardianError::InvalidGuardianLog;
+use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::KpShareStateLogMessage;
@@ -178,9 +178,7 @@ impl GuardianReader {
         self.enforce_build_policy(build_policy, &build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::Ceremony(msg) = record.message else {
-            return Err(InvalidGuardianLog(format!(
-                "expected a ceremony log at {key}"
-            )));
+            return Err(InvalidS3Log(format!("expected a ceremony log at {key}")));
         };
         log_verified_read(&key, &session_id);
         Ok(Some(*msg))
@@ -214,7 +212,7 @@ impl GuardianReader {
             .read_kp_share_state_log_at_key(&key, build_policy, HistoryCheck::AlreadyChecked)
             .await?;
         if msg.sharing_seq != sharing_seq {
-            return Err(InvalidGuardianLog(format!(
+            return Err(InvalidS3Log(format!(
                 "sharing_seq mismatch: {} != {}",
                 msg.sharing_seq, sharing_seq
             )));
@@ -259,9 +257,7 @@ impl GuardianReader {
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::KpShareState(msg) = record.message else {
-            return Err(InvalidGuardianLog(format!(
-                "expected a kp-shares log at {key}"
-            )));
+            return Err(InvalidS3Log(format!("expected a kp-shares log at {key}")));
         };
         log_verified_read(key, &session_id);
         Ok(*msg)
@@ -283,7 +279,7 @@ impl GuardianReader {
             .read_latest_kp_share_state_log(sharing_seq, build_policy)
             .await?
             .ok_or_else(|| {
-                InvalidGuardianLog(format!(
+                InvalidS3Log(format!(
                     "no kp-shares log found for latest ceremony sharing_seq {sharing_seq}"
                 ))
             })?;
@@ -327,14 +323,14 @@ impl GuardianReader {
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::CommitteeUpdate(msg) = record.message else {
-            return Err(InvalidGuardianLog(format!(
+            return Err(InvalidS3Log(format!(
                 "expected a committee-update log at {key}"
             )));
         };
         let committee = match *msg {
             CommitteeUpdateLogMessage::Success { new_committee, .. } => new_committee,
             CommitteeUpdateLogMessage::Failure { .. } => {
-                return Err(InvalidGuardianLog(format!(
+                return Err(InvalidS3Log(format!(
                     "lex-last non-failure key resolved to a Failure log at {key}"
                 )));
             }
@@ -358,7 +354,7 @@ impl GuardianReader {
             return Ok(None);
         }
         if keys != [key.clone()] {
-            return Err(InvalidGuardianLog(format!(
+            return Err(InvalidS3Log(format!(
                 "expected exactly one genesis record at {key}, found {keys:?}"
             )));
         }
@@ -367,9 +363,7 @@ impl GuardianReader {
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::Genesis(msg) = record.message else {
-            return Err(InvalidGuardianLog(format!(
-                "expected a genesis log at {key}"
-            )));
+            return Err(InvalidS3Log(format!("expected a genesis log at {key}")));
         };
         log_verified_read(&key, &session_id);
         Ok(Some(*msg))

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -8,6 +8,9 @@ use crate::OTHER_SESSION_QUIET_PERIOD;
 use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::time_utils::unix_millis_to_seconds;
 use hashi_types::guardian::time_utils::UnixSeconds;
+use hashi_types::guardian::GuardianError::InvalidGuardianLog;
+use hashi_types::guardian::GuardianError::InvalidInputs;
+use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::SessionID;
 use hashi_types::guardian::VerifiedLogRecord;
@@ -21,7 +24,7 @@ impl GuardianReader {
     pub async fn ensure_session_live_and_others_quiet(
         &mut self,
         live_session: &str,
-    ) -> anyhow::Result<()> {
+    ) -> GuardianResult<()> {
         let recent_heartbeats = self.read_recent_heartbeat_logs().await?;
         let summary = summarize_heartbeats_by_session(recent_heartbeats)?;
         let now = now_timestamp_secs();
@@ -48,7 +51,7 @@ impl GuardianReader {
         Ok(())
     }
 
-    async fn read_recent_heartbeat_logs(&mut self) -> anyhow::Result<Vec<VerifiedLogRecord>> {
+    async fn read_recent_heartbeat_logs(&mut self) -> GuardianResult<Vec<VerifiedLogRecord>> {
         // Read from the previous, current, and next hour-scoped prefixes to
         // cover clock-boundary cases and moderate clock skew.
         let one_hour_ago = now_timestamp_secs().saturating_sub(60 * 60);
@@ -71,12 +74,14 @@ struct GuardianSessionInfo {
 
 fn summarize_heartbeats_by_session(
     logs: Vec<VerifiedLogRecord>,
-) -> anyhow::Result<Vec<GuardianSessionInfo>> {
+) -> GuardianResult<Vec<GuardianSessionInfo>> {
     let mut map: BTreeMap<SessionID, (UnixSeconds, UnixSeconds)> = BTreeMap::new();
 
     for log in logs {
         if !matches!(log.message, LogMessage::Heartbeat(..)) {
-            anyhow::bail!("non-heartbeat logs found");
+            return Err(InvalidGuardianLog(
+                "non-heartbeat log found under the heartbeat prefix".into(),
+            ));
         }
 
         let ts = unix_millis_to_seconds(log.timestamp_ms);
@@ -106,19 +111,21 @@ fn validate_session_live_and_others_quiet(
     live_session: &str,
     live_session_max_age_secs: UnixSeconds,
     other_session_quiet_secs: UnixSeconds,
-) -> anyhow::Result<()> {
+) -> GuardianResult<()> {
     let live_session_info = summary
         .iter()
         .find(|s| s.session_id.as_str() == live_session)
-        .ok_or_else(|| anyhow::anyhow!("no heartbeat logs found for session {live_session}"))?;
+        .ok_or_else(|| {
+            InvalidInputs(format!(
+                "no heartbeat logs found for session {live_session}"
+            ))
+        })?;
     let live_session_age_secs = now.saturating_sub(live_session_info.last_heartbeat);
     if live_session_age_secs > live_session_max_age_secs {
-        anyhow::bail!(
+        return Err(InvalidInputs(format!(
             "session {} is stale: last heartbeat {}s ago (expected <= {}s)",
-            live_session,
-            live_session_age_secs,
-            live_session_max_age_secs
-        );
+            live_session, live_session_age_secs, live_session_max_age_secs
+        )));
     }
 
     let active_sessions = summary
@@ -131,11 +138,11 @@ fn validate_session_live_and_others_quiet(
         })
         .collect::<Vec<_>>();
     if !active_sessions.is_empty() {
-        anyhow::bail!(
+        return Err(InvalidInputs(format!(
             "sessions are still active within {}s: {}",
             other_session_quiet_secs,
             active_sessions.join(", ")
-        );
+        )));
     }
     Ok(())
 }

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -8,8 +8,8 @@ use crate::OTHER_SESSION_QUIET_PERIOD;
 use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::time_utils::unix_millis_to_seconds;
 use hashi_types::guardian::time_utils::UnixSeconds;
-use hashi_types::guardian::GuardianError::InvalidGuardianLog;
 use hashi_types::guardian::GuardianError::InvalidInputs;
+use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::SessionID;
@@ -79,7 +79,7 @@ fn summarize_heartbeats_by_session(
 
     for log in logs {
         if !matches!(log.message, LogMessage::Heartbeat(..)) {
-            return Err(InvalidGuardianLog(
+            return Err(InvalidS3Log(
                 "non-heartbeat log found under the heartbeat prefix".into(),
             ));
         }

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -204,7 +204,7 @@ mod tests {
     fn summarize_heartbeats_rejects_non_heartbeat_logs() {
         let err = summarize_heartbeats_by_session(vec![non_heartbeat_log()])
             .expect_err("must reject non-heartbeat logs");
-        assert!(err.to_string().contains("non-heartbeat logs"));
+        assert!(err.to_string().contains("non-heartbeat log"));
     }
 
     #[test]

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -27,6 +27,8 @@
 use super::GuardianReader;
 use crate::s3_client::GuardianS3Client;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
+use hashi_types::guardian::GuardianError::InvalidGuardianLog;
+use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::LogMessage;
@@ -47,7 +49,7 @@ impl GuardianReader {
     pub async fn recover_limiter_state(
         &mut self,
         limiter_config: &LimiterConfig,
-    ) -> anyhow::Result<LimiterState> {
+    ) -> GuardianResult<LimiterState> {
         let Some(mut cursor) = find_latest_success_bucket(self.s3()).await? else {
             // The search covers the complete S3 withdrawal history, so this
             // branch is reachable only if no withdrawal has ever succeeded.
@@ -66,7 +68,9 @@ impl GuardianReader {
             .flatten()
             .max_by_key(|s| s.next_seq)
             .ok_or_else(|| {
-                anyhow::anyhow!("latest success bucket contained no verified Success logs")
+                InvalidGuardianLog(
+                    "latest success bucket contained no verified Success logs".into(),
+                )
             })?;
         let state = cap_limiter_state_to_config(recovered_state, limiter_config);
         info!(
@@ -85,7 +89,7 @@ impl GuardianReader {
 /// order at each level. Returns `None` if no Success log exists anywhere.
 async fn find_latest_success_bucket(
     s3_client: &GuardianS3Client,
-) -> anyhow::Result<Option<S3HourScopedDirectory>> {
+) -> GuardianResult<Option<S3HourScopedDirectory>> {
     let root = format!("{}/", S3_DIR_WITHDRAW);
     let years = list_subdirs_desc(s3_client, &root).await?;
     for year in years {
@@ -96,7 +100,12 @@ async fn find_latest_success_bucket(
                 let hours = list_subdirs_desc(s3_client, &day).await?;
                 for hour in hours {
                     if hour_bucket_has_success(s3_client, &hour).await? {
-                        return Ok(Some(S3HourScopedDirectory::from_path(&hour)?));
+                        let dir = S3HourScopedDirectory::from_path(&hour).map_err(|e| {
+                            InvalidGuardianLog(format!(
+                                "invalid withdrawal-log directory {hour}: {e}"
+                            ))
+                        })?;
+                        return Ok(Some(dir));
                     }
                 }
             }
@@ -108,11 +117,8 @@ async fn find_latest_success_bucket(
 async fn list_subdirs_desc(
     s3_client: &GuardianS3Client,
     prefix: &str,
-) -> anyhow::Result<Vec<String>> {
-    let mut subs = s3_client
-        .list_common_prefixes(prefix)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
+) -> GuardianResult<Vec<String>> {
+    let mut subs = s3_client.list_common_prefixes(prefix).await?;
     subs.sort_by(|a, b| b.cmp(a));
     Ok(subs)
 }
@@ -120,11 +126,10 @@ async fn list_subdirs_desc(
 async fn hour_bucket_has_success(
     s3_client: &GuardianS3Client,
     bucket: &str,
-) -> anyhow::Result<bool> {
+) -> GuardianResult<bool> {
     let keys = s3_client
         .validate_prefix_history_and_list_keys(&format!("{bucket}success-"))
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
+        .await?;
     Ok(!keys.is_empty())
 }
 

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -27,7 +27,7 @@
 use super::GuardianReader;
 use crate::s3_client::GuardianS3Client;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
-use hashi_types::guardian::GuardianError::InvalidGuardianLog;
+use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
@@ -68,9 +68,7 @@ impl GuardianReader {
             .flatten()
             .max_by_key(|s| s.next_seq)
             .ok_or_else(|| {
-                InvalidGuardianLog(
-                    "latest success bucket contained no verified Success logs".into(),
-                )
+                InvalidS3Log("latest success bucket contained no verified Success logs".into())
             })?;
         let state = cap_limiter_state_to_config(recovered_state, limiter_config);
         info!(
@@ -101,9 +99,7 @@ async fn find_latest_success_bucket(
                 for hour in hours {
                     if hour_bucket_has_success(s3_client, &hour).await? {
                         let dir = S3HourScopedDirectory::from_path(&hour).map_err(|e| {
-                            InvalidGuardianLog(format!(
-                                "invalid withdrawal-log directory {hour}: {e}"
-                            ))
+                            InvalidS3Log(format!("invalid withdrawal-log directory {hour}: {e}"))
                         })?;
                         return Ok(Some(dir));
                     }

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -454,7 +454,11 @@ pub async fn create_fully_initialized_enclave(args: FullyInitializedArgs) -> Arc
     activate_enclave_for_testing(&enclave, committee, limiter_config, limiter_state)
         .expect("activate_enclave_for_testing should succeed on a fresh enclave");
 
-    assert!(enclave.is_fully_initialized());
+    assert_eq!(
+        enclave.lifecycle(),
+        WithdrawStage::Activated.into(),
+        "test activation should reach the activated lifecycle"
+    );
     assert!(enclave.temporary_init_state().is_err());
     enclave
 }

--- a/crates/hashi-guardian/src/withdraw_mode/committee_update.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/committee_update.rs
@@ -6,7 +6,6 @@ use crate::Enclave;
 use hashi_types::guardian::CommitteeTransitionRequest;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GuardianError;
-use hashi_types::guardian::GuardianError::EnclaveUninitialized;
 use hashi_types::guardian::GuardianError::InternalError;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianResult;
@@ -25,9 +24,7 @@ pub async fn update_committee(
     enclave: Arc<Enclave>,
     signed: HashiSigned<CommitteeTransitionRequest>,
 ) -> GuardianResult<u64> {
-    if !enclave.is_fully_initialized() {
-        return Err(EnclaveUninitialized);
-    }
+    enclave.require_fully_initialized("update_committee")?;
 
     let current = enclave.state.get_committee()?;
     let current_epoch = current.epoch();

--- a/crates/hashi-guardian/src/withdraw_mode/committee_update.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/committee_update.rs
@@ -24,7 +24,7 @@ pub async fn update_committee(
     enclave: Arc<Enclave>,
     signed: HashiSigned<CommitteeTransitionRequest>,
 ) -> GuardianResult<u64> {
-    enclave.require_fully_initialized("update_committee")?;
+    enclave.require_fully_initialized()?;
 
     let current = enclave.state.get_committee()?;
     let current_epoch = current.epoch();
@@ -266,8 +266,8 @@ mod tests {
             .expect_err("bad middle handoff must error");
 
         assert!(
-            matches!(err, GuardianError::InvalidInputs(_)),
-            "expected InvalidInputs, got {err:?}"
+            matches!(err, GuardianError::Unauthenticated(_)),
+            "expected Unauthenticated, got {err:?}"
         );
         assert_eq!(enclave.state.get_committee().unwrap().epoch(), 7);
     }
@@ -281,8 +281,8 @@ mod tests {
             .await
             .expect_err("mismatched signing epoch must error");
         assert!(
-            matches!(err, GuardianError::InvalidInputs(_)),
-            "expected InvalidInputs, got {err:?}"
+            matches!(err, GuardianError::Unauthenticated(_)),
+            "expected Unauthenticated, got {err:?}"
         );
         assert_eq!(enclave.state.get_committee().unwrap().epoch(), 5);
     }

--- a/crates/hashi-guardian/src/withdraw_mode/genesis.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/genesis.rs
@@ -13,8 +13,7 @@ pub(super) async fn ensure_no_serving_committee(enclave: &Enclave) -> GuardianRe
 
     if reader
         .read_latest_committee(BuildPolicy::AnyAllowlisted)
-        .await
-        .map_err(|e| InvalidInputs(format!("read latest committee before genesis write: {e}")))?
+        .await?
         .is_some()
     {
         return Err(InvalidInputs(

--- a/crates/hashi-guardian/src/withdraw_mode/mod.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/mod.rs
@@ -15,7 +15,7 @@ pub mod provisioner_rotate_cert;
 pub mod standard_withdrawal;
 
 use hashi_types::committee::certificate_threshold;
-use hashi_types::guardian::GuardianError::InvalidInputs;
+use hashi_types::guardian::GuardianError::Unauthenticated;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::HashiCommittee;
 use hashi_types::guardian::HashiSigned;
@@ -31,5 +31,5 @@ pub fn verify_hashi_cert<T: hashi_types::intent::IntentMessage>(
     let threshold = certificate_threshold(committee.total_weight());
     committee
         .verify_signature_and_weight(signed_request, threshold)
-        .map_err(|e| InvalidInputs(format!("signature verification failed {:?}", e)))
+        .map_err(|e| Unauthenticated(format!("signature verification failed: {e:?}")))
 }

--- a/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
@@ -101,7 +101,10 @@ pub async fn operator_activate(
 ) -> GuardianResult<()> {
     info!("/operator_activate - Received request.");
 
-    enclave.require_lifecycle(WithdrawStage::ProvisionerInitialized.into())?;
+    enclave.require_lifecycle(
+        "operator_activate",
+        WithdrawStage::ProvisionerInitialized.into(),
+    )?;
     info!("Lifecycle stage validated.");
 
     // ---- Validate & build: Nothing in this phase mutates enclave state, so any

--- a/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
@@ -17,7 +17,6 @@ use hashi_types::guardian::RateLimiter;
 use hashi_types::guardian::WithdrawStage;
 use std::sync::Arc;
 use tracing::info;
-use GuardianError::InternalError;
 use GuardianError::InvalidInputs;
 
 /// S3-derived activation state ready for its fail-stop commit.
@@ -52,16 +51,12 @@ impl OAInstall {
 
         let committee: HashiCommittee = reader
             .read_latest_committee(BuildPolicy::AnyAllowlisted)
-            .await
-            .map_err(|e| InternalError(format!("read latest serving committee: {e}")))?
+            .await?
             .ok_or_else(|| InvalidInputs("no committee-update or genesis record found".into()))?
             .try_into()
             .map_err(|e| InvalidInputs(format!("invalid serving committee: {e}")))?;
 
-        let limiter_state = reader
-            .recover_limiter_state(&limiter_config)
-            .await
-            .map_err(|e| InvalidInputs(format!("recover limiter state: {e}")))?;
+        let limiter_state = reader.recover_limiter_state(&limiter_config).await?;
         let rate_limiter = RateLimiter::new(limiter_config, limiter_state)?;
         let sharing_seq = armed_instance.sharing_seq();
         let committee_epoch = committee.epoch();
@@ -101,10 +96,7 @@ pub async fn operator_activate(
 ) -> GuardianResult<()> {
     info!("/operator_activate - Received request.");
 
-    enclave.require_lifecycle(
-        "operator_activate",
-        WithdrawStage::ProvisionerInitialized.into(),
-    )?;
+    enclave.require_lifecycle(WithdrawStage::ProvisionerInitialized.into())?;
     info!("Lifecycle stage validated.");
 
     // ---- Validate & build: Nothing in this phase mutates enclave state, so any

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -93,7 +93,10 @@ pub async fn provisioner_init(
 ) -> GuardianResult<()> {
     info!("/provisioner_init - Received request.");
 
-    enclave.require_lifecycle(WithdrawStage::OperatorInitialized.into())?;
+    enclave.require_lifecycle(
+        "provisioner_init",
+        WithdrawStage::OperatorInitialized.into(),
+    )?;
     info!("Lifecycle stage validated.");
 
     // ---- Validate & build: Nothing in this phase mutates enclave state, so any
@@ -205,6 +208,7 @@ mod tests {
     use super::*;
     use crate::OperatorInitTestArgs;
     use hashi_types::guardian::GuardianError::InvalidInputs;
+    use hashi_types::guardian::GuardianError::LifecycleMismatch;
     use hashi_types::pgp::test_utils::mock_pgp_keypair;
     use hashi_types::pgp::test_utils::sign_detached_in_process;
     use hashi_types::pgp::PgpPublicCert;
@@ -407,8 +411,6 @@ mod tests {
             WithdrawStage::ProvisionerInitialized.into(),
             "provisioner init complete"
         );
-        assert!(!ctx.enclave.is_fully_initialized(), "not active before OA");
-
         let captured = ctx.captures.lock().unwrap();
         assert_eq!(
             captured.len(),
@@ -472,7 +474,7 @@ mod tests {
             .provision(ctx.request(&ctx.shares[..TEST_T]))
             .await
             .expect_err("should reject");
-        assert!(matches!(err, InvalidInputs(_)));
+        assert!(matches!(err, LifecycleMismatch { .. }));
     }
 
     #[tokio::test]
@@ -504,7 +506,7 @@ mod tests {
         let err = provisioner_init(enclave, ProvisionerInitRequest(vec![]))
             .await
             .expect_err("should fail");
-        assert!(matches!(err, InvalidInputs(_)));
+        assert!(matches!(err, LifecycleMismatch { .. }));
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -153,7 +153,7 @@ fn verify_signed_submissions(
             let signer_fingerprint = signed.signer_fingerprint().to_hex();
             signed
                 .verify_signature()
-                .map_err(|e| GuardianError::Unauthenticated(e.to_string()))?;
+                .map_err(|error| GuardianError::Unauthenticated(error.to_string()))?;
             let submission = &signed.data;
 
             if submission.expected_session_id() != live_session_id.as_str() {
@@ -211,6 +211,7 @@ mod tests {
     use crate::OperatorInitTestArgs;
     use hashi_types::guardian::GuardianError::InvalidInputs;
     use hashi_types::guardian::GuardianError::LifecycleMismatch;
+    use hashi_types::guardian::GuardianError::Unauthenticated;
     use hashi_types::pgp::test_utils::mock_pgp_keypair;
     use hashi_types::pgp::test_utils::sign_detached_in_process;
     use hashi_types::pgp::PgpPublicCert;

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -93,10 +93,7 @@ pub async fn provisioner_init(
 ) -> GuardianResult<()> {
     info!("/provisioner_init - Received request.");
 
-    enclave.require_lifecycle(
-        "provisioner_init",
-        WithdrawStage::OperatorInitialized.into(),
-    )?;
+    enclave.require_lifecycle(WithdrawStage::OperatorInitialized.into())?;
     info!("Lifecycle stage validated.");
 
     // ---- Validate & build: Nothing in this phase mutates enclave state, so any

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -151,7 +151,9 @@ fn verify_signed_submissions(
         .iter()
         .map(|signed| {
             let signer_fingerprint = signed.signer_fingerprint().to_hex();
-            signed.verify_signature()?;
+            signed
+                .verify_signature()
+                .map_err(|e| GuardianError::Unauthenticated(e.to_string()))?;
             let submission = &signed.data;
 
             if submission.expected_session_id() != live_session_id.as_str() {
@@ -584,7 +586,7 @@ mod tests {
             .provision(ProvisionerInitRequest(submissions))
             .await
             .expect_err("should fail");
-        assert!(matches!(err, InvalidInputs(_)));
+        assert!(matches!(err, Unauthenticated(_)));
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -30,7 +30,7 @@ pub async fn provisioner_rotate_cert(
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
     let request = signed_request
         .verify()
-        .map_err(|e| Unauthenticated(e.to_string()))?;
+        .map_err(|error| Unauthenticated(error.to_string()))?;
 
     enclave.require_fully_initialized("provisioner_rotate_cert")?;
 

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -29,11 +29,7 @@ pub async fn provisioner_rotate_cert(
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
     let request = signed_request.verify()?;
 
-    if !enclave.is_fully_initialized() {
-        return Err(InvalidInputs(
-            "provisioner_rotate_cert requires operator_activate complete".into(),
-        ));
-    }
+    enclave.require_fully_initialized("provisioner_rotate_cert")?;
 
     let live_session_id = enclave.s3_session_id();
     if request.expected_session_id() != &live_session_id {

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -13,6 +13,7 @@ use hashi_types::guardian::crypto::decrypt_share;
 use hashi_types::guardian::crypto::encrypt_share_for_provisioner;
 use hashi_types::guardian::GuardianError::InternalError;
 use hashi_types::guardian::GuardianError::InvalidInputs;
+use hashi_types::guardian::GuardianError::Unauthenticated;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::GuardianSigned;
 use hashi_types::guardian::KpSigned;
@@ -27,7 +28,9 @@ pub async fn provisioner_rotate_cert(
     info!("/provisioner_rotate_cert - Received request.");
 
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
-    let request = signed_request.verify()?;
+    let request = signed_request
+        .verify()
+        .map_err(|e| Unauthenticated(e.to_string()))?;
 
     enclave.require_fully_initialized("provisioner_rotate_cert")?;
 

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -11,7 +11,6 @@ use crate::s3_reader::BuildPolicy;
 use crate::Enclave;
 use hashi_types::guardian::crypto::decrypt_share;
 use hashi_types::guardian::crypto::encrypt_share_for_provisioner;
-use hashi_types::guardian::GuardianError::InternalError;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianError::Unauthenticated;
 use hashi_types::guardian::GuardianResult;
@@ -32,7 +31,7 @@ pub async fn provisioner_rotate_cert(
         .verify()
         .map_err(|error| Unauthenticated(error.to_string()))?;
 
-    enclave.require_fully_initialized("provisioner_rotate_cert")?;
+    enclave.require_fully_initialized()?;
 
     let live_session_id = enclave.s3_session_id();
     if request.expected_session_id() != &live_session_id {
@@ -52,8 +51,7 @@ pub async fn provisioner_rotate_cert(
 
     let latest_state = reader
         .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
-        .await
-        .map_err(|e| InternalError(format!("read latest ceremony state: {e}")))?
+        .await?
         .ok_or_else(|| InvalidInputs("no ceremony log found during cert rotation".into()))?;
     let enclave_btc_pubkey = enclave.config.enclave_btc_pubkey()?;
     if latest_state.btc_master_pubkey != enclave_btc_pubkey {

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -6,7 +6,6 @@ use crate::Enclave;
 use bitcoin::Txid;
 use hashi_types::guardian::now_timestamp_secs;
 use hashi_types::guardian::GuardianError;
-use hashi_types::guardian::GuardianError::EnclaveUninitialized;
 use hashi_types::guardian::GuardianError::InternalError;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianResult;
@@ -71,9 +70,7 @@ async fn normal_withdrawal_inner(
     OwnedMutexGuard<RateLimiter>,
 )> {
     // 0) Validation
-    if !enclave.is_fully_initialized() {
-        return Err(EnclaveUninitialized);
-    }
+    enclave.require_fully_initialized("standard_withdrawal")?;
 
     // 1) Verify certificate (before acquiring limiter lock)
     let committee = enclave.state.get_committee()?;
@@ -172,6 +169,7 @@ mod tests {
     use bitcoin::Network;
     use hashi_types::bitcoin::create_btc_keypair_for_test;
     use hashi_types::bitcoin::hashi_master_g_from_btc_xonly_for_test;
+    use hashi_types::guardian::EnclaveLifecycle;
     use hashi_types::guardian::HashiCommittee;
     use hashi_types::guardian::InitConfig;
     use hashi_types::guardian::LimiterConfig;
@@ -223,7 +221,9 @@ mod tests {
         activate_enclave_for_testing(&enclave, committee, limiter_config, limiter_state)
             .expect("activate_enclave_for_testing should succeed on a fresh enclave");
 
-        assert!(enclave.is_fully_initialized());
+        assert!(enclave
+            .require_fully_initialized("standard_withdrawal")
+            .is_ok());
         (enclave, captures)
     }
 
@@ -232,7 +232,14 @@ mod tests {
         let enclave = Enclave::create_with_random_keys();
         let signed_request = StandardWithdrawalRequest::mock_signed_for_testing(Network::Regtest);
         let result = normal_withdrawal_inner(enclave, signed_request).await;
-        assert!(matches!(result, Err(EnclaveUninitialized)));
+        assert!(matches!(
+            result,
+            Err(GuardianError::LifecycleMismatch {
+                operation,
+                expected: EnclaveLifecycle::Withdraw(WithdrawStage::Activated),
+                actual: EnclaveLifecycle::Withdraw(WithdrawStage::Uninitialized),
+            }) if operation == "standard_withdrawal"
+        ));
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -70,7 +70,7 @@ async fn normal_withdrawal_inner(
     OwnedMutexGuard<RateLimiter>,
 )> {
     // 0) Validation
-    enclave.require_fully_initialized("standard_withdrawal")?;
+    enclave.require_fully_initialized()?;
 
     // 1) Verify certificate (before acquiring limiter lock)
     let committee = enclave.state.get_committee()?;
@@ -221,9 +221,7 @@ mod tests {
         activate_enclave_for_testing(&enclave, committee, limiter_config, limiter_state)
             .expect("activate_enclave_for_testing should succeed on a fresh enclave");
 
-        assert!(enclave
-            .require_fully_initialized("standard_withdrawal")
-            .is_ok());
+        assert!(enclave.require_fully_initialized().is_ok());
         (enclave, captures)
     }
 
@@ -235,10 +233,9 @@ mod tests {
         assert!(matches!(
             result,
             Err(GuardianError::LifecycleMismatch {
-                operation,
                 expected: EnclaveLifecycle::Withdraw(WithdrawStage::Activated),
                 actual: EnclaveLifecycle::Withdraw(WithdrawStage::Uninitialized),
-            }) if operation == "standard_withdrawal"
+            })
         ));
     }
 

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -5,12 +5,14 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeSet;
 
+#[cfg(not(any(test, feature = "non-enclave-dev")))]
+use super::CryptoVerificationError;
+use super::CryptoVerificationResult;
 use super::GuardianInfo;
 use super::GuardianPubKey;
 use super::GuardianResult;
-use super::VerificationError;
-use super::VerificationResult;
-use super::errors::GuardianError::GuardianBuildNotAccepted;
+use super::errors::GuardianError::BuildNotAllowlisted;
+use super::errors::GuardianError::BuildNotCurrent;
 use super::errors::GuardianError::InvalidInputs;
 #[cfg(not(any(test, feature = "non-enclave-dev")))]
 use super::time_utils::now_timestamp_ms;
@@ -42,7 +44,7 @@ impl NitroAttestation {
         &self,
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,
-    ) -> VerificationResult<()> {
+    ) -> CryptoVerificationResult<()> {
         self.verify_at(signing_pubkey, build_pcrs, VerifyTime::Now)
     }
 
@@ -57,7 +59,7 @@ impl NitroAttestation {
         &self,
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,
-    ) -> VerificationResult<()> {
+    ) -> CryptoVerificationResult<()> {
         self.verify_at(signing_pubkey, build_pcrs, VerifyTime::DocumentTimestamp)
     }
 
@@ -66,7 +68,7 @@ impl NitroAttestation {
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,
         verify_time: VerifyTime,
-    ) -> VerificationResult<()> {
+    ) -> CryptoVerificationResult<()> {
         #[cfg(any(test, feature = "non-enclave-dev"))]
         {
             let _ = (signing_pubkey, build_pcrs, verify_time);
@@ -94,28 +96,28 @@ impl NitroAttestation {
             // zero, so the pin below can't be bypassed by a missing entry.
             let (signature, signed_message, doc) =
                 parse_nitro_attestation(&self.0, true, true, true).map_err(|e| {
-                    VerificationError::new(format!("attestation parse failed: {e}"))
+                    CryptoVerificationError::new(format!("attestation parse failed: {e}"))
                 })?;
             let timestamp_ms = match verify_time {
                 VerifyTime::Now => now_timestamp_ms(),
                 VerifyTime::DocumentTimestamp => doc.timestamp,
             };
             verify_nitro_attestation(&signature, &signed_message, &doc, timestamp_ms).map_err(
-                |e| VerificationError::new(format!("attestation verification failed: {e}")),
+                |e| CryptoVerificationError::new(format!("attestation verification failed: {e}")),
             )?;
 
             let attested = doc
                 .public_key
-                .ok_or_else(|| VerificationError::new("attestation has no public_key"))?;
+                .ok_or_else(|| CryptoVerificationError::new("attestation has no public_key"))?;
             if attested != signing_pubkey.to_bytes() {
-                return Err(VerificationError::new(
+                return Err(CryptoVerificationError::new(
                     "attestation public_key does not match the session signing pubkey",
                 ));
             }
 
             // Pin PCR0 (the whole EIF image hash).
             if doc.pcr_map.get(&0).map(Vec::as_slice) != Some(build_pcrs.pcr0()) {
-                return Err(VerificationError::pcr_mismatch(
+                return Err(CryptoVerificationError::new(
                     "attestation PCR0 does not match the expected enclave image",
                 ));
             }
@@ -217,6 +219,9 @@ impl PcrAllowlist {
     }
 
     /// The `BuildPcrs` whose revision is `git_revision`.
+    ///
+    /// A missing revision may indicate either incomplete configured build
+    /// history or a build that was never approved.
     pub fn resolve(&self, git_revision: &str) -> GuardianResult<&BuildPcrs> {
         if self.current_build.git_revision == git_revision {
             return Ok(&self.current_build);
@@ -228,21 +233,17 @@ impl PcrAllowlist {
         {
             return Ok(prev_build);
         }
-        Err(GuardianBuildNotAccepted(format!(
+        Err(BuildNotAllowlisted(format!(
             "guardian reports build '{git_revision}', which is not present in the PCR allowlist"
         )))
     }
 
-    pub fn is_current_build(&self, build_pcrs: &BuildPcrs) -> bool {
-        self.current_build == *build_pcrs
-    }
-
     pub fn require_current_build(&self, build_pcrs: &BuildPcrs) -> GuardianResult<()> {
-        if self.is_current_build(build_pcrs) {
+        if self.current_build == *build_pcrs {
             Ok(())
         } else {
-            Err(GuardianBuildNotAccepted(format!(
-                "guardian build '{}' is allowlisted, but current build '{}' is required",
+            Err(BuildNotCurrent(format!(
+                "guardian build '{}' does not match the required current build '{}'",
                 build_pcrs.git_revision(),
                 self.current_build.git_revision()
             )))

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -8,6 +8,9 @@ use std::collections::BTreeSet;
 use super::GuardianInfo;
 use super::GuardianPubKey;
 use super::GuardianResult;
+use super::VerificationError;
+use super::VerificationResult;
+use super::errors::GuardianError::GuardianBuildNotAccepted;
 use super::errors::GuardianError::InvalidInputs;
 #[cfg(not(any(test, feature = "non-enclave-dev")))]
 use super::time_utils::now_timestamp_ms;
@@ -39,7 +42,7 @@ impl NitroAttestation {
         &self,
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,
-    ) -> GuardianResult<()> {
+    ) -> VerificationResult<()> {
         self.verify_at(signing_pubkey, build_pcrs, VerifyTime::Now)
     }
 
@@ -54,7 +57,7 @@ impl NitroAttestation {
         &self,
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,
-    ) -> GuardianResult<()> {
+    ) -> VerificationResult<()> {
         self.verify_at(signing_pubkey, build_pcrs, VerifyTime::DocumentTimestamp)
     }
 
@@ -63,7 +66,7 @@ impl NitroAttestation {
         signing_pubkey: &GuardianPubKey,
         build_pcrs: &BuildPcrs,
         verify_time: VerifyTime,
-    ) -> GuardianResult<()> {
+    ) -> VerificationResult<()> {
         #[cfg(any(test, feature = "non-enclave-dev"))]
         {
             let _ = (signing_pubkey, build_pcrs, verify_time);
@@ -90,28 +93,30 @@ impl NitroAttestation {
             // always_include_required_pcrs). The last keeps PCR0 in `pcr_map` even if
             // zero, so the pin below can't be bypassed by a missing entry.
             let (signature, signed_message, doc) =
-                parse_nitro_attestation(&self.0, true, true, true)
-                    .map_err(|e| InvalidInputs(format!("attestation parse failed: {e}")))?;
+                parse_nitro_attestation(&self.0, true, true, true).map_err(|e| {
+                    VerificationError::new(format!("attestation parse failed: {e}"))
+                })?;
             let timestamp_ms = match verify_time {
                 VerifyTime::Now => now_timestamp_ms(),
                 VerifyTime::DocumentTimestamp => doc.timestamp,
             };
-            verify_nitro_attestation(&signature, &signed_message, &doc, timestamp_ms)
-                .map_err(|e| InvalidInputs(format!("attestation verification failed: {e}")))?;
+            verify_nitro_attestation(&signature, &signed_message, &doc, timestamp_ms).map_err(
+                |e| VerificationError::new(format!("attestation verification failed: {e}")),
+            )?;
 
             let attested = doc
                 .public_key
-                .ok_or_else(|| InvalidInputs("attestation has no public_key".into()))?;
+                .ok_or_else(|| VerificationError::new("attestation has no public_key"))?;
             if attested != signing_pubkey.to_bytes() {
-                return Err(InvalidInputs(
-                    "attestation public_key does not match the session signing pubkey".into(),
+                return Err(VerificationError::new(
+                    "attestation public_key does not match the session signing pubkey",
                 ));
             }
 
             // Pin PCR0 (the whole EIF image hash).
             if doc.pcr_map.get(&0).map(Vec::as_slice) != Some(build_pcrs.pcr0()) {
-                return Err(InvalidInputs(
-                    "attestation PCR0 does not match the expected enclave image".into(),
+                return Err(VerificationError::pcr_mismatch(
+                    "attestation PCR0 does not match the expected enclave image",
                 ));
             }
             Ok(())
@@ -223,8 +228,8 @@ impl PcrAllowlist {
         {
             return Ok(prev_build);
         }
-        Err(InvalidInputs(format!(
-            "enclave reports build '{git_revision}' not present in PCR allowlist"
+        Err(GuardianBuildNotAccepted(format!(
+            "guardian reports build '{git_revision}', which is not present in the PCR allowlist"
         )))
     }
 
@@ -236,10 +241,11 @@ impl PcrAllowlist {
         if self.is_current_build(build_pcrs) {
             Ok(())
         } else {
-            Err(InvalidInputs(
-                "guardian attestation matched a non-current build, but current build is required"
-                    .into(),
-            ))
+            Err(GuardianBuildNotAccepted(format!(
+                "guardian build '{}' is allowlisted, but current build '{}' is required",
+                build_pcrs.git_revision(),
+                self.current_build.git_revision()
+            )))
         }
     }
 }

--- a/crates/hashi-types/src/guardian/errors.rs
+++ b/crates/hashi-types/src/guardian/errors.rs
@@ -28,9 +28,12 @@ pub enum GuardianError {
     /// The guardian build does not match the configured current build.
     BuildNotCurrent(String),
     LifecycleMismatch {
-        operation: String,
         expected: EnclaveLifecycle,
         actual: EnclaveLifecycle,
+    },
+    LimiterSequenceMismatch {
+        expected: u64,
+        actual: u64,
     },
     RateLimitExceeded,
     /// A service condition known to be temporary and safe for callers to retry.
@@ -77,13 +80,13 @@ impl std::fmt::Display for GuardianError {
             GuardianError::Unauthenticated(e) => write!(f, "Unauthenticated: {}", e),
             GuardianError::BuildNotAllowlisted(e) => write!(f, "BuildNotAllowlisted: {}", e),
             GuardianError::BuildNotCurrent(e) => write!(f, "BuildNotCurrent: {}", e),
-            GuardianError::LifecycleMismatch {
-                operation,
-                expected,
-                actual,
-            } => write!(
+            GuardianError::LifecycleMismatch { expected, actual } => write!(
                 f,
-                "LifecycleMismatch: {operation} requires {expected:?}, but enclave is {actual:?}"
+                "LifecycleMismatch: expected {expected:?}, but enclave is {actual:?}"
+            ),
+            GuardianError::LimiterSequenceMismatch { expected, actual } => write!(
+                f,
+                "LimiterSequenceMismatch: expected {expected}, got {actual}"
             ),
             GuardianError::RateLimitExceeded => write!(f, "Rate limit exceeded"),
             GuardianError::Unavailable(e) => write!(f, "Unavailable: {}", e),

--- a/crates/hashi-types/src/guardian/errors.rs
+++ b/crates/hashi-types/src/guardian/errors.rs
@@ -8,15 +8,25 @@ use super::lifecycle::EnclaveLifecycle;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum GuardianError {
+    // ========================================================================
+    // Errors requiring corrected input/data or investigation
+    // ========================================================================
     InternalError(String),
     /// S3 API, object-lock, or version-history failures.
     S3Error(String),
-    /// Persisted guardian log data failed structural or authenticity validation.
-    InvalidGuardianLog(String),
+    /// Persisted S3 guardian log data failed structural or authenticity validation.
+    InvalidS3Log(String),
     InvalidInputs(String),
     Unauthenticated(String),
-    /// The guardian build does not satisfy the configured PCR/build policy.
-    GuardianBuildNotAccepted(String),
+
+    // ========================================================================
+    // Errors that may succeed after configuration, lifecycle, or transient
+    // state changes
+    // ========================================================================
+    /// The guardian build is absent from the configured PCR allowlist.
+    BuildNotAllowlisted(String),
+    /// The guardian build does not match the configured current build.
+    BuildNotCurrent(String),
     LifecycleMismatch {
         operation: String,
         expected: EnclaveLifecycle,
@@ -29,50 +39,44 @@ pub enum GuardianError {
 
 pub type GuardianResult<T> = Result<T, GuardianError>;
 
-/// A trust or authenticity check failed.
+/// Low-level error returned by signature and attestation verifiers.
 ///
-/// Verification code does not know whether the untrusted value came from an
-/// RPC caller, S3, or another service. The boundary that knows the source maps
-/// this into the appropriate service error.
+/// This remains source-neutral so higher-level layers can convert it to
+/// [`GuardianError::Unauthenticated`] for inbound RPC evidence or
+/// [`GuardianError::InvalidS3Log`] for persisted S3 evidence. Client tooling
+/// may instead wrap it with its own context.
+///
+/// It is intended to be converted rather than exposed directly as the final
+/// RPC, API, or application error.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum VerificationError {
-    Invalid(String),
-    PcrMismatch(String),
-}
+pub struct CryptoVerificationError(String);
 
-impl VerificationError {
-    pub fn new(message: impl Into<String>) -> Self {
-        Self::Invalid(message.into())
-    }
-
-    pub fn pcr_mismatch(message: impl Into<String>) -> Self {
-        Self::PcrMismatch(message.into())
+impl CryptoVerificationError {
+    pub(super) fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
     }
 }
 
-pub type VerificationResult<T> = Result<T, VerificationError>;
+pub type CryptoVerificationResult<T> = Result<T, CryptoVerificationError>;
 
-impl std::fmt::Display for VerificationError {
+impl std::fmt::Display for CryptoVerificationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Invalid(message) | Self::PcrMismatch(message) => f.write_str(message),
-        }
+        f.write_str(&self.0)
     }
 }
 
-impl std::error::Error for VerificationError {}
+impl std::error::Error for CryptoVerificationError {}
 
 impl std::fmt::Display for GuardianError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             GuardianError::InternalError(e) => write!(f, "InternalError: {}", e),
-            GuardianError::Unavailable(e) => write!(f, "Unavailable: {}", e),
-            GuardianError::InvalidGuardianLog(e) => write!(f, "InvalidGuardianLog: {}", e),
+            GuardianError::S3Error(e) => write!(f, "S3Error: {}", e),
+            GuardianError::InvalidS3Log(e) => write!(f, "InvalidS3Log: {}", e),
             GuardianError::InvalidInputs(e) => write!(f, "InvalidInputs: {}", e),
             GuardianError::Unauthenticated(e) => write!(f, "Unauthenticated: {}", e),
-            GuardianError::GuardianBuildNotAccepted(e) => {
-                write!(f, "GuardianBuildNotAccepted: {}", e)
-            }
+            GuardianError::BuildNotAllowlisted(e) => write!(f, "BuildNotAllowlisted: {}", e),
+            GuardianError::BuildNotCurrent(e) => write!(f, "BuildNotCurrent: {}", e),
             GuardianError::LifecycleMismatch {
                 operation,
                 expected,
@@ -81,8 +85,8 @@ impl std::fmt::Display for GuardianError {
                 f,
                 "LifecycleMismatch: {operation} requires {expected:?}, but enclave is {actual:?}"
             ),
-            GuardianError::S3Error(e) => write!(f, "S3Error: {}", e),
             GuardianError::RateLimitExceeded => write!(f, "Rate limit exceeded"),
+            GuardianError::Unavailable(e) => write!(f, "Unavailable: {}", e),
         }
     }
 }

--- a/crates/hashi-types/src/guardian/errors.rs
+++ b/crates/hashi-types/src/guardian/errors.rs
@@ -4,17 +4,21 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::lifecycle::EnclaveLifecycle;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum GuardianError {
     InternalError(String),
     /// Internal errors related to S3
     S3Error(String),
     InvalidInputs(String),
-    EnclaveUninitialized,
+    LifecycleMismatch {
+        operation: String,
+        expected: EnclaveLifecycle,
+        actual: EnclaveLifecycle,
+    },
     RateLimitExceeded,
-    /// A temporary service condition that callers may retry.
-    // TODO: Audit other transient guardian failures and map retryable cases to
-    // `Unavailable` where appropriate.
+    /// A service condition known to be temporary and safe for callers to retry.
     Unavailable(String),
 }
 
@@ -26,8 +30,15 @@ impl std::fmt::Display for GuardianError {
             GuardianError::InternalError(e) => write!(f, "InternalError: {}", e),
             GuardianError::Unavailable(e) => write!(f, "Unavailable: {}", e),
             GuardianError::InvalidInputs(e) => write!(f, "InvalidInputs: {}", e),
+            GuardianError::LifecycleMismatch {
+                operation,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "LifecycleMismatch: {operation} requires {expected:?}, but enclave is {actual:?}"
+            ),
             GuardianError::S3Error(e) => write!(f, "S3Error: {}", e),
-            GuardianError::EnclaveUninitialized => write!(f, "Enclave is not fully initialized"),
             GuardianError::RateLimitExceeded => write!(f, "Rate limit exceeded"),
         }
     }

--- a/crates/hashi-types/src/guardian/errors.rs
+++ b/crates/hashi-types/src/guardian/errors.rs
@@ -9,9 +9,14 @@ use super::lifecycle::EnclaveLifecycle;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum GuardianError {
     InternalError(String),
-    /// Internal errors related to S3
+    /// S3 API, object-lock, or version-history failures.
     S3Error(String),
+    /// Persisted guardian log data failed structural or authenticity validation.
+    InvalidGuardianLog(String),
     InvalidInputs(String),
+    Unauthenticated(String),
+    /// The guardian build does not satisfy the configured PCR/build policy.
+    GuardianBuildNotAccepted(String),
     LifecycleMismatch {
         operation: String,
         expected: EnclaveLifecycle,
@@ -24,12 +29,50 @@ pub enum GuardianError {
 
 pub type GuardianResult<T> = Result<T, GuardianError>;
 
+/// A trust or authenticity check failed.
+///
+/// Verification code does not know whether the untrusted value came from an
+/// RPC caller, S3, or another service. The boundary that knows the source maps
+/// this into the appropriate service error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationError {
+    Invalid(String),
+    PcrMismatch(String),
+}
+
+impl VerificationError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self::Invalid(message.into())
+    }
+
+    pub fn pcr_mismatch(message: impl Into<String>) -> Self {
+        Self::PcrMismatch(message.into())
+    }
+}
+
+pub type VerificationResult<T> = Result<T, VerificationError>;
+
+impl std::fmt::Display for VerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(message) | Self::PcrMismatch(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for VerificationError {}
+
 impl std::fmt::Display for GuardianError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             GuardianError::InternalError(e) => write!(f, "InternalError: {}", e),
             GuardianError::Unavailable(e) => write!(f, "Unavailable: {}", e),
+            GuardianError::InvalidGuardianLog(e) => write!(f, "InvalidGuardianLog: {}", e),
             GuardianError::InvalidInputs(e) => write!(f, "InvalidInputs: {}", e),
+            GuardianError::Unauthenticated(e) => write!(f, "Unauthenticated: {}", e),
+            GuardianError::GuardianBuildNotAccepted(e) => {
+                write!(f, "GuardianBuildNotAccepted: {}", e)
+            }
             GuardianError::LifecycleMismatch {
                 operation,
                 expected,

--- a/crates/hashi-types/src/guardian/limiter.rs
+++ b/crates/hashi-types/src/guardian/limiter.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::GuardianError::InvalidInputs;
+use super::GuardianError::LimiterSequenceMismatch;
 use super::GuardianError::RateLimitExceeded;
 use super::GuardianResult;
 use serde::Deserialize;
@@ -75,10 +76,10 @@ impl RateLimiter {
     /// refills based on elapsed time, then debits the requested amount.
     pub fn consume(&mut self, seq: u64, timestamp: u64, amount_sats: u64) -> GuardianResult<()> {
         if seq != self.state.next_seq {
-            return Err(InvalidInputs(format!(
-                "seq mismatch: expected {}, got {}",
-                self.state.next_seq, seq
-            )));
+            return Err(LimiterSequenceMismatch {
+                expected: self.state.next_seq,
+                actual: seq,
+            });
         }
         if timestamp < self.state.last_updated_at {
             return Err(InvalidInputs(format!(

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -11,7 +11,7 @@ use super::message::LogMessageV1;
 use super::message::ObjectKeyPattern;
 use super::message::VersionedLogMessage;
 use crate::guardian::BuildPcrs;
-use crate::guardian::GuardianError::InvalidInputs;
+use crate::guardian::GuardianError::InvalidGuardianLog;
 use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
 use crate::guardian::GuardianSignKeyPair;
@@ -250,7 +250,7 @@ impl LogRecord {
         pub_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         if self.message.is_allowed_unsigned() {
-            return Err(InvalidInputs(
+            return Err(InvalidGuardianLog(
                 "expected signed log record but message is unsigned".into(),
             ));
         }
@@ -260,22 +260,27 @@ impl LogRecord {
         let signature = self
             .signature
             .as_ref()
-            .ok_or_else(|| InvalidInputs("missing log signature".into()))?;
-        verify_intent(&self.signing_payload(), timestamp_ms, signature, pub_key)?;
+            .ok_or_else(|| InvalidGuardianLog("missing log signature".into()))?;
+        verify_intent(&self.signing_payload(), timestamp_ms, signature, pub_key)
+            .map_err(|e| InvalidGuardianLog(format!("invalid log signature: {e}")))?;
 
-        Ok((self.session_id, timestamp_ms, self.message.into_current()?))
+        let message = self
+            .message
+            .into_current()
+            .map_err(|e| InvalidGuardianLog(format!("log schema conversion failed: {e}")))?;
+        Ok((self.session_id, timestamp_ms, message))
     }
 
     /// Validates the unsigned OI-attestation record's envelope and canonical
     /// session. The Nitro attestation itself must be authenticated separately.
     pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         if !self.message.is_allowed_unsigned() {
-            return Err(InvalidInputs(
+            return Err(InvalidGuardianLog(
                 "expected unsigned log record but message requires a signature".into(),
             ));
         }
         if self.signature.is_some() {
-            return Err(InvalidInputs(
+            return Err(InvalidGuardianLog(
                 "unsigned log record must not contain a signature".into(),
             ));
         }
@@ -292,18 +297,18 @@ impl LogRecord {
             unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
         };
         self.validate_session_id(signing_public_key)?;
-        Ok((
-            self.session_id,
-            self.timestamp_ms,
-            self.message.into_current()?,
-        ))
+        let message = self
+            .message
+            .into_current()
+            .map_err(|e| InvalidGuardianLog(format!("log schema conversion failed: {e}")))?;
+        Ok((self.session_id, self.timestamp_ms, message))
     }
 
     /// Rejects a record whose signed intended key differs from the key at which
     /// the S3 reader found it.
     pub fn validate_actual_object_key(&self, actual_object_key: &str) -> GuardianResult<()> {
         if self.object_key != actual_object_key {
-            return Err(InvalidInputs(format!(
+            return Err(InvalidGuardianLog(format!(
                 "S3 object key mismatch: record contains {}, actual key is {actual_object_key}",
                 self.object_key
             )));
@@ -317,13 +322,13 @@ impl LogRecord {
             .object_key_pattern(&self.session_id, self.timestamp_ms)
         {
             ObjectKeyPattern::Fixed(expected) if self.object_key != expected => {
-                return Err(InvalidInputs(format!(
+                return Err(InvalidGuardianLog(format!(
                     "non-canonical S3 object key: got {}, expected {expected}",
                     self.object_key
                 )));
             }
             ObjectKeyPattern::RandomSuffix(prefix) if !self.object_key.starts_with(&prefix) => {
-                return Err(InvalidInputs(format!(
+                return Err(InvalidGuardianLog(format!(
                     "non-canonical S3 object key: got {}, expected prefix {prefix}",
                     self.object_key
                 )));
@@ -336,7 +341,7 @@ impl LogRecord {
     fn validate_session_id(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
         let canonical_session_id = SessionID::from_signing_pubkey(signing_public_key);
         if self.session_id != canonical_session_id {
-            return Err(InvalidInputs(format!(
+            return Err(InvalidGuardianLog(format!(
                 "session ID mismatch: record contains {}, signing public key derives {canonical_session_id}",
                 self.session_id
             )));

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -11,7 +11,7 @@ use super::message::LogMessageV1;
 use super::message::ObjectKeyPattern;
 use super::message::VersionedLogMessage;
 use crate::guardian::BuildPcrs;
-use crate::guardian::GuardianError::InvalidGuardianLog;
+use crate::guardian::GuardianError::InvalidS3Log;
 use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
 use crate::guardian::GuardianSignKeyPair;
@@ -250,7 +250,7 @@ impl LogRecord {
         pub_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         if self.message.is_allowed_unsigned() {
-            return Err(InvalidGuardianLog(
+            return Err(InvalidS3Log(
                 "expected signed log record but message is unsigned".into(),
             ));
         }
@@ -260,14 +260,14 @@ impl LogRecord {
         let signature = self
             .signature
             .as_ref()
-            .ok_or_else(|| InvalidGuardianLog("missing log signature".into()))?;
+            .ok_or_else(|| InvalidS3Log("missing log signature".into()))?;
         verify_intent(&self.signing_payload(), timestamp_ms, signature, pub_key)
-            .map_err(|e| InvalidGuardianLog(format!("invalid log signature: {e}")))?;
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
 
         let message = self
             .message
             .into_current()
-            .map_err(|e| InvalidGuardianLog(format!("log schema conversion failed: {e}")))?;
+            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
         Ok((self.session_id, timestamp_ms, message))
     }
 
@@ -275,12 +275,12 @@ impl LogRecord {
     /// session. The Nitro attestation itself must be authenticated separately.
     pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         if !self.message.is_allowed_unsigned() {
-            return Err(InvalidGuardianLog(
+            return Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
             ));
         }
         if self.signature.is_some() {
-            return Err(InvalidGuardianLog(
+            return Err(InvalidS3Log(
                 "unsigned log record must not contain a signature".into(),
             ));
         }
@@ -300,7 +300,7 @@ impl LogRecord {
         let message = self
             .message
             .into_current()
-            .map_err(|e| InvalidGuardianLog(format!("log schema conversion failed: {e}")))?;
+            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
         Ok((self.session_id, self.timestamp_ms, message))
     }
 
@@ -308,7 +308,7 @@ impl LogRecord {
     /// the S3 reader found it.
     pub fn validate_actual_object_key(&self, actual_object_key: &str) -> GuardianResult<()> {
         if self.object_key != actual_object_key {
-            return Err(InvalidGuardianLog(format!(
+            return Err(InvalidS3Log(format!(
                 "S3 object key mismatch: record contains {}, actual key is {actual_object_key}",
                 self.object_key
             )));
@@ -322,13 +322,13 @@ impl LogRecord {
             .object_key_pattern(&self.session_id, self.timestamp_ms)
         {
             ObjectKeyPattern::Fixed(expected) if self.object_key != expected => {
-                return Err(InvalidGuardianLog(format!(
+                return Err(InvalidS3Log(format!(
                     "non-canonical S3 object key: got {}, expected {expected}",
                     self.object_key
                 )));
             }
             ObjectKeyPattern::RandomSuffix(prefix) if !self.object_key.starts_with(&prefix) => {
-                return Err(InvalidGuardianLog(format!(
+                return Err(InvalidS3Log(format!(
                     "non-canonical S3 object key: got {}, expected prefix {prefix}",
                     self.object_key
                 )));
@@ -341,7 +341,7 @@ impl LogRecord {
     fn validate_session_id(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
         let canonical_session_id = SessionID::from_signing_pubkey(signing_public_key);
         if self.session_id != canonical_session_id {
-            return Err(InvalidGuardianLog(format!(
+            return Err(InvalidS3Log(format!(
                 "session ID mismatch: record contains {}, signing public key derives {canonical_session_id}",
                 self.session_id
             )));

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -916,10 +916,13 @@ impl GetGuardianInfoResponse {
     /// - the Nitro attestation has a valid signature;
     /// - the certificate chain is valid now;
     /// - the attested public key and PCR0 match `signing_pub_key` and `expected_build`.
-    pub fn verify_live(&self, expected_build: &BuildPcrs) -> GuardianResult<VerifiedGuardianInfo> {
+    pub fn verify_live(
+        &self,
+        expected_build: &BuildPcrs,
+    ) -> VerificationResult<VerifiedGuardianInfo> {
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
         if info.untrusted_git_revision != expected_build.git_revision() {
-            return Err(InvalidInputs(format!(
+            return Err(VerificationError::pcr_mismatch(format!(
                 "guardian info reports build '{}', expected current build '{}'",
                 info.untrusted_git_revision,
                 expected_build.git_revision()
@@ -1101,11 +1104,12 @@ mod tests {
         sig_bytes[0] ^= 0xff;
         resp.signed_info.signature = GuardianSignature::from(sig_bytes);
 
-        assert!(matches!(
+        assert_eq!(
             resp.verify_live(&BuildPcrs::new("test-revision", vec![0]))
-                .unwrap_err(),
-            InvalidInputs(_)
-        ));
+                .unwrap_err()
+                .to_string(),
+            "signature invalid"
+        );
     }
 
     #[test]
@@ -1195,7 +1199,11 @@ mod tests {
         allowlist.require_current_build(current_build).unwrap();
 
         let prev_build = allowlist.resolve("prev").unwrap();
-        assert!(allowlist.require_current_build(prev_build).is_err());
+        assert!(matches!(
+            allowlist.require_current_build(prev_build).unwrap_err(),
+            GuardianBuildNotAccepted(message)
+                if message.contains("build 'prev'") && message.contains("build 'current'")
+        ));
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -919,10 +919,10 @@ impl GetGuardianInfoResponse {
     pub fn verify_live(
         &self,
         expected_build: &BuildPcrs,
-    ) -> VerificationResult<VerifiedGuardianInfo> {
+    ) -> CryptoVerificationResult<VerifiedGuardianInfo> {
         let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
         if info.untrusted_git_revision != expected_build.git_revision() {
-            return Err(VerificationError::pcr_mismatch(format!(
+            return Err(CryptoVerificationError::new(format!(
                 "guardian info reports build '{}', expected current build '{}'",
                 info.untrusted_git_revision,
                 expected_build.git_revision()
@@ -1146,12 +1146,15 @@ mod tests {
 
         let current_build = allowlist.resolve("current").unwrap();
         assert_eq!(current_build.pcr0(), &[0]);
-        assert!(allowlist.is_current_build(current_build));
         let prev_build = allowlist.resolve("prev-1").unwrap();
         assert_eq!(prev_build.pcr0(), &[1]);
-        assert!(!allowlist.is_current_build(prev_build));
         let prev2_build = allowlist.resolve("prev-2").unwrap();
         assert_eq!(prev2_build.pcr0(), &[2]);
+
+        assert!(matches!(
+            allowlist.resolve("missing").unwrap_err(),
+            BuildNotAllowlisted(message) if message.contains("build 'missing'")
+        ));
     }
 
     #[test]
@@ -1201,7 +1204,7 @@ mod tests {
         let prev_build = allowlist.resolve("prev").unwrap();
         assert!(matches!(
             allowlist.require_current_build(prev_build).unwrap_err(),
-            GuardianBuildNotAccepted(message)
+            BuildNotCurrent(message)
                 if message.contains("build 'prev'") && message.contains("build 'current'")
         ));
     }

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -8,7 +8,6 @@
 //! bytes so a signature over one type can never be replayed as another.
 
 use super::GuardianError::InternalError;
-use super::GuardianError::InvalidInputs;
 use super::GuardianInfo;
 use super::GuardianResult;
 use super::ProvisionerRotateCertRequest;
@@ -18,6 +17,8 @@ use super::SetupNewKeyResponse;
 use super::SingleProvisionerInitRequest;
 use super::StandardWithdrawalResponse;
 use super::UnixMillis;
+use super::VerificationError;
+use super::VerificationResult;
 use crate::pgp::Fingerprint;
 use crate::pgp::PgpPublicCert;
 use crate::pgp::sign_detached_via_gpg;
@@ -76,10 +77,10 @@ pub(crate) fn verify_intent<T: Serialize + SigningIntent>(
     timestamp_ms: UnixMillis,
     signature: &GuardianSignature,
     pub_key: &VerificationKey,
-) -> GuardianResult<()> {
+) -> VerificationResult<()> {
     pub_key
         .verify(signature, &data.signing_bytes(timestamp_ms))
-        .map_err(|_| InvalidInputs("signature invalid".into()))
+        .map_err(|_| VerificationError::new("signature invalid"))
 }
 
 /// All possible KP signing intent types.
@@ -163,7 +164,7 @@ impl<T: Serialize + SigningIntent> GuardianSigned<T> {
 
     /// Verify signature and extract payload
     /// Checks intent byte to ensure signature is for the correct type
-    pub fn verify(self, pub_key: &VerificationKey) -> GuardianResult<T> {
+    pub fn verify(self, pub_key: &VerificationKey) -> VerificationResult<T> {
         verify_intent(&self.data, self.timestamp_ms, &self.signature, pub_key)?;
         Ok(self.data)
     }
@@ -198,15 +199,16 @@ impl<T: Serialize + KpSigningIntent> KpSigned<T> {
 
     /// Verify the signature without consuming the signed request.
     /// Checks the intent byte to ensure the signature is for this request type.
-    pub fn verify_signature(&self) -> GuardianResult<()> {
+    pub fn verify_signature(&self) -> VerificationResult<()> {
         let msg_bytes = Self::signed_bytes(&self.data);
-        verify_detached_signature(&msg_bytes, &self.signature, &self.signer_cert)
-            .map_err(|e| InvalidInputs(format!("KP signature verification failed: {e}")))?;
+        verify_detached_signature(&msg_bytes, &self.signature, &self.signer_cert).map_err(|e| {
+            VerificationError::new(format!("KP signature verification failed: {e}"))
+        })?;
         Ok(())
     }
 
     /// Verify the signature and extract the payload.
-    pub fn verify(self) -> GuardianResult<T> {
+    pub fn verify(self) -> VerificationResult<T> {
         self.verify_signature()?;
         Ok(self.data)
     }

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -7,6 +7,8 @@
 //! value, and `GuardianSigned::{new,verify}` mix that value into the signed
 //! bytes so a signature over one type can never be replayed as another.
 
+use super::CryptoVerificationError;
+use super::CryptoVerificationResult;
 use super::GuardianError::InternalError;
 use super::GuardianInfo;
 use super::GuardianResult;
@@ -17,8 +19,6 @@ use super::SetupNewKeyResponse;
 use super::SingleProvisionerInitRequest;
 use super::StandardWithdrawalResponse;
 use super::UnixMillis;
-use super::VerificationError;
-use super::VerificationResult;
 use crate::pgp::Fingerprint;
 use crate::pgp::PgpPublicCert;
 use crate::pgp::sign_detached_via_gpg;
@@ -77,10 +77,10 @@ pub(crate) fn verify_intent<T: Serialize + SigningIntent>(
     timestamp_ms: UnixMillis,
     signature: &GuardianSignature,
     pub_key: &VerificationKey,
-) -> VerificationResult<()> {
+) -> CryptoVerificationResult<()> {
     pub_key
         .verify(signature, &data.signing_bytes(timestamp_ms))
-        .map_err(|_| VerificationError::new("signature invalid"))
+        .map_err(|_| CryptoVerificationError::new("signature invalid"))
 }
 
 /// All possible KP signing intent types.
@@ -164,7 +164,7 @@ impl<T: Serialize + SigningIntent> GuardianSigned<T> {
 
     /// Verify signature and extract payload
     /// Checks intent byte to ensure signature is for the correct type
-    pub fn verify(self, pub_key: &VerificationKey) -> VerificationResult<T> {
+    pub fn verify(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
         verify_intent(&self.data, self.timestamp_ms, &self.signature, pub_key)?;
         Ok(self.data)
     }
@@ -199,16 +199,16 @@ impl<T: Serialize + KpSigningIntent> KpSigned<T> {
 
     /// Verify the signature without consuming the signed request.
     /// Checks the intent byte to ensure the signature is for this request type.
-    pub fn verify_signature(&self) -> VerificationResult<()> {
+    pub fn verify_signature(&self) -> CryptoVerificationResult<()> {
         let msg_bytes = Self::signed_bytes(&self.data);
         verify_detached_signature(&msg_bytes, &self.signature, &self.signer_cert).map_err(|e| {
-            VerificationError::new(format!("KP signature verification failed: {e}"))
+            CryptoVerificationError::new(format!("KP signature verification failed: {e}"))
         })?;
         Ok(())
     }
 
     /// Verify the signature and extract the payload.
-    pub fn verify(self) -> VerificationResult<T> {
+    pub fn verify(self) -> CryptoVerificationResult<T> {
         self.verify_signature()?;
         Ok(self.data)
     }

--- a/crates/hashi/src/leader/guardian.rs
+++ b/crates/hashi/src/leader/guardian.rs
@@ -76,23 +76,25 @@ impl LeaderService {
         let rpc_elapsed = rpc_start.elapsed().as_secs_f64();
 
         let response_pb = rpc_result.map_err(|status| {
-            let (rpc_outcome, retry_label) = if status.message().contains("seq mismatch") {
-                (
+            let (rpc_outcome, retry_label) = match status.code() {
+                tonic::Code::Aborted => (
                     crate::metrics::GUARDIAN_RPC_OUTCOME_SEQ_MISMATCH,
                     "GuardianSeqMismatch",
-                )
-            } else if status.message().contains("Rate limit exceeded") {
-                warn!("Guardian rate-limited withdrawal, will retry later");
-                (
-                    crate::metrics::GUARDIAN_RPC_OUTCOME_RATE_LIMITED,
-                    "GuardianRateLimited",
-                )
-            } else {
-                error!("Guardian call failed: {}", status.message());
-                (
-                    crate::metrics::GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
-                    "GuardianUnavailable",
-                )
+                ),
+                tonic::Code::ResourceExhausted => {
+                    warn!("Guardian rate-limited withdrawal, will retry later");
+                    (
+                        crate::metrics::GUARDIAN_RPC_OUTCOME_RATE_LIMITED,
+                        "GuardianRateLimited",
+                    )
+                }
+                _ => {
+                    error!("Guardian call failed: {}", status.message());
+                    (
+                        crate::metrics::GUARDIAN_RPC_OUTCOME_UNAVAILABLE,
+                        "GuardianUnavailable",
+                    )
+                }
             };
             Self::record_guardian_rpc_outcome(inner, rpc_outcome, rpc_elapsed);
             inner


### PR DESCRIPTION
## Summary

- represent lifecycle mismatches with expected/actual lifecycle values and use lifecycle requirements consistently for activated-only operations
- distinguish S3 API/history failures, unrecoverable invalid S3 logs, and potentially recoverable guardian build/PCR policy failures
- keep reusable signature and attestation verification source-neutral, then classify failures at the request or persisted-log boundary
- preserve typed `GuardianReader` errors instead of flattening them into generic input or internal errors
- report invalid Hashi committee certificates as unauthenticated and rejected guardian builds as failed preconditions
- classify limiter sequence mismatches as gRPC `Aborted` and rate limiting as `ResourceExhausted`
- update the Hashi leader to consume those status codes instead of parsing Guardian error messages

## Verification

- `make fmt`
- `git diff --check`
