### PR TITLE
[Guardian] [3/3] Make S3 reader verification more robust

### DIFF
--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -6,7 +6,6 @@
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use std::path::Path;
 use tracing::info;
@@ -97,7 +96,7 @@ pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
         "scraping latest ceremony/ + kp-shares/ logs (attestation-anchored)",
     );
     let state = reader
-        .read_latest_ceremony_state(BuildPolicy::Current)
+        .read_latest_ceremony_state_from_current_build()
         .await?
         .context("no ceremony logs found in guardian S3 bucket")?;
     state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -35,7 +35,6 @@
 //!    enclave re-verifies every signature and binding.
 
 use anyhow::Context;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::EncPubKey;
@@ -158,9 +157,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         session_id = %session_id,
         "fetching + verifying pinned standby session's signed GuardianInfo from S3",
     );
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     let GuardianInfo {
         lifecycle,
         secret_sharing_instance,
@@ -261,7 +258,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         "scraping authoritative ceremony/ and kp-shares/ logs",
     );
     let state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state()
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     let sharing_seq = state.secret_sharing_instance.sharing_seq();
@@ -310,9 +307,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
 
     // Require the explicit intent marker to match S3 state. For genesis, bind
     // the independently read on-chain committee into this KP's signed PI submission.
-    let latest_committee = reader
-        .read_latest_committee(BuildPolicy::AnyAllowlisted)
-        .await?;
+    let latest_committee = reader.read_latest_committee().await?;
     let expected_genesis_state_hash = match (do_genesis, latest_committee) {
         (false, Some(_)) => None,
         (true, None) => {

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::anyhow;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::EncPubKey;
 use hashi_types::guardian::GuardianSignedResponse;
@@ -114,9 +113,7 @@ pub async fn run(
         guardian_s3.bucket_info,
         endpoint_bucket_info
     );
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     anyhow::ensure!(
         verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
@@ -134,7 +131,7 @@ pub async fn run(
         .map_err(anyhow::Error::msg)?;
 
     let state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state()
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
@@ -213,12 +210,7 @@ pub async fn run(
     );
 
     let updated_state = reader
-        .read_kp_share_state_log(
-            &session_id,
-            sharing_seq,
-            response.cert_seq,
-            BuildPolicy::Current,
-        )
+        .read_kp_share_state_log_from_current_build(&session_id, sharing_seq, response.cert_seq)
         .await
         .context("read the certificate-rotation kp-shares snapshot")?;
     updated_state

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -9,7 +9,6 @@ use anyhow::ensure;
 use hashi_guardian::HEARTBEAT_INTERVAL;
 use hashi_guardian::MAX_S3_WRITE_FAILURE_INTERVAL;
 use hashi_guardian::OTHER_SESSION_QUIET_PERIOD;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::ActivationState;
 use hashi_types::guardian::GuardianError;
@@ -124,9 +123,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         session_id = %session_id,
         "verifying OI GuardianInfo matches the live guardian identity/config",
     );
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     ensure!(
         verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
@@ -152,7 +149,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         "reading latest committee and recovering limiter state",
     );
     let move_committee = reader
-        .read_latest_committee(BuildPolicy::AnyAllowlisted)
+        .read_latest_committee()
         .await?
         .context("no committee-update or genesis record found")?;
     let committee_epoch = move_committee.epoch;

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -17,7 +17,6 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::ensure;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::CeremonyStage;
 use hashi_types::guardian::CeremonyState;
@@ -139,9 +138,7 @@ pub async fn run(cfg: Config) -> Result<()> {
     let mut reader = GuardianReader::new(&guardian_s3, allowlist)
         .await
         .context("connect to guardian log bucket")?;
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     let attested_signing_pub_key = verified_session.signing_pubkey();
     ensure!(
         attested_signing_pub_key == &signing_pub_key,
@@ -212,7 +209,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         "cross-checking the latest guardian ceremony/ and kp-shares/ logs",
     );
     let logged = reader
-        .read_latest_ceremony_state(BuildPolicy::Current)
+        .read_latest_ceremony_state_from_current_build()
         .await?
         .context("no ceremony logs found in guardian S3 bucket")?;
     logged.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -4,7 +4,6 @@
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::ensure;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::GenesisState;
 use hashi_types::guardian::GuardianInfo;
@@ -74,9 +73,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         phase = "committee",
         "checking latest committee-update/genesis record before operator_init",
     );
-    let latest_committee = reader
-        .read_latest_committee(BuildPolicy::AnyAllowlisted)
-        .await?;
+    let latest_committee = reader.read_latest_committee().await?;
     let genesis_state = match (do_genesis, latest_committee) {
         (false, Some(committee)) => {
             info!(
@@ -150,7 +147,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         "scraping authoritative ceremony/ and kp-shares/ logs",
     );
     let ceremony_state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state()
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     ceremony_state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
@@ -240,9 +237,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         session_id = %session_id,
         "verifying S3 init logs match the live guardian session",
     );
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     ensure!(
         verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -20,7 +20,6 @@
 use crate::metrics::ProxyMetrics;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::log::S3_DIR_WITHDRAW;
-use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
@@ -169,14 +168,6 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    if let LogRecord::Unsigned(entry) = &record {
-        let message = if entry.message().is_allowed_unsigned() {
-            "expected signed log record but message is unsigned"
-        } else {
-            "missing log signature"
-        };
-        return Err(InvalidS3Log(message.into()).into());
-    }
     let entry = record.into_entry_unchecked();
     let timestamp_ms = entry.timestamp_ms();
     let message = match entry.into_message() {

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -8,7 +8,6 @@
 
 use crate::attestation::get_attestation;
 use crate::enclave::TemporaryInitState;
-use crate::s3_reader::BuildPolicy;
 use crate::s3_reader::GuardianReader;
 use crate::Enclave;
 use crate::GuardianS3Client;
@@ -64,7 +63,7 @@ impl OIWithdrawModeInstall {
         let mut reader =
             GuardianReader::from_s3_client(logger.clone(), config.pcr_allowlist().clone());
         let ceremony_state = reader
-            .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+            .read_latest_ceremony_state()
             .await?
             .ok_or_else(|| InvalidInputs("no ceremony log found for withdraw init".into()))?;
 

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -1,27 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Verified read layer over the guardian's S3 logs.
+//! Verified reads of the guardian's S3 logs.
 //!
-//! The guardian writes its logs via [`GuardianS3Client`]; off-enclave readers
-//! (the monitor auditor, KP/operator init tooling) replay them here through a
-//! [`GuardianReader`], which owns the S3 client and a per-session info cache
-//! that records the build PCRs verified for each session. Streams are
-//! hour-partitioned (`withdraw/`/`heartbeat/`);
-//! [`withdraw_cursor`]/[`heartbeat_cursor`] open a cursor that the caller
-//! advances/retreats and feeds to [`GuardianReader::read_logs_in_dir`].
+//! [`GuardianReader`] applies each log stream's S3 immutability policy, verifies
+//! records with their writing session's attestation-anchored key, and caches the
+//! verified session info for reuse.
 
 use crate::s3_client::GuardianS3Client;
 use crate::s3_client::ImmutabilityCheck;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
-use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GenesisLogMessage;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
-use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::KpShareStateLogMessage;
 use hashi_types::guardian::LogMessageV1;
@@ -30,12 +24,8 @@ use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VersionedLogMessage;
-use hashi_types::guardian::S3_DIR_CEREMONY;
-use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
-use hashi_types::guardian::S3_DIR_GENESIS;
-use hashi_types::guardian::S3_DIR_HEARTBEAT;
-use hashi_types::guardian::S3_DIR_WITHDRAW;
+use hashi_types::guardian::VersionedLogMessage::V1;
+use hashi_types::guardian::VersionedLogMessage::V2;
 use hashi_types::move_types::Committee;
 use std::collections::HashMap;
 use tracing::info;
@@ -47,24 +37,13 @@ mod verified;
 pub use verified::VerifiedLogRecord;
 pub use verified::VerifiedSessionInfo;
 
-/// Open an hour-scoped cursor at `start` over the `withdraw/` stream. Advance/
-/// retreat with [`S3HourScopedDirectory::next_dir`]/`prev_dir`, gate on
-/// `write_completion_time`, and read via [`GuardianReader::read_logs_in_dir`].
-pub fn withdraw_cursor(start: UnixSeconds) -> S3HourScopedDirectory {
-    S3HourScopedDirectory::new(S3_DIR_WITHDRAW, start)
-}
-
-/// Like [`withdraw_cursor`], but over the `heartbeat/` stream.
-pub fn heartbeat_cursor(start: UnixSeconds) -> S3HourScopedDirectory {
-    S3HourScopedDirectory::new(S3_DIR_HEARTBEAT, start)
-}
-
+/// Internal policy for sharing read implementations that differ only in which
+/// attested guardian builds they accept.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum BuildPolicy {
-    /// Accept only the configured current guardian build.
+enum BuildPolicy {
+    /// Require the configured current build.
     Current,
-    /// Accept either the configured current build or an explicitly allowlisted
-    /// previous build. This is for historical log reads, not live-session checks.
+    /// Accept any build represented in the PCR allowlist.
     AnyAllowlisted,
 }
 
@@ -77,48 +56,65 @@ impl BuildPolicy {
     }
 }
 
-/// Verified reader over the guardian's S3 logs. Owns the S3 client and a private
-/// session cache. Thread a single `&mut GuardianReader` through a run so repeated
-/// reads can reuse session info and inspect the attested build.
+/// Verified reader over the guardian's S3 logs.
+///
+/// Reads accept any allowlisted build unless the method explicitly requires
+/// the current build. Reuse one reader so repeated reads can share cached
+/// session attestations and signing keys.
 pub struct GuardianReader {
     s3: GuardianS3Client,
-    cache: GuardianSessionCache,
+    allowlist: PcrAllowlist,
+    sessions: HashMap<SessionID, VerifiedSessionInfo>,
 }
 
 impl GuardianReader {
+    /// Create a reader after checking S3 connectivity and object-lock support.
     pub async fn new(config: &S3Config, allowlist: PcrAllowlist) -> GuardianResult<Self> {
         let s3 = GuardianS3Client::new_checked(config).await?;
         Ok(Self::from_s3_client(s3, allowlist))
     }
 
+    /// Create a reader from an existing S3 client without another connectivity
+    /// check.
     pub fn from_s3_client(s3: GuardianS3Client, allowlist: PcrAllowlist) -> Self {
         Self {
             s3,
-            cache: GuardianSessionCache::new(allowlist),
+            allowlist,
+            sessions: HashMap::new(),
         }
     }
 
-    /// Raw S3 client, for unverified listing/reads (e.g. the limiter's bucket walk).
-    pub fn s3(&self) -> &GuardianS3Client {
-        &self.s3
+    /// Load and verify a session's attestation and guardian info on first use,
+    /// then return the cached result.
+    async fn get_or_load_session_info(
+        &mut self,
+        session_id: &str,
+    ) -> GuardianResult<&VerifiedSessionInfo> {
+        if !self.sessions.contains_key(session_id) {
+            let session_info =
+                VerifiedSessionInfo::read_from_s3(&self.s3, session_id, &self.allowlist).await?;
+            self.sessions.insert(session_id.into(), session_info);
+        }
+        Ok(&self.sessions[session_id])
     }
 
-    pub fn require_current_build(&self, build_pcrs: &BuildPcrs) -> GuardianResult<()> {
-        self.cache.allowlist.require_current_build(build_pcrs)
+    /// Verify a record with its session's attestation-anchored signing key.
+    async fn verify_record(&mut self, record: LogRecord) -> GuardianResult<VerifiedLogRecord> {
+        let session_info = self.get_or_load_session_info(record.session_id()).await?;
+        session_info.verify_record(record)
     }
 
-    fn enforce_build_policy(
-        &self,
-        build_policy: BuildPolicy,
-        build_pcrs: &BuildPcrs,
-    ) -> GuardianResult<()> {
-        build_policy.enforce(&self.cache.allowlist, build_pcrs)
+    /// Read an immutable S3 record and verify it with its session's
+    /// attestation-anchored signing key.
+    async fn read_verified_record(&mut self, key: &str) -> GuardianResult<VerifiedLogRecord> {
+        let record = self.s3.get_log_record(key).await?;
+        self.verify_record(record).await
     }
 
-    /// Read and verify every record in `dir`, resolving each writing session's
-    /// signing pubkey via the cache. Batch readers can straddle upgrades, so
-    /// callers that need current-only semantics must inspect each returned
-    /// record's build PCRs with [`Self::require_current_build`].
+    /// Read and verify every immutable record in an hour-scoped directory.
+    ///
+    /// Each result retains its writing session's attested build PCRs because a
+    /// directory may contain records from more than one build.
     pub async fn read_logs_in_dir(
         &mut self,
         dir: &S3HourScopedDirectory,
@@ -126,66 +122,46 @@ impl GuardianReader {
         let all_logs = self.s3.list_all_log_records_in_dir(dir).await?;
 
         let mut out = Vec::with_capacity(all_logs.len());
-        for log in all_logs {
-            out.push(self.cache.verify_record(&self.s3, log).await?);
+        for record in all_logs {
+            let verified_record = self.verify_record(record).await?;
+            out.push(verified_record);
         }
         Ok(out)
     }
 
-    /// The session's verified guardian info. Served from the session cache, which
-    /// resolves the attestation + signed info on first touch and records the
-    /// verified build PCRs.
-    pub async fn get_session_info(
+    /// Return verified session info after requiring the attested PCRs to match
+    /// the current build.
+    pub async fn get_current_session_info(
         &mut self,
         session_id: &str,
-        build_policy: BuildPolicy,
     ) -> GuardianResult<VerifiedSessionInfo> {
-        let session_info = self
-            .cache
-            .get_or_load_session_info(&self.s3, session_id)
-            .await?
-            .clone();
-        self.enforce_build_policy(build_policy, session_info.build_pcrs())?;
+        let session_info = self.get_or_load_session_info(session_id).await?.clone();
+        self.allowlist
+            .require_current_build(session_info.build_pcrs())?;
         Ok(session_info)
     }
 
-    /// The session's verified `GuardianInfo`, discarding the verified build PCRs.
-    pub async fn get_info(
-        &mut self,
-        session_id: &str,
-        build_policy: BuildPolicy,
-    ) -> GuardianResult<GuardianInfo> {
-        Ok(self
-            .get_session_info(session_id, build_policy)
-            .await?
-            .into_info())
-    }
-
-    /// The latest ceremony from `ceremony/` — the max-`sharing_seq` (lex-last)
-    /// entry, attestation- and signature-verified. `None` if no ceremony has
-    /// been logged yet.
+    /// Read and verify the latest ceremony, or return `None` if none exists.
     ///
-    /// `kp-shares/` is read independently so later KP cert rotations can advance
-    /// `cert_seq` without rewriting the `ceremony/` instance.
+    /// Ceremony keys begin with a zero-padded `sharing_seq`, so the
+    /// lexicographically greatest key identifies the latest ceremony.
     async fn read_latest_ceremony_log(
         &mut self,
         build_policy: BuildPolicy,
     ) -> GuardianResult<Option<CeremonyLogMessage>> {
         let keys = self
             .s3
-            .list_keys(&format!("{}/", S3_DIR_CEREMONY), true)
+            .list_keys(&CeremonyLogMessage::object_key_dir(), true)
             .await?;
-        let Some(key) = pick_latest_key(keys, S3_DIR_CEREMONY) else {
+        let Some(key) = keys.into_iter().max() else {
             return Ok(None);
         };
-        let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, record.build_pcrs())?;
-        let session_id = record.entry().session_id().clone();
-        let msg = match record.into_entry().into_message() {
-            VersionedLogMessage::V1(LogMessageV1::Ceremony(msg)) => msg,
-            VersionedLogMessage::V2(LogMessageV2::Ceremony(msg)) => msg,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+        let verified_record = self.read_verified_record(&key).await?;
+        build_policy.enforce(&self.allowlist, verified_record.build_pcrs())?;
+        let session_id = verified_record.entry().session_id().clone();
+        let msg = match verified_record.into_entry().into_message() {
+            V1(LogMessageV1::Ceremony(msg)) | V2(LogMessageV2::Ceremony(msg)) => msg,
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(format!("expected a ceremony log at {key}")));
             }
         };
@@ -193,15 +169,12 @@ impl GuardianReader {
         Ok(Some(*msg))
     }
 
-    /// Read + verify the latest encrypted KP share state for `sharing_seq`.
-    /// The lex-greatest object under `kp-shares/{sharing_seq:020}/` has the
-    /// latest `cert_seq`, so future per-KP cert rotation can advance the share
-    /// recipient state without changing the `ceremony/` instance.
+    /// Read and verify the latest encrypted KP-share state for `sharing_seq`.
     ///
-    /// Uses the lock-agnostic read: shares carry only a short lock that is
-    /// expected to expire, and their integrity is the enclave signature checked
-    /// below — not S3 immutability — so the immutable-log lock assertion in
-    /// `get_log_record` doesn't apply.
+    /// Keys begin with a zero-padded `cert_seq`, so the lexicographically
+    /// greatest key identifies the latest state. KP-share locks are expected to
+    /// expire, so this read authenticates the selected record without claiming
+    /// S3 immutability.
     async fn read_latest_kp_share_state_log(
         &mut self,
         sharing_seq: u64,
@@ -224,45 +197,44 @@ impl GuardianReader {
         Ok(Some(msg))
     }
 
-    /// Read and verify one exact encrypted KP-share snapshot.
+    /// Read and verify an exact encrypted KP-share state written by the current
+    /// build.
     ///
     /// The object key binds the writing guardian session and the two sequence
     /// numbers. This lets callers verify the snapshot produced by one request
     /// even if a later request has already advanced the latest state.
-    pub async fn read_kp_share_state_log(
+    pub async fn read_kp_share_state_log_from_current_build(
         &mut self,
         session_id: &SessionID,
         sharing_seq: u64,
         cert_seq: u64,
-        build_policy: BuildPolicy,
     ) -> GuardianResult<KpShareStateLogMessage> {
         let key = KpShareStateLogMessage::object_key(session_id, sharing_seq, cert_seq);
-        self.read_kp_share_state_log_at_key(&key, build_policy)
+        self.read_kp_share_state_log_at_key(&key, BuildPolicy::Current)
             .await
     }
 
-    /// Shared verification path for both latest and exact KP-share reads.
+    /// Read and verify one KP-share object under the requested build policy.
     async fn read_kp_share_state_log_at_key(
         &mut self,
         key: &str,
         build_policy: BuildPolicy,
     ) -> GuardianResult<KpShareStateLogMessage> {
-        // KP-share locks are short-lived and expected to expire. Expiry permits
-        // deletion but does not cause it; while an object remains, its contents
-        // are authenticatable through the enclave signature verified below.
+        // KP-share locks are expected to expire, so authenticate the record
+        // without claiming that S3 still makes it immutable.
         let record = self
             .s3
             .get_log_record_inner(key, ImmutabilityCheck::Skipped)
             .await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, record.build_pcrs())?;
-        let session_id = record.entry().session_id().clone();
-        let msg = match record.into_entry().into_message() {
-            VersionedLogMessage::V1(LogMessageV1::KpShareState(msg)) => (*msg)
+        let verified_record = self.verify_record(record).await?;
+        build_policy.enforce(&self.allowlist, verified_record.build_pcrs())?;
+        let session_id = verified_record.entry().session_id().clone();
+        let msg = match verified_record.into_entry().into_message() {
+            V1(LogMessageV1::KpShareState(msg)) => (*msg)
                 .try_into()
                 .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?,
-            VersionedLogMessage::V2(LogMessageV2::KpShareState(msg)) => *msg,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            V2(LogMessageV2::KpShareState(msg)) => *msg,
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(format!("expected a kp-shares log at {key}")));
             }
         };
@@ -270,11 +242,26 @@ impl GuardianReader {
         Ok(msg)
     }
 
-    /// Read the latest ceremony together with the latest KP share state for its
-    /// `sharing_seq`. `None` means no ceremony has been logged. Once a ceremony
-    /// exists, its matching KP share state must also exist: ceremony writers
-    /// publish `kp-shares/` before `ceremony/`.
-    pub async fn read_latest_ceremony_state(
+    /// Read the latest ceremony together with the latest KP-share state for its
+    /// `sharing_seq`, accepting any allowlisted build.
+    pub async fn read_latest_ceremony_state(&mut self) -> GuardianResult<Option<CeremonyState>> {
+        self.read_latest_ceremony_state_with_build_policy(BuildPolicy::AnyAllowlisted)
+            .await
+    }
+
+    /// Read the latest ceremony together with the latest KP-share state for its
+    /// `sharing_seq`, requiring both records to come from the current build.
+    pub async fn read_latest_ceremony_state_from_current_build(
+        &mut self,
+    ) -> GuardianResult<Option<CeremonyState>> {
+        self.read_latest_ceremony_state_with_build_policy(BuildPolicy::Current)
+            .await
+    }
+
+    /// Return `None` only when no ceremony exists. Once a ceremony is present,
+    /// its matching KP-share state must also exist because writers publish
+    /// `kp-shares/` before `ceremony/`.
+    async fn read_latest_ceremony_state_with_build_policy(
         &mut self,
         build_policy: BuildPolicy,
     ) -> GuardianResult<Option<CeremonyState>> {
@@ -295,44 +282,43 @@ impl GuardianReader {
         )))
     }
 
-    /// Latest serving committee, preferring `committee-update/` and falling back
-    /// to the KP-authorized `genesis/record.json` bootstrap record. `None`
-    /// means neither source has been written yet.
-    pub async fn read_latest_committee(
-        &mut self,
-        build_policy: BuildPolicy,
-    ) -> GuardianResult<Option<Committee>> {
-        if let Some(committee) = self.read_latest_committee_update(build_policy).await? {
+    /// Read the latest serving committee.
+    ///
+    /// Prefer the latest successful `committee-update/` record, then fall back
+    /// to the KP-authorized `genesis/record.json` bootstrap record. Return
+    /// `None` if neither source exists.
+    pub async fn read_latest_committee(&mut self) -> GuardianResult<Option<Committee>> {
+        if let Some(committee) = self.read_latest_committee_update().await? {
             return Ok(Some(committee));
         }
         Ok(self
-            .read_genesis_log(build_policy)
+            .read_genesis_log()
             .await?
             .map(|genesis| genesis.committee))
     }
 
-    /// The latest applied committee from `committee-update/` — the lex-last
-    /// non-`failure-` (i.e. highest-epoch Success) entry, attestation- and
-    /// signature-verified. `None` if no committee update has been logged.
-    async fn read_latest_committee_update(
-        &mut self,
-        build_policy: BuildPolicy,
-    ) -> GuardianResult<Option<Committee>> {
+    /// Read and verify the successfully applied committee with the highest
+    /// epoch, or return `None` if no successful update exists.
+    ///
+    /// Success keys begin with a zero-padded epoch, so the lexicographically
+    /// greatest non-failure key identifies the latest applied committee.
+    async fn read_latest_committee_update(&mut self) -> GuardianResult<Option<Committee>> {
         let keys = self
             .s3
-            .list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE), true)
+            .list_keys(&CommitteeUpdateLogMessage::object_key_dir(), true)
             .await?;
-        let Some(key) = pick_latest_key(keys, S3_DIR_COMMITTEE_UPDATE) else {
+        let Some(key) = keys
+            .into_iter()
+            .filter(|key| !CommitteeUpdateLogMessage::is_failure_object_key(key))
+            .max()
+        else {
             return Ok(None);
         };
-        let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, record.build_pcrs())?;
-        let session_id = record.entry().session_id().clone();
-        let msg = match record.into_entry().into_message() {
-            VersionedLogMessage::V1(LogMessageV1::CommitteeUpdate(msg)) => msg,
-            VersionedLogMessage::V2(LogMessageV2::CommitteeUpdate(msg)) => msg,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+        let verified_record = self.read_verified_record(&key).await?;
+        let session_id = verified_record.entry().session_id().clone();
+        let msg = match verified_record.into_entry().into_message() {
+            V1(LogMessageV1::CommitteeUpdate(msg)) | V2(LogMessageV2::CommitteeUpdate(msg)) => msg,
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(format!(
                     "expected a committee-update log at {key}"
                 )));
@@ -341,25 +327,20 @@ impl GuardianReader {
         let committee = match *msg {
             CommitteeUpdateLogMessage::Success { new_committee, .. } => new_committee,
             CommitteeUpdateLogMessage::Failure { .. } => {
-                return Err(InvalidS3Log(format!(
-                    "lex-last non-failure key resolved to a Failure log at {key}"
-                )));
+                unreachable!("a verified non-failure key cannot contain a Failure log")
             }
         };
         log_verified_read(&key, &session_id);
         Ok(Some(committee))
     }
 
-    /// Fixed genesis record from `genesis/record.json`. `None` means the
-    /// KP-authorized bootstrap record has not been written yet.
-    async fn read_genesis_log(
-        &mut self,
-        build_policy: BuildPolicy,
-    ) -> GuardianResult<Option<GenesisLogMessage>> {
+    /// Read and verify the fixed KP-authorized bootstrap record, or return
+    /// `None` if `genesis/record.json` has not been written.
+    async fn read_genesis_log(&mut self) -> GuardianResult<Option<GenesisLogMessage>> {
         let key = GenesisLogMessage::object_key();
         let keys = self
             .s3
-            .list_keys(&format!("{}/", S3_DIR_GENESIS), true)
+            .list_keys(&GenesisLogMessage::object_key_dir(), true)
             .await?;
         if keys.is_empty() {
             return Ok(None);
@@ -369,14 +350,11 @@ impl GuardianReader {
                 "expected exactly one genesis record at {key}, found {keys:?}"
             )));
         }
-        let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, record.build_pcrs())?;
-        let session_id = record.entry().session_id().clone();
-        let msg = match record.into_entry().into_message() {
-            VersionedLogMessage::V1(LogMessageV1::Genesis(msg)) => msg,
-            VersionedLogMessage::V2(LogMessageV2::Genesis(msg)) => msg,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+        let verified_record = self.read_verified_record(&key).await?;
+        let session_id = verified_record.entry().session_id().clone();
+        let msg = match verified_record.into_entry().into_message() {
+            V1(LogMessageV1::Genesis(msg)) | V2(LogMessageV2::Genesis(msg)) => msg,
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(format!("expected a genesis log at {key}")));
             }
         };
@@ -387,100 +365,4 @@ impl GuardianReader {
 
 fn log_verified_read(key: &str, session_id: &SessionID) {
     info!("Successfully read {key} from session {session_id}.");
-}
-
-/// Per-session [`VerifiedSessionInfo`] cache, internal to [`GuardianReader`]. The first
-/// touch of a session resolves and verifies its info (attestation + signed
-/// info, PCR0 pinned against `allowlist`); later reads reuse it and expose the
-/// verified build PCRs to callers.
-struct GuardianSessionCache {
-    sessions: HashMap<SessionID, VerifiedSessionInfo>,
-    allowlist: PcrAllowlist,
-}
-
-impl GuardianSessionCache {
-    fn new(allowlist: PcrAllowlist) -> Self {
-        Self {
-            sessions: HashMap::new(),
-            allowlist,
-        }
-    }
-
-    /// The session's verified info, resolving and caching it on first use.
-    async fn get_or_load_session_info(
-        &mut self,
-        s3: &GuardianS3Client,
-        session_id: &str,
-    ) -> GuardianResult<&VerifiedSessionInfo> {
-        if !self.sessions.contains_key(session_id) {
-            let session_info = VerifiedSessionInfo::new(s3, session_id, &self.allowlist).await?;
-            self.sessions.insert(session_id.into(), session_info);
-        }
-        Ok(&self.sessions[session_id])
-    }
-
-    /// Fully verify `record` under its session's attested signing key.
-    async fn verify_record(
-        &mut self,
-        s3: &GuardianS3Client,
-        record: LogRecord,
-    ) -> GuardianResult<VerifiedLogRecord> {
-        let session_id = record.session_id().clone();
-        let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        VerifiedLogRecord::new(record, session_info)
-    }
-}
-
-/// Pick the lex-greatest key, skipping any whose name starts with `<dir>/failure-`.
-/// Keys are zero-padded (ceremony `sharing_seq`, committee `epoch`), so the lex-max
-/// non-failure key is the latest successful entry.
-fn pick_latest_key(keys: Vec<String>, dir: &str) -> Option<String> {
-    let failure_prefix = format!("{dir}/failure-");
-    keys.into_iter()
-        .filter(|k| !k.starts_with(&failure_prefix))
-        .max()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn success_key(epoch: u64) -> String {
-        format!("{S3_DIR_COMMITTEE_UPDATE}/{epoch:020}-sess.json")
-    }
-    fn failure_key(epoch: u64) -> String {
-        format!("{S3_DIR_COMMITTEE_UPDATE}/failure-{epoch:020}-sess-abcd1234.json")
-    }
-
-    #[test]
-    fn pick_latest_key_none_when_empty() {
-        assert_eq!(pick_latest_key(vec![], S3_DIR_COMMITTEE_UPDATE), None);
-    }
-
-    #[test]
-    fn pick_latest_key_takes_lex_max() {
-        let keys = vec![success_key(3), success_key(7), success_key(5)];
-        assert_eq!(
-            pick_latest_key(keys, S3_DIR_COMMITTEE_UPDATE),
-            Some(success_key(7))
-        );
-    }
-
-    #[test]
-    fn pick_latest_key_skips_higher_failure() {
-        // A later-epoch failure (lex-greater than any success) must not win.
-        let keys = vec![success_key(5), failure_key(9)];
-        assert_eq!(
-            pick_latest_key(keys, S3_DIR_COMMITTEE_UPDATE),
-            Some(success_key(5))
-        );
-    }
-
-    #[test]
-    fn pick_latest_key_none_when_all_failures() {
-        assert_eq!(
-            pick_latest_key(vec![failure_key(9)], S3_DIR_COMMITTEE_UPDATE),
-            None
-        );
-    }
 }

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::heartbeat_cursor;
 use super::GuardianReader;
 use super::VerifiedLogRecord;
 use crate::HEARTBEAT_INTERVAL;
 use crate::LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE;
 use crate::OTHER_SESSION_QUIET_PERIOD;
+use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::time_utils::unix_millis_to_seconds;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -17,7 +17,8 @@ use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VersionedLogMessage;
+use hashi_types::guardian::VersionedLogMessage::V1;
+use hashi_types::guardian::VersionedLogMessage::V2;
 use std::collections::BTreeMap;
 use tracing::info;
 
@@ -58,7 +59,7 @@ impl GuardianReader {
         // Read from the previous, current, and next hour-scoped prefixes to
         // cover clock-boundary cases and moderate clock skew.
         let one_hour_ago = now_timestamp_secs().saturating_sub(60 * 60);
-        let mut cursor = heartbeat_cursor(one_hour_ago);
+        let mut cursor = S3HourScopedDirectory::heartbeat(one_hour_ago);
         let mut logs = Vec::new();
         for _ in 0..3 {
             logs.extend(self.read_logs_in_dir(&cursor).await?);
@@ -85,9 +86,8 @@ fn summarize_heartbeats_by_session(
         let session_id = entry.session_id().clone();
         let ts = unix_millis_to_seconds(entry.timestamp_ms());
         match entry.into_message() {
-            VersionedLogMessage::V1(LogMessageV1::Heartbeat(..))
-            | VersionedLogMessage::V2(LogMessageV2::Heartbeat(..)) => {}
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            V1(LogMessageV1::Heartbeat(..)) | V2(LogMessageV2::Heartbeat(..)) => {}
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(
                     "non-heartbeat log found under the heartbeat prefix".into(),
                 ));

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -34,7 +34,8 @@ use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
-use hashi_types::guardian::VersionedLogMessage;
+use hashi_types::guardian::VersionedLogMessage::V1;
+use hashi_types::guardian::VersionedLogMessage::V2;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
 use tracing::info;
@@ -52,7 +53,7 @@ impl GuardianReader {
         &mut self,
         limiter_config: &LimiterConfig,
     ) -> GuardianResult<LimiterState> {
-        let Some(mut cursor) = find_latest_success_bucket(self.s3()).await? else {
+        let Some(mut cursor) = find_latest_success_bucket(&self.s3).await? else {
             // The search covers the complete S3 withdrawal history, so this
             // branch is reachable only if no withdrawal has ever succeeded.
             info!("no successful withdrawal logs found; using genesis limiter state");
@@ -135,9 +136,10 @@ fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {
     logs.into_iter()
         .filter_map(|log| {
             let boxed = match log.into_entry().into_message() {
-                VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,
-                VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) => message,
-                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => return None,
+                V1(LogMessageV1::Withdrawal(message)) | V2(LogMessageV2::Withdrawal(message)) => {
+                    message
+                }
+                V1(_) | V2(_) => return None,
             };
             match *boxed {
                 WithdrawalLogMessage::Success { post_state, .. } => Some(post_state),

--- a/crates/hashi-guardian/src/s3_reader/mod.rs
+++ b/crates/hashi-guardian/src/s3_reader/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Verified reads of the guardian's S3 logs.
+//! Verified reads from the guardian's S3 logs.
 //!
 //! [`GuardianReader`] applies each log stream's S3 immutability policy, verifies
 //! records with their writing session's attestation-anchored key, and caches the

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -13,7 +13,8 @@ use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::VersionedLogMessage;
+use hashi_types::guardian::VersionedLogMessage::V1;
+use hashi_types::guardian::VersionedLogMessage::V2;
 
 /// A session's verified guardian info: the attestation-anchored signing key,
 /// the signed [`GuardianInfo`], and the build PCRs proven by attestation.
@@ -25,7 +26,7 @@ pub struct VerifiedSessionInfo {
 }
 
 impl VerifiedSessionInfo {
-    pub(super) async fn new(
+    pub(super) async fn read_from_s3(
         s3: &GuardianS3Client,
         session_id: &str,
         allowlist: &PcrAllowlist,
@@ -34,16 +35,15 @@ impl VerifiedSessionInfo {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = s3.get_log_record(&att_key).await?;
-        let attestation_message =
-            match validate_into_entry(attestation_record, None)?.into_message() {
-                VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
-                VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
-                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
-                    return Err(InvalidS3Log(format!(
-                        "expected OIAttestationUnsigned at key {att_key}"
-                    )));
-                }
-            };
+        let attestation_message = match attestation_record.validate_into_entry(None)?.into_message()
+        {
+            V1(LogMessageV1::Init(message)) | V2(LogMessageV2::Init(message)) => message,
+            V1(_) | V2(_) => {
+                return Err(InvalidS3Log(format!(
+                    "expected OIAttestationUnsigned at key {att_key}"
+                )));
+            }
+        };
         let InitLogMessage::OIAttestationUnsigned {
             attestation,
             signing_public_key: signing_pubkey,
@@ -57,16 +57,17 @@ impl VerifiedSessionInfo {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = s3.get_log_record(&info_key).await?;
-        let info_message =
-            match validate_into_entry(info_record, Some(&signing_pubkey))?.into_message() {
-                VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
-                VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
-                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
-                    return Err(InvalidS3Log(format!(
-                        "expected OIGuardianInfo at key {info_key}"
-                    )));
-                }
-            };
+        let info_message = match info_record
+            .validate_into_entry(Some(&signing_pubkey))?
+            .into_message()
+        {
+            V1(LogMessageV1::Init(message)) | V2(LogMessageV2::Init(message)) => message,
+            V1(_) | V2(_) => {
+                return Err(InvalidS3Log(format!(
+                    "expected OIGuardianInfo at key {info_key}"
+                )));
+            }
+        };
         let InitLogMessage::OIGuardianInfo(info) = *info_message else {
             return Err(InvalidS3Log(format!(
                 "expected OIGuardianInfo at key {info_key}"
@@ -90,6 +91,15 @@ impl VerifiedSessionInfo {
         })
     }
 
+    /// Verify a record with this session's attestation-anchored signing key.
+    pub(super) fn verify_record(&self, record: LogRecord) -> GuardianResult<VerifiedLogRecord> {
+        let entry = record.validate_into_entry(Some(&self.signing_pubkey))?;
+        Ok(VerifiedLogRecord {
+            entry,
+            build_pcrs: self.build_pcrs.clone(),
+        })
+    }
+
     pub fn signing_pubkey(&self) -> &GuardianPubKey {
         &self.signing_pubkey
     }
@@ -100,10 +110,6 @@ impl VerifiedSessionInfo {
 
     pub fn build_pcrs(&self) -> &BuildPcrs {
         &self.build_pcrs
-    }
-
-    pub fn into_info(self) -> GuardianInfo {
-        self.info
     }
 }
 
@@ -117,17 +123,6 @@ pub struct VerifiedLogRecord {
 }
 
 impl VerifiedLogRecord {
-    pub(super) fn new(
-        record: LogRecord,
-        session_info: &VerifiedSessionInfo,
-    ) -> GuardianResult<Self> {
-        let entry = validate_into_entry(record, Some(&session_info.signing_pubkey))?;
-        Ok(Self {
-            entry,
-            build_pcrs: session_info.build_pcrs.clone(),
-        })
-    }
-
     #[cfg(test)]
     pub(super) fn new_for_test(entry: LogEntry, build_pcrs: BuildPcrs) -> Self {
         Self { entry, build_pcrs }
@@ -144,12 +139,4 @@ impl VerifiedLogRecord {
     pub fn into_entry(self) -> LogEntry {
         self.entry
     }
-}
-
-fn validate_into_entry(
-    record: LogRecord,
-    signing_public_key: Option<&GuardianPubKey>,
-) -> GuardianResult<LogEntry> {
-    record.validate(signing_public_key)?;
-    Ok(record.into_entry_unchecked())
 }

--- a/crates/hashi-guardian/src/withdraw_mode/genesis.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/genesis.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::s3_reader::BuildPolicy;
 use crate::Enclave;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianResult;
@@ -11,11 +10,7 @@ use hashi_types::guardian::GuardianResult;
 pub(super) async fn ensure_no_serving_committee(enclave: &Enclave) -> GuardianResult<()> {
     let mut reader = enclave.new_guardian_reader()?;
 
-    if reader
-        .read_latest_committee(BuildPolicy::AnyAllowlisted)
-        .await?
-        .is_some()
-    {
+    if reader.read_latest_committee().await?.is_some() {
         return Err(InvalidInputs(
             "genesis bootstrap is rejected after a serving committee exists".into(),
         ));

--- a/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
@@ -5,7 +5,6 @@
 //! withdrawal enclave by deriving live serving state from S3 logs and checking the
 //! operator-pinned `ActivationState` hash.
 
-use crate::s3_reader::BuildPolicy;
 use crate::Enclave;
 use hashi_types::guardian::ActivationState;
 use hashi_types::guardian::GuardianError;
@@ -49,7 +48,7 @@ impl OAInstall {
             .await?;
 
         let committee: HashiCommittee = reader
-            .read_latest_committee(BuildPolicy::AnyAllowlisted)
+            .read_latest_committee()
             .await?
             .ok_or_else(|| InvalidInputs("no committee-update or genesis record found".into()))?
             .try_into()

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -7,7 +7,6 @@
 
 use std::sync::Arc;
 
-use crate::s3_reader::BuildPolicy;
 use crate::Enclave;
 use hashi_types::guardian::crypto::decrypt_share;
 use hashi_types::guardian::crypto::encrypt_share_for_provisioner;
@@ -50,7 +49,7 @@ pub async fn provisioner_rotate_cert(
     let mut reader = enclave.new_guardian_reader()?;
 
     let latest_state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state()
         .await?
         .ok_or_else(|| InvalidInputs("no ceremony log found during cert rotation".into()))?;
     let enclave_btc_pubkey = enclave.config.enclave_btc_pubkey()?;

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -8,7 +8,6 @@ use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_guardian::s3_reader::VerifiedLogRecord;
-use hashi_guardian::s3_reader::withdraw_cursor;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::VersionedLogMessage;
@@ -77,7 +76,7 @@ impl GuardianWithdrawalsPoller {
     pub async fn new(config: &Config, start: UnixSeconds) -> anyhow::Result<Self> {
         Ok(Self {
             reader: GuardianReader::new(&config.guardian, config.pcr_allowlist()).await?,
-            cursor: withdraw_cursor(start),
+            cursor: S3HourScopedDirectory::withdraw(start),
         })
     }
 

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -165,7 +165,7 @@ impl BuildPcrs {
 }
 
 /// PCR pins for enclave builds that may appear in guardian attestations.
-/// Used by GuardianReader in s3_reader.rs.
+/// Used by the guardian S3 reader.
 ///
 /// `current_build` is the current/live build. `prev_builds` contains older
 /// builds that may still appear in persisted logs during an upgrade or replay.

--- a/crates/hashi-types/src/guardian/log/messages/ceremony.rs
+++ b/crates/hashi-types/src/guardian/log/messages/ceremony.rs
@@ -31,6 +31,11 @@ pub enum CeremonyLogMessage {
 }
 
 impl CeremonyLogMessage {
+    /// The slash-terminated prefix containing ceremony records.
+    pub fn object_key_dir() -> String {
+        format!("{S3_DIR_CEREMONY}/")
+    }
+
     /// Consume the ceremony result. `NewKey` yields its initial instance;
     /// `Rotate` yields the new instance after verifying that it advances exactly
     /// one `sharing_seq` from the consumed instance.
@@ -69,7 +74,8 @@ impl CeremonyLogMessage {
 
     pub fn object_key(&self, session_id: &str) -> String {
         format!(
-            "{S3_DIR_CEREMONY}/{:020}-{session_id}.json",
+            "{}{:020}-{session_id}.json",
+            Self::object_key_dir(),
             self.sharing_seq(),
         )
     }

--- a/crates/hashi-types/src/guardian/log/messages/committee_update.rs
+++ b/crates/hashi-types/src/guardian/log/messages/committee_update.rs
@@ -29,6 +29,20 @@ pub enum CommitteeUpdateLogMessage {
 }
 
 impl CommitteeUpdateLogMessage {
+    /// The slash-terminated prefix containing committee-update records.
+    pub fn object_key_dir() -> String {
+        format!("{S3_DIR_COMMITTEE_UPDATE}/")
+    }
+
+    fn failure_object_key_prefix() -> String {
+        format!("{}failure-", Self::object_key_dir())
+    }
+
+    /// Return whether `object_key` belongs to a failed committee update.
+    pub fn is_failure_object_key(object_key: &str) -> bool {
+        object_key.starts_with(&Self::failure_object_key_prefix())
+    }
+
     /// Success keys lead with the new epoch (zero-padded) so a lex listing
     /// is epoch-sorted; failures lead with `failure-` so they sort after
     /// all successes, leaving the lex-last success key as the latest
@@ -36,13 +50,33 @@ impl CommitteeUpdateLogMessage {
     pub fn object_key_pattern(&self, session_id: &str) -> ObjectKeyPattern {
         match self {
             Self::Success { new_committee, .. } => ObjectKeyPattern::Fixed(format!(
-                "{S3_DIR_COMMITTEE_UPDATE}/{:020}-{session_id}.json",
+                "{}{:020}-{session_id}.json",
+                Self::object_key_dir(),
                 new_committee.epoch,
             )),
             Self::Failure { new_committee, .. } => ObjectKeyPattern::RandomSuffix(format!(
-                "{S3_DIR_COMMITTEE_UPDATE}/failure-{:020}-{session_id}-",
+                "{}{:020}-{session_id}-",
+                Self::failure_object_key_prefix(),
                 new_committee.epoch,
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifies_failure_object_keys() {
+        assert!(CommitteeUpdateLogMessage::is_failure_object_key(
+            "committee-update/failure-00000000000000000009-session-abcd1234.json"
+        ));
+        assert!(!CommitteeUpdateLogMessage::is_failure_object_key(
+            "committee-update/00000000000000000009-session.json"
+        ));
+        assert!(!CommitteeUpdateLogMessage::is_failure_object_key(
+            "ceremony/failure-example.json"
+        ));
     }
 }

--- a/crates/hashi-types/src/guardian/log/messages/genesis.rs
+++ b/crates/hashi-types/src/guardian/log/messages/genesis.rs
@@ -14,8 +14,13 @@ pub struct GenesisLogMessage {
 }
 
 impl GenesisLogMessage {
+    /// The slash-terminated prefix containing the genesis record.
+    pub fn object_key_dir() -> String {
+        format!("{S3_DIR_GENESIS}/")
+    }
+
     pub fn object_key() -> String {
-        format!("{S3_DIR_GENESIS}/record.json")
+        format!("{}record.json", Self::object_key_dir())
     }
 
     pub fn object_key_pattern(&self) -> ObjectKeyPattern {

--- a/crates/hashi-types/src/guardian/log/messages/heartbeat.rs
+++ b/crates/hashi-types/src/guardian/log/messages/heartbeat.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ObjectKeyPattern;
-use super::super::S3_DIR_HEARTBEAT;
 use crate::guardian::UnixMillis;
 use crate::guardian::s3_utils::S3HourScopedDirectory;
 use crate::guardian::unix_millis_to_seconds;
@@ -22,7 +21,7 @@ impl HeartbeatLogMessage {
     pub fn object_key(&self, session_id: &str, timestamp_ms: UnixMillis) -> String {
         format!(
             "{}{session_id}-{:020}.json",
-            S3HourScopedDirectory::new(S3_DIR_HEARTBEAT, unix_millis_to_seconds(timestamp_ms)),
+            S3HourScopedDirectory::heartbeat(unix_millis_to_seconds(timestamp_ms)),
             self.seq,
         )
     }

--- a/crates/hashi-types/src/guardian/log/messages/withdrawal.rs
+++ b/crates/hashi-types/src/guardian/log/messages/withdrawal.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ObjectKeyPattern;
-use super::super::S3_DIR_WITHDRAW;
 use crate::committee::CommitteeSignature;
 use crate::guardian::LimiterState;
 use crate::guardian::StandardWithdrawalRequestWire;
@@ -45,8 +44,7 @@ impl WithdrawalLogMessage {
         session_id: &str,
         timestamp_ms: UnixMillis,
     ) -> ObjectKeyPattern {
-        let directory =
-            S3HourScopedDirectory::new(S3_DIR_WITHDRAW, unix_millis_to_seconds(timestamp_ms));
+        let directory = S3HourScopedDirectory::withdraw(unix_millis_to_seconds(timestamp_ms));
         match self {
             Self::Success { request_data, .. } => ObjectKeyPattern::Fixed(format!(
                 "{directory}success-{:020}-{session_id}-wid{}.json",

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The `LogRecord` written to S3: it wraps a
-//! `super::schema::VersionedLogMessage` with its routing context and, for
-//! signed logs, a guardian signature.
-//! The object key and lock duration are derived from the wrapped message.
+//! S3 log-record wire format and record-local validation.
+//!
+//! A [`LogRecord`] carries a [`VersionedLogMessage`] and its S3 routing
+//! context. Signed records carry a Guardian signature over their [`LogEntry`].
+//! The one permitted unsigned entry carries the OI attestation that establishes
+//! the Guardian signing key and must be authenticated separately.
 
 use super::ObjectKeyPattern;
 use super::retention::S3ObjectLockPolicy;
@@ -27,27 +29,35 @@ use serde::de::Error as _;
 use serde_json::Value;
 use std::time::Duration;
 
-/// The data authenticated by a signed log record.
+/// Routing context and versioned payload carried by a [`LogRecord`].
 ///
-/// Field order defines the BCS signing format.
+/// For signed records, field order defines the BCS signing format.
 #[derive(Debug, Serialize)]
 pub struct LogEntry {
+    /// Version of the message's serialized schema.
     schema_version: u64,
+    /// Guardian session that wrote the entry.
     session_id: SessionID,
     /// Final S3 destination selected before signing. Readers must compare this
     /// intended key with the actual key returned by S3.
     object_key: String,
+    /// Versioned log payload.
     message: VersionedLogMessage,
-    /// Milliseconds since Unix epoch.
+    /// Entry creation time in milliseconds since the Unix epoch.
     timestamp_ms: UnixMillis,
 }
 
-/// Write: `LogMessage` -> `LogRecord` -> JSON body.
-/// Read: actual S3 key + JSON body -> untrusted `LogRecord`; the reader layer
-/// fully verifies it before exposing its contents.
+/// A Guardian S3 log record.
+///
+/// Both variants use the same flat JSON representation; the optional
+/// `signature` field selects the variant during deserialization. A
+/// deserialized record remains untrusted until its routing context and
+/// applicable signature and attestation checks have been performed.
 #[derive(Debug)]
 pub enum LogRecord {
+    /// An entry carrying a Guardian signature.
     Signed(GuardianSigned<LogEntry>),
+    /// The OI-attestation entry, which is authenticated separately.
     Unsigned(LogEntry),
 }
 
@@ -145,26 +155,32 @@ impl<'de> Deserialize<'de> for LogRecord {
 }
 
 impl LogEntry {
+    /// Return the log schema version.
     pub fn schema_version(&self) -> u64 {
         self.schema_version
     }
 
+    /// Return the intended S3 object key.
     pub fn object_key(&self) -> &str {
         &self.object_key
     }
 
+    /// Return the writing Guardian session.
     pub fn session_id(&self) -> &SessionID {
         &self.session_id
     }
 
+    /// Return the entry creation time in milliseconds since the Unix epoch.
     pub fn timestamp_ms(&self) -> UnixMillis {
         self.timestamp_ms
     }
 
+    /// Return the versioned log payload.
     pub fn message(&self) -> &VersionedLogMessage {
         &self.message
     }
 
+    /// Consume the entry and return its versioned log payload.
     pub fn into_message(self) -> VersionedLogMessage {
         self.message
     }
@@ -202,8 +218,7 @@ impl LogEntry {
         Ok(())
     }
 
-    /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
-    /// must be authenticated separately.
+    // The Nitro attestation itself must be authenticated separately.
     fn validate_unsigned(&self) -> GuardianResult<()> {
         if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
@@ -228,7 +243,6 @@ impl LogEntry {
         Ok(())
     }
 
-    /// Validate signed-log routing context.
     fn validate_signed(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
         if self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
@@ -241,6 +255,10 @@ impl LogEntry {
 }
 
 impl LogRecord {
+    /// Construct a current-schema record using the current time.
+    ///
+    /// The OI-attestation message is emitted unsigned; every other message is
+    /// signed by `signing_key`.
     pub fn new(
         session_id: SessionID,
         message: LogMessage,
@@ -249,6 +267,10 @@ impl LogRecord {
         Self::new_at_timestamp(session_id, message, signing_key, now_timestamp_ms())
     }
 
+    /// Construct a current-schema record using an explicit timestamp.
+    ///
+    /// The OI-attestation message is emitted unsigned; every other message is
+    /// signed by `signing_key`.
     pub fn new_at_timestamp(
         session_id: SessionID,
         message: LogMessage,
@@ -266,28 +288,32 @@ impl LogRecord {
         }
     }
 
+    /// Return the intended S3 object key.
     pub fn object_key(&self) -> &str {
         &self.data().object_key
     }
 
+    /// Return the writing Guardian session.
     pub fn session_id(&self) -> &SessionID {
         &self.data().session_id
     }
 
+    /// Return the entry creation time in milliseconds since the Unix epoch.
     pub fn timestamp_ms(&self) -> UnixMillis {
         self.data().timestamp_ms
     }
 
+    /// Return the versioned log payload.
     pub fn message(&self) -> &VersionedLogMessage {
         &self.data().message
     }
 
-    /// Validate a record without consuming it.
+    /// Validate record-local invariants without consuming the record.
     ///
-    /// Validation checks record-local invariants and verifies a signed record
-    /// against the caller-supplied key. It does not establish that the key
-    /// belongs to an attested, approved guardian; the S3 reader's
-    /// `verify_record` performs that complete verification.
+    /// For a signed record, this also verifies the signature against the
+    /// caller-supplied key. It does not establish that the key belongs to an
+    /// attested, approved Guardian; the S3 reader performs that complete
+    /// verification.
     ///
     /// Signed records require `Some(signing_public_key)`; the one permitted
     /// unsigned record kind requires `None`. The caller is responsible for
@@ -321,11 +347,24 @@ impl LogRecord {
         }
     }
 
+    /// Validate the record, then consume it and return its versioned entry.
+    pub fn validate_into_entry(
+        self,
+        signing_public_key: Option<&GuardianPubKey>,
+    ) -> GuardianResult<LogEntry> {
+        self.validate(signing_public_key)?;
+        Ok(self.into_entry_unchecked())
+    }
+
+    /// Return the object-lock duration selected for the message type.
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
         policy.duration_for(self.data().message.log_type())
     }
 
-    /// Extract the entry without validating the record.
+    /// Consume the record and extract its entry without validation.
+    ///
+    /// This bypasses object-key and session-ID validation, Guardian signature
+    /// verification, and Nitro attestation authentication.
     pub fn into_entry_unchecked(self) -> LogEntry {
         match self {
             Self::Signed(signed) => signed.into_data_unchecked(),

--- a/crates/hashi-types/src/guardian/s3_utils.rs
+++ b/crates/hashi-types/src/guardian/s3_utils.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::guardian::log::S3_DIR_HEARTBEAT;
+use crate::guardian::log::S3_DIR_WITHDRAW;
 use crate::guardian::time_utils::UnixSeconds;
 use anyhow::Context;
 use std::convert::TryFrom;
@@ -42,6 +44,16 @@ impl S3HourScopedDirectory {
             day: datetime.day(),
             hour: datetime.hour(),
         }
+    }
+
+    /// Construct the withdrawal-log directory containing `t`.
+    pub fn withdraw(t: UnixSeconds) -> Self {
+        Self::new(S3_DIR_WITHDRAW, t)
+    }
+
+    /// Construct the heartbeat-log directory containing `t`.
+    pub fn heartbeat(t: UnixSeconds) -> Self {
+        Self::new(S3_DIR_HEARTBEAT, t)
     }
 
     pub fn next_dir(&self) -> Self {


### PR DESCRIPTION
Stacked on #931.

## Summary

- Move validate-then-consume extraction onto `LogRecord::validate_into_entry` and centralize verified-record reads in `GuardianReader`.
- Make verified session information own record verification, flatten session caching into `GuardianReader`, and keep verified fields behind accessors.
- Make allowlisted builds the default for historical reads while exposing current-build requirements through explicitly named methods and keeping `BuildPolicy` private.
- Update guardian-init and guardian consumers to use the narrower reader APIs.
- Simplify latest ceremony and committee selection, centralize log-directory prefixes on their message types, and move heartbeat/withdrawal cursor construction onto `S3HourScopedDirectory`.
- Move `s3_reader.rs` to `s3_reader/mod.rs`.

## Local validation

- `make fmt`