### PR TITLE
[watcher] Close the object mirror's remaining silent-gap paths

### DIFF
--- a/crates/hashi/src/onchain/apply.rs
+++ b/crates/hashi/src/onchain/apply.rs
@@ -50,13 +50,10 @@ pub(super) struct TxView {
     /// advance and the withdrawal duration metrics.
     pub timestamp_ms: u64,
     pub changes: Vec<TxChange>,
-}
-
-impl TxView {
-    /// The transaction's position in the chain's total order.
-    pub(super) fn position(&self) -> (u64, u64) {
-        (self.checkpoint, self.transaction_index)
-    }
+    /// Changed objects whose `output_state` was absent or unrecognized.
+    /// Neither a write nor a removal can be derived from them, so they
+    /// ride the unrouted tripwire rather than being dropped silently.
+    pub unknown_output_states: Vec<Address>,
 }
 
 #[derive(Debug)]
@@ -96,17 +93,24 @@ fn decode_object_pool(set: Option<&proto::ObjectSet>) -> anyhow::Result<ObjectPo
 }
 
 impl TxView {
+    /// The transaction's position in the chain's total order.
+    pub(super) fn position(&self) -> (u64, u64) {
+        (self.checkpoint, self.transaction_index)
+    }
+
     /// Decode a proto `ExecutedTransaction` (as delivered by the
     /// filtered transaction stream) into a `TxView`, sourcing
     /// post-state objects from its per-transaction object set. Returns
     /// `Ok(None)` for transactions that did not execute successfully —
     /// their object changes are gas-only and carry no Hashi state.
     pub(super) fn from_proto(tx: &proto::ExecutedTransaction) -> anyhow::Result<Option<Self>> {
-        let mut pool = decode_object_pool(tx.objects.as_ref())?;
         let effects = tx
             .effects
             .as_ref()
             .context("ExecutedTransaction is missing effects")?;
+        // Before decoding the object set: a failed transaction's objects
+        // are discarded anyway, so neither the work nor a decode failure
+        // on them should reach the stream.
         if !effects
             .status
             .as_ref()
@@ -115,8 +119,10 @@ impl TxView {
         {
             return Ok(None);
         }
+        let mut pool = decode_object_pool(tx.objects.as_ref())?;
 
         let mut changes = Vec::new();
+        let mut unknown_output_states = Vec::new();
         for changed in &effects.changed_objects {
             let id: Address = changed
                 .object_id
@@ -129,7 +135,7 @@ impl TxView {
                 .and_then(|s| OutputObjectState::try_from(s).ok())
                 .unwrap_or(OutputObjectState::Unknown);
             match state {
-                OutputObjectState::ObjectWrite | OutputObjectState::PackageWrite => {
+                OutputObjectState::ObjectWrite => {
                     let version = changed
                         .output_version
                         .context("written ChangedObject is missing output_version")?;
@@ -150,9 +156,19 @@ impl TxView {
                     changes.push(TxChange::Written(Box::new(object)));
                 }
                 OutputObjectState::DoesNotExist => changes.push(TxChange::Deleted { id }),
-                // Accumulator writes and unknown future states don't
-                // fit the object-contents shape; ignore them.
-                _ => {}
+                // The package object carries no mirrored state — the
+                // upgrade is derived from the root's `UpgradeCap` — so
+                // demanding it from the object set would only risk
+                // failing the frame over contents we discard.
+                OutputObjectState::PackageWrite => {}
+                // An accumulator value is not object contents.
+                OutputObjectState::AccumulatorWrite => {}
+                // `Unknown` (an absent or unrecognized discriminant)
+                // today, and whatever a future SDK adds tomorrow —
+                // `OutputObjectState` is `#[non_exhaustive]`, so this
+                // arm cannot be dropped. Either way the object's fate is
+                // undetermined, which is a mirror gap, not a no-op.
+                _ => unknown_output_states.push(id),
             }
         }
 
@@ -174,6 +190,7 @@ impl TxView {
             )
             .context("invalid ExecutedTransaction timestamp")?,
             changes,
+            unknown_output_states,
         }))
     }
 }
@@ -224,7 +241,14 @@ pub(super) fn apply_transaction(
     index: &mut ObjectIndex,
     tx: &TxView,
 ) -> ApplyOutcome {
-    let mut out = ApplyOutcome::default();
+    let mut out = ApplyOutcome {
+        unrouted: tx
+            .unknown_output_states
+            .iter()
+            .map(|id| (*id, "unknown output_state".into()))
+            .collect(),
+        ..Default::default()
+    };
 
     // Pass 1: the Hashi root and the BitcoinState dynamic field.
     for change in &tx.changes {
@@ -234,7 +258,7 @@ pub(super) fn apply_transaction(
         if obj.object_id() == routing.hashi_id() {
             apply_root(hashi, routing, index, obj, &mut out);
         } else if obj.object_id() == routing.bitcoin_state_field_id() {
-            apply_bitcoin_state(routing, index, obj, &mut out);
+            apply_bitcoin_state(routing, index, obj);
         }
     }
 
@@ -385,12 +409,7 @@ fn apply_root(
     index.record(id, obj.version(), TrackedKind::HashiRoot);
 }
 
-fn apply_bitcoin_state(
-    routing: &mut RoutingTable,
-    index: &mut ObjectIndex,
-    obj: &Object,
-    _out: &mut ApplyOutcome,
-) {
+fn apply_bitcoin_state(routing: &mut RoutingTable, index: &mut ObjectIndex, obj: &Object) {
     let id = obj.object_id();
     if index.is_stale_write(&id, obj.version()) {
         return;
@@ -898,6 +917,7 @@ mod tests {
             transaction_index: 0,
             timestamp_ms: 1_000,
             changes,
+            unknown_output_states: Vec::new(),
         }
     }
 
@@ -1574,5 +1594,83 @@ mod tests {
             .expect("successful transaction decodes to a view");
         assert_eq!(view.position(), (7, 0));
         assert_eq!(view.timestamp_ms, 1_234);
+    }
+
+    /// A successful proto transaction carrying `changed`, with the
+    /// position and timestamp fields `from_proto` requires.
+    fn proto_tx(changed: Vec<proto::ChangedObject>) -> proto::ExecutedTransaction {
+        let mut status = proto::ExecutionStatus::default();
+        status.success = Some(true);
+        let mut effects = proto::TransactionEffects::default();
+        effects.status = Some(status);
+        effects.changed_objects = changed;
+        let mut proto_tx = proto::ExecutedTransaction::default();
+        proto_tx.effects = Some(effects);
+        proto_tx.set_checkpoint(7);
+        proto_tx.set_transaction_index(0);
+        proto_tx.timestamp = Some(sui_rpc::proto::timestamp_ms_to_proto(1_234));
+        proto_tx
+    }
+
+    fn changed_object(id: Address, state: Option<OutputObjectState>) -> proto::ChangedObject {
+        let mut changed = proto::ChangedObject::default();
+        changed.object_id = Some(id.to_string());
+        changed.output_state = state.map(|state| state as i32);
+        changed.output_version = Some(3);
+        changed
+    }
+
+    #[test]
+    fn package_writes_do_not_need_the_package_object() {
+        // The package object is never mirrored — the upgrade is derived
+        // from the root's UpgradeCap — so an upgrade transaction must
+        // decode even with nothing for it in the object set.
+        let proto_tx = proto_tx(vec![changed_object(
+            addr(0x80),
+            Some(OutputObjectState::PackageWrite),
+        )]);
+        let view = TxView::from_proto(&proto_tx)
+            .unwrap()
+            .expect("successful transaction decodes to a view");
+        assert!(view.changes.is_empty());
+        assert!(view.unknown_output_states.is_empty());
+    }
+
+    #[test]
+    fn unknown_output_state_trips_the_unrouted_counter() {
+        let id = addr(0x81);
+        let view = TxView::from_proto(&proto_tx(vec![changed_object(id, None)]))
+            .unwrap()
+            .expect("successful transaction decodes to a view");
+        assert_eq!(view.unknown_output_states, vec![id]);
+        assert!(view.changes.is_empty());
+
+        // An uninterpretable state is a potential mirror gap, so it has
+        // to reach the tripwire rather than be skipped.
+        let out = Fixture::new().apply(&view);
+        assert_eq!(out.unrouted.len(), 1);
+        assert_eq!(out.unrouted[0].0, id);
+    }
+
+    #[test]
+    fn failed_transactions_drop_before_the_object_set_is_decoded() {
+        let mut bcs = proto::Bcs::default();
+        bcs.value = Some(vec![0xff; 4].into());
+        let mut object = proto::Object::default();
+        object.bcs = Some(bcs);
+        let mut objects = proto::ObjectSet::default();
+        objects.objects = vec![object];
+
+        let mut status = proto::ExecutionStatus::default();
+        status.success = Some(false);
+        let mut effects = proto::TransactionEffects::default();
+        effects.status = Some(status);
+        let mut proto_tx = proto::ExecutedTransaction::default();
+        proto_tx.effects = Some(effects);
+        proto_tx.objects = Some(objects);
+
+        // Undecodable contents on a failed transaction must not fail the
+        // frame; nothing from it reaches the mirror anyway.
+        assert!(TxView::from_proto(&proto_tx).unwrap().is_none());
     }
 }

--- a/crates/hashi/src/onchain/mirror.rs
+++ b/crates/hashi/src/onchain/mirror.rs
@@ -155,7 +155,7 @@ async fn ensure_bootstrapped(
     if mirror.is_some() {
         return Ok(());
     }
-    let (_, hashi, seed) = super::scrape_hashi(
+    let (_, hashi, mut seed) = super::scrape_hashi(
         client.clone(),
         state.hashi_id(),
         state.package_id_original(),
@@ -178,7 +178,12 @@ async fn ensure_bootstrapped(
     if let Some((version, package)) = latest_package {
         state.add_package_version(version, package);
     }
-    state.advance_state_watermark(seed.floor);
+    // A fresh routing table only knows the original package id; restore
+    // the publish history so the tripwire keeps recognizing types an
+    // intermediate upgrade defined.
+    seed.routing
+        .register_packages(state.state().package_versions());
+    state.reset_state_watermark(seed.floor);
     *mirror = Some(Mirror::from_seed(seed));
     state.request_limiter_reconcile();
     if let Some(metrics) = state.metrics() {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -238,6 +238,29 @@ impl OnchainState {
             *current = covered;
             true
         });
+        self.record_state_watermark();
+    }
+
+    /// Set the watermark to a re-bootstrap's scrape floor, which may be
+    /// *below* the current value. The scrape replaces the mirrored state
+    /// wholesale, so coverage claimed by the mirror it tore down no
+    /// longer holds; leaving the higher value would report state the new
+    /// mirror does not have until replay catches up. Waiters simply
+    /// block for longer.
+    fn reset_state_watermark(&self, floor: u64) {
+        let previous = self.state_watermark();
+        if floor < previous {
+            tracing::warn!(
+                previous,
+                floor,
+                "mirror re-bootstrapped below its previous coverage; state watermark reset"
+            );
+        }
+        self.0.state_watermark.send_replace(floor);
+        self.record_state_watermark();
+    }
+
+    fn record_state_watermark(&self) {
         if let Some(metrics) = &self.0.metrics {
             metrics
                 .watcher_state_watermark
@@ -322,7 +345,18 @@ impl OnchainState {
         if let Some(metrics) = &self.0.metrics {
             hashi.committees.set_metrics(metrics.clone());
         }
-        self.state_mut().hashi = hashi;
+        let mut guard = self.state_mut();
+        guard.hashi = hashi;
+        // A wholesale replace swallows the removal transition of any
+        // withdrawal that confirmed during the gap, so its signed-at
+        // entry would linger for the life of the process.
+        let State {
+            hashi,
+            withdrawal_signed_at_ms,
+            ..
+        } = &mut *guard;
+        withdrawal_signed_at_ms
+            .retain(|id, _| hashi.withdrawal_queue.withdrawal_txns().contains_key(id));
     }
 
     /// Record an on-chain package upgrade. The root's `UpgradeCap`
@@ -767,14 +801,16 @@ impl State {
         client: Client,
         ids: HashiIds,
     ) -> Result<(Self, CheckpointInfo, route::MirrorSeed)> {
-        let (package_versions, (checkpoint_info, hashi, seed)) = tokio::try_join!(
+        let (package_versions, (checkpoint_info, hashi, mut seed)) = tokio::try_join!(
             scrape_package_versions(client.clone(), ids.package_id),
             scrape_hashi(client, ids.hashi_object_id, ids.package_id),
         )?;
+        let package_versions = move_types::PackageVersions::new(package_versions);
+        seed.routing.register_packages(&package_versions);
 
         Ok((
             State {
-                package_versions: move_types::PackageVersions::new(package_versions),
+                package_versions,
                 hashi,
                 withdrawal_signed_at_ms: BTreeMap::new(),
             },

--- a/crates/hashi/src/onchain/route.rs
+++ b/crates/hashi/src/onchain/route.rs
@@ -92,6 +92,15 @@ impl RoutingTable {
         self.packages.insert(package);
     }
 
+    /// Register every published package id. A Move type keeps its
+    /// defining package's address forever, so a type introduced by an
+    /// upgrade carries that version's address and nothing else — the
+    /// tripwire needs the whole history, not just the original and the
+    /// current one.
+    pub(super) fn register_packages(&mut self, packages: &move_types::PackageVersions) {
+        self.packages.extend(packages.versions().values().copied());
+    }
+
     pub(super) fn is_hashi_package(&self, package: &Address) -> bool {
         self.packages.contains(package)
     }
@@ -393,6 +402,27 @@ mod tests {
         let wrapper = addr(0x21);
         routing.register_wrapper(wrapper, addr(0x99));
         assert_eq!(routing.resolve_owner(&wrapper), None);
+    }
+
+    #[test]
+    fn register_packages_covers_every_published_version() {
+        let (mut routing, _) = routing_with_bitcoin_state();
+        let (v1, v2, v3) = (addr(0xa1), addr(0xa2), addr(0xa3));
+        routing.register_package(v1);
+        assert!(!routing.is_hashi_package(&v2));
+
+        // A type introduced by an upgrade carries that version's address
+        // forever, so the tripwire needs the whole history and not just
+        // the first and last entries.
+        routing.register_packages(&move_types::PackageVersions::new(BTreeMap::from([
+            (1, v1),
+            (2, v2),
+            (3, v3),
+        ])));
+        assert!(routing.is_hashi_package(&v1));
+        assert!(routing.is_hashi_package(&v2));
+        assert!(routing.is_hashi_package(&v3));
+        assert!(!routing.is_hashi_package(&addr(0xa4)));
     }
 
     #[test]


### PR DESCRIPTION
Follow-ups from the #871 review, all in the mirror's ingest path. Each one is a place the mirror could go wrong without saying so.

- **`PackageWrite` demanded an object nothing reads.** It shared the `ObjectWrite` arm, so an upgrade transaction required the package object from the object set only for pass 3 to discard it (the upgrade comes from the root's `UpgradeCap`). A miss would have failed the frame with an error pointing at the read mask. Skipped now, with `AccumulatorWrite` given its own arm so the catch-all no longer absorbs known states.
- **Unknown `output_state` was dropped silently.** No log, no unrouted entry, no metric — the one path where the mirror could stop applying writes without a signal. Those ids ride the tripwire now. `OutputObjectState` is `#[non_exhaustive]`, so the wildcard also covers whatever a future SDK adds.
- **The tripwire's package set was blind to intermediate upgrades.** It only ever held the original id and the current one from the `UpgradeCap`, so a type introduced by, say, v2 of a three-version package looked foreign and never incremented `hashi_watcher_unrouted_objects_total` — exactly the "we added state and forgot to route it" case it exists to catch. Seeded from the full `PackageVersions` history at bootstrap and re-bootstrap.
- **A re-bootstrap could leave the watermark over-claiming.** The scrape installs state wholesale and can regress it, but `advance_state_watermark` is monotonic, so a scrape served below the previous coverage kept reporting state the new mirror did not have. It resets now, warning when it moves backwards.
- **`withdrawal_signed_at_ms` leaked across re-bootstraps.** The wholesale replace swallows the removal transition of any withdrawal that confirmed during the gap. Pruned against the in-flight bag.
- **Object set decoded before the status check**, so a failed transaction paid for a decode of objects nothing reads and could fail the frame on them. Status first.

Plus an unused parameter and the split `impl TxView`.

New tests cover the package-write skip, the unknown-state tripwire, the failed-transaction short circuit, and the package-history seeding.

## Not included

- **The handoff committee round-trip** (`apply.rs`, `move_types::Committee::from`). The scrape path passes `convert_move_committee_handoff` the raw on-chain committee; apply passes one rebuilt from the enriched type, and `convert_move_committee_member` substitutes `fallback_encryption_public_key()` when the on-chain key won't parse. Move only asserts `length == 32`, not validity. I couldn't tell which path is intended — the same reconstruction is already used when signing (`withdrawals.rs`, `leader/guardian.rs`), so the scrape may be the odd one out. Left alone rather than guessed at; happy to follow up either way.
- **A bound on the replay loop.** #871 fixed the client half by moving to `new_sui_rpc_client`, but `replay_transactions` still has no overall deadline: `LedgerTip` short of target sleeps and retries with no cap, and the live loop is never reached, so `STREAM_STALL_TIMEOUT` can't fire. A stuck transaction index would hang the watcher with a flat `hashi_watcher_state_watermark`. Left out as out of scope here.