### PR TITLE
Fix self-deadlock in deposit validation (state lock re-entry)

### DIFF
--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -115,11 +115,8 @@ impl Hashi {
                 // `approve_deposit` would reject it anyway, so we don't
                 // want to waste a signature exchange or a transaction.
                 //
-                // Read the epoch from the `state` snapshot held above: the
-                // state lock is a non-reentrant `std::sync::RwLock`, so
-                // going through `OnchainState::epoch()` here re-locks it and
-                // self-deadlocks as soon as the watcher has a write queued
-                // (readers block behind a waiting writer).
+                // Read from the held snapshot; `OnchainState::epoch()` would
+                // reacquire the same state lock.
                 let current_epoch = state.hashi().committees.epoch();
                 if let Some(cert) = &onchain_request.approval_cert
                     && cert.epoch == current_epoch

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -114,7 +114,13 @@ impl Hashi {
                 // already approved by the current committee. The on-chain
                 // `approve_deposit` would reject it anyway, so we don't
                 // want to waste a signature exchange or a transaction.
-                let current_epoch = self.onchain_state().epoch();
+                //
+                // Read the epoch from the `state` snapshot held above: the
+                // state lock is a non-reentrant `std::sync::RwLock`, so
+                // going through `OnchainState::epoch()` here re-locks it and
+                // self-deadlocks as soon as the watcher has a write queued
+                // (readers block behind a waiting writer).
+                let current_epoch = state.hashi().committees.epoch();
                 if let Some(cert) = &onchain_request.approval_cert
                     && cert.epoch == current_epoch
                 {


### PR DESCRIPTION
## The bug (reported by a validator; confirmed)

`validate_deposit_request_on_sui()` in `crates/hashi/src/deposits.rs` takes the onchain-state read guard:

```rust
let state = self.onchain_state().state();   // read lock #1, held to end of fn
```

and then, while that guard is still live, calls:

```rust
let current_epoch = self.onchain_state().epoch();   // re-locks the same RwLock
```

`OnchainState::epoch()` is `self.state().hashi.committees.epoch()` — a second read of the same **non-reentrant** `std::sync::RwLock<State>`. Rust's futex-based `RwLock` blocks new readers whenever a writer is waiting, so the interleaving

1. deposit task takes read #1
2. watcher queues a write (`state_mut()`)
3. deposit task requests read #2 → parked behind the writer
4. writer parked behind read #1

deadlocks the thread against itself. Because this is sync code on a tokio worker, the wedged thread starves the pool and every other `state()` reader piles up behind the queued writer — the process stays alive (systemd green, port open) while the node stops accepting, logging, and pushing metrics. This matches the reported 6h dark-node incidents on `ed2544a8e`; the path triggers on every deposit confirmation, racing the watcher's write cadence.

## The fix

Read the epoch from the already-held snapshot:

```rust
let current_epoch = state.hashi().committees.epoch();
```

This is also the more consistent value — it comes from the same state snapshot the request is being validated against, rather than a possibly-newer state. A comment now marks the non-reentrancy constraint at the call site.

The other `onchain_state()` uses in this file were audited: they either run with no guard held (`bitcoin_confirmation_threshold`, `onchain_verifying_key_g`) or take sequential transient locks that drop at the end of each statement (`sign_deposit_confirmation`), so this was the only nested-acquisition site in the file. A broader repo sweep for the same pattern is running separately.

## Validation

- `cargo check -p hashi` clean, `cargo fmt --check` clean
- Diff is 1 line of code (+ comment), no behavior change other than removing the re-lock

## Operator note

Until upgraded: the reported symptom check (`ss -tlnp` Recv-Q at/above backlog on 443) and restart-on-dead-metrics cron are sound workarounds.