### PR TITLE
[Guardian] Persist failure log errors as strings

### DIFF
--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -203,7 +203,7 @@ mod tests {
         let msg = WithdrawalLogMessage::Failure {
             request_data: StandardWithdrawalRequestWire::from(request_data),
             request_sign,
-            error: GuardianError::RateLimitExceeded,
+            error: GuardianError::RateLimitExceeded.to_string(),
         };
         VerifiedLogRecord {
             object_key: "withdraw/failure.json".to_string(),

--- a/crates/hashi-guardian/src/withdraw_mode/committee_update.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/committee_update.rs
@@ -105,7 +105,7 @@ async fn log_failure(
         from_epoch,
         new_committee: signed.message().new_committee.clone(),
         request_sign: signed.committee_signature().clone(),
-        error: err.clone(),
+        error: err.to_string(),
     };
     if let Err(log_err) = enclave.log_committee_update(msg).await {
         error!(

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -53,7 +53,7 @@ pub async fn standard_withdrawal(
             let msg = WithdrawalLogMessage::Failure {
                 request_data: unsigned_request,
                 request_sign: request_signature,
-                error: withdraw_err.clone(),
+                error: withdraw_err.to_string(),
             };
             log_withdrawal_failure(enclave.as_ref(), wid, msg, &withdraw_err).await?;
             Err(withdraw_err)
@@ -322,6 +322,6 @@ mod tests {
             panic!("expected failed withdrawal record");
         };
         assert_eq!(request_data.seq, 1);
-        assert_eq!(error, GuardianError::RateLimitExceeded);
+        assert_eq!(error, GuardianError::RateLimitExceeded.to_string());
     }
 }

--- a/crates/hashi-types/src/guardian/errors.rs
+++ b/crates/hashi-types/src/guardian/errors.rs
@@ -1,14 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::Deserialize;
-use serde::Serialize;
-
 use super::SessionID;
 use super::lifecycle::EnclaveLifecycle;
 use super::time_utils::UnixSeconds;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum GuardianError {
     // ========================================================================
     // Errors requiring corrected input/data or investigation

--- a/crates/hashi-types/src/guardian/log/envelope.rs
+++ b/crates/hashi-types/src/guardian/log/envelope.rs
@@ -530,7 +530,7 @@ mod tests {
                 LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Failure {
                     request_data,
                     request_sign: request_sign.clone(),
-                    error: GuardianError::RateLimitExceeded,
+                    error: GuardianError::RateLimitExceeded.to_string(),
                 })),
             ),
             (
@@ -570,7 +570,7 @@ mod tests {
                     from_epoch: 0,
                     new_committee: committee_1,
                     request_sign,
-                    error: GuardianError::InvalidInputs("test failure".into()),
+                    error: GuardianError::InvalidInputs("test failure".into()).to_string(),
                 })),
             ),
             (
@@ -662,9 +662,14 @@ mod tests {
             LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Failure {
                 request_data: request_data.into(),
                 request_sign,
-                error: GuardianError::RateLimitExceeded,
+                error: GuardianError::RateLimitExceeded.to_string(),
             })),
             &signing_key,
+        );
+        let json = serde_json::to_value(&log).unwrap();
+        assert_eq!(
+            json["message"]["Withdrawal"]["Failure"]["error"],
+            GuardianError::RateLimitExceeded.to_string()
         );
 
         assert_writer_key_is_stable_and_verifies(log, &signing_key);
@@ -687,9 +692,14 @@ mod tests {
                     config: crate::move_types::Config::default(),
                 },
                 request_sign,
-                error: GuardianError::InvalidInputs("test failure".to_string()),
+                error: GuardianError::InvalidInputs("test failure".to_string()).to_string(),
             })),
             &signing_key,
+        );
+        let json = serde_json::to_value(&log).unwrap();
+        assert_eq!(
+            json["message"]["CommitteeUpdate"]["Failure"]["error"],
+            GuardianError::InvalidInputs("test failure".to_string()).to_string()
         );
 
         assert_writer_key_is_stable_and_verifies(log, &signing_key);
@@ -809,7 +819,7 @@ mod tests {
             LogMessage::Withdrawal(Box::new(WithdrawalLogMessage::Failure {
                 request_data: request_data.into(),
                 request_sign,
-                error: GuardianError::RateLimitExceeded,
+                error: GuardianError::RateLimitExceeded.to_string(),
             })),
             &signing_key,
         );

--- a/crates/hashi-types/src/guardian/log/message.rs
+++ b/crates/hashi-types/src/guardian/log/message.rs
@@ -442,7 +442,7 @@ pub enum WithdrawalLogMessage {
     Failure {
         request_data: StandardWithdrawalRequestWire,
         request_sign: CommitteeSignature,
-        error: GuardianError,
+        error: String,
     },
 }
 
@@ -463,7 +463,7 @@ pub enum CommitteeUpdateLogMessage {
         from_epoch: u64,
         new_committee: crate::move_types::Committee,
         request_sign: CommitteeSignature,
-        error: GuardianError,
+        error: String,
     },
 }
 


### PR DESCRIPTION
## Summary

- store withdrawal and committee-update failure errors as rendered strings
- remove Serde support from `GuardianError` so the runtime enum cannot be embedded in persisted formats accidentally
- verify that signed failure-log JSON contains string error values

## Compatibility

This intentionally changes the failure-log wire shape before mainnet. Existing testnet failure records use the old structured error representation and will need to be handled in a custom way if they need to be read.

Stacked on #877.

## Verification

- `make fmt`
- `git diff --check`
