### PR TITLE
[withdrawals] Fix CPFP transactions

### DIFF
--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -209,12 +209,10 @@ pub struct Config {
 
     /// Floor (sat/vB) for the withdrawal settlement fee rate, applied
     /// after `estimatesmartfee`. Raising this is the lever for rescuing a
-    /// settlement that has stalled in the mempool: the boost that lifts an
-    /// underpaying unconfirmed ancestor is only computed for the amount by
-    /// which this floor exceeds what that ancestor already paid.
+    /// stalled settlement: the CPFP boost only covers the amount by which
+    /// this floor exceeds what the stalled ancestor already paid.
     ///
-    /// Defaults to
-    /// [`CoinSelectionParams::DEFAULT_MIN_FEE_RATE`](crate::utxo_pool::CoinSelectionParams::DEFAULT_MIN_FEE_RATE).
+    /// Defaults to `CoinSelectionParams::DEFAULT_MIN_FEE_RATE`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_min_fee_rate_sat_vb: Option<u64>,
 

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -207,6 +207,17 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub withdrawal_fee_conf_target: Option<u16>,
 
+    /// Floor (sat/vB) for the withdrawal settlement fee rate, applied
+    /// after `estimatesmartfee`. Raising this is the lever for rescuing a
+    /// settlement that has stalled in the mempool: the boost that lifts an
+    /// underpaying unconfirmed ancestor is only computed for the amount by
+    /// which this floor exceeds what that ancestor already paid.
+    ///
+    /// Defaults to
+    /// [`CoinSelectionParams::DEFAULT_MIN_FEE_RATE`](crate::utxo_pool::CoinSelectionParams::DEFAULT_MIN_FEE_RATE).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub withdrawal_min_fee_rate_sat_vb: Option<u64>,
+
     /// Interval (ms) between watcher polls of the on-chain Hashi config while
     /// the launch is pending — the safety net for `finish_publish`, which sets
     /// `guardian_url` and the guardian BTC key with no event. Polling stops
@@ -451,6 +462,12 @@ impl Config {
 
     pub fn withdrawal_fee_conf_target(&self) -> u16 {
         self.withdrawal_fee_conf_target.unwrap_or(3)
+    }
+
+    pub fn withdrawal_min_fee_rate(&self) -> bitcoin::FeeRate {
+        self.withdrawal_min_fee_rate_sat_vb
+            .and_then(bitcoin::FeeRate::from_sat_per_vb)
+            .unwrap_or(crate::utxo_pool::CoinSelectionParams::DEFAULT_MIN_FEE_RATE)
     }
 
     // Creates a new config suitable for testing. In particular this config will:

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -258,10 +258,9 @@ pub struct CoinSelectionParams {
     /// transaction that exceeds this limit.
     pub max_tx_weight: Weight,
 
-    /// Upper bound on the weight of this transaction plus all of its
-    /// unconfirmed ancestors. Keeps the resulting mempool cluster
-    /// inside Bitcoin's 101 kvB limit, which `max_tx_weight` alone
-    /// does not constrain.
+    /// Upper bound on this transaction plus all of its unconfirmed
+    /// ancestors, keeping the mempool cluster inside Bitcoin's 101 kvB
+    /// limit. `max_tx_weight` alone does not constrain this.
     pub max_ancestor_package_weight: Weight,
 
     /// Hard cap on the total number of transaction inputs, covering both the
@@ -348,16 +347,12 @@ impl CoinSelectionParams {
     /// Default cap on this transaction plus its unconfirmed ancestors
     /// (360 kWU = 90 kvB).
     ///
-    /// Bitcoin Core bounds a mempool cluster at 101 kvB
-    /// (`getmempoolinfo.limitclustersize`; pre-cluster-mempool nodes
-    /// apply the same figure as `-limitancestorsize`). A transaction
-    /// whose ancestors push the cluster past that is rejected outright,
-    /// which is how one stalled settlement blocks every batch behind it.
-    ///
-    /// [`Self::DEFAULT_MAX_TX_WEIGHT`] bounds only the transaction
-    /// itself, so it cannot catch this. The 11 kvB held back from the
-    /// 101 kvB budget is deliberate: it keeps room for a CPFP child to
-    /// rescue the package if it does stall.
+    /// Bitcoin rejects a mempool cluster over 101 kvB
+    /// (`getmempoolinfo.limitclustersize`), which is how one stalled
+    /// settlement blocks every batch behind it.
+    /// [`Self::DEFAULT_MAX_TX_WEIGHT`] bounds only the transaction, so
+    /// it cannot catch this. The 11 kvB held back leaves room for a
+    /// CPFP child to rescue the package.
     pub const DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT: Weight = Weight::from_wu(360_000);
 
     /// Default maximum total inputs selected for a withdrawal transaction,
@@ -369,19 +364,14 @@ impl CoinSelectionParams {
     /// room under Bitcoin's 101 kvB descendant-size budget for a direct child.
     pub const MAX_WITHDRAWAL_REQUESTS: usize = 40;
 
-    /// Default minimum fee rate floor (3 sat/vB).
+    /// Default minimum fee rate floor (3 sat/vB), deliberately above
+    /// Bitcoin Core's 1 sat/vB relay minimum.
     ///
-    /// Deliberately above Bitcoin Core's 1 sat/vB minimum relay fee. A
-    /// batched withdrawal is both the largest and (at the relay floor)
-    /// the cheapest entry in a mempool, so it is the first candidate
-    /// evicted under memory pressure — and nothing re-announces an
-    /// evicted transaction. Small transactions at 1 sat/vB confirm
-    /// fine; an ~80 kvB one can sit indefinitely.
-    ///
-    /// The floor also has to exceed the rate an already-broadcast
-    /// parent paid, or [`TransactionBuilder::cpfp_deficit`] computes a
-    /// zero deficit and the CPFP boost silently never fires — leaving
-    /// no way to rescue a stalled settlement.
+    /// A batched withdrawal at the relay floor is both the largest and
+    /// the cheapest mempool entry, so it is evicted first and nothing
+    /// re-announces it. The floor must also exceed what an unconfirmed
+    /// parent already paid, or the CPFP deficit is zero and a stalled
+    /// settlement cannot be rescued.
     pub const DEFAULT_MIN_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(3);
 
     /// Default long-term average fee rate (10 sat/vB), matching
@@ -578,9 +568,8 @@ pub enum CoinSelectionError {
     },
 
     /// The transaction plus its unconfirmed ancestors exceeds
-    /// `params.max_ancestor_package_weight`. Broadcasting it would be
-    /// rejected by Bitcoin's 101 kvB cluster-size policy, so the batch is
-    /// refused before signing rather than after.
+    /// `params.max_ancestor_package_weight`. Refused before signing
+    /// rather than after, since Bitcoin would reject the broadcast.
     #[error(
         "transaction weight {weight:#} plus unconfirmed ancestor weight \
          {ancestor_weight:#} exceeds the configured package maximum {max_weight:#}"
@@ -978,12 +967,10 @@ impl<'a> TransactionBuilder<'a> {
     /// Combined weight of every unconfirmed ancestor of the selected
     /// inputs.
     ///
-    /// Inputs sharing an unconfirmed parent count that parent once per
-    /// input, so this can overestimate. Both callers — the package
-    /// bound and [`Self::cpfp_deficit`] — fail safe on an overestimate
-    /// (a tighter bound, a larger fee), so it is left conservative
-    /// rather than deduplicated, which would require tracking ancestor
-    /// identity.
+    /// Inputs sharing a parent count it once each, so this can
+    /// overestimate. Both callers fail safe on an overestimate — a
+    /// tighter bound, a larger fee — and deduplicating would require
+    /// tracking ancestor identity.
     fn unconfirmed_ancestor_weight(&self) -> Weight {
         self.inputs
             .iter()
@@ -996,9 +983,8 @@ impl<'a> TransactionBuilder<'a> {
         self.weight() > self.params.max_tx_weight
     }
 
-    /// Whether this transaction plus its unconfirmed ancestors exceeds
-    /// the configured package maximum — i.e. whether broadcasting it
-    /// would breach Bitcoin's cluster-size policy.
+    /// Whether the transaction plus its unconfirmed ancestors exceeds
+    /// the configured package maximum.
     fn exceeds_max_ancestor_package_weight(&self) -> bool {
         self.weight() + self.unconfirmed_ancestor_weight() > self.params.max_ancestor_package_weight
     }

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -115,6 +115,11 @@ impl SpendPath {
 /// ancestor.
 #[derive(Clone, Debug)]
 pub struct AncestorTx {
+    /// Identity of the withdrawal that produced this transaction.
+    ///
+    /// Selected inputs can descend from a shared parent, and the CPFP
+    /// arithmetic is only correct if that parent is counted once.
+    pub id: Address,
     /// Number of confirmations. `0` means the transaction is in the
     /// mempool only (not yet included in a block). Values `1..N`
     /// mean it has been included but has not yet reached the
@@ -748,6 +753,12 @@ pub fn select_coins(
                 // Also ensure that if this UTXO were to be selected, the resulting unconfirmed
                 // chain depth would be less than the max relay limit
                 && u.status.mempool_chain_depth() < MAX_ANCESTOR_DEPTH
+                // A candidate whose ancestors alone fill the package budget can
+                // never be spent. Skip it here rather than letting it fail the
+                // whole selection: it is picked first (largest-first), so one
+                // stalled chain would otherwise block every withdrawal that the
+                // remaining confirmed UTXOs could have funded.
+                && u.status.unconfirmed_ancestor_weight() < params.max_ancestor_package_weight
         })
         .collect();
     pool.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| a.id.cmp(&b.id)));
@@ -969,17 +980,33 @@ impl<'a> TransactionBuilder<'a> {
         raw_change
     }
 
-    /// Combined weight of every unconfirmed ancestor of the selected
-    /// inputs.
+    /// Every unconfirmed ancestor of the selected inputs, each counted
+    /// once.
     ///
-    /// Inputs sharing a parent count it once each, so this can
-    /// overestimate. Both callers fail safe on an overestimate — a
-    /// tighter bound, a larger fee — and deduplicating would require
-    /// tracking ancestor identity.
-    fn unconfirmed_ancestor_weight(&self) -> Weight {
+    /// Deduplication is load-bearing, not tidiness. Two inputs can share
+    /// a parent, and counting it twice adds `fee_rate × weight − fee` to
+    /// the deficit a second time. For a parent paying *above* the target
+    /// that term is negative, so the duplicate credits its surplus twice
+    /// and can cancel out a genuinely underpaying ancestor — leaving the
+    /// package below the target rate it was supposed to reach.
+    fn unconfirmed_ancestors(&self) -> Vec<&AncestorTx> {
+        let mut seen = std::collections::HashSet::new();
         self.inputs
             .iter()
-            .map(|u| u.status.unconfirmed_ancestor_weight())
+            .filter_map(|u| match &u.status {
+                UtxoStatus::Confirmed => None,
+                UtxoStatus::Pending { chain } => Some(chain.iter()),
+            })
+            .flatten()
+            .filter(|a| a.confirmations == 0 && seen.insert(a.id))
+            .collect()
+    }
+
+    /// Combined weight of the unconfirmed ancestors, counted once each.
+    fn unconfirmed_ancestor_weight(&self) -> Weight {
+        self.unconfirmed_ancestors()
+            .iter()
+            .map(|a| a.tx_weight)
             .sum()
     }
 
@@ -1059,12 +1086,9 @@ impl<'a> TransactionBuilder<'a> {
     ///
     /// Returns 0 if the ancestors already pay enough.
     fn cpfp_deficit(&self) -> u64 {
-        let ancestor_weight: Weight = self.unconfirmed_ancestor_weight();
-        let ancestor_fee: u64 = self
-            .inputs
-            .iter()
-            .map(|u| u.status.unconfirmed_ancestor_fee())
-            .sum();
+        let ancestors = self.unconfirmed_ancestors();
+        let ancestor_weight: Weight = ancestors.iter().map(|a| a.tx_weight).sum();
+        let ancestor_fee: u64 = ancestors.iter().map(|a| a.tx_fee).sum();
 
         let needed_ancestor_fee = fee_for_weight(self.fee_rate, ancestor_weight);
         needed_ancestor_fee.saturating_sub(ancestor_fee)

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -258,6 +258,12 @@ pub struct CoinSelectionParams {
     /// transaction that exceeds this limit.
     pub max_tx_weight: Weight,
 
+    /// Upper bound on the weight of this transaction plus all of its
+    /// unconfirmed ancestors. Keeps the resulting mempool cluster
+    /// inside Bitcoin's 101 kvB limit, which `max_tx_weight` alone
+    /// does not constrain.
+    pub max_ancestor_package_weight: Weight,
+
     /// Hard cap on the total number of transaction inputs, covering both the
     /// primary inputs selected in Step 2 and any consolidation inputs added in
     /// Step 3.
@@ -339,6 +345,21 @@ impl CoinSelectionParams {
     /// will not propagate through the standard P2P network.
     pub const DEFAULT_MAX_TX_WEIGHT: Weight = Weight::from_wu(400_000);
 
+    /// Default cap on this transaction plus its unconfirmed ancestors
+    /// (360 kWU = 90 kvB).
+    ///
+    /// Bitcoin Core bounds a mempool cluster at 101 kvB
+    /// (`getmempoolinfo.limitclustersize`; pre-cluster-mempool nodes
+    /// apply the same figure as `-limitancestorsize`). A transaction
+    /// whose ancestors push the cluster past that is rejected outright,
+    /// which is how one stalled settlement blocks every batch behind it.
+    ///
+    /// [`Self::DEFAULT_MAX_TX_WEIGHT`] bounds only the transaction
+    /// itself, so it cannot catch this. The 11 kvB held back from the
+    /// 101 kvB budget is deliberate: it keeps room for a CPFP child to
+    /// rescue the package if it does stall.
+    pub const DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT: Weight = Weight::from_wu(360_000);
+
     /// Default maximum total inputs selected for a withdrawal transaction,
     /// including both funding inputs and consolidation inputs.
     pub const DEFAULT_MAX_INPUTS: usize = 400;
@@ -348,9 +369,20 @@ impl CoinSelectionParams {
     /// room under Bitcoin's 101 kvB descendant-size budget for a direct child.
     pub const MAX_WITHDRAWAL_REQUESTS: usize = 40;
 
-    /// Default minimum fee rate floor (1 sat/vB), matching Bitcoin
-    /// Core's minimum relay fee.
-    pub const DEFAULT_MIN_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(1);
+    /// Default minimum fee rate floor (3 sat/vB).
+    ///
+    /// Deliberately above Bitcoin Core's 1 sat/vB minimum relay fee. A
+    /// batched withdrawal is both the largest and (at the relay floor)
+    /// the cheapest entry in a mempool, so it is the first candidate
+    /// evicted under memory pressure — and nothing re-announces an
+    /// evicted transaction. Small transactions at 1 sat/vB confirm
+    /// fine; an ~80 kvB one can sit indefinitely.
+    ///
+    /// The floor also has to exceed the rate an already-broadcast
+    /// parent paid, or [`TransactionBuilder::cpfp_deficit`] computes a
+    /// zero deficit and the CPFP boost silently never fires — leaving
+    /// no way to rescue a stalled settlement.
+    pub const DEFAULT_MIN_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(3);
 
     /// Default long-term average fee rate (10 sat/vB), matching
     /// Bitcoin Core's `-consolidatefeerate` default. Below this rate,
@@ -415,6 +447,7 @@ impl CoinSelectionParams {
 
         Self {
             max_tx_weight: Self::DEFAULT_MAX_TX_WEIGHT,
+            max_ancestor_package_weight: Self::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT,
             max_inputs: Self::DEFAULT_MAX_INPUTS,
             max_withdrawal_requests: Self::MAX_WITHDRAWAL_REQUESTS,
             max_fee_per_request,
@@ -541,6 +574,23 @@ pub enum CoinSelectionError {
         /// Estimated weight of a single-request transaction.
         weight: Weight,
         /// Configured maximum (`params.max_tx_weight`).
+        max_weight: Weight,
+    },
+
+    /// The transaction plus its unconfirmed ancestors exceeds
+    /// `params.max_ancestor_package_weight`. Broadcasting it would be
+    /// rejected by Bitcoin's 101 kvB cluster-size policy, so the batch is
+    /// refused before signing rather than after.
+    #[error(
+        "transaction weight {weight:#} plus unconfirmed ancestor weight \
+         {ancestor_weight:#} exceeds the configured package maximum {max_weight:#}"
+    )]
+    ExceedsMaxAncestorPackageWeight {
+        /// Weight of the candidate transaction itself.
+        weight: Weight,
+        /// Combined weight of its unconfirmed ancestors.
+        ancestor_weight: Weight,
+        /// Configured maximum (`params.max_ancestor_package_weight`).
         max_weight: Weight,
     },
 
@@ -786,7 +836,7 @@ pub fn select_coins(
             // could theoretically eliminate dust padding and lower
             // total_deduction enough to pass. We accept this
             // approximation for simplicity.
-            if builder.check_fees().is_err() || builder.exceeds_max_weight() {
+            if builder.check_fees().is_err() || builder.exceeds_any_weight_limit() {
                 builder.inputs.pop();
                 builder.compute_raw_change();
                 break;
@@ -925,22 +975,57 @@ impl<'a> TransactionBuilder<'a> {
         raw_change
     }
 
+    /// Combined weight of every unconfirmed ancestor of the selected
+    /// inputs.
+    ///
+    /// Inputs sharing an unconfirmed parent count that parent once per
+    /// input, so this can overestimate. Both callers — the package
+    /// bound and [`Self::cpfp_deficit`] — fail safe on an overestimate
+    /// (a tighter bound, a larger fee), so it is left conservative
+    /// rather than deduplicated, which would require tracking ancestor
+    /// identity.
+    fn unconfirmed_ancestor_weight(&self) -> Weight {
+        self.inputs
+            .iter()
+            .map(|u| u.status.unconfirmed_ancestor_weight())
+            .sum()
+    }
+
     /// Whether the transaction weight exceeds the configured maximum.
     fn exceeds_max_weight(&self) -> bool {
         self.weight() > self.params.max_tx_weight
     }
 
-    /// Check that the transaction weight is within the configured
-    /// maximum. Returns an error if exceeded.
+    /// Whether this transaction plus its unconfirmed ancestors exceeds
+    /// the configured package maximum — i.e. whether broadcasting it
+    /// would breach Bitcoin's cluster-size policy.
+    fn exceeds_max_ancestor_package_weight(&self) -> bool {
+        self.weight() + self.unconfirmed_ancestor_weight() > self.params.max_ancestor_package_weight
+    }
+
+    /// Whether either weight bound is exceeded. Used to back off while
+    /// adding consolidation inputs.
+    fn exceeds_any_weight_limit(&self) -> bool {
+        self.exceeds_max_weight() || self.exceeds_max_ancestor_package_weight()
+    }
+
+    /// Check that both the transaction weight and the unconfirmed
+    /// ancestor package weight are within their configured maximums.
     fn check_weight(&self) -> Result<(), CoinSelectionError> {
         if self.exceeds_max_weight() {
-            Err(CoinSelectionError::ExceedsMaxWeight {
+            return Err(CoinSelectionError::ExceedsMaxWeight {
                 weight: self.weight(),
                 max_weight: self.params.max_tx_weight,
-            })
-        } else {
-            Ok(())
+            });
         }
+        if self.exceeds_max_ancestor_package_weight() {
+            return Err(CoinSelectionError::ExceedsMaxAncestorPackageWeight {
+                weight: self.weight(),
+                ancestor_weight: self.unconfirmed_ancestor_weight(),
+                max_weight: self.params.max_ancestor_package_weight,
+            });
+        }
+        Ok(())
     }
 
     /// The total amount deducted from requests: the transaction's own
@@ -983,11 +1068,7 @@ impl<'a> TransactionBuilder<'a> {
     ///
     /// Returns 0 if the ancestors already pay enough.
     fn cpfp_deficit(&self) -> u64 {
-        let ancestor_weight: Weight = self
-            .inputs
-            .iter()
-            .map(|u| u.status.unconfirmed_ancestor_weight())
-            .sum();
+        let ancestor_weight: Weight = self.unconfirmed_ancestor_weight();
         let ancestor_fee: u64 = self
             .inputs
             .iter()

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -345,15 +345,20 @@ impl CoinSelectionParams {
     pub const DEFAULT_MAX_TX_WEIGHT: Weight = Weight::from_wu(400_000);
 
     /// Default cap on this transaction plus its unconfirmed ancestors
-    /// (360 kWU = 90 kvB).
+    /// (400 kWU = 100 kvB), just under the 101 kvB mempool cluster limit
+    /// (`getmempoolinfo.limitclustersize`) that Bitcoin rejects above.
     ///
-    /// Bitcoin rejects a mempool cluster over 101 kvB
-    /// (`getmempoolinfo.limitclustersize`), which is how one stalled
-    /// settlement blocks every batch behind it.
-    /// [`Self::DEFAULT_MAX_TX_WEIGHT`] bounds only the transaction, so
-    /// it cannot catch this. The 11 kvB held back leaves room for a
-    /// CPFP child to rescue the package.
-    pub const DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT: Weight = Weight::from_wu(360_000);
+    /// [`Self::DEFAULT_MAX_TX_WEIGHT`] bounds only the transaction, so it
+    /// cannot catch a batch whose ancestors push the cluster over — which
+    /// is how one stalled settlement blocks every batch behind it.
+    ///
+    /// This tracks what the network accepts rather than reserving CPFP
+    /// headroom. A rescue child is subject to this same bound, so holding
+    /// weight back here would block the rescues it is meant to enable.
+    /// Headroom comes from [`Self::MAX_WITHDRAWAL_REQUESTS`] and
+    /// [`Self::DEFAULT_MAX_INPUTS`] keeping each settlement well under the
+    /// cluster budget.
+    pub const DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT: Weight = Weight::from_wu(400_000);
 
     /// Default maximum total inputs selected for a withdrawal transaction,
     /// including both funding inputs and consolidation inputs.

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -116,9 +116,8 @@ impl SpendPath {
 #[derive(Clone, Debug)]
 pub struct AncestorTx {
     /// Identity of the withdrawal that produced this transaction.
-    ///
-    /// Selected inputs can descend from a shared parent, and the CPFP
-    /// arithmetic is only correct if that parent is counted once.
+    /// Inputs can share a parent; the CPFP arithmetic is only correct
+    /// if it is counted once.
     pub id: Address,
     /// Number of confirmations. `0` means the transaction is in the
     /// mempool only (not yet included in a block). Values `1..N`
@@ -194,19 +193,6 @@ impl UtxoStatus {
                 .iter()
                 .filter(|a| a.confirmations == 0)
                 .map(|a| a.tx_weight)
-                .sum(),
-        }
-    }
-
-    /// Returns the total fee paid by all unconfirmed ancestors
-    /// (transactions with 0 confirmations).
-    pub fn unconfirmed_ancestor_fee(&self) -> u64 {
-        match self {
-            UtxoStatus::Confirmed => 0,
-            UtxoStatus::Pending { chain } => chain
-                .iter()
-                .filter(|a| a.confirmations == 0)
-                .map(|a| a.tx_fee)
                 .sum(),
         }
     }
@@ -753,12 +739,12 @@ pub fn select_coins(
                 // Also ensure that if this UTXO were to be selected, the resulting unconfirmed
                 // chain depth would be less than the max relay limit
                 && u.status.mempool_chain_depth() < MAX_ANCESTOR_DEPTH
-                // A candidate whose ancestors alone fill the package budget can
-                // never be spent. Skip it here rather than letting it fail the
-                // whole selection: it is picked first (largest-first), so one
-                // stalled chain would otherwise block every withdrawal that the
-                // remaining confirmed UTXOs could have funded.
-                && u.status.unconfirmed_ancestor_weight() < params.max_ancestor_package_weight
+                // Unspendable: its ancestors plus the input it would add
+                // already fill the package budget. Skipped rather than left
+                // to fail the selection, since largest-first would pick it
+                // on every retry and block withdrawals the others could fund.
+                && u.status.unconfirmed_ancestor_weight() + u.spend_path.input_weight()
+                    < params.max_ancestor_package_weight
         })
         .collect();
     pool.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| a.id.cmp(&b.id)));
@@ -980,15 +966,12 @@ impl<'a> TransactionBuilder<'a> {
         raw_change
     }
 
-    /// Every unconfirmed ancestor of the selected inputs, each counted
-    /// once.
+    /// Every unconfirmed ancestor of the selected inputs, counted once.
     ///
-    /// Deduplication is load-bearing, not tidiness. Two inputs can share
-    /// a parent, and counting it twice adds `fee_rate × weight − fee` to
-    /// the deficit a second time. For a parent paying *above* the target
-    /// that term is negative, so the duplicate credits its surplus twice
-    /// and can cancel out a genuinely underpaying ancestor — leaving the
-    /// package below the target rate it was supposed to reach.
+    /// Counting a shared parent twice re-applies `fee_rate × weight −
+    /// fee`, which is negative for one paying above the target: its
+    /// surplus is credited twice and can cancel out an underpaying
+    /// ancestor, leaving the package short.
     fn unconfirmed_ancestors(&self) -> Vec<&AncestorTx> {
         let mut seen = std::collections::HashSet::new();
         self.inputs

--- a/crates/hashi/src/utxo_pool/sim.rs
+++ b/crates/hashi/src/utxo_pool/sim.rs
@@ -493,6 +493,17 @@ impl Simulator {
         }
     }
 
+    /// Distinct identity for a simulated ancestor. Ancestors are
+    /// deduplicated by id, so each must be unique.
+    fn fresh_ancestor_id(&mut self) -> sui_sdk_types::Address {
+        let n = self.next_id;
+        self.next_id += 1;
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&n.to_be_bytes());
+        bytes[31] = 0xa1;
+        sui_sdk_types::Address::new(bytes)
+    }
+
     fn fresh_utxo_id(&mut self) -> UtxoId {
         let n = self.next_id;
         self.next_id += 1;
@@ -555,12 +566,14 @@ impl Simulator {
                 continue;
             }
             let id = self.fresh_utxo_id();
+            let anc = self.fresh_ancestor_id();
             let candidate = UtxoCandidate {
                 id,
                 amount,
                 spend_path: SpendPath::TaprootScriptPath2of2,
                 status: UtxoStatus::Pending {
                     chain: vec![AncestorTx {
+                        id: anc,
                         confirmations: 0,
                         tx_weight: Weight::from_wu(800),
                         tx_fee: 500,
@@ -756,12 +769,14 @@ impl Simulator {
             }
 
             let id = self.fresh_utxo_id();
+            let anc = self.fresh_ancestor_id();
             let candidate = UtxoCandidate {
                 id,
                 amount: change,
                 spend_path: SpendPath::TaprootScriptPath2of2,
                 status: UtxoStatus::Pending {
                     chain: vec![AncestorTx {
+                        id: anc,
                         confirmations: 0,
                         tx_weight: Weight::from_wu(result.inputs.len() as u64 * 300 + 500),
                         tx_fee: result.fee,

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -1820,15 +1820,23 @@ fn test_ancestor_package_weight_limit_rejects_oversized_cluster() {
     );
 }
 
-/// The package budget must leave room under Bitcoin's 101 kvB cluster
-/// limit for a rescue child.
+/// The budget must sit under Bitcoin's cluster limit so we never build a
+/// package the network rejects, but not so far under that it blocks a
+/// rescue child the network would have accepted.
 #[test]
-fn test_ancestor_package_budget_reserves_cpfp_headroom() {
+fn test_ancestor_package_budget_tracks_cluster_limit() {
     const CLUSTER_LIMIT_VB: u64 = 101_000;
     let budget_vb = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_vbytes_ceil();
     assert!(
         budget_vb < CLUSTER_LIMIT_VB,
-        "package budget {budget_vb} vB leaves no room for a CPFP child under {CLUSTER_LIMIT_VB} vB"
+        "budget {budget_vb} vB must stay under the {CLUSTER_LIMIT_VB} vB cluster limit"
+    );
+    // A stalled ~78.7 kvB settlement must still leave room for a rescue.
+    let stalled_vb = 78_666;
+    assert!(
+        budget_vb - stalled_vb >= 20_000,
+        "budget leaves only {} vB for descendants of a stalled settlement",
+        budget_vb - stalled_vb
     );
 }
 

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -53,9 +53,8 @@ fn confirmed_utxo_with_vout(vout: u32, amount: u64) -> UtxoCandidate {
     }
 }
 
-/// Distinct identity for a test ancestor. Ancestors are deduplicated by
-/// id, so fixtures that expect their weights and fees to sum must not
-/// share one.
+/// Distinct identity for a test ancestor. Ancestors dedupe by id, so
+/// fixtures expecting their weights to sum must not share one.
 fn ancestor_id(utxo: u8, idx: usize) -> Address {
     let mut b = [0u8; 32];
     b[0] = utxo;
@@ -1773,8 +1772,7 @@ fn test_consolidation_undo_when_fee_cap_exceeded() {
 // ── Stalled-settlement regression (signet, 2026-07-24) ────────────────────
 
 /// A settlement paying the old 1 sat/vB floor already met the target, so
-/// `cpfp_deficit` was zero and no child could boost it. Shape is the
-/// transaction from the incident: 314,662 wu paying 78,680 sat.
+/// the deficit was zero and no child could boost it.
 #[test]
 fn test_cpfp_boosts_ancestor_stalled_at_relay_floor() {
     const STALLED_WEIGHT_WU: u64 = 314_662;
@@ -1825,10 +1823,8 @@ fn test_min_fee_rate_floor_exceeds_relay_minimum() {
     );
 }
 
-/// Ancestors that individually fit but jointly overflow the package
-/// budget must be refused before signing; Bitcoin would reject the
-/// broadcast otherwise. A single oversized candidate is filtered out
-/// earlier, so this exercises the combined case.
+/// Ancestors that individually fit but jointly overflow the budget must
+/// be refused; a single oversized candidate is filtered out earlier.
 #[test]
 fn test_ancestor_package_weight_limit_rejects_oversized_cluster() {
     let half = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_wu() * 2 / 3;
@@ -1850,15 +1846,14 @@ fn test_ancestor_package_weight_limit_rejects_oversized_cluster() {
     );
 }
 
-/// A pending UTXO whose ancestors alone fill the budget can never be
-/// spent. Because selection is largest-first it would be picked every
-/// time, so it must be skipped rather than failing the batch — otherwise
-/// one stalled settlement wedges every withdrawal that the remaining
-/// confirmed UTXOs could have funded.
+/// Selection is largest-first, so an unspendable pending UTXO would be
+/// picked every retry. It must be skipped, not fail the batch.
 #[test]
 fn test_infeasible_pending_candidate_is_skipped_not_fatal() {
-    let over = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_wu() + 4_000;
-    let stalled = pending_utxo_mixed(1, 100_000_000, &[(0, over, 1_000)]);
+    // Ancestors alone fit; ancestors plus the input this UTXO would add
+    // do not. Selecting it can never produce a valid package.
+    let just_under = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_wu() - 100;
+    let stalled = pending_utxo_mixed(1, 100_000_000, &[(0, just_under, 1_000)]);
     let usable = confirmed_utxo(2, 5_000_000);
     let requests = vec![make_request(1, 1_000_000, 0)];
 
@@ -1883,9 +1878,8 @@ fn test_infeasible_pending_candidate_is_skipped_not_fatal() {
     assert_conservation(&result);
 }
 
-/// Inputs sharing a parent must count it once. A parent paying above the
-/// target carries a fee surplus; crediting it twice can cancel out a
-/// genuinely underpaying ancestor and leave the package short.
+/// A shared parent must count once: one paying above target carries a
+/// surplus that, credited twice, cancels an underpayer's deficit.
 #[test]
 fn test_shared_ancestor_counted_once() {
     let over_payer = (0u32, 1_000u64, 2_000u64); // 250 vB @ 8 sat/vB, target is 5
@@ -1922,9 +1916,8 @@ fn test_shared_ancestor_counted_once() {
     assert_conservation(&deduped);
 }
 
-/// The budget must sit under Bitcoin's cluster limit so we never build a
-/// package the network rejects, but not so far under that it blocks a
-/// rescue child the network would have accepted.
+/// The budget must sit under Bitcoin's cluster limit, but not so far
+/// under that it blocks a rescue the network would have accepted.
 #[test]
 fn test_ancestor_package_budget_tracks_cluster_limit() {
     const CLUSTER_LIMIT_VB: u64 = 101_000;

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -1743,3 +1743,100 @@ fn test_consolidation_undo_when_fee_cap_exceeded() {
     );
     assert_conservation(&result);
 }
+
+// ── Stalled-settlement regression (signet, 2026-07-24) ────────────────────
+
+/// A settlement that paid the old 1 sat/vB floor stalled on signet for
+/// hours: at a 1 sat/vB target its own rate already met the target, so
+/// `cpfp_deficit` was zero and the child never boosted it. Selecting
+/// against the current floor must produce a real deficit.
+///
+/// Shape is the transaction from the incident: 314,662 wu (78,666 vb)
+/// paying 78,680 sat, i.e. 1.0002 sat/vB.
+#[test]
+fn test_cpfp_boosts_ancestor_stalled_at_relay_floor() {
+    const STALLED_WEIGHT_WU: u64 = 314_662;
+    const STALLED_FEE: u64 = 78_680;
+
+    let stalled = pending_utxo_mixed(1, 50_000_000, &[(0, STALLED_WEIGHT_WU, STALLED_FEE)]);
+    let requests = vec![make_request(1, 1_000_000, 0)];
+
+    let floor = CoinSelectionParams::DEFAULT_MIN_FEE_RATE;
+    let result = select_coins(&[stalled], &requests, &default_params(), floor)
+        .expect("selection should succeed");
+
+    // The deficit is what lifts the stalled ancestor to the floor.
+    let deficit = floor
+        .fee_wu(Weight::from_wu(STALLED_WEIGHT_WU))
+        .expect("fee fits")
+        .to_sat()
+        - STALLED_FEE;
+    assert!(deficit > 0, "a 1 sat/vB ancestor must leave a deficit");
+
+    // The child pays that deficit on top of its own fee, so the whole
+    // package clears the floor — which is what gets the parent mined.
+    assert!(
+        result.fee > deficit,
+        "fee {} must cover the CPFP deficit {deficit} plus its own fee",
+        result.fee
+    );
+
+    // Regression guard: at the old 1 sat/vB floor this was zero, which
+    // is precisely why the settlement could not be rescued.
+    let old_floor = FeeRate::from_sat_per_vb_unchecked(1);
+    assert_eq!(
+        old_floor
+            .fee_wu(Weight::from_wu(STALLED_WEIGHT_WU))
+            .expect("fee fits")
+            .to_sat()
+            .saturating_sub(STALLED_FEE),
+        0,
+        "the 1 sat/vB floor produced no deficit — the original bug"
+    );
+
+    assert_conservation(&result);
+}
+
+/// The floor itself must stay above the relay minimum, or the deficit
+/// above collapses to zero again for any ancestor that paid 1 sat/vB.
+#[test]
+fn test_min_fee_rate_floor_exceeds_relay_minimum() {
+    assert!(
+        CoinSelectionParams::DEFAULT_MIN_FEE_RATE > FeeRate::from_sat_per_vb_unchecked(1),
+        "floor must exceed the 1 sat/vB relay minimum to rescue a stalled ancestor"
+    );
+}
+
+/// Unconfirmed ancestors that would push the mempool cluster past the
+/// configured package budget must be refused before signing — Bitcoin
+/// would reject the broadcast, wedging every batch behind it.
+#[test]
+fn test_ancestor_package_weight_limit_rejects_oversized_cluster() {
+    let over = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_wu() + 4_000;
+    // Fee is generous so the weight bound, not the CPFP deficit, binds.
+    let bloated = pending_utxo_mixed(1, 50_000_000, &[(0, over, 10_000_000)]);
+    let requests = vec![make_request(1, 1_000_000, 0)];
+
+    let err = select_coins(&[bloated], &requests, &default_params(), default_fee_rate())
+        .expect_err("selection must refuse an oversized ancestor package");
+
+    assert!(
+        matches!(
+            err,
+            CoinSelectionError::ExceedsMaxAncestorPackageWeight { .. }
+        ),
+        "expected ExceedsMaxAncestorPackageWeight, got {err:?}"
+    );
+}
+
+/// The package budget must leave room under Bitcoin's 101 kvB cluster
+/// limit for a rescue child.
+#[test]
+fn test_ancestor_package_budget_reserves_cpfp_headroom() {
+    const CLUSTER_LIMIT_VB: u64 = 101_000;
+    let budget_vb = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_vbytes_ceil();
+    assert!(
+        budget_vb < CLUSTER_LIMIT_VB,
+        "package budget {budget_vb} vB leaves no room for a CPFP child under {CLUSTER_LIMIT_VB} vB"
+    );
+}

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -1746,13 +1746,9 @@ fn test_consolidation_undo_when_fee_cap_exceeded() {
 
 // ── Stalled-settlement regression (signet, 2026-07-24) ────────────────────
 
-/// A settlement that paid the old 1 sat/vB floor stalled on signet for
-/// hours: at a 1 sat/vB target its own rate already met the target, so
-/// `cpfp_deficit` was zero and the child never boosted it. Selecting
-/// against the current floor must produce a real deficit.
-///
-/// Shape is the transaction from the incident: 314,662 wu (78,666 vb)
-/// paying 78,680 sat, i.e. 1.0002 sat/vB.
+/// A settlement paying the old 1 sat/vB floor already met the target, so
+/// `cpfp_deficit` was zero and no child could boost it. Shape is the
+/// transaction from the incident: 314,662 wu paying 78,680 sat.
 #[test]
 fn test_cpfp_boosts_ancestor_stalled_at_relay_floor() {
     const STALLED_WEIGHT_WU: u64 = 314_662;
@@ -1765,7 +1761,6 @@ fn test_cpfp_boosts_ancestor_stalled_at_relay_floor() {
     let result = select_coins(&[stalled], &requests, &default_params(), floor)
         .expect("selection should succeed");
 
-    // The deficit is what lifts the stalled ancestor to the floor.
     let deficit = floor
         .fee_wu(Weight::from_wu(STALLED_WEIGHT_WU))
         .expect("fee fits")
@@ -1773,16 +1768,13 @@ fn test_cpfp_boosts_ancestor_stalled_at_relay_floor() {
         - STALLED_FEE;
     assert!(deficit > 0, "a 1 sat/vB ancestor must leave a deficit");
 
-    // The child pays that deficit on top of its own fee, so the whole
-    // package clears the floor — which is what gets the parent mined.
     assert!(
         result.fee > deficit,
         "fee {} must cover the CPFP deficit {deficit} plus its own fee",
         result.fee
     );
 
-    // Regression guard: at the old 1 sat/vB floor this was zero, which
-    // is precisely why the settlement could not be rescued.
+    // At the old 1 sat/vB floor this was zero — the original bug.
     let old_floor = FeeRate::from_sat_per_vb_unchecked(1);
     assert_eq!(
         old_floor
@@ -1797,8 +1789,8 @@ fn test_cpfp_boosts_ancestor_stalled_at_relay_floor() {
     assert_conservation(&result);
 }
 
-/// The floor itself must stay above the relay minimum, or the deficit
-/// above collapses to zero again for any ancestor that paid 1 sat/vB.
+/// The floor must stay above the relay minimum, or the deficit collapses
+/// to zero again for any ancestor that paid 1 sat/vB.
 #[test]
 fn test_min_fee_rate_floor_exceeds_relay_minimum() {
     assert!(
@@ -1807,9 +1799,8 @@ fn test_min_fee_rate_floor_exceeds_relay_minimum() {
     );
 }
 
-/// Unconfirmed ancestors that would push the mempool cluster past the
-/// configured package budget must be refused before signing — Bitcoin
-/// would reject the broadcast, wedging every batch behind it.
+/// Ancestors pushing the cluster past the package budget must be refused
+/// before signing; Bitcoin would reject the broadcast otherwise.
 #[test]
 fn test_ancestor_package_weight_limit_rejects_oversized_cluster() {
     let over = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_wu() + 4_000;
@@ -1839,4 +1830,15 @@ fn test_ancestor_package_budget_reserves_cpfp_headroom() {
         budget_vb < CLUSTER_LIMIT_VB,
         "package budget {budget_vb} vB leaves no room for a CPFP child under {CLUSTER_LIMIT_VB} vB"
     );
+}
+
+/// The configured floor must not be able to invert the clamp against
+/// `DEFAULT_HIGH_FEE_RATE_THRESHOLD`, which would panic every node.
+#[test]
+fn test_configured_floor_capped_at_high_fee_threshold() {
+    let ceiling = CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD;
+    let absurd = FeeRate::from_sat_per_vb_unchecked(500);
+    let floor = absurd.min(ceiling);
+    assert!(floor <= ceiling, "floor must never exceed the ceiling");
+    let _ = FeeRate::from_sat_per_vb_unchecked(1).clamp(floor, ceiling);
 }

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -53,6 +53,17 @@ fn confirmed_utxo_with_vout(vout: u32, amount: u64) -> UtxoCandidate {
     }
 }
 
+/// Distinct identity for a test ancestor. Ancestors are deduplicated by
+/// id, so fixtures that expect their weights and fees to sum must not
+/// share one.
+fn ancestor_id(utxo: u8, idx: usize) -> Address {
+    let mut b = [0u8; 32];
+    b[0] = utxo;
+    b[1] = idx as u8;
+    b[2] = 0xa1;
+    Address::new(b)
+}
+
 /// Creates a pending UTXO with one 0-confirmation ancestor (mempool
 /// depth 1). The ancestor has weight 1000 WU and fee 500 sat.
 fn pending_utxo(n: u8, amount: u64) -> UtxoCandidate {
@@ -62,6 +73,7 @@ fn pending_utxo(n: u8, amount: u64) -> UtxoCandidate {
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
+                id: ancestor_id(n, 0),
                 confirmations: 0,
                 tx_weight: Weight::from_wu(1000),
                 tx_fee: 500,
@@ -74,7 +86,9 @@ fn pending_utxo(n: u8, amount: u64) -> UtxoCandidate {
 /// Each ancestor has weight 1000 WU and fee `fee_per_ancestor` sat.
 fn pending_utxo_deep(n: u8, amount: u64, depth: usize, fee_per_ancestor: u64) -> UtxoCandidate {
     let chain = (0..depth)
-        .map(|_| AncestorTx {
+        .enumerate()
+        .map(|(i, _)| AncestorTx {
+            id: ancestor_id(n, i),
             confirmations: 0,
             tx_weight: Weight::from_wu(1000),
             tx_fee: fee_per_ancestor,
@@ -93,7 +107,9 @@ fn pending_utxo_deep(n: u8, amount: u64, depth: usize, fee_per_ancestor: u64) ->
 fn pending_utxo_mixed(n: u8, amount: u64, ancestors: &[(u32, u64, u64)]) -> UtxoCandidate {
     let chain = ancestors
         .iter()
-        .map(|&(confirmations, weight_wu, fee)| AncestorTx {
+        .enumerate()
+        .map(|(i, &(confirmations, weight_wu, fee))| AncestorTx {
+            id: ancestor_id(n, i),
             confirmations,
             tx_weight: Weight::from_wu(weight_wu),
             tx_fee: fee,
@@ -340,6 +356,7 @@ fn test_cpfp_pending_utxo_increases_fee() {
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
+                id: ancestor_id(1, 0),
                 confirmations: 0,
                 tx_weight: Weight::from_wu(4000),
                 tx_fee: 10, // very low fee ancestor
@@ -395,6 +412,7 @@ fn test_cpfp_multiple_pending_utxos_summed() {
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
+                id: ancestor_id(1, 0),
                 confirmations: 0,
                 tx_weight: Weight::from_wu(2000),
                 tx_fee: 100, // underpaying
@@ -407,6 +425,7 @@ fn test_cpfp_multiple_pending_utxos_summed() {
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
+                id: ancestor_id(2, 0),
                 confirmations: 0,
                 tx_weight: Weight::from_wu(3000),
                 tx_fee: 150, // also underpaying
@@ -811,7 +830,8 @@ fn arb_pending_utxo() -> impl Strategy<Value = UtxoCandidate> {
     )
         .prop_map(|(id, amount, depth, fee_per_ancestor)| {
             let chain = (0..depth)
-                .map(|_| AncestorTx {
+                .map(|i| AncestorTx {
+                    id: ancestor_id(id, i),
                     confirmations: 0,
                     tx_weight: Weight::from_wu(1000),
                     tx_fee: fee_per_ancestor,
@@ -1285,6 +1305,7 @@ fn test_cpfp_no_deficit_for_well_paying_ancestor() {
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
+                id: ancestor_id(1, 0),
                 confirmations: 0,
                 tx_weight: Weight::from_wu(1000),
                 tx_fee: 2000,
@@ -1329,6 +1350,7 @@ fn test_cpfp_deficit_exhausts_fee_cap() {
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
+                id: ancestor_id(1, 0),
                 confirmations: 0,
                 tx_weight: Weight::from_wu(400_000), // huge ancestor
                 tx_fee: 1,                           // almost zero fee
@@ -1339,6 +1361,9 @@ fn test_cpfp_deficit_exhausts_fee_cap() {
     let requests = vec![make_request(1, 100_000, 0)];
     let params = CoinSelectionParams {
         max_fee_per_request: 5_000, // tight budget
+        // Leave the package budget out of it: this covers the fee cap,
+        // and the default would filter the heavy ancestor out first.
+        max_ancestor_package_weight: Weight::from_wu(800_000),
         ..default_params()
     };
     let result = select_coins(&[heavy_low_fee], &requests, &params, default_fee_rate());
@@ -1392,6 +1417,7 @@ fn test_fund_balance_with_cpfp() {
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
+                id: ancestor_id(1, 0),
                 confirmations: 0,
                 tx_weight: Weight::from_wu(5000),
                 tx_fee: 100, // severely underpaying
@@ -1799,16 +1825,20 @@ fn test_min_fee_rate_floor_exceeds_relay_minimum() {
     );
 }
 
-/// Ancestors pushing the cluster past the package budget must be refused
-/// before signing; Bitcoin would reject the broadcast otherwise.
+/// Ancestors that individually fit but jointly overflow the package
+/// budget must be refused before signing; Bitcoin would reject the
+/// broadcast otherwise. A single oversized candidate is filtered out
+/// earlier, so this exercises the combined case.
 #[test]
 fn test_ancestor_package_weight_limit_rejects_oversized_cluster() {
-    let over = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_wu() + 4_000;
-    // Fee is generous so the weight bound, not the CPFP deficit, binds.
-    let bloated = pending_utxo_mixed(1, 50_000_000, &[(0, over, 10_000_000)]);
+    let half = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_wu() * 2 / 3;
+    // Fees are generous so the weight bound, not the CPFP deficit, binds.
+    let a = pending_utxo_mixed(1, 600_000, &[(0, half, 10_000_000)]);
+    let b = pending_utxo_mixed(2, 600_000, &[(0, half, 10_000_000)]);
+    // One request large enough that both candidates are required.
     let requests = vec![make_request(1, 1_000_000, 0)];
 
-    let err = select_coins(&[bloated], &requests, &default_params(), default_fee_rate())
+    let err = select_coins(&[a, b], &requests, &default_params(), default_fee_rate())
         .expect_err("selection must refuse an oversized ancestor package");
 
     assert!(
@@ -1818,6 +1848,78 @@ fn test_ancestor_package_weight_limit_rejects_oversized_cluster() {
         ),
         "expected ExceedsMaxAncestorPackageWeight, got {err:?}"
     );
+}
+
+/// A pending UTXO whose ancestors alone fill the budget can never be
+/// spent. Because selection is largest-first it would be picked every
+/// time, so it must be skipped rather than failing the batch — otherwise
+/// one stalled settlement wedges every withdrawal that the remaining
+/// confirmed UTXOs could have funded.
+#[test]
+fn test_infeasible_pending_candidate_is_skipped_not_fatal() {
+    let over = CoinSelectionParams::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT.to_wu() + 4_000;
+    let stalled = pending_utxo_mixed(1, 100_000_000, &[(0, over, 1_000)]);
+    let usable = confirmed_utxo(2, 5_000_000);
+    let requests = vec![make_request(1, 1_000_000, 0)];
+
+    let result = select_coins(
+        &[stalled, usable],
+        &requests,
+        &default_params(),
+        default_fee_rate(),
+    )
+    .expect("the confirmed UTXO should still fund the batch");
+
+    assert_eq!(
+        result.inputs.len(),
+        1,
+        "only the usable UTXO should be spent"
+    );
+    assert_eq!(
+        result.inputs[0].id,
+        make_utxo_id(2),
+        "the stalled candidate must not be selected"
+    );
+    assert_conservation(&result);
+}
+
+/// Inputs sharing a parent must count it once. A parent paying above the
+/// target carries a fee surplus; crediting it twice can cancel out a
+/// genuinely underpaying ancestor and leave the package short.
+#[test]
+fn test_shared_ancestor_counted_once() {
+    let over_payer = (0u32, 1_000u64, 2_000u64); // 250 vB @ 8 sat/vB, target is 5
+    let under_payer = (0u32, 1_000u64, 100u64); //  250 vB @ 0.4 sat/vB
+    let requests = vec![make_request(1, 2_500_000, 0)];
+
+    let fee_for = |share_parent: bool| {
+        let a = pending_utxo_mixed(1, 1_000_000, &[over_payer]);
+        let mut b = pending_utxo_mixed(2, 1_000_000, &[over_payer]);
+        if share_parent {
+            let parent = match &a.status {
+                UtxoStatus::Pending { chain } => chain[0].id,
+                _ => unreachable!(),
+            };
+            if let UtxoStatus::Pending { chain } = &mut b.status {
+                chain[0].id = parent;
+            }
+        }
+        let c = pending_utxo_mixed(3, 1_000_000, &[under_payer]);
+        select_coins(&[a, b, c], &requests, &default_params(), default_fee_rate())
+            .expect("selection should succeed")
+    };
+
+    let deduped = fee_for(true);
+    let double_counted = fee_for(false);
+
+    assert!(
+        deduped.fee > double_counted.fee,
+        "counting the shared parent once must charge more ({} vs {}): \
+         double-crediting its surplus cancels the underpayer's deficit",
+        deduped.fee,
+        double_counted.fee
+    );
+    assert_conservation(&deduped);
 }
 
 /// The budget must sit under Bitcoin's cluster limit so we never build a

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -1092,10 +1092,8 @@ impl Hashi {
 
     /// The configured fee-rate floor, capped at the high-fee threshold.
     ///
-    /// Leader and validator must derive this identically: the leader builds
-    /// to it and the validator prices its ceiling from it, so an uncapped
-    /// value on either side would put them on different fee policies. It
-    /// also keeps `clamp`, which panics when inverted, well-formed.
+    /// Leader and validator must derive this identically or they price
+    /// fees differently. The cap also keeps `clamp` from inverting.
     fn effective_min_fee_rate(&self) -> FeeRate {
         self.config
             .withdrawal_min_fee_rate()
@@ -1606,17 +1604,14 @@ fn unconfirmed_ancestor_depth(
 /// one [`AncestorTx`] entry with its confirmation count, weight, and fee.
 /// The walk is a BFS over the ancestor DAG, capped at
 /// [`MAX_ANCESTOR_DEPTH`] levels.
-/// Aggregate weight and fee of every unconfirmed ancestor of `records`,
-/// counting each ancestor once.
+/// Aggregate weight and fee of the unconfirmed ancestors of `records`,
+/// counted once each.
 ///
 /// Mirrors `unconfirmed_ancestor_depth`: anything still in
-/// `withdrawal_txns` is treated as unconfirmed, so validation stays
-/// deterministic across the committee with no Bitcoin round-trip. Entries
-/// linger until the finality threshold, so an ancestor already in a block
-/// still contributes a deficit here even though CPFP cannot boost it.
-/// That only widens the fee *ceiling* — the binding limit is the on-chain
-/// per-request cap — but it makes this an upper bound on the leader's
-/// figure rather than a match for it.
+/// `withdrawal_txns` counts as unconfirmed, keeping validation
+/// deterministic without a Bitcoin round-trip. Entries linger until
+/// finality, so this is an upper bound on the leader's figure — it
+/// widens only the ceiling, which the on-chain per-request cap bounds.
 fn unconfirmed_ancestor_package(
     hashi: &Hashi,
     records: &[&UtxoRecord],
@@ -1690,9 +1685,8 @@ fn build_ancestor_chain(
             continue;
         }
 
-        // The ancestor set is a DAG, not a tree: a batch spending two
-        // change outputs of the same parent would otherwise record it
-        // twice and double its weight and fee in the CPFP arithmetic.
+        // A DAG, not a tree: spending two change outputs of one parent
+        // would otherwise record it twice.
         if !seen.insert(wid) {
             continue;
         }
@@ -1977,8 +1971,8 @@ mod tests {
         );
     }
 
-    /// The settlement that stalled on signet: 700 inputs, 71 outputs,
-    /// 314,662 wu on-chain against 127,060 wu unsigned.
+    /// The settlement that stalled on signet: 314,662 wu on-chain
+    /// against 127,060 wu unsigned.
     #[test]
     fn test_signed_weight_matches_onchain_weight() {
         use bitcoin::Amount;

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -401,13 +401,10 @@ impl Hashi {
             }
         }
 
-        // 6. Validate fee is reasonable.
-        //
-        // The ceiling is evaluated over the whole CPFP package, not the
-        // transaction alone. A leader spending unconfirmed change must
-        // also cover the shortfall its ancestors owe, so judging the fee
-        // in isolation would reject every legitimate rescue of a stalled
-        // settlement.
+        // 6. Validate fee is reasonable. The ceiling covers the whole CPFP
+        //    package: a leader spending unconfirmed change must also cover
+        //    what its ancestors owe, so judging the transaction alone
+        //    would reject every legitimate rescue of a stalled settlement.
         {
             // Estimate transaction weight.
             let num_inputs = selected_utxos.len() as u64;
@@ -432,10 +429,8 @@ impl Hashi {
                 "Fee {fee} sats is below minimum relay fee {relay_min_fee} sats"
             );
 
-            // Fee ceiling: clamp the node's estimate to the configured
-            // floor, then allow the tolerance multiplier over what a
-            // correct leader would pay — its own fee plus the CPFP
-            // deficit owed by any unconfirmed ancestors.
+            // Allow the tolerance multiplier over what a correct leader
+            // would pay: its own fee plus any ancestor CPFP deficit.
             let kyoto_fee_rate = self
                 .btc_monitor()
                 .get_recent_fee_rate(self.config.withdrawal_fee_conf_target())
@@ -1141,8 +1136,9 @@ impl Hashi {
             .get_recent_fee_rate(self.config.withdrawal_fee_conf_target())
             .await
             .map_err(|e| WithdrawalCommitmentError::FeeEstimateFailed(anyhow!(e)))?;
-        let min_fee_rate = CoinSelectionParams::DEFAULT_MIN_FEE_RATE;
         let max_fee_rate = CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD;
+        // Cap the configured floor at the ceiling: `clamp` panics if inverted.
+        let min_fee_rate = self.config.withdrawal_min_fee_rate().min(max_fee_rate);
         let fee_rate = kyoto_fee_rate.clamp(min_fee_rate, max_fee_rate);
 
         let change_address = self
@@ -1207,6 +1203,7 @@ impl Hashi {
 
             let params = CoinSelectionParams {
                 max_inputs,
+                min_fee_rate,
                 long_term_fee_rate: configured_long_term_fee_rate,
                 max_fee_per_request: self.onchain_state().worst_case_network_fee(),
                 max_withdrawal_requests: request_count,
@@ -1599,12 +1596,12 @@ fn unconfirmed_ancestor_depth(
 /// one [`AncestorTx`] entry with its confirmation count, weight, and fee.
 /// The walk is a BFS over the ancestor DAG, capped at
 /// [`MAX_ANCESTOR_DEPTH`] levels.
-/// Aggregate weight and fee of every unconfirmed ancestor of `records`.
+/// Aggregate weight and fee of every unconfirmed ancestor of `records`,
+/// counting each ancestor once.
 ///
-/// Mirrors [`unconfirmed_ancestor_depth`]: any ancestor still present in
-/// `withdrawal_txns` is treated as unconfirmed, so no Bitcoin round-trip
-/// is needed on the validation path. Each ancestor is counted once even
-/// when several selected UTXOs descend from it.
+/// Mirrors `unconfirmed_ancestor_depth`: anything still in
+/// `withdrawal_txns` is treated as unconfirmed, so validation needs no
+/// Bitcoin round-trip.
 fn unconfirmed_ancestor_package(
     hashi: &Hashi,
     records: &[&UtxoRecord],
@@ -1648,14 +1645,11 @@ fn unconfirmed_ancestor_package(
 
 /// Weight of a withdrawal transaction once signed.
 ///
-/// [`Hashi::build_unsigned_withdrawal_tx`] leaves every witness empty, so
-/// `Transaction::weight` on its result is base-only — for a 700-input
-/// settlement that is 127,060 wu against a real 314,662 wu, a 2.5x
-/// undercount. Feeding that to the CPFP calculation would compute a
-/// deficit far too small to lift a stalled ancestor.
-///
-/// Adds each input's witness satisfaction weight plus the 2 wu segwit
-/// marker and flag, which an all-empty-witness transaction omits.
+/// [`Hashi::build_unsigned_withdrawal_tx`] leaves witnesses empty, so its
+/// `weight()` is base-only — 127,060 wu for a 700-input settlement that
+/// weighs 314,662 wu on-chain. Sizing a CPFP deficit against that would
+/// badly underpay. Adds each input's satisfaction weight plus the 2 wu
+/// segwit marker and flag that an empty-witness transaction omits.
 fn signed_weight_of(unsigned: &bitcoin::Transaction, input_count: usize) -> Weight {
     let satisfaction = SpendPath::TaprootScriptPath2of2
         .satisfaction_weight()
@@ -1959,12 +1953,8 @@ mod tests {
         );
     }
 
-    /// The signed weight of the settlement that stalled on signet
-    /// (2026-07-24): 700 inputs, 71 outputs, 314,662 wu on-chain.
-    ///
-    /// The unsigned transaction is base-only at 127,060 wu. Using that
-    /// figure for CPFP would compute a deficit against 2.5x too little
-    /// weight and fail to lift a stalled ancestor.
+    /// The settlement that stalled on signet: 700 inputs, 71 outputs,
+    /// 314,662 wu on-chain against 127,060 wu unsigned.
     #[test]
     fn test_signed_weight_matches_onchain_weight() {
         use bitcoin::Amount;

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -435,8 +435,7 @@ impl Hashi {
                 .btc_monitor()
                 .get_recent_fee_rate(self.config.withdrawal_fee_conf_target())
                 .await?;
-            let clamped_fee_rate =
-                std::cmp::max(kyoto_fee_rate, self.config.withdrawal_min_fee_rate());
+            let clamped_fee_rate = std::cmp::max(kyoto_fee_rate, self.effective_min_fee_rate());
 
             let (ancestor_weight, ancestor_fee) = unconfirmed_ancestor_package(
                 self,
@@ -1091,6 +1090,18 @@ impl Hashi {
 
     // --- UTXO selection and tx crafting ---
 
+    /// The configured fee-rate floor, capped at the high-fee threshold.
+    ///
+    /// Leader and validator must derive this identically: the leader builds
+    /// to it and the validator prices its ceiling from it, so an uncapped
+    /// value on either side would put them on different fee policies. It
+    /// also keeps `clamp`, which panics when inverted, well-formed.
+    fn effective_min_fee_rate(&self) -> FeeRate {
+        self.config
+            .withdrawal_min_fee_rate()
+            .min(CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD)
+    }
+
     /// Build an unsigned Bitcoin transaction for a withdrawal. This is used both
     /// by the leader when initially crafting the tx, and by validators when
     /// verifying that a proposed `WithdrawalTxCommitment` produces the expected txid.
@@ -1137,8 +1148,7 @@ impl Hashi {
             .await
             .map_err(|e| WithdrawalCommitmentError::FeeEstimateFailed(anyhow!(e)))?;
         let max_fee_rate = CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD;
-        // Cap the configured floor at the ceiling: `clamp` panics if inverted.
-        let min_fee_rate = self.config.withdrawal_min_fee_rate().min(max_fee_rate);
+        let min_fee_rate = self.effective_min_fee_rate();
         let fee_rate = kyoto_fee_rate.clamp(min_fee_rate, max_fee_rate);
 
         let change_address = self
@@ -1600,8 +1610,13 @@ fn unconfirmed_ancestor_depth(
 /// counting each ancestor once.
 ///
 /// Mirrors `unconfirmed_ancestor_depth`: anything still in
-/// `withdrawal_txns` is treated as unconfirmed, so validation needs no
-/// Bitcoin round-trip.
+/// `withdrawal_txns` is treated as unconfirmed, so validation stays
+/// deterministic across the committee with no Bitcoin round-trip. Entries
+/// linger until the finality threshold, so an ancestor already in a block
+/// still contributes a deficit here even though CPFP cannot boost it.
+/// That only widens the fee *ceiling* — the binding limit is the on-chain
+/// per-request cap — but it makes this an upper bound on the leader's
+/// figure rather than a match for it.
 fn unconfirmed_ancestor_package(
     hashi: &Hashi,
     records: &[&UtxoRecord],
@@ -1666,11 +1681,19 @@ fn build_ancestor_chain(
     utxo_records: &BTreeMap<UtxoId, UtxoRecord>,
 ) -> Vec<AncestorTx> {
     let mut chain = Vec::new();
+    let mut seen: std::collections::HashSet<Address> = std::collections::HashSet::new();
     let mut queue = std::collections::VecDeque::new();
     queue.push_back((producing_id, 0usize));
 
     while let Some((wid, depth)) = queue.pop_front() {
         if depth >= MAX_ANCESTOR_DEPTH {
+            continue;
+        }
+
+        // The ancestor set is a DAG, not a tree: a batch spending two
+        // change outputs of the same parent would otherwise record it
+        // twice and double its weight and fee in the CPFP arithmetic.
+        if !seen.insert(wid) {
             continue;
         }
 
@@ -1687,6 +1710,7 @@ fn build_ancestor_chain(
         let output_total: u64 = txn.all_outputs().iter().map(|o| o.amount).sum();
 
         chain.push(AncestorTx {
+            id: wid,
             confirmations,
             tx_weight: signed_weight_of(&tx, txn.inputs.len()),
             tx_fee: input_total.saturating_sub(output_total),

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -403,13 +403,11 @@ impl Hashi {
 
         // 6. Validate fee is reasonable.
         //
-        // TODO: When spending unconfirmed change UTXOs the effective fee
-        // rate that matters for mining is the *package* fee rate across
-        // the entire ancestor chain (CPFP). This check currently
-        // evaluates the transaction in isolation, which may over- or
-        // under-estimate the true cost to get the package mined. A
-        // future revision should compute the aggregate ancestor weight
-        // and fees and validate the package fee rate instead.
+        // The ceiling is evaluated over the whole CPFP package, not the
+        // transaction alone. A leader spending unconfirmed change must
+        // also cover the shortfall its ancestors owe, so judging the fee
+        // in isolation would reject every legitimate rescue of a stalled
+        // settlement.
         {
             // Estimate transaction weight.
             let num_inputs = selected_utxos.len() as u64;
@@ -424,35 +422,52 @@ impl Hashi {
             let tx_weight =
                 Weight::from_wu(hashi_bitcoin::TX_FIXED_WEIGHT_WU + input_weight + output_weight);
 
-            let min_fee_rate = FeeRate::from_sat_per_vb_unchecked(1);
-
             // Fee must be at least the minimum relay fee (1 sat/vB).
-            let min_fee = min_fee_rate
+            let relay_min_fee = FeeRate::from_sat_per_vb_unchecked(1)
                 .fee_wu(tx_weight)
                 .map(|a| a.to_sat())
                 .unwrap_or(0);
             anyhow::ensure!(
-                fee >= min_fee,
-                "Fee {fee} sats is below minimum relay fee {min_fee} sats"
+                fee >= relay_min_fee,
+                "Fee {fee} sats is below minimum relay fee {relay_min_fee} sats"
             );
 
-            // Fee ceiling: clamp the fee rate from our Bitcoin node to
-            // a floor of 1 sat/vB, then cap at the tolerance multiplier.
+            // Fee ceiling: clamp the node's estimate to the configured
+            // floor, then allow the tolerance multiplier over what a
+            // correct leader would pay — its own fee plus the CPFP
+            // deficit owed by any unconfirmed ancestors.
             let kyoto_fee_rate = self
                 .btc_monitor()
                 .get_recent_fee_rate(self.config.withdrawal_fee_conf_target())
                 .await?;
-            let clamped_fee_rate = std::cmp::max(kyoto_fee_rate, min_fee_rate);
+            let clamped_fee_rate =
+                std::cmp::max(kyoto_fee_rate, self.config.withdrawal_min_fee_rate());
+
+            let (ancestor_weight, ancestor_fee) = unconfirmed_ancestor_package(
+                self,
+                &selected_records,
+                &withdrawal_txns,
+                &utxo_records,
+            );
+            let cpfp_deficit = clamped_fee_rate
+                .fee_wu(ancestor_weight)
+                .map(|a| a.to_sat())
+                .unwrap_or(0)
+                .saturating_sub(ancestor_fee);
+
             let estimated_fee = clamped_fee_rate
                 .fee_wu(tx_weight)
                 .map(|a| a.to_sat())
-                .unwrap_or(0);
+                .unwrap_or(0)
+                .saturating_add(cpfp_deficit);
             let max_fee = estimated_fee.saturating_mul(FEE_RATE_TOLERANCE_MULTIPLIER);
             anyhow::ensure!(
                 fee <= max_fee,
                 "Fee {fee} sats exceeds maximum allowed {max_fee} sats \
                  ({FEE_RATE_TOLERANCE_MULTIPLIER}x the clamped estimate of \
-                 {estimated_fee} sats at {clamped_fee_rate})"
+                 {estimated_fee} sats at {clamped_fee_rate}, including a \
+                 {cpfp_deficit} sat CPFP deficit for {ancestor_weight} of \
+                 unconfirmed ancestors)"
             );
         }
 
@@ -1584,6 +1599,71 @@ fn unconfirmed_ancestor_depth(
 /// one [`AncestorTx`] entry with its confirmation count, weight, and fee.
 /// The walk is a BFS over the ancestor DAG, capped at
 /// [`MAX_ANCESTOR_DEPTH`] levels.
+/// Aggregate weight and fee of every unconfirmed ancestor of `records`.
+///
+/// Mirrors [`unconfirmed_ancestor_depth`]: any ancestor still present in
+/// `withdrawal_txns` is treated as unconfirmed, so no Bitcoin round-trip
+/// is needed on the validation path. Each ancestor is counted once even
+/// when several selected UTXOs descend from it.
+fn unconfirmed_ancestor_package(
+    hashi: &Hashi,
+    records: &[&UtxoRecord],
+    withdrawal_txns: &BTreeMap<Address, WithdrawalTransaction>,
+    utxo_records: &BTreeMap<UtxoId, UtxoRecord>,
+) -> (Weight, u64) {
+    let mut seen: std::collections::HashSet<Address> = std::collections::HashSet::new();
+    let mut queue: std::collections::VecDeque<Address> = records
+        .iter()
+        .filter_map(|r| r.produced_by)
+        .collect::<std::collections::VecDeque<_>>();
+
+    let mut weight = Weight::ZERO;
+    let mut fee = 0u64;
+
+    while let Some(wid) = queue.pop_front() {
+        if !seen.insert(wid) {
+            continue;
+        }
+        let Some(txn) = withdrawal_txns.get(&wid) else {
+            continue;
+        };
+        let Ok(tx) = hashi.build_unsigned_withdrawal_tx(&txn.inputs, &txn.all_outputs()) else {
+            continue;
+        };
+
+        weight += signed_weight_of(&tx, txn.inputs.len());
+        let input_total: u64 = txn.inputs.iter().map(|u| u.amount).sum();
+        let output_total: u64 = txn.all_outputs().iter().map(|o| o.amount).sum();
+        fee = fee.saturating_add(input_total.saturating_sub(output_total));
+
+        for input_utxo in &txn.inputs {
+            if let Some(parent) = utxo_records.get(&input_utxo.id).and_then(|r| r.produced_by) {
+                queue.push_back(parent);
+            }
+        }
+    }
+
+    (weight, fee)
+}
+
+/// Weight of a withdrawal transaction once signed.
+///
+/// [`Hashi::build_unsigned_withdrawal_tx`] leaves every witness empty, so
+/// `Transaction::weight` on its result is base-only — for a 700-input
+/// settlement that is 127,060 wu against a real 314,662 wu, a 2.5x
+/// undercount. Feeding that to the CPFP calculation would compute a
+/// deficit far too small to lift a stalled ancestor.
+///
+/// Adds each input's witness satisfaction weight plus the 2 wu segwit
+/// marker and flag, which an all-empty-witness transaction omits.
+fn signed_weight_of(unsigned: &bitcoin::Transaction, input_count: usize) -> Weight {
+    let satisfaction = SpendPath::TaprootScriptPath2of2
+        .satisfaction_weight()
+        .checked_mul(input_count as u64)
+        .expect("ancestor satisfaction weight overflow");
+    unsigned.weight() + satisfaction + Weight::from_wu(2)
+}
+
 fn build_ancestor_chain(
     hashi: &Hashi,
     producing_id: Address,
@@ -1614,7 +1694,7 @@ fn build_ancestor_chain(
 
         chain.push(AncestorTx {
             confirmations,
-            tx_weight: tx.weight(),
+            tx_weight: signed_weight_of(&tx, txn.inputs.len()),
             tx_fee: input_total.saturating_sub(output_total),
         });
 
@@ -1876,6 +1956,60 @@ mod tests {
             safe_withdrawal_flow_max_inputs(10, CoinSelectionParams::DEFAULT_MAX_INPUTS),
             10 * CoinSelectionParams::DEFAULT_INPUT_BUDGET,
             "at low request counts, the per-request input budget is binding",
+        );
+    }
+
+    /// The signed weight of the settlement that stalled on signet
+    /// (2026-07-24): 700 inputs, 71 outputs, 314,662 wu on-chain.
+    ///
+    /// The unsigned transaction is base-only at 127,060 wu. Using that
+    /// figure for CPFP would compute a deficit against 2.5x too little
+    /// weight and fail to lift a stalled ancestor.
+    #[test]
+    fn test_signed_weight_matches_onchain_weight() {
+        use bitcoin::Amount;
+        use bitcoin::OutPoint;
+        use bitcoin::ScriptBuf;
+        use bitcoin::Sequence;
+        use bitcoin::TxIn;
+        use bitcoin::TxOut;
+        use bitcoin::Witness;
+
+        const INPUTS: usize = 700;
+        const OUTPUTS: usize = 71;
+        const ONCHAIN_WEIGHT_WU: u64 = 314_662;
+
+        let unsigned = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: (0..INPUTS)
+                .map(|_| TxIn {
+                    previous_output: OutPoint::null(),
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    witness: Witness::default(),
+                })
+                .collect(),
+            output: (0..OUTPUTS)
+                .map(|_| TxOut {
+                    value: Amount::from_sat(28_876),
+                    // P2TR: OP_1 <32-byte x-only key> = 34 bytes.
+                    script_pubkey: ScriptBuf::from_bytes(
+                        [vec![0x51, 0x20], vec![0u8; 32]].concat(),
+                    ),
+                })
+                .collect(),
+        };
+
+        assert_eq!(
+            unsigned.weight().to_wu(),
+            127_060,
+            "unsigned weight is base-only, as expected"
+        );
+        assert_eq!(
+            signed_weight_of(&unsigned, INPUTS).to_wu(),
+            ONCHAIN_WEIGHT_WU,
+            "signed weight must match the transaction actually broadcast"
         );
     }
 }


### PR DESCRIPTION
## Summary

The CPFP machinery is implemented in the codebase, but it could not fire, for three independent reasons:

- **The boost always computed as zero.** `cpfp_deficit` is `fee_rate × ancestor_weight − ancestor_fee`. The target was the 1 sat/vB floor and a stalled parent had already paid 1 sat/vB, so the shortfall was always nothing and the child paid no boost.
- **Ancestor size was measured off the unsigned transaction.** `build_ancestor_chain` used `build_unsigned_withdrawal_tx`, whose witnesses are empty — 127,060 wu for a 700-input settlement weighing 314,662 wu on chain. Sized against that, a deficit that should be 157,317 sat comes to 16,615: a 1.25 sat/vB package, still stuck.
- **Validators would have refused to sign the rescue.** The fee ceiling was 5× the estimate for the transaction *alone*, but a rescue deliberately overpays to cover its parent — ~163,000 sat against a ~9,700 ceiling. A `TODO` on that check already noted it should evaluate the package.

Each blocks a rescue on its own, so all three had to land together.

## Changes

- Fee floor 1 → 3 sat/vB, overridable via `withdrawal_min_fee_rate_sat_vb` and capped at the high-fee threshold so the clamp cannot invert.
- Ancestor weight computed signed: unsigned weight plus each input's satisfaction weight and the segwit marker/flag.
- Validator fee ceiling evaluated over the whole CPFP package, resolving the `TODO`.
- Coin selection bounded by ancestor package weight (90 kvB). `max_tx_weight` covers only the transaction, so nothing stopped a batch pushing its mempool cluster past Bitcoin's 101 kvB limit (`getmempoolinfo.limitclustersize`) and being rejected outright — which is *how* one stalled settlement blocks everything behind it. The 11 kvB held back leaves headroom for a rescue child.

Economic preferences are exposed to config, protocol constraints are not: the fee floor is a judgement call that may need changing mid-incident, so it is a knob; the package bound encodes what the network will *accept*, so it stays a constant like `max_tx_weight`.

`test_signed_weight_matches_onchain_weight` pins the signed weight of a 700-input settlement to the 314,662 wu actually broadcast. 496 tests pass; clippy, fmt and doc clean.

## Effects on existing stuck tx

[`026dc29c`](https://mempool.space/signet/tx/026dc29cecacf63282f724ae819fdcff2654aaf9ef3f3669da1660c6ddb1aa2a) (78,666 vB at 1.0002 sat/vB) has been unmined for 35+ blocks with withdrawals queued behind it. Its change output is currently unspent on chain, so the next batch that spends it computes a 157,317 sat deficit and lands the package at **3.00 sat/vB** — above the 2.0 sat/vB bar, inside the weight bound, and well under the on-chain `worst_case_network_fee` cap (4,075 sat per request at a 40-request batch).

If a `WithdrawalTransaction` has already been committed against that change output, coin selection skips it (`spent_by` is set) and the rescue instead chains onto *that* transaction's change. `build_ancestor_chain` walks the whole DAG, so the deficit covers the stalled parent and the intermediate child together — a grandchild CPFP rather than a direct one. That works provided the intermediate child is itself broadcastable, i.e. under 22.3 kvB given a 78.7 kvB parent. A full-size batch on top of this particular parent would exceed Bitcoin's cluster limit and be unbroadcastable, which no fee change can unlock; that case needs the ability to abort a committed transaction.

Two caveats for whoever rolls this:

- Needs **≥6 requests in the batch**. Below that the per-request cap binds and every `request_count` in the retry loop fails, so no batch forms. If the guardian limiter is throttling withdrawals out one at a time, check its token balance before concluding the fix did not work.
- The miner fee consumes guardian limiter capacity (`inputs − change`). At a 10 BTC bucket the 157,317 sat deficit is 0.016% of capacity, so this is noise, but it is not zero.

Verified on signet: a CPFP child on a matched 77,524 vB / 1.0 sat/vB transaction, lifting the package to 3.06 sat/vB, got that parent mined in the next block.

## Deferred deliberately

Validators still accept a below-floor fee and do not re-check the package weight, so a faulty leader can still commit a stalling or unbroadcastable transaction. Both are worth fixing and neither is fixed here, because enforcing them mid-rollout is the more dangerous option: a not-yet-upgraded leader would have its commitment refused by upgraded validators, leaving it committed on chain but unsignable with its inputs locked — the same shape as the wedge this PR exists to prevent, and what bit us in #626. They should land once the fleet is uniformly upgraded.

The validator also counts every entry still in `withdrawal_txns` as unconfirmed, so a confirmed-but-not-final ancestor inflates its allowance. That widens only the ceiling; the binding limit is the on-chain per-request cap, which is unchanged.

## Follow-ups

- `unconfirmed_ancestor_weight` counts a shared parent once per input. It fails safe (tighter bound, larger fee) but can overpay enough to trip the per-request cap; deduplicating needs identity on `AncestorTx`.
- Validators check ancestor *depth* but not package *weight*. Not required for correctness — an over-budget batch simply fails to broadcast — but it is the symmetric check.

