### PR TITLE
[Guardian] Unify S3 immutability checks

### DIFF
--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -376,23 +376,20 @@ impl GuardianS3Client {
     }
 }
 
-/// Controls whether an S3 read requires Compliance-mode object-lock metadata.
-pub(crate) enum LockCheck {
-    /// Reject the object unless its Compliance lock is still unexpired, except
+/// Controls whether an S3 read establishes that the object is still immutable.
+#[derive(Clone, Copy)]
+pub(crate) enum ImmutabilityCheck {
+    /// Validate the exact key has no mutation history and reject the object
+    /// unless its Compliance lock is still unexpired, except when the
+    /// process-wide temporary testnet override is set.
+    Required,
+    /// The caller already validated the enclosing prefix has no mutations;
+    /// still reject the object unless its Compliance lock is unexpired, except
     /// when the process-wide temporary testnet override is set.
-    Required,
-    /// Do not inspect lock metadata. Used for signed records whose short lock
-    /// is expected to expire, such as KP-share state.
+    MutationAlreadyChecked,
+    /// Do not claim S3 immutability. Used for signed records whose short locks
+    /// are expected to expire, such as KP-share state.
     Skipped,
-}
-
-/// Controls whether an S3 read validates that the key has no overwrite or
-/// deletion history.
-pub(crate) enum HistoryCheck {
-    /// Validate the exact key's history before fetching it.
-    Required,
-    /// The caller already validated the history of the enclosing prefix.
-    AlreadyChecked,
 }
 
 impl GuardianS3Client {
@@ -444,12 +441,15 @@ impl GuardianS3Client {
         Ok(out.into_iter().collect())
     }
 
-    /// Lists every key under `prefix`, refusing to proceed if any matching
-    /// object has a delete marker or non-latest version. The prefix may be a
-    /// directory or a complete object key. Returned keys are unique and sorted.
-    pub async fn validate_prefix_history_and_list_keys(
+    /// Lists the currently visible keys under `prefix` using S3 version
+    /// history. When `reject_mutations` is true, any overwrite or deletion is
+    /// rejected; otherwise it is logged and only the latest visible versions
+    /// are returned. Mutation validation establishes immutability only when
+    /// each selected object also has an unexpired lock.
+    pub(crate) async fn list_keys(
         &self,
         prefix: &str,
+        reject_mutations: bool,
     ) -> GuardianResult<Vec<String>> {
         let s3_client = &self.client;
         let s3_config = &self.config;
@@ -457,6 +457,7 @@ impl GuardianS3Client {
         let mut key_marker: Option<String> = None;
         let mut version_id_marker: Option<String> = None;
         let mut seen_keys: BTreeSet<String> = BTreeSet::new();
+        let mut found_mutation = false;
 
         loop {
             let mut req = s3_client
@@ -479,10 +480,13 @@ impl GuardianS3Client {
             })?;
 
             if !response.delete_markers().is_empty() {
-                return Err(S3Error(format!(
-                    "Delete marker found under prefix {}",
-                    prefix
-                )));
+                if reject_mutations {
+                    return Err(S3Error(format!(
+                        "Delete marker found under prefix {}",
+                        prefix
+                    )));
+                }
+                found_mutation = true;
             }
 
             // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ObjectVersion.html
@@ -494,18 +498,25 @@ impl GuardianS3Client {
                 // NOTE: If an object's lock expires, then all bets are off.
                 // For example, is_latest could be true even though an older version of it was deleted (post lock expiry).
                 if version.is_latest() != Some(true) {
-                    return Err(S3Error(format!(
-                        "Non-latest version found for key {} under prefix {}",
-                        key, prefix
-                    )));
+                    if reject_mutations {
+                        return Err(S3Error(format!(
+                            "Non-latest version found for key {} under prefix {}",
+                            key, prefix
+                        )));
+                    }
+                    found_mutation = true;
+                    continue;
                 }
 
                 if !seen_keys.insert(key.to_string()) {
-                    // this check is redundant as we ensure is_latest = true above
-                    return Err(S3Error(format!(
-                        "Duplicate version found for key {} under prefix {}",
-                        key, prefix
-                    )));
+                    if reject_mutations {
+                        // This check is redundant as we ensure is_latest = true above.
+                        return Err(S3Error(format!(
+                            "Duplicate version found for key {} under prefix {}",
+                            key, prefix
+                        )));
+                    }
+                    found_mutation = true;
                 }
             }
 
@@ -524,6 +535,12 @@ impl GuardianS3Client {
             }
         }
 
+        if found_mutation {
+            warn!(
+                prefix,
+                "S3 object mutation found; continuing because mutation rejection is disabled"
+            );
+        }
         Ok(seen_keys.into_iter().collect())
     }
 
@@ -537,32 +554,31 @@ impl GuardianS3Client {
         dir: &S3HourScopedDirectory,
     ) -> GuardianResult<Vec<LogRecord>> {
         let prefix = dir.to_string();
-        let keys = self.validate_prefix_history_and_list_keys(&prefix).await?;
+        let keys = self.list_keys(&prefix, true).await?;
         let mut out = Vec::with_capacity(keys.len());
         for key in keys {
             // The prefix history was checked above. Immutable batch logs also
             // require an unexpired Compliance lock unless the temporary
             // process-wide testnet override is set.
             out.push(
-                self.get_log_record_inner(&key, LockCheck::Required, HistoryCheck::AlreadyChecked)
+                self.get_log_record_inner(&key, ImmutabilityCheck::MutationAlreadyChecked)
                     .await?,
             );
         }
         Ok(out)
     }
 
-    /// Fetches and deserializes a record with explicit S3 integrity checks,
-    /// always rejecting a mismatch between its signed intended key and the
-    /// actual S3 key. `HistoryCheck::AlreadyChecked` requires the caller to have
-    /// validated the key's enclosing prefix.
+    /// Fetches and deserializes a record with the requested S3 immutability
+    /// policy, always rejecting a mismatch between its signed intended key and
+    /// the actual S3 key. `ImmutabilityCheck::MutationAlreadyChecked` requires
+    /// the caller to have validated the key's enclosing prefix.
     pub(crate) async fn get_log_record_inner(
         &self,
         key: &str,
-        lock_check: LockCheck,
-        history_check: HistoryCheck,
+        immutability_check: ImmutabilityCheck,
     ) -> GuardianResult<LogRecord> {
-        if matches!(history_check, HistoryCheck::Required) {
-            let keys = self.validate_prefix_history_and_list_keys(key).await?;
+        if matches!(immutability_check, ImmutabilityCheck::Required) {
+            let keys = self.list_keys(key, true).await?;
             if keys.len() != 1 || keys[0] != key {
                 return Err(S3Error(format!(
                     "expected exactly one object for key {}, found {:?}",
@@ -586,7 +602,7 @@ impl GuardianS3Client {
                 ))
             })?;
 
-        if matches!(lock_check, LockCheck::Required)
+        if !matches!(immutability_check, ImmutabilityCheck::Skipped)
             && !skip_s3_object_lock_check()
             && !has_unexpired_compliance_lock(
                 response.object_lock_mode(),
@@ -626,7 +642,7 @@ impl GuardianS3Client {
     /// Read an immutable-log object with history and Compliance-lock checks.
     /// The temporary process-wide testnet override skips only the lock check.
     pub(crate) async fn get_log_record(&self, key: &str) -> GuardianResult<LogRecord> {
-        self.get_log_record_inner(key, LockCheck::Required, HistoryCheck::Required)
+        self.get_log_record_inner(key, ImmutabilityCheck::Required)
             .await
     }
 }
@@ -940,7 +956,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
 
         let error = logger
-            .get_log_record_inner("key", LockCheck::Required, HistoryCheck::AlreadyChecked)
+            .get_log_record_inner("key", ImmutabilityCheck::MutationAlreadyChecked)
             .await
             .expect_err("an expired required lock must be rejected");
 
@@ -979,11 +995,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
 
         let record = logger
-            .get_log_record_inner(
-                "init/copied-attestation.json",
-                LockCheck::Skipped,
-                HistoryCheck::AlreadyChecked,
-            )
+            .get_log_record_inner("init/copied-attestation.json", ImmutabilityCheck::Skipped)
             .await
             .expect("the embedded key matches the actual S3 key");
         let error = record
@@ -1021,11 +1033,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
 
         let error = logger
-            .get_log_record_inner(
-                &relocated_key,
-                LockCheck::Skipped,
-                HistoryCheck::AlreadyChecked,
-            )
+            .get_log_record_inner(&relocated_key, ImmutabilityCheck::Skipped)
             .await
             .expect_err("a relocated record must be rejected");
 

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -12,8 +12,7 @@
 //! advances/retreats and feeds to [`GuardianReader::read_logs_in_dir`].
 
 use crate::s3_client::GuardianS3Client;
-use crate::s3_client::HistoryCheck;
-use crate::s3_client::LockCheck;
+use crate::s3_client::ImmutabilityCheck;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
@@ -174,7 +173,7 @@ impl GuardianReader {
     ) -> GuardianResult<Option<CeremonyLogMessage>> {
         let keys = self
             .s3
-            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_CEREMONY))
+            .list_keys(&format!("{}/", S3_DIR_CEREMONY), true)
             .await?;
         let Some(key) = pick_latest_key(keys, S3_DIR_CEREMONY) else {
             return Ok(None);
@@ -209,17 +208,12 @@ impl GuardianReader {
         build_policy: BuildPolicy,
     ) -> GuardianResult<Option<KpShareStateLogMessage>> {
         let prefix = KpShareStateLogMessage::object_key_dir(sharing_seq);
-        let keys = self
-            .s3
-            .validate_prefix_history_and_list_keys(&prefix)
-            .await?;
+        let keys = self.s3.list_keys(&prefix, false).await?;
         let Some(key) = keys.into_iter().max() else {
             return Ok(None);
         };
-        // The enclosing prefix's version history was checked while listing the
-        // candidate keys above, so the selected key does not need another check.
         let msg = self
-            .read_kp_share_state_log_at_key(&key, build_policy, HistoryCheck::AlreadyChecked)
+            .read_kp_share_state_log_at_key(&key, build_policy)
             .await?;
         if msg.sharing_seq != sharing_seq {
             return Err(InvalidS3Log(format!(
@@ -243,9 +237,7 @@ impl GuardianReader {
         build_policy: BuildPolicy,
     ) -> GuardianResult<KpShareStateLogMessage> {
         let key = KpShareStateLogMessage::object_key(session_id, sharing_seq, cert_seq);
-        // Unlike the latest-state path, this direct read has not already
-        // checked an enclosing prefix, so validate this exact key's history.
-        self.read_kp_share_state_log_at_key(&key, build_policy, HistoryCheck::Required)
+        self.read_kp_share_state_log_at_key(&key, build_policy)
             .await
     }
 
@@ -254,14 +246,13 @@ impl GuardianReader {
         &mut self,
         key: &str,
         build_policy: BuildPolicy,
-        history_check: HistoryCheck,
     ) -> GuardianResult<KpShareStateLogMessage> {
         // KP-share locks are short-lived and expected to expire. Expiry permits
         // deletion but does not cause it; while an object remains, its contents
         // are authenticatable through the enclave signature verified below.
         let record = self
             .s3
-            .get_log_record_inner(key, LockCheck::Skipped, history_check)
+            .get_log_record_inner(key, ImmutabilityCheck::Skipped)
             .await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, record.build_pcrs())?;
@@ -329,7 +320,7 @@ impl GuardianReader {
     ) -> GuardianResult<Option<Committee>> {
         let keys = self
             .s3
-            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE))
+            .list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE), true)
             .await?;
         let Some(key) = pick_latest_key(keys, S3_DIR_COMMITTEE_UPDATE) else {
             return Ok(None);
@@ -368,7 +359,7 @@ impl GuardianReader {
         let key = GenesisLogMessage::object_key();
         let keys = self
             .s3
-            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_GENESIS))
+            .list_keys(&format!("{}/", S3_DIR_GENESIS), true)
             .await?;
         if keys.is_empty() {
             return Ok(None);

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -126,7 +126,7 @@ async fn hour_bucket_has_success(
     bucket: &str,
 ) -> GuardianResult<bool> {
     let keys = s3_client
-        .validate_prefix_history_and_list_keys(&format!("{bucket}success-"))
+        .list_keys(&format!("{bucket}success-"), true)
         .await?;
     Ok(!keys.is_empty())
 }


### PR DESCRIPTION
## Summary

- replace the independent lock and mutation-history controls with one immutability policy
- require mutation checks and unexpired Compliance locks together for immutable logs
- list KP-share versions without claiming S3 immutability, warning rather than failing when mutation history is present

## Testing

- `make fmt`