### PR TITLE
Fix a state-lock re-entry deadlock in committee-transition signing

### DIFF
--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -285,12 +285,10 @@ impl LeaderService {
     }
 
     fn check_halt_deposit_processing(&mut self) -> bool {
-        // Evaluate both predicates from one scoped snapshot: the state lock
-        // is a non-reentrant `std::sync::RwLock`, and the temporary read
+        // Evaluate both predicates from one scoped snapshot. The temporary
         // guard from the `||`'s first operand lives until the whole condition
-        // finishes evaluating — so calling `is_reconfiguring()` (which
-        // re-locks) in the second operand self-deadlocks as soon as the
-        // watcher has a write queued (readers block behind a waiting writer).
+        // finishes evaluating, so `is_reconfiguring()` in the second operand
+        // would reacquire the same state lock while it is held.
         let halt = {
             let state = self.inner.onchain_state().state();
             state.hashi().config.paused()

--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -285,10 +285,7 @@ impl LeaderService {
     }
 
     fn check_halt_deposit_processing(&mut self) -> bool {
-        // Evaluate both predicates from one scoped snapshot. The temporary
-        // guard from the `||`'s first operand lives until the whole condition
-        // finishes evaluating, so `is_reconfiguring()` in the second operand
-        // would reacquire the same state lock while it is held.
+        // Evaluate both predicates from one consistent state snapshot.
         let halt = {
             let state = self.inner.onchain_state().state();
             state.hashi().config.paused()

--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -285,8 +285,18 @@ impl LeaderService {
     }
 
     fn check_halt_deposit_processing(&mut self) -> bool {
-        if !(self.inner.onchain_state().state().hashi().config.paused() || self.is_reconfiguring())
-        {
+        // Evaluate both predicates from one scoped snapshot: the state lock
+        // is a non-reentrant `std::sync::RwLock`, and the temporary read
+        // guard from the `||`'s first operand lives until the whole condition
+        // finishes evaluating — so calling `is_reconfiguring()` (which
+        // re-locks) in the second operand self-deadlocks as soon as the
+        // watcher has a write queued (readers block behind a waiting writer).
+        let halt = {
+            let state = self.inner.onchain_state().state();
+            state.hashi().config.paused()
+                || state.hashi().committees.pending_epoch_change().is_some()
+        };
+        if !halt {
             return false;
         }
 

--- a/crates/hashi/src/leader/guardian.rs
+++ b/crates/hashi/src/leader/guardian.rs
@@ -344,26 +344,13 @@ impl LeaderService {
         inner: &Arc<Hashi>,
         from_epoch: u64,
     ) -> anyhow::Result<SignedMessage<CommitteeTransitionRequest>> {
-        let (to_epoch, from_committee, new_committee) = {
-            let onchain = inner.onchain_state();
-            let state = onchain.state();
-            let committees_map = state.hashi().committees.committees();
-            let from = committees_map
-                .get(&from_epoch)
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("no on-chain committee for epoch {from_epoch}"))?;
-            // Hashi committee epochs are sparse: each reconfig only adds a
-            // new entry when Sui's epoch advances past hashi's AND the MPC
-            // reconfig completes, so the next entry is generally not
-            // `from_epoch + 1`. Both leader and followers derive the same
-            // `to_epoch` from on-chain state, so they sign the same transition.
-            let (to_epoch, to) = committees_map
-                .range((from_epoch + 1)..)
-                .next()
-                .map(|(&k, c)| (k, c.clone()))
-                .ok_or_else(|| anyhow::anyhow!("no on-chain committee epoch after {from_epoch}"))?;
-            (to_epoch, from, to)
-        };
+        let (from_committee, new_committee) = inner
+            .onchain_state()
+            .committee_transition(from_epoch)
+            .ok_or_else(|| {
+                anyhow::anyhow!("no on-chain committee transition from epoch {from_epoch}")
+            })?;
+        let to_epoch = new_committee.epoch();
 
         let transition = CommitteeTransitionRequest {
             new_committee: hashi_types::move_types::Committee::from(&new_committee),

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -492,6 +492,21 @@ impl OnchainState {
             .cloned()
     }
 
+    /// The committee transition out of `from_epoch`: that epoch's committee
+    /// and its on-chain successor. Hashi committee epochs are sparse — each
+    /// reconfig only adds an entry when Sui's epoch advances past hashi's and
+    /// the MPC reconfig completes — so the successor is generally not
+    /// `from_epoch + 1`. Both leader and followers derive the same successor
+    /// from on-chain state, so they sign the same transition. Returns owned
+    /// clones so no state guard escapes to the caller.
+    pub fn committee_transition(&self, from_epoch: u64) -> Option<(Committee, Committee)> {
+        let state = self.state();
+        let committees = state.hashi().committees.committees();
+        let from = committees.get(&from_epoch)?.clone();
+        let to = committees.range((from_epoch + 1)..).next()?.1.clone();
+        Some((from, to))
+    }
+
     /// Returns the MPC public key bytes.
     pub fn mpc_public_key(&self) -> Vec<u8> {
         self.state().hashi.committees.mpc_public_key().to_vec()

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -838,36 +838,20 @@ impl Hashi {
             .validator_address()
             .map_err(|e| anyhow!("No validator address configured: {e}"))?;
 
-        // Scope the read guard so it drops before signing;
-        // `sign_message_proto_at_epoch` reacquires the same state lock.
-        let transition = {
-            let onchain = self.onchain_state();
-            let state = onchain.state();
-            let committees_map = state.hashi().committees.committees();
-            let from_committee = committees_map
-                .get(&from_epoch)
-                .ok_or_else(|| anyhow!("no on-chain committee for epoch {from_epoch}"))?;
-            if !from_committee
-                .members()
-                .iter()
-                .any(|m| m.validator_address() == validator_address)
-            {
-                anyhow::bail!("not a member of the committee at epoch {from_epoch}");
-            }
+        let (from_committee, new_committee) = self
+            .onchain_state()
+            .committee_transition(from_epoch)
+            .ok_or_else(|| anyhow!("no on-chain committee transition from epoch {from_epoch}"))?;
+        if !from_committee
+            .members()
+            .iter()
+            .any(|m| m.validator_address() == validator_address)
+        {
+            anyhow::bail!("not a member of the committee at epoch {from_epoch}");
+        }
 
-            // Hashi committee epochs are sparse: the next entry after `from_epoch`
-            // is generally not `from_epoch + 1`. Both leader and followers derive
-            // the same `to_epoch` from on-chain state, so they sign the same
-            // transition.
-            let new_committee = committees_map
-                .range((from_epoch + 1)..)
-                .next()
-                .map(|(_, c)| c)
-                .ok_or_else(|| anyhow!("no on-chain committee epoch after {from_epoch}"))?;
-
-            hashi_types::guardian::CommitteeTransitionRequest {
-                new_committee: hashi_types::move_types::Committee::from(new_committee),
-            }
+        let transition = hashi_types::guardian::CommitteeTransitionRequest {
+            new_committee: hashi_types::move_types::Committee::from(&new_committee),
         };
 
         let signature = self.sign_message_proto_at_epoch(&transition, from_epoch)?;

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -838,32 +838,39 @@ impl Hashi {
             .validator_address()
             .map_err(|e| anyhow!("No validator address configured: {e}"))?;
 
-        let onchain = self.onchain_state();
-        let state = onchain.state();
-        let committees_map = state.hashi().committees.committees();
-        let from_committee = committees_map
-            .get(&from_epoch)
-            .ok_or_else(|| anyhow!("no on-chain committee for epoch {from_epoch}"))?;
-        if !from_committee
-            .members()
-            .iter()
-            .any(|m| m.validator_address() == validator_address)
-        {
-            anyhow::bail!("not a member of the committee at epoch {from_epoch}");
-        }
+        // Scope the state read guard so it drops before signing: the state
+        // lock is a non-reentrant `std::sync::RwLock`, and
+        // `sign_message_proto_at_epoch` re-acquires it — a nested read
+        // self-deadlocks as soon as the watcher has a write queued (readers
+        // block behind a waiting writer).
+        let transition = {
+            let onchain = self.onchain_state();
+            let state = onchain.state();
+            let committees_map = state.hashi().committees.committees();
+            let from_committee = committees_map
+                .get(&from_epoch)
+                .ok_or_else(|| anyhow!("no on-chain committee for epoch {from_epoch}"))?;
+            if !from_committee
+                .members()
+                .iter()
+                .any(|m| m.validator_address() == validator_address)
+            {
+                anyhow::bail!("not a member of the committee at epoch {from_epoch}");
+            }
 
-        // Hashi committee epochs are sparse: the next entry after `from_epoch`
-        // is generally not `from_epoch + 1`. Both leader and followers derive
-        // the same `to_epoch` from on-chain state, so they sign the same
-        // transition.
-        let new_committee = committees_map
-            .range((from_epoch + 1)..)
-            .next()
-            .map(|(_, c)| c)
-            .ok_or_else(|| anyhow!("no on-chain committee epoch after {from_epoch}"))?;
+            // Hashi committee epochs are sparse: the next entry after `from_epoch`
+            // is generally not `from_epoch + 1`. Both leader and followers derive
+            // the same `to_epoch` from on-chain state, so they sign the same
+            // transition.
+            let new_committee = committees_map
+                .range((from_epoch + 1)..)
+                .next()
+                .map(|(_, c)| c)
+                .ok_or_else(|| anyhow!("no on-chain committee epoch after {from_epoch}"))?;
 
-        let transition = hashi_types::guardian::CommitteeTransitionRequest {
-            new_committee: hashi_types::move_types::Committee::from(new_committee),
+            hashi_types::guardian::CommitteeTransitionRequest {
+                new_committee: hashi_types::move_types::Committee::from(new_committee),
+            }
         };
 
         let signature = self.sign_message_proto_at_epoch(&transition, from_epoch)?;

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -838,11 +838,8 @@ impl Hashi {
             .validator_address()
             .map_err(|e| anyhow!("No validator address configured: {e}"))?;
 
-        // Scope the state read guard so it drops before signing: the state
-        // lock is a non-reentrant `std::sync::RwLock`, and
-        // `sign_message_proto_at_epoch` re-acquires it — a nested read
-        // self-deadlocks as soon as the watcher has a write queued (readers
-        // block behind a waiting writer).
+        // Scope the read guard so it drops before signing;
+        // `sign_message_proto_at_epoch` reacquires the same state lock.
         let transition = {
             let onchain = self.onchain_state();
             let state = onchain.state();


### PR DESCRIPTION
Follow-up to #884: a systematic sweep of the workspace for the same bug class — nested acquisition of the non-reentrant `std::sync::RwLock<State>` behind `OnchainState`, which self-deadlocks the moment the watcher queues a write.

## 1. `withdrawals.rs` — `validate_and_sign_committee_transition()` (reconfig path) — real deadlock

Held the read guard from `let state = onchain.state();` for the entire function, then called `sign_message_proto_at_epoch()`, which re-locks via `self.onchain_state().state()`. Reachable from the `sign_committee_transition` gRPC handler on every committee-handoff signing request that misses the per-epoch signature cache — i.e. at least the first request per epoch on every node, **during reconfig**, exactly when the watcher is busiest writing. Same failure signature as the incident: process alive, node dark.

Per review feedback, the fix is now a shared owned accessor rather than guard scoping: `OnchainState::committee_transition(from_epoch) -> Option<(Committee, Committee)>` centralizes the sparse successor lookup and returns owned clones so no state guard can escape. Both this site and the leader's `collect_committee_transition_signatures` (which duplicated the lookup) now use it.

## 2. `leader/deposits.rs` — `check_halt_deposit_processing()` — consistency cleanup only (NOT a deadlock; original description corrected)

The PR originally claimed the `||`'s first-operand temporary guard outlived the condition and deadlocked against `is_reconfiguring()`. **That was wrong**: per the Rust Reference (Destructors → Temporary scopes), *each operand* of a lazy boolean expression is its own temporary scope, so the guard was dropped before the second operand ran — verified empirically with a `try_write` probe on both editions 2021/2024. Credit to @dlukegordon for catching it. The change is kept purely because evaluating both predicates from one snapshot is more consistent than two independent reads racing the watcher.

## Sweep scope

Six angles over the workspace (read-guard re-entry everywhere, write-guard scopes in the watcher, the `RwLock<MpcManager>` domain, std guards across `.await`, guardian/monitor/screener crates, AB-BA ordering), each candidate adversarially verified. Nothing else survived.

## Validation

- `cargo check -p hashi`, `cargo fmt --check` clean; `cargo test -p hashi --lib` 488 passed (gpg-dependent test skipped per local-env limitation)