### PR TITLE
[Guardian] [1/3] Unify signing and log validation APIs

### DIFF
--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -499,7 +499,7 @@ async fn submit_provisioner_init_to_relay(
     // Detached-sign the exact (session, config, share) bytes with this KP's
     // offline key. The relay pre-verifies the request before buffering it and
     // the enclave authoritatively re-verifies it before using the share.
-    let signed_request = KpSigned::new(request, signer_cert.clone(), None)
+    let signed_request = KpSigned::sign(request, signer_cert.clone(), None)
         .map_err(anyhow::Error::msg)
         .context("sign the relay submission with the KP key")?;
     let resp = relay_client

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -170,10 +170,10 @@ pub async fn run(
     let signed_response =
         GuardianSignedResponse::<ProvisionerRotateCertResponse>::try_from(response_pb)
             .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
-    signed_response
-        .verify_signature(&signing_pub_key)
-        .map_err(|e| anyhow!("verify ProvisionerRotateCertResponse signature: {e}"))?;
-    let response = signed_response.data.into_response();
+    let response = signed_response
+        .verify_into_data(&signing_pub_key)
+        .map_err(|e| anyhow!("verify ProvisionerRotateCertResponse signature: {e}"))?
+        .response;
     let expected_cert_seq = old_cert_seq.checked_add(1).context("cert_seq overflow")?;
     anyhow::ensure!(
         response.cert_seq == expected_cert_seq,

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -170,10 +170,10 @@ pub async fn run(
     let signed_response =
         GuardianSignedResponse::<ProvisionerRotateCertResponse>::try_from(response_pb)
             .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
-    let response = signed_response
-        .authenticate(&signing_pub_key)
-        .map_err(|e| anyhow!("authenticate ProvisionerRotateCertResponse: {e}"))?
-        .into_response();
+    signed_response
+        .verify_signature(&signing_pub_key)
+        .map_err(|e| anyhow!("verify ProvisionerRotateCertResponse signature: {e}"))?;
+    let response = signed_response.data.into_response();
     let expected_cert_seq = old_cert_seq.checked_add(1).context("cert_seq overflow")?;
     anyhow::ensure!(
         response.cert_seq == expected_cert_seq,

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -160,7 +160,7 @@ pub async fn run(
         &guardian_pub_key,
         &mut thread_rng(),
     );
-    let signed_request = KpSigned::new(request, signing_cert, None)
+    let signed_request = KpSigned::sign(request, signing_cert, None)
         .context("sign the certificate-rotation request with the authorizing KP key")?;
     let response_pb = client
         .provisioner_rotate_cert(pb::SignedProvisionerRotateCertRequest::from(signed_request))
@@ -170,8 +170,8 @@ pub async fn run(
     let signed_response = GuardianSigned::<ProvisionerRotateCertResponse>::try_from(response_pb)
         .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
     let response = signed_response
-        .verify(&signing_pub_key)
-        .map_err(|e| anyhow!("verify ProvisionerRotateCertResponse signature: {e}"))?;
+        .authenticate(&signing_pub_key)
+        .map_err(|e| anyhow!("authenticate ProvisionerRotateCertResponse: {e}"))?;
     let expected_cert_seq = old_cert_seq.checked_add(1).context("cert_seq overflow")?;
     anyhow::ensure!(
         response.cert_seq == expected_cert_seq,

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -11,7 +11,7 @@ use anyhow::anyhow;
 use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::EncPubKey;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::ProvisionerRotateCertRequest;
 use hashi_types::guardian::ProvisionerRotateCertResponse;
@@ -167,11 +167,13 @@ pub async fn run(
         .await
         .context("ProvisionerRotateCert RPC failed")?
         .into_inner();
-    let signed_response = GuardianSigned::<ProvisionerRotateCertResponse>::try_from(response_pb)
-        .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
+    let signed_response =
+        GuardianSignedResponse::<ProvisionerRotateCertResponse>::try_from(response_pb)
+            .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
     let response = signed_response
         .authenticate(&signing_pub_key)
-        .map_err(|e| anyhow!("authenticate ProvisionerRotateCertResponse: {e}"))?;
+        .map_err(|e| anyhow!("authenticate ProvisionerRotateCertResponse: {e}"))?
+        .into_response();
     let expected_cert_seq = old_cert_seq.checked_add(1).context("cert_seq overflow")?;
     anyhow::ensure!(
         response.cert_seq == expected_cert_seq,

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -21,7 +21,7 @@ use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::CeremonyStage;
 use hashi_types::guardian::CeremonyState;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::OperatorInitRequest;
 use hashi_types::guardian::SetupNewKeyRequest;
 use hashi_types::guardian::SetupNewKeyResponse;
@@ -165,14 +165,18 @@ pub async fn run(cfg: Config) -> Result<()> {
         .await
         .context("SetupNewKey RPC failed")?
         .into_inner();
-    let signed_resp = GuardianSigned::<SetupNewKeyResponse>::try_from(signed_resp_pb)
+    let signed_resp = GuardianSignedResponse::<SetupNewKeyResponse>::try_from(signed_resp_pb)
         .map_err(|e| anyhow!("decode SignedSetupNewKeyResponse: {e:?}"))?;
     info!(
         phase = "setup_new_key",
         n = cfg.kp_roster.num_shares,
         t = cfg.kp_roster.threshold,
-        share_count = signed_resp.data.encrypted_shares.share_count(),
-        ciphertext_count = signed_resp.data.encrypted_shares.ciphertext_count(),
+        share_count = signed_resp.data.response.encrypted_shares.share_count(),
+        ciphertext_count = signed_resp
+            .data
+            .response
+            .encrypted_shares
+            .ciphertext_count(),
         "setup_new_key response received",
     );
 
@@ -180,7 +184,8 @@ pub async fn run(cfg: Config) -> Result<()> {
     //    and sanity-check the shape; keep the now-authenticated BTC master pubkey.
     let response = signed_resp
         .authenticate(&signing_pub_key)
-        .map_err(|e| anyhow!("authenticate SetupNewKeyResponse: {e}"))?;
+        .map_err(|e| anyhow!("authenticate SetupNewKeyResponse: {e}"))?
+        .into_response();
     let live = CeremonyState::from(response);
     live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -180,12 +180,12 @@ pub async fn run(cfg: Config) -> Result<()> {
         "setup_new_key response received",
     );
 
-    // 7. Authenticate the response under the pinned session's signing key,
-    //    and sanity-check the shape; keep the now-authenticated BTC master pubkey.
-    let response = signed_resp
-        .authenticate(&signing_pub_key)
-        .map_err(|e| anyhow!("authenticate SetupNewKeyResponse: {e}"))?
-        .into_response();
+    // 7. Verify the response under the pinned session's signing key,
+    //    and sanity-check the shape; keep the verified BTC master pubkey.
+    signed_resp
+        .verify_signature(&signing_pub_key)
+        .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e}"))?;
+    let response = signed_resp.data.into_response();
     let live = CeremonyState::from(response);
     live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -176,11 +176,11 @@ pub async fn run(cfg: Config) -> Result<()> {
         "setup_new_key response received",
     );
 
-    // 7. Verify the response signature under the pinned session's signing key,
-    //    and sanity-check the shape; keep the now-verified BTC master pubkey.
+    // 7. Authenticate the response under the pinned session's signing key,
+    //    and sanity-check the shape; keep the now-authenticated BTC master pubkey.
     let response = signed_resp
-        .verify(&signing_pub_key)
-        .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e}"))?;
+        .authenticate(&signing_pub_key)
+        .map_err(|e| anyhow!("authenticate SetupNewKeyResponse: {e}"))?;
     let live = CeremonyState::from(response);
     live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -167,25 +167,22 @@ pub async fn run(cfg: Config) -> Result<()> {
         .into_inner();
     let signed_resp = GuardianSignedResponse::<SetupNewKeyResponse>::try_from(signed_resp_pb)
         .map_err(|e| anyhow!("decode SignedSetupNewKeyResponse: {e:?}"))?;
+
+    // 7. Verify the response under the pinned session's signing key,
+    //    and sanity-check the shape; keep the verified BTC master pubkey.
+    let response = signed_resp
+        .verify_into_data(&signing_pub_key)
+        .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e}"))?
+        .response;
     info!(
         phase = "setup_new_key",
         n = cfg.kp_roster.num_shares,
         t = cfg.kp_roster.threshold,
-        share_count = signed_resp.data.response.encrypted_shares.share_count(),
-        ciphertext_count = signed_resp
-            .data
-            .response
-            .encrypted_shares
-            .ciphertext_count(),
+        share_count = response.encrypted_shares.share_count(),
+        ciphertext_count = response.encrypted_shares.ciphertext_count(),
         "setup_new_key response received",
     );
 
-    // 7. Verify the response under the pinned session's signing key,
-    //    and sanity-check the shape; keep the verified BTC master pubkey.
-    signed_resp
-        .verify_signature(&signing_pub_key)
-        .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e}"))?;
-    let response = signed_resp.data.into_response();
     let live = CeremonyState::from(response);
     live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -589,7 +589,7 @@ mod tests {
             current_committee_epoch: None,
             mpc_master_g: Some(master_g),
         };
-        let signed_info = GuardianSigned::new(info, &signing_key, 1);
+        let signed_info = GuardianSigned::sign(info, &signing_key, 1);
         let domain = GetGuardianInfoResponse::new(
             NitroAttestation::new(vec![1, 2, 3]),
             signing_key.verification_key(),

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -415,6 +415,7 @@ mod tests {
     use hashi_types::bitcoin::sign_btc_tx;
     use hashi_types::guardian::proto_conversions::get_guardian_info_response_to_pb;
     use hashi_types::guardian::proto_conversions::signed_standard_withdrawal_request_to_pb;
+    use hashi_types::guardian::GuardianResponse;
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::GuardianSigned;
     use hashi_types::guardian::LimiterState;
@@ -589,7 +590,7 @@ mod tests {
             current_committee_epoch: None,
             mpc_master_g: Some(master_g),
         };
-        let signed_info = GuardianSigned::sign(info, &signing_key, 1);
+        let signed_info = GuardianSigned::sign(GuardianResponse::new(info, 1), &signing_key);
         let domain = GetGuardianInfoResponse::new(
             NitroAttestation::new(vec![1, 2, 3]),
             signing_key.verification_key(),

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -138,7 +138,6 @@ impl GuardianService for Forwarding {
 mod tests {
     use super::*;
     use crate::cache::CachingGuardianGrpc;
-    use hashi_types::guardian::proto_conversions::guardian_encrypted_share_to_pb;
     use hashi_types::guardian::Ciphertext;
     use hashi_types::guardian::GuardianEncryptedShare;
     use hashi_types::guardian::ShareID;
@@ -345,24 +344,23 @@ mod tests {
     fn verifies_provisioner_rotate_cert_signature_before_forwarding() {
         let (cert_armored, secret_armored) = mock_pgp_keypair();
         let cert = PgpPublicCert::new(cert_armored.clone()).unwrap();
-        let mut request = proto::SignedProvisionerRotateCertRequest {
-            new_kp_pgp_cert: cert_armored.clone(),
-            encrypted_share: Some(guardian_encrypted_share_to_pb(GuardianEncryptedShare {
+        let domain = ProvisionerRotateCertRequest::from_encrypted_share_for_testing(
+            "session".into(),
+            0,
+            cert.fingerprint().to_hex(),
+            cert.clone(),
+            GuardianEncryptedShare {
                 id: ShareID::new(1).unwrap(),
                 ciphertext: Ciphertext {
                     encapsulated_key: vec![1, 2, 3],
                     aes_ciphertext: vec![4, 5, 6],
                 },
-            })),
-            expected_session_id: "session".into(),
-            signer_cert: cert_armored,
-            kp_signature: "placeholder".into(),
-            expected_cert_seq: Some(0),
-            target_kp_pgp_fingerprint: cert.fingerprint().to_hex(),
-        };
-        let domain = KpSigned::<ProvisionerRotateCertRequest>::try_from(request.clone()).unwrap();
-        request.kp_signature =
-            sign_detached_in_process(&secret_armored, &KpSigned::signed_bytes(&domain.data));
+            },
+        );
+        let signature = sign_detached_in_process(&secret_armored, &KpSigned::signed_bytes(&domain));
+        let mut request = proto::SignedProvisionerRotateCertRequest::from(KpSigned::from_parts(
+            domain, cert, signature,
+        ));
 
         verify_provisioner_rotate_cert_signature(&request).unwrap();
 

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -45,7 +45,7 @@ fn verify_provisioner_rotate_cert_signature(
     let signed_request = KpSigned::<ProvisionerRotateCertRequest>::try_from(request.clone())
         .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
     signed_request
-        .authenticate()
+        .verify_signature()
         .map_err(|error| Status::unauthenticated(error.to_string()))?;
     Ok(())
 }

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -45,7 +45,7 @@ fn verify_provisioner_rotate_cert_signature(
     let signed_request = KpSigned::<ProvisionerRotateCertRequest>::try_from(request.clone())
         .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
     signed_request
-        .verify()
+        .authenticate()
         .map_err(|error| Status::unauthenticated(error.to_string()))?;
     Ok(())
 }

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -134,10 +134,10 @@ impl Relay {
 /// relay roster and its detached signature must cover these exact
 /// (session, config, share) bytes. This is only a DoS guard; the enclave repeats
 /// signature verification authoritatively.
-fn verify_kp_submission(
-    signed_request: &KpSigned<SingleProvisionerInitRequest>,
+fn verify_kp_submission<'a>(
+    signed_request: &'a KpSigned<SingleProvisionerInitRequest>,
     authorized_kp_fingerprints: &[Fingerprint],
-) -> Result<(), Status> {
+) -> Result<&'a SingleProvisionerInitRequest, Status> {
     let fingerprint = signed_request.signer_fingerprint();
     if !authorized_kp_fingerprints.contains(&fingerprint) {
         return Err(Status::permission_denied(format!(
@@ -196,11 +196,12 @@ impl GuardianRelayService for Relay {
 
         // Authenticate before the lock or any backend read: junk submissions
         // can't poison the batch, hold the mutex, or cost enclave round-trips.
-        verify_kp_submission(&signed_request, &self.authorized_kp_fingerprints)?;
-        let expected_session_id = signed_request.data.expected_session_id().to_string();
-        let expected_config_hash = *signed_request.data.expected_config_hash();
-        let expected_genesis_state_hash = signed_request.data.expected_genesis_state_hash();
-        let id = u32::from(signed_request.data.encrypted_share().id.get());
+        let verified_request =
+            verify_kp_submission(&signed_request, &self.authorized_kp_fingerprints)?;
+        let expected_session_id = verified_request.expected_session_id().to_string();
+        let expected_config_hash = *verified_request.expected_config_hash();
+        let expected_genesis_state_hash = verified_request.expected_genesis_state_hash();
+        let id = u32::from(verified_request.encrypted_share().id.get());
 
         // Hold the accumulator across the status read + batch submit so a racing
         // session change can't wipe a half-filled buffer, and only one runs at a time.
@@ -364,11 +365,7 @@ mod tests {
         );
         let signed_bytes = KpSigned::signed_bytes(&request);
         let good_sig = sign_detached_in_process(&secret_armored, &signed_bytes);
-        let signed_request = KpSigned {
-            data: request.clone(),
-            signer_cert: cert.clone(),
-            signature: good_sig.clone(),
-        };
+        let signed_request = KpSigned::from_parts(request.clone(), cert.clone(), good_sig.clone());
 
         // A rostered signer with a valid signature over the exact submission passes.
         verify_kp_submission(&signed_request, &roster).unwrap();
@@ -384,11 +381,8 @@ mod tests {
             None,
             other_share,
         );
-        let signed_other_share = KpSigned {
-            data: other_request,
-            signer_cert: cert.clone(),
-            signature: good_sig.clone(),
-        };
+        let signed_other_share =
+            KpSigned::from_parts(other_request, cert.clone(), good_sig.clone());
         assert!(
             verify_kp_submission(&signed_other_share, &roster).is_err(),
             "signature bound to another share must be rejected"
@@ -399,11 +393,7 @@ mod tests {
             "non-rostered signer must be rejected"
         );
 
-        let missing_signature = KpSigned {
-            data: request.clone(),
-            signer_cert: cert.clone(),
-            signature: String::new(),
-        };
+        let missing_signature = KpSigned::from_parts(request.clone(), cert.clone(), String::new());
         assert!(
             verify_kp_submission(&missing_signature, &roster).is_err(),
             "missing signature must be rejected"
@@ -417,11 +407,7 @@ mod tests {
         );
         let other_bytes = KpSigned::signed_bytes(&other_session_request);
         let stale_sig = sign_detached_in_process(&secret_armored, &other_bytes);
-        let stale_request = KpSigned {
-            data: request,
-            signer_cert: cert,
-            signature: stale_sig,
-        };
+        let stale_request = KpSigned::from_parts(request, cert, stale_sig);
         assert!(
             verify_kp_submission(&stale_request, &roster).is_err(),
             "signature bound to another session must be rejected"

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -166,9 +166,7 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    let signed = record.into_signed()?;
-    let timestamp_ms = signed.data.timestamp_ms();
-    let (_, message) = signed.into_data_unchecked().into_current()?;
+    let (_, timestamp_ms, message) = record.into_current_unchecked()?;
     let LogMessage::Withdrawal(message) = message else {
         anyhow::bail!("not a withdrawal record");
     };

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -166,8 +166,10 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    let timestamp_ms = record.timestamp_ms;
-    let LogMessage::Withdrawal(message) = record.message.into_current()? else {
+    let signed = record.into_signed()?;
+    let timestamp_ms = signed.data.timestamp_ms();
+    let (_, message) = signed.into_data_unchecked().into_current()?;
+    let LogMessage::Withdrawal(message) = message else {
         anyhow::bail!("not a withdrawal record");
     };
     let WithdrawalLogMessage::Success {

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -209,7 +209,7 @@ mod tests {
     ) -> KPEncryptedSharesRoster {
         let signed = rotate_kps(enclave.clone(), req).await.expect("ok");
         signed
-            .verify(&enclave.signing_pubkey())
+            .authenticate(&enclave.signing_pubkey())
             .expect("response signed by enclave")
             .encrypted_shares
     }

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -209,10 +209,9 @@ mod tests {
     ) -> KPEncryptedSharesRoster {
         let signed = rotate_kps(enclave.clone(), req).await.expect("ok");
         signed
-            .authenticate(&enclave.signing_pubkey())
-            .expect("response signed by enclave")
-            .into_response()
-            .encrypted_shares
+            .verify_signature(&enclave.signing_pubkey())
+            .expect("response signed by enclave");
+        signed.data.into_response().encrypted_shares
     }
 
     /// Assert the rotation returned `new_n` PGP-armored shares and produced

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -209,9 +209,10 @@ mod tests {
     ) -> KPEncryptedSharesRoster {
         let signed = rotate_kps(enclave.clone(), req).await.expect("ok");
         signed
-            .verify_signature(&enclave.signing_pubkey())
-            .expect("response signed by enclave");
-        signed.data.into_response().encrypted_shares
+            .verify_into_data(&enclave.signing_pubkey())
+            .expect("response signed by enclave")
+            .response
+            .encrypted_shares
     }
 
     /// Assert the rotation returned `new_n` PGP-armored shares and produced

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -18,7 +18,7 @@ use tracing::info;
 pub async fn rotate_kps(
     enclave: Arc<Enclave>,
     request: RotateKpsRequest,
-) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
+) -> GuardianResult<GuardianSignedResponse<RotateKpsResponse>> {
     info!("/rotate_kps - Received request.");
 
     enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
@@ -59,7 +59,7 @@ async fn finalize_rotation(
     old_shares: &[Share],
     old_instance: &SecretSharingInstance,
     state: RotateKpsState,
-) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
+) -> GuardianResult<GuardianSignedResponse<RotateKpsResponse>> {
     info!("Threshold reached, reconstructing BTC key.");
 
     let k256_sk =
@@ -211,6 +211,7 @@ mod tests {
         signed
             .authenticate(&enclave.signing_pubkey())
             .expect("response signed by enclave")
+            .into_response()
             .encrypted_shares
     }
 
@@ -253,14 +254,14 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message else {
+        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message() else {
             panic!("expected V2 Ceremony variant");
         };
         let CeremonyLogMessage::Rotate {
             old_instance,
             new_instance,
             btc_master_pubkey,
-        } = *ceremony
+        } = ceremony.as_ref()
         else {
             panic!("expected Rotate variant");
         };
@@ -282,7 +283,7 @@ mod tests {
         let reconstructed = combine_shares(&decrypted_shares[..new_t], new_t).unwrap();
         assert_eq!(
             k256_sk_to_btc_xonly_pubkey(&reconstructed),
-            btc_master_pubkey,
+            *btc_master_pubkey,
             "threshold decrypted rotation shares should reconstruct the original key"
         );
 
@@ -299,10 +300,11 @@ mod tests {
             "expected sharing_seq=1 cert_seq=0, got key {shares_key}"
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message
+        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message()
         else {
             panic!("expected V2 KpShareState variant");
         };
+        let shares = shares.as_ref();
         assert_eq!(shares.sharing_seq, 1);
         assert_eq!(shares.cert_seq, 0);
         assert_eq!(shares.encrypted_shares, *response_shares);

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -16,7 +16,7 @@ use tracing::info;
 pub async fn setup_new_key(
     enclave: Arc<Enclave>,
     request: SetupNewKeyRequest,
-) -> GuardianResult<GuardianSigned<SetupNewKeyResponse>> {
+) -> GuardianResult<GuardianSignedResponse<SetupNewKeyResponse>> {
     info!("/setup_new_key - Received request.");
 
     enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
@@ -119,7 +119,7 @@ mod tests {
         let verification_key = &enclave.signing_pubkey();
         let (request, secret_keys) = mock_setup_new_key_request();
         let resp = setup_new_key(enclave.clone(), request).await.unwrap();
-        let validated_resp = resp.authenticate(verification_key).unwrap();
+        let validated_resp = resp.authenticate(verification_key).unwrap().into_response();
         assert_eq!(enclave.lifecycle(), CeremonyStage::Completed.into());
 
         // Response still carries the armored ciphertexts.
@@ -162,22 +162,22 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message else {
+        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message() else {
             panic!("expected V2 Ceremony variant");
         };
         let CeremonyLogMessage::NewKey {
             instance,
             btc_master_pubkey,
-        } = *ceremony
+        } = ceremony.as_ref()
         else {
             panic!("expected NewKey variant");
         };
-        assert_eq!(instance, validated_resp.secret_sharing_instance);
+        assert_eq!(instance, &validated_resp.secret_sharing_instance);
         assert_eq!(instance.sharing_seq(), 0);
         assert_eq!(instance.num_shares(), TEST_N);
         assert_eq!(instance.threshold(), TEST_T);
         // The ceremony log records the same BTC master pubkey as the response.
-        assert_eq!(btc_master_pubkey, validated_resp.btc_master_pubkey);
+        assert_eq!(*btc_master_pubkey, validated_resp.btc_master_pubkey);
 
         // The encrypted shares are persisted to kp-shares/ keyed by sharing_seq
         // and cert_seq, and carry the ciphertexts the ceremony log omits.
@@ -197,10 +197,11 @@ mod tests {
             )
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message
+        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message()
         else {
             panic!("expected V2 KpShareState variant");
         };
+        let shares = shares.as_ref();
         assert_eq!(shares.sharing_seq, 0);
         assert_eq!(shares.cert_seq, 0);
         assert_eq!(shares.encrypted_shares, validated_resp.encrypted_shares);

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -119,8 +119,7 @@ mod tests {
         let verification_key = &enclave.signing_pubkey();
         let (request, secret_keys) = mock_setup_new_key_request();
         let resp = setup_new_key(enclave.clone(), request).await.unwrap();
-        resp.verify_signature(verification_key).unwrap();
-        let validated_resp = resp.data.into_response();
+        let validated_resp = resp.verify_into_data(verification_key).unwrap().response;
         assert_eq!(enclave.lifecycle(), CeremonyStage::Completed.into());
 
         // Response still carries the armored ciphertexts.

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -119,7 +119,7 @@ mod tests {
         let verification_key = &enclave.signing_pubkey();
         let (request, secret_keys) = mock_setup_new_key_request();
         let resp = setup_new_key(enclave.clone(), request).await.unwrap();
-        let validated_resp = resp.verify(verification_key).unwrap();
+        let validated_resp = resp.authenticate(verification_key).unwrap();
         assert_eq!(enclave.lifecycle(), CeremonyStage::Completed.into());
 
         // Response still carries the armored ciphertexts.

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -119,7 +119,8 @@ mod tests {
         let verification_key = &enclave.signing_pubkey();
         let (request, secret_keys) = mock_setup_new_key_request();
         let resp = setup_new_key(enclave.clone(), request).await.unwrap();
-        let validated_resp = resp.authenticate(verification_key).unwrap().into_response();
+        resp.verify_signature(verification_key).unwrap();
+        let validated_resp = resp.data.into_response();
         assert_eq!(enclave.lifecycle(), CeremonyStage::Completed.into());
 
         // Response still carries the armored ciphertexts.

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -492,10 +492,10 @@ impl Enclave {
         self.config.signing_keys.verification_key()
     }
 
-    pub fn sign<T: SigningIntent>(&self, data: T) -> GuardianSigned<T> {
+    pub fn sign<T: GuardianSigningIntent>(&self, data: T) -> GuardianSigned<T> {
         let kp = &self.config.signing_keys;
         let timestamp = now_timestamp_ms();
-        GuardianSigned::new(data, kp, timestamp)
+        GuardianSigned::sign(data, kp, timestamp)
     }
 
     // ========================================================================

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -492,10 +492,10 @@ impl Enclave {
         self.config.signing_keys.verification_key()
     }
 
-    pub fn sign<T: GuardianSigningIntent>(&self, data: T) -> GuardianSigned<T> {
+    pub fn sign<T: GuardianSigningIntent>(&self, response: T) -> GuardianSignedResponse<T> {
         let kp = &self.config.signing_keys;
         let timestamp = now_timestamp_ms();
-        GuardianSigned::sign(data, kp, timestamp)
+        GuardianSigned::sign(GuardianResponse::new(response, timestamp), kp)
     }
 
     // ========================================================================

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -492,7 +492,10 @@ impl Enclave {
         self.config.signing_keys.verification_key()
     }
 
-    pub fn sign<T: GuardianSigningIntent>(&self, response: T) -> GuardianSignedResponse<T> {
+    pub fn sign<T>(&self, response: T) -> GuardianSignedResponse<T>
+    where
+        GuardianResponse<T>: GuardianSigningIntent,
+    {
         let kp = &self.config.signing_keys;
         let timestamp = now_timestamp_ms();
         GuardianSigned::sign(GuardianResponse::new(response, timestamp), kp)

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -21,7 +21,6 @@ use hashi_types::guardian::GuardianError::LifecycleMismatch;
 use hashi_types::guardian::GuardianError::Unavailable;
 use hashi_types::guardian::*;
 use hpke::Serializable;
-use serde::Serialize;
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -493,7 +492,7 @@ impl Enclave {
         self.config.signing_keys.verification_key()
     }
 
-    pub fn sign<T: Serialize + SigningIntent>(&self, data: T) -> GuardianSigned<T> {
+    pub fn sign<T: SigningIntent>(&self, data: T) -> GuardianSigned<T> {
         let kp = &self.config.signing_keys;
         let timestamp = now_timestamp_ms();
         GuardianSigned::new(data, kp, timestamp)

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -270,16 +270,16 @@ mod tests {
 
         let attestation: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert!(matches!(
-            attestation.message,
+            attestation.message(),
             VersionedLogMessage::V2(LogMessage::Init(message))
-                if matches!(*message, OIAttestationUnsigned { .. })
+                if matches!(message.as_ref(), OIAttestationUnsigned { .. })
         ));
 
         let guardian_info: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Init(message)) = guardian_info.message else {
+        let VersionedLogMessage::V2(LogMessage::Init(message)) = guardian_info.message() else {
             panic!("expected V2 init record");
         };
-        let OIGuardianInfo(info) = *message else {
+        let OIGuardianInfo(info) = message.as_ref() else {
             panic!("expected operator-init GuardianInfo record");
         };
         assert_eq!(info.lifecycle, expected_lifecycle);

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -637,7 +637,8 @@ impl GuardianS3Client {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) = attestation_record.into_unsigned()?.validate()?;
+        let (_, _, attestation_message) =
+            attestation_record.into_unsigned()?.validate_unsigned()?;
         let (attestation, signing_pubkey) = attestation_message
             .into_init_log()
             .and_then(|x| match x {
@@ -655,8 +656,8 @@ impl GuardianS3Client {
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
         let signed = info_record.into_signed()?;
-        let timestamp_ms = signed.timestamp_ms;
-        signed.data.validate(timestamp_ms, &signing_pubkey)?;
+        let timestamp_ms = signed.data.timestamp_ms();
+        signed.data.validate(&signing_pubkey)?;
         let data = signed
             .authenticate(&signing_pubkey)
             .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
@@ -1030,7 +1031,7 @@ mod tests {
         let error = record
             .into_unsigned()
             .unwrap()
-            .validate()
+            .validate_unsigned()
             .expect_err("the copied key must still fail canonical validation");
 
         assert!(

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -637,8 +637,7 @@ impl GuardianS3Client {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) =
-            attestation_record.into_unsigned()?.validate_unsigned()?;
+        let (_, _, attestation_message) = attestation_record.validate_unsigned()?;
         let (attestation, signing_pubkey) = attestation_message
             .into_init_log()
             .and_then(|x| match x {
@@ -655,12 +654,7 @@ impl GuardianS3Client {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
-        let signed = info_record.into_signed()?;
-        signed.data.validate(&signing_pubkey)?;
-        let data = signed
-            .authenticate(&signing_pubkey)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-        let (_, info_message) = data.into_current()?;
+        let (_, _, info_message) = info_record.validate(&signing_pubkey)?;
         let info = info_message
             .into_init_log()
             .and_then(|x| match x {
@@ -1028,8 +1022,6 @@ mod tests {
             .await
             .expect("the embedded key matches the actual S3 key");
         let error = record
-            .into_unsigned()
-            .unwrap()
             .validate_unsigned()
             .expect_err("the copied key must still fail canonical validation");
 

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -609,7 +609,12 @@ impl GuardianS3Client {
                 key, e
             ))
         })?;
-        record.validate_actual_object_key(key)?;
+        if record.object_key() != key {
+            return Err(InvalidS3Log(format!(
+                "S3 object key mismatch: record contains {}, actual key is {key}",
+                record.object_key()
+            )));
+        }
         Ok(record)
     }
 
@@ -976,5 +981,80 @@ mod tests {
             matches!(error, S3Error(message) if message.contains("expired object lock metadata"))
         );
         assert_eq!(get_expired.num_calls(), 1);
+    }
+
+    async fn assert_log_read_rejects_relocation(relocated_key: &str) {
+        let signing_key = GuardianSignKeyPair::from([13u8; 32]);
+        let record = LogRecord::new_at_timestamp(
+            "session".into(),
+            LogMessage::Heartbeat(HeartbeatLogMessage::new(42)),
+            &signing_key,
+            1_700_000_000_000,
+        );
+        let intended_key = record.object_key().to_string();
+        let body = serde_json::to_vec(&record).unwrap();
+        let relocated_key = relocated_key.to_string();
+        let mock_key = relocated_key.clone();
+        let get_relocated = mock!(Client::get_object)
+            .match_requests(move |req| {
+                req.bucket() == Some("bucket") && req.key() == Some(mock_key.as_str())
+            })
+            .then_output(move || {
+                GetObjectOutput::builder()
+                    .body(ByteStream::from(body.clone()))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&get_relocated]);
+        let logger = mk_logger_with_client(client);
+
+        let error = logger
+            .get_log_record_inner(
+                &relocated_key,
+                LockCheck::Skipped,
+                HistoryCheck::AlreadyChecked,
+            )
+            .await
+            .expect_err("a relocated record must be rejected");
+
+        assert!(matches!(
+            error,
+            InvalidS3Log(message)
+                if message == format!(
+                    "S3 object key mismatch: record contains {intended_key}, actual key is {relocated_key}"
+                )
+        ));
+        assert_eq!(get_relocated.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn signed_log_rejects_cross_prefix_relocation() {
+        assert_log_read_rejects_relocation(
+            "withdraw/2023/11/14/22/session-00000000000000000042.json",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn signed_log_rejects_lexicographically_higher_key_relocation() {
+        assert_log_read_rejects_relocation(
+            "heartbeat/2023/11/14/22/session-00000000000000000043.json",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn signed_log_rejects_future_hour_relocation() {
+        assert_log_read_rejects_relocation(
+            "heartbeat/2023/11/14/23/session-00000000000000000042.json",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn signed_log_rejects_changed_session_relocation() {
+        assert_log_read_rejects_relocation(
+            "heartbeat/2023/11/14/22/aliased-session-00000000000000000042.json",
+        )
+        .await;
     }
 }

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -654,7 +654,7 @@ impl GuardianS3Client {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
-        let (_, _, info_message) = info_record.verify(&signing_pubkey)?;
+        let (_, _, info_message) = info_record.validate_signed(&signing_pubkey)?;
         let info = info_message
             .into_init_log()
             .and_then(|x| match x {
@@ -704,6 +704,8 @@ mod tests {
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::HeartbeatLogMessage;
     use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::NitroAttestation;
+    use hashi_types::guardian::SessionID;
 
     fn mk_logger_with_client(client: Client) -> GuardianS3Client {
         let config = S3Config {
@@ -981,6 +983,51 @@ mod tests {
             matches!(error, S3Error(message) if message.contains("expired object lock metadata"))
         );
         assert_eq!(get_expired.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn unsigned_log_replay_reaches_canonical_key_validation() {
+        let signing_key = GuardianSignKeyPair::from([14u8; 32]);
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
+        let mut record = LogRecord::new_at_timestamp(
+            session_id,
+            LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
+                attestation: NitroAttestation::new(vec![1, 2, 3]),
+                signing_public_key: signing_key.verification_key(),
+            })),
+            &signing_key,
+            1_700_000_000_000,
+        );
+        record.object_key = "init/copied-attestation.json".to_string();
+        let body = serde_json::to_vec(&record).unwrap();
+        let get_copied = mock!(Client::get_object)
+            .match_requests(|req| {
+                req.bucket() == Some("bucket") && req.key() == Some("init/copied-attestation.json")
+            })
+            .then_output(move || {
+                GetObjectOutput::builder()
+                    .body(ByteStream::from(body.clone()))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&get_copied]);
+        let logger = mk_logger_with_client(client);
+
+        let record = logger
+            .get_log_record_inner(
+                "init/copied-attestation.json",
+                LockCheck::Skipped,
+                HistoryCheck::AlreadyChecked,
+            )
+            .await
+            .expect("the embedded key matches the actual S3 key");
+        let error = record
+            .validate_unsigned()
+            .expect_err("the copied key must still fail canonical validation");
+
+        assert!(
+            matches!(error, InvalidS3Log(message) if message.contains("non-canonical S3 object key"))
+        );
+        assert_eq!(get_copied.num_calls(), 1);
     }
 
     async fn assert_log_read_rejects_relocation(relocated_key: &str) {

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -637,7 +637,7 @@ impl GuardianS3Client {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) = attestation_record.validate_unsigned()?;
+        let (_, _, attestation_message) = attestation_record.validate(None)?;
         let (attestation, signing_pubkey) = attestation_message
             .into_init_log()
             .and_then(|x| match x {
@@ -654,7 +654,7 @@ impl GuardianS3Client {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
-        let (_, _, info_message) = info_record.validate(&signing_pubkey)?;
+        let (_, _, info_message) = info_record.validate(Some(&signing_pubkey))?;
         let info = info_message
             .into_init_log()
             .and_then(|x| match x {
@@ -1022,7 +1022,7 @@ mod tests {
             .await
             .expect("the embedded key matches the actual S3 key");
         let error = record
-            .validate_unsigned()
+            .validate(None)
             .expect_err("the copied key must still fail canonical validation");
 
         assert!(

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -656,7 +656,6 @@ impl GuardianS3Client {
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
         let signed = info_record.into_signed()?;
-        let timestamp_ms = signed.data.timestamp_ms();
         signed.data.validate(&signing_pubkey)?;
         let data = signed
             .authenticate(&signing_pubkey)

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -637,7 +637,7 @@ impl GuardianS3Client {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) = attestation_record.validate_unsigned()?;
+        let (_, _, attestation_message) = attestation_record.into_unsigned()?.validate()?;
         let (attestation, signing_pubkey) = attestation_message
             .into_init_log()
             .and_then(|x| match x {
@@ -654,7 +654,13 @@ impl GuardianS3Client {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
-        let (_, _, info_message) = info_record.validate_signed(&signing_pubkey)?;
+        let signed = info_record.into_signed()?;
+        let timestamp_ms = signed.timestamp_ms;
+        signed.data.validate(timestamp_ms, &signing_pubkey)?;
+        let data = signed
+            .authenticate(&signing_pubkey)
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        let (_, info_message) = data.into_current()?;
         let info = info_message
             .into_init_log()
             .and_then(|x| match x {
@@ -989,7 +995,7 @@ mod tests {
     async fn unsigned_log_replay_reaches_canonical_key_validation() {
         let signing_key = GuardianSignKeyPair::from([14u8; 32]);
         let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
-        let mut record = LogRecord::new_at_timestamp(
+        let record = LogRecord::new_at_timestamp(
             session_id,
             LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
                 attestation: NitroAttestation::new(vec![1, 2, 3]),
@@ -998,8 +1004,9 @@ mod tests {
             &signing_key,
             1_700_000_000_000,
         );
-        record.object_key = "init/copied-attestation.json".to_string();
-        let body = serde_json::to_vec(&record).unwrap();
+        let mut record_json = serde_json::to_value(record).unwrap();
+        record_json["object_key"] = "init/copied-attestation.json".into();
+        let body = serde_json::to_vec(&record_json).unwrap();
         let get_copied = mock!(Client::get_object)
             .match_requests(|req| {
                 req.bucket() == Some("bucket") && req.key() == Some("init/copied-attestation.json")
@@ -1021,7 +1028,9 @@ mod tests {
             .await
             .expect("the embedded key matches the actual S3 key");
         let error = record
-            .validate_unsigned()
+            .into_unsigned()
+            .unwrap()
+            .validate()
             .expect_err("the copied key must still fail canonical validation");
 
         assert!(

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -15,6 +15,7 @@ use crate::s3_client::GuardianS3Client;
 use crate::s3_client::HistoryCheck;
 use crate::s3_client::LockCheck;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
+use hashi_types::guardian::time_utils::UnixMillis;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::CeremonyLogMessage;
@@ -30,7 +31,6 @@ use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::VerifiedSessionInfo;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
@@ -43,6 +43,61 @@ use tracing::info;
 
 mod heartbeat_checks;
 mod limiter_recovery;
+
+/// A log record whose message signature and writing session's attestation/PCRs
+/// have both been verified. Its message is normalized to the current schema.
+/// If a future schema cannot be converted losslessly, this type should retain
+/// the versioned message and leave version acceptance to callers instead.
+#[derive(Debug)]
+pub struct VerifiedLogRecord {
+    object_key: String,
+    session_id: SessionID,
+    timestamp_ms: UnixMillis,
+    message: LogMessage,
+    build_pcrs: BuildPcrs,
+}
+
+impl VerifiedLogRecord {
+    fn new(
+        object_key: String,
+        session_id: SessionID,
+        timestamp_ms: UnixMillis,
+        message: LogMessage,
+        build_pcrs: BuildPcrs,
+    ) -> Self {
+        Self {
+            object_key,
+            session_id,
+            timestamp_ms,
+            message,
+            build_pcrs,
+        }
+    }
+
+    pub fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub fn session_id(&self) -> &SessionID {
+        &self.session_id
+    }
+
+    pub fn timestamp_ms(&self) -> UnixMillis {
+        self.timestamp_ms
+    }
+
+    pub fn message(&self) -> &LogMessage {
+        &self.message
+    }
+
+    pub fn build_pcrs(&self) -> &BuildPcrs {
+        &self.build_pcrs
+    }
+
+    pub fn into_message(self) -> LogMessage {
+        self.message
+    }
+}
 
 /// Open an hour-scoped cursor at `start` over the `withdraw/` stream. Advance/
 /// retreat with [`S3HourScopedDirectory::next_dir`]/`prev_dir`, gate on

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -179,7 +179,7 @@ impl GuardianReader {
 
         let mut out = Vec::with_capacity(all_logs.len());
         for log in all_logs {
-            out.push(self.cache.authenticate_record(&self.s3, log).await?);
+            out.push(self.cache.verify_record(&self.s3, log).await?);
         }
         Ok(out)
     }
@@ -228,7 +228,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.authenticate_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy(build_policy, &build_pcrs)?;
         let session_id = record.session_id;
@@ -308,7 +308,7 @@ impl GuardianReader {
             .s3
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
-        let record = self.cache.authenticate_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::KpShareState(msg) = record.message else {
@@ -374,7 +374,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.authenticate_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::CommitteeUpdate(msg) = record.message else {
@@ -414,7 +414,7 @@ impl GuardianReader {
             )));
         }
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.authenticate_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::Genesis(msg) = record.message else {
@@ -461,8 +461,8 @@ impl GuardianSessionCache {
         Ok(&self.sessions[session_id])
     }
 
-    /// Authenticate `record` under its session's trusted signing key.
-    async fn authenticate_record(
+    /// Fully verify `record` under its session's attested signing key.
+    async fn verify_record(
         &mut self,
         s3: &GuardianS3Client,
         record: LogRecord,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -472,7 +472,7 @@ impl GuardianSessionCache {
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
         let signing_pubkey = session_info.signing_pubkey;
         let build_pcrs = session_info.build_pcrs.clone();
-        let (session_id, timestamp_ms, message) = record.validate(&signing_pubkey)?;
+        let (session_id, timestamp_ms, message) = record.validate(Some(&signing_pubkey))?;
         Ok(VerifiedLogRecord::new(
             object_key,
             session_id,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -415,7 +415,8 @@ impl GuardianSessionCache {
         let object_key = record.object_key.clone();
         let session_id = record.session_id.clone();
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        let (session_id, timestamp_ms, message) = record.verify(&session_info.signing_pubkey)?;
+        let (session_id, timestamp_ms, message) =
+            record.validate_signed(&session_info.signing_pubkey)?;
         Ok(VerifiedLogRecord::new(
             object_key,
             session_id,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -472,13 +472,7 @@ impl GuardianSessionCache {
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
         let signing_pubkey = session_info.signing_pubkey;
         let build_pcrs = session_info.build_pcrs.clone();
-        let signed = record.into_signed()?;
-        let timestamp_ms = signed.data.timestamp_ms();
-        signed.data.validate(&signing_pubkey)?;
-        let data = signed
-            .authenticate(&signing_pubkey)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-        let (session_id, message) = data.into_current()?;
+        let (session_id, timestamp_ms, message) = record.validate(&signing_pubkey)?;
         Ok(VerifiedLogRecord::new(
             object_key,
             session_id,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -124,7 +124,7 @@ impl GuardianReader {
 
         let mut out = Vec::with_capacity(all_logs.len());
         for log in all_logs {
-            out.push(self.cache.verify_record(&self.s3, log).await?);
+            out.push(self.cache.authenticate_record(&self.s3, log).await?);
         }
         Ok(out)
     }
@@ -173,7 +173,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.authenticate_record(&self.s3, record).await?;
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy(build_policy, &build_pcrs)?;
         let session_id = record.session_id;
@@ -253,7 +253,7 @@ impl GuardianReader {
             .s3
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.authenticate_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::KpShareState(msg) = record.message else {
@@ -319,7 +319,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.authenticate_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::CommitteeUpdate(msg) = record.message else {
@@ -359,7 +359,7 @@ impl GuardianReader {
             )));
         }
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.authenticate_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::Genesis(msg) = record.message else {
@@ -406,23 +406,30 @@ impl GuardianSessionCache {
         Ok(&self.sessions[session_id])
     }
 
-    /// Verify `record`'s signature under its session's trusted pubkey.
-    async fn verify_record(
+    /// Authenticate `record` under its session's trusted signing key.
+    async fn authenticate_record(
         &mut self,
         s3: &GuardianS3Client,
         record: LogRecord,
     ) -> GuardianResult<VerifiedLogRecord> {
-        let object_key = record.object_key.clone();
-        let session_id = record.session_id.clone();
+        let object_key = record.object_key().to_owned();
+        let session_id = record.session_id().clone();
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        let (session_id, timestamp_ms, message) =
-            record.validate_signed(&session_info.signing_pubkey)?;
+        let signing_pubkey = session_info.signing_pubkey;
+        let build_pcrs = session_info.build_pcrs.clone();
+        let signed = record.into_signed()?;
+        let timestamp_ms = signed.timestamp_ms;
+        signed.data.validate(timestamp_ms, &signing_pubkey)?;
+        let data = signed
+            .authenticate(&signing_pubkey)
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        let (session_id, message) = data.into_current()?;
         Ok(VerifiedLogRecord::new(
             object_key,
             session_id,
             timestamp_ms,
             message,
-            session_info.build_pcrs.clone(),
+            build_pcrs,
         ))
     }
 }

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -418,8 +418,8 @@ impl GuardianSessionCache {
         let signing_pubkey = session_info.signing_pubkey;
         let build_pcrs = session_info.build_pcrs.clone();
         let signed = record.into_signed()?;
-        let timestamp_ms = signed.timestamp_ms;
-        signed.data.validate(timestamp_ms, &signing_pubkey)?;
+        let timestamp_ms = signed.data.timestamp_ms();
+        signed.data.validate(&signing_pubkey)?;
         let data = signed
             .authenticate(&signing_pubkey)
             .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -3,6 +3,7 @@
 
 use super::heartbeat_cursor;
 use super::GuardianReader;
+use super::VerifiedLogRecord;
 use crate::HEARTBEAT_INTERVAL;
 use crate::LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE;
 use crate::OTHER_SESSION_QUIET_PERIOD;
@@ -15,7 +16,6 @@ use hashi_types::guardian::GuardianError::PriorSessionHeartbeatStillRecent;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VerifiedLogRecord;
 use std::collections::BTreeMap;
 use tracing::info;
 

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -25,6 +25,7 @@
 //! read-after-write consistency to cover the old session's final writes.
 
 use super::GuardianReader;
+use super::VerifiedLogRecord;
 use crate::s3_client::GuardianS3Client;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
@@ -32,7 +33,6 @@ use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::LogMessage;
-use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
 use tracing::info;

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -161,7 +161,7 @@ mod tests {
     use bitcoin::Txid;
     use hashi_types::guardian::BuildPcrs;
     use hashi_types::guardian::GuardianError;
-    use hashi_types::guardian::GuardianSigned;
+    use hashi_types::guardian::GuardianSignedResponse;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::StandardWithdrawalRequestWire;
     use hashi_types::guardian::StandardWithdrawalResponse;
@@ -185,7 +185,9 @@ mod tests {
             txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
             request_data: StandardWithdrawalRequestWire::from(request_data),
             request_sign,
-            response: GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data,
+            response: GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
+                .data
+                .response,
             post_state: state_with_seq(next_seq),
         };
         VerifiedLogRecord {

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -161,7 +161,6 @@ mod tests {
     use bitcoin::Txid;
     use hashi_types::guardian::BuildPcrs;
     use hashi_types::guardian::GuardianError;
-    use hashi_types::guardian::GuardianSignedResponse;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::StandardWithdrawalRequestWire;
     use hashi_types::guardian::StandardWithdrawalResponse;
@@ -185,9 +184,7 @@ mod tests {
             txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
             request_data: StandardWithdrawalRequestWire::from(request_data),
             request_sign,
-            response: GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
-                .data
-                .response,
+            response: StandardWithdrawalResponse::mock_for_testing(),
             post_state: state_with_seq(next_seq),
         };
         VerifiedLogRecord {

--- a/crates/hashi-guardian/src/task_spawner.rs
+++ b/crates/hashi-guardian/src/task_spawner.rs
@@ -24,7 +24,7 @@ use crate::withdraw_mode::standard_withdrawal as standard_withdrawal_domain;
 use crate::Enclave;
 use hashi_types::guardian::CommitteeTransitionRequest;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::HashiSigned;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::OperatorActivateRequest;
@@ -43,7 +43,7 @@ use std::sync::Arc;
 pub async fn setup_new_key(
     enclave: Arc<Enclave>,
     request: SetupNewKeyRequest,
-) -> GuardianResult<GuardianSigned<SetupNewKeyResponse>> {
+) -> GuardianResult<GuardianSignedResponse<SetupNewKeyResponse>> {
     enclave
         .spawn_control_task(request, setup::setup_new_key)
         .await
@@ -52,7 +52,7 @@ pub async fn setup_new_key(
 pub async fn rotate_kps(
     enclave: Arc<Enclave>,
     request: RotateKpsRequest,
-) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
+) -> GuardianResult<GuardianSignedResponse<RotateKpsResponse>> {
     enclave
         .spawn_control_task(request, rotate::rotate_kps)
         .await
@@ -88,7 +88,7 @@ pub async fn operator_activate(
 pub async fn provisioner_rotate_cert(
     enclave: Arc<Enclave>,
     signed_request: KpSigned<ProvisionerRotateCertRequest>,
-) -> GuardianResult<GuardianSigned<ProvisionerRotateCertResponse>> {
+) -> GuardianResult<GuardianSignedResponse<ProvisionerRotateCertResponse>> {
     enclave
         .spawn_control_task(
             signed_request,
@@ -100,7 +100,7 @@ pub async fn provisioner_rotate_cert(
 pub async fn standard_withdrawal(
     enclave: Arc<Enclave>,
     request: HashiSigned<StandardWithdrawalRequest>,
-) -> GuardianResult<GuardianSigned<StandardWithdrawalResponse>> {
+) -> GuardianResult<GuardianSignedResponse<StandardWithdrawalResponse>> {
     enclave
         .spawn_task(request, standard_withdrawal_domain::standard_withdrawal)
         .await

--- a/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
@@ -90,7 +90,7 @@ mod tests {
         assert_eq!(captured.len(), 1, "heartbeat tick should write one record");
         let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert_eq!(captured[0].0, record.object_key());
-        let VersionedLogMessage::V2(LogMessage::Heartbeat(message)) = record.message else {
+        let VersionedLogMessage::V2(LogMessage::Heartbeat(message)) = record.message() else {
             panic!("expected V2 heartbeat record");
         };
         assert_eq!(message.seq, 0);

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -418,7 +418,7 @@ mod tests {
             "provisioner init should write one record"
         );
         let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Init(message)) = record.message else {
+        let VersionedLogMessage::V2(LogMessage::Init(message)) = record.message() else {
             panic!("expected V2 init record");
         };
         assert_eq!(
@@ -429,20 +429,20 @@ mod tests {
             sharing_seq,
             share_ids,
             enclave_btc_pubkey,
-        } = *message
+        } = message.as_ref()
         else {
             panic!("expected provisioner-init completion record");
         };
-        assert_eq!(sharing_seq, 0);
+        assert_eq!(*sharing_seq, 0);
         assert_eq!(
             share_ids,
-            ctx.shares[..TEST_T]
+            &ctx.shares[..TEST_T]
                 .iter()
                 .map(|share| share.id)
                 .collect::<Vec<_>>()
         );
         assert_eq!(
-            enclave_btc_pubkey,
+            *enclave_btc_pubkey,
             ctx.enclave.config.enclave_btc_pubkey().unwrap()
         );
     }

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -148,10 +148,9 @@ fn verify_signed_submissions(
         .iter()
         .map(|signed| {
             let signer_fingerprint = signed.signer_fingerprint().to_hex();
-            signed
+            let submission = signed
                 .verify_signature()
                 .map_err(|error| GuardianError::Unauthenticated(error.to_string()))?;
-            let submission = &signed.data;
 
             if submission.expected_session_id() != live_session_id.as_str() {
                 return Err(GuardianError::InvalidInputs(format!(
@@ -367,11 +366,8 @@ mod tests {
                 &mut rand::thread_rng(),
             );
             let (cert, secret) = signer;
-            KpSigned {
-                signature: sign_detached_in_process(secret, &KpSigned::signed_bytes(&request)),
-                data: request,
-                signer_cert: cert.clone(),
-            }
+            let signature = sign_detached_in_process(secret, &KpSigned::signed_bytes(&request));
+            KpSigned::from_parts(request, cert.clone(), signature)
         }
 
         fn request(&self, shares: &[Share]) -> ProvisionerInitRequest {

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -28,7 +28,7 @@ pub async fn provisioner_rotate_cert(
 
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
     let request = signed_request
-        .verify()
+        .authenticate()
         .map_err(|error| Unauthenticated(error.to_string()))?;
 
     enclave.require_fully_initialized()?;

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -27,10 +27,9 @@ pub async fn provisioner_rotate_cert(
     info!("/provisioner_rotate_cert - Received request.");
 
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
-    signed_request
-        .verify_signature()
+    let request = signed_request
+        .verify_into_data()
         .map_err(|error| Unauthenticated(error.to_string()))?;
-    let request = signed_request.data;
 
     enclave.require_fully_initialized()?;
 

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -27,9 +27,10 @@ pub async fn provisioner_rotate_cert(
     info!("/provisioner_rotate_cert - Received request.");
 
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
-    let request = signed_request
-        .authenticate()
+    signed_request
+        .verify_signature()
         .map_err(|error| Unauthenticated(error.to_string()))?;
+    let request = signed_request.data;
 
     enclave.require_fully_initialized()?;
 

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -14,7 +14,7 @@ use hashi_types::guardian::crypto::encrypt_share_for_provisioner;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianError::Unauthenticated;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::ProvisionerRotateCertRequest;
 use hashi_types::guardian::ProvisionerRotateCertResponse;
@@ -23,7 +23,7 @@ use tracing::info;
 pub async fn provisioner_rotate_cert(
     enclave: Arc<Enclave>,
     signed_request: KpSigned<ProvisionerRotateCertRequest>,
-) -> GuardianResult<GuardianSigned<ProvisionerRotateCertResponse>> {
+) -> GuardianResult<GuardianSignedResponse<ProvisionerRotateCertResponse>> {
     info!("/provisioner_rotate_cert - Received request.");
 
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -9,7 +9,7 @@ use hashi_types::guardian::GuardianError;
 use hashi_types::guardian::GuardianError::InternalError;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::HashiSigned;
 use hashi_types::guardian::RateLimiter;
 use hashi_types::guardian::StandardWithdrawalRequest;
@@ -25,7 +25,7 @@ use tracing::info;
 pub async fn standard_withdrawal(
     enclave: Arc<Enclave>,
     signed_request: HashiSigned<StandardWithdrawalRequest>,
-) -> GuardianResult<GuardianSigned<StandardWithdrawalResponse>> {
+) -> GuardianResult<GuardianSignedResponse<StandardWithdrawalResponse>> {
     info!("/standard_withdrawal - Received request.");
 
     let unsigned_request = StandardWithdrawalRequestWire::from(signed_request.message().clone()); // for logging

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -293,14 +293,14 @@ mod tests {
         );
         let success: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert_eq!(captured[0].0, success.object_key());
-        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = success.message else {
+        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = success.message() else {
             panic!("expected V2 withdrawal record");
         };
         let WithdrawalLogMessage::Success {
             request_data,
             post_state,
             ..
-        } = *message
+        } = message.as_ref()
         else {
             panic!("expected successful withdrawal record");
         };
@@ -310,18 +310,18 @@ mod tests {
 
         let failure: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
         assert_eq!(captured[1].0, failure.object_key());
-        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = failure.message else {
+        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = failure.message() else {
             panic!("expected V2 withdrawal record");
         };
         let WithdrawalLogMessage::Failure {
             request_data,
             error,
             ..
-        } = *message
+        } = message.as_ref()
         else {
             panic!("expected failed withdrawal record");
         };
         assert_eq!(request_data.seq, 1);
-        assert_eq!(error, GuardianError::RateLimitExceeded.to_string());
+        assert_eq!(error, &GuardianError::RateLimitExceeded.to_string());
     }
 }

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -7,9 +7,9 @@ use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
 use hashi_guardian::s3_reader::GuardianReader;
+use hashi_guardian::s3_reader::VerifiedLogRecord;
 use hashi_guardian::s3_reader::withdraw_cursor;
 use hashi_types::guardian::LogMessage;
-use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -27,7 +27,8 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
     type Error = anyhow::Error;
 
     fn try_from(log: VerifiedLogRecord) -> Result<Self, Self::Error> {
-        let LogMessage::Withdrawal(withdrawal_message) = log.message else {
+        let timestamp_ms = log.timestamp_ms();
+        let LogMessage::Withdrawal(withdrawal_message) = log.into_message() else {
             anyhow::bail!("non-withdrawal logs found");
         };
 
@@ -43,7 +44,7 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
                 Ok(VerifiedWithdrawal::Success(MonitorWithdrawalEvent {
                     event_type: WithdrawalEventType::E2GuardianApproved,
                     wid: request_data.wid,
-                    timestamp_secs: unix_millis_to_seconds(log.timestamp_ms),
+                    timestamp_secs: unix_millis_to_seconds(timestamp_ms),
                     btc_txid: txid,
                 }))
             }

--- a/crates/hashi-types/src/guardian/log/ceremony_state.rs
+++ b/crates/hashi-types/src/guardian/log/ceremony_state.rs
@@ -108,11 +108,13 @@ impl From<SetupNewKeyResponse> for CeremonyState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::guardian::GuardianSigned;
+    use crate::guardian::GuardianSignedResponse;
 
     #[test]
     fn serialization_includes_all_encrypted_shares() {
-        let response = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing().data;
+        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
+            .data
+            .response;
         let expected_share_count = response.encrypted_shares.share_count();
         let state = CeremonyState::from(response);
 
@@ -126,7 +128,9 @@ mod tests {
 
     #[test]
     fn new_rejects_mismatched_sharing_seq() {
-        let response = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing().data;
+        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
+            .data
+            .response;
         let sharing_seq = response.secret_sharing_instance.sharing_seq();
         let err = CeremonyState::new(
             CeremonyLogMessage::NewKey {
@@ -141,7 +145,9 @@ mod tests {
 
     #[test]
     fn new_rejects_mismatched_share_count() {
-        let response = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing().data;
+        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
+            .data
+            .response;
         let sharing_seq = response.secret_sharing_instance.sharing_seq();
         let err = CeremonyState::new(
             CeremonyLogMessage::NewKey {

--- a/crates/hashi-types/src/guardian/log/ceremony_state.rs
+++ b/crates/hashi-types/src/guardian/log/ceremony_state.rs
@@ -108,13 +108,10 @@ impl From<SetupNewKeyResponse> for CeremonyState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::guardian::GuardianSignedResponse;
 
     #[test]
     fn serialization_includes_all_encrypted_shares() {
-        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
-            .data
-            .response;
+        let response = SetupNewKeyResponse::mock_for_testing();
         let expected_share_count = response.encrypted_shares.share_count();
         let state = CeremonyState::from(response);
 
@@ -128,9 +125,7 @@ mod tests {
 
     #[test]
     fn new_rejects_mismatched_sharing_seq() {
-        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
-            .data
-            .response;
+        let response = SetupNewKeyResponse::mock_for_testing();
         let sharing_seq = response.secret_sharing_instance.sharing_seq();
         let err = CeremonyState::new(
             CeremonyLogMessage::NewKey {
@@ -145,9 +140,7 @@ mod tests {
 
     #[test]
     fn new_rejects_mismatched_share_count() {
-        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
-            .data
-            .response;
+        let response = SetupNewKeyResponse::mock_for_testing();
         let sharing_seq = response.secret_sharing_instance.sharing_seq();
         let err = CeremonyState::new(
             CeremonyLogMessage::NewKey {

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -772,7 +772,7 @@ mod tests {
             message: &signed.data.message,
         };
         let signed_bytes = bcs::to_bytes(&(
-            GuardianSigningIntentType::LogMessage,
+            GuardianSigningIntentType::LogEntry,
             payload,
             signed.data.timestamp_ms,
         ))

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The `LogRecord` envelope written to S3: it wraps a `super::schema::LogMessage`
-//! with the session id, timestamp, and (for signed logs) the guardian signature.
+//! The `LogRecord` written to S3: it wraps a `super::schema::LogMessage` with
+//! its routing context and, for signed logs, a guardian signature.
 //! The object key and lock duration are derived from the wrapped message.
 
 use super::ObjectKeyPattern;
@@ -17,8 +17,6 @@ use crate::guardian::GuardianResult;
 use crate::guardian::GuardianSignKeyPair;
 use crate::guardian::GuardianSignature;
 use crate::guardian::GuardianSigned;
-use crate::guardian::GuardianSigningIntent;
-use crate::guardian::GuardianSigningIntentType;
 use crate::guardian::SessionID;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
@@ -30,7 +28,7 @@ use std::time::Duration;
 
 /// The data authenticated by a signed log record.
 ///
-/// Field order is part of the deployed BCS signing format and must not change.
+/// Field order defines the BCS signing format.
 #[derive(Debug, Serialize)]
 pub struct LogEntry {
     schema_version: u64,
@@ -39,13 +37,7 @@ pub struct LogEntry {
     /// intended key with the actual key returned by S3.
     object_key: String,
     message: VersionedLogMessage,
-}
-
-/// A log entry authenticated by its embedded Nitro attestation instead of a
-/// Guardian signature.
-#[derive(Debug)]
-pub struct UnsignedLogEntry {
-    data: LogEntry,
+    /// Milliseconds since Unix epoch.
     timestamp_ms: UnixMillis,
 }
 
@@ -54,7 +46,7 @@ pub struct UnsignedLogEntry {
 #[derive(Debug)]
 pub enum LogRecord {
     Signed(GuardianSigned<LogEntry>),
-    Unsigned(UnsignedLogEntry),
+    Unsigned(LogEntry),
 }
 
 impl Serialize for LogRecord {
@@ -73,9 +65,9 @@ impl Serialize for LogRecord {
             signature: &'a Option<GuardianSignature>,
         }
 
-        let (data, timestamp_ms, signature) = match self {
-            Self::Signed(signed) => (&signed.data, signed.timestamp_ms, Some(signed.signature)),
-            Self::Unsigned(unsigned) => (&unsigned.data, unsigned.timestamp_ms, None),
+        let (data, signature) = match self {
+            Self::Signed(signed) => (&signed.data, Some(signed.signature)),
+            Self::Unsigned(unsigned) => (unsigned, None),
         };
 
         match &data.message {
@@ -83,7 +75,7 @@ impl Serialize for LogRecord {
                 schema_version: data.schema_version,
                 object_key: &data.object_key,
                 session_id: &data.session_id,
-                timestamp_ms,
+                timestamp_ms: data.timestamp_ms,
                 message,
                 signature: &signature,
             }
@@ -92,7 +84,7 @@ impl Serialize for LogRecord {
                 schema_version: data.schema_version,
                 object_key: &data.object_key,
                 session_id: &data.session_id,
-                timestamp_ms,
+                timestamp_ms: data.timestamp_ms,
                 message,
                 signature: &signature,
             }
@@ -141,38 +133,28 @@ impl<'de> Deserialize<'de> for LogRecord {
             object_key: raw.object_key,
             session_id: raw.session_id,
             message,
+            timestamp_ms: raw.timestamp_ms,
         };
         Ok(match raw.signature {
-            Some(signature) => Self::Signed(GuardianSigned {
-                data,
-                timestamp_ms: raw.timestamp_ms,
-                signature,
-            }),
-            None => Self::Unsigned(UnsignedLogEntry {
-                data,
-                timestamp_ms: raw.timestamp_ms,
-            }),
+            Some(signature) => Self::Signed(GuardianSigned { data, signature }),
+            None => Self::Unsigned(data),
         })
     }
 }
 
-impl GuardianSigningIntent for LogEntry {
-    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
-}
-
 impl LogEntry {
+    pub fn timestamp_ms(&self) -> UnixMillis {
+        self.timestamp_ms
+    }
+
     /// Validate log-specific routing context without performing cryptography.
-    pub fn validate(
-        &self,
-        timestamp_ms: UnixMillis,
-        signing_public_key: &GuardianPubKey,
-    ) -> GuardianResult<()> {
+    pub fn validate(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
         if self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected signed log record but message is unsigned".into(),
             ));
         }
-        self.validate_object_key(timestamp_ms)?;
+        self.validate_object_key()?;
         self.validate_session_id(signing_public_key)
     }
 
@@ -184,10 +166,10 @@ impl LogEntry {
         Ok((self.session_id, message))
     }
 
-    fn validate_object_key(&self, timestamp_ms: UnixMillis) -> GuardianResult<()> {
+    fn validate_object_key(&self) -> GuardianResult<()> {
         match self
             .message
-            .object_key_pattern(&self.session_id, timestamp_ms)
+            .object_key_pattern(&self.session_id, self.timestamp_ms)
         {
             ObjectKeyPattern::Fixed(expected) if self.object_key != expected => {
                 return Err(InvalidS3Log(format!(
@@ -216,19 +198,16 @@ impl LogEntry {
         }
         Ok(())
     }
-}
-
-impl UnsignedLogEntry {
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
-    pub fn validate(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        if !self.data.message.is_allowed_unsigned() {
+    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
             ));
         }
-        self.data.validate_object_key(self.timestamp_ms)?;
-        let init = match &self.data.message {
+        self.validate_object_key()?;
+        let init = match &self.message {
             VersionedLogMessage::V1(LogMessageV1::Init(init)) => init,
             VersionedLogMessage::V2(LogMessage::Init(init)) => init,
             _ => unreachable!("is_allowed_unsigned only permits an init message"),
@@ -239,9 +218,9 @@ impl UnsignedLogEntry {
         else {
             unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
         };
-        self.data.validate_session_id(signing_public_key)?;
+        self.validate_session_id(signing_public_key)?;
         let timestamp_ms = self.timestamp_ms;
-        let (session_id, message) = self.data.into_current()?;
+        let (session_id, message) = self.into_current()?;
         Ok((session_id, timestamp_ms, message))
     }
 }
@@ -312,10 +291,7 @@ impl LogRecord {
     }
 
     pub fn timestamp_ms(&self) -> UnixMillis {
-        match self {
-            Self::Signed(signed) => signed.timestamp_ms,
-            Self::Unsigned(unsigned) => unsigned.timestamp_ms,
-        }
+        self.data().timestamp_ms
     }
 
     pub fn message(&self) -> &VersionedLogMessage {
@@ -329,14 +305,14 @@ impl LogRecord {
     pub fn into_signed(self) -> GuardianResult<GuardianSigned<LogEntry>> {
         match self {
             Self::Signed(signed) => Ok(signed),
-            Self::Unsigned(unsigned) if unsigned.data.message.is_allowed_unsigned() => Err(
+            Self::Unsigned(unsigned) if unsigned.message.is_allowed_unsigned() => Err(
                 InvalidS3Log("expected signed log record but message is unsigned".into()),
             ),
             Self::Unsigned(_) => Err(InvalidS3Log("missing log signature".into())),
         }
     }
 
-    pub fn into_unsigned(self) -> GuardianResult<UnsignedLogEntry> {
+    pub fn into_unsigned(self) -> GuardianResult<LogEntry> {
         match self {
             Self::Unsigned(unsigned) => Ok(unsigned),
             Self::Signed(signed) if signed.data.message.is_allowed_unsigned() => Err(InvalidS3Log(
@@ -360,8 +336,9 @@ impl LogRecord {
             object_key,
             session_id,
             message,
+            timestamp_ms,
         };
-        Self::Signed(GuardianSigned::sign(data, signing_key, timestamp_ms))
+        Self::Signed(GuardianSigned::sign(data, signing_key))
     }
 
     fn unsigned(
@@ -374,13 +351,11 @@ impl LogRecord {
             message.is_allowed_unsigned(),
             "message must be Init(OIAttestationUnsigned)"
         );
-        Self::Unsigned(UnsignedLogEntry {
-            data: LogEntry {
-                schema_version: message.schema_version(),
-                object_key,
-                session_id,
-                message,
-            },
+        Self::Unsigned(LogEntry {
+            schema_version: message.schema_version(),
+            object_key,
+            session_id,
+            message,
             timestamp_ms,
         })
     }
@@ -388,7 +363,7 @@ impl LogRecord {
     fn data(&self) -> &LogEntry {
         match self {
             Self::Signed(signed) => &signed.data,
-            Self::Unsigned(unsigned) => &unsigned.data,
+            Self::Unsigned(unsigned) => unsigned,
         }
     }
 
@@ -396,7 +371,7 @@ impl LogRecord {
     fn data_mut(&mut self) -> &mut LogEntry {
         match self {
             Self::Signed(signed) => &mut signed.data,
-            Self::Unsigned(unsigned) => &mut unsigned.data,
+            Self::Unsigned(unsigned) => unsigned,
         }
     }
 }
@@ -409,7 +384,7 @@ mod tests {
     use crate::guardian::GenesisLogMessage;
     use crate::guardian::GetGuardianInfoResponse;
     use crate::guardian::GuardianError;
-    use crate::guardian::GuardianSigned;
+    use crate::guardian::GuardianSignedResponse;
     use crate::guardian::HeartbeatLogMessage;
     use crate::guardian::InitLogMessage;
     use crate::guardian::KPEncryptedSharesRoster;
@@ -454,8 +429,8 @@ mod tests {
         signing_public_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         let signed = record.into_signed()?;
-        let timestamp_ms = signed.timestamp_ms;
-        signed.data.validate(timestamp_ms, signing_public_key)?;
+        let timestamp_ms = signed.data.timestamp_ms;
+        signed.data.validate(signing_public_key)?;
         let data = signed
             .authenticate(signing_public_key)
             .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
@@ -464,7 +439,7 @@ mod tests {
     }
 
     fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        record.into_unsigned()?.validate()
+        record.into_unsigned()?.validate_unsigned()
     }
 
     fn assert_writer_key_is_stable_and_verifies(log: LogRecord, signing_key: &GuardianSignKeyPair) {
@@ -510,9 +485,12 @@ mod tests {
             StandardWithdrawalRequest::mock_signed_and_committee_for_testing(Network::Regtest);
         let (request_sign, request_data) = signed_request.into_parts();
         let request_data: StandardWithdrawalRequestWire = request_data.into();
-        let response = GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data;
-        let encrypted_shares = GuardianSigned::<RotateKpsResponse>::mock_for_testing()
+        let response = GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
             .data
+            .response;
+        let encrypted_shares = GuardianSignedResponse::<RotateKpsResponse>::mock_for_testing()
+            .data
+            .response
             .encrypted_shares;
         let (guardian_info, _) = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
         let committee_0: crate::move_types::Committee = (&committee_0).into();
@@ -797,20 +775,20 @@ mod tests {
         let LogRecord::Signed(signed) = log else {
             panic!("heartbeat must be signed");
         };
-        let deployed_payload = DeployedLogSigningPayload {
+        let payload = DeployedLogSigningPayload {
             schema_version: signed.data.schema_version,
             session_id: &signed.data.session_id,
             object_key: &signed.data.object_key,
             message: &signed.data.message,
         };
-        let deployed_bytes = bcs::to_bytes(&(
+        let signed_bytes = bcs::to_bytes(&(
             GuardianSigningIntentType::LogMessage,
-            deployed_payload,
-            signed.timestamp_ms,
+            payload,
+            signed.data.timestamp_ms,
         ))
         .unwrap();
 
-        assert_eq!(signed.signature, signing_key.sign(&deployed_bytes));
+        assert_eq!(signed.signature, signing_key.sign(&signed_bytes));
     }
 
     #[test]
@@ -1089,7 +1067,9 @@ mod tests {
                 txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
                 request_data,
                 request_sign,
-                response: GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data,
+                response: GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
+                    .data
+                    .response,
                 post_state: LimiterState {
                     num_tokens_available: 0,
                     last_updated_at: 0,

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -66,7 +66,7 @@ impl Serialize for LogRecord {
         }
 
         let (data, signature) = match self {
-            Self::Signed(signed) => (&signed.data, Some(signed.signature)),
+            Self::Signed(signed) => (signed.data_unchecked(), Some(signed.signature)),
             Self::Unsigned(unsigned) => (unsigned, None),
         };
 
@@ -136,7 +136,7 @@ impl<'de> Deserialize<'de> for LogRecord {
             timestamp_ms: raw.timestamp_ms,
         };
         Ok(match raw.signature {
-            Some(signature) => Self::Signed(GuardianSigned { data, signature }),
+            Some(signature) => Self::Signed(GuardianSigned::from_parts(data, signature)),
             None => Self::Unsigned(data),
         })
     }
@@ -280,12 +280,13 @@ impl LogRecord {
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         match (self, signing_public_key) {
             (Self::Signed(signed), Some(signing_public_key)) => {
-                let timestamp_ms = signed.data.timestamp_ms;
-                signed.data.validate_signed(signing_public_key)?;
+                let timestamp_ms = signed.data_unchecked().timestamp_ms;
                 signed
-                    .verify_signature(signing_public_key)
+                    .data_unchecked()
+                    .validate_signed(signing_public_key)?;
+                let data = signed
+                    .verify_into_data(signing_public_key)
                     .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-                let data = signed.data;
                 let (session_id, message) = data.into_current()?;
                 Ok((session_id, timestamp_ms, message))
             }
@@ -294,9 +295,13 @@ impl LogRecord {
                 InvalidS3Log("expected signed log record but message is unsigned".into()),
             ),
             (Self::Unsigned(_), Some(_)) => Err(InvalidS3Log("missing log signature".into())),
-            (Self::Signed(signed), None) if signed.data.message.is_allowed_unsigned() => Err(
-                InvalidS3Log("unsigned log record must not contain a signature".into()),
-            ),
+            (Self::Signed(signed), None)
+                if signed.data_unchecked().message.is_allowed_unsigned() =>
+            {
+                Err(InvalidS3Log(
+                    "unsigned log record must not contain a signature".into(),
+                ))
+            }
             (Self::Signed(_), None) => Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
             )),
@@ -313,7 +318,7 @@ impl LogRecord {
     pub fn into_current_unchecked(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         match self {
             Self::Signed(signed) => {
-                let timestamp_ms = signed.data.timestamp_ms;
+                let timestamp_ms = signed.data_unchecked().timestamp_ms;
                 let (session_id, message) = signed.into_data_unchecked().into_current()?;
                 Ok((session_id, timestamp_ms, message))
             }
@@ -362,7 +367,7 @@ impl LogRecord {
 
     fn data(&self) -> &LogEntry {
         match self {
-            Self::Signed(signed) => &signed.data,
+            Self::Signed(signed) => signed.data_unchecked(),
             Self::Unsigned(unsigned) => unsigned,
         }
     }
@@ -370,7 +375,7 @@ impl LogRecord {
     #[cfg(test)]
     fn data_mut(&mut self) -> &mut LogEntry {
         match self {
-            Self::Signed(signed) => &mut signed.data,
+            Self::Signed(signed) => signed.data_unchecked_mut(),
             Self::Unsigned(unsigned) => unsigned,
         }
     }
@@ -382,9 +387,8 @@ mod tests {
     use crate::guardian::CeremonyLogMessage;
     use crate::guardian::CommitteeUpdateLogMessage;
     use crate::guardian::GenesisLogMessage;
-    use crate::guardian::GetGuardianInfoResponse;
     use crate::guardian::GuardianError;
-    use crate::guardian::GuardianSignedResponse;
+    use crate::guardian::GuardianInfo;
     use crate::guardian::GuardianSigningIntentType;
     use crate::guardian::HeartbeatLogMessage;
     use crate::guardian::InitLogMessage;
@@ -479,14 +483,9 @@ mod tests {
             StandardWithdrawalRequest::mock_signed_and_committee_for_testing(Network::Regtest);
         let (request_sign, request_data) = signed_request.into_parts();
         let request_data: StandardWithdrawalRequestWire = request_data.into();
-        let response = GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
-            .data
-            .response;
-        let encrypted_shares = GuardianSignedResponse::<RotateKpsResponse>::mock_for_testing()
-            .data
-            .response
-            .encrypted_shares;
-        let (guardian_info, _) = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
+        let response = StandardWithdrawalResponse::mock_for_testing();
+        let encrypted_shares = RotateKpsResponse::mock_for_testing().encrypted_shares;
+        let guardian_info = GuardianInfo::mock_for_testing();
         let committee_0: crate::move_types::Committee = (&committee_0).into();
         let mut committee_1 = committee_0.clone();
         committee_1.epoch = 1;
@@ -766,21 +765,22 @@ mod tests {
         }
 
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
-        let LogRecord::Signed(signed) = log else {
-            panic!("heartbeat must be signed");
-        };
+        let data = log.data();
         let payload = DeployedLogSigningPayload {
-            schema_version: signed.data.schema_version,
-            session_id: &signed.data.session_id,
-            object_key: &signed.data.object_key,
-            message: &signed.data.message,
+            schema_version: data.schema_version,
+            session_id: &data.session_id,
+            object_key: &data.object_key,
+            message: &data.message,
         };
         let signed_bytes = bcs::to_bytes(&(
             GuardianSigningIntentType::LogEntry,
             payload,
-            signed.data.timestamp_ms,
+            data.timestamp_ms,
         ))
         .unwrap();
+        let LogRecord::Signed(signed) = log else {
+            panic!("heartbeat must be signed");
+        };
 
         assert_eq!(signed.signature, signing_key.sign(&signed_bytes));
     }
@@ -1061,9 +1061,7 @@ mod tests {
                 txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
                 request_data,
                 request_sign,
-                response: GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
-                    .data
-                    .response,
+                response: StandardWithdrawalResponse::mock_for_testing(),
                 post_state: LimiterState {
                     num_tokens_available: 0,
                     last_updated_at: 0,

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -10,7 +10,6 @@ use super::retention::S3ObjectLockPolicy;
 use super::schema::LogMessage;
 use super::schema::LogMessageV1;
 use super::schema::VersionedLogMessage;
-use crate::guardian::BuildPcrs;
 use crate::guardian::GuardianError::InvalidS3Log;
 use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
@@ -42,7 +41,8 @@ pub struct LogEntry {
 }
 
 /// Write: `LogMessage` -> `LogRecord` -> JSON body.
-/// Read: actual S3 key + JSON body -> untrusted `LogRecord` -> `VerifiedLogRecord`.
+/// Read: actual S3 key + JSON body -> untrusted `LogRecord`; the reader layer
+/// authenticates it before exposing its contents.
 #[derive(Debug)]
 pub enum LogRecord {
     Signed(GuardianSigned<LogEntry>),
@@ -222,37 +222,6 @@ impl LogEntry {
         let timestamp_ms = self.timestamp_ms;
         let (session_id, message) = self.into_current()?;
         Ok((session_id, timestamp_ms, message))
-    }
-}
-
-/// A log record whose message signature and writing session's attestation/PCRs
-/// have both been verified. Its message is normalized to the current schema.
-/// If a future schema cannot be converted losslessly, this type should retain
-/// `VersionedLogMessage` and leave version acceptance to callers instead.
-#[derive(Debug)]
-pub struct VerifiedLogRecord {
-    pub object_key: String,
-    pub session_id: SessionID,
-    pub timestamp_ms: UnixMillis,
-    pub message: LogMessage,
-    pub build_pcrs: BuildPcrs,
-}
-
-impl VerifiedLogRecord {
-    pub fn new(
-        object_key: String,
-        session_id: SessionID,
-        timestamp_ms: UnixMillis,
-        message: LogMessage,
-        build_pcrs: BuildPcrs,
-    ) -> Self {
-        Self {
-            object_key,
-            session_id,
-            timestamp_ms,
-            message,
-            build_pcrs,
-        }
     }
 }
 

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -21,8 +21,6 @@ use crate::guardian::SessionID;
 use crate::guardian::SigningIntent;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
-use crate::guardian::signing::sign_intent;
-use crate::guardian::signing::verify_intent;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::Error as _;
@@ -218,11 +216,7 @@ impl LogRecord {
             message,
             signature: None,
         };
-        record.signature = Some(sign_intent(
-            &record.signing_payload(),
-            timestamp_ms,
-            signing_key,
-        ));
+        record.signature = Some(record.signing_payload().sign(timestamp_ms, signing_key));
         record
     }
 
@@ -263,7 +257,8 @@ impl LogRecord {
             .signature
             .as_ref()
             .ok_or_else(|| InvalidS3Log("missing log signature".into()))?;
-        verify_intent(&self.signing_payload(), timestamp_ms, signature, pub_key)
+        self.signing_payload()
+            .verify_signature(timestamp_ms, signature, pub_key)
             .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
 
         let message = self

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -16,39 +16,45 @@ use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
 use crate::guardian::GuardianSignKeyPair;
 use crate::guardian::GuardianSignature;
+use crate::guardian::GuardianSigned;
 use crate::guardian::GuardianSigningIntent;
 use crate::guardian::GuardianSigningIntentType;
 use crate::guardian::SessionID;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
-use crate::guardian::signing::sign_guardian_payload;
-use crate::guardian::signing::verify_guardian_payload_signature;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::Error as _;
 use serde_json::Value;
 use std::time::Duration;
 
+/// The data authenticated by a signed log record.
+///
+/// Field order is part of the deployed BCS signing format and must not change.
+#[derive(Debug, Serialize)]
+pub struct LogEntry {
+    schema_version: u64,
+    session_id: SessionID,
+    /// Final S3 destination selected before signing. Readers must compare this
+    /// intended key with the actual key returned by S3.
+    object_key: String,
+    message: VersionedLogMessage,
+}
+
+/// A log entry authenticated by its embedded Nitro attestation instead of a
+/// Guardian signature.
+#[derive(Debug)]
+pub struct UnsignedLogEntry {
+    data: LogEntry,
+    timestamp_ms: UnixMillis,
+}
+
 /// Write: `LogMessage` -> `LogRecord` -> JSON body.
 /// Read: actual S3 key + JSON body -> untrusted `LogRecord` -> `VerifiedLogRecord`.
 #[derive(Debug)]
-pub struct LogRecord {
-    /// Final S3 destination selected before signing. Readers must compare this
-    /// signed intended key with the actual key returned by S3.
-    pub object_key: String,
-    pub session_id: SessionID,
-    pub timestamp_ms: UnixMillis,
-    pub message: VersionedLogMessage,
-    /// Present for signed logs; omitted for unsigned logs (currently only OIAttestationUnsigned).
-    pub signature: Option<GuardianSignature>,
-}
-
-#[derive(Serialize)]
-struct LogSigningPayload<'a> {
-    schema_version: u64,
-    session_id: &'a SessionID,
-    object_key: &'a str,
-    message: &'a VersionedLogMessage,
+pub enum LogRecord {
+    Signed(GuardianSigned<LogEntry>),
+    Unsigned(UnsignedLogEntry),
 }
 
 impl Serialize for LogRecord {
@@ -67,23 +73,28 @@ impl Serialize for LogRecord {
             signature: &'a Option<GuardianSignature>,
         }
 
-        match &self.message {
+        let (data, timestamp_ms, signature) = match self {
+            Self::Signed(signed) => (&signed.data, signed.timestamp_ms, Some(signed.signature)),
+            Self::Unsigned(unsigned) => (&unsigned.data, unsigned.timestamp_ms, None),
+        };
+
+        match &data.message {
             VersionedLogMessage::V1(message) => LogRecordWire {
-                schema_version: VersionedLogMessage::SCHEMA_VERSION_V1,
-                object_key: &self.object_key,
-                session_id: &self.session_id,
-                timestamp_ms: self.timestamp_ms,
+                schema_version: data.schema_version,
+                object_key: &data.object_key,
+                session_id: &data.session_id,
+                timestamp_ms,
                 message,
-                signature: &self.signature,
+                signature: &signature,
             }
             .serialize(serializer),
             VersionedLogMessage::V2(message) => LogRecordWire {
-                schema_version: VersionedLogMessage::SCHEMA_VERSION_V2,
-                object_key: &self.object_key,
-                session_id: &self.session_id,
-                timestamp_ms: self.timestamp_ms,
+                schema_version: data.schema_version,
+                object_key: &data.object_key,
+                session_id: &data.session_id,
+                timestamp_ms,
                 message,
-                signature: &self.signature,
+                signature: &signature,
             }
             .serialize(serializer),
         }
@@ -125,18 +136,114 @@ impl<'de> Deserialize<'de> for LogRecord {
             }
         };
 
-        Ok(Self {
+        let data = LogEntry {
+            schema_version: raw.schema_version,
             object_key: raw.object_key,
             session_id: raw.session_id,
-            timestamp_ms: raw.timestamp_ms,
             message,
-            signature: raw.signature,
+        };
+        Ok(match raw.signature {
+            Some(signature) => Self::Signed(GuardianSigned {
+                data,
+                timestamp_ms: raw.timestamp_ms,
+                signature,
+            }),
+            None => Self::Unsigned(UnsignedLogEntry {
+                data,
+                timestamp_ms: raw.timestamp_ms,
+            }),
         })
     }
 }
 
-impl GuardianSigningIntent for LogSigningPayload<'_> {
+impl GuardianSigningIntent for LogEntry {
     const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
+}
+
+impl LogEntry {
+    /// Validate log-specific routing context without performing cryptography.
+    pub fn validate(
+        &self,
+        timestamp_ms: UnixMillis,
+        signing_public_key: &GuardianPubKey,
+    ) -> GuardianResult<()> {
+        if self.message.is_allowed_unsigned() {
+            return Err(InvalidS3Log(
+                "expected signed log record but message is unsigned".into(),
+            ));
+        }
+        self.validate_object_key(timestamp_ms)?;
+        self.validate_session_id(signing_public_key)
+    }
+
+    pub fn into_current(self) -> GuardianResult<(SessionID, LogMessage)> {
+        let message = self
+            .message
+            .into_current()
+            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
+        Ok((self.session_id, message))
+    }
+
+    fn validate_object_key(&self, timestamp_ms: UnixMillis) -> GuardianResult<()> {
+        match self
+            .message
+            .object_key_pattern(&self.session_id, timestamp_ms)
+        {
+            ObjectKeyPattern::Fixed(expected) if self.object_key != expected => {
+                return Err(InvalidS3Log(format!(
+                    "non-canonical S3 object key: got {}, expected {expected}",
+                    self.object_key
+                )));
+            }
+            ObjectKeyPattern::RandomSuffix(prefix) if !self.object_key.starts_with(&prefix) => {
+                return Err(InvalidS3Log(format!(
+                    "non-canonical S3 object key: got {}, expected prefix {prefix}",
+                    self.object_key
+                )));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn validate_session_id(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
+        let canonical_session_id = SessionID::from_signing_pubkey(signing_public_key);
+        if self.session_id != canonical_session_id {
+            return Err(InvalidS3Log(format!(
+                "session ID mismatch: record contains {}, signing public key derives {canonical_session_id}",
+                self.session_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl UnsignedLogEntry {
+    /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
+    /// must be authenticated separately.
+    pub fn validate(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        if !self.data.message.is_allowed_unsigned() {
+            return Err(InvalidS3Log(
+                "expected unsigned log record but message requires a signature".into(),
+            ));
+        }
+        self.data.validate_object_key(self.timestamp_ms)?;
+        let init = match &self.data.message {
+            VersionedLogMessage::V1(LogMessageV1::Init(init)) => init,
+            VersionedLogMessage::V2(LogMessage::Init(init)) => init,
+            _ => unreachable!("is_allowed_unsigned only permits an init message"),
+        };
+        let super::messages::InitLogMessage::OIAttestationUnsigned {
+            signing_public_key, ..
+        } = init.as_ref()
+        else {
+            unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
+        };
+        self.data.validate_session_id(signing_public_key)?;
+        let timestamp_ms = self.timestamp_ms;
+        let (session_id, message) = self.data.into_current()?;
+        Ok((session_id, timestamp_ms, message))
+    }
 }
 
 /// A log record whose message signature and writing session's attestation/PCRs
@@ -197,11 +304,48 @@ impl LogRecord {
     }
 
     pub fn object_key(&self) -> &str {
-        &self.object_key
+        &self.data().object_key
+    }
+
+    pub fn session_id(&self) -> &SessionID {
+        &self.data().session_id
+    }
+
+    pub fn timestamp_ms(&self) -> UnixMillis {
+        match self {
+            Self::Signed(signed) => signed.timestamp_ms,
+            Self::Unsigned(unsigned) => unsigned.timestamp_ms,
+        }
+    }
+
+    pub fn message(&self) -> &VersionedLogMessage {
+        &self.data().message
     }
 
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
-        policy.duration_for(self.message.log_type())
+        policy.duration_for(self.data().message.log_type())
+    }
+
+    pub fn into_signed(self) -> GuardianResult<GuardianSigned<LogEntry>> {
+        match self {
+            Self::Signed(signed) => Ok(signed),
+            Self::Unsigned(unsigned) if unsigned.data.message.is_allowed_unsigned() => Err(
+                InvalidS3Log("expected signed log record but message is unsigned".into()),
+            ),
+            Self::Unsigned(_) => Err(InvalidS3Log("missing log signature".into())),
+        }
+    }
+
+    pub fn into_unsigned(self) -> GuardianResult<UnsignedLogEntry> {
+        match self {
+            Self::Unsigned(unsigned) => Ok(unsigned),
+            Self::Signed(signed) if signed.data.message.is_allowed_unsigned() => Err(InvalidS3Log(
+                "unsigned log record must not contain a signature".into(),
+            )),
+            Self::Signed(_) => Err(InvalidS3Log(
+                "expected unsigned log record but message requires a signature".into(),
+            )),
+        }
     }
 
     fn signed(
@@ -211,19 +355,13 @@ impl LogRecord {
         timestamp_ms: UnixMillis,
         object_key: String,
     ) -> Self {
-        let mut record = Self {
+        let data = LogEntry {
+            schema_version: message.schema_version(),
             object_key,
             session_id,
-            timestamp_ms,
             message,
-            signature: None,
         };
-        record.signature = Some(sign_guardian_payload(
-            &record.signing_payload(),
-            timestamp_ms,
-            signing_key,
-        ));
-        record
+        Self::Signed(GuardianSigned::sign(data, signing_key, timestamp_ms))
     }
 
     fn unsigned(
@@ -236,120 +374,29 @@ impl LogRecord {
             message.is_allowed_unsigned(),
             "message must be Init(OIAttestationUnsigned)"
         );
-        Self {
-            object_key,
-            session_id,
+        Self::Unsigned(UnsignedLogEntry {
+            data: LogEntry {
+                schema_version: message.schema_version(),
+                object_key,
+                session_id,
+                message,
+            },
             timestamp_ms,
-            message,
-            signature: None,
+        })
+    }
+
+    fn data(&self) -> &LogEntry {
+        match self {
+            Self::Signed(signed) => &signed.data,
+            Self::Unsigned(unsigned) => &unsigned.data,
         }
     }
 
-    /// Validates the signed record's envelope, canonical session, and Guardian
-    /// signature. The caller must establish trust in `pub_key` separately.
-    pub fn validate_signed(
-        self,
-        pub_key: &GuardianPubKey,
-    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        if self.message.is_allowed_unsigned() {
-            return Err(InvalidS3Log(
-                "expected signed log record but message is unsigned".into(),
-            ));
-        }
-        self.validate_object_key()?;
-        self.validate_session_id(pub_key)?;
-        let timestamp_ms = self.timestamp_ms;
-        let signature = self
-            .signature
-            .as_ref()
-            .ok_or_else(|| InvalidS3Log("missing log signature".into()))?;
-        verify_guardian_payload_signature(
-            &self.signing_payload(),
-            timestamp_ms,
-            signature,
-            pub_key,
-        )
-        .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-
-        let message = self
-            .message
-            .into_current()
-            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
-        Ok((self.session_id, timestamp_ms, message))
-    }
-
-    /// Validates the unsigned OI-attestation record's envelope and canonical
-    /// session. The Nitro attestation itself must be authenticated separately.
-    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        if !self.message.is_allowed_unsigned() {
-            return Err(InvalidS3Log(
-                "expected unsigned log record but message requires a signature".into(),
-            ));
-        }
-        if self.signature.is_some() {
-            return Err(InvalidS3Log(
-                "unsigned log record must not contain a signature".into(),
-            ));
-        }
-        self.validate_object_key()?;
-        let init = match &self.message {
-            VersionedLogMessage::V1(LogMessageV1::Init(init)) => init,
-            VersionedLogMessage::V2(LogMessage::Init(init)) => init,
-            _ => unreachable!("is_allowed_unsigned only permits an init message"),
-        };
-        let super::messages::InitLogMessage::OIAttestationUnsigned {
-            signing_public_key, ..
-        } = init.as_ref()
-        else {
-            unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
-        };
-        self.validate_session_id(signing_public_key)?;
-        let message = self
-            .message
-            .into_current()
-            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
-        Ok((self.session_id, self.timestamp_ms, message))
-    }
-
-    fn validate_object_key(&self) -> GuardianResult<()> {
-        match self
-            .message
-            .object_key_pattern(&self.session_id, self.timestamp_ms)
-        {
-            ObjectKeyPattern::Fixed(expected) if self.object_key != expected => {
-                return Err(InvalidS3Log(format!(
-                    "non-canonical S3 object key: got {}, expected {expected}",
-                    self.object_key
-                )));
-            }
-            ObjectKeyPattern::RandomSuffix(prefix) if !self.object_key.starts_with(&prefix) => {
-                return Err(InvalidS3Log(format!(
-                    "non-canonical S3 object key: got {}, expected prefix {prefix}",
-                    self.object_key
-                )));
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn validate_session_id(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
-        let canonical_session_id = SessionID::from_signing_pubkey(signing_public_key);
-        if self.session_id != canonical_session_id {
-            return Err(InvalidS3Log(format!(
-                "session ID mismatch: record contains {}, signing public key derives {canonical_session_id}",
-                self.session_id
-            )));
-        }
-        Ok(())
-    }
-
-    fn signing_payload(&self) -> LogSigningPayload<'_> {
-        LogSigningPayload {
-            schema_version: self.message.schema_version(),
-            session_id: &self.session_id,
-            object_key: &self.object_key,
-            message: &self.message,
+    #[cfg(test)]
+    fn data_mut(&mut self) -> &mut LogEntry {
+        match self {
+            Self::Signed(signed) => &mut signed.data,
+            Self::Unsigned(unsigned) => &mut unsigned.data,
         }
     }
 }
@@ -402,6 +449,24 @@ mod tests {
         (object_key, record, signing_key)
     }
 
+    fn authenticate_signed(
+        record: LogRecord,
+        signing_public_key: &GuardianPubKey,
+    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        let signed = record.into_signed()?;
+        let timestamp_ms = signed.timestamp_ms;
+        signed.data.validate(timestamp_ms, signing_public_key)?;
+        let data = signed
+            .authenticate(signing_public_key)
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        let (session_id, message) = data.into_current()?;
+        Ok((session_id, timestamp_ms, message))
+    }
+
+    fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        record.into_unsigned()?.validate()
+    }
+
     fn assert_writer_key_is_stable_and_verifies(log: LogRecord, signing_key: &GuardianSignKeyPair) {
         let writer_key = log.object_key().to_string();
         for _ in 0..4 {
@@ -415,8 +480,7 @@ mod tests {
         let body = serde_json::to_vec(&log).unwrap();
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
-        record_read_from_s3
-            .validate_signed(&signing_key.verification_key())
+        authenticate_signed(record_read_from_s3, &signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
     }
 
@@ -587,13 +651,11 @@ mod tests {
                 object_key,
                 "{name} did not preserve its object key"
             );
-            if decoded.message.is_allowed_unsigned() {
-                decoded
-                    .validate_unsigned()
+            if decoded.message().is_allowed_unsigned() {
+                validate_unsigned(decoded)
                     .unwrap_or_else(|error| panic!("{name} failed validation: {error}"));
             } else {
-                decoded
-                    .validate_signed(&signing_key.verification_key())
+                authenticate_signed(decoded, &signing_key.verification_key())
                     .unwrap_or_else(|error| panic!("{name} failed verification: {error}"));
             }
         }
@@ -604,7 +666,7 @@ mod tests {
         let fixture = r#"{"schema_version":1,"object_key":"kp-shares/00000000000000000000/00000000000000000000-916c711a5e81c2b0.json","session_id":"916c711a5e81c2b0","timestamp_ms":1784219535816,"message":{"KpShareState":{"sharing_seq":0,"cert_seq":0,"encrypted_shares":[{"id":1,"recipient_fingerprint":"010AFFD5514AE454CA0D56DAA40FE24388998D2A","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DT5hsKqzbvdwSAQdACnLThsK4Jq+u0g98VJzmYXrG05xLKgM1ki4FSGrOljkw\ndnHArbGaerEC8lBXZPVNhxMB8rOAfvgqxOUtt7SIMmjGIZMy7tzwfbM1YL45wgac\n0lkBE7TsICEPN/B/EwheDv/Ooid3NTDsoIsUGGuqtzUPCVYJTGPR+LWVY+F2xZxb\nHaLZO65VgrA3pcnyLsUy8iN3giOrIxmiZy/GjQBUwkeSCbVuopTZ2mpxPg==\n=7m3k\n-----END PGP MESSAGE-----\n"},{"id":2,"recipient_fingerprint":"69A798B4CD1FE3F7C827381BC56DF2575EC846C3","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DIHt6s8jZpqASAQdALWbHtxu0R/ANnNighIV7VtFgkIX3CGJzfW51GkSJkBQw\n7Ec2Y2wBmo4sDM2VGmxqK5ADvGVSYgLvIlByRdRV2NaJ1xkjHUoA39PDTqCvwCOK\n0lkBOZPrJPrBInDax3ceQwDkC/rkJrQXT8oVWGxNjxp244q66jhMdOBZSEc8T/oZ\noAdjEccCcDLYt+S+bEVZeuNhZowDSx14soiALI16hrzbDqJq04e7K9W0uQ==\n=tfbb\n-----END PGP MESSAGE-----\n"},{"id":3,"recipient_fingerprint":"8D798722C24B2A15C15036A1DEFA2C01C4350A31","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DZcZnV1kFupoSAQdA4X4hRbapAgL8eAouMEM0aRE4frVwmQZVHsXB6aOOxgkw\nsc2w0UU8bLzgt3aCe4HqBA9/v3jlKqK4STYVRFzG6o8fa+tb2qX94g6bCcIE07x4\n0lkBeTRYLlUlg7Jl2s7X9d9Ns60O8A2DQKwSYtQZV1pEwX44UQPz8Od/C9nIPeLP\nQEIA1BYRghu0ePQaqsfKohRXUunOrgVpYSCNFoupOKoVTl0qFgeDz5dw7Q==\n=giUp\n-----END PGP MESSAGE-----\n"},{"id":4,"recipient_fingerprint":"5551B442C80AB4D9CF3C95B90DA471909B35BFE9","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DJ51dk/19HSASAQdAgq4QrNM43HykXcLxDfRtHHRtd4BdVJBirC2esDoXEjkw\nF7YLVWrMoXUtwOxFqXGkoUhEhfPAzdLG3WyuZQDnOdPBl0r/2qxmlmZIjFFBGXVc\n0lkBLfdxmJ8BOQYcaiEhBODpY7o2xO13agT28X6Uyv3rc5qw5km1WDw5+AlTLKZj\nw7aathIK+Qof15Tj7VxzSzRmo/pIf/Plcz9JoBNOYPgz/ewuzsPzDQ9+Qw==\n=iAGD\n-----END PGP MESSAGE-----\n"},{"id":5,"recipient_fingerprint":"354807E1940BFC2763D15EBB8E7048E384EBBC7A","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4D6mDrwWj9BrASAQdAazktC+Jd2EMtE8Gav7ROlkVmL+Ty1duA3RttbKQ5eAEw\nbKIxkq1Jp9J4ZqcvjfxcBzVOfZPQwdhxXxDv2pOUG7ioZuDTRlGNNbsiyodvmlgy\n0lkB8eaGI0/LBZ++1vbGsZ/uQ7phGVFkPdcZzXm0pyD1poDKhTTyiHpAgDub2yph\nAAWsEIYzjLQWJvuOw0JXzwu1HBy+z5QTY4nK+wKrh6ojcLKjjyRVehhtTw==\n=m9Mm\n-----END PGP MESSAGE-----\n"},{"id":6,"recipient_fingerprint":"CB27C30ABAAC7EEDE92E71C6017C4627E937F5B0","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DuqwfDzk48aQSAQdAoJevGCVjo+1pD/WVPkWza4qGxBU9tsXbqE/kaSynsGYw\nskjzNOD5oY+/S0CMeH+6xspbLUZ9uZFy98fWOKMi9nbftH1nWXtKRdCNweaaCAPu\n0lkBR4DxLFCydQKfFzENlKRl9qc4m5NkVnjWaGR+cgK1U2UAPf/p82eRggyf6Obp\nNcdOnAfu0aLB70FESJEHtDFj36QCyC0SwTdtZwXUfCOo0AykDph9rTYVpA==\n=DQ4F\n-----END PGP MESSAGE-----\n"}]}},"signature":"2895193893f1feaea65fb6b441c011815c937df33cde136e4721f4173db86c1fe44a2095a6f8753fecbdaa5c99b744a22368f41ab8ca01edff99fafb6710a304"}"#;
         let record: LogRecord = serde_json::from_str(fixture).unwrap();
         assert!(matches!(
-            &record.message,
+            record.message(),
             VersionedLogMessage::V1(LogMessageV1::KpShareState(..))
         ));
         assert_eq!(serde_json::to_string(&record).unwrap(), fixture);
@@ -612,9 +674,9 @@ mod tests {
             hex::decode("916c711a5e81c2b032f15952b515205a20ef2a16f8a88da504885f392e314dca")
                 .unwrap();
         let signing_pubkey = GuardianPubKey::try_from(signing_pubkey.as_slice()).unwrap();
-        let (session_id, timestamp_ms, LogMessageV2::KpShareState(message)) = record
-            .validate_signed(&signing_pubkey)
-            .expect("the deployed V1 signature must verify before normalization")
+        let (session_id, timestamp_ms, LogMessageV2::KpShareState(message)) =
+            authenticate_signed(record, &signing_pubkey)
+                .expect("the deployed V1 signature must verify before normalization")
         else {
             panic!("expected normalized KP share state");
         };
@@ -689,8 +751,7 @@ mod tests {
     fn signed_log_verifies_at_canonical_object_key() {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
 
-        let (_, timestamp_ms, message) = log
-            .validate_signed(&signing_key.verification_key())
+        let (_, timestamp_ms, message) = authenticate_signed(log, &signing_key.verification_key())
             .expect("record should verify at its intended S3 key");
 
         assert_eq!(timestamp_ms, 1_700_000_000_000);
@@ -718,9 +779,38 @@ mod tests {
         assert!(serde_json::from_value::<LogRecord>(malformed).is_err());
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
-        from_s3
-            .validate_signed(&signing_key.verification_key())
+        authenticate_signed(from_s3, &signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
+    }
+
+    #[test]
+    fn signed_log_preserves_deployed_signing_preimage() {
+        #[derive(Serialize)]
+        struct DeployedLogSigningPayload<'a> {
+            schema_version: u64,
+            session_id: &'a SessionID,
+            object_key: &'a str,
+            message: &'a VersionedLogMessage,
+        }
+
+        let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
+        let LogRecord::Signed(signed) = log else {
+            panic!("heartbeat must be signed");
+        };
+        let deployed_payload = DeployedLogSigningPayload {
+            schema_version: signed.data.schema_version,
+            session_id: &signed.data.session_id,
+            object_key: &signed.data.object_key,
+            message: &signed.data.message,
+        };
+        let deployed_bytes = bcs::to_bytes(&(
+            GuardianSigningIntentType::LogMessage,
+            deployed_payload,
+            signed.timestamp_ms,
+        ))
+        .unwrap();
+
+        assert_eq!(signed.signature, signing_key.sign(&deployed_bytes));
     }
 
     #[test]
@@ -741,14 +831,13 @@ mod tests {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
         let mut tampered: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        tampered.message = LogMessage::Heartbeat(HeartbeatLogMessage::new(43)).into();
-        tampered.object_key = format!(
+        tampered.data_mut().message = LogMessage::Heartbeat(HeartbeatLogMessage::new(43)).into();
+        tampered.data_mut().object_key = format!(
             "heartbeat/2023/11/14/22/{}-00000000000000000043.json",
             heartbeat_session_id()
         );
 
-        let err = tampered
-            .validate_signed(&signing_key.verification_key())
+        let err = authenticate_signed(tampered, &signing_key.verification_key())
             .expect_err("signature must cover the canonical object key and message");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -777,9 +866,8 @@ mod tests {
 
         let mut record_read_from_s3: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        record_read_from_s3.object_key = relocated_key;
-        let err = record_read_from_s3
-            .validate_signed(&signing_key.verification_key())
+        record_read_from_s3.data_mut().object_key = relocated_key;
+        let err = authenticate_signed(record_read_from_s3, &signing_key.verification_key())
             .expect_err("the signature must authenticate the random failure suffix");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -804,11 +892,10 @@ mod tests {
         );
         let mut aliased: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        aliased.session_id = "aliased-session".into();
-        aliased.object_key = GenesisLogMessage::object_key();
+        aliased.data_mut().session_id = "aliased-session".into();
+        aliased.data_mut().object_key = GenesisLogMessage::object_key();
 
-        let err = aliased
-            .validate_signed(&signing_key.verification_key())
+        let err = authenticate_signed(aliased, &signing_key.verification_key())
             .expect_err("session ID must be part of the signed routing context");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -828,9 +915,8 @@ mod tests {
             1_700_000_000_000,
         );
 
-        log.object_key = "init/copied-attestation.json".to_string();
-        let err = log
-            .validate_unsigned()
+        log.data_mut().object_key = "init/copied-attestation.json".to_string();
+        let err = validate_unsigned(log)
             .expect_err("unsigned record copied to another S3 key must be rejected");
 
         assert!(format!("{err:?}").contains("non-canonical S3 object key"));
@@ -848,8 +934,7 @@ mod tests {
             &signing_key,
             1_700_000_000_000,
         );
-        let err = log
-            .validate_unsigned()
+        let err = validate_unsigned(log)
             .expect_err("attestation session ID must come from its signing public key");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -912,9 +997,7 @@ mod tests {
         assert_eq!(message["config_hash"], hex::encode([0xcd; 32]));
 
         let from_json: LogRecord = serde_json::from_value(json).unwrap();
-        from_json
-            .validate_signed(&signing_key.verification_key())
-            .unwrap();
+        authenticate_signed(from_json, &signing_key.verification_key()).unwrap();
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -278,9 +278,10 @@ impl LogRecord {
             (Self::Signed(signed), Some(signing_public_key)) => {
                 let timestamp_ms = signed.data.timestamp_ms;
                 signed.data.validate_signed(signing_public_key)?;
-                let data = signed
-                    .authenticate(signing_public_key)
+                signed
+                    .verify_signature(signing_public_key)
                     .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+                let data = signed.data;
                 let (session_id, message) = data.into_current()?;
                 Ok((session_id, timestamp_ms, message))
             }

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -143,22 +143,7 @@ impl<'de> Deserialize<'de> for LogRecord {
 }
 
 impl LogEntry {
-    pub fn timestamp_ms(&self) -> UnixMillis {
-        self.timestamp_ms
-    }
-
-    /// Validate signed-log routing context without performing cryptography.
-    fn validate_signed(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
-        if self.message.is_allowed_unsigned() {
-            return Err(InvalidS3Log(
-                "expected signed log record but message is unsigned".into(),
-            ));
-        }
-        self.validate_object_key()?;
-        self.validate_session_id(signing_public_key)
-    }
-
-    pub fn into_current(self) -> GuardianResult<(SessionID, LogMessage)> {
+    fn into_current(self) -> GuardianResult<(SessionID, LogMessage)> {
         let message = self
             .message
             .into_current()
@@ -198,6 +183,7 @@ impl LogEntry {
         }
         Ok(())
     }
+
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
     fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
@@ -222,6 +208,17 @@ impl LogEntry {
         let timestamp_ms = self.timestamp_ms;
         let (session_id, message) = self.into_current()?;
         Ok((session_id, timestamp_ms, message))
+    }
+
+    /// Validate signed-log routing context.
+    fn validate_signed(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
+        if self.message.is_allowed_unsigned() {
+            return Err(InvalidS3Log(
+                "expected signed log record but message is unsigned".into(),
+            ));
+        }
+        self.validate_object_key()?;
+        self.validate_session_id(signing_public_key)
     }
 }
 
@@ -267,53 +264,58 @@ impl LogRecord {
         &self.data().message
     }
 
-    /// Validate a signed record under `signing_public_key` and normalize its
-    /// message to the current schema. The caller is responsible for establishing
-    /// that the signing key is authorized.
+    /// Validate a record and normalize its message to the current schema.
+    ///
+    /// Signed records require `Some(signing_public_key)`; the one permitted
+    /// unsigned record kind requires `None`. The caller is responsible for
+    /// establishing that a supplied signing key is authorized, or for
+    /// authenticating the Nitro attestation carried by an unsigned record.
     pub fn validate(
         self,
-        signing_public_key: &GuardianPubKey,
+        signing_public_key: Option<&GuardianPubKey>,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        let signed = self.into_signed()?;
-        let timestamp_ms = signed.data.timestamp_ms;
-        signed.data.validate_signed(signing_public_key)?;
-        let data = signed
-            .authenticate(signing_public_key)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-        let (session_id, message) = data.into_current()?;
-        Ok((session_id, timestamp_ms, message))
-    }
-
-    /// Validate the one permitted unsigned record kind and normalize its
-    /// message to the current schema. The embedded Nitro attestation must be
-    /// authenticated separately.
-    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        self.into_unsigned()?.validate_unsigned()
+        match (self, signing_public_key) {
+            (Self::Signed(signed), Some(signing_public_key)) => {
+                let timestamp_ms = signed.data.timestamp_ms;
+                signed.data.validate_signed(signing_public_key)?;
+                let data = signed
+                    .authenticate(signing_public_key)
+                    .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+                let (session_id, message) = data.into_current()?;
+                Ok((session_id, timestamp_ms, message))
+            }
+            (Self::Unsigned(unsigned), None) => unsigned.validate_unsigned(),
+            (Self::Unsigned(unsigned), Some(_)) if unsigned.message.is_allowed_unsigned() => Err(
+                InvalidS3Log("expected signed log record but message is unsigned".into()),
+            ),
+            (Self::Unsigned(_), Some(_)) => Err(InvalidS3Log("missing log signature".into())),
+            (Self::Signed(signed), None) if signed.data.message.is_allowed_unsigned() => Err(
+                InvalidS3Log("unsigned log record must not contain a signature".into()),
+            ),
+            (Self::Signed(_), None) => Err(InvalidS3Log(
+                "expected unsigned log record but message requires a signature".into(),
+            )),
+        }
     }
 
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
         policy.duration_for(self.data().message.log_type())
     }
 
-    pub fn into_signed(self) -> GuardianResult<GuardianSigned<LogEntry>> {
+    /// Extract and normalize a signed record without authenticating its
+    /// Guardian signature. This is only for callers that independently
+    /// authenticate the extracted payload.
+    pub fn into_current_unchecked(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         match self {
-            Self::Signed(signed) => Ok(signed),
+            Self::Signed(signed) => {
+                let timestamp_ms = signed.data.timestamp_ms;
+                let (session_id, message) = signed.into_data_unchecked().into_current()?;
+                Ok((session_id, timestamp_ms, message))
+            }
             Self::Unsigned(unsigned) if unsigned.message.is_allowed_unsigned() => Err(
                 InvalidS3Log("expected signed log record but message is unsigned".into()),
             ),
             Self::Unsigned(_) => Err(InvalidS3Log("missing log signature".into())),
-        }
-    }
-
-    pub fn into_unsigned(self) -> GuardianResult<LogEntry> {
-        match self {
-            Self::Unsigned(unsigned) => Ok(unsigned),
-            Self::Signed(signed) if signed.data.message.is_allowed_unsigned() => Err(InvalidS3Log(
-                "unsigned log record must not contain a signature".into(),
-            )),
-            Self::Signed(_) => Err(InvalidS3Log(
-                "expected unsigned log record but message requires a signature".into(),
-            )),
         }
     }
 
@@ -422,11 +424,11 @@ mod tests {
         record: LogRecord,
         signing_public_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        record.validate(signing_public_key)
+        record.validate(Some(signing_public_key))
     }
 
     fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        record.validate_unsigned()
+        record.validate(None)
     }
 
     fn assert_writer_key_is_stable_and_verifies(log: LogRecord, signing_key: &GuardianSignKeyPair) {

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -16,11 +16,13 @@ use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
 use crate::guardian::GuardianSignKeyPair;
 use crate::guardian::GuardianSignature;
-use crate::guardian::IntentType;
+use crate::guardian::GuardianSigningIntent;
+use crate::guardian::GuardianSigningIntentType;
 use crate::guardian::SessionID;
-use crate::guardian::SigningIntent;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
+use crate::guardian::signing::sign_guardian_payload;
+use crate::guardian::signing::verify_guardian_payload_signature;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::Error as _;
@@ -133,8 +135,8 @@ impl<'de> Deserialize<'de> for LogRecord {
     }
 }
 
-impl SigningIntent for LogSigningPayload<'_> {
-    const INTENT: IntentType = IntentType::LogMessage;
+impl GuardianSigningIntent for LogSigningPayload<'_> {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
 }
 
 /// A log record whose message signature and writing session's attestation/PCRs
@@ -216,7 +218,11 @@ impl LogRecord {
             message,
             signature: None,
         };
-        record.signature = Some(record.signing_payload().sign(timestamp_ms, signing_key));
+        record.signature = Some(sign_guardian_payload(
+            &record.signing_payload(),
+            timestamp_ms,
+            signing_key,
+        ));
         record
     }
 
@@ -257,9 +263,13 @@ impl LogRecord {
             .signature
             .as_ref()
             .ok_or_else(|| InvalidS3Log("missing log signature".into()))?;
-        self.signing_payload()
-            .verify_signature(timestamp_ms, signature, pub_key)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        verify_guardian_payload_signature(
+            &self.signing_payload(),
+            timestamp_ms,
+            signature,
+            pub_key,
+        )
+        .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
 
         let message = self
             .message

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -304,18 +304,6 @@ impl LogRecord {
         Ok((self.session_id, self.timestamp_ms, message))
     }
 
-    /// Rejects a record whose signed intended key differs from the key at which
-    /// the S3 reader found it.
-    pub fn validate_actual_object_key(&self, actual_object_key: &str) -> GuardianResult<()> {
-        if self.object_key != actual_object_key {
-            return Err(InvalidS3Log(format!(
-                "S3 object key mismatch: record contains {}, actual key is {actual_object_key}",
-                self.object_key
-            )));
-        }
-        Ok(())
-    }
-
     fn validate_object_key(&self) -> GuardianResult<()> {
         match self
             .message
@@ -421,19 +409,8 @@ mod tests {
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
         record_read_from_s3
-            .validate_actual_object_key(&writer_key)
-            .expect("the serialized key must match the writer's S3 destination");
-        record_read_from_s3
             .verify(&signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
-    }
-
-    fn assert_heartbeat_relocation_rejected(relocated_key: String) {
-        let (_, log, _) = signed_heartbeat(1_700_000_000_000);
-        let err = log
-            .validate_actual_object_key(&relocated_key)
-            .expect_err("relocated record must be rejected");
-        assert!(format!("{err:?}").contains("S3 object key mismatch"));
     }
 
     fn test_sharing_instance(sharing_seq: u64) -> SecretSharingInstance {
@@ -598,9 +575,11 @@ mod tests {
                 json,
                 "{name} did not reserialize canonically"
             );
-            decoded
-                .validate_actual_object_key(&object_key)
-                .unwrap_or_else(|error| panic!("{name} failed key validation: {error}"));
+            assert_eq!(
+                decoded.object_key(),
+                object_key,
+                "{name} did not preserve its object key"
+            );
             if decoded.message.is_allowed_unsigned() {
                 decoded
                     .validate_unsigned()
@@ -622,12 +601,6 @@ mod tests {
             VersionedLogMessage::V1(LogMessageV1::KpShareState(..))
         ));
         assert_eq!(serde_json::to_string(&record).unwrap(), fixture);
-        record
-            .validate_actual_object_key(
-                "kp-shares/00000000000000000000/00000000000000000000-916c711a5e81c2b0.json",
-            )
-            .unwrap();
-
         let signing_pubkey =
             hex::decode("916c711a5e81c2b032f15952b515205a20ef2a16f8a88da504885f392e314dca")
                 .unwrap();
@@ -739,9 +712,6 @@ mod tests {
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
         from_s3
-            .validate_actual_object_key(&object_key)
-            .expect("embedded key should match the S3 destination");
-        from_s3
             .verify(&signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
     }
@@ -756,37 +726,6 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("unsupported log schema version: 3")
-        );
-    }
-
-    #[test]
-    fn signed_log_rejects_cross_prefix_relocation() {
-        assert_heartbeat_relocation_rejected(format!(
-            "withdraw/2023/11/14/22/{}-00000000000000000042.json",
-            heartbeat_session_id()
-        ));
-    }
-
-    #[test]
-    fn signed_log_rejects_lexicographically_higher_key_relocation() {
-        assert_heartbeat_relocation_rejected(format!(
-            "heartbeat/2023/11/14/22/{}-00000000000000000043.json",
-            heartbeat_session_id()
-        ));
-    }
-
-    #[test]
-    fn signed_log_rejects_future_hour_relocation() {
-        assert_heartbeat_relocation_rejected(format!(
-            "heartbeat/2023/11/14/23/{}-00000000000000000042.json",
-            heartbeat_session_id()
-        ));
-    }
-
-    #[test]
-    fn signed_log_rejects_changed_session_relocation() {
-        assert_heartbeat_relocation_rejected(
-            "heartbeat/2023/11/14/22/aliased-session-00000000000000000042.json".to_string(),
         );
     }
 
@@ -831,12 +770,6 @@ mod tests {
 
         let mut record_read_from_s3: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        let err = record_read_from_s3
-            .validate_actual_object_key(&relocated_key)
-            .expect_err("changing only the random failure suffix must invalidate placement");
-
-        assert!(format!("{err:?}").contains("S3 object key mismatch"));
-
         record_read_from_s3.object_key = relocated_key;
         let err = record_read_from_s3
             .verify(&signing_key.verification_key())
@@ -889,8 +822,6 @@ mod tests {
         );
 
         log.object_key = "init/copied-attestation.json".to_string();
-        log.validate_actual_object_key("init/copied-attestation.json")
-            .expect("the operator can edit an unsigned record's embedded key");
         let err = log
             .validate_unsigned()
             .expect_err("unsigned record copied to another S3 key must be rejected");

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -266,9 +266,13 @@ impl LogRecord {
 
     /// Validate a record and normalize its message to the current schema.
     ///
+    /// Validation checks record-local invariants and verifies a signed record
+    /// against the caller-supplied key. It does not establish that the key
+    /// belongs to an attested, approved guardian; the S3 reader's
+    /// `verify_record` performs that complete verification.
+    ///
     /// Signed records require `Some(signing_public_key)`; the one permitted
     /// unsigned record kind requires `None`. The caller is responsible for
-    /// establishing that a supplied signing key is authorized, or for
     /// authenticating the Nitro attestation carried by an unsigned record.
     pub fn validate(
         self,

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -147,8 +147,8 @@ impl LogEntry {
         self.timestamp_ms
     }
 
-    /// Validate log-specific routing context without performing cryptography.
-    pub fn validate(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
+    /// Validate signed-log routing context without performing cryptography.
+    fn validate_signed(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
         if self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected signed log record but message is unsigned".into(),
@@ -200,7 +200,7 @@ impl LogEntry {
     }
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
-    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
@@ -265,6 +265,30 @@ impl LogRecord {
 
     pub fn message(&self) -> &VersionedLogMessage {
         &self.data().message
+    }
+
+    /// Validate a signed record under `signing_public_key` and normalize its
+    /// message to the current schema. The caller is responsible for establishing
+    /// that the signing key is authorized.
+    pub fn validate(
+        self,
+        signing_public_key: &GuardianPubKey,
+    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        let signed = self.into_signed()?;
+        let timestamp_ms = signed.data.timestamp_ms;
+        signed.data.validate_signed(signing_public_key)?;
+        let data = signed
+            .authenticate(signing_public_key)
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        let (session_id, message) = data.into_current()?;
+        Ok((session_id, timestamp_ms, message))
+    }
+
+    /// Validate the one permitted unsigned record kind and normalize its
+    /// message to the current schema. The embedded Nitro attestation must be
+    /// authenticated separately.
+    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        self.into_unsigned()?.validate_unsigned()
     }
 
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
@@ -398,18 +422,11 @@ mod tests {
         record: LogRecord,
         signing_public_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        let signed = record.into_signed()?;
-        let timestamp_ms = signed.data.timestamp_ms;
-        signed.data.validate(signing_public_key)?;
-        let data = signed
-            .authenticate(signing_public_key)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-        let (session_id, message) = data.into_current()?;
-        Ok((session_id, timestamp_ms, message))
+        record.validate(signing_public_key)
     }
 
     fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        record.into_unsigned()?.validate_unsigned()
+        record.validate_unsigned()
     }
 
     fn assert_writer_key_is_stable_and_verifies(log: LogRecord, signing_key: &GuardianSignKeyPair) {

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -385,6 +385,7 @@ mod tests {
     use crate::guardian::GetGuardianInfoResponse;
     use crate::guardian::GuardianError;
     use crate::guardian::GuardianSignedResponse;
+    use crate::guardian::GuardianSigningIntentType;
     use crate::guardian::HeartbeatLogMessage;
     use crate::guardian::InitLogMessage;
     use crate::guardian::KPEncryptedSharesRoster;

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -245,7 +245,9 @@ impl LogRecord {
         }
     }
 
-    pub fn verify(
+    /// Validates the signed record's envelope, canonical session, and Guardian
+    /// signature. The caller must establish trust in `pub_key` separately.
+    pub fn validate_signed(
         self,
         pub_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
@@ -409,7 +411,7 @@ mod tests {
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
         record_read_from_s3
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
     }
 
@@ -586,7 +588,7 @@ mod tests {
                     .unwrap_or_else(|error| panic!("{name} failed validation: {error}"));
             } else {
                 decoded
-                    .verify(&signing_key.verification_key())
+                    .validate_signed(&signing_key.verification_key())
                     .unwrap_or_else(|error| panic!("{name} failed verification: {error}"));
             }
         }
@@ -606,7 +608,7 @@ mod tests {
                 .unwrap();
         let signing_pubkey = GuardianPubKey::try_from(signing_pubkey.as_slice()).unwrap();
         let (session_id, timestamp_ms, LogMessageV2::KpShareState(message)) = record
-            .verify(&signing_pubkey)
+            .validate_signed(&signing_pubkey)
             .expect("the deployed V1 signature must verify before normalization")
         else {
             panic!("expected normalized KP share state");
@@ -683,7 +685,7 @@ mod tests {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
 
         let (_, timestamp_ms, message) = log
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect("record should verify at its intended S3 key");
 
         assert_eq!(timestamp_ms, 1_700_000_000_000);
@@ -712,7 +714,7 @@ mod tests {
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
         from_s3
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
     }
 
@@ -741,7 +743,7 @@ mod tests {
         );
 
         let err = tampered
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect_err("signature must cover the canonical object key and message");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -772,7 +774,7 @@ mod tests {
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
         record_read_from_s3.object_key = relocated_key;
         let err = record_read_from_s3
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect_err("the signature must authenticate the random failure suffix");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -801,7 +803,7 @@ mod tests {
         aliased.object_key = GenesisLogMessage::object_key();
 
         let err = aliased
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect_err("session ID must be part of the signed routing context");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -905,7 +907,9 @@ mod tests {
         assert_eq!(message["config_hash"], hex::encode([0xcd; 32]));
 
         let from_json: LogRecord = serde_json::from_value(json).unwrap();
-        from_json.verify(&signing_key.verification_key()).unwrap();
+        from_json
+            .validate_signed(&signing_key.verification_key())
+            .unwrap();
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -922,11 +922,8 @@ impl GetGuardianInfoResponse {
         &self,
         expected_build: &BuildPcrs,
     ) -> CryptoVerificationResult<VerifiedGuardianInfo> {
-        let info = self
-            .signed_info
-            .clone()
-            .authenticate(&self.signing_pub_key)?
-            .into_response();
+        self.signed_info.verify_signature(&self.signing_pub_key)?;
+        let info = self.signed_info.data.clone().into_response();
         if info.untrusted_git_revision != expected_build.git_revision() {
             return Err(CryptoVerificationError::new(format!(
                 "guardian info reports build '{}', expected current build '{}'",

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -26,7 +26,9 @@ pub use limiter::LimiterConfig;
 pub use limiter::LimiterState;
 pub use limiter::RateLimiter;
 pub use log::*;
+pub use signing::GuardianResponse;
 pub use signing::GuardianSigned;
+pub use signing::GuardianSignedResponse;
 pub use signing::GuardianSigningIntent;
 pub use signing::GuardianSigningIntentType;
 pub use signing::KpSigned;
@@ -86,7 +88,7 @@ pub struct GetGuardianInfoResponse {
     /// Signing pub key of the guardian
     signing_pub_key: GuardianPubKey,
     /// Signed guardian info
-    signed_info: GuardianSigned<GuardianInfo>,
+    signed_info: GuardianSignedResponse<GuardianInfo>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -299,8 +301,8 @@ pub struct ProvisionerRotateCertRequest {
     encrypted_share: GuardianEncryptedShare,
 }
 
-/// `GuardianSigned<ProvisionerRotateCertResponse>`. Returned after the guardian appends
-/// the next `kp-shares/` certificate-state snapshot.
+/// `GuardianSignedResponse<ProvisionerRotateCertResponse>`. Returned after the
+/// guardian appends the next `kp-shares/` certificate-state snapshot.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProvisionerRotateCertResponse {
     pub cert_seq: u64,
@@ -896,7 +898,7 @@ impl GetGuardianInfoResponse {
     pub fn new(
         attestation: NitroAttestation,
         signing_pub_key: GuardianPubKey,
-        signed_info: GuardianSigned<GuardianInfo>,
+        signed_info: GuardianSignedResponse<GuardianInfo>,
     ) -> Self {
         Self {
             attestation,
@@ -923,7 +925,8 @@ impl GetGuardianInfoResponse {
         let info = self
             .signed_info
             .clone()
-            .authenticate(&self.signing_pub_key)?;
+            .authenticate(&self.signing_pub_key)?
+            .into_response();
         if info.untrusted_git_revision != expected_build.git_revision() {
             return Err(CryptoVerificationError::new(format!(
                 "guardian info reports build '{}', expected current build '{}'",
@@ -943,7 +946,10 @@ impl GetGuardianInfoResponse {
     /// Extract the guardian's self-reported info and signing key WITHOUT verifying
     /// the signature or attestation.
     pub fn into_info_unchecked(self) -> (GuardianInfo, GuardianPubKey) {
-        (self.signed_info.into_data_unchecked(), self.signing_pub_key)
+        (
+            self.signed_info.into_data_unchecked().into_response(),
+            self.signing_pub_key,
+        )
     }
 }
 
@@ -1092,7 +1098,7 @@ mod tests {
     #[test]
     fn get_guardian_info_into_info_unchecked_returns_info_and_signing_key() {
         let resp = GetGuardianInfoResponse::mock_for_testing();
-        let expected_info = resp.signed_info.data.clone();
+        let expected_info = resp.signed_info.data.response.clone();
         let expected_signing_pub_key = resp.signing_pub_key;
         let (info, signing_pub_key) = resp.into_info_unchecked();
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -923,8 +923,11 @@ impl GetGuardianInfoResponse {
         &self,
         expected_build: &BuildPcrs,
     ) -> CryptoVerificationResult<VerifiedGuardianInfo> {
-        self.signed_info.verify_signature(&self.signing_pub_key)?;
-        let info = self.signed_info.data.clone().into_response();
+        let info = self
+            .signed_info
+            .verify_signature(&self.signing_pub_key)?
+            .response
+            .clone();
         if info.untrusted_git_revision != expected_build.git_revision() {
             return Err(CryptoVerificationError::new(format!(
                 "guardian info reports build '{}', expected current build '{}'",
@@ -945,7 +948,7 @@ impl GetGuardianInfoResponse {
     /// the signature or attestation.
     pub fn into_info_unchecked(self) -> (GuardianInfo, GuardianPubKey) {
         (
-            self.signed_info.into_data_unchecked().into_response(),
+            self.signed_info.into_data_unchecked().response,
             self.signing_pub_key,
         )
     }
@@ -1068,7 +1071,7 @@ mod tests {
 
     #[test]
     fn guardian_info_json_encodes_binary_fields_as_strings() {
-        let (mut info, _) = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
+        let mut info = GuardianInfo::mock_for_testing();
         info.config_hash = Some([0xab; 32]);
         let btc_pubkey = crate::bitcoin::create_btc_keypair_for_test(&[3u8; 32])
             .x_only_public_key()
@@ -1096,7 +1099,7 @@ mod tests {
     #[test]
     fn get_guardian_info_into_info_unchecked_returns_info_and_signing_key() {
         let resp = GetGuardianInfoResponse::mock_for_testing();
-        let expected_info = resp.signed_info.data.response.clone();
+        let expected_info = GuardianInfo::mock_for_testing();
         let expected_signing_pub_key = resp.signing_pub_key;
         let (info, signing_pub_key) = resp.into_info_unchecked();
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -27,11 +27,11 @@ pub use limiter::LimiterState;
 pub use limiter::RateLimiter;
 pub use log::*;
 pub use signing::GuardianSigned;
-pub use signing::IntentType;
+pub use signing::GuardianSigningIntent;
+pub use signing::GuardianSigningIntentType;
 pub use signing::KpSigned;
 pub use signing::KpSigningIntent;
 pub use signing::KpSigningIntentType;
-pub use signing::SigningIntent;
 pub use time_utils::UnixMillis;
 pub use time_utils::now_timestamp_ms;
 pub use time_utils::now_timestamp_secs;
@@ -920,7 +920,10 @@ impl GetGuardianInfoResponse {
         &self,
         expected_build: &BuildPcrs,
     ) -> CryptoVerificationResult<VerifiedGuardianInfo> {
-        let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
+        let info = self
+            .signed_info
+            .clone()
+            .authenticate(&self.signing_pub_key)?;
         if info.untrusted_git_revision != expected_build.git_revision() {
             return Err(CryptoVerificationError::new(format!(
                 "guardian info reports build '{}', expected current build '{}'",

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -223,7 +223,7 @@ impl crate::intent::IntentMessage for StandardWithdrawalRequest {
     const INTENT: crate::intent::Intent = crate::intent::Intent::GuardianWithdrawalRequest;
 }
 
-/// `EnclaveSigned<T>`
+/// `GuardianSignedResponse<StandardWithdrawalResponse>`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StandardWithdrawalResponse {
     pub enclave_signatures: Vec<BitcoinSignature>,
@@ -251,7 +251,7 @@ pub struct SetupNewKeyRequest {
     params: SecretSharingParams,
 }
 
-/// `EnclaveSigned<T>`
+/// `GuardianSignedResponse<SetupNewKeyResponse>`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SetupNewKeyResponse {
     pub encrypted_shares: KPEncryptedSharesRoster,
@@ -282,7 +282,8 @@ pub struct RotateKpsState {
     new_params: SecretSharingParams,
 }
 
-/// `EnclaveSigned<T>`. The new KP set's encrypted shares, returned by `rotate_kps`.
+/// `GuardianSignedResponse<RotateKpsResponse>`. The new KP set's encrypted
+/// shares, returned by `rotate_kps`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RotateKpsResponse {
     pub encrypted_shares: KPEncryptedSharesRoster,

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -1758,13 +1758,13 @@ mod tests {
         );
         assert_eq!(back.data.encrypted_share(), &encrypted_share);
         assert_eq!(back.signer_cert.fingerprint(), cert.fingerprint());
-        back.authenticate().unwrap();
+        back.verify_signature().unwrap();
 
         let mut tampered = pb.clone();
         tampered.expected_session_id = "other-session".to_string();
         let tampered = KpSigned::<SingleProvisionerInitRequest>::try_from(tampered).unwrap();
         assert!(
-            tampered.authenticate().is_err(),
+            tampered.verify_signature().is_err(),
             "signature must bind the expected guardian session"
         );
 
@@ -1772,7 +1772,7 @@ mod tests {
         tampered.expected_config_hash = Some(vec![8u8; 32].into());
         let tampered = KpSigned::<SingleProvisionerInitRequest>::try_from(tampered).unwrap();
         assert!(
-            tampered.authenticate().is_err(),
+            tampered.verify_signature().is_err(),
             "signature must bind the expected operator-init config hash"
         );
     }

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -17,9 +17,11 @@ use super::GuardianError;
 use super::GuardianError::InvalidInputs;
 use super::GuardianInfo;
 use super::GuardianPubKey;
+use super::GuardianResponse;
 use super::GuardianResult;
 use super::GuardianSignature;
 use super::GuardianSigned;
+use super::GuardianSignedResponse;
 use super::HashiCommittee;
 use super::HashiCommitteeMember;
 use super::HashiSigned;
@@ -133,7 +135,7 @@ impl TryFrom<pb::SetupNewKeyRequest> for SetupNewKeyRequest {
     }
 }
 
-impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSigned<SetupNewKeyResponse> {
+impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSignedResponse<SetupNewKeyResponse> {
     type Error = GuardianError;
 
     fn try_from(resp: pb::SignedSetupNewKeyResponse) -> Result<Self, Self::Error> {
@@ -162,12 +164,14 @@ impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSigned<SetupNewKeyRespon
         let timestamp_ms = resp.timestamp_ms.ok_or_else(|| missing("timestamp_ms"))?;
 
         Ok(GuardianSigned {
-            data: SetupNewKeyResponse {
-                encrypted_shares,
-                secret_sharing_instance,
-                btc_master_pubkey,
-            },
-            timestamp_ms,
+            data: GuardianResponse::new(
+                SetupNewKeyResponse {
+                    encrypted_shares,
+                    secret_sharing_instance,
+                    btc_master_pubkey,
+                },
+                timestamp_ms,
+            ),
             signature,
         })
     }
@@ -387,7 +391,7 @@ impl TryFrom<pb::RotateKpsRequest> for RotateKpsRequest {
     }
 }
 
-impl TryFrom<pb::SignedRotateKpsResponse> for GuardianSigned<RotateKpsResponse> {
+impl TryFrom<pb::SignedRotateKpsResponse> for GuardianSignedResponse<RotateKpsResponse> {
     type Error = GuardianError;
 
     fn try_from(resp: pb::SignedRotateKpsResponse) -> Result<Self, Self::Error> {
@@ -406,15 +410,14 @@ impl TryFrom<pb::SignedRotateKpsResponse> for GuardianSigned<RotateKpsResponse> 
         let timestamp_ms = resp.timestamp_ms.ok_or_else(|| missing("timestamp_ms"))?;
 
         Ok(GuardianSigned {
-            data: RotateKpsResponse { encrypted_shares },
-            timestamp_ms,
+            data: GuardianResponse::new(RotateKpsResponse { encrypted_shares }, timestamp_ms),
             signature,
         })
     }
 }
 
 impl TryFrom<pb::SignedProvisionerRotateCertResponse>
-    for GuardianSigned<ProvisionerRotateCertResponse>
+    for GuardianSignedResponse<ProvisionerRotateCertResponse>
 {
     type Error = GuardianError;
 
@@ -429,11 +432,13 @@ impl TryFrom<pb::SignedProvisionerRotateCertResponse>
         )?;
 
         Ok(GuardianSigned {
-            data: ProvisionerRotateCertResponse {
-                cert_seq: resp.cert_seq.ok_or_else(|| missing("cert_seq"))?,
-                encrypted_shares,
-            },
-            timestamp_ms,
+            data: GuardianResponse::new(
+                ProvisionerRotateCertResponse {
+                    cert_seq: resp.cert_seq.ok_or_else(|| missing("cert_seq"))?,
+                    encrypted_shares,
+                },
+                timestamp_ms,
+            ),
             signature,
         })
     }
@@ -521,7 +526,7 @@ impl TryFrom<pb::GetGuardianInfoResponse> for GetGuardianInfoResponse {
             .map_err(|e| InvalidInputs(format!("invalid signing_pub_key: {e}")))?;
 
         let signed_info_pb = resp.signed_info.ok_or_else(|| missing("signed_info"))?;
-        let signed_info = GuardianSigned::<GuardianInfo>::try_from(signed_info_pb)?;
+        let signed_info = GuardianSignedResponse::<GuardianInfo>::try_from(signed_info_pb)?;
 
         Ok(GetGuardianInfoResponse::new(
             NitroAttestation::new(attestation.to_vec()),
@@ -563,7 +568,9 @@ impl TryFrom<pb::SignedStandardWithdrawalRequest> for SignedStandardWithdrawalRe
     }
 }
 
-impl TryFrom<pb::SignedStandardWithdrawalResponse> for GuardianSigned<StandardWithdrawalResponse> {
+impl TryFrom<pb::SignedStandardWithdrawalResponse>
+    for GuardianSignedResponse<StandardWithdrawalResponse>
+{
     type Error = GuardianError;
 
     fn try_from(resp: pb::SignedStandardWithdrawalResponse) -> Result<Self, Self::Error> {
@@ -584,8 +591,10 @@ impl TryFrom<pb::SignedStandardWithdrawalResponse> for GuardianSigned<StandardWi
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(GuardianSigned {
-            data: StandardWithdrawalResponse { enclave_signatures },
-            timestamp_ms,
+            data: GuardianResponse::new(
+                StandardWithdrawalResponse { enclave_signatures },
+                timestamp_ms,
+            ),
             signature,
         })
     }
@@ -596,19 +605,19 @@ impl TryFrom<pb::SignedStandardWithdrawalResponse> for GuardianSigned<StandardWi
 // ----------------------------------------------------------
 
 pub fn setup_new_key_response_signed_to_pb(
-    s: GuardianSigned<SetupNewKeyResponse>,
+    s: GuardianSignedResponse<SetupNewKeyResponse>,
 ) -> pb::SignedSetupNewKeyResponse {
     let signature = s.signature.to_bytes().to_vec();
 
     pb::SignedSetupNewKeyResponse {
-        data: Some(setup_new_key_response_to_pb(s.data)),
-        timestamp_ms: Some(s.timestamp_ms),
+        data: Some(setup_new_key_response_to_pb(s.data.response)),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(signature.into()),
     }
 }
 
 pub fn rotate_kps_response_signed_to_pb(
-    s: GuardianSigned<RotateKpsResponse>,
+    s: GuardianSignedResponse<RotateKpsResponse>,
 ) -> pb::SignedRotateKpsResponse {
     let signature = s.signature.to_bytes().to_vec();
 
@@ -616,24 +625,25 @@ pub fn rotate_kps_response_signed_to_pb(
         data: Some(pb::RotateKpsResponseData {
             encrypted_shares: s
                 .data
+                .response
                 .encrypted_shares
                 .into_vec()
                 .into_iter()
                 .map(kp_encrypted_shares_to_pb)
                 .collect(),
         }),
-        timestamp_ms: Some(s.timestamp_ms),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(signature.into()),
     }
 }
 
 pub fn provisioner_rotate_cert_response_signed_to_pb(
-    s: GuardianSigned<ProvisionerRotateCertResponse>,
+    s: GuardianSignedResponse<ProvisionerRotateCertResponse>,
 ) -> pb::SignedProvisionerRotateCertResponse {
     pb::SignedProvisionerRotateCertResponse {
-        cert_seq: Some(s.data.cert_seq),
-        encrypted_shares: Some(kp_encrypted_shares_to_pb(s.data.encrypted_shares)),
-        timestamp_ms: Some(s.timestamp_ms),
+        cert_seq: Some(s.data.response.cert_seq),
+        encrypted_shares: Some(kp_encrypted_shares_to_pb(s.data.response.encrypted_shares)),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(s.signature.to_bytes().to_vec().into()),
     }
 }
@@ -815,7 +825,7 @@ pub fn signed_standard_withdrawal_request_to_pb(
 }
 
 pub fn standard_withdrawal_response_signed_to_pb(
-    s: GuardianSigned<StandardWithdrawalResponse>,
+    s: GuardianSignedResponse<StandardWithdrawalResponse>,
 ) -> pb::SignedStandardWithdrawalResponse {
     let signature = s.signature.to_bytes().to_vec();
 
@@ -823,12 +833,13 @@ pub fn standard_withdrawal_response_signed_to_pb(
         data: Some(pb::StandardWithdrawalResponseData {
             enclave_signatures: s
                 .data
+                .response
                 .enclave_signatures
                 .iter()
                 .map(|sig| sig.to_vec().into())
                 .collect(),
         }),
-        timestamp_ms: Some(s.timestamp_ms),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(signature.into()),
     }
 }
@@ -1063,7 +1074,7 @@ fn guardian_info_data_to_pb(info: GuardianInfo) -> pb::GuardianInfoData {
     }
 }
 
-impl TryFrom<pb::SignedGuardianInfo> for GuardianSigned<GuardianInfo> {
+impl TryFrom<pb::SignedGuardianInfo> for GuardianSignedResponse<GuardianInfo> {
     type Error = GuardianError;
 
     fn try_from(s: pb::SignedGuardianInfo) -> Result<Self, Self::Error> {
@@ -1079,17 +1090,16 @@ impl TryFrom<pb::SignedGuardianInfo> for GuardianSigned<GuardianInfo> {
             .map_err(|e| InvalidInputs(format!("invalid signed_info.signature: {e}")))?;
 
         Ok(Self {
-            data: GuardianInfo::try_from(data_pb)?,
-            timestamp_ms,
+            data: GuardianResponse::new(GuardianInfo::try_from(data_pb)?, timestamp_ms),
             signature,
         })
     }
 }
 
-fn signed_guardian_info_to_pb(s: GuardianSigned<GuardianInfo>) -> pb::SignedGuardianInfo {
+fn signed_guardian_info_to_pb(s: GuardianSignedResponse<GuardianInfo>) -> pb::SignedGuardianInfo {
     pb::SignedGuardianInfo {
-        data: Some(guardian_info_data_to_pb(s.data)),
-        timestamp_ms: Some(s.timestamp_ms),
+        data: Some(guardian_info_data_to_pb(s.data.response)),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(s.signature.to_bytes().to_vec().into()),
     }
 }
@@ -1670,25 +1680,26 @@ mod tests {
 
     #[test]
     fn setup_new_key_response_round_trip() {
-        let resp = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing();
+        let resp = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing();
         let pb = setup_new_key_response_signed_to_pb(resp.clone());
-        let back = GuardianSigned::<SetupNewKeyResponse>::try_from(pb).unwrap();
+        let back = GuardianSignedResponse::<SetupNewKeyResponse>::try_from(pb).unwrap();
         assert_eq!(resp, back);
     }
 
     #[test]
     fn signed_rotate_kps_response_round_trip() {
-        let resp = GuardianSigned::<RotateKpsResponse>::mock_for_testing();
+        let resp = GuardianSignedResponse::<RotateKpsResponse>::mock_for_testing();
         let pb = rotate_kps_response_signed_to_pb(resp.clone());
-        let back = GuardianSigned::<RotateKpsResponse>::try_from(pb).unwrap();
+        let back = GuardianSignedResponse::<RotateKpsResponse>::try_from(pb).unwrap();
         assert_eq!(resp, back);
     }
 
     #[test]
     fn signed_provisioner_rotate_cert_response_round_trip() {
-        let response = GuardianSigned::<ProvisionerRotateCertResponse>::mock_for_testing();
+        let response = GuardianSignedResponse::<ProvisionerRotateCertResponse>::mock_for_testing();
         let pb = provisioner_rotate_cert_response_signed_to_pb(response.clone());
-        let round_trip = GuardianSigned::<ProvisionerRotateCertResponse>::try_from(pb).unwrap();
+        let round_trip =
+            GuardianSignedResponse::<ProvisionerRotateCertResponse>::try_from(pb).unwrap();
         assert_eq!(response, round_trip);
     }
 
@@ -1797,9 +1808,9 @@ mod tests {
 
     #[test]
     fn standard_withdrawal_response_round_trip() {
-        let resp = GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing();
+        let resp = GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing();
         let pb = standard_withdrawal_response_signed_to_pb(resp.clone());
-        let back = GuardianSigned::<StandardWithdrawalResponse>::try_from(pb).unwrap();
+        let back = GuardianSignedResponse::<StandardWithdrawalResponse>::try_from(pb).unwrap();
         assert_eq!(resp, back);
     }
 

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -1747,13 +1747,13 @@ mod tests {
         );
         assert_eq!(back.data.encrypted_share(), &encrypted_share);
         assert_eq!(back.signer_cert.fingerprint(), cert.fingerprint());
-        back.verify().unwrap();
+        back.authenticate().unwrap();
 
         let mut tampered = pb.clone();
         tampered.expected_session_id = "other-session".to_string();
         let tampered = KpSigned::<SingleProvisionerInitRequest>::try_from(tampered).unwrap();
         assert!(
-            tampered.verify().is_err(),
+            tampered.authenticate().is_err(),
             "signature must bind the expected guardian session"
         );
 
@@ -1761,7 +1761,7 @@ mod tests {
         tampered.expected_config_hash = Some(vec![8u8; 32].into());
         let tampered = KpSigned::<SingleProvisionerInitRequest>::try_from(tampered).unwrap();
         assert!(
-            tampered.verify().is_err(),
+            tampered.authenticate().is_err(),
             "signature must bind the expected operator-init config hash"
         );
     }

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -163,8 +163,8 @@ impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSignedResponse<SetupNewK
 
         let timestamp_ms = resp.timestamp_ms.ok_or_else(|| missing("timestamp_ms"))?;
 
-        Ok(GuardianSigned {
-            data: GuardianResponse::new(
+        Ok(GuardianSigned::from_parts(
+            GuardianResponse::new(
                 SetupNewKeyResponse {
                     encrypted_shares,
                     secret_sharing_instance,
@@ -173,7 +173,7 @@ impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSignedResponse<SetupNewK
                 timestamp_ms,
             ),
             signature,
-        })
+        ))
     }
 }
 
@@ -301,11 +301,7 @@ impl TryFrom<pb::SignedSingleProvisionerInitRequest> for KpSigned<SingleProvisio
             expected_genesis_state_hash,
             encrypted_share,
         );
-        Ok(KpSigned {
-            data: request,
-            signer_cert,
-            signature: req.kp_signature,
-        })
+        Ok(KpSigned::from_parts(request, signer_cert, req.kp_signature))
     }
 }
 
@@ -345,11 +341,7 @@ impl TryFrom<pb::SignedProvisionerRotateCertRequest> for KpSigned<ProvisionerRot
             new_kp_pgp_cert,
             encrypted_share,
         );
-        Ok(KpSigned {
-            data: request,
-            signer_cert,
-            signature: req.kp_signature,
-        })
+        Ok(KpSigned::from_parts(request, signer_cert, req.kp_signature))
     }
 }
 
@@ -409,10 +401,10 @@ impl TryFrom<pb::SignedRotateKpsResponse> for GuardianSignedResponse<RotateKpsRe
 
         let timestamp_ms = resp.timestamp_ms.ok_or_else(|| missing("timestamp_ms"))?;
 
-        Ok(GuardianSigned {
-            data: GuardianResponse::new(RotateKpsResponse { encrypted_shares }, timestamp_ms),
+        Ok(GuardianSigned::from_parts(
+            GuardianResponse::new(RotateKpsResponse { encrypted_shares }, timestamp_ms),
             signature,
-        })
+        ))
     }
 }
 
@@ -431,8 +423,8 @@ impl TryFrom<pb::SignedProvisionerRotateCertResponse>
                 .ok_or_else(|| missing("encrypted_shares"))?,
         )?;
 
-        Ok(GuardianSigned {
-            data: GuardianResponse::new(
+        Ok(GuardianSigned::from_parts(
+            GuardianResponse::new(
                 ProvisionerRotateCertResponse {
                     cert_seq: resp.cert_seq.ok_or_else(|| missing("cert_seq"))?,
                     encrypted_shares,
@@ -440,7 +432,7 @@ impl TryFrom<pb::SignedProvisionerRotateCertResponse>
                 timestamp_ms,
             ),
             signature,
-        })
+        ))
     }
 }
 
@@ -590,13 +582,13 @@ impl TryFrom<pb::SignedStandardWithdrawalResponse>
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(GuardianSigned {
-            data: GuardianResponse::new(
+        Ok(GuardianSigned::from_parts(
+            GuardianResponse::new(
                 StandardWithdrawalResponse { enclave_signatures },
                 timestamp_ms,
             ),
             signature,
-        })
+        ))
     }
 }
 
@@ -607,24 +599,23 @@ impl TryFrom<pb::SignedStandardWithdrawalResponse>
 pub fn setup_new_key_response_signed_to_pb(
     s: GuardianSignedResponse<SetupNewKeyResponse>,
 ) -> pb::SignedSetupNewKeyResponse {
-    let signature = s.signature.to_bytes().to_vec();
+    let (data, signature) = s.into_parts();
 
     pb::SignedSetupNewKeyResponse {
-        data: Some(setup_new_key_response_to_pb(s.data.response)),
-        timestamp_ms: Some(s.data.timestamp_ms),
-        signature: Some(signature.into()),
+        data: Some(setup_new_key_response_to_pb(data.response)),
+        timestamp_ms: Some(data.timestamp_ms),
+        signature: Some(signature.to_bytes().to_vec().into()),
     }
 }
 
 pub fn rotate_kps_response_signed_to_pb(
     s: GuardianSignedResponse<RotateKpsResponse>,
 ) -> pb::SignedRotateKpsResponse {
-    let signature = s.signature.to_bytes().to_vec();
+    let (data, signature) = s.into_parts();
 
     pb::SignedRotateKpsResponse {
         data: Some(pb::RotateKpsResponseData {
-            encrypted_shares: s
-                .data
+            encrypted_shares: data
                 .response
                 .encrypted_shares
                 .into_vec()
@@ -632,19 +623,20 @@ pub fn rotate_kps_response_signed_to_pb(
                 .map(kp_encrypted_shares_to_pb)
                 .collect(),
         }),
-        timestamp_ms: Some(s.data.timestamp_ms),
-        signature: Some(signature.into()),
+        timestamp_ms: Some(data.timestamp_ms),
+        signature: Some(signature.to_bytes().to_vec().into()),
     }
 }
 
 pub fn provisioner_rotate_cert_response_signed_to_pb(
     s: GuardianSignedResponse<ProvisionerRotateCertResponse>,
 ) -> pb::SignedProvisionerRotateCertResponse {
+    let (data, signature) = s.into_parts();
     pb::SignedProvisionerRotateCertResponse {
-        cert_seq: Some(s.data.response.cert_seq),
-        encrypted_shares: Some(kp_encrypted_shares_to_pb(s.data.response.encrypted_shares)),
-        timestamp_ms: Some(s.data.timestamp_ms),
-        signature: Some(s.signature.to_bytes().to_vec().into()),
+        cert_seq: Some(data.response.cert_seq),
+        encrypted_shares: Some(kp_encrypted_shares_to_pb(data.response.encrypted_shares)),
+        timestamp_ms: Some(data.timestamp_ms),
+        signature: Some(signature.to_bytes().to_vec().into()),
     }
 }
 
@@ -695,11 +687,7 @@ pub fn provisioner_init_request_to_pb(
 
 impl From<KpSigned<SingleProvisionerInitRequest>> for pb::SignedSingleProvisionerInitRequest {
     fn from(r: KpSigned<SingleProvisionerInitRequest>) -> Self {
-        let KpSigned {
-            data: request,
-            signer_cert,
-            signature,
-        } = r;
+        let (request, signer_cert, signature) = r.into_parts();
         let (
             expected_session_id,
             expected_config_hash,
@@ -720,11 +708,7 @@ impl From<KpSigned<SingleProvisionerInitRequest>> for pb::SignedSingleProvisione
 
 impl From<KpSigned<ProvisionerRotateCertRequest>> for pb::SignedProvisionerRotateCertRequest {
     fn from(r: KpSigned<ProvisionerRotateCertRequest>) -> Self {
-        let KpSigned {
-            data: request,
-            signer_cert,
-            signature,
-        } = r;
+        let (request, signer_cert, signature) = r.into_parts();
         let (
             expected_session_id,
             expected_cert_seq,
@@ -827,20 +811,19 @@ pub fn signed_standard_withdrawal_request_to_pb(
 pub fn standard_withdrawal_response_signed_to_pb(
     s: GuardianSignedResponse<StandardWithdrawalResponse>,
 ) -> pb::SignedStandardWithdrawalResponse {
-    let signature = s.signature.to_bytes().to_vec();
+    let (data, signature) = s.into_parts();
 
     pb::SignedStandardWithdrawalResponse {
         data: Some(pb::StandardWithdrawalResponseData {
-            enclave_signatures: s
-                .data
+            enclave_signatures: data
                 .response
                 .enclave_signatures
                 .iter()
                 .map(|sig| sig.to_vec().into())
                 .collect(),
         }),
-        timestamp_ms: Some(s.data.timestamp_ms),
-        signature: Some(signature.into()),
+        timestamp_ms: Some(data.timestamp_ms),
+        signature: Some(signature.to_bytes().to_vec().into()),
     }
 }
 
@@ -1089,18 +1072,19 @@ impl TryFrom<pb::SignedGuardianInfo> for GuardianSignedResponse<GuardianInfo> {
         let signature = GuardianSignature::try_from(signature_bytes.as_ref())
             .map_err(|e| InvalidInputs(format!("invalid signed_info.signature: {e}")))?;
 
-        Ok(Self {
-            data: GuardianResponse::new(GuardianInfo::try_from(data_pb)?, timestamp_ms),
+        Ok(Self::from_parts(
+            GuardianResponse::new(GuardianInfo::try_from(data_pb)?, timestamp_ms),
             signature,
-        })
+        ))
     }
 }
 
 fn signed_guardian_info_to_pb(s: GuardianSignedResponse<GuardianInfo>) -> pb::SignedGuardianInfo {
+    let (data, signature) = s.into_parts();
     pb::SignedGuardianInfo {
-        data: Some(guardian_info_data_to_pb(s.data.response)),
-        timestamp_ms: Some(s.data.timestamp_ms),
-        signature: Some(s.signature.to_bytes().to_vec().into()),
+        data: Some(guardian_info_data_to_pb(data.response)),
+        timestamp_ms: Some(data.timestamp_ms),
+        signature: Some(signature.to_bytes().to_vec().into()),
     }
 }
 
@@ -1726,12 +1710,8 @@ mod tests {
 
         let (cert_armored, secret_armored) = mock_pgp_keypair();
         let cert = PgpPublicCert::new(cert_armored).unwrap();
-        let encrypted_share = ProvisionerInitRequest::mock_for_testing()
-            .0
-            .pop()
-            .unwrap()
-            .data
-            .encrypted_share;
+        let (_, _, _, encrypted_share) =
+            SingleProvisionerInitRequest::mock_for_testing().into_parts();
         let expected_config_hash = [9u8; 32];
         let expected_genesis_state_hash = Some([10u8; 32]);
         let request = SingleProvisionerInitRequest::new(
@@ -1742,23 +1722,19 @@ mod tests {
         );
         let signature =
             sign_detached_in_process(&secret_armored, &KpSigned::signed_bytes(&request));
-        let signed = KpSigned {
-            data: request,
-            signer_cert: cert.clone(),
-            signature,
-        };
+        let signed = KpSigned::from_parts(request, cert.clone(), signature);
 
         let pb = pb::SignedSingleProvisionerInitRequest::from(signed);
         let back = KpSigned::<SingleProvisionerInitRequest>::try_from(pb.clone()).unwrap();
-        assert_eq!(back.data.expected_session_id(), "session-a");
-        assert_eq!(back.data.expected_config_hash(), &expected_config_hash);
+        let data = back.verify_signature().unwrap();
+        assert_eq!(data.expected_session_id(), "session-a");
+        assert_eq!(data.expected_config_hash(), &expected_config_hash);
         assert_eq!(
-            back.data.expected_genesis_state_hash(),
+            data.expected_genesis_state_hash(),
             expected_genesis_state_hash
         );
-        assert_eq!(back.data.encrypted_share(), &encrypted_share);
+        assert_eq!(data.encrypted_share(), &encrypted_share);
         assert_eq!(back.signer_cert.fingerprint(), cert.fingerprint());
-        back.verify_signature().unwrap();
 
         let mut tampered = pb.clone();
         tampered.expected_session_id = "other-session".to_string();

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -38,7 +38,7 @@ use std::path::Path;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GuardianSigningIntentType {
     /// Intent for LogEntry.
-    LogMessage = 0,
+    LogEntry = 0,
     /// Intent for SetupNewKeyResponse.
     SetupNewKeyResponse = 1,
     /// Intent for StandardWithdrawalResponse.
@@ -108,7 +108,7 @@ pub struct GuardianSigned<T> {
 }
 
 impl GuardianSigningIntent for LogEntry {
-    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogEntry;
 }
 
 impl GuardianSigningIntent for SetupNewKeyResponse {

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -49,38 +49,34 @@ pub enum IntentType {
     ProvisionerRotateCertResponse = 5,
 }
 
-/// Trait for types that can be signed, providing domain separation via an intent.
-pub trait SigningIntent {
+/// Trait for serializable types that can be signed with intent-based domain
+/// separation.
+pub trait SigningIntent: Serialize {
     const INTENT: IntentType;
 
     /// Canonical bytes covered by this guardian signature. Most payloads use
     /// the standard `(intent, data, timestamp)` layout; routing-sensitive
     /// payloads may override this while retaining the central intent registry.
-    fn signing_bytes(&self, timestamp_ms: UnixMillis) -> Vec<u8>
-    where
-        Self: Serialize,
-    {
+    fn signing_bytes(&self, timestamp_ms: UnixMillis) -> Vec<u8> {
         bcs::to_bytes(&(Self::INTENT, self, timestamp_ms)).expect("serialization should not fail")
     }
-}
 
-pub(crate) fn sign_intent<T: Serialize + SigningIntent>(
-    data: &T,
-    timestamp_ms: UnixMillis,
-    signing_key: &SigningKey,
-) -> GuardianSignature {
-    signing_key.sign(&data.signing_bytes(timestamp_ms))
-}
+    /// Signs this payload's canonical intent-bound bytes.
+    fn sign(&self, timestamp_ms: UnixMillis, signing_key: &SigningKey) -> GuardianSignature {
+        signing_key.sign(&self.signing_bytes(timestamp_ms))
+    }
 
-pub(crate) fn verify_intent<T: Serialize + SigningIntent>(
-    data: &T,
-    timestamp_ms: UnixMillis,
-    signature: &GuardianSignature,
-    pub_key: &VerificationKey,
-) -> CryptoVerificationResult<()> {
-    pub_key
-        .verify(signature, &data.signing_bytes(timestamp_ms))
-        .map_err(|_| CryptoVerificationError::new("signature invalid"))
+    /// Verifies a signature over this payload's canonical intent-bound bytes.
+    fn verify_signature(
+        &self,
+        timestamp_ms: UnixMillis,
+        signature: &GuardianSignature,
+        pub_key: &VerificationKey,
+    ) -> CryptoVerificationResult<()> {
+        pub_key
+            .verify(signature, &self.signing_bytes(timestamp_ms))
+            .map_err(|_| CryptoVerificationError::new("signature invalid"))
+    }
 }
 
 /// All possible KP signing intent types.
@@ -150,11 +146,11 @@ pub struct GuardianSigned<T> {
 }
 
 /// Methods for `Signed<T>` wrapper - signing and verification
-impl<T: Serialize + SigningIntent> GuardianSigned<T> {
+impl<T: SigningIntent> GuardianSigned<T> {
     /// Create a new signed payload (used by enclave)
     /// Includes intent byte for domain separation to prevent cross-type signature attacks
     pub fn new(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
-        let signature = sign_intent(&data, timestamp_ms, signing_key);
+        let signature = data.sign(timestamp_ms, signing_key);
         Self {
             data,
             timestamp_ms,
@@ -165,7 +161,8 @@ impl<T: Serialize + SigningIntent> GuardianSigned<T> {
     /// Verify signature and extract payload
     /// Checks intent byte to ensure signature is for the correct type
     pub fn verify(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
-        verify_intent(&self.data, self.timestamp_ms, &self.signature, pub_key)?;
+        self.data
+            .verify_signature(self.timestamp_ms, &self.signature, pub_key)?;
         Ok(self.data)
     }
 }

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -13,6 +13,7 @@ use super::CryptoVerificationResult;
 use super::GuardianError::InternalError;
 use super::GuardianInfo;
 use super::GuardianResult;
+use super::LogEntry;
 use super::ProvisionerRotateCertRequest;
 use super::ProvisionerRotateCertResponse;
 use super::RotateKpsResponse;
@@ -55,10 +56,6 @@ pub trait GuardianSigningIntent: Serialize {
     const INTENT: GuardianSigningIntentType;
 }
 
-fn guardian_signing_bytes<T: GuardianSigningIntent>(data: &T, timestamp_ms: UnixMillis) -> Vec<u8> {
-    bcs::to_bytes(&(T::INTENT, data, timestamp_ms)).expect("serialization should not fail")
-}
-
 /// All possible KP signing intent types.
 ///
 /// These signatures are detached OpenPGP signatures produced by KPs, not
@@ -77,6 +74,10 @@ pub enum KpSigningIntentType {
 /// KP-signed payloads and their intent-based domain separation.
 pub trait KpSigningIntent: Serialize {
     const INTENT: KpSigningIntentType;
+}
+
+impl GuardianSigningIntent for LogEntry {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
 }
 
 impl GuardianSigningIntent for SetupNewKeyResponse {
@@ -117,33 +118,69 @@ pub struct KpSigned<T> {
     pub signature: String,
 }
 
-/// Guardian-signed wrapper - adds timestamp and signature to any data
+/// A timestamped response produced by the Guardian.
+///
+/// The timestamp is response metadata rather than a property of every
+/// Guardian-signed payload. Wrapping this value in [`GuardianSigned`] keeps the
+/// timestamp authenticated.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct GuardianSigned<T> {
-    pub data: T,
+pub struct GuardianResponse<T> {
+    pub response: T,
     /// Milliseconds since Unix epoch.
     pub timestamp_ms: UnixMillis,
-    pub signature: GuardianSignature,
 }
 
-impl<T: GuardianSigningIntent> GuardianSigned<T> {
-    /// Sign a payload with intent-based domain separation.
-    pub fn sign(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
-        let signature = signing_key.sign(&guardian_signing_bytes(&data, timestamp_ms));
+impl<T> GuardianResponse<T> {
+    pub fn new(response: T, timestamp_ms: UnixMillis) -> Self {
         Self {
-            data,
+            response,
             timestamp_ms,
-            signature,
         }
     }
 
+    pub fn into_response(self) -> T {
+        self.response
+    }
+}
+
+impl<T: GuardianSigningIntent> GuardianSigningIntent for GuardianResponse<T> {
+    const INTENT: GuardianSigningIntentType = T::INTENT;
+}
+
+/// A signed, timestamped response produced by the Guardian.
+pub type GuardianSignedResponse<T> = GuardianSigned<GuardianResponse<T>>;
+
+/// Guardian-signed wrapper - adds a signature to any signable payload.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GuardianSigned<T> {
+    pub data: T,
+    pub signature: GuardianSignature,
+}
+
+impl<T> GuardianSigned<T> {
+    fn signed_bytes(data: &T) -> Vec<u8>
+    where
+        T: GuardianSigningIntent,
+    {
+        bcs::to_bytes(&(T::INTENT, data)).expect("serialization should not fail")
+    }
+
+    /// Sign a payload with intent-based domain separation.
+    pub fn sign(data: T, signing_key: &SigningKey) -> Self
+    where
+        T: GuardianSigningIntent,
+    {
+        let signature = signing_key.sign(&Self::signed_bytes(&data));
+        Self { data, signature }
+    }
+
     /// Verify the Guardian signature without consuming the signed payload.
-    pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()> {
+    pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()>
+    where
+        T: GuardianSigningIntent,
+    {
         pub_key
-            .verify(
-                &self.signature,
-                &guardian_signing_bytes(&self.data, self.timestamp_ms),
-            )
+            .verify(&self.signature, &Self::signed_bytes(&self.data))
             .map_err(|_| CryptoVerificationError::new("signature invalid"))
     }
 
@@ -151,9 +188,19 @@ impl<T: GuardianSigningIntent> GuardianSigned<T> {
     ///
     /// The caller remains responsible for authorizing the signing key for the
     /// requested operation and current state.
-    pub fn authenticate(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
+    pub fn authenticate(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T>
+    where
+        T: GuardianSigningIntent,
+    {
         self.verify_signature(pub_key)?;
         Ok(self.data)
+    }
+
+    /// Move out the payload WITHOUT verifying the signature. The node uses this
+    /// on guardian responses it has already authenticated over TLS; the ed25519
+    /// signing key is verified only by KPs/monitors on the S3 audit logs.
+    pub fn into_data_unchecked(self) -> T {
+        self.data
     }
 }
 
@@ -205,14 +252,5 @@ impl<T: KpSigningIntent> KpSigned<T> {
 
     pub fn signer_fingerprint(&self) -> Fingerprint {
         self.signer_cert.fingerprint()
-    }
-}
-
-impl<T> GuardianSigned<T> {
-    /// Move out the payload WITHOUT verifying the signature. The node uses this
-    /// on guardian responses it has already authenticated over TLS; the ed25519
-    /// signing key is verified only by KPs/monitors on the S3 audit logs.
-    pub fn into_data_unchecked(self) -> T {
-        self.data
     }
 }

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -3,9 +3,10 @@
 
 //! The guardian-signed envelope and its intent-based domain separation.
 //!
-//! `IntentType` is a registry: each signable type maps to exactly one intent
-//! value, and `GuardianSigned::{new,verify}` mix that value into the signed
-//! bytes so a signature over one type can never be replayed as another.
+//! `GuardianSigningIntentType` is a registry: each signable type maps to
+//! exactly one intent value, and `GuardianSigned::{sign,authenticate}` mix that
+//! value into the signed bytes so a signature over one type can never be
+//! replayed as another.
 
 use super::CryptoVerificationError;
 use super::CryptoVerificationResult;
@@ -34,7 +35,7 @@ use std::path::Path;
 /// Using an enum ensures no two types can accidentally share the same intent value.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum IntentType {
+pub enum GuardianSigningIntentType {
     /// Intent for key-bound guardian log records.
     LogMessage = 0,
     /// Intent for SetupNewKeyResponse
@@ -49,34 +50,32 @@ pub enum IntentType {
     ProvisionerRotateCertResponse = 5,
 }
 
-/// Trait for serializable types that can be signed with intent-based domain
-/// separation.
-pub trait SigningIntent: Serialize {
-    const INTENT: IntentType;
+/// Guardian-signed payloads and their intent-based domain separation.
+pub trait GuardianSigningIntent: Serialize {
+    const INTENT: GuardianSigningIntentType;
+}
 
-    /// Canonical bytes covered by this guardian signature. Most payloads use
-    /// the standard `(intent, data, timestamp)` layout; routing-sensitive
-    /// payloads may override this while retaining the central intent registry.
-    fn signing_bytes(&self, timestamp_ms: UnixMillis) -> Vec<u8> {
-        bcs::to_bytes(&(Self::INTENT, self, timestamp_ms)).expect("serialization should not fail")
-    }
+fn guardian_signing_bytes<T: GuardianSigningIntent>(data: &T, timestamp_ms: UnixMillis) -> Vec<u8> {
+    bcs::to_bytes(&(T::INTENT, data, timestamp_ms)).expect("serialization should not fail")
+}
 
-    /// Signs this payload's canonical intent-bound bytes.
-    fn sign(&self, timestamp_ms: UnixMillis, signing_key: &SigningKey) -> GuardianSignature {
-        signing_key.sign(&self.signing_bytes(timestamp_ms))
-    }
+pub(crate) fn sign_guardian_payload<T: GuardianSigningIntent>(
+    data: &T,
+    timestamp_ms: UnixMillis,
+    signing_key: &SigningKey,
+) -> GuardianSignature {
+    signing_key.sign(&guardian_signing_bytes(data, timestamp_ms))
+}
 
-    /// Verifies a signature over this payload's canonical intent-bound bytes.
-    fn verify_signature(
-        &self,
-        timestamp_ms: UnixMillis,
-        signature: &GuardianSignature,
-        pub_key: &VerificationKey,
-    ) -> CryptoVerificationResult<()> {
-        pub_key
-            .verify(signature, &self.signing_bytes(timestamp_ms))
-            .map_err(|_| CryptoVerificationError::new("signature invalid"))
-    }
+pub(crate) fn verify_guardian_payload_signature<T: GuardianSigningIntent>(
+    data: &T,
+    timestamp_ms: UnixMillis,
+    signature: &GuardianSignature,
+    pub_key: &VerificationKey,
+) -> CryptoVerificationResult<()> {
+    pub_key
+        .verify(signature, &guardian_signing_bytes(data, timestamp_ms))
+        .map_err(|_| CryptoVerificationError::new("signature invalid"))
 }
 
 /// All possible KP signing intent types.
@@ -94,29 +93,30 @@ pub enum KpSigningIntentType {
     ProvisionerRotateCertRequest = 1,
 }
 
-/// Trait for KP-submitted request payloads that need detached signatures.
-pub trait KpSigningIntent {
+/// KP-signed payloads and their intent-based domain separation.
+pub trait KpSigningIntent: Serialize {
     const INTENT: KpSigningIntentType;
 }
 
-impl SigningIntent for SetupNewKeyResponse {
-    const INTENT: IntentType = IntentType::SetupNewKeyResponse;
+impl GuardianSigningIntent for SetupNewKeyResponse {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::SetupNewKeyResponse;
 }
 
-impl SigningIntent for StandardWithdrawalResponse {
-    const INTENT: IntentType = IntentType::StandardWithdrawalResponse;
+impl GuardianSigningIntent for StandardWithdrawalResponse {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::StandardWithdrawalResponse;
 }
 
-impl SigningIntent for GuardianInfo {
-    const INTENT: IntentType = IntentType::GuardianInfo;
+impl GuardianSigningIntent for GuardianInfo {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::GuardianInfo;
 }
 
-impl SigningIntent for RotateKpsResponse {
-    const INTENT: IntentType = IntentType::RotateKpsResponse;
+impl GuardianSigningIntent for RotateKpsResponse {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::RotateKpsResponse;
 }
 
-impl SigningIntent for ProvisionerRotateCertResponse {
-    const INTENT: IntentType = IntentType::ProvisionerRotateCertResponse;
+impl GuardianSigningIntent for ProvisionerRotateCertResponse {
+    const INTENT: GuardianSigningIntentType =
+        GuardianSigningIntentType::ProvisionerRotateCertResponse;
 }
 
 impl KpSigningIntent for SingleProvisionerInitRequest {
@@ -145,12 +145,10 @@ pub struct GuardianSigned<T> {
     pub signature: GuardianSignature,
 }
 
-/// Methods for `Signed<T>` wrapper - signing and verification
-impl<T: SigningIntent> GuardianSigned<T> {
-    /// Create a new signed payload (used by enclave)
-    /// Includes intent byte for domain separation to prevent cross-type signature attacks
-    pub fn new(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
-        let signature = data.sign(timestamp_ms, signing_key);
+impl<T: GuardianSigningIntent> GuardianSigned<T> {
+    /// Sign a payload with intent-based domain separation.
+    pub fn sign(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
+        let signature = sign_guardian_payload(&data, timestamp_ms, signing_key);
         Self {
             data,
             timestamp_ms,
@@ -158,20 +156,26 @@ impl<T: SigningIntent> GuardianSigned<T> {
         }
     }
 
-    /// Verify signature and extract payload
-    /// Checks intent byte to ensure signature is for the correct type
-    pub fn verify(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
-        self.data
-            .verify_signature(self.timestamp_ms, &self.signature, pub_key)?;
+    /// Verify the Guardian signature without consuming the signed payload.
+    pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()> {
+        verify_guardian_payload_signature(&self.data, self.timestamp_ms, &self.signature, pub_key)
+    }
+
+    /// Authenticate the Guardian signer and extract the payload.
+    ///
+    /// The caller remains responsible for authorizing the signing key for the
+    /// requested operation and current state.
+    pub fn authenticate(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
+        self.verify_signature(pub_key)?;
         Ok(self.data)
     }
 }
 
-impl<T: Serialize + KpSigningIntent> KpSigned<T> {
-    /// Create a new signed KP payload by invoking `gpg --detach-sign` for the
+impl<T: KpSigningIntent> KpSigned<T> {
+    /// Sign a KP payload by invoking `gpg --detach-sign` for the
     /// signer certificate's fingerprint. Includes the KP intent in the signed
     /// bytes; payload types carry any request-specific replay-binding fields.
-    pub fn new(
+    pub fn sign(
         data: T,
         signer_cert: PgpPublicCert,
         gpg_home: Option<&Path>,
@@ -204,8 +208,11 @@ impl<T: Serialize + KpSigningIntent> KpSigned<T> {
         Ok(())
     }
 
-    /// Verify the signature and extract the payload.
-    pub fn verify(self) -> CryptoVerificationResult<T> {
+    /// Authenticate the KP signer and extract the payload.
+    ///
+    /// The caller remains responsible for authorizing the signer fingerprint
+    /// for the requested operation and current state.
+    pub fn authenticate(self) -> CryptoVerificationResult<T> {
         self.verify_signature()?;
         Ok(self.data)
     }

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -59,25 +59,6 @@ fn guardian_signing_bytes<T: GuardianSigningIntent>(data: &T, timestamp_ms: Unix
     bcs::to_bytes(&(T::INTENT, data, timestamp_ms)).expect("serialization should not fail")
 }
 
-pub(crate) fn sign_guardian_payload<T: GuardianSigningIntent>(
-    data: &T,
-    timestamp_ms: UnixMillis,
-    signing_key: &SigningKey,
-) -> GuardianSignature {
-    signing_key.sign(&guardian_signing_bytes(data, timestamp_ms))
-}
-
-pub(crate) fn verify_guardian_payload_signature<T: GuardianSigningIntent>(
-    data: &T,
-    timestamp_ms: UnixMillis,
-    signature: &GuardianSignature,
-    pub_key: &VerificationKey,
-) -> CryptoVerificationResult<()> {
-    pub_key
-        .verify(signature, &guardian_signing_bytes(data, timestamp_ms))
-        .map_err(|_| CryptoVerificationError::new("signature invalid"))
-}
-
 /// All possible KP signing intent types.
 ///
 /// These signatures are detached OpenPGP signatures produced by KPs, not
@@ -148,7 +129,7 @@ pub struct GuardianSigned<T> {
 impl<T: GuardianSigningIntent> GuardianSigned<T> {
     /// Sign a payload with intent-based domain separation.
     pub fn sign(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
-        let signature = sign_guardian_payload(&data, timestamp_ms, signing_key);
+        let signature = signing_key.sign(&guardian_signing_bytes(&data, timestamp_ms));
         Self {
             data,
             timestamp_ms,
@@ -158,7 +139,12 @@ impl<T: GuardianSigningIntent> GuardianSigned<T> {
 
     /// Verify the Guardian signature without consuming the signed payload.
     pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()> {
-        verify_guardian_payload_signature(&self.data, self.timestamp_ms, &self.signature, pub_key)
+        pub_key
+            .verify(
+                &self.signature,
+                &guardian_signing_bytes(&self.data, self.timestamp_ms),
+            )
+            .map_err(|_| CryptoVerificationError::new("signature invalid"))
     }
 
     /// Authenticate the Guardian signer and extract the payload.

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -80,7 +80,7 @@ pub trait KpSigningIntent: Serialize {
 /// KP-submitted request payload.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct KpSigned<T> {
-    pub data: T,
+    data: T,
     pub signer_cert: PgpPublicCert,
     pub signature: String,
 }
@@ -103,7 +103,7 @@ pub type GuardianSignedResponse<T> = GuardianSigned<GuardianResponse<T>>;
 /// Guardian-signed wrapper - adds a signature to any signable payload.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GuardianSigned<T> {
-    pub data: T,
+    data: T,
     pub signature: GuardianSignature,
 }
 
@@ -111,23 +111,23 @@ impl GuardianSigningIntent for LogEntry {
     const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogEntry;
 }
 
-impl GuardianSigningIntent for SetupNewKeyResponse {
+impl GuardianSigningIntent for GuardianResponse<SetupNewKeyResponse> {
     const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::SetupNewKeyResponse;
 }
 
-impl GuardianSigningIntent for StandardWithdrawalResponse {
+impl GuardianSigningIntent for GuardianResponse<StandardWithdrawalResponse> {
     const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::StandardWithdrawalResponse;
 }
 
-impl GuardianSigningIntent for GuardianInfo {
+impl GuardianSigningIntent for GuardianResponse<GuardianInfo> {
     const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::GuardianInfo;
 }
 
-impl GuardianSigningIntent for RotateKpsResponse {
+impl GuardianSigningIntent for GuardianResponse<RotateKpsResponse> {
     const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::RotateKpsResponse;
 }
 
-impl GuardianSigningIntent for ProvisionerRotateCertResponse {
+impl GuardianSigningIntent for GuardianResponse<ProvisionerRotateCertResponse> {
     const INTENT: GuardianSigningIntentType =
         GuardianSigningIntentType::ProvisionerRotateCertResponse;
 }
@@ -147,17 +147,17 @@ impl<T> GuardianResponse<T> {
             timestamp_ms,
         }
     }
-
-    pub fn into_response(self) -> T {
-        self.response
-    }
 }
 
-impl<T: GuardianSigningIntent> GuardianSigningIntent for GuardianResponse<T> {
-    const INTENT: GuardianSigningIntentType = T::INTENT;
-}
-
+// Guardian unchecked access is intentionally narrow: LogRecord's custom wire
+// handling and node/proxy/CLI paths that establish trust independently.
+// KpSigned has no unchecked extraction; production KP payloads are always
+// verified before access.
 impl<T> GuardianSigned<T> {
+    pub fn from_parts(data: T, signature: GuardianSignature) -> Self {
+        Self { data, signature }
+    }
+
     fn signed_bytes(data: &T) -> Vec<u8>
     where
         T: GuardianSigningIntent,
@@ -174,25 +174,56 @@ impl<T> GuardianSigned<T> {
         Self { data, signature }
     }
 
-    /// Verify the Guardian signature without consuming the signed payload.
-    pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()>
+    /// Verify the Guardian signature and borrow the authenticated payload.
+    pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<&T>
     where
         T: GuardianSigningIntent,
     {
         pub_key
             .verify(&self.signature, &Self::signed_bytes(&self.data))
-            .map_err(|_| CryptoVerificationError::new("signature invalid"))
+            .map_err(|_| CryptoVerificationError::new("signature invalid"))?;
+        Ok(&self.data)
     }
 
-    /// Move out the payload WITHOUT verifying the signature. The node uses this
-    /// on guardian responses it has already authenticated over TLS; the ed25519
-    /// signing key is verified only by KPs/monitors on the S3 audit logs.
+    /// Verify the Guardian signature and move out the authenticated payload.
+    pub fn verify_into_data(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T>
+    where
+        T: GuardianSigningIntent,
+    {
+        self.verify_signature(pub_key)?;
+        Ok(self.data)
+    }
+
+    /// Borrow the payload WITHOUT verifying the signature.
+    pub(crate) fn data_unchecked(&self) -> &T {
+        &self.data
+    }
+
+    #[cfg(test)]
+    pub(crate) fn data_unchecked_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+
+    /// Move out the payload WITHOUT verifying the signature.
+    /// The caller must establish trust in the payload independently.
     pub fn into_data_unchecked(self) -> T {
         self.data
+    }
+
+    pub(crate) fn into_parts(self) -> (T, GuardianSignature) {
+        (self.data, self.signature)
     }
 }
 
 impl<T: KpSigningIntent> KpSigned<T> {
+    pub fn from_parts(data: T, signer_cert: PgpPublicCert, signature: String) -> Self {
+        Self {
+            data,
+            signer_cert,
+            signature,
+        }
+    }
+
     /// Sign a KP payload by invoking `gpg --detach-sign` for the
     /// signer certificate's fingerprint. Includes the KP intent in the signed
     /// bytes; payload types carry any request-specific replay-binding fields.
@@ -219,14 +250,24 @@ impl<T: KpSigningIntent> KpSigned<T> {
         bcs::to_bytes(&tuple).expect("serialization should not fail")
     }
 
-    /// Verify the signature without consuming the signed request.
+    /// Verify the signature and borrow the authenticated request.
     /// Checks the intent byte to ensure the signature is for this request type.
-    pub fn verify_signature(&self) -> CryptoVerificationResult<()> {
+    pub fn verify_signature(&self) -> CryptoVerificationResult<&T> {
         let msg_bytes = Self::signed_bytes(&self.data);
         verify_detached_signature(&msg_bytes, &self.signature, &self.signer_cert).map_err(|e| {
             CryptoVerificationError::new(format!("KP signature verification failed: {e}"))
         })?;
-        Ok(())
+        Ok(&self.data)
+    }
+
+    /// Verify the KP signature and move out the authenticated payload.
+    pub fn verify_into_data(self) -> CryptoVerificationResult<T> {
+        self.verify_signature()?;
+        Ok(self.data)
+    }
+
+    pub(crate) fn into_parts(self) -> (T, PgpPublicCert, String) {
+        (self.data, self.signer_cert, self.signature)
     }
 
     pub fn signer_fingerprint(&self) -> Fingerprint {

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The guardian-signed envelope and its intent-based domain separation.
+//! Guardian- and KP-signed envelopes with intent-based domain separation.
 //!
-//! `GuardianSigningIntentType` is a registry: each signable type maps to
-//! exactly one intent value, and `GuardianSigned::{sign,authenticate}` mix that
-//! value into the signed bytes so a signature over one type can never be
-//! replayed as another.
+//! [`GuardianSigned`] uses Ed25519 signatures produced by the Guardian, while
+//! [`KpSigned`] uses detached OpenPGP signatures produced by key provisioners.
+//! Both serialize a payload together with its signing intent so a signature for
+//! one payload type cannot be replayed as another.
 
 use super::CryptoVerificationError;
 use super::CryptoVerificationResult;
@@ -37,17 +37,17 @@ use std::path::Path;
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GuardianSigningIntentType {
-    /// Intent for key-bound guardian log records.
+    /// Intent for LogEntry.
     LogMessage = 0,
-    /// Intent for SetupNewKeyResponse
+    /// Intent for SetupNewKeyResponse.
     SetupNewKeyResponse = 1,
-    /// Intent for StandardWithdrawalResponse
+    /// Intent for StandardWithdrawalResponse.
     StandardWithdrawalResponse = 2,
-    /// Intent for GuardianInfo
+    /// Intent for GuardianInfo.
     GuardianInfo = 3,
-    /// Intent for RotateKpsResponse
+    /// Intent for RotateKpsResponse.
     RotateKpsResponse = 4,
-    /// Intent for ProvisionerRotateCertResponse
+    /// Intent for ProvisionerRotateCertResponse.
     ProvisionerRotateCertResponse = 5,
 }
 
@@ -65,15 +65,46 @@ pub trait GuardianSigningIntent: Serialize {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum KpSigningIntentType {
-    /// One KP's share submission to the provisioning relay.
-    ProvisionerInitRelaySubmission = 0,
-    /// One KP's request to replace one certificate wrapping its committed share.
+    /// Intent for SingleProvisionerInitRequest.
+    SingleProvisionerInitRequest = 0,
+    /// Intent for ProvisionerRotateCertRequest.
     ProvisionerRotateCertRequest = 1,
 }
 
 /// KP-signed payloads and their intent-based domain separation.
 pub trait KpSigningIntent: Serialize {
     const INTENT: KpSigningIntentType;
+}
+
+/// KP-signed wrapper - adds signer cert and detached OpenPGP signature to any
+/// KP-submitted request payload.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct KpSigned<T> {
+    pub data: T,
+    pub signer_cert: PgpPublicCert,
+    pub signature: String,
+}
+
+/// A timestamped response produced by the Guardian.
+///
+/// The timestamp is response metadata rather than a property of every
+/// Guardian-signed payload. Wrapping this value in [`GuardianSigned`] keeps the
+/// timestamp authenticated.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GuardianResponse<T> {
+    pub response: T,
+    /// Milliseconds since Unix epoch.
+    pub timestamp_ms: UnixMillis,
+}
+
+/// A signed, timestamped response produced by the Guardian.
+pub type GuardianSignedResponse<T> = GuardianSigned<GuardianResponse<T>>;
+
+/// Guardian-signed wrapper - adds a signature to any signable payload.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GuardianSigned<T> {
+    pub data: T,
+    pub signature: GuardianSignature,
 }
 
 impl GuardianSigningIntent for LogEntry {
@@ -102,32 +133,11 @@ impl GuardianSigningIntent for ProvisionerRotateCertResponse {
 }
 
 impl KpSigningIntent for SingleProvisionerInitRequest {
-    const INTENT: KpSigningIntentType = KpSigningIntentType::ProvisionerInitRelaySubmission;
+    const INTENT: KpSigningIntentType = KpSigningIntentType::SingleProvisionerInitRequest;
 }
 
 impl KpSigningIntent for ProvisionerRotateCertRequest {
     const INTENT: KpSigningIntentType = KpSigningIntentType::ProvisionerRotateCertRequest;
-}
-
-/// KP-signed wrapper - adds signer cert and detached OpenPGP signature to any
-/// KP-submitted request payload.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct KpSigned<T> {
-    pub data: T,
-    pub signer_cert: PgpPublicCert,
-    pub signature: String,
-}
-
-/// A timestamped response produced by the Guardian.
-///
-/// The timestamp is response metadata rather than a property of every
-/// Guardian-signed payload. Wrapping this value in [`GuardianSigned`] keeps the
-/// timestamp authenticated.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct GuardianResponse<T> {
-    pub response: T,
-    /// Milliseconds since Unix epoch.
-    pub timestamp_ms: UnixMillis,
 }
 
 impl<T> GuardianResponse<T> {
@@ -145,16 +155,6 @@ impl<T> GuardianResponse<T> {
 
 impl<T: GuardianSigningIntent> GuardianSigningIntent for GuardianResponse<T> {
     const INTENT: GuardianSigningIntentType = T::INTENT;
-}
-
-/// A signed, timestamped response produced by the Guardian.
-pub type GuardianSignedResponse<T> = GuardianSigned<GuardianResponse<T>>;
-
-/// Guardian-signed wrapper - adds a signature to any signable payload.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct GuardianSigned<T> {
-    pub data: T,
-    pub signature: GuardianSignature,
 }
 
 impl<T> GuardianSigned<T> {
@@ -182,18 +182,6 @@ impl<T> GuardianSigned<T> {
         pub_key
             .verify(&self.signature, &Self::signed_bytes(&self.data))
             .map_err(|_| CryptoVerificationError::new("signature invalid"))
-    }
-
-    /// Authenticate the Guardian signer and extract the payload.
-    ///
-    /// The caller remains responsible for authorizing the signing key for the
-    /// requested operation and current state.
-    pub fn authenticate(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T>
-    where
-        T: GuardianSigningIntent,
-    {
-        self.verify_signature(pub_key)?;
-        Ok(self.data)
     }
 
     /// Move out the payload WITHOUT verifying the signature. The node uses this
@@ -239,15 +227,6 @@ impl<T: KpSigningIntent> KpSigned<T> {
             CryptoVerificationError::new(format!("KP signature verification failed: {e}"))
         })?;
         Ok(())
-    }
-
-    /// Authenticate the KP signer and extract the payload.
-    ///
-    /// The caller remains responsible for authorizing the signer fingerprint
-    /// for the requested operation and current state.
-    pub fn authenticate(self) -> CryptoVerificationResult<T> {
-        self.verify_signature()?;
-        Ok(self.data)
     }
 
     pub fn signer_fingerprint(&self) -> Fingerprint {

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -107,7 +107,7 @@ impl GetGuardianInfoResponse {
         GetGuardianInfoResponse::new(
             NitroAttestation::new("abcd".as_bytes().to_vec()),
             signing_pub_key,
-            GuardianSigned::new(info, &signing_key, 1234),
+            GuardianSigned::sign(info, &signing_key, 1234),
         )
     }
 }
@@ -167,7 +167,7 @@ impl GuardianSigned<SetupNewKeyResponse> {
         };
 
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::new(resp, &signing_kp, 0)
+        GuardianSigned::sign(resp, &signing_kp, 0)
     }
 }
 
@@ -177,7 +177,7 @@ impl GuardianSigned<RotateKpsResponse> {
             encrypted_shares: dummy_encrypted_shares(),
         };
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::new(resp, &signing_kp, 0)
+        GuardianSigned::sign(resp, &signing_kp, 0)
     }
 }
 
@@ -192,7 +192,7 @@ impl GuardianSigned<ProvisionerRotateCertResponse> {
                 .expect("dummy shares should be non-empty"),
         };
         let signing_key = SigningKey::from([1u8; 32]);
-        GuardianSigned::new(response, &signing_key, 0)
+        GuardianSigned::sign(response, &signing_key, 0)
     }
 }
 
@@ -409,7 +409,7 @@ impl GuardianSigned<StandardWithdrawalResponse> {
         let resp = StandardWithdrawalResponse { enclave_signatures };
 
         let signing_kp = SigningKey::from([4u8; 32]);
-        GuardianSigned::new(resp, &signing_kp, 0)
+        GuardianSigned::sign(resp, &signing_kp, 0)
     }
 }
 

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -23,11 +23,13 @@ use super::NitroAttestation;
 use super::OperatorInitRequest;
 use super::PcrAllowlist;
 use super::ProvisionerInitRequest;
+use super::ProvisionerRotateCertRequest;
 use super::ProvisionerRotateCertResponse;
 use super::RotateKpsResponse;
 use super::S3BucketInfo;
 use super::S3Config;
 use super::SecretSharingInstance;
+use super::SessionID;
 use super::SetupNewKeyRequest;
 use super::SetupNewKeyResponse;
 use super::ShareCommitment;
@@ -54,6 +56,7 @@ use crate::committee::Bls12381PrivateKey;
 use crate::committee::BlsSignatureAggregator;
 use crate::committee::EncryptionPrivateKey;
 use crate::committee::EncryptionPublicKey;
+use crate::pgp::PgpPublicCert;
 use bitcoin::Amount;
 use bitcoin::Network;
 use bitcoin::hashes::Hash as _;
@@ -83,12 +86,9 @@ const TEST_SIGNER_ADDRESS: SuiAddress = SuiAddress::new([1u8; 32]);
 /// Deterministic committee signing key material used across tests.
 const TEST_HASHI_BLS_SK_BYTES: [u8; Bls12381PrivateKey::LENGTH] = [9u8; Bls12381PrivateKey::LENGTH];
 
-impl GetGuardianInfoResponse {
+impl GuardianInfo {
     pub fn mock_for_testing() -> Self {
-        let signing_key = ed25519_consensus::SigningKey::from([1u8; 32]);
-        let signing_pub_key = signing_key.verification_key();
-
-        let info = GuardianInfo {
+        Self {
             lifecycle: WithdrawStage::OperatorInitialized.into(),
             secret_sharing_instance: None,
             bucket_info: Some(super::S3BucketInfo {
@@ -104,12 +104,22 @@ impl GetGuardianInfoResponse {
             limiter_config: None,
             current_committee_epoch: None,
             mpc_master_g: None,
-        };
+        }
+    }
+}
+
+impl GetGuardianInfoResponse {
+    pub fn mock_for_testing() -> Self {
+        let signing_key = ed25519_consensus::SigningKey::from([1u8; 32]);
+        let signing_pub_key = signing_key.verification_key();
 
         GetGuardianInfoResponse::new(
             NitroAttestation::new("abcd".as_bytes().to_vec()),
             signing_pub_key,
-            GuardianSigned::sign(GuardianResponse::new(info, 1234), &signing_key),
+            GuardianSigned::sign(
+                GuardianResponse::new(GuardianInfo::mock_for_testing(), 1234),
+                &signing_key,
+            ),
         )
     }
 }
@@ -158,43 +168,66 @@ fn dummy_encrypted_shares() -> KPEncryptedSharesRoster {
     .unwrap()
 }
 
-impl GuardianSignedResponse<SetupNewKeyResponse> {
+impl SetupNewKeyResponse {
     pub fn mock_for_testing() -> Self {
-        let resp = SetupNewKeyResponse {
+        Self {
             encrypted_shares: dummy_encrypted_shares(),
             secret_sharing_instance: dummy_secret_sharing_instance(),
             btc_master_pubkey: crate::guardian::crypto::k256_sk_to_btc_xonly_pubkey(
                 &k256::SecretKey::from_slice(&[7u8; 32]).expect("valid k256 sk"),
             ),
-        };
+        }
+    }
+}
 
+impl GuardianSignedResponse<SetupNewKeyResponse> {
+    pub fn mock_for_testing() -> Self {
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
+        GuardianSigned::sign(
+            GuardianResponse::new(SetupNewKeyResponse::mock_for_testing(), 0),
+            &signing_kp,
+        )
+    }
+}
+
+impl RotateKpsResponse {
+    pub fn mock_for_testing() -> Self {
+        Self {
+            encrypted_shares: dummy_encrypted_shares(),
+        }
     }
 }
 
 impl GuardianSignedResponse<RotateKpsResponse> {
     pub fn mock_for_testing() -> Self {
-        let resp = RotateKpsResponse {
-            encrypted_shares: dummy_encrypted_shares(),
-        };
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
+        GuardianSigned::sign(
+            GuardianResponse::new(RotateKpsResponse::mock_for_testing(), 0),
+            &signing_kp,
+        )
     }
 }
 
-impl GuardianSignedResponse<ProvisionerRotateCertResponse> {
+impl ProvisionerRotateCertResponse {
     pub fn mock_for_testing() -> Self {
-        let response = ProvisionerRotateCertResponse {
+        Self {
             cert_seq: 7,
             encrypted_shares: dummy_encrypted_shares()
                 .into_vec()
                 .into_iter()
                 .next()
                 .expect("dummy shares should be non-empty"),
-        };
+        }
+    }
+}
+
+impl GuardianSignedResponse<ProvisionerRotateCertResponse> {
+    pub fn mock_for_testing() -> Self {
         let signing_key = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(GuardianResponse::new(response, 0), &signing_key)
+        GuardianSigned::sign(
+            GuardianResponse::new(ProvisionerRotateCertResponse::mock_for_testing(), 0),
+            &signing_key,
+        )
     }
 }
 
@@ -214,8 +247,7 @@ impl OperatorInitRequest {
     }
 }
 
-impl ProvisionerInitRequest {
-    // NOTE: Incorrect encryption is used. Fix later if needed.
+impl SingleProvisionerInitRequest {
     pub fn mock_for_testing() -> Self {
         let encrypted_share = GuardianEncryptedShare {
             id: NonZeroU16::new(1).unwrap(),
@@ -224,18 +256,37 @@ impl ProvisionerInitRequest {
                 aes_ciphertext: vec![0u8; 32],
             },
         };
+        Self::new("mock-session".into(), [7u8; 32], None, encrypted_share)
+    }
+}
+
+impl ProvisionerInitRequest {
+    // NOTE: Incorrect encryption is used. Fix later if needed.
+    pub fn mock_for_testing() -> Self {
         let (cert_armored, _) = crate::pgp::test_utils::mock_pgp_keypair();
-        let request = SingleProvisionerInitRequest::new(
-            "mock-session".into(),
-            [7u8; 32],
-            None,
+        ProvisionerInitRequest(vec![KpSigned::from_parts(
+            SingleProvisionerInitRequest::mock_for_testing(),
+            crate::pgp::PgpPublicCert::new(cert_armored).unwrap(),
+            "mock-signature".into(),
+        )])
+    }
+}
+
+impl ProvisionerRotateCertRequest {
+    pub fn from_encrypted_share_for_testing(
+        expected_session_id: SessionID,
+        expected_cert_seq: u64,
+        target_kp_pgp_fingerprint: String,
+        new_kp_pgp_cert: PgpPublicCert,
+        encrypted_share: GuardianEncryptedShare,
+    ) -> Self {
+        Self::from_encrypted_share(
+            expected_session_id,
+            expected_cert_seq,
+            target_kp_pgp_fingerprint,
+            new_kp_pgp_cert,
             encrypted_share,
-        );
-        ProvisionerInitRequest(vec![KpSigned {
-            data: request,
-            signer_cert: crate::pgp::PgpPublicCert::new(cert_armored).unwrap(),
-            signature: "mock-signature".into(),
-        }])
+        )
     }
 }
 
@@ -402,16 +453,22 @@ impl StandardWithdrawalRequest {
     }
 }
 
-impl GuardianSignedResponse<StandardWithdrawalResponse> {
+impl StandardWithdrawalResponse {
     pub fn mock_for_testing() -> Self {
         let kp = create_btc_keypair_for_test(&[3u8; 32]);
         let msg = Message::from_digest([5u8; 32]);
         let enclave_signatures = sign_btc_tx(&[msg], &kp);
+        Self { enclave_signatures }
+    }
+}
 
-        let resp = StandardWithdrawalResponse { enclave_signatures };
-
+impl GuardianSignedResponse<StandardWithdrawalResponse> {
+    pub fn mock_for_testing() -> Self {
         let signing_kp = SigningKey::from([4u8; 32]);
-        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
+        GuardianSigned::sign(
+            GuardianResponse::new(StandardWithdrawalResponse::mock_for_testing(), 0),
+            &signing_kp,
+        )
     }
 }
 

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -6,7 +6,9 @@ use super::Ciphertext;
 use super::GetGuardianInfoResponse;
 use super::GuardianEncryptedShare;
 use super::GuardianInfo;
+use super::GuardianResponse;
 use super::GuardianSigned;
+use super::GuardianSignedResponse;
 use super::HashiCommittee;
 use super::HashiCommitteeMember;
 use super::HashiSigned;
@@ -107,7 +109,7 @@ impl GetGuardianInfoResponse {
         GetGuardianInfoResponse::new(
             NitroAttestation::new("abcd".as_bytes().to_vec()),
             signing_pub_key,
-            GuardianSigned::sign(info, &signing_key, 1234),
+            GuardianSigned::sign(GuardianResponse::new(info, 1234), &signing_key),
         )
     }
 }
@@ -156,7 +158,7 @@ fn dummy_encrypted_shares() -> KPEncryptedSharesRoster {
     .unwrap()
 }
 
-impl GuardianSigned<SetupNewKeyResponse> {
+impl GuardianSignedResponse<SetupNewKeyResponse> {
     pub fn mock_for_testing() -> Self {
         let resp = SetupNewKeyResponse {
             encrypted_shares: dummy_encrypted_shares(),
@@ -167,21 +169,21 @@ impl GuardianSigned<SetupNewKeyResponse> {
         };
 
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(resp, &signing_kp, 0)
+        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
     }
 }
 
-impl GuardianSigned<RotateKpsResponse> {
+impl GuardianSignedResponse<RotateKpsResponse> {
     pub fn mock_for_testing() -> Self {
         let resp = RotateKpsResponse {
             encrypted_shares: dummy_encrypted_shares(),
         };
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(resp, &signing_kp, 0)
+        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
     }
 }
 
-impl GuardianSigned<ProvisionerRotateCertResponse> {
+impl GuardianSignedResponse<ProvisionerRotateCertResponse> {
     pub fn mock_for_testing() -> Self {
         let response = ProvisionerRotateCertResponse {
             cert_seq: 7,
@@ -192,7 +194,7 @@ impl GuardianSigned<ProvisionerRotateCertResponse> {
                 .expect("dummy shares should be non-empty"),
         };
         let signing_key = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(response, &signing_key, 0)
+        GuardianSigned::sign(GuardianResponse::new(response, 0), &signing_key)
     }
 }
 
@@ -400,7 +402,7 @@ impl StandardWithdrawalRequest {
     }
 }
 
-impl GuardianSigned<StandardWithdrawalResponse> {
+impl GuardianSignedResponse<StandardWithdrawalResponse> {
     pub fn mock_for_testing() -> Self {
         let kp = create_btc_keypair_for_test(&[3u8; 32]);
         let msg = Message::from_digest([5u8; 32]);
@@ -409,7 +411,7 @@ impl GuardianSigned<StandardWithdrawalResponse> {
         let resp = StandardWithdrawalResponse { enclave_signatures };
 
         let signing_kp = SigningKey::from([4u8; 32]);
-        GuardianSigned::sign(resp, &signing_kp, 0)
+        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
     }
 }
 

--- a/crates/hashi/src/leader/guardian.rs
+++ b/crates/hashi/src/leader/guardian.rs
@@ -118,7 +118,7 @@ impl LeaderService {
         // Authenticated by TLS; the per-input BTC witness signatures below only
         // spend the 2-of-2 if they verify against the on-chain guardian BTC key
         // (enforced by Bitcoin), so the response itself isn't signature-checked.
-        let response = signed_response.into_data_unchecked().into_response();
+        let response = signed_response.into_data_unchecked().response;
 
         anyhow::ensure!(
             response.enclave_signatures.len() == txn.inputs.len(),

--- a/crates/hashi/src/leader/guardian.rs
+++ b/crates/hashi/src/leader/guardian.rs
@@ -11,7 +11,7 @@ use hashi_types::committee::MemberSignature;
 use hashi_types::committee::SignedMessage;
 use hashi_types::committee::certificate_threshold;
 use hashi_types::guardian::CommitteeTransitionRequest;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::StandardWithdrawalRequest;
 use hashi_types::guardian::StandardWithdrawalResponse;
 use hashi_types::guardian::proto_conversions::signed_committee_transition_to_pb;
@@ -105,7 +105,7 @@ impl LeaderService {
             anyhow::anyhow!("Guardian rejected withdrawal: {}", status.message())
         })?;
 
-        let signed_response: GuardianSigned<StandardWithdrawalResponse> = response_pb
+        let signed_response: GuardianSignedResponse<StandardWithdrawalResponse> = response_pb
             .try_into()
             .inspect_err(|_| {
                 Self::record_guardian_rpc_outcome(
@@ -118,7 +118,7 @@ impl LeaderService {
         // Authenticated by TLS; the per-input BTC witness signatures below only
         // spend the 2-of-2 if they verify against the on-chain guardian BTC key
         // (enforced by Bitcoin), so the response itself isn't signature-checked.
-        let response = signed_response.into_data_unchecked();
+        let response = signed_response.into_data_unchecked().into_response();
 
         anyhow::ensure!(
             response.enclave_signatures.len() == txn.inputs.len(),


### PR DESCRIPTION
Unify Guardian and KP signed envelopes around intent-based sign and verify_signature APIs.

Separate response timestamps into GuardianResponse while keeping them inside the signed payload, and represent signed logs as GuardianSigned<LogEntry> alongside explicit unsigned records.

Centralize LogRecord validation, keep the actual S3 key comparison at the read boundary, and move VerifiedLogRecord to the reader that establishes attestation and PCR trust.

Local check: make fmt