### PR TITLE
[Guardian] Move activation heartbeat retries into guardian-init

### DIFF
--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -6,10 +6,15 @@
 
 use anyhow::Context;
 use anyhow::ensure;
+use hashi_guardian::HEARTBEAT_INTERVAL;
+use hashi_guardian::MAX_S3_WRITE_FAILURE_INTERVAL;
+use hashi_guardian::OTHER_SESSION_QUIET_PERIOD;
 use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::ActivationState;
+use hashi_types::guardian::GuardianError;
 use hashi_types::guardian::GuardianInfo;
+use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::HashiCommittee;
 use hashi_types::guardian::InitConfig;
 use hashi_types::guardian::OperatorActivateRequest;
@@ -18,10 +23,28 @@ use hashi_types::guardian::VerifiedGuardianInfo;
 use hashi_types::guardian::WithdrawStage;
 use hashi_types::guardian::proto_conversions::operator_activate_request_to_pb;
 use hashi_types::proto::guardian_service_client::GuardianServiceClient;
+use std::time::Duration;
+use tokio::time::Instant;
+use tokio::time::sleep_until;
 use tracing::info;
+use tracing::warn;
 
 use crate::config::Config;
 use crate::guardian_info::verified_live_guardian_info;
+
+// The live-session freshness threshold is intentionally shorter than the
+// writer's normal upper bound: one heartbeat interval plus the S3 write-failure
+// interval (six minutes). A not-live session may therefore still recover, and
+// ten minutes leaves an explicit operational buffer for that recovery.
+const CURRENT_SESSION_HEARTBEAT_RETRY_WINDOW: Duration = Duration::from_mins(10);
+const _: () = assert!(
+    HEARTBEAT_INTERVAL.as_secs() + MAX_S3_WRITE_FAILURE_INTERVAL.as_secs()
+        < CURRENT_SESSION_HEARTBEAT_RETRY_WINDOW.as_secs()
+);
+
+// Allow a prior guardian time to stop while retaining enough time to observe
+// the complete quiet period afterward.
+const ACTIVATION_HEARTBEAT_WAIT_BUFFER: Duration = Duration::from_mins(5);
 
 /// Activate a provisioner-initialized standby guardian.
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
@@ -120,8 +143,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         session_id = %session_id,
         "checking that the standby session is live and all other sessions are quiet",
     );
-    reader
-        .ensure_session_live_and_others_quiet(&session_id)
+    wait_for_activation_heartbeat_conditions(&mut reader, &session_id)
         .await
         .context("heartbeat activation check failed")?;
 
@@ -218,6 +240,52 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     println!("  region:           {}", guardian_s3.region());
 
     Ok(())
