### PR TITLE
[cli] scrape only governance state for governance commands

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -1739,8 +1739,8 @@ mod tests {
         // Positive control: the outage must have been real.
         let severed_watermark = proxied.onchain_state().state_watermark();
         assert!(
-            severed_watermark < last_checkpoint,
-            "the severed node's watermark ({severed_watermark}) covers the outage \
+            severed_watermark.is_none_or(|covered| covered < last_checkpoint),
+            "the severed node's watermark ({severed_watermark:?}) covers the outage \
              transactions (checkpoint {last_checkpoint}); the outage was not effective"
         );
         {

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -11,6 +11,7 @@
 
 use crate::config::HashiIds;
 use crate::onchain::OnchainState;
+use crate::onchain::ScrapeScope;
 use crate::onchain::types::MemberInfo;
 use crate::onchain::types::Proposal;
 use crate::sui_tx_executor::SUI_CLOCK_OBJECT_ID;
@@ -104,11 +105,28 @@ pub struct HashiClient {
 }
 
 impl HashiClient {
-    /// Create a new client
+    /// Create a client for governance and configuration commands.
     ///
-    /// This scrapes the current on-chain state and optionally sets up
-    /// transaction execution if a keypair is configured.
+    /// Skips the Bitcoin queues and UTXO pool, which are by far the most
+    /// expensive part of a scrape and which nothing in the proposal,
+    /// committee or config paths reads. Use
+    /// [`HashiClient::new_with_bitcoin_state`] for commands that list
+    /// deposits or withdrawals.
     pub async fn new(config: &CliConfig) -> Result<Self> {
+        Self::with_scope(config, ScrapeScope::GovernanceOnly).await
+    }
+
+    /// Create a client that also loads the deposit queue, withdrawal queue and
+    /// UTXO pool. Only for commands that read them — on a busy chain this
+    /// pages through every entry and is orders of magnitude slower than
+    /// [`HashiClient::new`].
+    pub async fn new_with_bitcoin_state(config: &CliConfig) -> Result<Self> {
+        Self::with_scope(config, ScrapeScope::Full).await
+    }
+
+    /// Scrape at `scope` and optionally set up transaction execution if a
+    /// keypair is configured.
+    async fn with_scope(config: &CliConfig, scope: ScrapeScope) -> Result<Self> {
         config.validate()?;
 
         let hashi_ids = HashiIds {
@@ -116,16 +134,13 @@ impl HashiClient {
             hashi_object_id: config.hashi_object_id(),
         };
 
-        // Create OnchainState which scrapes the current state.
-        // Dropping the service immediately aborts the background watcher task, so the
-        // OnchainState will have the initial scraped state but won't receive live updates.
-        // This is fine for CLI commands for now.
-        let (onchain_state, _service) = OnchainState::new(
+        // CLI commands are one-shot, so this reader starts no watcher and the
+        // scraped state is never refreshed.
+        let onchain_state = OnchainState::new_reader(
             &config.sui_rpc_url,
             hashi_ids,
-            None,
             Some(crate::config::DEFAULT_GRPC_MAX_DECODING_MESSAGE_SIZE),
-            None,
+            scope,
         )
         .await
         .context("Failed to initialize on-chain state")?;
@@ -151,6 +166,18 @@ impl HashiClient {
             hashi_ids,
             executor,
         })
+    }
+
+    /// Turn a missing-Bitcoin-state mistake into a CLI error rather than the
+    /// panic `OnchainState`'s accessors raise — those assume the validator's
+    /// always-`Full` scrape.
+    fn require_bitcoin_state(&self, accessor: &str) -> Result<()> {
+        anyhow::ensure!(
+            self.onchain_state.state().hashi().try_bitcoin().is_some(),
+            "{accessor} requires Bitcoin state; build the client with \
+             HashiClient::new_with_bitcoin_state",
+        );
+        Ok(())
     }
 
     /// Get the Hashi IDs
@@ -355,19 +382,32 @@ impl HashiClient {
             .map(<[u8]>::to_vec)
     }
 
-    /// Fetch pending deposit requests
-    pub fn fetch_deposit_requests(&self) -> Vec<crate::onchain::types::DepositRequest> {
-        self.onchain_state.deposit_requests()
+    /// Fetch pending deposit requests.
+    ///
+    /// Requires [`HashiClient::new_with_bitcoin_state`].
+    pub fn fetch_deposit_requests(&self) -> Result<Vec<crate::onchain::types::DepositRequest>> {
+        self.require_bitcoin_state("fetch_deposit_requests")?;
+        Ok(self.onchain_state.deposit_requests())
     }
 
-    /// Fetch pending withdrawal requests
-    pub fn fetch_withdrawal_requests(&self) -> Vec<crate::onchain::types::WithdrawalRequest> {
-        self.onchain_state.withdrawal_requests()
+    /// Fetch pending withdrawal requests.
+    ///
+    /// Requires [`HashiClient::new_with_bitcoin_state`].
+    pub fn fetch_withdrawal_requests(
+        &self,
+    ) -> Result<Vec<crate::onchain::types::WithdrawalRequest>> {
+        self.require_bitcoin_state("fetch_withdrawal_requests")?;
+        Ok(self.onchain_state.withdrawal_requests())
     }
 
-    /// Fetch committed/signed withdrawal transactions
-    pub fn fetch_withdrawal_txns(&self) -> Vec<crate::onchain::types::WithdrawalTransaction> {
-        self.onchain_state.withdrawal_txns()
+    /// Fetch committed/signed withdrawal transactions.
+    ///
+    /// Requires [`HashiClient::new_with_bitcoin_state`].
+    pub fn fetch_withdrawal_txns(
+        &self,
+    ) -> Result<Vec<crate::onchain::types::WithdrawalTransaction>> {
+        self.require_bitcoin_state("fetch_withdrawal_txns")?;
+        Ok(self.onchain_state.withdrawal_txns())
     }
 
     // ========================================================================

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -105,27 +105,18 @@ pub struct HashiClient {
 }
 
 impl HashiClient {
-    /// Create a client for governance and configuration commands.
-    ///
-    /// Skips the Bitcoin queues and UTXO pool, which are by far the most
-    /// expensive part of a scrape and which nothing in the proposal,
-    /// committee or config paths reads. Use
-    /// [`HashiClient::new_with_bitcoin_state`] for commands that list
-    /// deposits or withdrawals.
+    /// Client for governance and config commands. Skips the Bitcoin
+    /// collections, which none of them read.
     pub async fn new(config: &CliConfig) -> Result<Self> {
         Self::with_scope(config, ScrapeScope::GovernanceOnly).await
     }
 
-    /// Create a client that also loads the deposit queue, withdrawal queue and
-    /// UTXO pool. Only for commands that read them — on a busy chain this
-    /// pages through every entry and is orders of magnitude slower than
-    /// [`HashiClient::new`].
+    /// Client that also loads the Bitcoin collections. Much slower — only for
+    /// commands that read them.
     pub async fn new_with_bitcoin_state(config: &CliConfig) -> Result<Self> {
         Self::with_scope(config, ScrapeScope::Full).await
     }
 
-    /// Scrape at `scope` and optionally set up transaction execution if a
-    /// keypair is configured.
     async fn with_scope(config: &CliConfig, scope: ScrapeScope) -> Result<Self> {
         config.validate()?;
 
@@ -134,8 +125,6 @@ impl HashiClient {
             hashi_object_id: config.hashi_object_id(),
         };
 
-        // CLI commands are one-shot, so this reader starts no watcher and the
-        // scraped state is never refreshed.
         let onchain_state = OnchainState::new_reader(
             &config.sui_rpc_url,
             hashi_ids,
@@ -168,13 +157,12 @@ impl HashiClient {
         })
     }
 
-    /// Turn a missing-Bitcoin-state mistake into a CLI error rather than the
-    /// panic `OnchainState`'s accessors raise — those assume the validator's
-    /// always-`Full` scrape.
-    fn require_bitcoin_state(&self, accessor: &str) -> Result<()> {
+    /// `OnchainState`'s Bitcoin accessors panic on a governance-only scrape;
+    /// surface that as a CLI error instead.
+    fn require_bitcoin_state(&self) -> Result<()> {
         anyhow::ensure!(
             self.onchain_state.state().hashi().try_bitcoin().is_some(),
-            "{accessor} requires Bitcoin state; build the client with \
+            "this command needs Bitcoin state; build the client with \
              HashiClient::new_with_bitcoin_state",
         );
         Ok(())
@@ -383,30 +371,24 @@ impl HashiClient {
     }
 
     /// Fetch pending deposit requests.
-    ///
-    /// Requires [`HashiClient::new_with_bitcoin_state`].
     pub fn fetch_deposit_requests(&self) -> Result<Vec<crate::onchain::types::DepositRequest>> {
-        self.require_bitcoin_state("fetch_deposit_requests")?;
+        self.require_bitcoin_state()?;
         Ok(self.onchain_state.deposit_requests())
     }
 
     /// Fetch pending withdrawal requests.
-    ///
-    /// Requires [`HashiClient::new_with_bitcoin_state`].
     pub fn fetch_withdrawal_requests(
         &self,
     ) -> Result<Vec<crate::onchain::types::WithdrawalRequest>> {
-        self.require_bitcoin_state("fetch_withdrawal_requests")?;
+        self.require_bitcoin_state()?;
         Ok(self.onchain_state.withdrawal_requests())
     }
 
     /// Fetch committed/signed withdrawal transactions.
-    ///
-    /// Requires [`HashiClient::new_with_bitcoin_state`].
     pub fn fetch_withdrawal_txns(
         &self,
     ) -> Result<Vec<crate::onchain::types::WithdrawalTransaction>> {
-        self.require_bitcoin_state("fetch_withdrawal_txns")?;
+        self.require_bitcoin_state()?;
         Ok(self.onchain_state.withdrawal_txns())
     }
 

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -374,13 +374,13 @@ async fn request_all(
 }
 
 async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
-    let client = HashiClient::new(config).await?;
+    let client = HashiClient::new_with_bitcoin_state(config).await?;
 
     let req_addr = request_id
         .parse::<sui_sdk_types::Address>()
         .context("Invalid request ID")?;
 
-    let deposits = client.fetch_deposit_requests();
+    let deposits = client.fetch_deposit_requests()?;
     let deposit = deposits.iter().find(|d| d.id == req_addr);
 
     println!("\n{}", "Deposit Request Status".bold());
@@ -430,9 +430,9 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
 }
 
 async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
-    let client = HashiClient::new(config).await?;
+    let client = HashiClient::new_with_bitcoin_state(config).await?;
 
-    let deposits = client.fetch_deposit_requests();
+    let deposits = client.fetch_deposit_requests()?;
 
     match output_format {
         OutputFormat::Json => {

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -226,14 +226,14 @@ async fn cancel(config: &CliConfig, tx_opts: &TxOptions, request_id: &str) -> Re
 }
 
 async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
-    let client = HashiClient::new(config).await?;
+    let client = HashiClient::new_with_bitcoin_state(config).await?;
 
     let req_addr = request_id
         .parse::<sui_sdk_types::Address>()
         .context("Invalid request ID")?;
 
-    let withdrawal_requests = client.fetch_withdrawal_requests();
-    let withdrawal_txns = client.fetch_withdrawal_txns();
+    let withdrawal_requests = client.fetch_withdrawal_requests()?;
+    let withdrawal_txns = client.fetch_withdrawal_txns()?;
 
     println!("\n{}", "Withdrawal Status".bold());
     println!("{}", "━".repeat(60).dimmed());
@@ -365,10 +365,10 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
 }
 
 async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
-    let client = HashiClient::new(config).await?;
+    let client = HashiClient::new_with_bitcoin_state(config).await?;
 
-    let requests = client.fetch_withdrawal_requests();
-    let pending = client.fetch_withdrawal_txns();
+    let requests = client.fetch_withdrawal_requests()?;
+    let pending = client.fetch_withdrawal_txns()?;
     let signed_count = pending.iter().filter(|pw| pw.is_fully_signed()).count();
     let committed_count = pending.len() - signed_count;
 

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -1327,8 +1327,13 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
 
     // Pre-flight: read the launch state and who would form the initial
     // committee. No hard failures yet — status mode reports every state.
-    let (onchain, _watcher) =
-        crate::onchain::OnchainState::new(&opts.sui_rpc_url, ids, None, None, None).await?;
+    let onchain = crate::onchain::OnchainState::new_reader(
+        &opts.sui_rpc_url,
+        ids,
+        None,
+        crate::onchain::ScrapeScope::GovernanceOnly,
+    )
+    .await?;
     let (launched, roster): (bool, Vec<(sui_sdk_types::Address, bool)>) = {
         let state = onchain.state();
         (

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -89,7 +89,7 @@ impl Hashi {
         deposit_request: &DepositRequest,
     ) -> Result<(), UnapprovedDepositError> {
         let state = self.onchain_state().state();
-        let deposit_queue = &state.hashi().deposit_queue;
+        let deposit_queue = &state.hashi().bitcoin().deposit_queue;
         match deposit_queue.requests().get(&deposit_request.id) {
             None => {
                 return Err(UnapprovedDepositError::InvalidOnchainRequest(anyhow!(
@@ -127,7 +127,7 @@ impl Hashi {
             }
         }
 
-        let utxo_pool = &state.hashi().utxo_pool;
+        let utxo_pool = &state.hashi().bitcoin().utxo_pool;
         if utxo_pool.is_active_or_spent(&deposit_request.utxo.id) {
             return Err(UnapprovedDepositError::DuplicateOrSpentOnSui(anyhow!(
                 "UTXO {:?} is already active or spent",

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1082,8 +1082,9 @@ impl Metrics {
             });
         self.paused.set(if hashi.config.paused() { 1 } else { 0 });
         self.deposit_queue_size
-            .set(hashi.deposit_queue.requests().len() as i64);
+            .set(hashi.bitcoin().deposit_queue.requests().len() as i64);
         let (requested, approved) = hashi
+            .bitcoin()
             .withdrawal_queue
             .requests()
             .values()
@@ -1096,7 +1097,7 @@ impl Metrics {
         let mut signed = Vec::new();
         let mut signing = Vec::new();
         let mut pending = Vec::new();
-        for w in hashi.withdrawal_queue.withdrawal_txns().values() {
+        for w in hashi.bitcoin().withdrawal_queue.withdrawal_txns().values() {
             if w.is_fully_signed() {
                 signed.push(w);
             } else if w.signing.signed_count() > 0 {
@@ -1167,7 +1168,7 @@ impl Metrics {
         let mut available_value = 0u64;
         let mut unconfirmed_change_value = 0u64;
         let mut locked_value = 0u64;
-        for record in hashi.utxo_pool.utxo_records().values() {
+        for record in hashi.bitcoin().utxo_pool.utxo_records().values() {
             if record.spent_by.is_some() {
                 locked_count += 1;
                 locked_value += record.utxo.amount;

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -622,7 +622,7 @@ impl MpcService {
                 .ok_or_else(|| anyhow::anyhow!("No committee found for epoch {epoch}"))?
                 .clone();
             let mut pending: HashSet<u64> = HashSet::new();
-            for txn in hashi.withdrawal_queue.withdrawal_txns().values() {
+            for txn in hashi.bitcoin().withdrawal_queue.withdrawal_txns().values() {
                 if txn.signing_epoch() != epoch {
                     continue;
                 }

--- a/crates/hashi/src/onchain/apply.rs
+++ b/crates/hashi/src/onchain/apply.rs
@@ -581,34 +581,50 @@ fn apply_write(
         )
         .map(|field| {
             let utxo_id = field.value.utxo.id;
-            hashi.utxo_pool.utxo_records.insert(utxo_id, field.value);
+            hashi
+                .bitcoin_mut()
+                .utxo_pool
+                .utxo_records
+                .insert(utxo_id, field.value);
             TrackedKind::UtxoRecord(utxo_id)
         }),
         Slot::SpentUtxos => {
             decode::<move_types::Field<types::UtxoId, u64>>(contents, &id).map(|field| {
-                hashi.utxo_pool.spent_utxos.insert(field.name, field.value);
+                hashi
+                    .bitcoin_mut()
+                    .utxo_pool
+                    .spent_utxos
+                    .insert(field.name, field.value);
                 TrackedKind::SpentUtxo(field.name)
             })
         }
         Slot::DepositRequests => {
             decode::<move_types::DepositRequest>(contents, &id).map(|request| {
                 let request_id = request.id;
-                hashi.deposit_queue.requests.insert(request_id, request);
+                hashi
+                    .bitcoin_mut()
+                    .deposit_queue
+                    .requests
+                    .insert(request_id, request);
                 TrackedKind::DepositRequest(request_id)
             })
         }
         Slot::WithdrawalRequests => {
             decode::<move_types::WithdrawalRequest>(contents, &id).map(|request| {
                 let request_id = request.id;
-                hashi.withdrawal_queue.requests.insert(request_id, request);
+                hashi
+                    .bitcoin_mut()
+                    .withdrawal_queue
+                    .requests
+                    .insert(request_id, request);
                 TrackedKind::WithdrawalRequest(request_id)
             })
         }
         Slot::WithdrawalTxns => {
             decode::<move_types::WithdrawalTransaction>(contents, &id).map(|txn| {
                 let txn_id = txn.id;
-                let was_fully_signed = hashi
-                    .withdrawal_queue
+                let withdrawal_queue = &mut hashi.bitcoin_mut().withdrawal_queue;
+                let was_fully_signed = withdrawal_queue
                     .withdrawal_txns
                     .get(&txn_id)
                     .is_some_and(|t| t.is_fully_signed());
@@ -616,7 +632,7 @@ fn apply_write(
                     out.effects
                         .push(Effect::WithdrawalTxnFullySigned(Box::new(txn.clone())));
                 }
-                hashi.withdrawal_queue.withdrawal_txns.insert(txn_id, txn);
+                withdrawal_queue.withdrawal_txns.insert(txn_id, txn);
                 TrackedKind::WithdrawalTxn(txn_id)
             })
         }
@@ -757,19 +773,24 @@ fn retire(
             hashi.committees.committee_handoffs_mut().remove(epoch);
         }
         TrackedKind::UtxoRecord(utxo_id) => {
-            hashi.utxo_pool.utxo_records.remove(utxo_id);
+            hashi.bitcoin_mut().utxo_pool.utxo_records.remove(utxo_id);
         }
         TrackedKind::SpentUtxo(utxo_id) => {
-            hashi.utxo_pool.spent_utxos.remove(utxo_id);
+            hashi.bitcoin_mut().utxo_pool.spent_utxos.remove(utxo_id);
         }
         TrackedKind::DepositRequest(id) => {
-            hashi.deposit_queue.requests.remove(id);
+            hashi.bitcoin_mut().deposit_queue.requests.remove(id);
         }
         TrackedKind::WithdrawalRequest(id) => {
-            hashi.withdrawal_queue.requests.remove(id);
+            hashi.bitcoin_mut().withdrawal_queue.requests.remove(id);
         }
         TrackedKind::WithdrawalTxn(id) => {
-            if let Some(txn) = hashi.withdrawal_queue.withdrawal_txns.remove(id) {
+            if let Some(txn) = hashi
+                .bitcoin_mut()
+                .withdrawal_queue
+                .withdrawal_txns
+                .remove(id)
+            {
                 effects.push(Effect::WithdrawalTxnRemoved(Box::new(txn)));
             }
         }
@@ -979,25 +1000,27 @@ mod tests {
                     treasury_caps: BTreeMap::new(),
                     metadata_caps: BTreeMap::new(),
                 },
-                deposit_queue: types::DepositRequestQueue {
-                    id: dep_requests_id(),
-                    requests: BTreeMap::new(),
-                    processed_id: dep_processed_id(),
-                },
-                withdrawal_queue: types::WithdrawalRequestQueue {
-                    requests_id: wdr_requests_id(),
-                    requests: BTreeMap::new(),
-                    processed_id: wdr_processed_id(),
-                    withdrawal_txns_id: withdrawal_txns_id(),
-                    withdrawal_txns: BTreeMap::new(),
-                    confirmed_txns_id: confirmed_txns_id(),
-                },
-                utxo_pool: types::UtxoPool {
-                    utxo_records_id: utxo_records_id(),
-                    utxo_records: BTreeMap::new(),
-                    spent_utxos_id: spent_utxos_id(),
-                    spent_utxos: BTreeMap::new(),
-                },
+                bitcoin: Some(types::BitcoinCollections {
+                    deposit_queue: types::DepositRequestQueue {
+                        id: dep_requests_id(),
+                        requests: BTreeMap::new(),
+                        processed_id: dep_processed_id(),
+                    },
+                    withdrawal_queue: types::WithdrawalRequestQueue {
+                        requests_id: wdr_requests_id(),
+                        requests: BTreeMap::new(),
+                        processed_id: wdr_processed_id(),
+                        withdrawal_txns_id: withdrawal_txns_id(),
+                        withdrawal_txns: BTreeMap::new(),
+                        confirmed_txns_id: confirmed_txns_id(),
+                    },
+                    utxo_pool: types::UtxoPool {
+                        utxo_records_id: utxo_records_id(),
+                        utxo_records: BTreeMap::new(),
+                        spent_utxos_id: spent_utxos_id(),
+                        spent_utxos: BTreeMap::new(),
+                    },
+                }),
                 proposals: types::Proposals {
                     active_id: active_id(),
                     executed_id: executed_id(),
@@ -1308,13 +1331,13 @@ mod tests {
 
         let out = fixture.apply(&tx(vec![written(utxo_field_object(field_id, 1, 1_000))]));
         assert!(out.unrouted.is_empty());
-        assert_eq!(fixture.hashi.utxo_pool.utxo_records.len(), 1);
+        assert_eq!(fixture.hashi.bitcoin().utxo_pool.utxo_records.len(), 1);
 
         // The cleanup transaction deletes the Field object with no
         // event; the mirror must still drop the record.
         let out = fixture.apply(&tx(vec![TxChange::Deleted { id: field_id }]));
         assert!(out.unrouted.is_empty());
-        assert!(fixture.hashi.utxo_pool.utxo_records.is_empty());
+        assert!(fixture.hashi.bitcoin().utxo_pool.utxo_records.is_empty());
         assert!(fixture.index.get(&field_id).is_none());
     }
 
@@ -1331,6 +1354,7 @@ mod tests {
 
         let record = fixture
             .hashi
+            .bitcoin()
             .utxo_pool
             .utxo_records
             .values()
@@ -1353,7 +1377,15 @@ mod tests {
         ]));
         assert!(out.unrouted.is_empty());
         assert!(out.effects.is_empty());
-        assert_eq!(fixture.hashi.withdrawal_queue.withdrawal_txns.len(), 1);
+        assert_eq!(
+            fixture
+                .hashi
+                .bitcoin()
+                .withdrawal_queue
+                .withdrawal_txns
+                .len(),
+            1
+        );
 
         // Finalized: value-only mutation (the wrapper is not part of
         // the transaction) flips it to fully signed exactly once.
@@ -1382,7 +1414,14 @@ mod tests {
         assert!(
             matches!(out.effects.as_slice(), [Effect::WithdrawalTxnRemoved(txn)] if txn.id == value_id)
         );
-        assert!(fixture.hashi.withdrawal_queue.withdrawal_txns.is_empty());
+        assert!(
+            fixture
+                .hashi
+                .bitcoin()
+                .withdrawal_queue
+                .withdrawal_txns
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/hashi/src/onchain/mirror.rs
+++ b/crates/hashi/src/onchain/mirror.rs
@@ -155,9 +155,8 @@ async fn ensure_bootstrapped(
     if mirror.is_some() {
         return Ok(());
     }
-    // Always [`ScrapeScope::Full`]: this replaces the authoritative
-    // snapshot, so a partial scrape would drop the Bitcoin collections
-    // on the floor — and yields no seed to rebuild the mirror from.
+    // Always `Full` — this replaces the authoritative snapshot, and only
+    // a full scrape yields a seed to rebuild the mirror from.
     let (_, hashi, seed) = super::scrape_hashi(
         client.clone(),
         state.hashi_id(),

--- a/crates/hashi/src/onchain/mirror.rs
+++ b/crates/hashi/src/onchain/mirror.rs
@@ -155,12 +155,17 @@ async fn ensure_bootstrapped(
     if mirror.is_some() {
         return Ok(());
     }
+    // Always [`ScrapeScope::Full`]: this replaces the authoritative
+    // snapshot, so a partial scrape would drop the Bitcoin collections
+    // on the floor — and yields no seed to rebuild the mirror from.
     let (_, hashi, seed) = super::scrape_hashi(
         client.clone(),
         state.hashi_id(),
         state.package_id_original(),
+        super::ScrapeScope::Full,
     )
     .await?;
+    let seed = seed.context("a full scrape must produce a mirror seed")?;
     tracing::info!(
         floor = seed.floor,
         objects = seed.index.len(),

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -48,25 +48,13 @@ const BROADCAST_CHANNEL_CAPACITY: usize = 100;
 /// the gRPC decode limit; the SDK still pages through every entry.
 const SCRAPE_PAGE_SIZE: u32 = 1000;
 
-/// How much of the on-chain state a scrape loads.
-///
-/// The Bitcoin-side collections (deposit queue, withdrawal queue, UTXO pool)
-/// live in dynamic-field tables paged [`SCRAPE_PAGE_SIZE`] at a time, so they
-/// dominate the cost of a scrape — a 70k-entry withdrawal queue alone is ~70
-/// extra round-trips, enough to trip a fullnode's rate limiter. Governance
-/// reads (config, committees, proposals) never touch them.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// How much of the on-chain state a scrape loads. The Bitcoin collections are
+/// paged [`SCRAPE_PAGE_SIZE`] at a time and dominate the cost — a 70k-entry
+/// withdrawal queue is ~70 extra round-trips, enough to draw a 429.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ScrapeScope {
-    /// Load everything. Required by the validator and by any reader of the
-    /// deposit/withdrawal queues or the UTXO pool.
-    #[default]
     Full,
-    /// Load governance state only: package versions, config, committees,
-    /// members, treasury and proposals.
-    ///
-    /// The Bitcoin collections keep their real table ids but come back empty,
-    /// so reading their *contents* under this scope yields silently wrong
-    /// answers. Only use it for callers that don't.
+    /// Everything but the Bitcoin collections, which are left `None`.
     GovernanceOnly,
 }
 
@@ -182,9 +170,8 @@ impl OnchainState {
         Ok((state, service))
     }
 
-    /// One-shot reader for short-lived callers such as the CLI: scrapes once
-    /// at `scope` and starts no watcher, so the state never refreshes.
-    /// Anything that needs live state must use [`OnchainState::new`].
+    /// One-shot reader: scrapes once and starts no watcher, so the state
+    /// never refreshes. Live state needs [`OnchainState::new`].
     pub async fn new_reader(
         sui_rpc_url: &str,
         ids: HashiIds,
@@ -203,9 +190,8 @@ impl OnchainState {
         Ok(state)
     }
 
-    /// Scrape once and assemble the shared state. Both constructors funnel
-    /// through here; only [`OnchainState::new`] goes on to start a watcher,
-    /// and only it needs the mirror seed.
+    /// Shared by both constructors; only [`OnchainState::new`] goes on to
+    /// start a watcher, and only it needs the seed.
     async fn scrape_into_state(
         sui_rpc_url: &str,
         ids: HashiIds,
@@ -1187,9 +1173,8 @@ async fn scrape_tob_entries(client: Client, tob_id: Address) -> Result<route::Co
     Ok(seed)
 }
 
-/// The three Bitcoin-side collections, scraped as a unit, or `None` when
-/// the caller skipped the `BitcoinState` read that hands them their
-/// table ids.
+/// `None` when the caller skipped the `BitcoinState` lookup, which exists only
+/// to hand these their table ids.
 async fn scrape_bitcoin_collections(
     client: Client,
     bitcoin_state: Option<move_types::BitcoinState>,

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -110,7 +110,9 @@ struct Inner {
     /// The state watermark: the checkpoint through which the object
     /// mirror has applied every Hashi transaction. Never reported ahead
     /// of what has been applied; drives `wait_until_checkpoint`.
-    state_watermark: watch::Sender<u64>,
+    /// `None` when no mirror runs, which is not the same as covering
+    /// nothing yet — there is no claim to make at all.
+    state_watermark: watch::Sender<Option<u64>>,
     state: RwLock<State>,
     tls_private_key: Option<ed25519_dalek::SigningKey>,
     grpc_max_decoding_message_size: Option<usize>,
@@ -226,9 +228,8 @@ impl OnchainState {
 
         let (sender, _) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
         let (checkpoint, _) = watch::channel(checkpoint);
-        // No seed means no floor to claim; 0 makes a waiter block rather
-        // than see coverage no mirror is maintaining.
-        let (state_watermark, _) = watch::channel(seed.as_ref().map_or(0, |seed| seed.floor));
+        // No seed means no mirror, so there is no floor to claim.
+        let (state_watermark, _) = watch::channel(seed.as_ref().map(|seed| seed.floor));
         let state = Inner {
             ids,
             client,
@@ -279,8 +280,8 @@ impl OnchainState {
     }
 
     /// The checkpoint through which the object mirror has applied every
-    /// Hashi transaction.
-    pub fn state_watermark(&self) -> u64 {
+    /// Hashi transaction, or `None` when no mirror runs.
+    pub fn state_watermark(&self) -> Option<u64> {
         *self.0.state_watermark.borrow()
     }
 
@@ -288,10 +289,10 @@ impl OnchainState {
     /// calls this, from server coverage claims and applied transactions.
     fn advance_state_watermark(&self, covered: u64) {
         self.0.state_watermark.send_if_modified(|current| {
-            if covered <= *current {
+            if current.is_some_and(|current| covered <= current) {
                 return false;
             }
-            *current = covered;
+            *current = Some(covered);
             true
         });
         self.observe_state_watermark();
@@ -307,24 +308,26 @@ impl OnchainState {
     /// idempotent applies.
     fn reset_state_watermark(&self, covered: u64) {
         self.0.state_watermark.send_if_modified(|current| {
-            if covered < *current {
+            if let Some(current) = *current
+                && covered < current
+            {
                 tracing::warn!(
-                    from = *current,
+                    from = current,
                     to = covered,
                     "state watermark reset backwards: the re-bootstrap scrape is older than \
                      the mirror was"
                 );
             }
-            std::mem::replace(current, covered) != covered
+            current.replace(covered) != Some(covered)
         });
         self.observe_state_watermark();
     }
 
     fn observe_state_watermark(&self) {
-        if let Some(metrics) = &self.0.metrics {
-            metrics
-                .watcher_state_watermark
-                .set(self.state_watermark() as i64);
+        if let Some(metrics) = &self.0.metrics
+            && let Some(watermark) = self.state_watermark()
+        {
+            metrics.watcher_state_watermark.set(watermark as i64);
         }
     }
 
@@ -338,10 +341,15 @@ impl OnchainState {
     /// matching transaction in it has been delivered (or a later
     /// transaction proves it by arriving). Waiters never observe a
     /// checkpoint whose Hashi transactions are still in flight.
+    ///
+    /// With no mirror there is nothing to advance the watermark, so this
+    /// blocks until the caller's timeout rather than answering from a
+    /// coverage claim no one maintains.
     pub async fn wait_until_checkpoint(&self, target_seq: u64) {
         let mut rx = self.0.state_watermark.subscribe();
         loop {
-            if *rx.borrow_and_update() >= target_seq {
+            let covered = *rx.borrow_and_update();
+            if covered.is_some_and(|covered| covered >= target_seq) {
                 return;
             }
             if rx.changed().await.is_err() {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -49,7 +49,7 @@ const BROADCAST_CHANNEL_CAPACITY: usize = 100;
 const SCRAPE_PAGE_SIZE: u32 = 1000;
 
 /// How much of the on-chain state a scrape loads. The Bitcoin collections are
-/// paged [`SCRAPE_PAGE_SIZE`] at a time and dominate the cost — a 70k-entry
+/// paged `SCRAPE_PAGE_SIZE` at a time and dominate the cost — a 70k-entry
 /// withdrawal queue is ~70 extra round-trips, enough to draw a 429.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ScrapeScope {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -48,6 +48,28 @@ const BROADCAST_CHANNEL_CAPACITY: usize = 100;
 /// the gRPC decode limit; the SDK still pages through every entry.
 const SCRAPE_PAGE_SIZE: u32 = 1000;
 
+/// How much of the on-chain state a scrape loads.
+///
+/// The Bitcoin-side collections (deposit queue, withdrawal queue, UTXO pool)
+/// live in dynamic-field tables paged [`SCRAPE_PAGE_SIZE`] at a time, so they
+/// dominate the cost of a scrape — a 70k-entry withdrawal queue alone is ~70
+/// extra round-trips, enough to trip a fullnode's rate limiter. Governance
+/// reads (config, committees, proposals) never touch them.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ScrapeScope {
+    /// Load everything. Required by the validator and by any reader of the
+    /// deposit/withdrawal queues or the UTXO pool.
+    #[default]
+    Full,
+    /// Load governance state only: package versions, config, committees,
+    /// members, treasury and proposals.
+    ///
+    /// The Bitcoin collections keep their real table ids but come back empty,
+    /// so reading their *contents* under this scope yields silently wrong
+    /// answers. Only use it for callers that don't.
+    GovernanceOnly,
+}
+
 mod apply;
 mod mirror;
 mod route;
@@ -138,6 +160,60 @@ impl OnchainState {
         grpc_max_decoding_message_size: Option<usize>,
         metrics: Option<Arc<crate::metrics::Metrics>>,
     ) -> Result<(Self, Service)> {
+        let (state, seed) = Self::scrape_into_state(
+            sui_rpc_url,
+            ids,
+            ScrapeScope::Full,
+            tls_private_key,
+            grpc_max_decoding_message_size,
+            metrics.clone(),
+        )
+        .await?;
+        let seed = seed.context("a full scrape must produce a mirror seed")?;
+
+        let watcher_state = state.clone();
+        // The watcher rebuilds its client on every reconnect, so hand it the URL.
+        let sui_rpc_url = sui_rpc_url.to_owned();
+        let service = Service::new().spawn_aborting(async move {
+            watcher::watcher(sui_rpc_url, watcher_state, seed, metrics).await;
+            Ok(())
+        });
+
+        Ok((state, service))
+    }
+
+    /// One-shot reader for short-lived callers such as the CLI: scrapes once
+    /// at `scope` and starts no watcher, so the state never refreshes.
+    /// Anything that needs live state must use [`OnchainState::new`].
+    pub async fn new_reader(
+        sui_rpc_url: &str,
+        ids: HashiIds,
+        grpc_max_decoding_message_size: Option<usize>,
+        scope: ScrapeScope,
+    ) -> Result<Self> {
+        let (state, _seed) = Self::scrape_into_state(
+            sui_rpc_url,
+            ids,
+            scope,
+            None,
+            grpc_max_decoding_message_size,
+            None,
+        )
+        .await?;
+        Ok(state)
+    }
+
+    /// Scrape once and assemble the shared state. Both constructors funnel
+    /// through here; only [`OnchainState::new`] goes on to start a watcher,
+    /// and only it needs the mirror seed.
+    async fn scrape_into_state(
+        sui_rpc_url: &str,
+        ids: HashiIds,
+        scope: ScrapeScope,
+        tls_private_key: Option<ed25519_dalek::SigningKey>,
+        grpc_max_decoding_message_size: Option<usize>,
+        metrics: Option<Arc<crate::metrics::Metrics>>,
+    ) -> Result<(Self, Option<route::MirrorSeed>)> {
         let mut client = crate::sui_rpc_client::new_sui_rpc_client(sui_rpc_url)?;
         // The scrape client reads the full on-chain state (the largest
         // responses), so it needs the decode limit too — not just `committees`.
@@ -145,7 +221,7 @@ impl OnchainState {
             client = client.with_max_decoding_message_size(limit);
         }
 
-        let (mut state, checkpoint, seed) = State::scrape(client.clone(), ids).await?;
+        let (mut state, checkpoint, seed) = State::scrape(client.clone(), ids, scope).await?;
         if let Some(tls_private_key) = &tls_private_key {
             state
                 .hashi
@@ -164,32 +240,26 @@ impl OnchainState {
 
         let (sender, _) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
         let (checkpoint, _) = watch::channel(checkpoint);
-        let (state_watermark, _) = watch::channel(seed.floor);
+        // No seed means no floor to claim; 0 makes a waiter block rather
+        // than see coverage no mirror is maintaining.
+        let (state_watermark, _) = watch::channel(seed.as_ref().map_or(0, |seed| seed.floor));
         let state = Inner {
             ids,
-            client: client.clone(),
+            client,
             sender,
             checkpoint,
             state_watermark,
             state: RwLock::new(state),
             tls_private_key,
             grpc_max_decoding_message_size,
-            metrics: metrics.clone(),
+            metrics,
             local_limiter: OnceLock::new(),
             guardian_reconcile_notify: Arc::new(tokio::sync::Notify::new()),
         }
         .pipe(Arc::new)
         .pipe(Self);
 
-        let watcher_state = state.clone();
-        // The watcher rebuilds its client on every reconnect, so hand it the URL.
-        let sui_rpc_url = sui_rpc_url.to_owned();
-        let service = Service::new().spawn_aborting(async move {
-            watcher::watcher(sui_rpc_url, watcher_state, seed, metrics).await;
-            Ok(())
-        });
-
-        Ok((state, service))
+        Ok((state, seed))
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<Notification> {
@@ -512,6 +582,7 @@ impl OnchainState {
     pub fn deposit_requests(&self) -> Vec<types::DepositRequest> {
         self.state()
             .hashi()
+            .bitcoin()
             .deposit_queue
             .requests()
             .values()
@@ -522,6 +593,7 @@ impl OnchainState {
     pub fn has_deposit_request(&self, deposit_id: &Address) -> bool {
         self.state()
             .hashi()
+            .bitcoin()
             .deposit_queue
             .requests()
             .contains_key(deposit_id)
@@ -530,6 +602,7 @@ impl OnchainState {
     pub fn withdrawal_requests(&self) -> Vec<types::WithdrawalRequest> {
         self.state()
             .hashi()
+            .bitcoin()
             .withdrawal_queue
             .requests()
             .values()
@@ -540,6 +613,7 @@ impl OnchainState {
     pub fn withdrawal_request(&self, id: &Address) -> Option<types::WithdrawalRequest> {
         self.state()
             .hashi()
+            .bitcoin()
             .withdrawal_queue
             .requests()
             .get(id)
@@ -549,6 +623,7 @@ impl OnchainState {
     pub fn withdrawal_txns(&self) -> Vec<types::WithdrawalTransaction> {
         self.state()
             .hashi()
+            .bitcoin()
             .withdrawal_queue
             .withdrawal_txns()
             .values()
@@ -560,6 +635,7 @@ impl OnchainState {
     pub fn has_unsigned_withdrawal_txn(&self) -> bool {
         self.state()
             .hashi()
+            .bitcoin()
             .withdrawal_queue
             .withdrawal_txns()
             .values()
@@ -569,6 +645,7 @@ impl OnchainState {
     pub fn spent_utxos_entries(&self) -> Vec<(types::UtxoId, u64)> {
         self.state()
             .hashi()
+            .bitcoin()
             .utxo_pool
             .spent_utxos()
             .iter()
@@ -579,6 +656,7 @@ impl OnchainState {
     pub fn active_utxos(&self) -> Vec<types::Utxo> {
         self.state()
             .hashi()
+            .bitcoin()
             .utxo_pool
             .active_utxos()
             .map(|(_, utxo)| utxo.clone())
@@ -591,7 +669,7 @@ impl OnchainState {
     ) -> HashSet<types::UtxoId> {
         let mut utxo_ids: HashSet<_> = utxo_ids.into_iter().collect();
         let state = self.state();
-        let utxo_pool = &state.hashi().utxo_pool;
+        let utxo_pool = &state.hashi().bitcoin().utxo_pool;
         utxo_ids.retain(|id| utxo_pool.is_active_or_spent(id));
         utxo_ids
     }
@@ -599,6 +677,7 @@ impl OnchainState {
     pub fn withdrawal_txn(&self, id: &Address) -> Option<types::WithdrawalTransaction> {
         self.state()
             .hashi()
+            .bitcoin()
             .withdrawal_queue
             .withdrawal_txns()
             .get(id)
@@ -608,6 +687,7 @@ impl OnchainState {
     pub fn active_utxo(&self, id: &types::UtxoId) -> Option<types::Utxo> {
         self.state()
             .hashi()
+            .bitcoin()
             .utxo_pool
             .active_utxos()
             .find(|(utxo_id, _)| *utxo_id == id)
@@ -615,7 +695,12 @@ impl OnchainState {
     }
 
     pub fn utxo_records(&self) -> std::collections::BTreeMap<types::UtxoId, types::UtxoRecord> {
-        self.state().hashi().utxo_pool.utxo_records().clone()
+        self.state()
+            .hashi()
+            .bitcoin()
+            .utxo_pool
+            .utxo_records()
+            .clone()
     }
 
     pub fn bitcoin_deposit_minimum(&self) -> u64 {
@@ -804,10 +889,11 @@ impl State {
     async fn scrape(
         client: Client,
         ids: HashiIds,
-    ) -> Result<(Self, CheckpointInfo, route::MirrorSeed)> {
+        scope: ScrapeScope,
+    ) -> Result<(Self, CheckpointInfo, Option<route::MirrorSeed>)> {
         let (package_versions, (checkpoint_info, hashi, seed)) = tokio::try_join!(
             scrape_package_versions(client.clone(), ids.package_id),
-            scrape_hashi(client, ids.hashi_object_id, ids.package_id),
+            scrape_hashi(client, ids.hashi_object_id, ids.package_id, scope),
         )?;
 
         Ok((
@@ -940,7 +1026,8 @@ async fn scrape_hashi(
     mut client: Client,
     hashi_object_id: Address,
     package_id: Address,
-) -> Result<(CheckpointInfo, types::Hashi, route::MirrorSeed)> {
+    scope: ScrapeScope,
+) -> Result<(CheckpointInfo, types::Hashi, Option<route::MirrorSeed>)> {
     let response = client
         .ledger_client()
         .get_object(
@@ -987,47 +1074,61 @@ async fn scrape_hashi(
         num_consumed_presigs,
     } = root;
 
-    let (bitcoin_state_height, bitcoin_state_version, bitcoin_state) =
-        fetch_bitcoin_state(client.clone(), id, package_id).await?;
-    seed.observe_height(bitcoin_state_height);
-    seed.routing.set_bitcoin_state_containers(&bitcoin_state);
-    seed.index.record(
-        seed.routing.bitcoin_state_field_id(),
-        bitcoin_state_version,
-        route::TrackedKind::BitcoinStateField,
-    );
+    // Under `GovernanceOnly` this read is skipped along with the
+    // collections: the `BitcoinState` exists only to hand them their
+    // table ids and the mirror its Bitcoin-side routing.
+    let bitcoin_state = match scope {
+        ScrapeScope::Full => {
+            let (bitcoin_state_height, bitcoin_state_version, bitcoin_state) =
+                fetch_bitcoin_state(client.clone(), id, package_id).await?;
+            seed.observe_height(bitcoin_state_height);
+            seed.routing.set_bitcoin_state_containers(&bitcoin_state);
+            seed.index.record(
+                seed.routing.bitcoin_state_field_id(),
+                bitcoin_state_version,
+                route::TrackedKind::BitcoinStateField,
+            );
+            Some(bitcoin_state)
+        }
+        ScrapeScope::GovernanceOnly => None,
+    };
 
     let (
         (member_seed, member_info),
         (committee_seed, (committees_per_epoch, raw_committees_per_epoch, committee_handoffs)),
         (treasury_seed, treasury),
-        (deposit_seed, deposit_queue),
-        (withdrawal_seed, withdrawal_queue),
-        (utxo_seed, utxo_pool),
         (proposal_seed, proposals),
         tob_seed,
+        bitcoin,
     ) = tokio::try_join!(
         scrape_all_member_info(client.clone(), committees.members.id),
         scrape_committees(client.clone(), committees.committees.id),
         scrape_treasury(client.clone(), treasury),
-        scrape_deposit_requests(client.clone(), bitcoin_state.deposit_queue),
-        scrape_withdrawal_queue(client.clone(), bitcoin_state.withdrawal_queue),
-        scrape_utxo_pool(client.clone(), bitcoin_state.utxo_pool),
         scrape_proposals(client.clone(), proposals),
         scrape_tob_entries(client.clone(), tob.id),
+        scrape_bitcoin_collections(client.clone(), bitcoin_state),
     )?;
     for container_seed in [
         member_seed,
         committee_seed,
         treasury_seed,
-        deposit_seed,
-        withdrawal_seed,
-        utxo_seed,
         proposal_seed,
         tob_seed,
     ] {
         seed.absorb(container_seed);
     }
+
+    // Withhold the seed on a governance-only scrape: it neither routes
+    // the Bitcoin containers nor folded their serving heights into the
+    // replay floor, so a mirror bootstrapped from it would silently miss
+    // every deposit, withdrawal and UTXO write below the floor.
+    let (bitcoin, seed) = match bitcoin {
+        Some((bitcoin_seed, collections)) => {
+            seed.absorb(bitcoin_seed);
+            (Some(collections), Some(seed))
+        }
+        None => (None, None),
+    };
 
     let mut committee_set =
         types::CommitteeSet::new(committees.members.id, committees.committees.id);
@@ -1047,9 +1148,7 @@ async fn scrape_hashi(
             committees: committee_set,
             config: convert_move_config(config, versioning),
             treasury,
-            deposit_queue,
-            withdrawal_queue,
-            utxo_pool,
+            bitcoin,
             proposals,
             tob_id: tob.id,
             num_consumed_presigs,
@@ -1086,6 +1185,36 @@ async fn scrape_tob_entries(client: Client, tob_id: Address) -> Result<route::Co
         seed.interior.push((certs.certs.id, route::Slot::TobCerts));
     }
     Ok(seed)
+}
+
+/// The three Bitcoin-side collections, scraped as a unit, or `None` when
+/// the caller skipped the `BitcoinState` read that hands them their
+/// table ids.
+async fn scrape_bitcoin_collections(
+    client: Client,
+    bitcoin_state: Option<move_types::BitcoinState>,
+) -> Result<Option<(route::ContainerSeed, types::BitcoinCollections)>> {
+    let Some(bitcoin_state) = bitcoin_state else {
+        return Ok(None);
+    };
+
+    let ((mut seed, deposit_queue), (withdrawal_seed, withdrawal_queue), (utxo_seed, utxo_pool)) =
+        tokio::try_join!(
+            scrape_deposit_requests(client.clone(), bitcoin_state.deposit_queue),
+            scrape_withdrawal_queue(client.clone(), bitcoin_state.withdrawal_queue),
+            scrape_utxo_pool(client.clone(), bitcoin_state.utxo_pool),
+        )?;
+    seed.merge(withdrawal_seed);
+    seed.merge(utxo_seed);
+
+    Ok(Some((
+        seed,
+        types::BitcoinCollections {
+            deposit_queue,
+            withdrawal_queue,
+            utxo_pool,
+        },
+    )))
 }
 
 fn convert_move_config(

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -36,9 +36,9 @@ pub use hashi_types::move_types::WithdrawalRequest;
 pub use hashi_types::move_types::WithdrawalStatus;
 pub use hashi_types::move_types::WithdrawalTransaction;
 
-/// The Bitcoin-side collections. Scraped as a unit or not at all, so they
-/// share one `Option` on [`Hashi`] rather than three: there is no state in
-/// which some are loaded and others aren't.
+const NOT_SCRAPED: &str = "Bitcoin state was not scraped (ScrapeScope::GovernanceOnly)";
+
+/// The Bitcoin-side collections, scraped as a unit or not at all.
 #[derive(Debug)]
 pub struct BitcoinCollections {
     pub deposit_queue: DepositRequestQueue,
@@ -52,11 +52,8 @@ pub struct Hashi {
     pub committees: CommitteeSet,
     pub config: Config,
     pub treasury: Treasury,
-    /// `None` when scraped with `ScrapeScope::GovernanceOnly`.
-    ///
-    /// Deliberately an `Option` rather than empty collections: "not loaded"
-    /// and "loaded and empty" are different facts, and conflating them turns
-    /// a scope mistake into a silently wrong answer instead of a loud one.
+    /// `None` under `ScrapeScope::GovernanceOnly`. An `Option` rather than
+    /// empty collections so a scope mistake can't read as "no withdrawals".
     pub(super) bitcoin: Option<BitcoinCollections>,
     pub proposals: Proposals,
     pub tob_id: Address,
@@ -64,37 +61,20 @@ pub struct Hashi {
 }
 
 impl Hashi {
-    /// The Bitcoin collections.
-    ///
-    /// # Panics
-    ///
-    /// If the state was scraped with `ScrapeScope::GovernanceOnly`. The
-    /// validator always scrapes `Full`, so its paths can rely on this;
-    /// callers that may run against a governance-scoped scrape (the CLI)
-    /// must use [`Hashi::try_bitcoin`].
+    /// Panics under a governance-only scrape; the validator always scrapes
+    /// `Full`. Callers that may not should use [`Hashi::try_bitcoin`].
     #[track_caller]
     pub fn bitcoin(&self) -> &BitcoinCollections {
-        self.bitcoin
-            .as_ref()
-            .expect("Bitcoin state was not scraped (ScrapeScope::GovernanceOnly)")
+        self.bitcoin.as_ref().expect(NOT_SCRAPED)
     }
 
-    /// The Bitcoin collections, or `None` under a governance-only scrape.
     pub fn try_bitcoin(&self) -> Option<&BitcoinCollections> {
         self.bitcoin.as_ref()
     }
 
-    /// Mutable access for the watcher, which applies events to the scraped
-    /// snapshot. Only reachable from the always-`Full` validator paths.
-    ///
-    /// # Panics
-    ///
-    /// If the state was scraped with `ScrapeScope::GovernanceOnly`.
     #[track_caller]
     pub(super) fn bitcoin_mut(&mut self) -> &mut BitcoinCollections {
-        self.bitcoin
-            .as_mut()
-            .expect("Bitcoin state was not scraped (ScrapeScope::GovernanceOnly)")
+        self.bitcoin.as_mut().expect(NOT_SCRAPED)
     }
 }
 

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -36,18 +36,66 @@ pub use hashi_types::move_types::WithdrawalRequest;
 pub use hashi_types::move_types::WithdrawalStatus;
 pub use hashi_types::move_types::WithdrawalTransaction;
 
+/// The Bitcoin-side collections. Scraped as a unit or not at all, so they
+/// share one `Option` on [`Hashi`] rather than three: there is no state in
+/// which some are loaded and others aren't.
+#[derive(Debug)]
+pub struct BitcoinCollections {
+    pub deposit_queue: DepositRequestQueue,
+    pub withdrawal_queue: WithdrawalRequestQueue,
+    pub utxo_pool: UtxoPool,
+}
+
 #[derive(Debug)]
 pub struct Hashi {
     pub id: Address,
     pub committees: CommitteeSet,
     pub config: Config,
     pub treasury: Treasury,
-    pub deposit_queue: DepositRequestQueue,
-    pub withdrawal_queue: WithdrawalRequestQueue,
-    pub utxo_pool: UtxoPool,
+    /// `None` when scraped with `ScrapeScope::GovernanceOnly`.
+    ///
+    /// Deliberately an `Option` rather than empty collections: "not loaded"
+    /// and "loaded and empty" are different facts, and conflating them turns
+    /// a scope mistake into a silently wrong answer instead of a loud one.
+    pub(super) bitcoin: Option<BitcoinCollections>,
     pub proposals: Proposals,
     pub tob_id: Address,
     pub num_consumed_presigs: u64,
+}
+
+impl Hashi {
+    /// The Bitcoin collections.
+    ///
+    /// # Panics
+    ///
+    /// If the state was scraped with `ScrapeScope::GovernanceOnly`. The
+    /// validator always scrapes `Full`, so its paths can rely on this;
+    /// callers that may run against a governance-scoped scrape (the CLI)
+    /// must use [`Hashi::try_bitcoin`].
+    #[track_caller]
+    pub fn bitcoin(&self) -> &BitcoinCollections {
+        self.bitcoin
+            .as_ref()
+            .expect("Bitcoin state was not scraped (ScrapeScope::GovernanceOnly)")
+    }
+
+    /// The Bitcoin collections, or `None` under a governance-only scrape.
+    pub fn try_bitcoin(&self) -> Option<&BitcoinCollections> {
+        self.bitcoin.as_ref()
+    }
+
+    /// Mutable access for the watcher, which applies events to the scraped
+    /// snapshot. Only reachable from the always-`Full` validator paths.
+    ///
+    /// # Panics
+    ///
+    /// If the state was scraped with `ScrapeScope::GovernanceOnly`.
+    #[track_caller]
+    pub(super) fn bitcoin_mut(&mut self) -> &mut BitcoinCollections {
+        self.bitcoin
+            .as_mut()
+            .expect("Bitcoin state was not scraped (ScrapeScope::GovernanceOnly)")
+    }
 }
 
 pub struct CommitteeSet {

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -475,8 +475,13 @@ impl Hashi {
         let (utxo_records, withdrawal_txns) = {
             let state = self.onchain_state().state();
             (
-                state.hashi().utxo_pool.utxo_records().clone(),
-                state.hashi().withdrawal_queue.withdrawal_txns().clone(),
+                state.hashi().bitcoin().utxo_pool.utxo_records().clone(),
+                state
+                    .hashi()
+                    .bitcoin()
+                    .withdrawal_queue
+                    .withdrawal_txns()
+                    .clone(),
             )
         };
 
@@ -1305,8 +1310,13 @@ impl Hashi {
         let (withdrawal_txns, utxo_records) = {
             let state = self.onchain_state().state();
             (
-                state.hashi().withdrawal_queue.withdrawal_txns().clone(),
-                state.hashi().utxo_pool.utxo_records().clone(),
+                state
+                    .hashi()
+                    .bitcoin()
+                    .withdrawal_queue
+                    .withdrawal_txns()
+                    .clone(),
+                state.hashi().bitcoin().utxo_pool.utxo_records().clone(),
             )
         };
 


### PR DESCRIPTION
## Changes

- Add `ScrapeScope { Full, GovernanceOnly }`, threaded through `State::scrape` / `scrape_hashi`.
- Group the three Bitcoin collections into `types::BitcoinCollections` and store them as `Option` on `types::Hashi`, behind `bitcoin()` (panics, for the always-`Full` validator paths) and `try_bitcoin()`.
- Add `OnchainState::new_reader`: scrapes at a scope and starts no watcher, since the CLI is one-shot and was dropping the watcher's `Service` immediately anyway. Both constructors share `scrape_into_state`.
- `GovernanceOnly` also skips the `BitcoinState` lookup, which only exists to hand the collections their table ids and the mirror its Bitcoin-side routing.
- `scrape_hashi` returns the `MirrorSeed` as an `Option` for the same reason: a governance scrape routes none of the Bitcoin containers and folds none of their serving heights into the replay floor, so a mirror bootstrapped from it would silently miss every deposit, withdrawal and UTXO write below that floor. `OnchainState::new` and the mirror's re-bootstrap are the only callers that need one, and both scrape `Full`.
- `HashiClient::new` is now governance-scoped; `new_with_bitcoin_state` is the opt-in for `deposit list/status` and `withdraw list/status`, the only CLI commands that read this state. Their fetchers return `Result` so a scope mistake is a CLI error, not a panic.
- Point the `launch` preflight at the governance scope too.