+}
+
+async fn wait_for_activation_heartbeat_conditions(
+    reader: &mut GuardianReader,
+    session_id: &str,
+) -> GuardianResult<()> {
+    let now = Instant::now();
+    let current_session_deadline = now + CURRENT_SESSION_HEARTBEAT_RETRY_WINDOW;
+    let prior_session_deadline =
+        now + OTHER_SESSION_QUIET_PERIOD + ACTIVATION_HEARTBEAT_WAIT_BUFFER;
+    loop {
+        match reader
+            .ensure_session_live_and_others_quiet(session_id)
+            .await
+        {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                let deadline = match &error {
+                    GuardianError::CurrentSessionHeartbeatNotLive { .. } => {
+                        current_session_deadline
+                    }
+                    GuardianError::PriorSessionHeartbeatStillRecent { .. } => {
+                        prior_session_deadline
+                    }
+                    _ => return Err(error),
+                };
+                let Some(retry_after_secs) = error.retry_after_secs() else {
+                    return Err(error);
+                };
+                let retry_delay = Duration::from_secs(retry_after_secs);
+
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(error);
+                }
+
+                let retry_at = (now + retry_delay).min(deadline);
+                warn!(
+                    error = %error,
+                    retry_in_secs = retry_at.duration_since(now).as_secs(),
+                    "activation heartbeat conditions are not ready; retrying"
+                );
+                sleep_until(retry_at).await;
+            }
+        }
+    }
 }
 
 struct StandbyChecks {

--- a/crates/hashi-guardian/src/rpc.rs
+++ b/crates/hashi-guardian/src/rpc.rs
@@ -43,6 +43,33 @@ fn to_status(e: GuardianError) -> Status {
         LimiterSequenceMismatch { expected, actual } => Status::aborted(format!(
             "limiter sequence mismatch: expected {expected}, got {actual}"
         )),
+        CurrentSessionHeartbeatNotLive {
+            session_id,
+            heartbeat_age_secs,
+            retry_after_secs,
+        } => {
+            let detail = match heartbeat_age_secs {
+                Some(heartbeat_age_secs) => {
+                    format!("last heartbeated {heartbeat_age_secs}s ago")
+                }
+                None => "has no heartbeat in the recent scan".into(),
+            };
+            Status::unavailable(format!(
+                "operator_activate blocked: current guardian session {session_id} {detail}; \
+                 expected a heartbeat within {}s; retry in {retry_after_secs}s",
+                crate::LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE.as_secs()
+            ))
+        }
+        PriorSessionHeartbeatStillRecent {
+            session_id,
+            heartbeat_age_secs,
+            required_quiet_secs,
+        } => Status::unavailable(format!(
+            "operator_activate blocked: prior guardian session {session_id} heartbeated \
+             {heartbeat_age_secs}s ago; required quiet period is {required_quiet_secs}s; retry in \
+             {}s",
+            required_quiet_secs.saturating_sub(heartbeat_age_secs)
+        )),
         RateLimitExceeded => Status::resource_exhausted("Rate limit exceeded"),
         S3Error(msg) => Status::internal(msg),
         InvalidS3Log(msg) => Status::internal(msg),
@@ -210,5 +237,40 @@ impl proto::guardian_service_server::GuardianService for GuardianGrpc {
         Ok(Response::new(proto::UpdateCommitteeResponse {
             current_committee_epoch: Some(current_committee_epoch),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn heartbeat_readiness_errors_have_actionable_status_codes() {
+        let missing_error = CurrentSessionHeartbeatNotLive {
+            session_id: "current".into(),
+            heartbeat_age_secs: None,
+            retry_after_secs: 60,
+        };
+        assert_eq!(missing_error.retry_after_secs(), Some(60));
+        let missing = to_status(missing_error);
+        assert_eq!(missing.code(), tonic::Code::Unavailable);
+
+        let stale_error = CurrentSessionHeartbeatNotLive {
+            session_id: "current".into(),
+            heartbeat_age_secs: Some(200),
+            retry_after_secs: 60,
+        };
+        assert_eq!(stale_error.retry_after_secs(), Some(60));
+        let stale = to_status(stale_error);
+        assert_eq!(stale.code(), tonic::Code::Unavailable);
+
+        let prior_error = PriorSessionHeartbeatStillRecent {
+            session_id: "prior".into(),
+            heartbeat_age_secs: 30,
+            required_quiet_secs: 600,
+        };
+        assert_eq!(prior_error.retry_after_secs(), Some(570));
+        let prior = to_status(prior_error);
+        assert_eq!(prior.code(), tonic::Code::Unavailable);
     }
 }

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -3,13 +3,15 @@
 
 use super::heartbeat_cursor;
 use super::GuardianReader;
+use crate::HEARTBEAT_INTERVAL;
 use crate::LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE;
 use crate::OTHER_SESSION_QUIET_PERIOD;
 use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::time_utils::unix_millis_to_seconds;
 use hashi_types::guardian::time_utils::UnixSeconds;
-use hashi_types::guardian::GuardianError::InvalidInputs;
+use hashi_types::guardian::GuardianError::CurrentSessionHeartbeatNotLive;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
+use hashi_types::guardian::GuardianError::PriorSessionHeartbeatStillRecent;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::SessionID;
@@ -33,7 +35,6 @@ impl GuardianReader {
             &summary,
             now,
             live_session,
-            LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE.as_secs(),
             OTHER_SESSION_QUIET_PERIOD.as_secs(),
         )?;
 
@@ -109,40 +110,38 @@ fn validate_session_live_and_others_quiet(
     summary: &[GuardianSessionInfo],
     now: UnixSeconds,
     live_session: &str,
-    live_session_max_age_secs: UnixSeconds,
     other_session_quiet_secs: UnixSeconds,
 ) -> GuardianResult<()> {
     let live_session_info = summary
         .iter()
         .find(|s| s.session_id.as_str() == live_session)
-        .ok_or_else(|| {
-            InvalidInputs(format!(
-                "no heartbeat logs found for session {live_session}"
-            ))
+        .ok_or_else(|| CurrentSessionHeartbeatNotLive {
+            session_id: live_session.into(),
+            heartbeat_age_secs: None,
+            retry_after_secs: HEARTBEAT_INTERVAL.as_secs(),
         })?;
     let live_session_age_secs = now.saturating_sub(live_session_info.last_heartbeat);
-    if live_session_age_secs > live_session_max_age_secs {
-        return Err(InvalidInputs(format!(
-            "session {} is stale: last heartbeat {}s ago (expected <= {}s)",
-            live_session, live_session_age_secs, live_session_max_age_secs
-        )));
+    if live_session_age_secs > LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE.as_secs() {
+        return Err(CurrentSessionHeartbeatNotLive {
+            session_id: live_session.into(),
+            heartbeat_age_secs: Some(live_session_age_secs),
+            retry_after_secs: HEARTBEAT_INTERVAL.as_secs(),
+        });
     }
 
-    let active_sessions = summary
+    if let Some(most_recent_other_session) = summary
         .iter()
         .filter(|s| s.session_id.as_str() != live_session)
-        .filter_map(|s| {
-            let age_secs = now.saturating_sub(s.last_heartbeat);
-            (age_secs < other_session_quiet_secs)
-                .then(|| format!("{} ({}s ago)", s.session_id, age_secs))
-        })
-        .collect::<Vec<_>>();
-    if !active_sessions.is_empty() {
-        return Err(InvalidInputs(format!(
-            "sessions are still active within {}s: {}",
-            other_session_quiet_secs,
-            active_sessions.join(", ")
-        )));
+        .max_by_key(|s| s.last_heartbeat)
+    {
+        let heartbeat_age_secs = now.saturating_sub(most_recent_other_session.last_heartbeat);
+        if heartbeat_age_secs < other_session_quiet_secs {
+            return Err(PriorSessionHeartbeatStillRecent {
+                session_id: most_recent_other_session.session_id.clone(),
+                heartbeat_age_secs,
+                required_quiet_secs: other_session_quiet_secs,
+            });
+        }
     }
     Ok(())
 }
@@ -222,8 +221,27 @@ mod tests {
             },
         ];
 
-        validate_session_live_and_others_quiet(&summary, 1_000, "live", 100, 600)
+        validate_session_live_and_others_quiet(&summary, 1_000, "live", 600)
             .expect("live session is recent and other session is quiet");
+    }
+
+    #[test]
+    fn validate_session_live_and_others_quiet_accepts_boundary_ages() {
+        let summary = vec![
+            GuardianSessionInfo {
+                session_id: "live".into(),
+                first_heartbeat: 820,
+                last_heartbeat: 820,
+            },
+            GuardianSessionInfo {
+                session_id: "old".into(),
+                first_heartbeat: 400,
+                last_heartbeat: 400,
+            },
+        ];
+
+        validate_session_live_and_others_quiet(&summary, 1_000, "live", 600)
+            .expect("boundary ages satisfy the heartbeat requirements");
     }
 
     #[test]
@@ -234,9 +252,16 @@ mod tests {
             last_heartbeat: 200,
         }];
 
-        let err = validate_session_live_and_others_quiet(&summary, 1_000, "live", 100, 600)
+        let err = validate_session_live_and_others_quiet(&summary, 1_000, "live", 600)
             .expect_err("must require heartbeat for live session");
-        assert!(err.to_string().contains("no heartbeat logs found"));
+        assert_eq!(
+            err,
+            CurrentSessionHeartbeatNotLive {
+                session_id: "live".into(),
+                heartbeat_age_secs: None,
+                retry_after_secs: HEARTBEAT_INTERVAL.as_secs(),
+            }
+        );
     }
 
     #[test]
@@ -247,13 +272,20 @@ mod tests {
             last_heartbeat: 800,
         }];
 
-        let err = validate_session_live_and_others_quiet(&summary, 1_000, "live", 100, 600)
+        let err = validate_session_live_and_others_quiet(&summary, 1_000, "live", 600)
             .expect_err("must reject stale live session");
-        assert!(err.to_string().contains("stale"));
+        assert_eq!(
+            err,
+            CurrentSessionHeartbeatNotLive {
+                session_id: "live".into(),
+                heartbeat_age_secs: Some(200),
+                retry_after_secs: HEARTBEAT_INTERVAL.as_secs(),
+            }
+        );
     }
 
     #[test]
-    fn validate_session_live_and_others_quiet_fails_when_other_session_active() {
+    fn validate_session_live_and_others_quiet_reports_most_recent_other_heartbeat() {
         let summary = vec![
             GuardianSessionInfo {
                 session_id: "live".into(),
@@ -261,14 +293,26 @@ mod tests {
                 last_heartbeat: 990,
             },
             GuardianSessionInfo {
-                session_id: "other".into(),
+                session_id: "other-older".into(),
+                first_heartbeat: 920,
+                last_heartbeat: 920,
+            },
+            GuardianSessionInfo {
+                session_id: "other-newer".into(),
                 first_heartbeat: 950,
                 last_heartbeat: 950,
             },
         ];
 
-        let err = validate_session_live_and_others_quiet(&summary, 1_000, "live", 100, 100)
-            .expect_err("must reject active other session");
-        assert!(err.to_string().contains("sessions are still active"));
+        let err = validate_session_live_and_others_quiet(&summary, 1_000, "live", 100)
+            .expect_err("must reject a recent heartbeat from another session");
+        assert_eq!(
+            err,
+            PriorSessionHeartbeatStillRecent {
+                session_id: "other-newer".into(),
+                heartbeat_age_secs: 50,
+                required_quiet_secs: 100,
+            }
+        );
     }
 }

--- a/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
@@ -46,8 +46,7 @@ impl OAInstall {
 
         reader
             .ensure_session_live_and_others_quiet(&enclave.s3_session_id())
-            .await
-            .map_err(|e| InvalidInputs(format!("heartbeat activation check failed: {e}")))?;
+            .await?;
 
         let committee: HashiCommittee = reader
             .read_latest_committee(BuildPolicy::AnyAllowlisted)

--- a/crates/hashi-types/src/guardian/errors.rs
+++ b/crates/hashi-types/src/guardian/errors.rs
@@ -4,7 +4,9 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::SessionID;
 use super::lifecycle::EnclaveLifecycle;
+use super::time_utils::UnixSeconds;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum GuardianError {
@@ -35,12 +37,43 @@ pub enum GuardianError {
         expected: u64,
         actual: u64,
     },
+    /// The standby session has no heartbeat recent enough for activation.
+    CurrentSessionHeartbeatNotLive {
+        session_id: SessionID,
+        /// `None` means no heartbeat was found in the recent scan.
+        heartbeat_age_secs: Option<UnixSeconds>,
+        retry_after_secs: UnixSeconds,
+    },
+    /// A prior session remains inside the activation quiet period.
+    PriorSessionHeartbeatStillRecent {
+        session_id: SessionID,
+        heartbeat_age_secs: UnixSeconds,
+        required_quiet_secs: UnixSeconds,
+    },
     RateLimitExceeded,
     /// A service condition known to be temporary and safe for callers to retry.
     Unavailable(String),
 }
 
 pub type GuardianResult<T> = Result<T, GuardianError>;
+
+impl GuardianError {
+    /// Returns how long a caller should wait before retrying, when the error
+    /// describes a condition that becomes ready on a known schedule.
+    pub fn retry_after_secs(&self) -> Option<UnixSeconds> {
+        match self {
+            Self::CurrentSessionHeartbeatNotLive {
+                retry_after_secs, ..
+            } => Some(*retry_after_secs),
+            Self::PriorSessionHeartbeatStillRecent {
+                heartbeat_age_secs,
+                required_quiet_secs,
+                ..
+            } => Some(required_quiet_secs.saturating_sub(*heartbeat_age_secs)),
+            _ => None,
+        }
+    }
+}
 
 /// Low-level error returned by signature and attestation verifiers.
 ///
@@ -87,6 +120,33 @@ impl std::fmt::Display for GuardianError {
             GuardianError::LimiterSequenceMismatch { expected, actual } => write!(
                 f,
                 "LimiterSequenceMismatch: expected {expected}, got {actual}"
+            ),
+            GuardianError::CurrentSessionHeartbeatNotLive {
+                session_id,
+                heartbeat_age_secs,
+                retry_after_secs,
+            } => match heartbeat_age_secs {
+                Some(heartbeat_age_secs) => write!(
+                    f,
+                    "CurrentSessionHeartbeatNotLive: session {session_id} last heartbeated \
+                     {heartbeat_age_secs}s ago; retry in {retry_after_secs}s"
+                ),
+                None => write!(
+                    f,
+                    "CurrentSessionHeartbeatNotLive: no recent heartbeat found for session \
+                     {session_id}; retry in {retry_after_secs}s"
+                ),
+            },
+            GuardianError::PriorSessionHeartbeatStillRecent {
+                session_id,
+                heartbeat_age_secs,
+                required_quiet_secs,
+            } => write!(
+                f,
+                "PriorSessionHeartbeatStillRecent: session {session_id} heartbeated \
+                 {heartbeat_age_secs}s ago; required quiet period is {required_quiet_secs}s; retry \
+                 in {}s",
+                required_quiet_secs.saturating_sub(*heartbeat_age_secs)
             ),
             GuardianError::RateLimitExceeded => write!(f, "Rate limit exceeded"),
             GuardianError::Unavailable(e) => write!(f, "Unavailable: {}", e),

--- a/docker/hashi-guardian-local/scripts/provision.sh
+++ b/docker/hashi-guardian-local/scripts/provision.sh
@@ -36,30 +36,10 @@ for i in $(seq 1 "${THRESHOLD}"); do
   hashi-guardian-init key-provisioner provision --config "${CONFIG}" --do-genesis
 done
 
-operator_activate() {
-  local deadline=$(( SECONDS + 180 )) out
-  render_config "${WITHDRAW_GUARDIAN_ENDPOINT:-http://host:3000}" ""
-  while :; do
-    if out="$(hashi-guardian-init operator activate --config "${CONFIG}" 2>&1)"; then
-      printf '%s\n' "${out}"
-      return 0
-    fi
-    printf '%s\n' "${out}" >&2
-    if ! grep -q "no heartbeat logs found for session" <<<"${out}"; then
-      return 1
-    fi
-    if [ "${SECONDS}" -ge "${deadline}" ]; then
-      echo "guardian still has no heartbeat after 180s — aborting activation." >&2
-      return 1
-    fi
-    echo "guardian has not heartbeated yet; waiting 10s before activation..." >&2
-    sleep 10
-  done
-}
-
 echo
 echo "== operator activate =="
-operator_activate
+render_config "${WITHDRAW_GUARDIAN_ENDPOINT:-http://host:3000}" ""
+hashi-guardian-init operator activate --config "${CONFIG}"
 
 echo
 echo "Provisioning and activation complete — the guardian should now be serving withdrawals."


### PR DESCRIPTION
## Summary

- model activation heartbeat readiness with structured current-session-not-live and prior-session-still-recent Guardian errors
- treat missing and stale current-session heartbeats uniformly, retrying once per heartbeat interval for a fixed ten-minute window
- wait for prior sessions using the ten-minute quiet period plus a five-minute shutdown/startup buffer
- compute both retry deadlines once so repeated checks cannot extend either wait window
- preserve heartbeat error types through the Guardian activation path and map retryable readiness to gRPC `Unavailable`
- fail immediately for S3, integrity, build, authentication, and other non-heartbeat errors
- remove the local provisioning script message-parsing retry loop now that the CLI owns the bounded retry policy

## Tradeoff

The recent heartbeat scan remains bounded. If the presumed current session last heartbeated outside that scan, it is treated like any other current-session-not-live result and may wait up to ten minutes before failing. A historical lookup can be added later if this uncommon delay becomes operationally significant.

## Follow-up

- Replace serialized `GuardianError` values in failure logs with strings before mainnet.
- Extend and test `docker/hashi-guardian-local` with standby-guardian activation; the current harness covers genesis activation only.

## Verification

- `make fmt`
- `git diff --check`
