### PR TITLE
[Guardian] Clarify the S3 reader API

### DIFF
--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -6,7 +6,6 @@
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use std::path::Path;
 use tracing::info;
@@ -97,7 +96,7 @@ pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
         "scraping latest ceremony/ + kp-shares/ logs (attestation-anchored)",
     );
     let state = reader
-        .read_latest_ceremony_state(BuildPolicy::Current)
+        .read_latest_ceremony_state_from_current_build()
         .await?
         .context("no ceremony logs found in guardian S3 bucket")?;
     state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -35,7 +35,6 @@
 //!    enclave re-verifies every signature and binding.
 
 use anyhow::Context;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::EncPubKey;
@@ -158,9 +157,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         session_id = %session_id,
         "fetching + verifying pinned standby session's signed GuardianInfo from S3",
     );
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     let GuardianInfo {
         lifecycle,
         secret_sharing_instance,
@@ -261,7 +258,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         "scraping authoritative ceremony/ and kp-shares/ logs",
     );
     let state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state()
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     let sharing_seq = state.secret_sharing_instance.sharing_seq();
@@ -310,9 +307,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
 
     // Require the explicit intent marker to match S3 state. For genesis, bind
     // the independently read on-chain committee into this KP's signed PI submission.
-    let latest_committee = reader
-        .read_latest_committee(BuildPolicy::AnyAllowlisted)
-        .await?;
+    let latest_committee = reader.read_latest_committee().await?;
     let expected_genesis_state_hash = match (do_genesis, latest_committee) {
         (false, Some(_)) => None,
         (true, None) => {

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -240,7 +240,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         enclave_current_committee_epoch.is_none(),
         "Guardian has current_committee_epoch => operator activation already ran"
     );
-    let oi_info = verified_session.info;
+    let oi_info = verified_session.into_info();
     ensure_oi_info_matches_post_init(&oi_info, &guardian_info)
         .with_context(|| format!("S3 GuardianInfo mismatch for session {session_id}"))?;
     anyhow::ensure!(

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -240,8 +240,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         enclave_current_committee_epoch.is_none(),
         "Guardian has current_committee_epoch => operator activation already ran"
     );
-    let oi_info = verified_session.into_info();
-    ensure_oi_info_matches_post_init(&oi_info, &guardian_info)
+    ensure_oi_info_matches_post_init(verified_session.info(), &guardian_info)
         .with_context(|| format!("S3 GuardianInfo mismatch for session {session_id}"))?;
     anyhow::ensure!(
         &master_g == enclave_mpc_master_g,

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -499,7 +499,7 @@ async fn submit_provisioner_init_to_relay(
     // Detached-sign the exact (session, config, share) bytes with this KP's
     // offline key. The relay pre-verifies the request before buffering it and
     // the enclave authoritatively re-verifies it before using the share.
-    let signed_request = KpSigned::new(request, signer_cert.clone(), None)
+    let signed_request = KpSigned::sign(request, signer_cert.clone(), None)
         .map_err(anyhow::Error::msg)
         .context("sign the relay submission with the KP key")?;
     let resp = relay_client

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -170,10 +170,10 @@ pub async fn run(
     let signed_response =
         GuardianSignedResponse::<ProvisionerRotateCertResponse>::try_from(response_pb)
             .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
-    let response = signed_response
-        .authenticate(&signing_pub_key)
-        .map_err(|e| anyhow!("authenticate ProvisionerRotateCertResponse: {e}"))?
-        .into_response();
+    signed_response
+        .verify_signature(&signing_pub_key)
+        .map_err(|e| anyhow!("verify ProvisionerRotateCertResponse signature: {e}"))?;
+    let response = signed_response.data.into_response();
     let expected_cert_seq = old_cert_seq.checked_add(1).context("cert_seq overflow")?;
     anyhow::ensure!(
         response.cert_seq == expected_cert_seq,

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::anyhow;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::EncPubKey;
 use hashi_types::guardian::GuardianSignedResponse;
@@ -114,9 +113,7 @@ pub async fn run(
         guardian_s3.bucket_info,
         endpoint_bucket_info
     );
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     anyhow::ensure!(
         verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
@@ -134,7 +131,7 @@ pub async fn run(
         .map_err(anyhow::Error::msg)?;
 
     let state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state()
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
@@ -213,12 +210,7 @@ pub async fn run(
     );
 
     let updated_state = reader
-        .read_kp_share_state_log(
-            &session_id,
-            sharing_seq,
-            response.cert_seq,
-            BuildPolicy::Current,
-        )
+        .read_kp_share_state_log_from_current_build(&session_id, sharing_seq, response.cert_seq)
         .await
         .context("read the certificate-rotation kp-shares snapshot")?;
     updated_state

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -160,7 +160,7 @@ pub async fn run(
         &guardian_pub_key,
         &mut thread_rng(),
     );
-    let signed_request = KpSigned::new(request, signing_cert, None)
+    let signed_request = KpSigned::sign(request, signing_cert, None)
         .context("sign the certificate-rotation request with the authorizing KP key")?;
     let response_pb = client
         .provisioner_rotate_cert(pb::SignedProvisionerRotateCertRequest::from(signed_request))
@@ -170,8 +170,8 @@ pub async fn run(
     let signed_response = GuardianSigned::<ProvisionerRotateCertResponse>::try_from(response_pb)
         .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
     let response = signed_response
-        .verify(&signing_pub_key)
-        .map_err(|e| anyhow!("verify ProvisionerRotateCertResponse signature: {e}"))?;
+        .authenticate(&signing_pub_key)
+        .map_err(|e| anyhow!("authenticate ProvisionerRotateCertResponse: {e}"))?;
     let expected_cert_seq = old_cert_seq.checked_add(1).context("cert_seq overflow")?;
     anyhow::ensure!(
         response.cert_seq == expected_cert_seq,

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -11,7 +11,7 @@ use anyhow::anyhow;
 use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::EncPubKey;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::ProvisionerRotateCertRequest;
 use hashi_types::guardian::ProvisionerRotateCertResponse;
@@ -167,11 +167,13 @@ pub async fn run(
         .await
         .context("ProvisionerRotateCert RPC failed")?
         .into_inner();
-    let signed_response = GuardianSigned::<ProvisionerRotateCertResponse>::try_from(response_pb)
-        .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
+    let signed_response =
+        GuardianSignedResponse::<ProvisionerRotateCertResponse>::try_from(response_pb)
+            .map_err(|e| anyhow!("decode SignedProvisionerRotateCertResponse: {e:?}"))?;
     let response = signed_response
         .authenticate(&signing_pub_key)
-        .map_err(|e| anyhow!("authenticate ProvisionerRotateCertResponse: {e}"))?;
+        .map_err(|e| anyhow!("authenticate ProvisionerRotateCertResponse: {e}"))?
+        .into_response();
     let expected_cert_seq = old_cert_seq.checked_add(1).context("cert_seq overflow")?;
     anyhow::ensure!(
         response.cert_seq == expected_cert_seq,

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -118,11 +118,11 @@ pub async fn run(
         .get_session_info(&session_id, BuildPolicy::Current)
         .await?;
     anyhow::ensure!(
-        verified_session.signing_pubkey == signing_pub_key,
+        verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
     anyhow::ensure!(
-        verified_session.info.bucket_info.as_ref() == Some(endpoint_bucket_info),
+        verified_session.info().bucket_info.as_ref() == Some(endpoint_bucket_info),
         "guardian S3 session bucket info differs from live GuardianInfo"
     );
     let endpoint_btc_pubkey = endpoint_verified

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -9,7 +9,6 @@ use anyhow::ensure;
 use hashi_guardian::HEARTBEAT_INTERVAL;
 use hashi_guardian::MAX_S3_WRITE_FAILURE_INTERVAL;
 use hashi_guardian::OTHER_SESSION_QUIET_PERIOD;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::ActivationState;
 use hashi_types::guardian::GuardianError;
@@ -124,9 +123,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         session_id = %session_id,
         "verifying OI GuardianInfo matches the live guardian identity/config",
     );
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     ensure!(
         verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
@@ -152,7 +149,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         "reading latest committee and recovering limiter state",
     );
     let move_committee = reader
-        .read_latest_committee(BuildPolicy::AnyAllowlisted)
+        .read_latest_committee()
         .await?
         .context("no committee-update or genesis record found")?;
     let committee_epoch = move_committee.epoch;

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -128,10 +128,10 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         .get_session_info(&session_id, BuildPolicy::Current)
         .await?;
     ensure!(
-        verified_session.signing_pubkey == signing_pub_key,
+        verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
-    verify_oi_info_matches_provisioned_standby(&verified_session.info, &pre_info)?;
+    verify_oi_info_matches_provisioned_standby(verified_session.info(), &pre_info)?;
     info!(
         phase = "attestation pin",
         session_id = %session_id,

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -17,7 +17,6 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::ensure;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::CeremonyStage;
 use hashi_types::guardian::CeremonyState;
@@ -139,9 +138,7 @@ pub async fn run(cfg: Config) -> Result<()> {
     let mut reader = GuardianReader::new(&guardian_s3, allowlist)
         .await
         .context("connect to guardian log bucket")?;
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     let attested_signing_pub_key = verified_session.signing_pubkey();
     ensure!(
         attested_signing_pub_key == &signing_pub_key,
@@ -215,7 +212,7 @@ pub async fn run(cfg: Config) -> Result<()> {
         "cross-checking the latest guardian ceremony/ and kp-shares/ logs",
     );
     let logged = reader
-        .read_latest_ceremony_state(BuildPolicy::Current)
+        .read_latest_ceremony_state_from_current_build()
         .await?
         .context("no ceremony logs found in guardian S3 bucket")?;
     logged.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -21,7 +21,7 @@ use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::CeremonyStage;
 use hashi_types::guardian::CeremonyState;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::OperatorInitRequest;
 use hashi_types::guardian::SetupNewKeyRequest;
 use hashi_types::guardian::SetupNewKeyResponse;
@@ -165,14 +165,18 @@ pub async fn run(cfg: Config) -> Result<()> {
         .await
         .context("SetupNewKey RPC failed")?
         .into_inner();
-    let signed_resp = GuardianSigned::<SetupNewKeyResponse>::try_from(signed_resp_pb)
+    let signed_resp = GuardianSignedResponse::<SetupNewKeyResponse>::try_from(signed_resp_pb)
         .map_err(|e| anyhow!("decode SignedSetupNewKeyResponse: {e:?}"))?;
     info!(
         phase = "setup_new_key",
         n = cfg.kp_roster.num_shares,
         t = cfg.kp_roster.threshold,
-        share_count = signed_resp.data.encrypted_shares.share_count(),
-        ciphertext_count = signed_resp.data.encrypted_shares.ciphertext_count(),
+        share_count = signed_resp.data.response.encrypted_shares.share_count(),
+        ciphertext_count = signed_resp
+            .data
+            .response
+            .encrypted_shares
+            .ciphertext_count(),
         "setup_new_key response received",
     );
 
@@ -180,7 +184,8 @@ pub async fn run(cfg: Config) -> Result<()> {
     //    and sanity-check the shape; keep the now-authenticated BTC master pubkey.
     let response = signed_resp
         .authenticate(&signing_pub_key)
-        .map_err(|e| anyhow!("authenticate SetupNewKeyResponse: {e}"))?;
+        .map_err(|e| anyhow!("authenticate SetupNewKeyResponse: {e}"))?
+        .into_response();
     let live = CeremonyState::from(response);
     live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -142,9 +142,9 @@ pub async fn run(cfg: Config) -> Result<()> {
     let verified_session = reader
         .get_session_info(&session_id, BuildPolicy::Current)
         .await?;
-    let attested_signing_pub_key = verified_session.signing_pubkey;
+    let attested_signing_pub_key = verified_session.signing_pubkey();
     ensure!(
-        attested_signing_pub_key == signing_pub_key,
+        attested_signing_pub_key == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
     info!(

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -180,12 +180,12 @@ pub async fn run(cfg: Config) -> Result<()> {
         "setup_new_key response received",
     );
 
-    // 7. Authenticate the response under the pinned session's signing key,
-    //    and sanity-check the shape; keep the now-authenticated BTC master pubkey.
-    let response = signed_resp
-        .authenticate(&signing_pub_key)
-        .map_err(|e| anyhow!("authenticate SetupNewKeyResponse: {e}"))?
-        .into_response();
+    // 7. Verify the response under the pinned session's signing key,
+    //    and sanity-check the shape; keep the verified BTC master pubkey.
+    signed_resp
+        .verify_signature(&signing_pub_key)
+        .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e}"))?;
+    let response = signed_resp.data.into_response();
     let live = CeremonyState::from(response);
     live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -176,11 +176,11 @@ pub async fn run(cfg: Config) -> Result<()> {
         "setup_new_key response received",
     );
 
-    // 7. Verify the response signature under the pinned session's signing key,
-    //    and sanity-check the shape; keep the now-verified BTC master pubkey.
+    // 7. Authenticate the response under the pinned session's signing key,
+    //    and sanity-check the shape; keep the now-authenticated BTC master pubkey.
     let response = signed_resp
-        .verify(&signing_pub_key)
-        .map_err(|e| anyhow!("verify SetupNewKeyResponse signature: {e}"))?;
+        .authenticate(&signing_pub_key)
+        .map_err(|e| anyhow!("authenticate SetupNewKeyResponse: {e}"))?;
     let live = CeremonyState::from(response);
     live.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -244,10 +244,10 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         .get_session_info(&session_id, BuildPolicy::Current)
         .await?;
     ensure!(
-        verified_session.signing_pubkey == signing_pub_key,
+        verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
-    let oi_info = verified_session.info;
+    let oi_info = verified_session.into_info();
     ensure_oi_info_matches_post_init(&oi_info, &post.info)?;
     info!(
         phase = "attestation pin",

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -247,8 +247,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
-    let oi_info = verified_session.into_info();
-    ensure_oi_info_matches_post_init(&oi_info, &post.info)?;
+    ensure_oi_info_matches_post_init(verified_session.info(), &post.info)?;
     info!(
         phase = "attestation pin",
         session_id = %session_id,

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -4,7 +4,6 @@
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::ensure;
-use hashi_guardian::s3_reader::BuildPolicy;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::GenesisState;
 use hashi_types::guardian::GuardianInfo;
@@ -74,9 +73,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         phase = "committee",
         "checking latest committee-update/genesis record before operator_init",
     );
-    let latest_committee = reader
-        .read_latest_committee(BuildPolicy::AnyAllowlisted)
-        .await?;
+    let latest_committee = reader.read_latest_committee().await?;
     let genesis_state = match (do_genesis, latest_committee) {
         (false, Some(committee)) => {
             info!(
@@ -150,7 +147,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         "scraping authoritative ceremony/ and kp-shares/ logs",
     );
     let ceremony_state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state()
         .await?
         .context("no ceremony log found in S3; key setup has not run")?;
     ceremony_state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
@@ -240,9 +237,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         session_id = %session_id,
         "verifying S3 init logs match the live guardian session",
     );
-    let verified_session = reader
-        .get_session_info(&session_id, BuildPolicy::Current)
-        .await?;
+    let verified_session = reader.get_current_session_info(&session_id).await?;
     ensure!(
         verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -589,7 +589,7 @@ mod tests {
             current_committee_epoch: None,
             mpc_master_g: Some(master_g),
         };
-        let signed_info = GuardianSigned::new(info, &signing_key, 1);
+        let signed_info = GuardianSigned::sign(info, &signing_key, 1);
         let domain = GetGuardianInfoResponse::new(
             NitroAttestation::new(vec![1, 2, 3]),
             signing_key.verification_key(),

--- a/crates/hashi-guardian-proxy/src/cache.rs
+++ b/crates/hashi-guardian-proxy/src/cache.rs
@@ -415,6 +415,7 @@ mod tests {
     use hashi_types::bitcoin::sign_btc_tx;
     use hashi_types::guardian::proto_conversions::get_guardian_info_response_to_pb;
     use hashi_types::guardian::proto_conversions::signed_standard_withdrawal_request_to_pb;
+    use hashi_types::guardian::GuardianResponse;
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::GuardianSigned;
     use hashi_types::guardian::LimiterState;
@@ -589,7 +590,7 @@ mod tests {
             current_committee_epoch: None,
             mpc_master_g: Some(master_g),
         };
-        let signed_info = GuardianSigned::sign(info, &signing_key, 1);
+        let signed_info = GuardianSigned::sign(GuardianResponse::new(info, 1), &signing_key);
         let domain = GetGuardianInfoResponse::new(
             NitroAttestation::new(vec![1, 2, 3]),
             signing_key.verification_key(),

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -45,7 +45,7 @@ fn verify_provisioner_rotate_cert_signature(
     let signed_request = KpSigned::<ProvisionerRotateCertRequest>::try_from(request.clone())
         .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
     signed_request
-        .authenticate()
+        .verify_signature()
         .map_err(|error| Status::unauthenticated(error.to_string()))?;
     Ok(())
 }

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -45,7 +45,7 @@ fn verify_provisioner_rotate_cert_signature(
     let signed_request = KpSigned::<ProvisionerRotateCertRequest>::try_from(request.clone())
         .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
     signed_request
-        .verify()
+        .authenticate()
         .map_err(|error| Status::unauthenticated(error.to_string()))?;
     Ok(())
 }

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -20,6 +20,7 @@
 use crate::metrics::ProxyMetrics;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::log::S3_DIR_WITHDRAW;
+use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
@@ -168,7 +169,15 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    let entry = record.into_entry_unchecked()?;
+    if let LogRecord::Unsigned(entry) = &record {
+        let message = if entry.message().is_allowed_unsigned() {
+            "expected signed log record but message is unsigned"
+        } else {
+            "missing log signature"
+        };
+        return Err(InvalidS3Log(message.into()).into());
+    }
+    let entry = record.into_entry_unchecked();
     let timestamp_ms = entry.timestamp_ms();
     let message = match entry.into_message() {
         VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -166,9 +166,7 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    let signed = record.into_signed()?;
-    let timestamp_ms = signed.data.timestamp_ms();
-    let (_, message) = signed.into_data_unchecked().into_current()?;
+    let (_, timestamp_ms, message) = record.into_current_unchecked()?;
     let LogMessage::Withdrawal(message) = message else {
         anyhow::bail!("not a withdrawal record");
     };

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -20,7 +20,6 @@
 use crate::metrics::ProxyMetrics;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::log::S3_DIR_WITHDRAW;
-use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
@@ -306,6 +305,7 @@ pub(crate) mod test_store {
     use bitcoin::hashes::Hash as _;
     use bitcoin::Network;
     use hashi_types::guardian::GuardianSignKeyPair;
+    use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::StandardWithdrawalRequestWire;

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -20,7 +20,6 @@
 use crate::metrics::ProxyMetrics;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::log::S3_DIR_WITHDRAW;
-use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
@@ -169,14 +168,6 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    if let LogRecord::Unsigned(entry) = &record {
-        let message = if entry.message().is_allowed_unsigned() {
-            "expected signed log record but message is unsigned"
-        } else {
-            "missing log signature"
-        };
-        return Err(InvalidS3Log(message.into()).into());
-    }
     let entry = record.into_entry_unchecked();
     let timestamp_ms = entry.timestamp_ms();
     let message = match entry.into_message() {

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -21,8 +21,11 @@ use crate::metrics::ProxyMetrics;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::log::S3_DIR_WITHDRAW;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::StandardWithdrawalResponse;
+use hashi_types::guardian::VersionedLogMessage;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::WithdrawalLogMessage;
 use tracing::warn;
@@ -166,9 +169,14 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    let (_, timestamp_ms, message) = record.into_current_unchecked()?;
-    let LogMessage::Withdrawal(message) = message else {
-        anyhow::bail!("not a withdrawal record");
+    let entry = record.into_entry_unchecked()?;
+    let timestamp_ms = entry.timestamp_ms();
+    let message = match entry.into_message() {
+        VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,
+        VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) => message,
+        VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            anyhow::bail!("not a withdrawal record");
+        }
     };
     let WithdrawalLogMessage::Success {
         request_data,

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -166,8 +166,10 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    let timestamp_ms = record.timestamp_ms;
-    let LogMessage::Withdrawal(message) = record.message.into_current()? else {
+    let signed = record.into_signed()?;
+    let timestamp_ms = signed.data.timestamp_ms();
+    let (_, message) = signed.into_data_unchecked().into_current()?;
+    let LogMessage::Withdrawal(message) = message else {
         anyhow::bail!("not a withdrawal record");
     };
     let WithdrawalLogMessage::Success {

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -209,7 +209,7 @@ mod tests {
     ) -> KPEncryptedSharesRoster {
         let signed = rotate_kps(enclave.clone(), req).await.expect("ok");
         signed
-            .verify(&enclave.signing_pubkey())
+            .authenticate(&enclave.signing_pubkey())
             .expect("response signed by enclave")
             .encrypted_shares
     }

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -136,6 +136,7 @@ mod tests {
     use hashi_types::guardian::GuardianError::InvalidInputs;
     use hashi_types::guardian::GuardianError::LifecycleMismatch;
     use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;
     use k256::SecretKey;
@@ -253,7 +254,7 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Ceremony(ceremony)) = record.message() else {
             panic!("expected V2 Ceremony variant");
         };
         let CeremonyLogMessage::Rotate {
@@ -299,7 +300,7 @@ mod tests {
             "expected sharing_seq=1 cert_seq=0, got key {shares_key}"
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message()
+        let VersionedLogMessage::V2(LogMessageV2::KpShareState(shares)) = shares_record.message()
         else {
             panic!("expected V2 KpShareState variant");
         };

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -135,7 +135,6 @@ mod tests {
     use hashi_types::guardian::test_utils::mock_kp_certs_roster;
     use hashi_types::guardian::GuardianError::InvalidInputs;
     use hashi_types::guardian::GuardianError::LifecycleMismatch;
-    use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -209,10 +209,9 @@ mod tests {
     ) -> KPEncryptedSharesRoster {
         let signed = rotate_kps(enclave.clone(), req).await.expect("ok");
         signed
-            .authenticate(&enclave.signing_pubkey())
-            .expect("response signed by enclave")
-            .into_response()
-            .encrypted_shares
+            .verify_signature(&enclave.signing_pubkey())
+            .expect("response signed by enclave");
+        signed.data.into_response().encrypted_shares
     }
 
     /// Assert the rotation returned `new_n` PGP-armored shares and produced

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -18,7 +18,7 @@ use tracing::info;
 pub async fn rotate_kps(
     enclave: Arc<Enclave>,
     request: RotateKpsRequest,
-) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
+) -> GuardianResult<GuardianSignedResponse<RotateKpsResponse>> {
     info!("/rotate_kps - Received request.");
 
     enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
@@ -59,7 +59,7 @@ async fn finalize_rotation(
     old_shares: &[Share],
     old_instance: &SecretSharingInstance,
     state: RotateKpsState,
-) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
+) -> GuardianResult<GuardianSignedResponse<RotateKpsResponse>> {
     info!("Threshold reached, reconstructing BTC key.");
 
     let k256_sk =
@@ -211,6 +211,7 @@ mod tests {
         signed
             .authenticate(&enclave.signing_pubkey())
             .expect("response signed by enclave")
+            .into_response()
             .encrypted_shares
     }
 
@@ -253,14 +254,14 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message else {
+        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message() else {
             panic!("expected V2 Ceremony variant");
         };
         let CeremonyLogMessage::Rotate {
             old_instance,
             new_instance,
             btc_master_pubkey,
-        } = *ceremony
+        } = ceremony.as_ref()
         else {
             panic!("expected Rotate variant");
         };
@@ -282,7 +283,7 @@ mod tests {
         let reconstructed = combine_shares(&decrypted_shares[..new_t], new_t).unwrap();
         assert_eq!(
             k256_sk_to_btc_xonly_pubkey(&reconstructed),
-            btc_master_pubkey,
+            *btc_master_pubkey,
             "threshold decrypted rotation shares should reconstruct the original key"
         );
 
@@ -299,10 +300,11 @@ mod tests {
             "expected sharing_seq=1 cert_seq=0, got key {shares_key}"
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message
+        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message()
         else {
             panic!("expected V2 KpShareState variant");
         };
+        let shares = shares.as_ref();
         assert_eq!(shares.sharing_seq, 1);
         assert_eq!(shares.cert_seq, 0);
         assert_eq!(shares.encrypted_shares, *response_shares);

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -16,7 +16,7 @@ use tracing::info;
 pub async fn setup_new_key(
     enclave: Arc<Enclave>,
     request: SetupNewKeyRequest,
-) -> GuardianResult<GuardianSigned<SetupNewKeyResponse>> {
+) -> GuardianResult<GuardianSignedResponse<SetupNewKeyResponse>> {
     info!("/setup_new_key - Received request.");
 
     enclave.require_lifecycle(CeremonyStage::OperatorInitialized.into())?;
@@ -119,7 +119,7 @@ mod tests {
         let verification_key = &enclave.signing_pubkey();
         let (request, secret_keys) = mock_setup_new_key_request();
         let resp = setup_new_key(enclave.clone(), request).await.unwrap();
-        let validated_resp = resp.authenticate(verification_key).unwrap();
+        let validated_resp = resp.authenticate(verification_key).unwrap().into_response();
         assert_eq!(enclave.lifecycle(), CeremonyStage::Completed.into());
 
         // Response still carries the armored ciphertexts.
@@ -162,22 +162,22 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message else {
+        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message() else {
             panic!("expected V2 Ceremony variant");
         };
         let CeremonyLogMessage::NewKey {
             instance,
             btc_master_pubkey,
-        } = *ceremony
+        } = ceremony.as_ref()
         else {
             panic!("expected NewKey variant");
         };
-        assert_eq!(instance, validated_resp.secret_sharing_instance);
+        assert_eq!(instance, &validated_resp.secret_sharing_instance);
         assert_eq!(instance.sharing_seq(), 0);
         assert_eq!(instance.num_shares(), TEST_N);
         assert_eq!(instance.threshold(), TEST_T);
         // The ceremony log records the same BTC master pubkey as the response.
-        assert_eq!(btc_master_pubkey, validated_resp.btc_master_pubkey);
+        assert_eq!(*btc_master_pubkey, validated_resp.btc_master_pubkey);
 
         // The encrypted shares are persisted to kp-shares/ keyed by sharing_seq
         // and cert_seq, and carry the ciphertexts the ceremony log omits.
@@ -197,10 +197,11 @@ mod tests {
             )
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message
+        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message()
         else {
             panic!("expected V2 KpShareState variant");
         };
+        let shares = shares.as_ref();
         assert_eq!(shares.sharing_seq, 0);
         assert_eq!(shares.cert_seq, 0);
         assert_eq!(shares.encrypted_shares, validated_resp.encrypted_shares);

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -97,7 +97,6 @@ mod tests {
     use crate::test_utils::decrypt_kp_shares;
     use crate::test_utils::mock_kp_certs_roster_with_secrets;
     use hashi_types::guardian::crypto::combine_shares;
-    use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -98,6 +98,7 @@ mod tests {
     use crate::test_utils::mock_kp_certs_roster_with_secrets;
     use hashi_types::guardian::crypto::combine_shares;
     use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;
 
@@ -163,7 +164,7 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Ceremony(ceremony)) = record.message() else {
             panic!("expected V2 Ceremony variant");
         };
         let CeremonyLogMessage::NewKey {
@@ -198,7 +199,7 @@ mod tests {
             )
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message()
+        let VersionedLogMessage::V2(LogMessageV2::KpShareState(shares)) = shares_record.message()
         else {
             panic!("expected V2 KpShareState variant");
         };

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -119,7 +119,7 @@ mod tests {
         let verification_key = &enclave.signing_pubkey();
         let (request, secret_keys) = mock_setup_new_key_request();
         let resp = setup_new_key(enclave.clone(), request).await.unwrap();
-        let validated_resp = resp.verify(verification_key).unwrap();
+        let validated_resp = resp.authenticate(verification_key).unwrap();
         assert_eq!(enclave.lifecycle(), CeremonyStage::Completed.into());
 
         // Response still carries the armored ciphertexts.

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -119,7 +119,8 @@ mod tests {
         let verification_key = &enclave.signing_pubkey();
         let (request, secret_keys) = mock_setup_new_key_request();
         let resp = setup_new_key(enclave.clone(), request).await.unwrap();
-        let validated_resp = resp.authenticate(verification_key).unwrap().into_response();
+        resp.verify_signature(verification_key).unwrap();
+        let validated_resp = resp.data.into_response();
         assert_eq!(enclave.lifecycle(), CeremonyStage::Completed.into());
 
         // Response still carries the armored ciphertexts.

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -492,10 +492,10 @@ impl Enclave {
         self.config.signing_keys.verification_key()
     }
 
-    pub fn sign<T: SigningIntent>(&self, data: T) -> GuardianSigned<T> {
+    pub fn sign<T: GuardianSigningIntent>(&self, data: T) -> GuardianSigned<T> {
         let kp = &self.config.signing_keys;
         let timestamp = now_timestamp_ms();
-        GuardianSigned::new(data, kp, timestamp)
+        GuardianSigned::sign(data, kp, timestamp)
     }
 
     // ========================================================================

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -492,10 +492,10 @@ impl Enclave {
         self.config.signing_keys.verification_key()
     }
 
-    pub fn sign<T: GuardianSigningIntent>(&self, data: T) -> GuardianSigned<T> {
+    pub fn sign<T: GuardianSigningIntent>(&self, response: T) -> GuardianSignedResponse<T> {
         let kp = &self.config.signing_keys;
         let timestamp = now_timestamp_ms();
-        GuardianSigned::sign(data, kp, timestamp)
+        GuardianSigned::sign(GuardianResponse::new(response, timestamp), kp)
     }
 
     // ========================================================================

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -21,7 +21,6 @@ use hashi_types::guardian::GuardianError::LifecycleMismatch;
 use hashi_types::guardian::GuardianError::Unavailable;
 use hashi_types::guardian::*;
 use hpke::Serializable;
-use serde::Serialize;
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -493,7 +492,7 @@ impl Enclave {
         self.config.signing_keys.verification_key()
     }
 
-    pub fn sign<T: Serialize + SigningIntent>(&self, data: T) -> GuardianSigned<T> {
+    pub fn sign<T: SigningIntent>(&self, data: T) -> GuardianSigned<T> {
         let kp = &self.config.signing_keys;
         let timestamp = now_timestamp_ms();
         GuardianSigned::new(data, kp, timestamp)

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -8,7 +8,6 @@
 
 use crate::attestation::get_attestation;
 use crate::enclave::TemporaryInitState;
-use crate::s3_reader::BuildPolicy;
 use crate::s3_reader::GuardianReader;
 use crate::Enclave;
 use crate::GuardianS3Client;
@@ -64,7 +63,7 @@ impl OIWithdrawModeInstall {
         let mut reader =
             GuardianReader::from_s3_client(logger.clone(), config.pcr_allowlist().clone());
         let ceremony_state = reader
-            .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+            .read_latest_ceremony_state()
             .await?
             .ok_or_else(|| InvalidInputs("no ceremony log found for withdraw init".into()))?;
 

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -271,12 +271,12 @@ mod tests {
         let attestation: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert!(matches!(
             attestation.message(),
-            VersionedLogMessage::V2(LogMessage::Init(message))
+            VersionedLogMessage::V2(LogMessageV2::Init(message))
                 if matches!(message.as_ref(), OIAttestationUnsigned { .. })
         ));
 
         let guardian_info: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Init(message)) = guardian_info.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Init(message)) = guardian_info.message() else {
             panic!("expected V2 init record");
         };
         let OIGuardianInfo(info) = message.as_ref() else {

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -270,16 +270,16 @@ mod tests {
 
         let attestation: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert!(matches!(
-            attestation.message,
+            attestation.message(),
             VersionedLogMessage::V2(LogMessage::Init(message))
-                if matches!(*message, OIAttestationUnsigned { .. })
+                if matches!(message.as_ref(), OIAttestationUnsigned { .. })
         ));
 
         let guardian_info: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Init(message)) = guardian_info.message else {
+        let VersionedLogMessage::V2(LogMessage::Init(message)) = guardian_info.message() else {
             panic!("expected V2 init record");
         };
-        let OIGuardianInfo(info) = *message else {
+        let OIGuardianInfo(info) = message.as_ref() else {
             panic!("expected operator-init GuardianInfo record");
         };
         assert_eq!(info.lifecycle, expected_lifecycle);

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -637,7 +637,8 @@ impl GuardianS3Client {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) = attestation_record.into_unsigned()?.validate()?;
+        let (_, _, attestation_message) =
+            attestation_record.into_unsigned()?.validate_unsigned()?;
         let (attestation, signing_pubkey) = attestation_message
             .into_init_log()
             .and_then(|x| match x {
@@ -655,8 +656,8 @@ impl GuardianS3Client {
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
         let signed = info_record.into_signed()?;
-        let timestamp_ms = signed.timestamp_ms;
-        signed.data.validate(timestamp_ms, &signing_pubkey)?;
+        let timestamp_ms = signed.data.timestamp_ms();
+        signed.data.validate(&signing_pubkey)?;
         let data = signed
             .authenticate(&signing_pubkey)
             .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
@@ -1030,7 +1031,7 @@ mod tests {
         let error = record
             .into_unsigned()
             .unwrap()
-            .validate()
+            .validate_unsigned()
             .expect_err("the copied key must still fail canonical validation");
 
         assert!(

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -637,8 +637,7 @@ impl GuardianS3Client {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) =
-            attestation_record.into_unsigned()?.validate_unsigned()?;
+        let (_, _, attestation_message) = attestation_record.validate_unsigned()?;
         let (attestation, signing_pubkey) = attestation_message
             .into_init_log()
             .and_then(|x| match x {
@@ -655,12 +654,7 @@ impl GuardianS3Client {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
-        let signed = info_record.into_signed()?;
-        signed.data.validate(&signing_pubkey)?;
-        let data = signed
-            .authenticate(&signing_pubkey)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-        let (_, info_message) = data.into_current()?;
+        let (_, _, info_message) = info_record.validate(&signing_pubkey)?;
         let info = info_message
             .into_init_log()
             .and_then(|x| match x {
@@ -1028,8 +1022,6 @@ mod tests {
             .await
             .expect("the embedded key matches the actual S3 key");
         let error = record
-            .into_unsigned()
-            .unwrap()
             .validate_unsigned()
             .expect_err("the copied key must still fail canonical validation");
 

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -609,7 +609,12 @@ impl GuardianS3Client {
                 key, e
             ))
         })?;
-        record.validate_actual_object_key(key)?;
+        if record.object_key() != key {
+            return Err(InvalidS3Log(format!(
+                "S3 object key mismatch: record contains {}, actual key is {key}",
+                record.object_key()
+            )));
+        }
         Ok(record)
     }
 
@@ -976,5 +981,80 @@ mod tests {
             matches!(error, S3Error(message) if message.contains("expired object lock metadata"))
         );
         assert_eq!(get_expired.num_calls(), 1);
+    }
+
+    async fn assert_log_read_rejects_relocation(relocated_key: &str) {
+        let signing_key = GuardianSignKeyPair::from([13u8; 32]);
+        let record = LogRecord::new_at_timestamp(
+            "session".into(),
+            LogMessage::Heartbeat(HeartbeatLogMessage::new(42)),
+            &signing_key,
+            1_700_000_000_000,
+        );
+        let intended_key = record.object_key().to_string();
+        let body = serde_json::to_vec(&record).unwrap();
+        let relocated_key = relocated_key.to_string();
+        let mock_key = relocated_key.clone();
+        let get_relocated = mock!(Client::get_object)
+            .match_requests(move |req| {
+                req.bucket() == Some("bucket") && req.key() == Some(mock_key.as_str())
+            })
+            .then_output(move || {
+                GetObjectOutput::builder()
+                    .body(ByteStream::from(body.clone()))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&get_relocated]);
+        let logger = mk_logger_with_client(client);
+
+        let error = logger
+            .get_log_record_inner(
+                &relocated_key,
+                LockCheck::Skipped,
+                HistoryCheck::AlreadyChecked,
+            )
+            .await
+            .expect_err("a relocated record must be rejected");
+
+        assert!(matches!(
+            error,
+            InvalidS3Log(message)
+                if message == format!(
+                    "S3 object key mismatch: record contains {intended_key}, actual key is {relocated_key}"
+                )
+        ));
+        assert_eq!(get_relocated.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn signed_log_rejects_cross_prefix_relocation() {
+        assert_log_read_rejects_relocation(
+            "withdraw/2023/11/14/22/session-00000000000000000042.json",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn signed_log_rejects_lexicographically_higher_key_relocation() {
+        assert_log_read_rejects_relocation(
+            "heartbeat/2023/11/14/22/session-00000000000000000043.json",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn signed_log_rejects_future_hour_relocation() {
+        assert_log_read_rejects_relocation(
+            "heartbeat/2023/11/14/23/session-00000000000000000042.json",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn signed_log_rejects_changed_session_relocation() {
+        assert_log_read_rejects_relocation(
+            "heartbeat/2023/11/14/22/aliased-session-00000000000000000042.json",
+        )
+        .await;
     }
 }

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -654,7 +654,7 @@ impl GuardianS3Client {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
-        let (_, _, info_message) = info_record.verify(&signing_pubkey)?;
+        let (_, _, info_message) = info_record.validate_signed(&signing_pubkey)?;
         let info = info_message
             .into_init_log()
             .and_then(|x| match x {
@@ -704,6 +704,8 @@ mod tests {
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::HeartbeatLogMessage;
     use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::NitroAttestation;
+    use hashi_types::guardian::SessionID;
 
     fn mk_logger_with_client(client: Client) -> GuardianS3Client {
         let config = S3Config {
@@ -981,6 +983,51 @@ mod tests {
             matches!(error, S3Error(message) if message.contains("expired object lock metadata"))
         );
         assert_eq!(get_expired.num_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn unsigned_log_replay_reaches_canonical_key_validation() {
+        let signing_key = GuardianSignKeyPair::from([14u8; 32]);
+        let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
+        let mut record = LogRecord::new_at_timestamp(
+            session_id,
+            LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
+                attestation: NitroAttestation::new(vec![1, 2, 3]),
+                signing_public_key: signing_key.verification_key(),
+            })),
+            &signing_key,
+            1_700_000_000_000,
+        );
+        record.object_key = "init/copied-attestation.json".to_string();
+        let body = serde_json::to_vec(&record).unwrap();
+        let get_copied = mock!(Client::get_object)
+            .match_requests(|req| {
+                req.bucket() == Some("bucket") && req.key() == Some("init/copied-attestation.json")
+            })
+            .then_output(move || {
+                GetObjectOutput::builder()
+                    .body(ByteStream::from(body.clone()))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&get_copied]);
+        let logger = mk_logger_with_client(client);
+
+        let record = logger
+            .get_log_record_inner(
+                "init/copied-attestation.json",
+                LockCheck::Skipped,
+                HistoryCheck::AlreadyChecked,
+            )
+            .await
+            .expect("the embedded key matches the actual S3 key");
+        let error = record
+            .validate_unsigned()
+            .expect_err("the copied key must still fail canonical validation");
+
+        assert!(
+            matches!(error, InvalidS3Log(message) if message.contains("non-canonical S3 object key"))
+        );
+        assert_eq!(get_copied.num_calls(), 1);
     }
 
     async fn assert_log_read_rejects_relocation(relocated_key: &str) {

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -637,7 +637,7 @@ impl GuardianS3Client {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) = attestation_record.validate_unsigned()?;
+        let (_, _, attestation_message) = attestation_record.validate(None)?;
         let (attestation, signing_pubkey) = attestation_message
             .into_init_log()
             .and_then(|x| match x {
@@ -654,7 +654,7 @@ impl GuardianS3Client {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
-        let (_, _, info_message) = info_record.validate(&signing_pubkey)?;
+        let (_, _, info_message) = info_record.validate(Some(&signing_pubkey))?;
         let info = info_message
             .into_init_log()
             .and_then(|x| match x {
@@ -1022,7 +1022,7 @@ mod tests {
             .await
             .expect("the embedded key matches the actual S3 key");
         let error = record
-            .validate_unsigned()
+            .validate(None)
             .expect_err("the copied key must still fail canonical validation");
 
         assert!(

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -371,22 +371,18 @@ impl GuardianS3Client {
     }
 }
 
-/// Controls whether an S3 read requires Compliance-mode object-lock metadata.
-pub(crate) enum LockCheck {
-    /// Reject the object unless its Compliance lock is still unexpired.
+/// Controls whether an S3 read establishes that the object is still immutable.
+#[derive(Clone, Copy)]
+pub(crate) enum ImmutabilityCheck {
+    /// Validate the exact key has no mutation history and reject the object
+    /// unless its Compliance lock is still unexpired.
     Required,
-    /// Do not inspect lock metadata. Used for signed records whose short lock
-    /// is expected to expire, such as KP-share state.
+    /// The caller already validated the enclosing prefix has no mutations;
+    /// still reject the object unless its Compliance lock is unexpired.
+    MutationAlreadyChecked,
+    /// Do not claim S3 immutability. Used for signed records whose short locks
+    /// are expected to expire, such as KP-share state.
     Skipped,
-}
-
-/// Controls whether an S3 read validates that the key has no overwrite or
-/// deletion history.
-pub(crate) enum HistoryCheck {
-    /// Validate the exact key's history before fetching it.
-    Required,
-    /// The caller already validated the history of the enclosing prefix.
-    AlreadyChecked,
 }
 
 impl GuardianS3Client {
@@ -438,12 +434,15 @@ impl GuardianS3Client {
         Ok(out.into_iter().collect())
     }
 
-    /// Lists every key under `prefix`, refusing to proceed if any matching
-    /// object has a delete marker or non-latest version. The prefix may be a
-    /// directory or a complete object key. Returned keys are unique and sorted.
-    pub async fn validate_prefix_history_and_list_keys(
+    /// Lists the currently visible keys under `prefix` using S3 version
+    /// history. When `reject_mutations` is true, any overwrite or deletion is
+    /// rejected; otherwise it is logged and only the latest visible versions
+    /// are returned. Mutation validation establishes immutability only when
+    /// each selected object also has an unexpired lock.
+    pub(crate) async fn list_keys(
         &self,
         prefix: &str,
+        reject_mutations: bool,
     ) -> GuardianResult<Vec<String>> {
         let s3_client = &self.client;
         let s3_config = &self.config;
@@ -451,6 +450,7 @@ impl GuardianS3Client {
         let mut key_marker: Option<String> = None;
         let mut version_id_marker: Option<String> = None;
         let mut seen_keys: BTreeSet<String> = BTreeSet::new();
+        let mut found_mutation = false;
 
         loop {
             let mut req = s3_client
@@ -473,10 +473,13 @@ impl GuardianS3Client {
             })?;
 
             if !response.delete_markers().is_empty() {
-                return Err(S3Error(format!(
-                    "Delete marker found under prefix {}",
-                    prefix
-                )));
+                if reject_mutations {
+                    return Err(S3Error(format!(
+                        "Delete marker found under prefix {}",
+                        prefix
+                    )));
+                }
+                found_mutation = true;
             }
 
             // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ObjectVersion.html
@@ -488,18 +491,25 @@ impl GuardianS3Client {
                 // NOTE: If an object's lock expires, then all bets are off.
                 // For example, is_latest could be true even though an older version of it was deleted (post lock expiry).
                 if version.is_latest() != Some(true) {
-                    return Err(S3Error(format!(
-                        "Non-latest version found for key {} under prefix {}",
-                        key, prefix
-                    )));
+                    if reject_mutations {
+                        return Err(S3Error(format!(
+                            "Non-latest version found for key {} under prefix {}",
+                            key, prefix
+                        )));
+                    }
+                    found_mutation = true;
+                    continue;
                 }
 
                 if !seen_keys.insert(key.to_string()) {
-                    // this check is redundant as we ensure is_latest = true above
-                    return Err(S3Error(format!(
-                        "Duplicate version found for key {} under prefix {}",
-                        key, prefix
-                    )));
+                    if reject_mutations {
+                        // This check is redundant as we ensure is_latest = true above.
+                        return Err(S3Error(format!(
+                            "Duplicate version found for key {} under prefix {}",
+                            key, prefix
+                        )));
+                    }
+                    found_mutation = true;
                 }
             }
 
@@ -518,44 +528,47 @@ impl GuardianS3Client {
             }
         }
 
+        if found_mutation {
+            warn!(
+                prefix,
+                "S3 object mutation found; continuing because mutation rejection is disabled"
+            );
+        }
         Ok(seen_keys.into_iter().collect())
     }
 
-    /// Batch read. Callers must ensure that all objects with prefix `dir.to_string()` have
-    /// unexpired compliance-mode object locks.
-    ///
-    /// Each returned record's signed object key is checked against the actual
-    /// S3 key from which it was read.
+    /// Batch read that rejects mutations under the directory and requires an
+    /// unexpired Compliance lock on every object. Each returned record's signed
+    /// object key is also checked against the actual S3 key.
     pub async fn list_all_log_records_in_dir(
         &self,
         dir: &S3HourScopedDirectory,
     ) -> GuardianResult<Vec<LogRecord>> {
         let prefix = dir.to_string();
-        let keys = self.validate_prefix_history_and_list_keys(&prefix).await?;
+        let keys = self.list_keys(&prefix, true).await?;
         let mut out = Vec::with_capacity(keys.len());
         for key in keys {
-            // The prefix history was checked above. Immutable batch logs are
-            // also expected to remain under Compliance lock.
+            // Mutations were checked across the prefix above; each selected
+            // object must still have an unexpired Compliance lock.
             out.push(
-                self.get_log_record_inner(&key, LockCheck::Required, HistoryCheck::AlreadyChecked)
+                self.get_log_record_inner(&key, ImmutabilityCheck::MutationAlreadyChecked)
                     .await?,
             );
         }
         Ok(out)
     }
 
-    /// Fetches and deserializes a record with explicit S3 integrity checks,
-    /// always rejecting a mismatch between its signed intended key and the
-    /// actual S3 key. `HistoryCheck::AlreadyChecked` requires the caller to have
-    /// validated the key's enclosing prefix.
+    /// Fetches and deserializes a record with the requested S3 immutability
+    /// policy, always rejecting a mismatch between its signed intended key and
+    /// the actual S3 key. `ImmutabilityCheck::MutationAlreadyChecked` requires
+    /// the caller to have validated the key's enclosing prefix.
     pub(crate) async fn get_log_record_inner(
         &self,
         key: &str,
-        lock_check: LockCheck,
-        history_check: HistoryCheck,
+        immutability_check: ImmutabilityCheck,
     ) -> GuardianResult<LogRecord> {
-        if matches!(history_check, HistoryCheck::Required) {
-            let keys = self.validate_prefix_history_and_list_keys(key).await?;
+        if matches!(immutability_check, ImmutabilityCheck::Required) {
+            let keys = self.list_keys(key, true).await?;
             if keys.len() != 1 || keys[0] != key {
                 return Err(S3Error(format!(
                     "expected exactly one object for key {}, found {:?}",
@@ -579,7 +592,7 @@ impl GuardianS3Client {
                 ))
             })?;
 
-        if matches!(lock_check, LockCheck::Required)
+        if !matches!(immutability_check, ImmutabilityCheck::Skipped)
             && !has_unexpired_compliance_lock(
                 response.object_lock_mode(),
                 response.object_lock_retain_until_date(),
@@ -615,9 +628,10 @@ impl GuardianS3Client {
         Ok(record)
     }
 
-    /// Reads an immutable-log object, asserting its Compliance lock is unexpired.
+    /// Reads an immutable log, rejecting mutation history and requiring an
+    /// unexpired Compliance lock.
     pub(crate) async fn get_log_record(&self, key: &str) -> GuardianResult<LogRecord> {
-        self.get_log_record_inner(key, LockCheck::Required, HistoryCheck::Required)
+        self.get_log_record_inner(key, ImmutabilityCheck::Required)
             .await
     }
 }
@@ -918,7 +932,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
 
         let error = logger
-            .get_log_record_inner("key", LockCheck::Required, HistoryCheck::AlreadyChecked)
+            .get_log_record_inner("key", ImmutabilityCheck::MutationAlreadyChecked)
             .await
             .expect_err("an expired required lock must be rejected");
 
@@ -957,11 +971,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
 
         let record = logger
-            .get_log_record_inner(
-                "init/copied-attestation.json",
-                LockCheck::Skipped,
-                HistoryCheck::AlreadyChecked,
-            )
+            .get_log_record_inner("init/copied-attestation.json", ImmutabilityCheck::Skipped)
             .await
             .expect("the embedded key matches the actual S3 key");
         let error = record
@@ -999,11 +1009,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
 
         let error = logger
-            .get_log_record_inner(
-                &relocated_key,
-                LockCheck::Skipped,
-                HistoryCheck::AlreadyChecked,
-            )
+            .get_log_record_inner(&relocated_key, ImmutabilityCheck::Skipped)
             .await
             .expect_err("a relocated record must be rejected");
 

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -23,9 +23,6 @@ use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianError::S3Error;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::InitLogMessage;
-use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::VerifiedSessionInfo;
 use serde::Serialize;
 use tracing::info;
 use tracing::warn;
@@ -623,61 +620,6 @@ impl GuardianS3Client {
         self.get_log_record_inner(key, LockCheck::Required, HistoryCheck::Required)
             .await
     }
-
-    /// Resolve a session's [`VerifiedSessionInfo`]: read the AWS-self-signed
-    /// attestation (anchoring the signing pubkey), then the signed `GuardianInfo`,
-    /// and pin the attestation's PCR0 against the `allowlist` entry named by the
-    /// info's reported build. No caller needs the raw attestation bytes.
-    pub(crate) async fn get_verified_session_info(
-        &self,
-        session_id: &str,
-        allowlist: &PcrAllowlist,
-    ) -> GuardianResult<VerifiedSessionInfo> {
-        // 1. Attestation (unsigned: authenticated by AWS, not the enclave key) →
-        //    the signing pubkey it commits to.
-        let att_key = InitLogMessage::attestation_object_key(session_id);
-        let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) = attestation_record.validate(None)?;
-        let (attestation, signing_pubkey) = attestation_message
-            .into_init_log()
-            .and_then(|x| match x {
-                InitLogMessage::OIAttestationUnsigned {
-                    attestation,
-                    signing_public_key,
-                } => Some((attestation, signing_public_key)),
-                _ => None,
-            })
-            .ok_or_else(|| {
-                InvalidS3Log(format!("expected OIAttestationUnsigned at key {att_key}"))
-            })?;
-
-        // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
-        let info_key = InitLogMessage::guardian_info_object_key(session_id);
-        let info_record = self.get_log_record(&info_key).await?;
-        let (_, _, info_message) = info_record.validate(Some(&signing_pubkey))?;
-        let info = info_message
-            .into_init_log()
-            .and_then(|x| match x {
-                InitLogMessage::OIGuardianInfo(info) => Some(*info),
-                _ => None,
-            })
-            .ok_or_else(|| InvalidS3Log(format!("expected OIGuardianInfo at key {info_key}")))?;
-
-        // 3. Anchor the pubkey and pin PCR0 to the allowlist entry for the
-        //    reported build. This replays a logged attestation whose short-lived
-        //    leaf cert has typically expired, so the chain is checked at the
-        //    document's own signed timestamp, not now.
-        let build_pcrs = allowlist.resolve(&info.untrusted_git_revision)?.clone();
-        attestation
-            .verify_replay(&signing_pubkey, &build_pcrs)
-            .map_err(|e| InvalidS3Log(format!("attestation at key {att_key}: {e}")))?;
-
-        Ok(VerifiedSessionInfo {
-            signing_pubkey,
-            info,
-            build_pcrs,
-        })
-    }
 }
 
 // TODO(testnet-wipe): Once legacy seven-day logs are gone, also verify that the
@@ -703,6 +645,7 @@ mod tests {
     use aws_smithy_mocks::RuleMode;
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::HeartbeatLogMessage;
+    use hashi_types::guardian::InitLogMessage;
     use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::NitroAttestation;
     use hashi_types::guardian::SessionID;

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -656,7 +656,6 @@ impl GuardianS3Client {
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
         let signed = info_record.into_signed()?;
-        let timestamp_ms = signed.data.timestamp_ms();
         signed.data.validate(&signing_pubkey)?;
         let data = signed
             .authenticate(&signing_pubkey)

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -637,7 +637,7 @@ impl GuardianS3Client {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) = attestation_record.validate_unsigned()?;
+        let (_, _, attestation_message) = attestation_record.into_unsigned()?.validate()?;
         let (attestation, signing_pubkey) = attestation_message
             .into_init_log()
             .and_then(|x| match x {
@@ -654,7 +654,13 @@ impl GuardianS3Client {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = self.get_log_record(&info_key).await?;
-        let (_, _, info_message) = info_record.validate_signed(&signing_pubkey)?;
+        let signed = info_record.into_signed()?;
+        let timestamp_ms = signed.timestamp_ms;
+        signed.data.validate(timestamp_ms, &signing_pubkey)?;
+        let data = signed
+            .authenticate(&signing_pubkey)
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        let (_, info_message) = data.into_current()?;
         let info = info_message
             .into_init_log()
             .and_then(|x| match x {
@@ -989,7 +995,7 @@ mod tests {
     async fn unsigned_log_replay_reaches_canonical_key_validation() {
         let signing_key = GuardianSignKeyPair::from([14u8; 32]);
         let session_id = SessionID::from_signing_pubkey(&signing_key.verification_key());
-        let mut record = LogRecord::new_at_timestamp(
+        let record = LogRecord::new_at_timestamp(
             session_id,
             LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
                 attestation: NitroAttestation::new(vec![1, 2, 3]),
@@ -998,8 +1004,9 @@ mod tests {
             &signing_key,
             1_700_000_000_000,
         );
-        record.object_key = "init/copied-attestation.json".to_string();
-        let body = serde_json::to_vec(&record).unwrap();
+        let mut record_json = serde_json::to_value(record).unwrap();
+        record_json["object_key"] = "init/copied-attestation.json".into();
+        let body = serde_json::to_vec(&record_json).unwrap();
         let get_copied = mock!(Client::get_object)
             .match_requests(|req| {
                 req.bucket() == Some("bucket") && req.key() == Some("init/copied-attestation.json")
@@ -1021,7 +1028,9 @@ mod tests {
             .await
             .expect("the embedded key matches the actual S3 key");
         let error = record
-            .validate_unsigned()
+            .into_unsigned()
+            .unwrap()
+            .validate()
             .expect_err("the copied key must still fail canonical validation");
 
         assert!(

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -15,6 +15,7 @@ use crate::s3_client::GuardianS3Client;
 use crate::s3_client::HistoryCheck;
 use crate::s3_client::LockCheck;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
+use hashi_types::guardian::time_utils::UnixMillis;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::CeremonyLogMessage;
@@ -30,7 +31,6 @@ use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::VerifiedSessionInfo;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
@@ -43,6 +43,61 @@ use tracing::info;
 
 mod heartbeat_checks;
 mod limiter_recovery;
+
+/// A log record whose message signature and writing session's attestation/PCRs
+/// have both been verified. Its message is normalized to the current schema.
+/// If a future schema cannot be converted losslessly, this type should retain
+/// the versioned message and leave version acceptance to callers instead.
+#[derive(Debug)]
+pub struct VerifiedLogRecord {
+    object_key: String,
+    session_id: SessionID,
+    timestamp_ms: UnixMillis,
+    message: LogMessage,
+    build_pcrs: BuildPcrs,
+}
+
+impl VerifiedLogRecord {
+    fn new(
+        object_key: String,
+        session_id: SessionID,
+        timestamp_ms: UnixMillis,
+        message: LogMessage,
+        build_pcrs: BuildPcrs,
+    ) -> Self {
+        Self {
+            object_key,
+            session_id,
+            timestamp_ms,
+            message,
+            build_pcrs,
+        }
+    }
+
+    pub fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub fn session_id(&self) -> &SessionID {
+        &self.session_id
+    }
+
+    pub fn timestamp_ms(&self) -> UnixMillis {
+        self.timestamp_ms
+    }
+
+    pub fn message(&self) -> &LogMessage {
+        &self.message
+    }
+
+    pub fn build_pcrs(&self) -> &BuildPcrs {
+        &self.build_pcrs
+    }
+
+    pub fn into_message(self) -> LogMessage {
+        self.message
+    }
+}
 
 /// Open an hour-scoped cursor at `start` over the `withdraw/` stream. Advance/
 /// retreat with [`S3HourScopedDirectory::next_dir`]/`prev_dir`, gate on

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -179,7 +179,7 @@ impl GuardianReader {
 
         let mut out = Vec::with_capacity(all_logs.len());
         for log in all_logs {
-            out.push(self.cache.authenticate_record(&self.s3, log).await?);
+            out.push(self.cache.verify_record(&self.s3, log).await?);
         }
         Ok(out)
     }
@@ -228,7 +228,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.authenticate_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy(build_policy, &build_pcrs)?;
         let session_id = record.session_id;
@@ -308,7 +308,7 @@ impl GuardianReader {
             .s3
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
-        let record = self.cache.authenticate_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::KpShareState(msg) = record.message else {
@@ -374,7 +374,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.authenticate_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::CommitteeUpdate(msg) = record.message else {
@@ -414,7 +414,7 @@ impl GuardianReader {
             )));
         }
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.authenticate_record(&self.s3, record).await?;
+        let record = self.cache.verify_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::Genesis(msg) = record.message else {
@@ -461,8 +461,8 @@ impl GuardianSessionCache {
         Ok(&self.sessions[session_id])
     }
 
-    /// Authenticate `record` under its session's trusted signing key.
-    async fn authenticate_record(
+    /// Fully verify `record` under its session's attested signing key.
+    async fn verify_record(
         &mut self,
         s3: &GuardianS3Client,
         record: LogRecord,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -22,7 +22,6 @@ use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GenesisLogMessage;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
-use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::KpShareStateLogMessage;
 use hashi_types::guardian::LogMessageV1;
@@ -31,7 +30,8 @@ use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VersionedLogMessage;
+use hashi_types::guardian::VersionedLogMessage::V1;
+use hashi_types::guardian::VersionedLogMessage::V2;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
 use hashi_types::guardian::S3_DIR_GENESIS;
@@ -61,11 +61,8 @@ pub fn heartbeat_cursor(start: UnixSeconds) -> S3HourScopedDirectory {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum BuildPolicy {
-    /// Accept only the configured current guardian build.
+enum BuildPolicy {
     Current,
-    /// Accept either the configured current build or an explicitly allowlisted
-    /// previous build. This is for historical log reads, not live-session checks.
     AnyAllowlisted,
 }
 
@@ -78,12 +75,14 @@ impl BuildPolicy {
     }
 }
 
-/// Verified reader over the guardian's S3 logs. Owns the S3 client and a private
-/// session cache. Thread a single `&mut GuardianReader` through a run so repeated
-/// reads can reuse session info and inspect the attested build.
+/// Verified reader over the guardian's S3 logs. Verified reads accept any
+/// allowlisted build unless the method explicitly requires the current build.
+/// Thread a single `&mut GuardianReader` through a run so repeated reads can
+/// reuse session info and inspect the attested build.
 pub struct GuardianReader {
     s3: GuardianS3Client,
-    cache: GuardianSessionCache,
+    allowlist: PcrAllowlist,
+    sessions: HashMap<SessionID, VerifiedSessionInfo>,
 }
 
 impl GuardianReader {
@@ -95,31 +94,34 @@ impl GuardianReader {
     pub fn from_s3_client(s3: GuardianS3Client, allowlist: PcrAllowlist) -> Self {
         Self {
             s3,
-            cache: GuardianSessionCache::new(allowlist),
+            allowlist,
+            sessions: HashMap::new(),
         }
     }
 
-    /// Raw S3 client, for unverified listing/reads (e.g. the limiter's bucket walk).
-    pub fn s3(&self) -> &GuardianS3Client {
-        &self.s3
+    /// The session's verified info, resolving and caching it on first use.
+    async fn get_or_load_session_info(
+        &mut self,
+        session_id: &str,
+    ) -> GuardianResult<&VerifiedSessionInfo> {
+        if !self.sessions.contains_key(session_id) {
+            let session_info =
+                VerifiedSessionInfo::read_from_s3(&self.s3, session_id, &self.allowlist).await?;
+            self.sessions.insert(session_id.into(), session_info);
+        }
+        Ok(&self.sessions[session_id])
     }
 
-    pub fn require_current_build(&self, build_pcrs: &BuildPcrs) -> GuardianResult<()> {
-        self.cache.allowlist.require_current_build(build_pcrs)
-    }
-
-    fn enforce_build_policy(
-        &self,
-        build_policy: BuildPolicy,
-        build_pcrs: &BuildPcrs,
-    ) -> GuardianResult<()> {
-        build_policy.enforce(&self.cache.allowlist, build_pcrs)
+    /// Fully verify `record` under its session's attested signing key.
+    async fn verify_record(&mut self, record: LogRecord) -> GuardianResult<VerifiedLogRecord> {
+        let session_id = record.session_id().clone();
+        let session_info = self.get_or_load_session_info(&session_id).await?;
+        VerifiedLogRecord::new(record, session_info)
     }
 
     /// Read and verify every record in `dir`, resolving each writing session's
-    /// signing pubkey via the cache. Batch readers can straddle upgrades, so
-    /// callers that need current-only semantics must inspect each returned
-    /// record's build PCRs with [`Self::require_current_build`].
+    /// signing pubkey. Batch readers can straddle upgrades, so each returned
+    /// record retains its attested build PCRs.
     pub async fn read_logs_in_dir(
         &mut self,
         dir: &S3HourScopedDirectory,
@@ -128,39 +130,21 @@ impl GuardianReader {
 
         let mut out = Vec::with_capacity(all_logs.len());
         for record in all_logs {
-            let verified_record = self.cache.verify_record(&self.s3, record).await?;
+            let verified_record = self.verify_record(record).await?;
             out.push(verified_record);
         }
         Ok(out)
     }
 
-    /// The session's verified guardian info. Served from the session cache, which
-    /// resolves the attestation + signed info on first touch and records the
-    /// verified build PCRs.
-    pub async fn get_session_info(
+    /// The current build's verified guardian info for `session_id`.
+    pub async fn get_current_session_info(
         &mut self,
         session_id: &str,
-        build_policy: BuildPolicy,
     ) -> GuardianResult<VerifiedSessionInfo> {
-        let session_info = self
-            .cache
-            .get_or_load_session_info(&self.s3, session_id)
-            .await?
-            .clone();
-        self.enforce_build_policy(build_policy, session_info.build_pcrs())?;
+        let session_info = self.get_or_load_session_info(session_id).await?.clone();
+        self.allowlist
+            .require_current_build(session_info.build_pcrs())?;
         Ok(session_info)
-    }
-
-    /// The session's verified `GuardianInfo`, discarding the verified build PCRs.
-    pub async fn get_info(
-        &mut self,
-        session_id: &str,
-        build_policy: BuildPolicy,
-    ) -> GuardianResult<GuardianInfo> {
-        Ok(self
-            .get_session_info(session_id, build_policy)
-            .await?
-            .into_info())
     }
 
     /// The latest ceremony from `ceremony/` — the max-`sharing_seq` (lex-last)
@@ -181,13 +165,12 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let verified_record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, verified_record.build_pcrs())?;
+        let verified_record = self.verify_record(record).await?;
+        build_policy.enforce(&self.allowlist, verified_record.build_pcrs())?;
         let session_id = verified_record.entry().session_id().clone();
         let msg = match verified_record.into_entry().into_message() {
-            VersionedLogMessage::V1(LogMessageV1::Ceremony(msg)) => msg,
-            VersionedLogMessage::V2(LogMessageV2::Ceremony(msg)) => msg,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            V1(LogMessageV1::Ceremony(msg)) | V2(LogMessageV2::Ceremony(msg)) => msg,
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(format!("expected a ceremony log at {key}")));
             }
         };
@@ -231,22 +214,22 @@ impl GuardianReader {
         Ok(Some(msg))
     }
 
-    /// Read and verify one exact encrypted KP-share snapshot.
+    /// Read and verify one exact encrypted KP-share snapshot written by the
+    /// current build.
     ///
     /// The object key binds the writing guardian session and the two sequence
     /// numbers. This lets callers verify the snapshot produced by one request
     /// even if a later request has already advanced the latest state.
-    pub async fn read_kp_share_state_log(
+    pub async fn read_kp_share_state_log_from_current_build(
         &mut self,
         session_id: &SessionID,
         sharing_seq: u64,
         cert_seq: u64,
-        build_policy: BuildPolicy,
     ) -> GuardianResult<KpShareStateLogMessage> {
         let key = KpShareStateLogMessage::object_key(session_id, sharing_seq, cert_seq);
         // Unlike the latest-state path, this direct read has not already
         // checked an enclosing prefix, so validate this exact key's history.
-        self.read_kp_share_state_log_at_key(&key, build_policy, HistoryCheck::Required)
+        self.read_kp_share_state_log_at_key(&key, BuildPolicy::Current, HistoryCheck::Required)
             .await
     }
 
@@ -264,13 +247,13 @@ impl GuardianReader {
             .s3
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
-        let verified_record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, verified_record.build_pcrs())?;
+        let verified_record = self.verify_record(record).await?;
+        build_policy.enforce(&self.allowlist, verified_record.build_pcrs())?;
         let session_id = verified_record.entry().session_id().clone();
         let msg = match verified_record.into_entry().into_message() {
-            VersionedLogMessage::V1(LogMessageV1::KpShareState(msg)) => (*msg).try_into()?,
-            VersionedLogMessage::V2(LogMessageV2::KpShareState(msg)) => *msg,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            V1(LogMessageV1::KpShareState(msg)) => (*msg).try_into()?,
+            V2(LogMessageV2::KpShareState(msg)) => *msg,
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(format!("expected a kp-shares log at {key}")));
             }
         };
@@ -279,10 +262,25 @@ impl GuardianReader {
     }
 
     /// Read the latest ceremony together with the latest KP share state for its
-    /// `sharing_seq`. `None` means no ceremony has been logged. Once a ceremony
-    /// exists, its matching KP share state must also exist: ceremony writers
-    /// publish `kp-shares/` before `ceremony/`.
-    pub async fn read_latest_ceremony_state(
+    /// `sharing_seq`, accepting any allowlisted build.
+    pub async fn read_latest_ceremony_state(&mut self) -> GuardianResult<Option<CeremonyState>> {
+        self.read_latest_ceremony_state_with_build_policy(BuildPolicy::AnyAllowlisted)
+            .await
+    }
+
+    /// Read the latest ceremony together with the latest KP share state for its
+    /// `sharing_seq`, requiring both records to come from the current build.
+    pub async fn read_latest_ceremony_state_from_current_build(
+        &mut self,
+    ) -> GuardianResult<Option<CeremonyState>> {
+        self.read_latest_ceremony_state_with_build_policy(BuildPolicy::Current)
+            .await
+    }
+
+    /// `None` means no ceremony has been logged. Once a ceremony exists, its
+    /// matching KP share state must also exist: ceremony writers publish
+    /// `kp-shares/` before `ceremony/`.
+    async fn read_latest_ceremony_state_with_build_policy(
         &mut self,
         build_policy: BuildPolicy,
     ) -> GuardianResult<Option<CeremonyState>> {
@@ -306,15 +304,12 @@ impl GuardianReader {
     /// Latest serving committee, preferring `committee-update/` and falling back
     /// to the KP-authorized `genesis/record.json` bootstrap record. `None`
     /// means neither source has been written yet.
-    pub async fn read_latest_committee(
-        &mut self,
-        build_policy: BuildPolicy,
-    ) -> GuardianResult<Option<Committee>> {
-        if let Some(committee) = self.read_latest_committee_update(build_policy).await? {
+    pub async fn read_latest_committee(&mut self) -> GuardianResult<Option<Committee>> {
+        if let Some(committee) = self.read_latest_committee_update().await? {
             return Ok(Some(committee));
         }
         Ok(self
-            .read_genesis_log(build_policy)
+            .read_genesis_log()
             .await?
             .map(|genesis| genesis.committee))
     }
@@ -322,10 +317,7 @@ impl GuardianReader {
     /// The latest applied committee from `committee-update/` — the lex-last
     /// non-`failure-` (i.e. highest-epoch Success) entry, attestation- and
     /// signature-verified. `None` if no committee update has been logged.
-    async fn read_latest_committee_update(
-        &mut self,
-        build_policy: BuildPolicy,
-    ) -> GuardianResult<Option<Committee>> {
+    async fn read_latest_committee_update(&mut self) -> GuardianResult<Option<Committee>> {
         let keys = self
             .s3
             .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE))
@@ -338,13 +330,11 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let verified_record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, verified_record.build_pcrs())?;
+        let verified_record = self.verify_record(record).await?;
         let session_id = verified_record.entry().session_id().clone();
         let msg = match verified_record.into_entry().into_message() {
-            VersionedLogMessage::V1(LogMessageV1::CommitteeUpdate(msg)) => msg,
-            VersionedLogMessage::V2(LogMessageV2::CommitteeUpdate(msg)) => msg,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            V1(LogMessageV1::CommitteeUpdate(msg)) | V2(LogMessageV2::CommitteeUpdate(msg)) => msg,
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(format!(
                     "expected a committee-update log at {key}"
                 )));
@@ -362,10 +352,7 @@ impl GuardianReader {
 
     /// Fixed genesis record from `genesis/record.json`. `None` means the
     /// KP-authorized bootstrap record has not been written yet.
-    async fn read_genesis_log(
-        &mut self,
-        build_policy: BuildPolicy,
-    ) -> GuardianResult<Option<GenesisLogMessage>> {
+    async fn read_genesis_log(&mut self) -> GuardianResult<Option<GenesisLogMessage>> {
         let key = GenesisLogMessage::object_key();
         let keys = self
             .s3
@@ -380,13 +367,11 @@ impl GuardianReader {
             )));
         }
         let record = self.s3.get_log_record(&key).await?;
-        let verified_record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, verified_record.build_pcrs())?;
+        let verified_record = self.verify_record(record).await?;
         let session_id = verified_record.entry().session_id().clone();
         let msg = match verified_record.into_entry().into_message() {
-            VersionedLogMessage::V1(LogMessageV1::Genesis(msg)) => msg,
-            VersionedLogMessage::V2(LogMessageV2::Genesis(msg)) => msg,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            V1(LogMessageV1::Genesis(msg)) | V2(LogMessageV2::Genesis(msg)) => msg,
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(format!("expected a genesis log at {key}")));
             }
         };
@@ -397,46 +382,4 @@ impl GuardianReader {
 
 fn log_verified_read(key: &str, session_id: &SessionID) {
     info!("Successfully read {key} from session {session_id}.");
-}
-
-/// Per-session [`VerifiedSessionInfo`] cache, internal to [`GuardianReader`]. The first
-/// touch of a session resolves and verifies its info (attestation + signed
-/// info, PCR0 pinned against `allowlist`); later reads reuse it and expose the
-/// verified build PCRs to callers.
-struct GuardianSessionCache {
-    sessions: HashMap<SessionID, VerifiedSessionInfo>,
-    allowlist: PcrAllowlist,
-}
-
-impl GuardianSessionCache {
-    fn new(allowlist: PcrAllowlist) -> Self {
-        Self {
-            sessions: HashMap::new(),
-            allowlist,
-        }
-    }
-
-    /// The session's verified info, resolving and caching it on first use.
-    async fn get_or_load_session_info(
-        &mut self,
-        s3: &GuardianS3Client,
-        session_id: &str,
-    ) -> GuardianResult<&VerifiedSessionInfo> {
-        if !self.sessions.contains_key(session_id) {
-            let session_info = VerifiedSessionInfo::new(s3, session_id, &self.allowlist).await?;
-            self.sessions.insert(session_id.into(), session_info);
-        }
-        Ok(&self.sessions[session_id])
-    }
-
-    /// Fully verify `record` under its session's attested signing key.
-    async fn verify_record(
-        &mut self,
-        s3: &GuardianS3Client,
-        record: LogRecord,
-    ) -> GuardianResult<VerifiedLogRecord> {
-        let session_id = record.session_id().clone();
-        let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        VerifiedLogRecord::new(record, session_info)
-    }
 }

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -472,7 +472,7 @@ impl GuardianSessionCache {
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
         let signing_pubkey = session_info.signing_pubkey;
         let build_pcrs = session_info.build_pcrs.clone();
-        let (session_id, timestamp_ms, message) = record.validate(&signing_pubkey)?;
+        let (session_id, timestamp_ms, message) = record.validate(Some(&signing_pubkey))?;
         Ok(VerifiedLogRecord::new(
             object_key,
             session_id,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -415,7 +415,8 @@ impl GuardianSessionCache {
         let object_key = record.object_key.clone();
         let session_id = record.session_id.clone();
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        let (session_id, timestamp_ms, message) = record.verify(&session_info.signing_pubkey)?;
+        let (session_id, timestamp_ms, message) =
+            record.validate_signed(&session_info.signing_pubkey)?;
         Ok(VerifiedLogRecord::new(
             object_key,
             session_id,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -472,13 +472,7 @@ impl GuardianSessionCache {
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
         let signing_pubkey = session_info.signing_pubkey;
         let build_pcrs = session_info.build_pcrs.clone();
-        let signed = record.into_signed()?;
-        let timestamp_ms = signed.data.timestamp_ms();
-        signed.data.validate(&signing_pubkey)?;
-        let data = signed
-            .authenticate(&signing_pubkey)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-        let (session_id, message) = data.into_current()?;
+        let (session_id, timestamp_ms, message) = record.validate(&signing_pubkey)?;
         Ok(VerifiedLogRecord::new(
             object_key,
             session_id,

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -124,7 +124,7 @@ impl GuardianReader {
 
         let mut out = Vec::with_capacity(all_logs.len());
         for log in all_logs {
-            out.push(self.cache.verify_record(&self.s3, log).await?);
+            out.push(self.cache.authenticate_record(&self.s3, log).await?);
         }
         Ok(out)
     }
@@ -173,7 +173,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.authenticate_record(&self.s3, record).await?;
         let build_pcrs = record.build_pcrs.clone();
         self.enforce_build_policy(build_policy, &build_pcrs)?;
         let session_id = record.session_id;
@@ -253,7 +253,7 @@ impl GuardianReader {
             .s3
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.authenticate_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::KpShareState(msg) = record.message else {
@@ -319,7 +319,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.authenticate_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::CommitteeUpdate(msg) = record.message else {
@@ -359,7 +359,7 @@ impl GuardianReader {
             )));
         }
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
+        let record = self.cache.authenticate_record(&self.s3, record).await?;
         self.enforce_build_policy(build_policy, &record.build_pcrs)?;
         let session_id = record.session_id;
         let LogMessage::Genesis(msg) = record.message else {
@@ -406,23 +406,30 @@ impl GuardianSessionCache {
         Ok(&self.sessions[session_id])
     }
 
-    /// Verify `record`'s signature under its session's trusted pubkey.
-    async fn verify_record(
+    /// Authenticate `record` under its session's trusted signing key.
+    async fn authenticate_record(
         &mut self,
         s3: &GuardianS3Client,
         record: LogRecord,
     ) -> GuardianResult<VerifiedLogRecord> {
-        let object_key = record.object_key.clone();
-        let session_id = record.session_id.clone();
+        let object_key = record.object_key().to_owned();
+        let session_id = record.session_id().clone();
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        let (session_id, timestamp_ms, message) =
-            record.validate_signed(&session_info.signing_pubkey)?;
+        let signing_pubkey = session_info.signing_pubkey;
+        let build_pcrs = session_info.build_pcrs.clone();
+        let signed = record.into_signed()?;
+        let timestamp_ms = signed.timestamp_ms;
+        signed.data.validate(timestamp_ms, &signing_pubkey)?;
+        let data = signed
+            .authenticate(&signing_pubkey)
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        let (session_id, message) = data.into_current()?;
         Ok(VerifiedLogRecord::new(
             object_key,
             session_id,
             timestamp_ms,
             message,
-            session_info.build_pcrs.clone(),
+            build_pcrs,
         ))
     }
 }

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -1,20 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Verified read layer over the guardian's S3 logs.
+//! Verified reads of the guardian's S3 logs.
 //!
-//! The guardian writes its logs via [`GuardianS3Client`]; off-enclave readers
-//! (the monitor auditor, KP/operator init tooling) replay them here through a
-//! [`GuardianReader`], which owns the S3 client and a per-session info cache
-//! that records the build PCRs verified for each session. Streams are
-//! hour-partitioned (`withdraw/`/`heartbeat/`);
-//! [`withdraw_cursor`]/[`heartbeat_cursor`] open a cursor that the caller
-//! advances/retreats and feeds to [`GuardianReader::read_logs_in_dir`].
+//! [`GuardianReader`] applies each log stream's S3 immutability policy, verifies
+//! records with their writing session's attestation-anchored key, and caches the
+//! verified session info for reuse.
 
 use crate::s3_client::GuardianS3Client;
 use crate::s3_client::ImmutabilityCheck;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
-use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::CeremonyState;
@@ -34,8 +29,6 @@ use hashi_types::guardian::VersionedLogMessage::V2;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
 use hashi_types::guardian::S3_DIR_GENESIS;
-use hashi_types::guardian::S3_DIR_HEARTBEAT;
-use hashi_types::guardian::S3_DIR_WITHDRAW;
 use hashi_types::move_types::Committee;
 use std::collections::HashMap;
 use tracing::info;
@@ -47,21 +40,13 @@ mod verified;
 pub use verified::VerifiedLogRecord;
 pub use verified::VerifiedSessionInfo;
 
-/// Open an hour-scoped cursor at `start` over the `withdraw/` stream. Advance/
-/// retreat with [`S3HourScopedDirectory::next_dir`]/`prev_dir`, gate on
-/// `write_completion_time`, and read via [`GuardianReader::read_logs_in_dir`].
-pub fn withdraw_cursor(start: UnixSeconds) -> S3HourScopedDirectory {
-    S3HourScopedDirectory::new(S3_DIR_WITHDRAW, start)
-}
-
-/// Like [`withdraw_cursor`], but over the `heartbeat/` stream.
-pub fn heartbeat_cursor(start: UnixSeconds) -> S3HourScopedDirectory {
-    S3HourScopedDirectory::new(S3_DIR_HEARTBEAT, start)
-}
-
+/// Internal policy for sharing read implementations that differ only in which
+/// attested guardian builds they accept.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BuildPolicy {
+    /// Require the configured current build.
     Current,
+    /// Accept any build represented in the PCR allowlist.
     AnyAllowlisted,
 }
 
@@ -74,10 +59,11 @@ impl BuildPolicy {
     }
 }
 
-/// Verified reader over the guardian's S3 logs. Verified reads accept any
-/// allowlisted build unless the method explicitly requires the current build.
-/// Thread a single `&mut GuardianReader` through a run so repeated reads can
-/// reuse session info and inspect the attested build.
+/// Verified reader over the guardian's S3 logs.
+///
+/// Reads accept any allowlisted build unless the method explicitly requires
+/// the current build. Reuse one reader so repeated reads can share cached
+/// session attestations and signing keys.
 pub struct GuardianReader {
     s3: GuardianS3Client,
     allowlist: PcrAllowlist,
@@ -85,11 +71,14 @@ pub struct GuardianReader {
 }
 
 impl GuardianReader {
+    /// Create a reader after checking S3 connectivity and object-lock support.
     pub async fn new(config: &S3Config, allowlist: PcrAllowlist) -> GuardianResult<Self> {
         let s3 = GuardianS3Client::new_checked(config).await?;
         Ok(Self::from_s3_client(s3, allowlist))
     }
 
+    /// Create a reader from an existing S3 client without another connectivity
+    /// check.
     pub fn from_s3_client(s3: GuardianS3Client, allowlist: PcrAllowlist) -> Self {
         Self {
             s3,
@@ -98,7 +87,8 @@ impl GuardianReader {
         }
     }
 
-    /// The session's verified info, resolving and caching it on first use.
+    /// Load and verify a session's attestation and guardian info on first use,
+    /// then return the cached result.
     async fn get_or_load_session_info(
         &mut self,
         session_id: &str,
@@ -111,16 +101,17 @@ impl GuardianReader {
         Ok(&self.sessions[session_id])
     }
 
-    /// Fully verify `record` under its session's attested signing key.
+    /// Verify a record with its session's attestation-anchored signing key.
     async fn verify_record(&mut self, record: LogRecord) -> GuardianResult<VerifiedLogRecord> {
         let session_id = record.session_id().clone();
         let session_info = self.get_or_load_session_info(&session_id).await?;
-        VerifiedLogRecord::new(record, session_info)
+        session_info.verify_record(record)
     }
 
-    /// Read and verify every record in `dir`, resolving each writing session's
-    /// signing pubkey. Batch readers can straddle upgrades, so each returned
-    /// record retains its attested build PCRs.
+    /// Read and verify every immutable record in an hour-scoped directory.
+    ///
+    /// Each result retains its writing session's attested build PCRs because a
+    /// directory may contain records from more than one build.
     pub async fn read_logs_in_dir(
         &mut self,
         dir: &S3HourScopedDirectory,
@@ -135,7 +126,8 @@ impl GuardianReader {
         Ok(out)
     }
 
-    /// The current build's verified guardian info for `session_id`.
+    /// Return verified session info after requiring the attested PCRs to match
+    /// the current build.
     pub async fn get_current_session_info(
         &mut self,
         session_id: &str,
@@ -146,12 +138,14 @@ impl GuardianReader {
         Ok(session_info)
     }
 
-    /// The latest ceremony from `ceremony/` — the max-`sharing_seq` (lex-last)
-    /// entry, attestation- and signature-verified. `None` if no ceremony has
-    /// been logged yet.
+    /// Read and verify the latest ceremony, or return `None` if none exists.
     ///
-    /// `kp-shares/` is read independently so later KP cert rotations can advance
-    /// `cert_seq` without rewriting the `ceremony/` instance.
+    /// Ceremony keys begin with a zero-padded `sharing_seq`, so the
+    /// lexicographically greatest key identifies the latest ceremony.
+    ///
+    /// The matching `kp-shares/` state is selected separately because later KP
+    /// certificate rotations can advance `cert_seq` without rewriting the
+    /// ceremony.
     async fn read_latest_ceremony_log(
         &mut self,
         build_policy: BuildPolicy,
@@ -177,15 +171,12 @@ impl GuardianReader {
         Ok(Some(*msg))
     }
 
-    /// Read + verify the latest encrypted KP share state for `sharing_seq`.
-    /// The lex-greatest object under `kp-shares/{sharing_seq:020}/` has the
-    /// latest `cert_seq`, so future per-KP cert rotation can advance the share
-    /// recipient state without changing the `ceremony/` instance.
+    /// Read and verify the latest encrypted KP-share state for `sharing_seq`.
     ///
-    /// Uses the lock-agnostic read: shares carry only a short lock that is
-    /// expected to expire, and their integrity is the enclave signature checked
-    /// below — not S3 immutability — so the immutable-log lock assertion in
-    /// `get_log_record` doesn't apply.
+    /// Keys begin with a zero-padded `cert_seq`, so the lexicographically
+    /// greatest key identifies the latest state. KP-share locks are expected to
+    /// expire, so this read authenticates the selected record without claiming
+    /// S3 immutability.
     async fn read_latest_kp_share_state_log(
         &mut self,
         sharing_seq: u64,
@@ -208,8 +199,8 @@ impl GuardianReader {
         Ok(Some(msg))
     }
 
-    /// Read and verify one exact encrypted KP-share snapshot written by the
-    /// current build.
+    /// Read and verify an exact encrypted KP-share state written by the current
+    /// build.
     ///
     /// The object key binds the writing guardian session and the two sequence
     /// numbers. This lets callers verify the snapshot produced by one request
@@ -225,15 +216,14 @@ impl GuardianReader {
             .await
     }
 
-    /// Shared verification path for both latest and exact KP-share reads.
+    /// Read and verify one KP-share object under the requested build policy.
     async fn read_kp_share_state_log_at_key(
         &mut self,
         key: &str,
         build_policy: BuildPolicy,
     ) -> GuardianResult<KpShareStateLogMessage> {
-        // KP-share locks are short-lived and expected to expire. Expiry permits
-        // deletion but does not cause it; while an object remains, its contents
-        // are authenticatable through the enclave signature verified below.
+        // KP-share locks are expected to expire, so authenticate the record
+        // without claiming that S3 still makes it immutable.
         let record = self
             .s3
             .get_log_record_inner(key, ImmutabilityCheck::Skipped)
@@ -252,14 +242,14 @@ impl GuardianReader {
         Ok(msg)
     }
 
-    /// Read the latest ceremony together with the latest KP share state for its
+    /// Read the latest ceremony together with the latest KP-share state for its
     /// `sharing_seq`, accepting any allowlisted build.
     pub async fn read_latest_ceremony_state(&mut self) -> GuardianResult<Option<CeremonyState>> {
         self.read_latest_ceremony_state_with_build_policy(BuildPolicy::AnyAllowlisted)
             .await
     }
 
-    /// Read the latest ceremony together with the latest KP share state for its
+    /// Read the latest ceremony together with the latest KP-share state for its
     /// `sharing_seq`, requiring both records to come from the current build.
     pub async fn read_latest_ceremony_state_from_current_build(
         &mut self,
@@ -268,8 +258,8 @@ impl GuardianReader {
             .await
     }
 
-    /// `None` means no ceremony has been logged. Once a ceremony exists, its
-    /// matching KP share state must also exist: ceremony writers publish
+    /// Return `None` only when no ceremony exists. Once a ceremony is present,
+    /// its matching KP-share state must also exist because writers publish
     /// `kp-shares/` before `ceremony/`.
     async fn read_latest_ceremony_state_with_build_policy(
         &mut self,
@@ -292,9 +282,11 @@ impl GuardianReader {
         )))
     }
 
-    /// Latest serving committee, preferring `committee-update/` and falling back
-    /// to the KP-authorized `genesis/record.json` bootstrap record. `None`
-    /// means neither source has been written yet.
+    /// Read the latest serving committee.
+    ///
+    /// Prefer the latest successful `committee-update/` record, then fall back
+    /// to the KP-authorized `genesis/record.json` bootstrap record. Return
+    /// `None` if neither source exists.
     pub async fn read_latest_committee(&mut self) -> GuardianResult<Option<Committee>> {
         if let Some(committee) = self.read_latest_committee_update().await? {
             return Ok(Some(committee));
@@ -305,9 +297,11 @@ impl GuardianReader {
             .map(|genesis| genesis.committee))
     }
 
-    /// The latest applied committee from `committee-update/` — the lex-last
-    /// non-`failure-` (i.e. highest-epoch Success) entry, attestation- and
-    /// signature-verified. `None` if no committee update has been logged.
+    /// Read and verify the successfully applied committee with the highest
+    /// epoch, or return `None` if no successful update exists.
+    ///
+    /// Success keys begin with a zero-padded epoch, so the lexicographically
+    /// greatest non-failure key identifies the latest applied committee.
     async fn read_latest_committee_update(&mut self) -> GuardianResult<Option<Committee>> {
         let keys = self
             .s3
@@ -341,8 +335,8 @@ impl GuardianReader {
         Ok(Some(committee))
     }
 
-    /// Fixed genesis record from `genesis/record.json`. `None` means the
-    /// KP-authorized bootstrap record has not been written yet.
+    /// Read and verify the fixed KP-authorized bootstrap record, or return
+    /// `None` if `genesis/record.json` has not been written.
     async fn read_genesis_log(&mut self) -> GuardianResult<Option<GenesisLogMessage>> {
         let key = GenesisLogMessage::object_key();
         let keys = self

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -177,7 +177,7 @@ impl GuardianReader {
             .s3
             .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_CEREMONY))
             .await?;
-        let Some(key) = pick_latest_key(keys, S3_DIR_CEREMONY) else {
+        let Some(key) = keys.into_iter().max() else {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
@@ -330,7 +330,11 @@ impl GuardianReader {
             .s3
             .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE))
             .await?;
-        let Some(key) = pick_latest_key(keys, S3_DIR_COMMITTEE_UPDATE) else {
+        let Some(key) = keys
+            .into_iter()
+            .filter(|key| !CommitteeUpdateLogMessage::is_failure_object_key(key))
+            .max()
+        else {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
@@ -349,9 +353,7 @@ impl GuardianReader {
         let committee = match *msg {
             CommitteeUpdateLogMessage::Success { new_committee, .. } => new_committee,
             CommitteeUpdateLogMessage::Failure { .. } => {
-                return Err(InvalidS3Log(format!(
-                    "lex-last non-failure key resolved to a Failure log at {key}"
-                )));
+                unreachable!("a verified non-failure key cannot contain a Failure log")
             }
         };
         log_verified_read(&key, &session_id);
@@ -436,59 +438,5 @@ impl GuardianSessionCache {
         let session_id = record.session_id().clone();
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
         VerifiedLogRecord::new(record, session_info)
-    }
-}
-
-/// Pick the lex-greatest key, skipping any whose name starts with `<dir>/failure-`.
-/// Keys are zero-padded (ceremony `sharing_seq`, committee `epoch`), so the lex-max
-/// non-failure key is the latest successful entry.
-fn pick_latest_key(keys: Vec<String>, dir: &str) -> Option<String> {
-    let failure_prefix = format!("{dir}/failure-");
-    keys.into_iter()
-        .filter(|k| !k.starts_with(&failure_prefix))
-        .max()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn success_key(epoch: u64) -> String {
-        format!("{S3_DIR_COMMITTEE_UPDATE}/{epoch:020}-sess.json")
-    }
-    fn failure_key(epoch: u64) -> String {
-        format!("{S3_DIR_COMMITTEE_UPDATE}/failure-{epoch:020}-sess-abcd1234.json")
-    }
-
-    #[test]
-    fn pick_latest_key_none_when_empty() {
-        assert_eq!(pick_latest_key(vec![], S3_DIR_COMMITTEE_UPDATE), None);
-    }
-
-    #[test]
-    fn pick_latest_key_takes_lex_max() {
-        let keys = vec![success_key(3), success_key(7), success_key(5)];
-        assert_eq!(
-            pick_latest_key(keys, S3_DIR_COMMITTEE_UPDATE),
-            Some(success_key(7))
-        );
-    }
-
-    #[test]
-    fn pick_latest_key_skips_higher_failure() {
-        // A later-epoch failure (lex-greater than any success) must not win.
-        let keys = vec![success_key(5), failure_key(9)];
-        assert_eq!(
-            pick_latest_key(keys, S3_DIR_COMMITTEE_UPDATE),
-            Some(success_key(5))
-        );
-    }
-
-    #[test]
-    fn pick_latest_key_none_when_all_failures() {
-        assert_eq!(
-            pick_latest_key(vec![failure_key(9)], S3_DIR_COMMITTEE_UPDATE),
-            None
-        );
     }
 }

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -418,8 +418,8 @@ impl GuardianSessionCache {
         let signing_pubkey = session_info.signing_pubkey;
         let build_pcrs = session_info.build_pcrs.clone();
         let signed = record.into_signed()?;
-        let timestamp_ms = signed.timestamp_ms;
-        signed.data.validate(timestamp_ms, &signing_pubkey)?;
+        let timestamp_ms = signed.data.timestamp_ms();
+        signed.data.validate(&signing_pubkey)?;
         let data = signed
             .authenticate(&signing_pubkey)
             .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -12,8 +12,7 @@
 //! advances/retreats and feeds to [`GuardianReader::read_logs_in_dir`].
 
 use crate::s3_client::GuardianS3Client;
-use crate::s3_client::HistoryCheck;
-use crate::s3_client::LockCheck;
+use crate::s3_client::ImmutabilityCheck;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
@@ -159,7 +158,7 @@ impl GuardianReader {
     ) -> GuardianResult<Option<CeremonyLogMessage>> {
         let keys = self
             .s3
-            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_CEREMONY))
+            .list_keys(&format!("{}/", S3_DIR_CEREMONY), true)
             .await?;
         let Some(key) = keys.into_iter().max() else {
             return Ok(None);
@@ -193,17 +192,12 @@ impl GuardianReader {
         build_policy: BuildPolicy,
     ) -> GuardianResult<Option<KpShareStateLogMessage>> {
         let prefix = KpShareStateLogMessage::object_key_dir(sharing_seq);
-        let keys = self
-            .s3
-            .validate_prefix_history_and_list_keys(&prefix)
-            .await?;
+        let keys = self.s3.list_keys(&prefix, false).await?;
         let Some(key) = keys.into_iter().max() else {
             return Ok(None);
         };
-        // The enclosing prefix's version history was checked while listing the
-        // candidate keys above, so the selected key does not need another check.
         let msg = self
-            .read_kp_share_state_log_at_key(&key, build_policy, HistoryCheck::AlreadyChecked)
+            .read_kp_share_state_log_at_key(&key, build_policy)
             .await?;
         if msg.sharing_seq != sharing_seq {
             return Err(InvalidS3Log(format!(
@@ -227,9 +221,7 @@ impl GuardianReader {
         cert_seq: u64,
     ) -> GuardianResult<KpShareStateLogMessage> {
         let key = KpShareStateLogMessage::object_key(session_id, sharing_seq, cert_seq);
-        // Unlike the latest-state path, this direct read has not already
-        // checked an enclosing prefix, so validate this exact key's history.
-        self.read_kp_share_state_log_at_key(&key, BuildPolicy::Current, HistoryCheck::Required)
+        self.read_kp_share_state_log_at_key(&key, BuildPolicy::Current)
             .await
     }
 
@@ -238,14 +230,13 @@ impl GuardianReader {
         &mut self,
         key: &str,
         build_policy: BuildPolicy,
-        history_check: HistoryCheck,
     ) -> GuardianResult<KpShareStateLogMessage> {
         // KP-share locks are short-lived and expected to expire. Expiry permits
         // deletion but does not cause it; while an object remains, its contents
         // are authenticatable through the enclave signature verified below.
         let record = self
             .s3
-            .get_log_record_inner(key, LockCheck::Skipped, history_check)
+            .get_log_record_inner(key, ImmutabilityCheck::Skipped)
             .await?;
         let verified_record = self.verify_record(record).await?;
         build_policy.enforce(&self.allowlist, verified_record.build_pcrs())?;
@@ -320,7 +311,7 @@ impl GuardianReader {
     async fn read_latest_committee_update(&mut self) -> GuardianResult<Option<Committee>> {
         let keys = self
             .s3
-            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE))
+            .list_keys(&format!("{}/", S3_DIR_COMMITTEE_UPDATE), true)
             .await?;
         let Some(key) = keys
             .into_iter()
@@ -356,7 +347,7 @@ impl GuardianReader {
         let key = GenesisLogMessage::object_key();
         let keys = self
             .s3
-            .validate_prefix_history_and_list_keys(&format!("{}/", S3_DIR_GENESIS))
+            .list_keys(&format!("{}/", S3_DIR_GENESIS), true)
             .await?;
         if keys.is_empty() {
             return Ok(None);

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -15,7 +15,6 @@ use crate::s3_client::GuardianS3Client;
 use crate::s3_client::HistoryCheck;
 use crate::s3_client::LockCheck;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
-use hashi_types::guardian::time_utils::UnixMillis;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::CeremonyLogMessage;
@@ -26,12 +25,13 @@ use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::KpShareStateLogMessage;
-use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VerifiedSessionInfo;
+use hashi_types::guardian::VersionedLogMessage;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
 use hashi_types::guardian::S3_DIR_GENESIS;
@@ -43,61 +43,10 @@ use tracing::info;
 
 mod heartbeat_checks;
 mod limiter_recovery;
+mod verified;
 
-/// A log record whose message signature and writing session's attestation/PCRs
-/// have both been verified. Its message is normalized to the current schema.
-/// If a future schema cannot be converted losslessly, this type should retain
-/// the versioned message and leave version acceptance to callers instead.
-#[derive(Debug)]
-pub struct VerifiedLogRecord {
-    object_key: String,
-    session_id: SessionID,
-    timestamp_ms: UnixMillis,
-    message: LogMessage,
-    build_pcrs: BuildPcrs,
-}
-
-impl VerifiedLogRecord {
-    fn new(
-        object_key: String,
-        session_id: SessionID,
-        timestamp_ms: UnixMillis,
-        message: LogMessage,
-        build_pcrs: BuildPcrs,
-    ) -> Self {
-        Self {
-            object_key,
-            session_id,
-            timestamp_ms,
-            message,
-            build_pcrs,
-        }
-    }
-
-    pub fn object_key(&self) -> &str {
-        &self.object_key
-    }
-
-    pub fn session_id(&self) -> &SessionID {
-        &self.session_id
-    }
-
-    pub fn timestamp_ms(&self) -> UnixMillis {
-        self.timestamp_ms
-    }
-
-    pub fn message(&self) -> &LogMessage {
-        &self.message
-    }
-
-    pub fn build_pcrs(&self) -> &BuildPcrs {
-        &self.build_pcrs
-    }
-
-    pub fn into_message(self) -> LogMessage {
-        self.message
-    }
-}
+pub use verified::VerifiedLogRecord;
+pub use verified::VerifiedSessionInfo;
 
 /// Open an hour-scoped cursor at `start` over the `withdraw/` stream. Advance/
 /// retreat with [`S3HourScopedDirectory::next_dir`]/`prev_dir`, gate on
@@ -197,7 +146,7 @@ impl GuardianReader {
             .get_or_load_session_info(&self.s3, session_id)
             .await?
             .clone();
-        self.enforce_build_policy(build_policy, &session_info.build_pcrs)?;
+        self.enforce_build_policy(build_policy, session_info.build_pcrs())?;
         Ok(session_info)
     }
 
@@ -207,7 +156,10 @@ impl GuardianReader {
         session_id: &str,
         build_policy: BuildPolicy,
     ) -> GuardianResult<GuardianInfo> {
-        Ok(self.get_session_info(session_id, build_policy).await?.info)
+        Ok(self
+            .get_session_info(session_id, build_policy)
+            .await?
+            .into_info())
     }
 
     /// The latest ceremony from `ceremony/` — the max-`sharing_seq` (lex-last)
@@ -229,11 +181,14 @@ impl GuardianReader {
         };
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        let build_pcrs = record.build_pcrs.clone();
-        self.enforce_build_policy(build_policy, &build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::Ceremony(msg) = record.message else {
-            return Err(InvalidS3Log(format!("expected a ceremony log at {key}")));
+        self.enforce_build_policy(build_policy, record.build_pcrs())?;
+        let session_id = record.entry().session_id().clone();
+        let msg = match record.into_entry().into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Ceremony(msg)) => msg,
+            VersionedLogMessage::V2(LogMessageV2::Ceremony(msg)) => msg,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!("expected a ceremony log at {key}")));
+            }
         };
         log_verified_read(&key, &session_id);
         Ok(Some(*msg))
@@ -309,13 +264,17 @@ impl GuardianReader {
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::KpShareState(msg) = record.message else {
-            return Err(InvalidS3Log(format!("expected a kp-shares log at {key}")));
+        self.enforce_build_policy(build_policy, record.build_pcrs())?;
+        let session_id = record.entry().session_id().clone();
+        let msg = match record.into_entry().into_message() {
+            VersionedLogMessage::V1(LogMessageV1::KpShareState(msg)) => (*msg).try_into()?,
+            VersionedLogMessage::V2(LogMessageV2::KpShareState(msg)) => *msg,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!("expected a kp-shares log at {key}")));
+            }
         };
         log_verified_read(key, &session_id);
-        Ok(*msg)
+        Ok(msg)
     }
 
     /// Read the latest ceremony together with the latest KP share state for its
@@ -375,12 +334,16 @@ impl GuardianReader {
         };
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::CommitteeUpdate(msg) = record.message else {
-            return Err(InvalidS3Log(format!(
-                "expected a committee-update log at {key}"
-            )));
+        self.enforce_build_policy(build_policy, record.build_pcrs())?;
+        let session_id = record.entry().session_id().clone();
+        let msg = match record.into_entry().into_message() {
+            VersionedLogMessage::V1(LogMessageV1::CommitteeUpdate(msg)) => msg,
+            VersionedLogMessage::V2(LogMessageV2::CommitteeUpdate(msg)) => msg,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!(
+                    "expected a committee-update log at {key}"
+                )));
+            }
         };
         let committee = match *msg {
             CommitteeUpdateLogMessage::Success { new_committee, .. } => new_committee,
@@ -415,10 +378,14 @@ impl GuardianReader {
         }
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::Genesis(msg) = record.message else {
-            return Err(InvalidS3Log(format!("expected a genesis log at {key}")));
+        self.enforce_build_policy(build_policy, record.build_pcrs())?;
+        let session_id = record.entry().session_id().clone();
+        let msg = match record.into_entry().into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Genesis(msg)) => msg,
+            VersionedLogMessage::V2(LogMessageV2::Genesis(msg)) => msg,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!("expected a genesis log at {key}")));
+            }
         };
         log_verified_read(&key, &session_id);
         Ok(Some(*msg))
@@ -453,9 +420,7 @@ impl GuardianSessionCache {
         session_id: &str,
     ) -> GuardianResult<&VerifiedSessionInfo> {
         if !self.sessions.contains_key(session_id) {
-            let session_info = s3
-                .get_verified_session_info(session_id, &self.allowlist)
-                .await?;
+            let session_info = VerifiedSessionInfo::new(s3, session_id, &self.allowlist).await?;
             self.sessions.insert(session_id.into(), session_info);
         }
         Ok(&self.sessions[session_id])
@@ -467,19 +432,9 @@ impl GuardianSessionCache {
         s3: &GuardianS3Client,
         record: LogRecord,
     ) -> GuardianResult<VerifiedLogRecord> {
-        let object_key = record.object_key().to_owned();
         let session_id = record.session_id().clone();
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        let signing_pubkey = session_info.signing_pubkey;
-        let build_pcrs = session_info.build_pcrs.clone();
-        let (session_id, timestamp_ms, message) = record.validate(Some(&signing_pubkey))?;
-        Ok(VerifiedLogRecord::new(
-            object_key,
-            session_id,
-            timestamp_ms,
-            message,
-            build_pcrs,
-        ))
+        VerifiedLogRecord::new(record, session_info)
     }
 }
 

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -127,8 +127,9 @@ impl GuardianReader {
         let all_logs = self.s3.list_all_log_records_in_dir(dir).await?;
 
         let mut out = Vec::with_capacity(all_logs.len());
-        for log in all_logs {
-            out.push(self.cache.verify_record(&self.s3, log).await?);
+        for record in all_logs {
+            let verified_record = self.cache.verify_record(&self.s3, record).await?;
+            out.push(verified_record);
         }
         Ok(out)
     }
@@ -180,10 +181,10 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, record.build_pcrs())?;
-        let session_id = record.entry().session_id().clone();
-        let msg = match record.into_entry().into_message() {
+        let verified_record = self.cache.verify_record(&self.s3, record).await?;
+        self.enforce_build_policy(build_policy, verified_record.build_pcrs())?;
+        let session_id = verified_record.entry().session_id().clone();
+        let msg = match verified_record.into_entry().into_message() {
             VersionedLogMessage::V1(LogMessageV1::Ceremony(msg)) => msg,
             VersionedLogMessage::V2(LogMessageV2::Ceremony(msg)) => msg,
             VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
@@ -263,10 +264,10 @@ impl GuardianReader {
             .s3
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, record.build_pcrs())?;
-        let session_id = record.entry().session_id().clone();
-        let msg = match record.into_entry().into_message() {
+        let verified_record = self.cache.verify_record(&self.s3, record).await?;
+        self.enforce_build_policy(build_policy, verified_record.build_pcrs())?;
+        let session_id = verified_record.entry().session_id().clone();
+        let msg = match verified_record.into_entry().into_message() {
             VersionedLogMessage::V1(LogMessageV1::KpShareState(msg)) => (*msg).try_into()?,
             VersionedLogMessage::V2(LogMessageV2::KpShareState(msg)) => *msg,
             VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
@@ -333,10 +334,10 @@ impl GuardianReader {
             return Ok(None);
         };
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, record.build_pcrs())?;
-        let session_id = record.entry().session_id().clone();
-        let msg = match record.into_entry().into_message() {
+        let verified_record = self.cache.verify_record(&self.s3, record).await?;
+        self.enforce_build_policy(build_policy, verified_record.build_pcrs())?;
+        let session_id = verified_record.entry().session_id().clone();
+        let msg = match verified_record.into_entry().into_message() {
             VersionedLogMessage::V1(LogMessageV1::CommitteeUpdate(msg)) => msg,
             VersionedLogMessage::V2(LogMessageV2::CommitteeUpdate(msg)) => msg,
             VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
@@ -377,10 +378,10 @@ impl GuardianReader {
             )));
         }
         let record = self.s3.get_log_record(&key).await?;
-        let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, record.build_pcrs())?;
-        let session_id = record.entry().session_id().clone();
-        let msg = match record.into_entry().into_message() {
+        let verified_record = self.cache.verify_record(&self.s3, record).await?;
+        self.enforce_build_policy(build_policy, verified_record.build_pcrs())?;
+        let session_id = verified_record.entry().session_id().clone();
+        let msg = match verified_record.into_entry().into_message() {
             VersionedLogMessage::V1(LogMessageV1::Genesis(msg)) => msg,
             VersionedLogMessage::V2(LogMessageV2::Genesis(msg)) => msg,
             VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -197,8 +197,7 @@ mod tests {
             &signing_key,
             timestamp_ms,
         )
-        .into_entry_unchecked()
-        .unwrap();
+        .into_entry_unchecked();
         VerifiedLogRecord::new_for_test(entry, build_pcrs())
     }
 

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -3,6 +3,7 @@
 
 use super::heartbeat_cursor;
 use super::GuardianReader;
+use super::VerifiedLogRecord;
 use crate::HEARTBEAT_INTERVAL;
 use crate::LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE;
 use crate::OTHER_SESSION_QUIET_PERIOD;
@@ -15,7 +16,6 @@ use hashi_types::guardian::GuardianError::PriorSessionHeartbeatStillRecent;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VerifiedLogRecord;
 use std::collections::BTreeMap;
 use tracing::info;
 

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::heartbeat_cursor;
 use super::GuardianReader;
 use super::VerifiedLogRecord;
 use crate::HEARTBEAT_INTERVAL;
 use crate::LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE;
 use crate::OTHER_SESSION_QUIET_PERIOD;
+use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::time_utils::unix_millis_to_seconds;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -59,7 +59,7 @@ impl GuardianReader {
         // Read from the previous, current, and next hour-scoped prefixes to
         // cover clock-boundary cases and moderate clock skew.
         let one_hour_ago = now_timestamp_secs().saturating_sub(60 * 60);
-        let mut cursor = heartbeat_cursor(one_hour_ago);
+        let mut cursor = S3HourScopedDirectory::heartbeat(one_hour_ago);
         let mut logs = Vec::new();
         for _ in 0..3 {
             logs.extend(self.read_logs_in_dir(&cursor).await?);

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -15,7 +15,10 @@ use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianError::PriorSessionHeartbeatStillRecent;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::SessionID;
+use hashi_types::guardian::VersionedLogMessage;
 use std::collections::BTreeMap;
 use tracing::info;
 
@@ -79,14 +82,20 @@ fn summarize_heartbeats_by_session(
     let mut map: BTreeMap<SessionID, (UnixSeconds, UnixSeconds)> = BTreeMap::new();
 
     for log in logs {
-        if !matches!(log.message, LogMessage::Heartbeat(..)) {
-            return Err(InvalidS3Log(
-                "non-heartbeat log found under the heartbeat prefix".into(),
-            ));
+        let entry = log.into_entry();
+        let session_id = entry.session_id().clone();
+        let ts = unix_millis_to_seconds(entry.timestamp_ms());
+        match entry.into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Heartbeat(..))
+            | VersionedLogMessage::V2(LogMessageV2::Heartbeat(..)) => {}
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(
+                    "non-heartbeat log found under the heartbeat prefix".into(),
+                ));
+            }
         }
 
-        let ts = unix_millis_to_seconds(log.timestamp_ms);
-        map.entry(log.session_id)
+        map.entry(session_id)
             .and_modify(|(first, last)| {
                 *first = (*first).min(ts);
                 *last = (*last).max(ts);
@@ -150,6 +159,7 @@ fn validate_session_live_and_others_quiet(
 mod tests {
     use super::*;
     use hashi_types::guardian::BuildPcrs;
+    use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::HeartbeatLogMessage;
     use hashi_types::guardian::InitLogMessage;
 
@@ -158,29 +168,38 @@ mod tests {
     }
 
     fn heartbeat_log(session_id: &str, timestamp_secs: UnixSeconds) -> VerifiedLogRecord {
-        VerifiedLogRecord {
-            object_key: format!("heartbeat/{session_id}.json"),
-            session_id: session_id.into(),
-            timestamp_ms: timestamp_secs * 1_000,
-            message: LogMessage::Heartbeat(HeartbeatLogMessage::new(0)),
-            build_pcrs: build_pcrs(),
-        }
+        verified_log(
+            session_id,
+            timestamp_secs * 1_000,
+            LogMessage::Heartbeat(HeartbeatLogMessage::new(0)),
+        )
     }
 
     fn non_heartbeat_log() -> VerifiedLogRecord {
-        VerifiedLogRecord {
-            object_key: "init/test-session/03-pi-enclave-fully-initialized.json".to_string(),
-            session_id: "test-session".into(),
-            timestamp_ms: 0,
-            message: LogMessage::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
+        verified_log(
+            "test-session",
+            0,
+            LogMessage::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
                 sharing_seq: 0,
                 share_ids: vec![],
                 enclave_btc_pubkey: hashi_types::bitcoin::create_btc_keypair_for_test(&[1; 32])
                     .x_only_public_key()
                     .0,
             })),
-            build_pcrs: build_pcrs(),
-        }
+        )
+    }
+
+    fn verified_log(session_id: &str, timestamp_ms: u64, message: LogMessage) -> VerifiedLogRecord {
+        let signing_key = GuardianSignKeyPair::from([7u8; 32]);
+        let entry = hashi_types::guardian::LogRecord::new_at_timestamp(
+            session_id.into(),
+            message,
+            &signing_key,
+            timestamp_ms,
+        )
+        .into_entry_unchecked()
+        .unwrap();
+        VerifiedLogRecord::new_for_test(entry, build_pcrs())
     }
 
     #[test]

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -14,7 +14,6 @@ use hashi_types::guardian::GuardianError::CurrentSessionHeartbeatNotLive;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianError::PriorSessionHeartbeatStillRecent;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::SessionID;
@@ -162,6 +161,7 @@ mod tests {
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::HeartbeatLogMessage;
     use hashi_types::guardian::InitLogMessage;
+    use hashi_types::guardian::LogMessage;
 
     fn build_pcrs() -> BuildPcrs {
         BuildPcrs::new("current", vec![0])

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -17,7 +17,8 @@ use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VersionedLogMessage;
+use hashi_types::guardian::VersionedLogMessage::V1;
+use hashi_types::guardian::VersionedLogMessage::V2;
 use std::collections::BTreeMap;
 use tracing::info;
 
@@ -85,9 +86,8 @@ fn summarize_heartbeats_by_session(
         let session_id = entry.session_id().clone();
         let ts = unix_millis_to_seconds(entry.timestamp_ms());
         match entry.into_message() {
-            VersionedLogMessage::V1(LogMessageV1::Heartbeat(..))
-            | VersionedLogMessage::V2(LogMessageV2::Heartbeat(..)) => {}
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            V1(LogMessageV1::Heartbeat(..)) | V2(LogMessageV2::Heartbeat(..)) => {}
+            V1(_) | V2(_) => {
                 return Err(InvalidS3Log(
                     "non-heartbeat log found under the heartbeat prefix".into(),
                 ));

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -34,7 +34,8 @@ use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
-use hashi_types::guardian::VersionedLogMessage;
+use hashi_types::guardian::VersionedLogMessage::V1;
+use hashi_types::guardian::VersionedLogMessage::V2;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
 use tracing::info;
@@ -52,7 +53,7 @@ impl GuardianReader {
         &mut self,
         limiter_config: &LimiterConfig,
     ) -> GuardianResult<LimiterState> {
-        let Some(mut cursor) = find_latest_success_bucket(self.s3()).await? else {
+        let Some(mut cursor) = find_latest_success_bucket(&self.s3).await? else {
             // The search covers the complete S3 withdrawal history, so this
             // branch is reachable only if no withdrawal has ever succeeded.
             info!("no successful withdrawal logs found; using genesis limiter state");
@@ -135,9 +136,10 @@ fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {
     logs.into_iter()
         .filter_map(|log| {
             let boxed = match log.into_entry().into_message() {
-                VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,
-                VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) => message,
-                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => return None,
+                V1(LogMessageV1::Withdrawal(message)) | V2(LogMessageV2::Withdrawal(message)) => {
+                    message
+                }
+                V1(_) | V2(_) => return None,
             };
             match *boxed {
                 WithdrawalLogMessage::Success { post_state, .. } => Some(post_state),

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -32,7 +32,6 @@ use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
-use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::VersionedLogMessage;
@@ -168,6 +167,7 @@ mod tests {
     use hashi_types::guardian::GuardianError;
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::GuardianSignedResponse;
+    use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::StandardWithdrawalRequestWire;

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -25,6 +25,7 @@
 //! read-after-write consistency to cover the old session's final writes.
 
 use super::GuardianReader;
+use super::VerifiedLogRecord;
 use crate::s3_client::GuardianS3Client;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
@@ -32,7 +33,6 @@ use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::LogMessage;
-use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
 use tracing::info;

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -219,8 +219,7 @@ mod tests {
             &signing_key,
             0,
         )
-        .into_entry_unchecked()
-        .expect("withdrawal records are signed");
+        .into_entry_unchecked();
         VerifiedLogRecord::new_for_test(entry, build_pcrs())
     }
 

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -33,6 +33,9 @@ use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
 use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
+use hashi_types::guardian::VersionedLogMessage;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
 use tracing::info;
@@ -132,8 +135,10 @@ async fn hour_bucket_has_success(
 fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {
     logs.into_iter()
         .filter_map(|log| {
-            let LogMessage::Withdrawal(boxed) = log.message else {
-                return None;
+            let boxed = match log.into_entry().into_message() {
+                VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,
+                VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) => message,
+                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => return None,
             };
             match *boxed {
                 WithdrawalLogMessage::Success { post_state, .. } => Some(post_state),
@@ -161,7 +166,9 @@ mod tests {
     use bitcoin::Txid;
     use hashi_types::guardian::BuildPcrs;
     use hashi_types::guardian::GuardianError;
+    use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::GuardianSignedResponse;
+    use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::StandardWithdrawalRequestWire;
     use hashi_types::guardian::StandardWithdrawalResponse;
@@ -190,13 +197,7 @@ mod tests {
                 .response,
             post_state: state_with_seq(next_seq),
         };
-        VerifiedLogRecord {
-            object_key: format!("withdraw/success-{next_seq}.json"),
-            session_id: "test-session".into(),
-            timestamp_ms: 0,
-            message: LogMessage::Withdrawal(Box::new(msg)),
-            build_pcrs: build_pcrs(),
-        }
+        verified_withdrawal_log(msg)
     }
 
     fn withdrawal_failure_log() -> VerifiedLogRecord {
@@ -207,13 +208,20 @@ mod tests {
             request_sign,
             error: GuardianError::RateLimitExceeded.to_string(),
         };
-        VerifiedLogRecord {
-            object_key: "withdraw/failure.json".to_string(),
-            session_id: "test-session".into(),
-            timestamp_ms: 0,
-            message: LogMessage::Withdrawal(Box::new(msg)),
-            build_pcrs: build_pcrs(),
-        }
+        verified_withdrawal_log(msg)
+    }
+
+    fn verified_withdrawal_log(message: WithdrawalLogMessage) -> VerifiedLogRecord {
+        let signing_key = GuardianSignKeyPair::from([7u8; 32]);
+        let entry = LogRecord::new_at_timestamp(
+            "test-session".into(),
+            LogMessage::Withdrawal(Box::new(message)),
+            &signing_key,
+            0,
+        )
+        .into_entry_unchecked()
+        .expect("withdrawal records are signed");
+        VerifiedLogRecord::new_for_test(entry, build_pcrs())
     }
 
     #[test]

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -127,7 +127,7 @@ async fn hour_bucket_has_success(
     bucket: &str,
 ) -> GuardianResult<bool> {
     let keys = s3_client
-        .validate_prefix_history_and_list_keys(&format!("{bucket}success-"))
+        .list_keys(&format!("{bucket}success-"), true)
         .await?;
     Ok(!keys.is_empty())
 }

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -161,7 +161,7 @@ mod tests {
     use bitcoin::Txid;
     use hashi_types::guardian::BuildPcrs;
     use hashi_types::guardian::GuardianError;
-    use hashi_types::guardian::GuardianSigned;
+    use hashi_types::guardian::GuardianSignedResponse;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::StandardWithdrawalRequestWire;
     use hashi_types::guardian::StandardWithdrawalResponse;
@@ -185,7 +185,9 @@ mod tests {
             txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
             request_data: StandardWithdrawalRequestWire::from(request_data),
             request_sign,
-            response: GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data,
+            response: GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
+                .data
+                .response,
             post_state: state_with_seq(next_seq),
         };
         VerifiedLogRecord {

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -89,6 +89,15 @@ impl VerifiedSessionInfo {
         })
     }
 
+    /// Verify a record with this session's attestation-anchored signing key.
+    pub(super) fn verify_record(&self, record: LogRecord) -> GuardianResult<VerifiedLogRecord> {
+        let entry = validate_into_entry(record, Some(&self.signing_pubkey))?;
+        Ok(VerifiedLogRecord {
+            entry,
+            build_pcrs: self.build_pcrs.clone(),
+        })
+    }
+
     pub fn signing_pubkey(&self) -> &GuardianPubKey {
         &self.signing_pubkey
     }
@@ -112,17 +121,6 @@ pub struct VerifiedLogRecord {
 }
 
 impl VerifiedLogRecord {
-    pub(super) fn new(
-        record: LogRecord,
-        session_info: &VerifiedSessionInfo,
-    ) -> GuardianResult<Self> {
-        let entry = validate_into_entry(record, Some(&session_info.signing_pubkey))?;
-        Ok(Self {
-            entry,
-            build_pcrs: session_info.build_pcrs.clone(),
-        })
-    }
-
     #[cfg(test)]
     pub(super) fn new_for_test(entry: LogEntry, build_pcrs: BuildPcrs) -> Self {
         Self { entry, build_pcrs }

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -34,16 +34,16 @@ impl VerifiedSessionInfo {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = s3.get_log_record(&att_key).await?;
-        attestation_record.validate(None)?;
-        let attestation_message = match into_validated_entry(attestation_record).into_message() {
-            VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
-            VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
-                return Err(InvalidS3Log(format!(
-                    "expected OIAttestationUnsigned at key {att_key}"
-                )));
-            }
-        };
+        let attestation_message =
+            match validate_into_entry(attestation_record, None)?.into_message() {
+                VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
+                VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
+                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                    return Err(InvalidS3Log(format!(
+                        "expected OIAttestationUnsigned at key {att_key}"
+                    )));
+                }
+            };
         let InitLogMessage::OIAttestationUnsigned {
             attestation,
             signing_public_key: signing_pubkey,
@@ -57,16 +57,16 @@ impl VerifiedSessionInfo {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = s3.get_log_record(&info_key).await?;
-        info_record.validate(Some(&signing_pubkey))?;
-        let info_message = match into_validated_entry(info_record).into_message() {
-            VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
-            VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
-            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
-                return Err(InvalidS3Log(format!(
-                    "expected OIGuardianInfo at key {info_key}"
-                )));
-            }
-        };
+        let info_message =
+            match validate_into_entry(info_record, Some(&signing_pubkey))?.into_message() {
+                VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
+                VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
+                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                    return Err(InvalidS3Log(format!(
+                        "expected OIGuardianInfo at key {info_key}"
+                    )));
+                }
+            };
         let InitLogMessage::OIGuardianInfo(info) = *info_message else {
             return Err(InvalidS3Log(format!(
                 "expected OIGuardianInfo at key {info_key}"
@@ -121,8 +121,7 @@ impl VerifiedLogRecord {
         record: LogRecord,
         session_info: &VerifiedSessionInfo,
     ) -> GuardianResult<Self> {
-        record.validate(Some(&session_info.signing_pubkey))?;
-        let entry = into_validated_entry(record);
+        let entry = validate_into_entry(record, Some(&session_info.signing_pubkey))?;
         Ok(Self {
             entry,
             build_pcrs: session_info.build_pcrs.clone(),
@@ -147,9 +146,10 @@ impl VerifiedLogRecord {
     }
 }
 
-fn into_validated_entry(record: LogRecord) -> LogEntry {
-    match record {
-        LogRecord::Signed(signed) => signed.into_data_unchecked(),
-        LogRecord::Unsigned(entry) => entry,
-    }
+fn validate_into_entry(
+    record: LogRecord,
+    signing_public_key: Option<&GuardianPubKey>,
+) -> GuardianResult<LogEntry> {
+    record.validate(signing_public_key)?;
+    Ok(record.into_entry_unchecked())
 }

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -13,7 +13,8 @@ use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::VersionedLogMessage;
+use hashi_types::guardian::VersionedLogMessage::V1;
+use hashi_types::guardian::VersionedLogMessage::V2;
 
 /// A session's verified guardian info: the attestation-anchored signing key,
 /// the signed [`GuardianInfo`], and the build PCRs proven by attestation.
@@ -25,7 +26,7 @@ pub struct VerifiedSessionInfo {
 }
 
 impl VerifiedSessionInfo {
-    pub(super) async fn new(
+    pub(super) async fn read_from_s3(
         s3: &GuardianS3Client,
         session_id: &str,
         allowlist: &PcrAllowlist,
@@ -36,9 +37,8 @@ impl VerifiedSessionInfo {
         let attestation_record = s3.get_log_record(&att_key).await?;
         let attestation_message =
             match validate_into_entry(attestation_record, None)?.into_message() {
-                VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
-                VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
-                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                V1(LogMessageV1::Init(message)) | V2(LogMessageV2::Init(message)) => message,
+                V1(_) | V2(_) => {
                     return Err(InvalidS3Log(format!(
                         "expected OIAttestationUnsigned at key {att_key}"
                     )));
@@ -59,9 +59,8 @@ impl VerifiedSessionInfo {
         let info_record = s3.get_log_record(&info_key).await?;
         let info_message =
             match validate_into_entry(info_record, Some(&signing_pubkey))?.into_message() {
-                VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
-                VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
-                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                V1(LogMessageV1::Init(message)) | V2(LogMessageV2::Init(message)) => message,
+                V1(_) | V2(_) => {
                     return Err(InvalidS3Log(format!(
                         "expected OIGuardianInfo at key {info_key}"
                     )));
@@ -100,10 +99,6 @@ impl VerifiedSessionInfo {
 
     pub fn build_pcrs(&self) -> &BuildPcrs {
         &self.build_pcrs
-    }
-
-    pub fn into_info(self) -> GuardianInfo {
-        self.info
     }
 }
 

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -34,7 +34,8 @@ impl VerifiedSessionInfo {
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
         let attestation_record = s3.get_log_record(&att_key).await?;
-        let attestation_message = match attestation_record.validate(None)?.into_message() {
+        attestation_record.validate(None)?;
+        let attestation_message = match into_validated_entry(attestation_record).into_message() {
             VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
             VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
             VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
@@ -56,7 +57,8 @@ impl VerifiedSessionInfo {
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
         let info_record = s3.get_log_record(&info_key).await?;
-        let info_message = match info_record.validate(Some(&signing_pubkey))?.into_message() {
+        info_record.validate(Some(&signing_pubkey))?;
+        let info_message = match into_validated_entry(info_record).into_message() {
             VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
             VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
             VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
@@ -119,7 +121,8 @@ impl VerifiedLogRecord {
         record: LogRecord,
         session_info: &VerifiedSessionInfo,
     ) -> GuardianResult<Self> {
-        let entry = record.validate(Some(&session_info.signing_pubkey))?;
+        record.validate(Some(&session_info.signing_pubkey))?;
+        let entry = into_validated_entry(record);
         Ok(Self {
             entry,
             build_pcrs: session_info.build_pcrs.clone(),
@@ -141,5 +144,12 @@ impl VerifiedLogRecord {
 
     pub fn into_entry(self) -> LogEntry {
         self.entry
+    }
+}
+
+fn into_validated_entry(record: LogRecord) -> LogEntry {
+    match record {
+        LogRecord::Signed(signed) => signed.into_data_unchecked(),
+        LogRecord::Unsigned(entry) => entry,
     }
 }

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -1,0 +1,145 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::s3_client::GuardianS3Client;
+use hashi_types::guardian::BuildPcrs;
+use hashi_types::guardian::GuardianError::InvalidS3Log;
+use hashi_types::guardian::GuardianInfo;
+use hashi_types::guardian::GuardianPubKey;
+use hashi_types::guardian::GuardianResult;
+use hashi_types::guardian::InitLogMessage;
+use hashi_types::guardian::LogEntry;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
+use hashi_types::guardian::LogRecord;
+use hashi_types::guardian::PcrAllowlist;
+use hashi_types::guardian::VersionedLogMessage;
+
+/// A session's verified guardian info: the attestation-anchored signing key,
+/// the signed [`GuardianInfo`], and the build PCRs proven by attestation.
+#[derive(Debug, Clone)]
+pub struct VerifiedSessionInfo {
+    signing_pubkey: GuardianPubKey,
+    info: GuardianInfo,
+    build_pcrs: BuildPcrs,
+}
+
+impl VerifiedSessionInfo {
+    pub(super) async fn new(
+        s3: &GuardianS3Client,
+        session_id: &str,
+        allowlist: &PcrAllowlist,
+    ) -> GuardianResult<Self> {
+        // 1. Attestation (unsigned: authenticated by AWS, not the enclave key) →
+        //    the signing pubkey it commits to.
+        let att_key = InitLogMessage::attestation_object_key(session_id);
+        let attestation_record = s3.get_log_record(&att_key).await?;
+        let attestation_message = match attestation_record.validate(None)?.into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
+            VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!(
+                    "expected OIAttestationUnsigned at key {att_key}"
+                )));
+            }
+        };
+        let InitLogMessage::OIAttestationUnsigned {
+            attestation,
+            signing_public_key: signing_pubkey,
+        } = *attestation_message
+        else {
+            return Err(InvalidS3Log(format!(
+                "expected OIAttestationUnsigned at key {att_key}"
+            )));
+        };
+
+        // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
+        let info_key = InitLogMessage::guardian_info_object_key(session_id);
+        let info_record = s3.get_log_record(&info_key).await?;
+        let info_message = match info_record.validate(Some(&signing_pubkey))?.into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
+            VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!(
+                    "expected OIGuardianInfo at key {info_key}"
+                )));
+            }
+        };
+        let InitLogMessage::OIGuardianInfo(info) = *info_message else {
+            return Err(InvalidS3Log(format!(
+                "expected OIGuardianInfo at key {info_key}"
+            )));
+        };
+        let info = *info;
+
+        // 3. Anchor the pubkey and pin PCR0 to the allowlist entry for the
+        //    reported build. This replays a logged attestation whose short-lived
+        //    leaf cert has typically expired, so the chain is checked at the
+        //    document's own signed timestamp, not now.
+        let build_pcrs = allowlist.resolve(&info.untrusted_git_revision)?.clone();
+        attestation
+            .verify_replay(&signing_pubkey, &build_pcrs)
+            .map_err(|e| InvalidS3Log(format!("attestation at key {att_key}: {e}")))?;
+
+        Ok(Self {
+            signing_pubkey,
+            info,
+            build_pcrs,
+        })
+    }
+
+    pub fn signing_pubkey(&self) -> &GuardianPubKey {
+        &self.signing_pubkey
+    }
+
+    pub fn info(&self) -> &GuardianInfo {
+        &self.info
+    }
+
+    pub fn build_pcrs(&self) -> &BuildPcrs {
+        &self.build_pcrs
+    }
+
+    pub fn into_info(self) -> GuardianInfo {
+        self.info
+    }
+}
+
+/// A log record whose message signature and writing session's attestation/PCRs
+/// have both been verified. The exact versioned entry is retained so callers
+/// can choose which schema versions they accept and how to interpret them.
+#[derive(Debug)]
+pub struct VerifiedLogRecord {
+    entry: LogEntry,
+    build_pcrs: BuildPcrs,
+}
+
+impl VerifiedLogRecord {
+    pub(super) fn new(
+        record: LogRecord,
+        session_info: &VerifiedSessionInfo,
+    ) -> GuardianResult<Self> {
+        let entry = record.validate(Some(&session_info.signing_pubkey))?;
+        Ok(Self {
+            entry,
+            build_pcrs: session_info.build_pcrs.clone(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn new_for_test(entry: LogEntry, build_pcrs: BuildPcrs) -> Self {
+        Self { entry, build_pcrs }
+    }
+
+    pub fn entry(&self) -> &LogEntry {
+        &self.entry
+    }
+
+    pub fn build_pcrs(&self) -> &BuildPcrs {
+        &self.build_pcrs
+    }
+
+    pub fn into_entry(self) -> LogEntry {
+        self.entry
+    }
+}

--- a/crates/hashi-guardian/src/task_spawner.rs
+++ b/crates/hashi-guardian/src/task_spawner.rs
@@ -24,7 +24,7 @@ use crate::withdraw_mode::standard_withdrawal as standard_withdrawal_domain;
 use crate::Enclave;
 use hashi_types::guardian::CommitteeTransitionRequest;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::HashiSigned;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::OperatorActivateRequest;
@@ -43,7 +43,7 @@ use std::sync::Arc;
 pub async fn setup_new_key(
     enclave: Arc<Enclave>,
     request: SetupNewKeyRequest,
-) -> GuardianResult<GuardianSigned<SetupNewKeyResponse>> {
+) -> GuardianResult<GuardianSignedResponse<SetupNewKeyResponse>> {
     enclave
         .spawn_control_task(request, setup::setup_new_key)
         .await
@@ -52,7 +52,7 @@ pub async fn setup_new_key(
 pub async fn rotate_kps(
     enclave: Arc<Enclave>,
     request: RotateKpsRequest,
-) -> GuardianResult<GuardianSigned<RotateKpsResponse>> {
+) -> GuardianResult<GuardianSignedResponse<RotateKpsResponse>> {
     enclave
         .spawn_control_task(request, rotate::rotate_kps)
         .await
@@ -88,7 +88,7 @@ pub async fn operator_activate(
 pub async fn provisioner_rotate_cert(
     enclave: Arc<Enclave>,
     signed_request: KpSigned<ProvisionerRotateCertRequest>,
-) -> GuardianResult<GuardianSigned<ProvisionerRotateCertResponse>> {
+) -> GuardianResult<GuardianSignedResponse<ProvisionerRotateCertResponse>> {
     enclave
         .spawn_control_task(
             signed_request,
@@ -100,7 +100,7 @@ pub async fn provisioner_rotate_cert(
 pub async fn standard_withdrawal(
     enclave: Arc<Enclave>,
     request: HashiSigned<StandardWithdrawalRequest>,
-) -> GuardianResult<GuardianSigned<StandardWithdrawalResponse>> {
+) -> GuardianResult<GuardianSignedResponse<StandardWithdrawalResponse>> {
     enclave
         .spawn_task(request, standard_withdrawal_domain::standard_withdrawal)
         .await

--- a/crates/hashi-guardian/src/withdraw_mode/genesis.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/genesis.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::s3_reader::BuildPolicy;
 use crate::Enclave;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianResult;
@@ -11,11 +10,7 @@ use hashi_types::guardian::GuardianResult;
 pub(super) async fn ensure_no_serving_committee(enclave: &Enclave) -> GuardianResult<()> {
     let mut reader = enclave.new_guardian_reader()?;
 
-    if reader
-        .read_latest_committee(BuildPolicy::AnyAllowlisted)
-        .await?
-        .is_some()
-    {
+    if reader.read_latest_committee().await?.is_some() {
         return Err(InvalidInputs(
             "genesis bootstrap is rejected after a serving committee exists".into(),
         ));

--- a/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
@@ -64,7 +64,6 @@ impl HeartbeatWriter {
 mod tests {
     use super::*;
     use crate::OperatorInitTestArgs;
-    use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;

--- a/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
@@ -65,6 +65,7 @@ mod tests {
     use super::*;
     use crate::OperatorInitTestArgs;
     use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;
 
@@ -90,7 +91,7 @@ mod tests {
         assert_eq!(captured.len(), 1, "heartbeat tick should write one record");
         let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert_eq!(captured[0].0, record.object_key());
-        let VersionedLogMessage::V2(LogMessage::Heartbeat(message)) = record.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Heartbeat(message)) = record.message() else {
             panic!("expected V2 heartbeat record");
         };
         assert_eq!(message.seq, 0);

--- a/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
@@ -90,7 +90,7 @@ mod tests {
         assert_eq!(captured.len(), 1, "heartbeat tick should write one record");
         let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert_eq!(captured[0].0, record.object_key());
-        let VersionedLogMessage::V2(LogMessage::Heartbeat(message)) = record.message else {
+        let VersionedLogMessage::V2(LogMessage::Heartbeat(message)) = record.message() else {
             panic!("expected V2 heartbeat record");
         };
         assert_eq!(message.seq, 0);

--- a/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/operator_activate.rs
@@ -5,7 +5,6 @@
 //! withdrawal enclave by deriving live serving state from S3 logs and checking the
 //! operator-pinned `ActivationState` hash.
 
-use crate::s3_reader::BuildPolicy;
 use crate::Enclave;
 use hashi_types::guardian::ActivationState;
 use hashi_types::guardian::GuardianError;
@@ -49,7 +48,7 @@ impl OAInstall {
             .await?;
 
         let committee: HashiCommittee = reader
-            .read_latest_committee(BuildPolicy::AnyAllowlisted)
+            .read_latest_committee()
             .await?
             .ok_or_else(|| InvalidInputs("no committee-update or genesis record found".into()))?
             .try_into()

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -418,7 +418,7 @@ mod tests {
             "provisioner init should write one record"
         );
         let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Init(message)) = record.message else {
+        let VersionedLogMessage::V2(LogMessage::Init(message)) = record.message() else {
             panic!("expected V2 init record");
         };
         assert_eq!(
@@ -429,20 +429,20 @@ mod tests {
             sharing_seq,
             share_ids,
             enclave_btc_pubkey,
-        } = *message
+        } = message.as_ref()
         else {
             panic!("expected provisioner-init completion record");
         };
-        assert_eq!(sharing_seq, 0);
+        assert_eq!(*sharing_seq, 0);
         assert_eq!(
             share_ids,
-            ctx.shares[..TEST_T]
+            &ctx.shares[..TEST_T]
                 .iter()
                 .map(|share| share.id)
                 .collect::<Vec<_>>()
         );
         assert_eq!(
-            enclave_btc_pubkey,
+            *enclave_btc_pubkey,
             ctx.enclave.config.enclave_btc_pubkey().unwrap()
         );
     }

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -418,7 +418,7 @@ mod tests {
             "provisioner init should write one record"
         );
         let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Init(message)) = record.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Init(message)) = record.message() else {
             panic!("expected V2 init record");
         };
         assert_eq!(

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -28,7 +28,7 @@ pub async fn provisioner_rotate_cert(
 
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
     let request = signed_request
-        .verify()
+        .authenticate()
         .map_err(|error| Unauthenticated(error.to_string()))?;
 
     enclave.require_fully_initialized()?;

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -27,9 +27,10 @@ pub async fn provisioner_rotate_cert(
     info!("/provisioner_rotate_cert - Received request.");
 
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();
-    let request = signed_request
-        .authenticate()
+    signed_request
+        .verify_signature()
         .map_err(|error| Unauthenticated(error.to_string()))?;
+    let request = signed_request.data;
 
     enclave.require_fully_initialized()?;
 

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -14,7 +14,7 @@ use hashi_types::guardian::crypto::encrypt_share_for_provisioner;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianError::Unauthenticated;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::ProvisionerRotateCertRequest;
 use hashi_types::guardian::ProvisionerRotateCertResponse;
@@ -23,7 +23,7 @@ use tracing::info;
 pub async fn provisioner_rotate_cert(
     enclave: Arc<Enclave>,
     signed_request: KpSigned<ProvisionerRotateCertRequest>,
-) -> GuardianResult<GuardianSigned<ProvisionerRotateCertResponse>> {
+) -> GuardianResult<GuardianSignedResponse<ProvisionerRotateCertResponse>> {
     info!("/provisioner_rotate_cert - Received request.");
 
     let signer_fingerprint = signed_request.signer_fingerprint().to_hex();

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_rotate_cert.rs
@@ -7,7 +7,6 @@
 
 use std::sync::Arc;
 
-use crate::s3_reader::BuildPolicy;
 use crate::Enclave;
 use hashi_types::guardian::crypto::decrypt_share;
 use hashi_types::guardian::crypto::encrypt_share_for_provisioner;
@@ -51,7 +50,7 @@ pub async fn provisioner_rotate_cert(
     let mut reader = enclave.new_guardian_reader()?;
 
     let latest_state = reader
-        .read_latest_ceremony_state(BuildPolicy::AnyAllowlisted)
+        .read_latest_ceremony_state()
         .await?
         .ok_or_else(|| InvalidInputs("no ceremony log found during cert rotation".into()))?;
     let enclave_btc_pubkey = enclave.config.enclave_btc_pubkey()?;

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -174,7 +174,6 @@ mod tests {
     use hashi_types::guardian::InitConfig;
     use hashi_types::guardian::LimiterConfig;
     use hashi_types::guardian::LimiterState;
-    use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -9,7 +9,7 @@ use hashi_types::guardian::GuardianError;
 use hashi_types::guardian::GuardianError::InternalError;
 use hashi_types::guardian::GuardianError::InvalidInputs;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::HashiSigned;
 use hashi_types::guardian::RateLimiter;
 use hashi_types::guardian::StandardWithdrawalRequest;
@@ -25,7 +25,7 @@ use tracing::info;
 pub async fn standard_withdrawal(
     enclave: Arc<Enclave>,
     signed_request: HashiSigned<StandardWithdrawalRequest>,
-) -> GuardianResult<GuardianSigned<StandardWithdrawalResponse>> {
+) -> GuardianResult<GuardianSignedResponse<StandardWithdrawalResponse>> {
     info!("/standard_withdrawal - Received request.");
 
     let unsigned_request = StandardWithdrawalRequestWire::from(signed_request.message().clone()); // for logging

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -175,6 +175,7 @@ mod tests {
     use hashi_types::guardian::LimiterConfig;
     use hashi_types::guardian::LimiterState;
     use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::VersionedLogMessage;
@@ -293,7 +294,7 @@ mod tests {
         );
         let success: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert_eq!(captured[0].0, success.object_key());
-        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = success.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) = success.message() else {
             panic!("expected V2 withdrawal record");
         };
         let WithdrawalLogMessage::Success {
@@ -310,7 +311,7 @@ mod tests {
 
         let failure: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
         assert_eq!(captured[1].0, failure.object_key());
-        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = failure.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) = failure.message() else {
             panic!("expected V2 withdrawal record");
         };
         let WithdrawalLogMessage::Failure {

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -293,14 +293,14 @@ mod tests {
         );
         let success: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert_eq!(captured[0].0, success.object_key());
-        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = success.message else {
+        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = success.message() else {
             panic!("expected V2 withdrawal record");
         };
         let WithdrawalLogMessage::Success {
             request_data,
             post_state,
             ..
-        } = *message
+        } = message.as_ref()
         else {
             panic!("expected successful withdrawal record");
         };
@@ -310,18 +310,18 @@ mod tests {
 
         let failure: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
         assert_eq!(captured[1].0, failure.object_key());
-        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = failure.message else {
+        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = failure.message() else {
             panic!("expected V2 withdrawal record");
         };
         let WithdrawalLogMessage::Failure {
             request_data,
             error,
             ..
-        } = *message
+        } = message.as_ref()
         else {
             panic!("expected failed withdrawal record");
         };
         assert_eq!(request_data.seq, 1);
-        assert_eq!(error, GuardianError::RateLimitExceeded.to_string());
+        assert_eq!(error, &GuardianError::RateLimitExceeded.to_string());
     }
 }

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -8,7 +8,6 @@ use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_guardian::s3_reader::VerifiedLogRecord;
-use hashi_guardian::s3_reader::withdraw_cursor;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::VersionedLogMessage;
@@ -77,7 +76,7 @@ impl GuardianWithdrawalsPoller {
     pub async fn new(config: &Config, start: UnixSeconds) -> anyhow::Result<Self> {
         Ok(Self {
             reader: GuardianReader::new(&config.guardian, config.pcr_allowlist()).await?,
-            cursor: withdraw_cursor(start),
+            cursor: S3HourScopedDirectory::withdraw(start),
         })
     }
 

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -9,7 +9,9 @@ use crate::domain::WithdrawalEventType;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_guardian::s3_reader::VerifiedLogRecord;
 use hashi_guardian::s3_reader::withdraw_cursor;
-use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
+use hashi_types::guardian::VersionedLogMessage;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -27,9 +29,14 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
     type Error = anyhow::Error;
 
     fn try_from(log: VerifiedLogRecord) -> Result<Self, Self::Error> {
-        let timestamp_ms = log.timestamp_ms();
-        let LogMessage::Withdrawal(withdrawal_message) = log.into_message() else {
-            anyhow::bail!("non-withdrawal logs found");
+        let entry = log.into_entry();
+        let timestamp_ms = entry.timestamp_ms();
+        let withdrawal_message = match entry.into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,
+            VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) => message,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                anyhow::bail!("non-withdrawal logs found");
+            }
         };
 
         match *withdrawal_message {

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -7,9 +7,9 @@ use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
 use hashi_guardian::s3_reader::GuardianReader;
+use hashi_guardian::s3_reader::VerifiedLogRecord;
 use hashi_guardian::s3_reader::withdraw_cursor;
 use hashi_types::guardian::LogMessage;
-use hashi_types::guardian::VerifiedLogRecord;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -27,7 +27,8 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
     type Error = anyhow::Error;
 
     fn try_from(log: VerifiedLogRecord) -> Result<Self, Self::Error> {
-        let LogMessage::Withdrawal(withdrawal_message) = log.message else {
+        let timestamp_ms = log.timestamp_ms();
+        let LogMessage::Withdrawal(withdrawal_message) = log.into_message() else {
             anyhow::bail!("non-withdrawal logs found");
         };
 
@@ -43,7 +44,7 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
                 Ok(VerifiedWithdrawal::Success(MonitorWithdrawalEvent {
                     event_type: WithdrawalEventType::E2GuardianApproved,
                     wid: request_data.wid,
-                    timestamp_secs: unix_millis_to_seconds(log.timestamp_ms),
+                    timestamp_secs: unix_millis_to_seconds(timestamp_ms),
                     btc_txid: txid,
                 }))
             }

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -8,7 +8,6 @@ use std::collections::BTreeSet;
 #[cfg(not(any(test, feature = "non-enclave-dev")))]
 use super::CryptoVerificationError;
 use super::CryptoVerificationResult;
-use super::GuardianInfo;
 use super::GuardianPubKey;
 use super::GuardianResult;
 use super::errors::GuardianError::BuildNotAllowlisted;
@@ -133,15 +132,6 @@ impl NitroAttestation {
 enum VerifyTime {
     Now,
     DocumentTimestamp,
-}
-
-/// A session's verified guardian info: the attestation-anchored signing pubkey,
-/// the signed `GuardianInfo`, and the build PCRs proven by attestation.
-#[derive(Debug, Clone)]
-pub struct VerifiedSessionInfo {
-    pub signing_pubkey: GuardianPubKey,
-    pub info: GuardianInfo,
-    pub build_pcrs: BuildPcrs,
 }
 
 /// One enclave build: its git revision and known-good Nitro measurement. A build is

--- a/crates/hashi-types/src/guardian/log/ceremony_state.rs
+++ b/crates/hashi-types/src/guardian/log/ceremony_state.rs
@@ -108,11 +108,13 @@ impl From<SetupNewKeyResponse> for CeremonyState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::guardian::GuardianSigned;
+    use crate::guardian::GuardianSignedResponse;
 
     #[test]
     fn serialization_includes_all_encrypted_shares() {
-        let response = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing().data;
+        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
+            .data
+            .response;
         let expected_share_count = response.encrypted_shares.share_count();
         let state = CeremonyState::from(response);
 
@@ -126,7 +128,9 @@ mod tests {
 
     #[test]
     fn new_rejects_mismatched_sharing_seq() {
-        let response = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing().data;
+        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
+            .data
+            .response;
         let sharing_seq = response.secret_sharing_instance.sharing_seq();
         let err = CeremonyState::new(
             CeremonyLogMessage::NewKey {
@@ -141,7 +145,9 @@ mod tests {
 
     #[test]
     fn new_rejects_mismatched_share_count() {
-        let response = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing().data;
+        let response = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing()
+            .data
+            .response;
         let sharing_seq = response.secret_sharing_instance.sharing_seq();
         let err = CeremonyState::new(
             CeremonyLogMessage::NewKey {

--- a/crates/hashi-types/src/guardian/log/messages/committee_update.rs
+++ b/crates/hashi-types/src/guardian/log/messages/committee_update.rs
@@ -29,6 +29,15 @@ pub enum CommitteeUpdateLogMessage {
 }
 
 impl CommitteeUpdateLogMessage {
+    fn failure_object_key_prefix() -> String {
+        format!("{S3_DIR_COMMITTEE_UPDATE}/failure-")
+    }
+
+    /// Return whether `object_key` belongs to a failed committee update.
+    pub fn is_failure_object_key(object_key: &str) -> bool {
+        object_key.starts_with(&Self::failure_object_key_prefix())
+    }
+
     /// Success keys lead with the new epoch (zero-padded) so a lex listing
     /// is epoch-sorted; failures lead with `failure-` so they sort after
     /// all successes, leaving the lex-last success key as the latest
@@ -40,9 +49,28 @@ impl CommitteeUpdateLogMessage {
                 new_committee.epoch,
             )),
             Self::Failure { new_committee, .. } => ObjectKeyPattern::RandomSuffix(format!(
-                "{S3_DIR_COMMITTEE_UPDATE}/failure-{:020}-{session_id}-",
+                "{}{:020}-{session_id}-",
+                Self::failure_object_key_prefix(),
                 new_committee.epoch,
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifies_failure_object_keys() {
+        assert!(CommitteeUpdateLogMessage::is_failure_object_key(
+            "committee-update/failure-00000000000000000009-session-abcd1234.json"
+        ));
+        assert!(!CommitteeUpdateLogMessage::is_failure_object_key(
+            "committee-update/00000000000000000009-session.json"
+        ));
+        assert!(!CommitteeUpdateLogMessage::is_failure_object_key(
+            "ceremony/failure-example.json"
+        ));
     }
 }

--- a/crates/hashi-types/src/guardian/log/messages/heartbeat.rs
+++ b/crates/hashi-types/src/guardian/log/messages/heartbeat.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ObjectKeyPattern;
-use super::super::S3_DIR_HEARTBEAT;
 use crate::guardian::UnixMillis;
 use crate::guardian::s3_utils::S3HourScopedDirectory;
 use crate::guardian::unix_millis_to_seconds;
@@ -22,7 +21,7 @@ impl HeartbeatLogMessage {
     pub fn object_key(&self, session_id: &str, timestamp_ms: UnixMillis) -> String {
         format!(
             "{}{session_id}-{:020}.json",
-            S3HourScopedDirectory::new(S3_DIR_HEARTBEAT, unix_millis_to_seconds(timestamp_ms)),
+            S3HourScopedDirectory::heartbeat(unix_millis_to_seconds(timestamp_ms)),
             self.seq,
         )
     }

--- a/crates/hashi-types/src/guardian/log/messages/kp_share.rs
+++ b/crates/hashi-types/src/guardian/log/messages/kp_share.rs
@@ -23,8 +23,7 @@ pub struct KpShareStateLogMessageV2 {
     pub encrypted_shares: KPEncryptedSharesRoster,
 }
 
-/// The current normalized KP-share state exposed to writers and verified
-/// readers.
+/// The KP-share state emitted by writers and returned by ceremony readers.
 pub type KpShareStateLogMessage = KpShareStateLogMessageV2;
 
 /// V1 encrypted share state: exactly one certificate and ciphertext per KP.
@@ -90,9 +89,13 @@ impl KpShareStateLogMessageV1 {
             self.cert_seq,
         ))
     }
+}
 
-    pub fn into_current(self) -> Result<KpShareStateLogMessageV2, GuardianError> {
-        let shares = self
+impl TryFrom<KpShareStateLogMessageV1> for KpShareStateLogMessageV2 {
+    type Error = GuardianError;
+
+    fn try_from(message: KpShareStateLogMessageV1) -> Result<Self, Self::Error> {
+        let shares = message
             .encrypted_shares
             .0
             .into_iter()
@@ -104,9 +107,9 @@ impl KpShareStateLogMessageV1 {
                 )]),
             })
             .collect();
-        Ok(KpShareStateLogMessageV2::new(
-            self.sharing_seq,
-            self.cert_seq,
+        Ok(Self::new(
+            message.sharing_seq,
+            message.cert_seq,
             KPEncryptedSharesRoster::new(shares)?,
         ))
     }

--- a/crates/hashi-types/src/guardian/log/messages/withdrawal.rs
+++ b/crates/hashi-types/src/guardian/log/messages/withdrawal.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ObjectKeyPattern;
-use super::super::S3_DIR_WITHDRAW;
 use crate::committee::CommitteeSignature;
 use crate::guardian::LimiterState;
 use crate::guardian::StandardWithdrawalRequestWire;
@@ -45,8 +44,7 @@ impl WithdrawalLogMessage {
         session_id: &str,
         timestamp_ms: UnixMillis,
     ) -> ObjectKeyPattern {
-        let directory =
-            S3HourScopedDirectory::new(S3_DIR_WITHDRAW, unix_millis_to_seconds(timestamp_ms));
+        let directory = S3HourScopedDirectory::withdraw(unix_millis_to_seconds(timestamp_ms));
         match self {
             Self::Success { request_data, .. } => ObjectKeyPattern::Fixed(format!(
                 "{directory}success-{:020}-{session_id}-wid{}.json",

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -772,7 +772,7 @@ mod tests {
             message: &signed.data.message,
         };
         let signed_bytes = bcs::to_bytes(&(
-            GuardianSigningIntentType::LogMessage,
+            GuardianSigningIntentType::LogEntry,
             payload,
             signed.data.timestamp_ms,
         ))

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The `LogRecord` envelope written to S3: it wraps a `super::schema::LogMessage`
-//! with the session id, timestamp, and (for signed logs) the guardian signature.
+//! The `LogRecord` written to S3: it wraps a `super::schema::LogMessage` with
+//! its routing context and, for signed logs, a guardian signature.
 //! The object key and lock duration are derived from the wrapped message.
 
 use super::ObjectKeyPattern;
@@ -17,8 +17,6 @@ use crate::guardian::GuardianResult;
 use crate::guardian::GuardianSignKeyPair;
 use crate::guardian::GuardianSignature;
 use crate::guardian::GuardianSigned;
-use crate::guardian::GuardianSigningIntent;
-use crate::guardian::GuardianSigningIntentType;
 use crate::guardian::SessionID;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
@@ -30,7 +28,7 @@ use std::time::Duration;
 
 /// The data authenticated by a signed log record.
 ///
-/// Field order is part of the deployed BCS signing format and must not change.
+/// Field order defines the BCS signing format.
 #[derive(Debug, Serialize)]
 pub struct LogEntry {
     schema_version: u64,
@@ -39,13 +37,7 @@ pub struct LogEntry {
     /// intended key with the actual key returned by S3.
     object_key: String,
     message: VersionedLogMessage,
-}
-
-/// A log entry authenticated by its embedded Nitro attestation instead of a
-/// Guardian signature.
-#[derive(Debug)]
-pub struct UnsignedLogEntry {
-    data: LogEntry,
+    /// Milliseconds since Unix epoch.
     timestamp_ms: UnixMillis,
 }
 
@@ -54,7 +46,7 @@ pub struct UnsignedLogEntry {
 #[derive(Debug)]
 pub enum LogRecord {
     Signed(GuardianSigned<LogEntry>),
-    Unsigned(UnsignedLogEntry),
+    Unsigned(LogEntry),
 }
 
 impl Serialize for LogRecord {
@@ -73,9 +65,9 @@ impl Serialize for LogRecord {
             signature: &'a Option<GuardianSignature>,
         }
 
-        let (data, timestamp_ms, signature) = match self {
-            Self::Signed(signed) => (&signed.data, signed.timestamp_ms, Some(signed.signature)),
-            Self::Unsigned(unsigned) => (&unsigned.data, unsigned.timestamp_ms, None),
+        let (data, signature) = match self {
+            Self::Signed(signed) => (&signed.data, Some(signed.signature)),
+            Self::Unsigned(unsigned) => (unsigned, None),
         };
 
         match &data.message {
@@ -83,7 +75,7 @@ impl Serialize for LogRecord {
                 schema_version: data.schema_version,
                 object_key: &data.object_key,
                 session_id: &data.session_id,
-                timestamp_ms,
+                timestamp_ms: data.timestamp_ms,
                 message,
                 signature: &signature,
             }
@@ -92,7 +84,7 @@ impl Serialize for LogRecord {
                 schema_version: data.schema_version,
                 object_key: &data.object_key,
                 session_id: &data.session_id,
-                timestamp_ms,
+                timestamp_ms: data.timestamp_ms,
                 message,
                 signature: &signature,
             }
@@ -141,38 +133,28 @@ impl<'de> Deserialize<'de> for LogRecord {
             object_key: raw.object_key,
             session_id: raw.session_id,
             message,
+            timestamp_ms: raw.timestamp_ms,
         };
         Ok(match raw.signature {
-            Some(signature) => Self::Signed(GuardianSigned {
-                data,
-                timestamp_ms: raw.timestamp_ms,
-                signature,
-            }),
-            None => Self::Unsigned(UnsignedLogEntry {
-                data,
-                timestamp_ms: raw.timestamp_ms,
-            }),
+            Some(signature) => Self::Signed(GuardianSigned { data, signature }),
+            None => Self::Unsigned(data),
         })
     }
 }
 
-impl GuardianSigningIntent for LogEntry {
-    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
-}
-
 impl LogEntry {
+    pub fn timestamp_ms(&self) -> UnixMillis {
+        self.timestamp_ms
+    }
+
     /// Validate log-specific routing context without performing cryptography.
-    pub fn validate(
-        &self,
-        timestamp_ms: UnixMillis,
-        signing_public_key: &GuardianPubKey,
-    ) -> GuardianResult<()> {
+    pub fn validate(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
         if self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected signed log record but message is unsigned".into(),
             ));
         }
-        self.validate_object_key(timestamp_ms)?;
+        self.validate_object_key()?;
         self.validate_session_id(signing_public_key)
     }
 
@@ -184,10 +166,10 @@ impl LogEntry {
         Ok((self.session_id, message))
     }
 
-    fn validate_object_key(&self, timestamp_ms: UnixMillis) -> GuardianResult<()> {
+    fn validate_object_key(&self) -> GuardianResult<()> {
         match self
             .message
-            .object_key_pattern(&self.session_id, timestamp_ms)
+            .object_key_pattern(&self.session_id, self.timestamp_ms)
         {
             ObjectKeyPattern::Fixed(expected) if self.object_key != expected => {
                 return Err(InvalidS3Log(format!(
@@ -216,19 +198,16 @@ impl LogEntry {
         }
         Ok(())
     }
-}
-
-impl UnsignedLogEntry {
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
-    pub fn validate(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        if !self.data.message.is_allowed_unsigned() {
+    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
             ));
         }
-        self.data.validate_object_key(self.timestamp_ms)?;
-        let init = match &self.data.message {
+        self.validate_object_key()?;
+        let init = match &self.message {
             VersionedLogMessage::V1(LogMessageV1::Init(init)) => init,
             VersionedLogMessage::V2(LogMessage::Init(init)) => init,
             _ => unreachable!("is_allowed_unsigned only permits an init message"),
@@ -239,9 +218,9 @@ impl UnsignedLogEntry {
         else {
             unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
         };
-        self.data.validate_session_id(signing_public_key)?;
+        self.validate_session_id(signing_public_key)?;
         let timestamp_ms = self.timestamp_ms;
-        let (session_id, message) = self.data.into_current()?;
+        let (session_id, message) = self.into_current()?;
         Ok((session_id, timestamp_ms, message))
     }
 }
@@ -312,10 +291,7 @@ impl LogRecord {
     }
 
     pub fn timestamp_ms(&self) -> UnixMillis {
-        match self {
-            Self::Signed(signed) => signed.timestamp_ms,
-            Self::Unsigned(unsigned) => unsigned.timestamp_ms,
-        }
+        self.data().timestamp_ms
     }
 
     pub fn message(&self) -> &VersionedLogMessage {
@@ -329,14 +305,14 @@ impl LogRecord {
     pub fn into_signed(self) -> GuardianResult<GuardianSigned<LogEntry>> {
         match self {
             Self::Signed(signed) => Ok(signed),
-            Self::Unsigned(unsigned) if unsigned.data.message.is_allowed_unsigned() => Err(
+            Self::Unsigned(unsigned) if unsigned.message.is_allowed_unsigned() => Err(
                 InvalidS3Log("expected signed log record but message is unsigned".into()),
             ),
             Self::Unsigned(_) => Err(InvalidS3Log("missing log signature".into())),
         }
     }
 
-    pub fn into_unsigned(self) -> GuardianResult<UnsignedLogEntry> {
+    pub fn into_unsigned(self) -> GuardianResult<LogEntry> {
         match self {
             Self::Unsigned(unsigned) => Ok(unsigned),
             Self::Signed(signed) if signed.data.message.is_allowed_unsigned() => Err(InvalidS3Log(
@@ -360,8 +336,9 @@ impl LogRecord {
             object_key,
             session_id,
             message,
+            timestamp_ms,
         };
-        Self::Signed(GuardianSigned::sign(data, signing_key, timestamp_ms))
+        Self::Signed(GuardianSigned::sign(data, signing_key))
     }
 
     fn unsigned(
@@ -374,13 +351,11 @@ impl LogRecord {
             message.is_allowed_unsigned(),
             "message must be Init(OIAttestationUnsigned)"
         );
-        Self::Unsigned(UnsignedLogEntry {
-            data: LogEntry {
-                schema_version: message.schema_version(),
-                object_key,
-                session_id,
-                message,
-            },
+        Self::Unsigned(LogEntry {
+            schema_version: message.schema_version(),
+            object_key,
+            session_id,
+            message,
             timestamp_ms,
         })
     }
@@ -388,7 +363,7 @@ impl LogRecord {
     fn data(&self) -> &LogEntry {
         match self {
             Self::Signed(signed) => &signed.data,
-            Self::Unsigned(unsigned) => &unsigned.data,
+            Self::Unsigned(unsigned) => unsigned,
         }
     }
 
@@ -396,7 +371,7 @@ impl LogRecord {
     fn data_mut(&mut self) -> &mut LogEntry {
         match self {
             Self::Signed(signed) => &mut signed.data,
-            Self::Unsigned(unsigned) => &mut unsigned.data,
+            Self::Unsigned(unsigned) => unsigned,
         }
     }
 }
@@ -409,7 +384,7 @@ mod tests {
     use crate::guardian::GenesisLogMessage;
     use crate::guardian::GetGuardianInfoResponse;
     use crate::guardian::GuardianError;
-    use crate::guardian::GuardianSigned;
+    use crate::guardian::GuardianSignedResponse;
     use crate::guardian::HeartbeatLogMessage;
     use crate::guardian::InitLogMessage;
     use crate::guardian::KPEncryptedSharesRoster;
@@ -454,8 +429,8 @@ mod tests {
         signing_public_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         let signed = record.into_signed()?;
-        let timestamp_ms = signed.timestamp_ms;
-        signed.data.validate(timestamp_ms, signing_public_key)?;
+        let timestamp_ms = signed.data.timestamp_ms;
+        signed.data.validate(signing_public_key)?;
         let data = signed
             .authenticate(signing_public_key)
             .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
@@ -464,7 +439,7 @@ mod tests {
     }
 
     fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        record.into_unsigned()?.validate()
+        record.into_unsigned()?.validate_unsigned()
     }
 
     fn assert_writer_key_is_stable_and_verifies(log: LogRecord, signing_key: &GuardianSignKeyPair) {
@@ -510,9 +485,12 @@ mod tests {
             StandardWithdrawalRequest::mock_signed_and_committee_for_testing(Network::Regtest);
         let (request_sign, request_data) = signed_request.into_parts();
         let request_data: StandardWithdrawalRequestWire = request_data.into();
-        let response = GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data;
-        let encrypted_shares = GuardianSigned::<RotateKpsResponse>::mock_for_testing()
+        let response = GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
             .data
+            .response;
+        let encrypted_shares = GuardianSignedResponse::<RotateKpsResponse>::mock_for_testing()
+            .data
+            .response
             .encrypted_shares;
         let (guardian_info, _) = GetGuardianInfoResponse::mock_for_testing().into_info_unchecked();
         let committee_0: crate::move_types::Committee = (&committee_0).into();
@@ -797,20 +775,20 @@ mod tests {
         let LogRecord::Signed(signed) = log else {
             panic!("heartbeat must be signed");
         };
-        let deployed_payload = DeployedLogSigningPayload {
+        let payload = DeployedLogSigningPayload {
             schema_version: signed.data.schema_version,
             session_id: &signed.data.session_id,
             object_key: &signed.data.object_key,
             message: &signed.data.message,
         };
-        let deployed_bytes = bcs::to_bytes(&(
+        let signed_bytes = bcs::to_bytes(&(
             GuardianSigningIntentType::LogMessage,
-            deployed_payload,
-            signed.timestamp_ms,
+            payload,
+            signed.data.timestamp_ms,
         ))
         .unwrap();
 
-        assert_eq!(signed.signature, signing_key.sign(&deployed_bytes));
+        assert_eq!(signed.signature, signing_key.sign(&signed_bytes));
     }
 
     #[test]
@@ -1089,7 +1067,9 @@ mod tests {
                 txid: Txid::from_slice(&[3u8; 32]).expect("valid txid"),
                 request_data,
                 request_sign,
-                response: GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing().data,
+                response: GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing()
+                    .data
+                    .response,
                 post_state: LimiterState {
                     num_tokens_available: 0,
                     last_updated_at: 0,

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -347,8 +347,8 @@ impl LogRecord {
 
     /// Consume the record and extract its entry without validation.
     ///
-    /// This does not check the routing context, whether the message requires a
-    /// signature, the Guardian signature, or the Nitro attestation.
+    /// This bypasses routing checks, signed-versus-unsigned envelope checks,
+    /// Guardian signature verification, and Nitro attestation authentication.
     pub fn into_entry_unchecked(self) -> LogEntry {
         match self {
             Self::Signed(signed) => signed.into_data_unchecked(),

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -32,19 +32,22 @@ use std::time::Duration;
 /// Field order defines the BCS signing format.
 #[derive(Debug, Serialize)]
 pub struct LogEntry {
+    /// Version of the serialized log schema.
     schema_version: u64,
+    /// Guardian session that wrote the entry.
     session_id: SessionID,
     /// Final S3 destination selected before signing. Readers must compare this
     /// intended key with the actual key returned by S3.
     object_key: String,
+    /// Versioned log payload.
     message: VersionedLogMessage,
-    /// Milliseconds since Unix epoch.
+    /// Entry creation time in milliseconds since the Unix epoch.
     timestamp_ms: UnixMillis,
 }
 
 /// Write: `LogMessage` -> `LogRecord` -> JSON body.
 /// Read: actual S3 key + JSON body -> untrusted `LogRecord`; the reader layer
-/// fully verifies it before exposing its contents.
+/// fully verifies it before exposing its contents (see `VerifiedLogRecord`).
 #[derive(Debug)]
 pub enum LogRecord {
     Signed(GuardianSigned<LogEntry>),

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -10,7 +10,6 @@ use super::retention::S3ObjectLockPolicy;
 use super::schema::LogMessage;
 use super::schema::LogMessageV1;
 use super::schema::VersionedLogMessage;
-use crate::guardian::BuildPcrs;
 use crate::guardian::GuardianError::InvalidS3Log;
 use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
@@ -42,7 +41,8 @@ pub struct LogEntry {
 }
 
 /// Write: `LogMessage` -> `LogRecord` -> JSON body.
-/// Read: actual S3 key + JSON body -> untrusted `LogRecord` -> `VerifiedLogRecord`.
+/// Read: actual S3 key + JSON body -> untrusted `LogRecord`; the reader layer
+/// authenticates it before exposing its contents.
 #[derive(Debug)]
 pub enum LogRecord {
     Signed(GuardianSigned<LogEntry>),
@@ -222,37 +222,6 @@ impl LogEntry {
         let timestamp_ms = self.timestamp_ms;
         let (session_id, message) = self.into_current()?;
         Ok((session_id, timestamp_ms, message))
-    }
-}
-
-/// A log record whose message signature and writing session's attestation/PCRs
-/// have both been verified. Its message is normalized to the current schema.
-/// If a future schema cannot be converted losslessly, this type should retain
-/// `VersionedLogMessage` and leave version acceptance to callers instead.
-#[derive(Debug)]
-pub struct VerifiedLogRecord {
-    pub object_key: String,
-    pub session_id: SessionID,
-    pub timestamp_ms: UnixMillis,
-    pub message: LogMessage,
-    pub build_pcrs: BuildPcrs,
-}
-
-impl VerifiedLogRecord {
-    pub fn new(
-        object_key: String,
-        session_id: SessionID,
-        timestamp_ms: UnixMillis,
-        message: LogMessage,
-        build_pcrs: BuildPcrs,
-    ) -> Self {
-        Self {
-            object_key,
-            session_id,
-            timestamp_ms,
-            message,
-            build_pcrs,
-        }
     }
 }
 

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -204,7 +204,7 @@ impl LogEntry {
 
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
-    fn validate_unsigned(self) -> GuardianResult<Self> {
+    fn validate_unsigned(&self) -> GuardianResult<()> {
         if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
@@ -225,7 +225,7 @@ impl LogEntry {
             unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
         };
         self.validate_session_id(signing_public_key)?;
-        Ok(self)
+        Ok(())
     }
 
     /// Validate signed-log routing context.
@@ -301,7 +301,10 @@ impl LogRecord {
                     .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
                 Ok(signed.data)
             }
-            (Self::Unsigned(unsigned), None) => unsigned.validate_unsigned(),
+            (Self::Unsigned(unsigned), None) => {
+                unsigned.validate_unsigned()?;
+                Ok(unsigned)
+            }
             (Self::Unsigned(unsigned), Some(_)) if unsigned.message.is_allowed_unsigned() => Err(
                 InvalidS3Log("expected signed log record but message is unsigned".into()),
             ),

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -21,8 +21,6 @@ use crate::guardian::SessionID;
 use crate::guardian::SigningIntent;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
-use crate::guardian::signing::sign_intent;
-use crate::guardian::signing::verify_intent;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::Error as _;
@@ -218,11 +216,7 @@ impl LogRecord {
             message,
             signature: None,
         };
-        record.signature = Some(sign_intent(
-            &record.signing_payload(),
-            timestamp_ms,
-            signing_key,
-        ));
+        record.signature = Some(record.signing_payload().sign(timestamp_ms, signing_key));
         record
     }
 
@@ -263,7 +257,8 @@ impl LogRecord {
             .signature
             .as_ref()
             .ok_or_else(|| InvalidS3Log("missing log signature".into()))?;
-        verify_intent(&self.signing_payload(), timestamp_ms, signature, pub_key)
+        self.signing_payload()
+            .verify_signature(timestamp_ms, signature, pub_key)
             .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
 
         let message = self

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -16,39 +16,45 @@ use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
 use crate::guardian::GuardianSignKeyPair;
 use crate::guardian::GuardianSignature;
+use crate::guardian::GuardianSigned;
 use crate::guardian::GuardianSigningIntent;
 use crate::guardian::GuardianSigningIntentType;
 use crate::guardian::SessionID;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
-use crate::guardian::signing::sign_guardian_payload;
-use crate::guardian::signing::verify_guardian_payload_signature;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::Error as _;
 use serde_json::Value;
 use std::time::Duration;
 
+/// The data authenticated by a signed log record.
+///
+/// Field order is part of the deployed BCS signing format and must not change.
+#[derive(Debug, Serialize)]
+pub struct LogEntry {
+    schema_version: u64,
+    session_id: SessionID,
+    /// Final S3 destination selected before signing. Readers must compare this
+    /// intended key with the actual key returned by S3.
+    object_key: String,
+    message: VersionedLogMessage,
+}
+
+/// A log entry authenticated by its embedded Nitro attestation instead of a
+/// Guardian signature.
+#[derive(Debug)]
+pub struct UnsignedLogEntry {
+    data: LogEntry,
+    timestamp_ms: UnixMillis,
+}
+
 /// Write: `LogMessage` -> `LogRecord` -> JSON body.
 /// Read: actual S3 key + JSON body -> untrusted `LogRecord` -> `VerifiedLogRecord`.
 #[derive(Debug)]
-pub struct LogRecord {
-    /// Final S3 destination selected before signing. Readers must compare this
-    /// signed intended key with the actual key returned by S3.
-    pub object_key: String,
-    pub session_id: SessionID,
-    pub timestamp_ms: UnixMillis,
-    pub message: VersionedLogMessage,
-    /// Present for signed logs; omitted for unsigned logs (currently only OIAttestationUnsigned).
-    pub signature: Option<GuardianSignature>,
-}
-
-#[derive(Serialize)]
-struct LogSigningPayload<'a> {
-    schema_version: u64,
-    session_id: &'a SessionID,
-    object_key: &'a str,
-    message: &'a VersionedLogMessage,
+pub enum LogRecord {
+    Signed(GuardianSigned<LogEntry>),
+    Unsigned(UnsignedLogEntry),
 }
 
 impl Serialize for LogRecord {
@@ -67,23 +73,28 @@ impl Serialize for LogRecord {
             signature: &'a Option<GuardianSignature>,
         }
 
-        match &self.message {
+        let (data, timestamp_ms, signature) = match self {
+            Self::Signed(signed) => (&signed.data, signed.timestamp_ms, Some(signed.signature)),
+            Self::Unsigned(unsigned) => (&unsigned.data, unsigned.timestamp_ms, None),
+        };
+
+        match &data.message {
             VersionedLogMessage::V1(message) => LogRecordWire {
-                schema_version: VersionedLogMessage::SCHEMA_VERSION_V1,
-                object_key: &self.object_key,
-                session_id: &self.session_id,
-                timestamp_ms: self.timestamp_ms,
+                schema_version: data.schema_version,
+                object_key: &data.object_key,
+                session_id: &data.session_id,
+                timestamp_ms,
                 message,
-                signature: &self.signature,
+                signature: &signature,
             }
             .serialize(serializer),
             VersionedLogMessage::V2(message) => LogRecordWire {
-                schema_version: VersionedLogMessage::SCHEMA_VERSION_V2,
-                object_key: &self.object_key,
-                session_id: &self.session_id,
-                timestamp_ms: self.timestamp_ms,
+                schema_version: data.schema_version,
+                object_key: &data.object_key,
+                session_id: &data.session_id,
+                timestamp_ms,
                 message,
-                signature: &self.signature,
+                signature: &signature,
             }
             .serialize(serializer),
         }
@@ -125,18 +136,114 @@ impl<'de> Deserialize<'de> for LogRecord {
             }
         };
 
-        Ok(Self {
+        let data = LogEntry {
+            schema_version: raw.schema_version,
             object_key: raw.object_key,
             session_id: raw.session_id,
-            timestamp_ms: raw.timestamp_ms,
             message,
-            signature: raw.signature,
+        };
+        Ok(match raw.signature {
+            Some(signature) => Self::Signed(GuardianSigned {
+                data,
+                timestamp_ms: raw.timestamp_ms,
+                signature,
+            }),
+            None => Self::Unsigned(UnsignedLogEntry {
+                data,
+                timestamp_ms: raw.timestamp_ms,
+            }),
         })
     }
 }
 
-impl GuardianSigningIntent for LogSigningPayload<'_> {
+impl GuardianSigningIntent for LogEntry {
     const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
+}
+
+impl LogEntry {
+    /// Validate log-specific routing context without performing cryptography.
+    pub fn validate(
+        &self,
+        timestamp_ms: UnixMillis,
+        signing_public_key: &GuardianPubKey,
+    ) -> GuardianResult<()> {
+        if self.message.is_allowed_unsigned() {
+            return Err(InvalidS3Log(
+                "expected signed log record but message is unsigned".into(),
+            ));
+        }
+        self.validate_object_key(timestamp_ms)?;
+        self.validate_session_id(signing_public_key)
+    }
+
+    pub fn into_current(self) -> GuardianResult<(SessionID, LogMessage)> {
+        let message = self
+            .message
+            .into_current()
+            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
+        Ok((self.session_id, message))
+    }
+
+    fn validate_object_key(&self, timestamp_ms: UnixMillis) -> GuardianResult<()> {
+        match self
+            .message
+            .object_key_pattern(&self.session_id, timestamp_ms)
+        {
+            ObjectKeyPattern::Fixed(expected) if self.object_key != expected => {
+                return Err(InvalidS3Log(format!(
+                    "non-canonical S3 object key: got {}, expected {expected}",
+                    self.object_key
+                )));
+            }
+            ObjectKeyPattern::RandomSuffix(prefix) if !self.object_key.starts_with(&prefix) => {
+                return Err(InvalidS3Log(format!(
+                    "non-canonical S3 object key: got {}, expected prefix {prefix}",
+                    self.object_key
+                )));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn validate_session_id(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
+        let canonical_session_id = SessionID::from_signing_pubkey(signing_public_key);
+        if self.session_id != canonical_session_id {
+            return Err(InvalidS3Log(format!(
+                "session ID mismatch: record contains {}, signing public key derives {canonical_session_id}",
+                self.session_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl UnsignedLogEntry {
+    /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
+    /// must be authenticated separately.
+    pub fn validate(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        if !self.data.message.is_allowed_unsigned() {
+            return Err(InvalidS3Log(
+                "expected unsigned log record but message requires a signature".into(),
+            ));
+        }
+        self.data.validate_object_key(self.timestamp_ms)?;
+        let init = match &self.data.message {
+            VersionedLogMessage::V1(LogMessageV1::Init(init)) => init,
+            VersionedLogMessage::V2(LogMessage::Init(init)) => init,
+            _ => unreachable!("is_allowed_unsigned only permits an init message"),
+        };
+        let super::messages::InitLogMessage::OIAttestationUnsigned {
+            signing_public_key, ..
+        } = init.as_ref()
+        else {
+            unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
+        };
+        self.data.validate_session_id(signing_public_key)?;
+        let timestamp_ms = self.timestamp_ms;
+        let (session_id, message) = self.data.into_current()?;
+        Ok((session_id, timestamp_ms, message))
+    }
 }
 
 /// A log record whose message signature and writing session's attestation/PCRs
@@ -197,11 +304,48 @@ impl LogRecord {
     }
 
     pub fn object_key(&self) -> &str {
-        &self.object_key
+        &self.data().object_key
+    }
+
+    pub fn session_id(&self) -> &SessionID {
+        &self.data().session_id
+    }
+
+    pub fn timestamp_ms(&self) -> UnixMillis {
+        match self {
+            Self::Signed(signed) => signed.timestamp_ms,
+            Self::Unsigned(unsigned) => unsigned.timestamp_ms,
+        }
+    }
+
+    pub fn message(&self) -> &VersionedLogMessage {
+        &self.data().message
     }
 
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
-        policy.duration_for(self.message.log_type())
+        policy.duration_for(self.data().message.log_type())
+    }
+
+    pub fn into_signed(self) -> GuardianResult<GuardianSigned<LogEntry>> {
+        match self {
+            Self::Signed(signed) => Ok(signed),
+            Self::Unsigned(unsigned) if unsigned.data.message.is_allowed_unsigned() => Err(
+                InvalidS3Log("expected signed log record but message is unsigned".into()),
+            ),
+            Self::Unsigned(_) => Err(InvalidS3Log("missing log signature".into())),
+        }
+    }
+
+    pub fn into_unsigned(self) -> GuardianResult<UnsignedLogEntry> {
+        match self {
+            Self::Unsigned(unsigned) => Ok(unsigned),
+            Self::Signed(signed) if signed.data.message.is_allowed_unsigned() => Err(InvalidS3Log(
+                "unsigned log record must not contain a signature".into(),
+            )),
+            Self::Signed(_) => Err(InvalidS3Log(
+                "expected unsigned log record but message requires a signature".into(),
+            )),
+        }
     }
 
     fn signed(
@@ -211,19 +355,13 @@ impl LogRecord {
         timestamp_ms: UnixMillis,
         object_key: String,
     ) -> Self {
-        let mut record = Self {
+        let data = LogEntry {
+            schema_version: message.schema_version(),
             object_key,
             session_id,
-            timestamp_ms,
             message,
-            signature: None,
         };
-        record.signature = Some(sign_guardian_payload(
-            &record.signing_payload(),
-            timestamp_ms,
-            signing_key,
-        ));
-        record
+        Self::Signed(GuardianSigned::sign(data, signing_key, timestamp_ms))
     }
 
     fn unsigned(
@@ -236,120 +374,29 @@ impl LogRecord {
             message.is_allowed_unsigned(),
             "message must be Init(OIAttestationUnsigned)"
         );
-        Self {
-            object_key,
-            session_id,
+        Self::Unsigned(UnsignedLogEntry {
+            data: LogEntry {
+                schema_version: message.schema_version(),
+                object_key,
+                session_id,
+                message,
+            },
             timestamp_ms,
-            message,
-            signature: None,
+        })
+    }
+
+    fn data(&self) -> &LogEntry {
+        match self {
+            Self::Signed(signed) => &signed.data,
+            Self::Unsigned(unsigned) => &unsigned.data,
         }
     }
 
-    /// Validates the signed record's envelope, canonical session, and Guardian
-    /// signature. The caller must establish trust in `pub_key` separately.
-    pub fn validate_signed(
-        self,
-        pub_key: &GuardianPubKey,
-    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        if self.message.is_allowed_unsigned() {
-            return Err(InvalidS3Log(
-                "expected signed log record but message is unsigned".into(),
-            ));
-        }
-        self.validate_object_key()?;
-        self.validate_session_id(pub_key)?;
-        let timestamp_ms = self.timestamp_ms;
-        let signature = self
-            .signature
-            .as_ref()
-            .ok_or_else(|| InvalidS3Log("missing log signature".into()))?;
-        verify_guardian_payload_signature(
-            &self.signing_payload(),
-            timestamp_ms,
-            signature,
-            pub_key,
-        )
-        .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-
-        let message = self
-            .message
-            .into_current()
-            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
-        Ok((self.session_id, timestamp_ms, message))
-    }
-
-    /// Validates the unsigned OI-attestation record's envelope and canonical
-    /// session. The Nitro attestation itself must be authenticated separately.
-    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        if !self.message.is_allowed_unsigned() {
-            return Err(InvalidS3Log(
-                "expected unsigned log record but message requires a signature".into(),
-            ));
-        }
-        if self.signature.is_some() {
-            return Err(InvalidS3Log(
-                "unsigned log record must not contain a signature".into(),
-            ));
-        }
-        self.validate_object_key()?;
-        let init = match &self.message {
-            VersionedLogMessage::V1(LogMessageV1::Init(init)) => init,
-            VersionedLogMessage::V2(LogMessage::Init(init)) => init,
-            _ => unreachable!("is_allowed_unsigned only permits an init message"),
-        };
-        let super::messages::InitLogMessage::OIAttestationUnsigned {
-            signing_public_key, ..
-        } = init.as_ref()
-        else {
-            unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
-        };
-        self.validate_session_id(signing_public_key)?;
-        let message = self
-            .message
-            .into_current()
-            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
-        Ok((self.session_id, self.timestamp_ms, message))
-    }
-
-    fn validate_object_key(&self) -> GuardianResult<()> {
-        match self
-            .message
-            .object_key_pattern(&self.session_id, self.timestamp_ms)
-        {
-            ObjectKeyPattern::Fixed(expected) if self.object_key != expected => {
-                return Err(InvalidS3Log(format!(
-                    "non-canonical S3 object key: got {}, expected {expected}",
-                    self.object_key
-                )));
-            }
-            ObjectKeyPattern::RandomSuffix(prefix) if !self.object_key.starts_with(&prefix) => {
-                return Err(InvalidS3Log(format!(
-                    "non-canonical S3 object key: got {}, expected prefix {prefix}",
-                    self.object_key
-                )));
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    fn validate_session_id(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
-        let canonical_session_id = SessionID::from_signing_pubkey(signing_public_key);
-        if self.session_id != canonical_session_id {
-            return Err(InvalidS3Log(format!(
-                "session ID mismatch: record contains {}, signing public key derives {canonical_session_id}",
-                self.session_id
-            )));
-        }
-        Ok(())
-    }
-
-    fn signing_payload(&self) -> LogSigningPayload<'_> {
-        LogSigningPayload {
-            schema_version: self.message.schema_version(),
-            session_id: &self.session_id,
-            object_key: &self.object_key,
-            message: &self.message,
+    #[cfg(test)]
+    fn data_mut(&mut self) -> &mut LogEntry {
+        match self {
+            Self::Signed(signed) => &mut signed.data,
+            Self::Unsigned(unsigned) => &mut unsigned.data,
         }
     }
 }
@@ -402,6 +449,24 @@ mod tests {
         (object_key, record, signing_key)
     }
 
+    fn authenticate_signed(
+        record: LogRecord,
+        signing_public_key: &GuardianPubKey,
+    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        let signed = record.into_signed()?;
+        let timestamp_ms = signed.timestamp_ms;
+        signed.data.validate(timestamp_ms, signing_public_key)?;
+        let data = signed
+            .authenticate(signing_public_key)
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        let (session_id, message) = data.into_current()?;
+        Ok((session_id, timestamp_ms, message))
+    }
+
+    fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        record.into_unsigned()?.validate()
+    }
+
     fn assert_writer_key_is_stable_and_verifies(log: LogRecord, signing_key: &GuardianSignKeyPair) {
         let writer_key = log.object_key().to_string();
         for _ in 0..4 {
@@ -415,8 +480,7 @@ mod tests {
         let body = serde_json::to_vec(&log).unwrap();
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
-        record_read_from_s3
-            .validate_signed(&signing_key.verification_key())
+        authenticate_signed(record_read_from_s3, &signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
     }
 
@@ -587,13 +651,11 @@ mod tests {
                 object_key,
                 "{name} did not preserve its object key"
             );
-            if decoded.message.is_allowed_unsigned() {
-                decoded
-                    .validate_unsigned()
+            if decoded.message().is_allowed_unsigned() {
+                validate_unsigned(decoded)
                     .unwrap_or_else(|error| panic!("{name} failed validation: {error}"));
             } else {
-                decoded
-                    .validate_signed(&signing_key.verification_key())
+                authenticate_signed(decoded, &signing_key.verification_key())
                     .unwrap_or_else(|error| panic!("{name} failed verification: {error}"));
             }
         }
@@ -604,7 +666,7 @@ mod tests {
         let fixture = r#"{"schema_version":1,"object_key":"kp-shares/00000000000000000000/00000000000000000000-916c711a5e81c2b0.json","session_id":"916c711a5e81c2b0","timestamp_ms":1784219535816,"message":{"KpShareState":{"sharing_seq":0,"cert_seq":0,"encrypted_shares":[{"id":1,"recipient_fingerprint":"010AFFD5514AE454CA0D56DAA40FE24388998D2A","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DT5hsKqzbvdwSAQdACnLThsK4Jq+u0g98VJzmYXrG05xLKgM1ki4FSGrOljkw\ndnHArbGaerEC8lBXZPVNhxMB8rOAfvgqxOUtt7SIMmjGIZMy7tzwfbM1YL45wgac\n0lkBE7TsICEPN/B/EwheDv/Ooid3NTDsoIsUGGuqtzUPCVYJTGPR+LWVY+F2xZxb\nHaLZO65VgrA3pcnyLsUy8iN3giOrIxmiZy/GjQBUwkeSCbVuopTZ2mpxPg==\n=7m3k\n-----END PGP MESSAGE-----\n"},{"id":2,"recipient_fingerprint":"69A798B4CD1FE3F7C827381BC56DF2575EC846C3","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DIHt6s8jZpqASAQdALWbHtxu0R/ANnNighIV7VtFgkIX3CGJzfW51GkSJkBQw\n7Ec2Y2wBmo4sDM2VGmxqK5ADvGVSYgLvIlByRdRV2NaJ1xkjHUoA39PDTqCvwCOK\n0lkBOZPrJPrBInDax3ceQwDkC/rkJrQXT8oVWGxNjxp244q66jhMdOBZSEc8T/oZ\noAdjEccCcDLYt+S+bEVZeuNhZowDSx14soiALI16hrzbDqJq04e7K9W0uQ==\n=tfbb\n-----END PGP MESSAGE-----\n"},{"id":3,"recipient_fingerprint":"8D798722C24B2A15C15036A1DEFA2C01C4350A31","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DZcZnV1kFupoSAQdA4X4hRbapAgL8eAouMEM0aRE4frVwmQZVHsXB6aOOxgkw\nsc2w0UU8bLzgt3aCe4HqBA9/v3jlKqK4STYVRFzG6o8fa+tb2qX94g6bCcIE07x4\n0lkBeTRYLlUlg7Jl2s7X9d9Ns60O8A2DQKwSYtQZV1pEwX44UQPz8Od/C9nIPeLP\nQEIA1BYRghu0ePQaqsfKohRXUunOrgVpYSCNFoupOKoVTl0qFgeDz5dw7Q==\n=giUp\n-----END PGP MESSAGE-----\n"},{"id":4,"recipient_fingerprint":"5551B442C80AB4D9CF3C95B90DA471909B35BFE9","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DJ51dk/19HSASAQdAgq4QrNM43HykXcLxDfRtHHRtd4BdVJBirC2esDoXEjkw\nF7YLVWrMoXUtwOxFqXGkoUhEhfPAzdLG3WyuZQDnOdPBl0r/2qxmlmZIjFFBGXVc\n0lkBLfdxmJ8BOQYcaiEhBODpY7o2xO13agT28X6Uyv3rc5qw5km1WDw5+AlTLKZj\nw7aathIK+Qof15Tj7VxzSzRmo/pIf/Plcz9JoBNOYPgz/ewuzsPzDQ9+Qw==\n=iAGD\n-----END PGP MESSAGE-----\n"},{"id":5,"recipient_fingerprint":"354807E1940BFC2763D15EBB8E7048E384EBBC7A","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4D6mDrwWj9BrASAQdAazktC+Jd2EMtE8Gav7ROlkVmL+Ty1duA3RttbKQ5eAEw\nbKIxkq1Jp9J4ZqcvjfxcBzVOfZPQwdhxXxDv2pOUG7ioZuDTRlGNNbsiyodvmlgy\n0lkB8eaGI0/LBZ++1vbGsZ/uQ7phGVFkPdcZzXm0pyD1poDKhTTyiHpAgDub2yph\nAAWsEIYzjLQWJvuOw0JXzwu1HBy+z5QTY4nK+wKrh6ojcLKjjyRVehhtTw==\n=m9Mm\n-----END PGP MESSAGE-----\n"},{"id":6,"recipient_fingerprint":"CB27C30ABAAC7EEDE92E71C6017C4627E937F5B0","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DuqwfDzk48aQSAQdAoJevGCVjo+1pD/WVPkWza4qGxBU9tsXbqE/kaSynsGYw\nskjzNOD5oY+/S0CMeH+6xspbLUZ9uZFy98fWOKMi9nbftH1nWXtKRdCNweaaCAPu\n0lkBR4DxLFCydQKfFzENlKRl9qc4m5NkVnjWaGR+cgK1U2UAPf/p82eRggyf6Obp\nNcdOnAfu0aLB70FESJEHtDFj36QCyC0SwTdtZwXUfCOo0AykDph9rTYVpA==\n=DQ4F\n-----END PGP MESSAGE-----\n"}]}},"signature":"2895193893f1feaea65fb6b441c011815c937df33cde136e4721f4173db86c1fe44a2095a6f8753fecbdaa5c99b744a22368f41ab8ca01edff99fafb6710a304"}"#;
         let record: LogRecord = serde_json::from_str(fixture).unwrap();
         assert!(matches!(
-            &record.message,
+            record.message(),
             VersionedLogMessage::V1(LogMessageV1::KpShareState(..))
         ));
         assert_eq!(serde_json::to_string(&record).unwrap(), fixture);
@@ -612,9 +674,9 @@ mod tests {
             hex::decode("916c711a5e81c2b032f15952b515205a20ef2a16f8a88da504885f392e314dca")
                 .unwrap();
         let signing_pubkey = GuardianPubKey::try_from(signing_pubkey.as_slice()).unwrap();
-        let (session_id, timestamp_ms, LogMessageV2::KpShareState(message)) = record
-            .validate_signed(&signing_pubkey)
-            .expect("the deployed V1 signature must verify before normalization")
+        let (session_id, timestamp_ms, LogMessageV2::KpShareState(message)) =
+            authenticate_signed(record, &signing_pubkey)
+                .expect("the deployed V1 signature must verify before normalization")
         else {
             panic!("expected normalized KP share state");
         };
@@ -689,8 +751,7 @@ mod tests {
     fn signed_log_verifies_at_canonical_object_key() {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
 
-        let (_, timestamp_ms, message) = log
-            .validate_signed(&signing_key.verification_key())
+        let (_, timestamp_ms, message) = authenticate_signed(log, &signing_key.verification_key())
             .expect("record should verify at its intended S3 key");
 
         assert_eq!(timestamp_ms, 1_700_000_000_000);
@@ -718,9 +779,38 @@ mod tests {
         assert!(serde_json::from_value::<LogRecord>(malformed).is_err());
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
-        from_s3
-            .validate_signed(&signing_key.verification_key())
+        authenticate_signed(from_s3, &signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
+    }
+
+    #[test]
+    fn signed_log_preserves_deployed_signing_preimage() {
+        #[derive(Serialize)]
+        struct DeployedLogSigningPayload<'a> {
+            schema_version: u64,
+            session_id: &'a SessionID,
+            object_key: &'a str,
+            message: &'a VersionedLogMessage,
+        }
+
+        let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
+        let LogRecord::Signed(signed) = log else {
+            panic!("heartbeat must be signed");
+        };
+        let deployed_payload = DeployedLogSigningPayload {
+            schema_version: signed.data.schema_version,
+            session_id: &signed.data.session_id,
+            object_key: &signed.data.object_key,
+            message: &signed.data.message,
+        };
+        let deployed_bytes = bcs::to_bytes(&(
+            GuardianSigningIntentType::LogMessage,
+            deployed_payload,
+            signed.timestamp_ms,
+        ))
+        .unwrap();
+
+        assert_eq!(signed.signature, signing_key.sign(&deployed_bytes));
     }
 
     #[test]
@@ -741,14 +831,13 @@ mod tests {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
         let mut tampered: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        tampered.message = LogMessage::Heartbeat(HeartbeatLogMessage::new(43)).into();
-        tampered.object_key = format!(
+        tampered.data_mut().message = LogMessage::Heartbeat(HeartbeatLogMessage::new(43)).into();
+        tampered.data_mut().object_key = format!(
             "heartbeat/2023/11/14/22/{}-00000000000000000043.json",
             heartbeat_session_id()
         );
 
-        let err = tampered
-            .validate_signed(&signing_key.verification_key())
+        let err = authenticate_signed(tampered, &signing_key.verification_key())
             .expect_err("signature must cover the canonical object key and message");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -777,9 +866,8 @@ mod tests {
 
         let mut record_read_from_s3: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        record_read_from_s3.object_key = relocated_key;
-        let err = record_read_from_s3
-            .validate_signed(&signing_key.verification_key())
+        record_read_from_s3.data_mut().object_key = relocated_key;
+        let err = authenticate_signed(record_read_from_s3, &signing_key.verification_key())
             .expect_err("the signature must authenticate the random failure suffix");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -804,11 +892,10 @@ mod tests {
         );
         let mut aliased: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        aliased.session_id = "aliased-session".into();
-        aliased.object_key = GenesisLogMessage::object_key();
+        aliased.data_mut().session_id = "aliased-session".into();
+        aliased.data_mut().object_key = GenesisLogMessage::object_key();
 
-        let err = aliased
-            .validate_signed(&signing_key.verification_key())
+        let err = authenticate_signed(aliased, &signing_key.verification_key())
             .expect_err("session ID must be part of the signed routing context");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -828,9 +915,8 @@ mod tests {
             1_700_000_000_000,
         );
 
-        log.object_key = "init/copied-attestation.json".to_string();
-        let err = log
-            .validate_unsigned()
+        log.data_mut().object_key = "init/copied-attestation.json".to_string();
+        let err = validate_unsigned(log)
             .expect_err("unsigned record copied to another S3 key must be rejected");
 
         assert!(format!("{err:?}").contains("non-canonical S3 object key"));
@@ -848,8 +934,7 @@ mod tests {
             &signing_key,
             1_700_000_000_000,
         );
-        let err = log
-            .validate_unsigned()
+        let err = validate_unsigned(log)
             .expect_err("attestation session ID must come from its signing public key");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -912,9 +997,7 @@ mod tests {
         assert_eq!(message["config_hash"], hex::encode([0xcd; 32]));
 
         let from_json: LogRecord = serde_json::from_value(json).unwrap();
-        from_json
-            .validate_signed(&signing_key.verification_key())
-            .unwrap();
+        authenticate_signed(from_json, &signing_key.verification_key()).unwrap();
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -1,14 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The `LogRecord` written to S3: it wraps a `super::schema::LogMessage` with
-//! its routing context and, for signed logs, a guardian signature.
+//! The `LogRecord` written to S3: it wraps a
+//! `super::schema::VersionedLogMessage` with its routing context and, for
+//! signed logs, a guardian signature.
 //! The object key and lock duration are derived from the wrapped message.
 
 use super::ObjectKeyPattern;
 use super::retention::S3ObjectLockPolicy;
 use super::schema::LogMessage;
 use super::schema::LogMessageV1;
+use super::schema::LogMessageV2;
 use super::schema::VersionedLogMessage;
 use crate::guardian::GuardianError::InvalidS3Log;
 use crate::guardian::GuardianPubKey;
@@ -42,7 +44,7 @@ pub struct LogEntry {
 
 /// Write: `LogMessage` -> `LogRecord` -> JSON body.
 /// Read: actual S3 key + JSON body -> untrusted `LogRecord`; the reader layer
-/// authenticates it before exposing its contents.
+/// fully verifies it before exposing its contents.
 #[derive(Debug)]
 pub enum LogRecord {
     Signed(GuardianSigned<LogEntry>),
@@ -117,7 +119,7 @@ impl<'de> Deserialize<'de> for LogRecord {
                     .map_err(D::Error::custom)?
             }
             VersionedLogMessage::SCHEMA_VERSION_V2 => {
-                serde_json::from_value::<LogMessage>(raw.message)
+                serde_json::from_value::<LogMessageV2>(raw.message)
                     .map(VersionedLogMessage::V2)
                     .map_err(D::Error::custom)?
             }
@@ -143,12 +145,28 @@ impl<'de> Deserialize<'de> for LogRecord {
 }
 
 impl LogEntry {
-    fn into_current(self) -> GuardianResult<(SessionID, LogMessage)> {
-        let message = self
-            .message
-            .into_current()
-            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
-        Ok((self.session_id, message))
+    pub fn schema_version(&self) -> u64 {
+        self.schema_version
+    }
+
+    pub fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub fn session_id(&self) -> &SessionID {
+        &self.session_id
+    }
+
+    pub fn timestamp_ms(&self) -> UnixMillis {
+        self.timestamp_ms
+    }
+
+    pub fn message(&self) -> &VersionedLogMessage {
+        &self.message
+    }
+
+    pub fn into_message(self) -> VersionedLogMessage {
+        self.message
     }
 
     fn validate_object_key(&self) -> GuardianResult<()> {
@@ -186,7 +204,7 @@ impl LogEntry {
 
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
-    fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    fn validate_unsigned(self) -> GuardianResult<Self> {
         if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
@@ -195,8 +213,10 @@ impl LogEntry {
         self.validate_object_key()?;
         let init = match &self.message {
             VersionedLogMessage::V1(LogMessageV1::Init(init)) => init,
-            VersionedLogMessage::V2(LogMessage::Init(init)) => init,
-            _ => unreachable!("is_allowed_unsigned only permits an init message"),
+            VersionedLogMessage::V2(LogMessageV2::Init(init)) => init,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                unreachable!("is_allowed_unsigned only permits an init message")
+            }
         };
         let super::messages::InitLogMessage::OIAttestationUnsigned {
             signing_public_key, ..
@@ -205,9 +225,7 @@ impl LogEntry {
             unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
         };
         self.validate_session_id(signing_public_key)?;
-        let timestamp_ms = self.timestamp_ms;
-        let (session_id, message) = self.into_current()?;
-        Ok((session_id, timestamp_ms, message))
+        Ok(self)
     }
 
     /// Validate signed-log routing context.
@@ -264,7 +282,7 @@ impl LogRecord {
         &self.data().message
     }
 
-    /// Validate a record and normalize its message to the current schema.
+    /// Validate a record and return the exact entry that was authenticated.
     ///
     /// Validation checks record-local invariants and verifies a signed record
     /// against the caller-supplied key. It does not establish that the key
@@ -274,20 +292,14 @@ impl LogRecord {
     /// Signed records require `Some(signing_public_key)`; the one permitted
     /// unsigned record kind requires `None`. The caller is responsible for
     /// authenticating the Nitro attestation carried by an unsigned record.
-    pub fn validate(
-        self,
-        signing_public_key: Option<&GuardianPubKey>,
-    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    pub fn validate(self, signing_public_key: Option<&GuardianPubKey>) -> GuardianResult<LogEntry> {
         match (self, signing_public_key) {
             (Self::Signed(signed), Some(signing_public_key)) => {
-                let timestamp_ms = signed.data.timestamp_ms;
                 signed.data.validate_signed(signing_public_key)?;
                 signed
                     .verify_signature(signing_public_key)
                     .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-                let data = signed.data;
-                let (session_id, message) = data.into_current()?;
-                Ok((session_id, timestamp_ms, message))
+                Ok(signed.data)
             }
             (Self::Unsigned(unsigned), None) => unsigned.validate_unsigned(),
             (Self::Unsigned(unsigned), Some(_)) if unsigned.message.is_allowed_unsigned() => Err(
@@ -307,16 +319,12 @@ impl LogRecord {
         policy.duration_for(self.data().message.log_type())
     }
 
-    /// Extract and normalize a signed record without authenticating its
-    /// Guardian signature. This is only for callers that independently
-    /// authenticate the extracted payload.
-    pub fn into_current_unchecked(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    /// Extract a signed record's entry without authenticating its Guardian
+    /// signature. This is only for callers that independently authenticate the
+    /// extracted payload.
+    pub fn into_entry_unchecked(self) -> GuardianResult<LogEntry> {
         match self {
-            Self::Signed(signed) => {
-                let timestamp_ms = signed.data.timestamp_ms;
-                let (session_id, message) = signed.into_data_unchecked().into_current()?;
-                Ok((session_id, timestamp_ms, message))
-            }
+            Self::Signed(signed) => Ok(signed.into_data_unchecked()),
             Self::Unsigned(unsigned) if unsigned.message.is_allowed_unsigned() => Err(
                 InvalidS3Log("expected signed log record but message is unsigned".into()),
             ),
@@ -391,7 +399,6 @@ mod tests {
     use crate::guardian::KPEncryptedSharesRoster;
     use crate::guardian::KpShareStateLogMessage;
     use crate::guardian::LimiterState;
-    use crate::guardian::LogMessageV2;
     use crate::guardian::MAINNET_S3_OBJECT_LOCK_POLICY;
     use crate::guardian::NitroAttestation;
     use crate::guardian::RotateKpsResponse;
@@ -425,14 +432,14 @@ mod tests {
         (object_key, record, signing_key)
     }
 
-    fn authenticate_signed(
+    fn validate_signed(
         record: LogRecord,
         signing_public_key: &GuardianPubKey,
-    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    ) -> GuardianResult<LogEntry> {
         record.validate(Some(signing_public_key))
     }
 
-    fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    fn validate_unsigned(record: LogRecord) -> GuardianResult<LogEntry> {
         record.validate(None)
     }
 
@@ -449,7 +456,7 @@ mod tests {
         let body = serde_json::to_vec(&log).unwrap();
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
-        authenticate_signed(record_read_from_s3, &signing_key.verification_key())
+        validate_signed(record_read_from_s3, &signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
     }
 
@@ -627,14 +634,14 @@ mod tests {
                 validate_unsigned(decoded)
                     .unwrap_or_else(|error| panic!("{name} failed validation: {error}"));
             } else {
-                authenticate_signed(decoded, &signing_key.verification_key())
+                validate_signed(decoded, &signing_key.verification_key())
                     .unwrap_or_else(|error| panic!("{name} failed verification: {error}"));
             }
         }
     }
 
     #[test]
-    fn deployed_v1_kp_share_state_verifies_and_normalizes() {
+    fn deployed_v1_kp_share_state_verifies_and_is_retained() {
         let fixture = r#"{"schema_version":1,"object_key":"kp-shares/00000000000000000000/00000000000000000000-916c711a5e81c2b0.json","session_id":"916c711a5e81c2b0","timestamp_ms":1784219535816,"message":{"KpShareState":{"sharing_seq":0,"cert_seq":0,"encrypted_shares":[{"id":1,"recipient_fingerprint":"010AFFD5514AE454CA0D56DAA40FE24388998D2A","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DT5hsKqzbvdwSAQdACnLThsK4Jq+u0g98VJzmYXrG05xLKgM1ki4FSGrOljkw\ndnHArbGaerEC8lBXZPVNhxMB8rOAfvgqxOUtt7SIMmjGIZMy7tzwfbM1YL45wgac\n0lkBE7TsICEPN/B/EwheDv/Ooid3NTDsoIsUGGuqtzUPCVYJTGPR+LWVY+F2xZxb\nHaLZO65VgrA3pcnyLsUy8iN3giOrIxmiZy/GjQBUwkeSCbVuopTZ2mpxPg==\n=7m3k\n-----END PGP MESSAGE-----\n"},{"id":2,"recipient_fingerprint":"69A798B4CD1FE3F7C827381BC56DF2575EC846C3","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DIHt6s8jZpqASAQdALWbHtxu0R/ANnNighIV7VtFgkIX3CGJzfW51GkSJkBQw\n7Ec2Y2wBmo4sDM2VGmxqK5ADvGVSYgLvIlByRdRV2NaJ1xkjHUoA39PDTqCvwCOK\n0lkBOZPrJPrBInDax3ceQwDkC/rkJrQXT8oVWGxNjxp244q66jhMdOBZSEc8T/oZ\noAdjEccCcDLYt+S+bEVZeuNhZowDSx14soiALI16hrzbDqJq04e7K9W0uQ==\n=tfbb\n-----END PGP MESSAGE-----\n"},{"id":3,"recipient_fingerprint":"8D798722C24B2A15C15036A1DEFA2C01C4350A31","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DZcZnV1kFupoSAQdA4X4hRbapAgL8eAouMEM0aRE4frVwmQZVHsXB6aOOxgkw\nsc2w0UU8bLzgt3aCe4HqBA9/v3jlKqK4STYVRFzG6o8fa+tb2qX94g6bCcIE07x4\n0lkBeTRYLlUlg7Jl2s7X9d9Ns60O8A2DQKwSYtQZV1pEwX44UQPz8Od/C9nIPeLP\nQEIA1BYRghu0ePQaqsfKohRXUunOrgVpYSCNFoupOKoVTl0qFgeDz5dw7Q==\n=giUp\n-----END PGP MESSAGE-----\n"},{"id":4,"recipient_fingerprint":"5551B442C80AB4D9CF3C95B90DA471909B35BFE9","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DJ51dk/19HSASAQdAgq4QrNM43HykXcLxDfRtHHRtd4BdVJBirC2esDoXEjkw\nF7YLVWrMoXUtwOxFqXGkoUhEhfPAzdLG3WyuZQDnOdPBl0r/2qxmlmZIjFFBGXVc\n0lkBLfdxmJ8BOQYcaiEhBODpY7o2xO13agT28X6Uyv3rc5qw5km1WDw5+AlTLKZj\nw7aathIK+Qof15Tj7VxzSzRmo/pIf/Plcz9JoBNOYPgz/ewuzsPzDQ9+Qw==\n=iAGD\n-----END PGP MESSAGE-----\n"},{"id":5,"recipient_fingerprint":"354807E1940BFC2763D15EBB8E7048E384EBBC7A","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4D6mDrwWj9BrASAQdAazktC+Jd2EMtE8Gav7ROlkVmL+Ty1duA3RttbKQ5eAEw\nbKIxkq1Jp9J4ZqcvjfxcBzVOfZPQwdhxXxDv2pOUG7ioZuDTRlGNNbsiyodvmlgy\n0lkB8eaGI0/LBZ++1vbGsZ/uQ7phGVFkPdcZzXm0pyD1poDKhTTyiHpAgDub2yph\nAAWsEIYzjLQWJvuOw0JXzwu1HBy+z5QTY4nK+wKrh6ojcLKjjyRVehhtTw==\n=m9Mm\n-----END PGP MESSAGE-----\n"},{"id":6,"recipient_fingerprint":"CB27C30ABAAC7EEDE92E71C6017C4627E937F5B0","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DuqwfDzk48aQSAQdAoJevGCVjo+1pD/WVPkWza4qGxBU9tsXbqE/kaSynsGYw\nskjzNOD5oY+/S0CMeH+6xspbLUZ9uZFy98fWOKMi9nbftH1nWXtKRdCNweaaCAPu\n0lkBR4DxLFCydQKfFzENlKRl9qc4m5NkVnjWaGR+cgK1U2UAPf/p82eRggyf6Obp\nNcdOnAfu0aLB70FESJEHtDFj36QCyC0SwTdtZwXUfCOo0AykDph9rTYVpA==\n=DQ4F\n-----END PGP MESSAGE-----\n"}]}},"signature":"2895193893f1feaea65fb6b441c011815c937df33cde136e4721f4173db86c1fe44a2095a6f8753fecbdaa5c99b744a22368f41ab8ca01edff99fafb6710a304"}"#;
         let record: LogRecord = serde_json::from_str(fixture).unwrap();
         assert!(matches!(
@@ -646,14 +653,17 @@ mod tests {
             hex::decode("916c711a5e81c2b032f15952b515205a20ef2a16f8a88da504885f392e314dca")
                 .unwrap();
         let signing_pubkey = GuardianPubKey::try_from(signing_pubkey.as_slice()).unwrap();
-        let (session_id, timestamp_ms, LogMessageV2::KpShareState(message)) =
-            authenticate_signed(record, &signing_pubkey)
-                .expect("the deployed V1 signature must verify before normalization")
+        let entry = validate_signed(record, &signing_pubkey)
+            .expect("the deployed V1 signature must verify");
+        assert_eq!(entry.session_id().as_str(), "916c711a5e81c2b0");
+        assert_eq!(entry.timestamp_ms(), 1_784_219_535_816);
+        let VersionedLogMessage::V1(LogMessageV1::KpShareState(message)) = entry.into_message()
         else {
-            panic!("expected normalized KP share state");
+            panic!("expected the exact V1 KP share state");
         };
-        assert_eq!(session_id.as_str(), "916c711a5e81c2b0");
-        assert_eq!(timestamp_ms, 1_784_219_535_816);
+        let message: KpShareStateLogMessage = (*message)
+            .try_into()
+            .expect("the deployed V1 KP share state must convert");
         assert_eq!(message.sharing_seq, 0);
         assert_eq!(message.cert_seq, 0);
         assert_eq!(message.encrypted_shares.share_count(), 6);
@@ -723,13 +733,13 @@ mod tests {
     fn signed_log_verifies_at_canonical_object_key() {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
 
-        let (_, timestamp_ms, message) = authenticate_signed(log, &signing_key.verification_key())
+        let entry = validate_signed(log, &signing_key.verification_key())
             .expect("record should verify at its intended S3 key");
 
-        assert_eq!(timestamp_ms, 1_700_000_000_000);
+        assert_eq!(entry.timestamp_ms(), 1_700_000_000_000);
         assert!(matches!(
-            message,
-            LogMessage::Heartbeat(HeartbeatLogMessage { seq: 42 })
+            entry.message(),
+            VersionedLogMessage::V2(LogMessageV2::Heartbeat(HeartbeatLogMessage { seq: 42 }))
         ));
     }
 
@@ -751,7 +761,7 @@ mod tests {
         assert!(serde_json::from_value::<LogRecord>(malformed).is_err());
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
-        authenticate_signed(from_s3, &signing_key.verification_key())
+        validate_signed(from_s3, &signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
     }
 
@@ -809,7 +819,7 @@ mod tests {
             heartbeat_session_id()
         );
 
-        let err = authenticate_signed(tampered, &signing_key.verification_key())
+        let err = validate_signed(tampered, &signing_key.verification_key())
             .expect_err("signature must cover the canonical object key and message");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -839,7 +849,7 @@ mod tests {
         let mut record_read_from_s3: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
         record_read_from_s3.data_mut().object_key = relocated_key;
-        let err = authenticate_signed(record_read_from_s3, &signing_key.verification_key())
+        let err = validate_signed(record_read_from_s3, &signing_key.verification_key())
             .expect_err("the signature must authenticate the random failure suffix");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -867,7 +877,7 @@ mod tests {
         aliased.data_mut().session_id = "aliased-session".into();
         aliased.data_mut().object_key = GenesisLogMessage::object_key();
 
-        let err = authenticate_signed(aliased, &signing_key.verification_key())
+        let err = validate_signed(aliased, &signing_key.verification_key())
             .expect_err("session ID must be part of the signed routing context");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -969,7 +979,7 @@ mod tests {
         assert_eq!(message["config_hash"], hex::encode([0xcd; 32]));
 
         let from_json: LogRecord = serde_json::from_value(json).unwrap();
-        authenticate_signed(from_json, &signing_key.verification_key()).unwrap();
+        validate_signed(from_json, &signing_key.verification_key()).unwrap();
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -278,9 +278,10 @@ impl LogRecord {
             (Self::Signed(signed), Some(signing_public_key)) => {
                 let timestamp_ms = signed.data.timestamp_ms;
                 signed.data.validate_signed(signing_public_key)?;
-                let data = signed
-                    .authenticate(signing_public_key)
+                signed
+                    .verify_signature(signing_public_key)
                     .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+                let data = signed.data;
                 let (session_id, message) = data.into_current()?;
                 Ok((session_id, timestamp_ms, message))
             }

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The `LogRecord` written to S3: it wraps a
-//! `super::schema::VersionedLogMessage` with its routing context and, for
-//! signed logs, a guardian signature.
-//! The object key and lock duration are derived from the wrapped message.
+//! S3 log-record wire format and record-local validation.
+//!
+//! A [`LogRecord`] carries a [`VersionedLogMessage`] and its S3 routing
+//! context. Signed records carry a Guardian signature over their [`LogEntry`].
+//! The one permitted unsigned entry carries the OI attestation that establishes
+//! the Guardian signing key and must be authenticated separately.
 
 use super::ObjectKeyPattern;
 use super::retention::S3ObjectLockPolicy;
@@ -27,12 +29,12 @@ use serde::de::Error as _;
 use serde_json::Value;
 use std::time::Duration;
 
-/// The data authenticated by a signed log record.
+/// Routing context and versioned payload carried by a [`LogRecord`].
 ///
-/// Field order defines the BCS signing format.
+/// For signed records, field order defines the BCS signing format.
 #[derive(Debug, Serialize)]
 pub struct LogEntry {
-    /// Version of the serialized log schema.
+    /// Version of the message's serialized schema.
     schema_version: u64,
     /// Guardian session that wrote the entry.
     session_id: SessionID,
@@ -45,12 +47,17 @@ pub struct LogEntry {
     timestamp_ms: UnixMillis,
 }
 
-/// Write: `LogMessage` -> `LogRecord` -> JSON body.
-/// Read: actual S3 key + JSON body -> untrusted `LogRecord`; the reader layer
-/// fully verifies it before exposing its contents (see `VerifiedLogRecord`).
+/// A Guardian S3 log record.
+///
+/// Both variants use the same flat JSON representation; the optional
+/// `signature` field selects the variant during deserialization. A
+/// deserialized record remains untrusted until its routing context and
+/// applicable signature and attestation checks have been performed.
 #[derive(Debug)]
 pub enum LogRecord {
+    /// An entry carrying a Guardian signature.
     Signed(GuardianSigned<LogEntry>),
+    /// The OI-attestation entry, which is authenticated separately.
     Unsigned(LogEntry),
 }
 
@@ -148,26 +155,32 @@ impl<'de> Deserialize<'de> for LogRecord {
 }
 
 impl LogEntry {
+    /// Return the log schema version.
     pub fn schema_version(&self) -> u64 {
         self.schema_version
     }
 
+    /// Return the intended S3 object key.
     pub fn object_key(&self) -> &str {
         &self.object_key
     }
 
+    /// Return the writing Guardian session.
     pub fn session_id(&self) -> &SessionID {
         &self.session_id
     }
 
+    /// Return the entry creation time in milliseconds since the Unix epoch.
     pub fn timestamp_ms(&self) -> UnixMillis {
         self.timestamp_ms
     }
 
+    /// Return the versioned log payload.
     pub fn message(&self) -> &VersionedLogMessage {
         &self.message
     }
 
+    /// Consume the entry and return its versioned log payload.
     pub fn into_message(self) -> VersionedLogMessage {
         self.message
     }
@@ -205,8 +218,7 @@ impl LogEntry {
         Ok(())
     }
 
-    /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
-    /// must be authenticated separately.
+    // The Nitro attestation itself must be authenticated separately.
     fn validate_unsigned(&self) -> GuardianResult<()> {
         if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
@@ -231,7 +243,6 @@ impl LogEntry {
         Ok(())
     }
 
-    /// Validate signed-log routing context.
     fn validate_signed(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
         if self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
@@ -244,6 +255,10 @@ impl LogEntry {
 }
 
 impl LogRecord {
+    /// Construct a current-schema record using the current time.
+    ///
+    /// The OI-attestation message is emitted unsigned; every other message is
+    /// signed by `signing_key`.
     pub fn new(
         session_id: SessionID,
         message: LogMessage,
@@ -252,6 +267,10 @@ impl LogRecord {
         Self::new_at_timestamp(session_id, message, signing_key, now_timestamp_ms())
     }
 
+    /// Construct a current-schema record using an explicit timestamp.
+    ///
+    /// The OI-attestation message is emitted unsigned; every other message is
+    /// signed by `signing_key`.
     pub fn new_at_timestamp(
         session_id: SessionID,
         message: LogMessage,
@@ -269,28 +288,32 @@ impl LogRecord {
         }
     }
 
+    /// Return the intended S3 object key.
     pub fn object_key(&self) -> &str {
         &self.data().object_key
     }
 
+    /// Return the writing Guardian session.
     pub fn session_id(&self) -> &SessionID {
         &self.data().session_id
     }
 
+    /// Return the entry creation time in milliseconds since the Unix epoch.
     pub fn timestamp_ms(&self) -> UnixMillis {
         self.data().timestamp_ms
     }
 
+    /// Return the versioned log payload.
     pub fn message(&self) -> &VersionedLogMessage {
         &self.data().message
     }
 
-    /// Validate a record without consuming it.
+    /// Validate record-local invariants without consuming the record.
     ///
-    /// Validation checks record-local invariants and verifies a signed record
-    /// against the caller-supplied key. It does not establish that the key
-    /// belongs to an attested, approved guardian; the S3 reader's
-    /// `verify_record` performs that complete verification.
+    /// For a signed record, this also verifies the signature against the
+    /// caller-supplied key. It does not establish that the key belongs to an
+    /// attested, approved Guardian; the S3 reader performs that complete
+    /// verification.
     ///
     /// Signed records require `Some(signing_public_key)`; the one permitted
     /// unsigned record kind requires `None`. The caller is responsible for
@@ -317,11 +340,15 @@ impl LogRecord {
         }
     }
 
+    /// Return the object-lock duration selected for the message type.
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
         policy.duration_for(self.data().message.log_type())
     }
 
-    /// Extract the entry without validating the record.
+    /// Consume the record and extract its entry without validation.
+    ///
+    /// This does not check the routing context, whether the message requires a
+    /// signature, the Guardian signature, or the Nitro attestation.
     pub fn into_entry_unchecked(self) -> LogEntry {
         match self {
             Self::Signed(signed) => signed.into_data_unchecked(),

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -318,16 +318,11 @@ impl LogRecord {
         policy.duration_for(self.data().message.log_type())
     }
 
-    /// Extract a signed record's entry without authenticating its Guardian
-    /// signature. This is only for callers that independently authenticate the
-    /// extracted payload.
-    pub fn into_entry_unchecked(self) -> GuardianResult<LogEntry> {
+    /// Extract the entry without validating the record.
+    pub fn into_entry_unchecked(self) -> LogEntry {
         match self {
-            Self::Signed(signed) => Ok(signed.into_data_unchecked()),
-            Self::Unsigned(unsigned) if unsigned.message.is_allowed_unsigned() => Err(
-                InvalidS3Log("expected signed log record but message is unsigned".into()),
-            ),
-            Self::Unsigned(_) => Err(InvalidS3Log("missing log signature".into())),
+            Self::Signed(signed) => signed.into_data_unchecked(),
+            Self::Unsigned(unsigned) => unsigned,
         }
     }
 
@@ -653,9 +648,7 @@ mod tests {
                 .unwrap();
         let signing_pubkey = GuardianPubKey::try_from(signing_pubkey.as_slice()).unwrap();
         validate_signed(&record, &signing_pubkey).expect("the deployed V1 signature must verify");
-        let entry = record
-            .into_entry_unchecked()
-            .expect("the deployed V1 record is signed");
+        let entry = record.into_entry_unchecked();
         assert_eq!(entry.session_id().as_str(), "916c711a5e81c2b0");
         assert_eq!(entry.timestamp_ms(), 1_784_219_535_816);
         let VersionedLogMessage::V1(LogMessageV1::KpShareState(message)) = entry.into_message()

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -347,8 +347,8 @@ impl LogRecord {
 
     /// Consume the record and extract its entry without validation.
     ///
-    /// This bypasses routing checks, signed-versus-unsigned envelope checks,
-    /// Guardian signature verification, and Nitro attestation authentication.
+    /// This bypasses object-key and session-ID validation, Guardian signature
+    /// verification, and Nitro attestation authentication.
     pub fn into_entry_unchecked(self) -> LogEntry {
         match self {
             Self::Signed(signed) => signed.into_data_unchecked(),

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -143,22 +143,7 @@ impl<'de> Deserialize<'de> for LogRecord {
 }
 
 impl LogEntry {
-    pub fn timestamp_ms(&self) -> UnixMillis {
-        self.timestamp_ms
-    }
-
-    /// Validate signed-log routing context without performing cryptography.
-    fn validate_signed(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
-        if self.message.is_allowed_unsigned() {
-            return Err(InvalidS3Log(
-                "expected signed log record but message is unsigned".into(),
-            ));
-        }
-        self.validate_object_key()?;
-        self.validate_session_id(signing_public_key)
-    }
-
-    pub fn into_current(self) -> GuardianResult<(SessionID, LogMessage)> {
+    fn into_current(self) -> GuardianResult<(SessionID, LogMessage)> {
         let message = self
             .message
             .into_current()
@@ -198,6 +183,7 @@ impl LogEntry {
         }
         Ok(())
     }
+
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
     fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
@@ -222,6 +208,17 @@ impl LogEntry {
         let timestamp_ms = self.timestamp_ms;
         let (session_id, message) = self.into_current()?;
         Ok((session_id, timestamp_ms, message))
+    }
+
+    /// Validate signed-log routing context.
+    fn validate_signed(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
+        if self.message.is_allowed_unsigned() {
+            return Err(InvalidS3Log(
+                "expected signed log record but message is unsigned".into(),
+            ));
+        }
+        self.validate_object_key()?;
+        self.validate_session_id(signing_public_key)
     }
 }
 
@@ -267,53 +264,58 @@ impl LogRecord {
         &self.data().message
     }
 
-    /// Validate a signed record under `signing_public_key` and normalize its
-    /// message to the current schema. The caller is responsible for establishing
-    /// that the signing key is authorized.
+    /// Validate a record and normalize its message to the current schema.
+    ///
+    /// Signed records require `Some(signing_public_key)`; the one permitted
+    /// unsigned record kind requires `None`. The caller is responsible for
+    /// establishing that a supplied signing key is authorized, or for
+    /// authenticating the Nitro attestation carried by an unsigned record.
     pub fn validate(
         self,
-        signing_public_key: &GuardianPubKey,
+        signing_public_key: Option<&GuardianPubKey>,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        let signed = self.into_signed()?;
-        let timestamp_ms = signed.data.timestamp_ms;
-        signed.data.validate_signed(signing_public_key)?;
-        let data = signed
-            .authenticate(signing_public_key)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-        let (session_id, message) = data.into_current()?;
-        Ok((session_id, timestamp_ms, message))
-    }
-
-    /// Validate the one permitted unsigned record kind and normalize its
-    /// message to the current schema. The embedded Nitro attestation must be
-    /// authenticated separately.
-    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        self.into_unsigned()?.validate_unsigned()
+        match (self, signing_public_key) {
+            (Self::Signed(signed), Some(signing_public_key)) => {
+                let timestamp_ms = signed.data.timestamp_ms;
+                signed.data.validate_signed(signing_public_key)?;
+                let data = signed
+                    .authenticate(signing_public_key)
+                    .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+                let (session_id, message) = data.into_current()?;
+                Ok((session_id, timestamp_ms, message))
+            }
+            (Self::Unsigned(unsigned), None) => unsigned.validate_unsigned(),
+            (Self::Unsigned(unsigned), Some(_)) if unsigned.message.is_allowed_unsigned() => Err(
+                InvalidS3Log("expected signed log record but message is unsigned".into()),
+            ),
+            (Self::Unsigned(_), Some(_)) => Err(InvalidS3Log("missing log signature".into())),
+            (Self::Signed(signed), None) if signed.data.message.is_allowed_unsigned() => Err(
+                InvalidS3Log("unsigned log record must not contain a signature".into()),
+            ),
+            (Self::Signed(_), None) => Err(InvalidS3Log(
+                "expected unsigned log record but message requires a signature".into(),
+            )),
+        }
     }
 
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
         policy.duration_for(self.data().message.log_type())
     }
 
-    pub fn into_signed(self) -> GuardianResult<GuardianSigned<LogEntry>> {
+    /// Extract and normalize a signed record without authenticating its
+    /// Guardian signature. This is only for callers that independently
+    /// authenticate the extracted payload.
+    pub fn into_current_unchecked(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         match self {
-            Self::Signed(signed) => Ok(signed),
+            Self::Signed(signed) => {
+                let timestamp_ms = signed.data.timestamp_ms;
+                let (session_id, message) = signed.into_data_unchecked().into_current()?;
+                Ok((session_id, timestamp_ms, message))
+            }
             Self::Unsigned(unsigned) if unsigned.message.is_allowed_unsigned() => Err(
                 InvalidS3Log("expected signed log record but message is unsigned".into()),
             ),
             Self::Unsigned(_) => Err(InvalidS3Log("missing log signature".into())),
-        }
-    }
-
-    pub fn into_unsigned(self) -> GuardianResult<LogEntry> {
-        match self {
-            Self::Unsigned(unsigned) => Ok(unsigned),
-            Self::Signed(signed) if signed.data.message.is_allowed_unsigned() => Err(InvalidS3Log(
-                "unsigned log record must not contain a signature".into(),
-            )),
-            Self::Signed(_) => Err(InvalidS3Log(
-                "expected unsigned log record but message requires a signature".into(),
-            )),
         }
     }
 
@@ -422,11 +424,11 @@ mod tests {
         record: LogRecord,
         signing_public_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        record.validate(signing_public_key)
+        record.validate(Some(signing_public_key))
     }
 
     fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        record.validate_unsigned()
+        record.validate(None)
     }
 
     fn assert_writer_key_is_stable_and_verifies(log: LogRecord, signing_key: &GuardianSignKeyPair) {

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -16,11 +16,13 @@ use crate::guardian::GuardianPubKey;
 use crate::guardian::GuardianResult;
 use crate::guardian::GuardianSignKeyPair;
 use crate::guardian::GuardianSignature;
-use crate::guardian::IntentType;
+use crate::guardian::GuardianSigningIntent;
+use crate::guardian::GuardianSigningIntentType;
 use crate::guardian::SessionID;
-use crate::guardian::SigningIntent;
 use crate::guardian::UnixMillis;
 use crate::guardian::now_timestamp_ms;
+use crate::guardian::signing::sign_guardian_payload;
+use crate::guardian::signing::verify_guardian_payload_signature;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::Error as _;
@@ -133,8 +135,8 @@ impl<'de> Deserialize<'de> for LogRecord {
     }
 }
 
-impl SigningIntent for LogSigningPayload<'_> {
-    const INTENT: IntentType = IntentType::LogMessage;
+impl GuardianSigningIntent for LogSigningPayload<'_> {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
 }
 
 /// A log record whose message signature and writing session's attestation/PCRs
@@ -216,7 +218,11 @@ impl LogRecord {
             message,
             signature: None,
         };
-        record.signature = Some(record.signing_payload().sign(timestamp_ms, signing_key));
+        record.signature = Some(sign_guardian_payload(
+            &record.signing_payload(),
+            timestamp_ms,
+            signing_key,
+        ));
         record
     }
 
@@ -257,9 +263,13 @@ impl LogRecord {
             .signature
             .as_ref()
             .ok_or_else(|| InvalidS3Log("missing log signature".into()))?;
-        self.signing_payload()
-            .verify_signature(timestamp_ms, signature, pub_key)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        verify_guardian_payload_signature(
+            &self.signing_payload(),
+            timestamp_ms,
+            signature,
+            pub_key,
+        )
+        .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
 
         let message = self
             .message

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -304,18 +304,6 @@ impl LogRecord {
         Ok((self.session_id, self.timestamp_ms, message))
     }
 
-    /// Rejects a record whose signed intended key differs from the key at which
-    /// the S3 reader found it.
-    pub fn validate_actual_object_key(&self, actual_object_key: &str) -> GuardianResult<()> {
-        if self.object_key != actual_object_key {
-            return Err(InvalidS3Log(format!(
-                "S3 object key mismatch: record contains {}, actual key is {actual_object_key}",
-                self.object_key
-            )));
-        }
-        Ok(())
-    }
-
     fn validate_object_key(&self) -> GuardianResult<()> {
         match self
             .message
@@ -421,19 +409,8 @@ mod tests {
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
         record_read_from_s3
-            .validate_actual_object_key(&writer_key)
-            .expect("the serialized key must match the writer's S3 destination");
-        record_read_from_s3
             .verify(&signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
-    }
-
-    fn assert_heartbeat_relocation_rejected(relocated_key: String) {
-        let (_, log, _) = signed_heartbeat(1_700_000_000_000);
-        let err = log
-            .validate_actual_object_key(&relocated_key)
-            .expect_err("relocated record must be rejected");
-        assert!(format!("{err:?}").contains("S3 object key mismatch"));
     }
 
     fn test_sharing_instance(sharing_seq: u64) -> SecretSharingInstance {
@@ -598,9 +575,11 @@ mod tests {
                 json,
                 "{name} did not reserialize canonically"
             );
-            decoded
-                .validate_actual_object_key(&object_key)
-                .unwrap_or_else(|error| panic!("{name} failed key validation: {error}"));
+            assert_eq!(
+                decoded.object_key(),
+                object_key,
+                "{name} did not preserve its object key"
+            );
             if decoded.message.is_allowed_unsigned() {
                 decoded
                     .validate_unsigned()
@@ -622,12 +601,6 @@ mod tests {
             VersionedLogMessage::V1(LogMessageV1::KpShareState(..))
         ));
         assert_eq!(serde_json::to_string(&record).unwrap(), fixture);
-        record
-            .validate_actual_object_key(
-                "kp-shares/00000000000000000000/00000000000000000000-916c711a5e81c2b0.json",
-            )
-            .unwrap();
-
         let signing_pubkey =
             hex::decode("916c711a5e81c2b032f15952b515205a20ef2a16f8a88da504885f392e314dca")
                 .unwrap();
@@ -739,9 +712,6 @@ mod tests {
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
         from_s3
-            .validate_actual_object_key(&object_key)
-            .expect("embedded key should match the S3 destination");
-        from_s3
             .verify(&signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
     }
@@ -756,37 +726,6 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("unsupported log schema version: 3")
-        );
-    }
-
-    #[test]
-    fn signed_log_rejects_cross_prefix_relocation() {
-        assert_heartbeat_relocation_rejected(format!(
-            "withdraw/2023/11/14/22/{}-00000000000000000042.json",
-            heartbeat_session_id()
-        ));
-    }
-
-    #[test]
-    fn signed_log_rejects_lexicographically_higher_key_relocation() {
-        assert_heartbeat_relocation_rejected(format!(
-            "heartbeat/2023/11/14/22/{}-00000000000000000043.json",
-            heartbeat_session_id()
-        ));
-    }
-
-    #[test]
-    fn signed_log_rejects_future_hour_relocation() {
-        assert_heartbeat_relocation_rejected(format!(
-            "heartbeat/2023/11/14/23/{}-00000000000000000042.json",
-            heartbeat_session_id()
-        ));
-    }
-
-    #[test]
-    fn signed_log_rejects_changed_session_relocation() {
-        assert_heartbeat_relocation_rejected(
-            "heartbeat/2023/11/14/22/aliased-session-00000000000000000042.json".to_string(),
         );
     }
 
@@ -831,12 +770,6 @@ mod tests {
 
         let mut record_read_from_s3: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
-        let err = record_read_from_s3
-            .validate_actual_object_key(&relocated_key)
-            .expect_err("changing only the random failure suffix must invalidate placement");
-
-        assert!(format!("{err:?}").contains("S3 object key mismatch"));
-
         record_read_from_s3.object_key = relocated_key;
         let err = record_read_from_s3
             .verify(&signing_key.verification_key())
@@ -889,8 +822,6 @@ mod tests {
         );
 
         log.object_key = "init/copied-attestation.json".to_string();
-        log.validate_actual_object_key("init/copied-attestation.json")
-            .expect("the operator can edit an unsigned record's embedded key");
         let err = log
             .validate_unsigned()
             .expect_err("unsigned record copied to another S3 key must be rejected");

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -266,9 +266,13 @@ impl LogRecord {
 
     /// Validate a record and normalize its message to the current schema.
     ///
+    /// Validation checks record-local invariants and verifies a signed record
+    /// against the caller-supplied key. It does not establish that the key
+    /// belongs to an attested, approved guardian; the S3 reader's
+    /// `verify_record` performs that complete verification.
+    ///
     /// Signed records require `Some(signing_public_key)`; the one permitted
     /// unsigned record kind requires `None`. The caller is responsible for
-    /// establishing that a supplied signing key is authorized, or for
     /// authenticating the Nitro attestation carried by an unsigned record.
     pub fn validate(
         self,

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -147,8 +147,8 @@ impl LogEntry {
         self.timestamp_ms
     }
 
-    /// Validate log-specific routing context without performing cryptography.
-    pub fn validate(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
+    /// Validate signed-log routing context without performing cryptography.
+    fn validate_signed(&self, signing_public_key: &GuardianPubKey) -> GuardianResult<()> {
         if self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected signed log record but message is unsigned".into(),
@@ -200,7 +200,7 @@ impl LogEntry {
     }
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
-    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
         if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
@@ -265,6 +265,30 @@ impl LogRecord {
 
     pub fn message(&self) -> &VersionedLogMessage {
         &self.data().message
+    }
+
+    /// Validate a signed record under `signing_public_key` and normalize its
+    /// message to the current schema. The caller is responsible for establishing
+    /// that the signing key is authorized.
+    pub fn validate(
+        self,
+        signing_public_key: &GuardianPubKey,
+    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        let signed = self.into_signed()?;
+        let timestamp_ms = signed.data.timestamp_ms;
+        signed.data.validate_signed(signing_public_key)?;
+        let data = signed
+            .authenticate(signing_public_key)
+            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
+        let (session_id, message) = data.into_current()?;
+        Ok((session_id, timestamp_ms, message))
+    }
+
+    /// Validate the one permitted unsigned record kind and normalize its
+    /// message to the current schema. The embedded Nitro attestation must be
+    /// authenticated separately.
+    pub fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+        self.into_unsigned()?.validate_unsigned()
     }
 
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
@@ -398,18 +422,11 @@ mod tests {
         record: LogRecord,
         signing_public_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        let signed = record.into_signed()?;
-        let timestamp_ms = signed.data.timestamp_ms;
-        signed.data.validate(signing_public_key)?;
-        let data = signed
-            .authenticate(signing_public_key)
-            .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-        let (session_id, message) = data.into_current()?;
-        Ok((session_id, timestamp_ms, message))
+        record.validate(signing_public_key)
     }
 
     fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
-        record.into_unsigned()?.validate_unsigned()
+        record.validate_unsigned()
     }
 
     fn assert_writer_key_is_stable_and_verifies(log: LogRecord, signing_key: &GuardianSignKeyPair) {

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -282,7 +282,7 @@ impl LogRecord {
         &self.data().message
     }
 
-    /// Validate a record and return the exact entry that was authenticated.
+    /// Validate a record without consuming it.
     ///
     /// Validation checks record-local invariants and verifies a signed record
     /// against the caller-supplied key. It does not establish that the key
@@ -292,19 +292,15 @@ impl LogRecord {
     /// Signed records require `Some(signing_public_key)`; the one permitted
     /// unsigned record kind requires `None`. The caller is responsible for
     /// authenticating the Nitro attestation carried by an unsigned record.
-    pub fn validate(self, signing_public_key: Option<&GuardianPubKey>) -> GuardianResult<LogEntry> {
+    pub fn validate(&self, signing_public_key: Option<&GuardianPubKey>) -> GuardianResult<()> {
         match (self, signing_public_key) {
             (Self::Signed(signed), Some(signing_public_key)) => {
                 signed.data.validate_signed(signing_public_key)?;
                 signed
                     .verify_signature(signing_public_key)
-                    .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-                Ok(signed.data)
+                    .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))
             }
-            (Self::Unsigned(unsigned), None) => {
-                unsigned.validate_unsigned()?;
-                Ok(unsigned)
-            }
+            (Self::Unsigned(unsigned), None) => unsigned.validate_unsigned(),
             (Self::Unsigned(unsigned), Some(_)) if unsigned.message.is_allowed_unsigned() => Err(
                 InvalidS3Log("expected signed log record but message is unsigned".into()),
             ),
@@ -436,13 +432,13 @@ mod tests {
     }
 
     fn validate_signed(
-        record: LogRecord,
+        record: &LogRecord,
         signing_public_key: &GuardianPubKey,
-    ) -> GuardianResult<LogEntry> {
+    ) -> GuardianResult<()> {
         record.validate(Some(signing_public_key))
     }
 
-    fn validate_unsigned(record: LogRecord) -> GuardianResult<LogEntry> {
+    fn validate_unsigned(record: &LogRecord) -> GuardianResult<()> {
         record.validate(None)
     }
 
@@ -459,7 +455,7 @@ mod tests {
         let body = serde_json::to_vec(&log).unwrap();
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
-        validate_signed(record_read_from_s3, &signing_key.verification_key())
+        validate_signed(&record_read_from_s3, &signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
     }
 
@@ -634,10 +630,10 @@ mod tests {
                 "{name} did not preserve its object key"
             );
             if decoded.message().is_allowed_unsigned() {
-                validate_unsigned(decoded)
+                validate_unsigned(&decoded)
                     .unwrap_or_else(|error| panic!("{name} failed validation: {error}"));
             } else {
-                validate_signed(decoded, &signing_key.verification_key())
+                validate_signed(&decoded, &signing_key.verification_key())
                     .unwrap_or_else(|error| panic!("{name} failed verification: {error}"));
             }
         }
@@ -656,8 +652,10 @@ mod tests {
             hex::decode("916c711a5e81c2b032f15952b515205a20ef2a16f8a88da504885f392e314dca")
                 .unwrap();
         let signing_pubkey = GuardianPubKey::try_from(signing_pubkey.as_slice()).unwrap();
-        let entry = validate_signed(record, &signing_pubkey)
-            .expect("the deployed V1 signature must verify");
+        validate_signed(&record, &signing_pubkey).expect("the deployed V1 signature must verify");
+        let entry = record
+            .into_entry_unchecked()
+            .expect("the deployed V1 record is signed");
         assert_eq!(entry.session_id().as_str(), "916c711a5e81c2b0");
         assert_eq!(entry.timestamp_ms(), 1_784_219_535_816);
         let VersionedLogMessage::V1(LogMessageV1::KpShareState(message)) = entry.into_message()
@@ -736,12 +734,12 @@ mod tests {
     fn signed_log_verifies_at_canonical_object_key() {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
 
-        let entry = validate_signed(log, &signing_key.verification_key())
+        validate_signed(&log, &signing_key.verification_key())
             .expect("record should verify at its intended S3 key");
 
-        assert_eq!(entry.timestamp_ms(), 1_700_000_000_000);
+        assert_eq!(log.timestamp_ms(), 1_700_000_000_000);
         assert!(matches!(
-            entry.message(),
+            log.message(),
             VersionedLogMessage::V2(LogMessageV2::Heartbeat(HeartbeatLogMessage { seq: 42 }))
         ));
     }
@@ -764,7 +762,7 @@ mod tests {
         assert!(serde_json::from_value::<LogRecord>(malformed).is_err());
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
-        validate_signed(from_s3, &signing_key.verification_key())
+        validate_signed(&from_s3, &signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
     }
 
@@ -822,7 +820,7 @@ mod tests {
             heartbeat_session_id()
         );
 
-        let err = validate_signed(tampered, &signing_key.verification_key())
+        let err = validate_signed(&tampered, &signing_key.verification_key())
             .expect_err("signature must cover the canonical object key and message");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -852,7 +850,7 @@ mod tests {
         let mut record_read_from_s3: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
         record_read_from_s3.data_mut().object_key = relocated_key;
-        let err = validate_signed(record_read_from_s3, &signing_key.verification_key())
+        let err = validate_signed(&record_read_from_s3, &signing_key.verification_key())
             .expect_err("the signature must authenticate the random failure suffix");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -880,7 +878,7 @@ mod tests {
         aliased.data_mut().session_id = "aliased-session".into();
         aliased.data_mut().object_key = GenesisLogMessage::object_key();
 
-        let err = validate_signed(aliased, &signing_key.verification_key())
+        let err = validate_signed(&aliased, &signing_key.verification_key())
             .expect_err("session ID must be part of the signed routing context");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -901,7 +899,7 @@ mod tests {
         );
 
         log.data_mut().object_key = "init/copied-attestation.json".to_string();
-        let err = validate_unsigned(log)
+        let err = validate_unsigned(&log)
             .expect_err("unsigned record copied to another S3 key must be rejected");
 
         assert!(format!("{err:?}").contains("non-canonical S3 object key"));
@@ -919,7 +917,7 @@ mod tests {
             &signing_key,
             1_700_000_000_000,
         );
-        let err = validate_unsigned(log)
+        let err = validate_unsigned(&log)
             .expect_err("attestation session ID must come from its signing public key");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -982,7 +980,7 @@ mod tests {
         assert_eq!(message["config_hash"], hex::encode([0xcd; 32]));
 
         let from_json: LogRecord = serde_json::from_value(json).unwrap();
-        validate_signed(from_json, &signing_key.verification_key()).unwrap();
+        validate_signed(&from_json, &signing_key.verification_key()).unwrap();
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -385,6 +385,7 @@ mod tests {
     use crate::guardian::GetGuardianInfoResponse;
     use crate::guardian::GuardianError;
     use crate::guardian::GuardianSignedResponse;
+    use crate::guardian::GuardianSigningIntentType;
     use crate::guardian::HeartbeatLogMessage;
     use crate::guardian::InitLogMessage;
     use crate::guardian::KPEncryptedSharesRoster;

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -245,7 +245,9 @@ impl LogRecord {
         }
     }
 
-    pub fn verify(
+    /// Validates the signed record's envelope, canonical session, and Guardian
+    /// signature. The caller must establish trust in `pub_key` separately.
+    pub fn validate_signed(
         self,
         pub_key: &GuardianPubKey,
     ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
@@ -409,7 +411,7 @@ mod tests {
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
         record_read_from_s3
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
     }
 
@@ -586,7 +588,7 @@ mod tests {
                     .unwrap_or_else(|error| panic!("{name} failed validation: {error}"));
             } else {
                 decoded
-                    .verify(&signing_key.verification_key())
+                    .validate_signed(&signing_key.verification_key())
                     .unwrap_or_else(|error| panic!("{name} failed verification: {error}"));
             }
         }
@@ -606,7 +608,7 @@ mod tests {
                 .unwrap();
         let signing_pubkey = GuardianPubKey::try_from(signing_pubkey.as_slice()).unwrap();
         let (session_id, timestamp_ms, LogMessageV2::KpShareState(message)) = record
-            .verify(&signing_pubkey)
+            .validate_signed(&signing_pubkey)
             .expect("the deployed V1 signature must verify before normalization")
         else {
             panic!("expected normalized KP share state");
@@ -683,7 +685,7 @@ mod tests {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
 
         let (_, timestamp_ms, message) = log
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect("record should verify at its intended S3 key");
 
         assert_eq!(timestamp_ms, 1_700_000_000_000);
@@ -712,7 +714,7 @@ mod tests {
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
         from_s3
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
     }
 
@@ -741,7 +743,7 @@ mod tests {
         );
 
         let err = tampered
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect_err("signature must cover the canonical object key and message");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -772,7 +774,7 @@ mod tests {
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
         record_read_from_s3.object_key = relocated_key;
         let err = record_read_from_s3
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect_err("the signature must authenticate the random failure suffix");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -801,7 +803,7 @@ mod tests {
         aliased.object_key = GenesisLogMessage::object_key();
 
         let err = aliased
-            .verify(&signing_key.verification_key())
+            .validate_signed(&signing_key.verification_key())
             .expect_err("session ID must be part of the signed routing context");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -905,7 +907,9 @@ mod tests {
         assert_eq!(message["config_hash"], hex::encode([0xcd; 32]));
 
         let from_json: LogRecord = serde_json::from_value(json).unwrap();
-        from_json.verify(&signing_key.verification_key()).unwrap();
+        from_json
+            .validate_signed(&signing_key.verification_key())
+            .unwrap();
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/log/schema.rs
+++ b/crates/hashi-types/src/guardian/log/schema.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The versioned `LogMessage` family the enclave emits and conversion into the
-//! current message shape. The `LogRecord` wrapper that carries these to S3 lives
-//! in `super::record`.
+//! The versioned `LogMessage` family the enclave emits. The `LogRecord` wrapper
+//! that carries these to S3 lives in `super::record`.
 
 use super::LogType;
 use super::ObjectKeyPattern;
@@ -15,7 +14,6 @@ use super::messages::InitLogMessage;
 use super::messages::KpShareStateLogMessageV1;
 use super::messages::KpShareStateLogMessageV2;
 use super::messages::WithdrawalLogMessage;
-use crate::guardian::GuardianError;
 use crate::guardian::UnixMillis;
 use serde::Deserialize;
 use serde::Serialize;
@@ -23,6 +21,9 @@ use serde::Serialize;
 /// The wire message stored in a [`super::LogRecord`]. Its version is serialized
 /// as the record's sibling `schema_version` field rather than as an additional
 /// JSON enum layer.
+///
+/// Readers match these variants exhaustively at their consumption boundary so
+/// adding a schema version requires each reader to opt in explicitly.
 #[derive(Debug)]
 pub enum VersionedLogMessage {
     V1(LogMessageV1),
@@ -67,7 +68,7 @@ pub enum LogMessageV1 {
     Genesis(Box<GenesisLogMessage>),
 }
 
-/// Current log schema emitted by the guardian enclave.
+/// Schema-version-2 log messages emitted by the guardian enclave.
 /// Uses an enum discriminator for automatic domain separation between variants.
 // TODO(testnet-wipe): Collapse the V1/V2 compatibility layer into a single log
 // schema once existing testnet records no longer need to be read.
@@ -82,8 +83,7 @@ pub enum LogMessageV2 {
     Genesis(Box<GenesisLogMessage>),
 }
 
-/// The current normalized log-message shape exposed to writers and verified
-/// readers. Wire-version handling remains internal to [`VersionedLogMessage`].
+/// Writer-facing alias for the log-message schema emitted by guardians.
 pub type LogMessage = LogMessageV2;
 
 trait LogMessageSchema {
@@ -146,31 +146,6 @@ macro_rules! impl_log_message_schema {
 impl_log_message_schema!(LogMessageV1);
 impl_log_message_schema!(LogMessageV2);
 
-impl LogMessageV1 {
-    fn into_current(self) -> Result<LogMessage, GuardianError> {
-        Ok(match self {
-            LogMessageV1::Heartbeat(message) => LogMessage::Heartbeat(message),
-            LogMessageV1::Init(message) => LogMessage::Init(message),
-            LogMessageV1::Withdrawal(message) => LogMessage::Withdrawal(message),
-            LogMessageV1::Ceremony(message) => LogMessage::Ceremony(message),
-            LogMessageV1::KpShareState(message) => {
-                LogMessage::KpShareState(Box::new((*message).into_current()?))
-            }
-            LogMessageV1::CommitteeUpdate(message) => LogMessage::CommitteeUpdate(message),
-            LogMessageV1::Genesis(message) => LogMessage::Genesis(message),
-        })
-    }
-}
-
-impl LogMessageV2 {
-    pub fn into_init_log(self) -> Option<InitLogMessage> {
-        match self {
-            Self::Init(init_message) => Some(*init_message),
-            _ => None,
-        }
-    }
-}
-
 impl VersionedLogMessage {
     pub const SCHEMA_VERSION_V1: u64 = 1;
     pub const SCHEMA_VERSION_V2: u64 = 2;
@@ -208,13 +183,6 @@ impl VersionedLogMessage {
         match self {
             Self::V1(message) => message.object_key_pattern(session_id, timestamp_ms),
             Self::V2(message) => message.object_key_pattern(session_id, timestamp_ms),
-        }
-    }
-
-    pub fn into_current(self) -> Result<LogMessage, GuardianError> {
-        match self {
-            Self::V1(message) => message.into_current(),
-            Self::V2(message) => Ok(message),
         }
     }
 }

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -922,11 +922,8 @@ impl GetGuardianInfoResponse {
         &self,
         expected_build: &BuildPcrs,
     ) -> CryptoVerificationResult<VerifiedGuardianInfo> {
-        let info = self
-            .signed_info
-            .clone()
-            .authenticate(&self.signing_pub_key)?
-            .into_response();
+        self.signed_info.verify_signature(&self.signing_pub_key)?;
+        let info = self.signed_info.data.clone().into_response();
         if info.untrusted_git_revision != expected_build.git_revision() {
             return Err(CryptoVerificationError::new(format!(
                 "guardian info reports build '{}', expected current build '{}'",

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -26,7 +26,9 @@ pub use limiter::LimiterConfig;
 pub use limiter::LimiterState;
 pub use limiter::RateLimiter;
 pub use log::*;
+pub use signing::GuardianResponse;
 pub use signing::GuardianSigned;
+pub use signing::GuardianSignedResponse;
 pub use signing::GuardianSigningIntent;
 pub use signing::GuardianSigningIntentType;
 pub use signing::KpSigned;
@@ -86,7 +88,7 @@ pub struct GetGuardianInfoResponse {
     /// Signing pub key of the guardian
     signing_pub_key: GuardianPubKey,
     /// Signed guardian info
-    signed_info: GuardianSigned<GuardianInfo>,
+    signed_info: GuardianSignedResponse<GuardianInfo>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -299,8 +301,8 @@ pub struct ProvisionerRotateCertRequest {
     encrypted_share: GuardianEncryptedShare,
 }
 
-/// `GuardianSigned<ProvisionerRotateCertResponse>`. Returned after the guardian appends
-/// the next `kp-shares/` certificate-state snapshot.
+/// `GuardianSignedResponse<ProvisionerRotateCertResponse>`. Returned after the
+/// guardian appends the next `kp-shares/` certificate-state snapshot.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ProvisionerRotateCertResponse {
     pub cert_seq: u64,
@@ -896,7 +898,7 @@ impl GetGuardianInfoResponse {
     pub fn new(
         attestation: NitroAttestation,
         signing_pub_key: GuardianPubKey,
-        signed_info: GuardianSigned<GuardianInfo>,
+        signed_info: GuardianSignedResponse<GuardianInfo>,
     ) -> Self {
         Self {
             attestation,
@@ -923,7 +925,8 @@ impl GetGuardianInfoResponse {
         let info = self
             .signed_info
             .clone()
-            .authenticate(&self.signing_pub_key)?;
+            .authenticate(&self.signing_pub_key)?
+            .into_response();
         if info.untrusted_git_revision != expected_build.git_revision() {
             return Err(CryptoVerificationError::new(format!(
                 "guardian info reports build '{}', expected current build '{}'",
@@ -943,7 +946,10 @@ impl GetGuardianInfoResponse {
     /// Extract the guardian's self-reported info and signing key WITHOUT verifying
     /// the signature or attestation.
     pub fn into_info_unchecked(self) -> (GuardianInfo, GuardianPubKey) {
-        (self.signed_info.into_data_unchecked(), self.signing_pub_key)
+        (
+            self.signed_info.into_data_unchecked().into_response(),
+            self.signing_pub_key,
+        )
     }
 }
 
@@ -1092,7 +1098,7 @@ mod tests {
     #[test]
     fn get_guardian_info_into_info_unchecked_returns_info_and_signing_key() {
         let resp = GetGuardianInfoResponse::mock_for_testing();
-        let expected_info = resp.signed_info.data.clone();
+        let expected_info = resp.signed_info.data.response.clone();
         let expected_signing_pub_key = resp.signing_pub_key;
         let (info, signing_pub_key) = resp.into_info_unchecked();
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -20,7 +20,6 @@ pub use attestation::BuildPcrs;
 pub use attestation::GitRevision;
 pub use attestation::NitroAttestation;
 pub use attestation::PcrAllowlist;
-pub use attestation::VerifiedSessionInfo;
 pub use lifecycle::*;
 pub use limiter::LimiterConfig;
 pub use limiter::LimiterState;

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -27,11 +27,11 @@ pub use limiter::LimiterState;
 pub use limiter::RateLimiter;
 pub use log::*;
 pub use signing::GuardianSigned;
-pub use signing::IntentType;
+pub use signing::GuardianSigningIntent;
+pub use signing::GuardianSigningIntentType;
 pub use signing::KpSigned;
 pub use signing::KpSigningIntent;
 pub use signing::KpSigningIntentType;
-pub use signing::SigningIntent;
 pub use time_utils::UnixMillis;
 pub use time_utils::now_timestamp_ms;
 pub use time_utils::now_timestamp_secs;
@@ -920,7 +920,10 @@ impl GetGuardianInfoResponse {
         &self,
         expected_build: &BuildPcrs,
     ) -> CryptoVerificationResult<VerifiedGuardianInfo> {
-        let info = self.signed_info.clone().verify(&self.signing_pub_key)?;
+        let info = self
+            .signed_info
+            .clone()
+            .authenticate(&self.signing_pub_key)?;
         if info.untrusted_git_revision != expected_build.git_revision() {
             return Err(CryptoVerificationError::new(format!(
                 "guardian info reports build '{}', expected current build '{}'",

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -223,7 +223,7 @@ impl crate::intent::IntentMessage for StandardWithdrawalRequest {
     const INTENT: crate::intent::Intent = crate::intent::Intent::GuardianWithdrawalRequest;
 }
 
-/// `EnclaveSigned<T>`
+/// `GuardianSignedResponse<StandardWithdrawalResponse>`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StandardWithdrawalResponse {
     pub enclave_signatures: Vec<BitcoinSignature>,
@@ -251,7 +251,7 @@ pub struct SetupNewKeyRequest {
     params: SecretSharingParams,
 }
 
-/// `EnclaveSigned<T>`
+/// `GuardianSignedResponse<SetupNewKeyResponse>`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SetupNewKeyResponse {
     pub encrypted_shares: KPEncryptedSharesRoster,
@@ -282,7 +282,8 @@ pub struct RotateKpsState {
     new_params: SecretSharingParams,
 }
 
-/// `EnclaveSigned<T>`. The new KP set's encrypted shares, returned by `rotate_kps`.
+/// `GuardianSignedResponse<RotateKpsResponse>`. The new KP set's encrypted
+/// shares, returned by `rotate_kps`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RotateKpsResponse {
     pub encrypted_shares: KPEncryptedSharesRoster,

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -1758,13 +1758,13 @@ mod tests {
         );
         assert_eq!(back.data.encrypted_share(), &encrypted_share);
         assert_eq!(back.signer_cert.fingerprint(), cert.fingerprint());
-        back.authenticate().unwrap();
+        back.verify_signature().unwrap();
 
         let mut tampered = pb.clone();
         tampered.expected_session_id = "other-session".to_string();
         let tampered = KpSigned::<SingleProvisionerInitRequest>::try_from(tampered).unwrap();
         assert!(
-            tampered.authenticate().is_err(),
+            tampered.verify_signature().is_err(),
             "signature must bind the expected guardian session"
         );
 
@@ -1772,7 +1772,7 @@ mod tests {
         tampered.expected_config_hash = Some(vec![8u8; 32].into());
         let tampered = KpSigned::<SingleProvisionerInitRequest>::try_from(tampered).unwrap();
         assert!(
-            tampered.authenticate().is_err(),
+            tampered.verify_signature().is_err(),
             "signature must bind the expected operator-init config hash"
         );
     }

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -17,9 +17,11 @@ use super::GuardianError;
 use super::GuardianError::InvalidInputs;
 use super::GuardianInfo;
 use super::GuardianPubKey;
+use super::GuardianResponse;
 use super::GuardianResult;
 use super::GuardianSignature;
 use super::GuardianSigned;
+use super::GuardianSignedResponse;
 use super::HashiCommittee;
 use super::HashiCommitteeMember;
 use super::HashiSigned;
@@ -133,7 +135,7 @@ impl TryFrom<pb::SetupNewKeyRequest> for SetupNewKeyRequest {
     }
 }
 
-impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSigned<SetupNewKeyResponse> {
+impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSignedResponse<SetupNewKeyResponse> {
     type Error = GuardianError;
 
     fn try_from(resp: pb::SignedSetupNewKeyResponse) -> Result<Self, Self::Error> {
@@ -162,12 +164,14 @@ impl TryFrom<pb::SignedSetupNewKeyResponse> for GuardianSigned<SetupNewKeyRespon
         let timestamp_ms = resp.timestamp_ms.ok_or_else(|| missing("timestamp_ms"))?;
 
         Ok(GuardianSigned {
-            data: SetupNewKeyResponse {
-                encrypted_shares,
-                secret_sharing_instance,
-                btc_master_pubkey,
-            },
-            timestamp_ms,
+            data: GuardianResponse::new(
+                SetupNewKeyResponse {
+                    encrypted_shares,
+                    secret_sharing_instance,
+                    btc_master_pubkey,
+                },
+                timestamp_ms,
+            ),
             signature,
         })
     }
@@ -387,7 +391,7 @@ impl TryFrom<pb::RotateKpsRequest> for RotateKpsRequest {
     }
 }
 
-impl TryFrom<pb::SignedRotateKpsResponse> for GuardianSigned<RotateKpsResponse> {
+impl TryFrom<pb::SignedRotateKpsResponse> for GuardianSignedResponse<RotateKpsResponse> {
     type Error = GuardianError;
 
     fn try_from(resp: pb::SignedRotateKpsResponse) -> Result<Self, Self::Error> {
@@ -406,15 +410,14 @@ impl TryFrom<pb::SignedRotateKpsResponse> for GuardianSigned<RotateKpsResponse> 
         let timestamp_ms = resp.timestamp_ms.ok_or_else(|| missing("timestamp_ms"))?;
 
         Ok(GuardianSigned {
-            data: RotateKpsResponse { encrypted_shares },
-            timestamp_ms,
+            data: GuardianResponse::new(RotateKpsResponse { encrypted_shares }, timestamp_ms),
             signature,
         })
     }
 }
 
 impl TryFrom<pb::SignedProvisionerRotateCertResponse>
-    for GuardianSigned<ProvisionerRotateCertResponse>
+    for GuardianSignedResponse<ProvisionerRotateCertResponse>
 {
     type Error = GuardianError;
 
@@ -429,11 +432,13 @@ impl TryFrom<pb::SignedProvisionerRotateCertResponse>
         )?;
 
         Ok(GuardianSigned {
-            data: ProvisionerRotateCertResponse {
-                cert_seq: resp.cert_seq.ok_or_else(|| missing("cert_seq"))?,
-                encrypted_shares,
-            },
-            timestamp_ms,
+            data: GuardianResponse::new(
+                ProvisionerRotateCertResponse {
+                    cert_seq: resp.cert_seq.ok_or_else(|| missing("cert_seq"))?,
+                    encrypted_shares,
+                },
+                timestamp_ms,
+            ),
             signature,
         })
     }
@@ -521,7 +526,7 @@ impl TryFrom<pb::GetGuardianInfoResponse> for GetGuardianInfoResponse {
             .map_err(|e| InvalidInputs(format!("invalid signing_pub_key: {e}")))?;
 
         let signed_info_pb = resp.signed_info.ok_or_else(|| missing("signed_info"))?;
-        let signed_info = GuardianSigned::<GuardianInfo>::try_from(signed_info_pb)?;
+        let signed_info = GuardianSignedResponse::<GuardianInfo>::try_from(signed_info_pb)?;
 
         Ok(GetGuardianInfoResponse::new(
             NitroAttestation::new(attestation.to_vec()),
@@ -563,7 +568,9 @@ impl TryFrom<pb::SignedStandardWithdrawalRequest> for SignedStandardWithdrawalRe
     }
 }
 
-impl TryFrom<pb::SignedStandardWithdrawalResponse> for GuardianSigned<StandardWithdrawalResponse> {
+impl TryFrom<pb::SignedStandardWithdrawalResponse>
+    for GuardianSignedResponse<StandardWithdrawalResponse>
+{
     type Error = GuardianError;
 
     fn try_from(resp: pb::SignedStandardWithdrawalResponse) -> Result<Self, Self::Error> {
@@ -584,8 +591,10 @@ impl TryFrom<pb::SignedStandardWithdrawalResponse> for GuardianSigned<StandardWi
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(GuardianSigned {
-            data: StandardWithdrawalResponse { enclave_signatures },
-            timestamp_ms,
+            data: GuardianResponse::new(
+                StandardWithdrawalResponse { enclave_signatures },
+                timestamp_ms,
+            ),
             signature,
         })
     }
@@ -596,19 +605,19 @@ impl TryFrom<pb::SignedStandardWithdrawalResponse> for GuardianSigned<StandardWi
 // ----------------------------------------------------------
 
 pub fn setup_new_key_response_signed_to_pb(
-    s: GuardianSigned<SetupNewKeyResponse>,
+    s: GuardianSignedResponse<SetupNewKeyResponse>,
 ) -> pb::SignedSetupNewKeyResponse {
     let signature = s.signature.to_bytes().to_vec();
 
     pb::SignedSetupNewKeyResponse {
-        data: Some(setup_new_key_response_to_pb(s.data)),
-        timestamp_ms: Some(s.timestamp_ms),
+        data: Some(setup_new_key_response_to_pb(s.data.response)),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(signature.into()),
     }
 }
 
 pub fn rotate_kps_response_signed_to_pb(
-    s: GuardianSigned<RotateKpsResponse>,
+    s: GuardianSignedResponse<RotateKpsResponse>,
 ) -> pb::SignedRotateKpsResponse {
     let signature = s.signature.to_bytes().to_vec();
 
@@ -616,24 +625,25 @@ pub fn rotate_kps_response_signed_to_pb(
         data: Some(pb::RotateKpsResponseData {
             encrypted_shares: s
                 .data
+                .response
                 .encrypted_shares
                 .into_vec()
                 .into_iter()
                 .map(kp_encrypted_shares_to_pb)
                 .collect(),
         }),
-        timestamp_ms: Some(s.timestamp_ms),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(signature.into()),
     }
 }
 
 pub fn provisioner_rotate_cert_response_signed_to_pb(
-    s: GuardianSigned<ProvisionerRotateCertResponse>,
+    s: GuardianSignedResponse<ProvisionerRotateCertResponse>,
 ) -> pb::SignedProvisionerRotateCertResponse {
     pb::SignedProvisionerRotateCertResponse {
-        cert_seq: Some(s.data.cert_seq),
-        encrypted_shares: Some(kp_encrypted_shares_to_pb(s.data.encrypted_shares)),
-        timestamp_ms: Some(s.timestamp_ms),
+        cert_seq: Some(s.data.response.cert_seq),
+        encrypted_shares: Some(kp_encrypted_shares_to_pb(s.data.response.encrypted_shares)),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(s.signature.to_bytes().to_vec().into()),
     }
 }
@@ -815,7 +825,7 @@ pub fn signed_standard_withdrawal_request_to_pb(
 }
 
 pub fn standard_withdrawal_response_signed_to_pb(
-    s: GuardianSigned<StandardWithdrawalResponse>,
+    s: GuardianSignedResponse<StandardWithdrawalResponse>,
 ) -> pb::SignedStandardWithdrawalResponse {
     let signature = s.signature.to_bytes().to_vec();
 
@@ -823,12 +833,13 @@ pub fn standard_withdrawal_response_signed_to_pb(
         data: Some(pb::StandardWithdrawalResponseData {
             enclave_signatures: s
                 .data
+                .response
                 .enclave_signatures
                 .iter()
                 .map(|sig| sig.to_vec().into())
                 .collect(),
         }),
-        timestamp_ms: Some(s.timestamp_ms),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(signature.into()),
     }
 }
@@ -1063,7 +1074,7 @@ fn guardian_info_data_to_pb(info: GuardianInfo) -> pb::GuardianInfoData {
     }
 }
 
-impl TryFrom<pb::SignedGuardianInfo> for GuardianSigned<GuardianInfo> {
+impl TryFrom<pb::SignedGuardianInfo> for GuardianSignedResponse<GuardianInfo> {
     type Error = GuardianError;
 
     fn try_from(s: pb::SignedGuardianInfo) -> Result<Self, Self::Error> {
@@ -1079,17 +1090,16 @@ impl TryFrom<pb::SignedGuardianInfo> for GuardianSigned<GuardianInfo> {
             .map_err(|e| InvalidInputs(format!("invalid signed_info.signature: {e}")))?;
 
         Ok(Self {
-            data: GuardianInfo::try_from(data_pb)?,
-            timestamp_ms,
+            data: GuardianResponse::new(GuardianInfo::try_from(data_pb)?, timestamp_ms),
             signature,
         })
     }
 }
 
-fn signed_guardian_info_to_pb(s: GuardianSigned<GuardianInfo>) -> pb::SignedGuardianInfo {
+fn signed_guardian_info_to_pb(s: GuardianSignedResponse<GuardianInfo>) -> pb::SignedGuardianInfo {
     pb::SignedGuardianInfo {
-        data: Some(guardian_info_data_to_pb(s.data)),
-        timestamp_ms: Some(s.timestamp_ms),
+        data: Some(guardian_info_data_to_pb(s.data.response)),
+        timestamp_ms: Some(s.data.timestamp_ms),
         signature: Some(s.signature.to_bytes().to_vec().into()),
     }
 }
@@ -1670,25 +1680,26 @@ mod tests {
 
     #[test]
     fn setup_new_key_response_round_trip() {
-        let resp = GuardianSigned::<SetupNewKeyResponse>::mock_for_testing();
+        let resp = GuardianSignedResponse::<SetupNewKeyResponse>::mock_for_testing();
         let pb = setup_new_key_response_signed_to_pb(resp.clone());
-        let back = GuardianSigned::<SetupNewKeyResponse>::try_from(pb).unwrap();
+        let back = GuardianSignedResponse::<SetupNewKeyResponse>::try_from(pb).unwrap();
         assert_eq!(resp, back);
     }
 
     #[test]
     fn signed_rotate_kps_response_round_trip() {
-        let resp = GuardianSigned::<RotateKpsResponse>::mock_for_testing();
+        let resp = GuardianSignedResponse::<RotateKpsResponse>::mock_for_testing();
         let pb = rotate_kps_response_signed_to_pb(resp.clone());
-        let back = GuardianSigned::<RotateKpsResponse>::try_from(pb).unwrap();
+        let back = GuardianSignedResponse::<RotateKpsResponse>::try_from(pb).unwrap();
         assert_eq!(resp, back);
     }
 
     #[test]
     fn signed_provisioner_rotate_cert_response_round_trip() {
-        let response = GuardianSigned::<ProvisionerRotateCertResponse>::mock_for_testing();
+        let response = GuardianSignedResponse::<ProvisionerRotateCertResponse>::mock_for_testing();
         let pb = provisioner_rotate_cert_response_signed_to_pb(response.clone());
-        let round_trip = GuardianSigned::<ProvisionerRotateCertResponse>::try_from(pb).unwrap();
+        let round_trip =
+            GuardianSignedResponse::<ProvisionerRotateCertResponse>::try_from(pb).unwrap();
         assert_eq!(response, round_trip);
     }
 
@@ -1797,9 +1808,9 @@ mod tests {
 
     #[test]
     fn standard_withdrawal_response_round_trip() {
-        let resp = GuardianSigned::<StandardWithdrawalResponse>::mock_for_testing();
+        let resp = GuardianSignedResponse::<StandardWithdrawalResponse>::mock_for_testing();
         let pb = standard_withdrawal_response_signed_to_pb(resp.clone());
-        let back = GuardianSigned::<StandardWithdrawalResponse>::try_from(pb).unwrap();
+        let back = GuardianSignedResponse::<StandardWithdrawalResponse>::try_from(pb).unwrap();
         assert_eq!(resp, back);
     }
 

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -1747,13 +1747,13 @@ mod tests {
         );
         assert_eq!(back.data.encrypted_share(), &encrypted_share);
         assert_eq!(back.signer_cert.fingerprint(), cert.fingerprint());
-        back.verify().unwrap();
+        back.authenticate().unwrap();
 
         let mut tampered = pb.clone();
         tampered.expected_session_id = "other-session".to_string();
         let tampered = KpSigned::<SingleProvisionerInitRequest>::try_from(tampered).unwrap();
         assert!(
-            tampered.verify().is_err(),
+            tampered.authenticate().is_err(),
             "signature must bind the expected guardian session"
         );
 
@@ -1761,7 +1761,7 @@ mod tests {
         tampered.expected_config_hash = Some(vec![8u8; 32].into());
         let tampered = KpSigned::<SingleProvisionerInitRequest>::try_from(tampered).unwrap();
         assert!(
-            tampered.verify().is_err(),
+            tampered.authenticate().is_err(),
             "signature must bind the expected operator-init config hash"
         );
     }

--- a/crates/hashi-types/src/guardian/s3_utils.rs
+++ b/crates/hashi-types/src/guardian/s3_utils.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::guardian::log::S3_DIR_HEARTBEAT;
+use crate::guardian::log::S3_DIR_WITHDRAW;
 use crate::guardian::time_utils::UnixSeconds;
 use anyhow::Context;
 use std::convert::TryFrom;
@@ -42,6 +44,16 @@ impl S3HourScopedDirectory {
             day: datetime.day(),
             hour: datetime.hour(),
         }
+    }
+
+    /// Construct the withdrawal-log directory containing `t`.
+    pub fn withdraw(t: UnixSeconds) -> Self {
+        Self::new(S3_DIR_WITHDRAW, t)
+    }
+
+    /// Construct the heartbeat-log directory containing `t`.
+    pub fn heartbeat(t: UnixSeconds) -> Self {
+        Self::new(S3_DIR_HEARTBEAT, t)
     }
 
     pub fn next_dir(&self) -> Self {

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -38,7 +38,7 @@ use std::path::Path;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GuardianSigningIntentType {
     /// Intent for LogEntry.
-    LogMessage = 0,
+    LogEntry = 0,
     /// Intent for SetupNewKeyResponse.
     SetupNewKeyResponse = 1,
     /// Intent for StandardWithdrawalResponse.
@@ -108,7 +108,7 @@ pub struct GuardianSigned<T> {
 }
 
 impl GuardianSigningIntent for LogEntry {
-    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogEntry;
 }
 
 impl GuardianSigningIntent for SetupNewKeyResponse {

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -49,38 +49,34 @@ pub enum IntentType {
     ProvisionerRotateCertResponse = 5,
 }
 
-/// Trait for types that can be signed, providing domain separation via an intent.
-pub trait SigningIntent {
+/// Trait for serializable types that can be signed with intent-based domain
+/// separation.
+pub trait SigningIntent: Serialize {
     const INTENT: IntentType;
 
     /// Canonical bytes covered by this guardian signature. Most payloads use
     /// the standard `(intent, data, timestamp)` layout; routing-sensitive
     /// payloads may override this while retaining the central intent registry.
-    fn signing_bytes(&self, timestamp_ms: UnixMillis) -> Vec<u8>
-    where
-        Self: Serialize,
-    {
+    fn signing_bytes(&self, timestamp_ms: UnixMillis) -> Vec<u8> {
         bcs::to_bytes(&(Self::INTENT, self, timestamp_ms)).expect("serialization should not fail")
     }
-}
 
-pub(crate) fn sign_intent<T: Serialize + SigningIntent>(
-    data: &T,
-    timestamp_ms: UnixMillis,
-    signing_key: &SigningKey,
-) -> GuardianSignature {
-    signing_key.sign(&data.signing_bytes(timestamp_ms))
-}
+    /// Signs this payload's canonical intent-bound bytes.
+    fn sign(&self, timestamp_ms: UnixMillis, signing_key: &SigningKey) -> GuardianSignature {
+        signing_key.sign(&self.signing_bytes(timestamp_ms))
+    }
 
-pub(crate) fn verify_intent<T: Serialize + SigningIntent>(
-    data: &T,
-    timestamp_ms: UnixMillis,
-    signature: &GuardianSignature,
-    pub_key: &VerificationKey,
-) -> CryptoVerificationResult<()> {
-    pub_key
-        .verify(signature, &data.signing_bytes(timestamp_ms))
-        .map_err(|_| CryptoVerificationError::new("signature invalid"))
+    /// Verifies a signature over this payload's canonical intent-bound bytes.
+    fn verify_signature(
+        &self,
+        timestamp_ms: UnixMillis,
+        signature: &GuardianSignature,
+        pub_key: &VerificationKey,
+    ) -> CryptoVerificationResult<()> {
+        pub_key
+            .verify(signature, &self.signing_bytes(timestamp_ms))
+            .map_err(|_| CryptoVerificationError::new("signature invalid"))
+    }
 }
 
 /// All possible KP signing intent types.
@@ -150,11 +146,11 @@ pub struct GuardianSigned<T> {
 }
 
 /// Methods for `Signed<T>` wrapper - signing and verification
-impl<T: Serialize + SigningIntent> GuardianSigned<T> {
+impl<T: SigningIntent> GuardianSigned<T> {
     /// Create a new signed payload (used by enclave)
     /// Includes intent byte for domain separation to prevent cross-type signature attacks
     pub fn new(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
-        let signature = sign_intent(&data, timestamp_ms, signing_key);
+        let signature = data.sign(timestamp_ms, signing_key);
         Self {
             data,
             timestamp_ms,
@@ -165,7 +161,8 @@ impl<T: Serialize + SigningIntent> GuardianSigned<T> {
     /// Verify signature and extract payload
     /// Checks intent byte to ensure signature is for the correct type
     pub fn verify(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
-        verify_intent(&self.data, self.timestamp_ms, &self.signature, pub_key)?;
+        self.data
+            .verify_signature(self.timestamp_ms, &self.signature, pub_key)?;
         Ok(self.data)
     }
 }

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -13,6 +13,7 @@ use super::CryptoVerificationResult;
 use super::GuardianError::InternalError;
 use super::GuardianInfo;
 use super::GuardianResult;
+use super::LogEntry;
 use super::ProvisionerRotateCertRequest;
 use super::ProvisionerRotateCertResponse;
 use super::RotateKpsResponse;
@@ -55,10 +56,6 @@ pub trait GuardianSigningIntent: Serialize {
     const INTENT: GuardianSigningIntentType;
 }
 
-fn guardian_signing_bytes<T: GuardianSigningIntent>(data: &T, timestamp_ms: UnixMillis) -> Vec<u8> {
-    bcs::to_bytes(&(T::INTENT, data, timestamp_ms)).expect("serialization should not fail")
-}
-
 /// All possible KP signing intent types.
 ///
 /// These signatures are detached OpenPGP signatures produced by KPs, not
@@ -77,6 +74,10 @@ pub enum KpSigningIntentType {
 /// KP-signed payloads and their intent-based domain separation.
 pub trait KpSigningIntent: Serialize {
     const INTENT: KpSigningIntentType;
+}
+
+impl GuardianSigningIntent for LogEntry {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::LogMessage;
 }
 
 impl GuardianSigningIntent for SetupNewKeyResponse {
@@ -117,33 +118,69 @@ pub struct KpSigned<T> {
     pub signature: String,
 }
 
-/// Guardian-signed wrapper - adds timestamp and signature to any data
+/// A timestamped response produced by the Guardian.
+///
+/// The timestamp is response metadata rather than a property of every
+/// Guardian-signed payload. Wrapping this value in [`GuardianSigned`] keeps the
+/// timestamp authenticated.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct GuardianSigned<T> {
-    pub data: T,
+pub struct GuardianResponse<T> {
+    pub response: T,
     /// Milliseconds since Unix epoch.
     pub timestamp_ms: UnixMillis,
-    pub signature: GuardianSignature,
 }
 
-impl<T: GuardianSigningIntent> GuardianSigned<T> {
-    /// Sign a payload with intent-based domain separation.
-    pub fn sign(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
-        let signature = signing_key.sign(&guardian_signing_bytes(&data, timestamp_ms));
+impl<T> GuardianResponse<T> {
+    pub fn new(response: T, timestamp_ms: UnixMillis) -> Self {
         Self {
-            data,
+            response,
             timestamp_ms,
-            signature,
         }
     }
 
+    pub fn into_response(self) -> T {
+        self.response
+    }
+}
+
+impl<T: GuardianSigningIntent> GuardianSigningIntent for GuardianResponse<T> {
+    const INTENT: GuardianSigningIntentType = T::INTENT;
+}
+
+/// A signed, timestamped response produced by the Guardian.
+pub type GuardianSignedResponse<T> = GuardianSigned<GuardianResponse<T>>;
+
+/// Guardian-signed wrapper - adds a signature to any signable payload.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GuardianSigned<T> {
+    pub data: T,
+    pub signature: GuardianSignature,
+}
+
+impl<T> GuardianSigned<T> {
+    fn signed_bytes(data: &T) -> Vec<u8>
+    where
+        T: GuardianSigningIntent,
+    {
+        bcs::to_bytes(&(T::INTENT, data)).expect("serialization should not fail")
+    }
+
+    /// Sign a payload with intent-based domain separation.
+    pub fn sign(data: T, signing_key: &SigningKey) -> Self
+    where
+        T: GuardianSigningIntent,
+    {
+        let signature = signing_key.sign(&Self::signed_bytes(&data));
+        Self { data, signature }
+    }
+
     /// Verify the Guardian signature without consuming the signed payload.
-    pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()> {
+    pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()>
+    where
+        T: GuardianSigningIntent,
+    {
         pub_key
-            .verify(
-                &self.signature,
-                &guardian_signing_bytes(&self.data, self.timestamp_ms),
-            )
+            .verify(&self.signature, &Self::signed_bytes(&self.data))
             .map_err(|_| CryptoVerificationError::new("signature invalid"))
     }
 
@@ -151,9 +188,19 @@ impl<T: GuardianSigningIntent> GuardianSigned<T> {
     ///
     /// The caller remains responsible for authorizing the signing key for the
     /// requested operation and current state.
-    pub fn authenticate(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
+    pub fn authenticate(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T>
+    where
+        T: GuardianSigningIntent,
+    {
         self.verify_signature(pub_key)?;
         Ok(self.data)
+    }
+
+    /// Move out the payload WITHOUT verifying the signature. The node uses this
+    /// on guardian responses it has already authenticated over TLS; the ed25519
+    /// signing key is verified only by KPs/monitors on the S3 audit logs.
+    pub fn into_data_unchecked(self) -> T {
+        self.data
     }
 }
 
@@ -205,14 +252,5 @@ impl<T: KpSigningIntent> KpSigned<T> {
 
     pub fn signer_fingerprint(&self) -> Fingerprint {
         self.signer_cert.fingerprint()
-    }
-}
-
-impl<T> GuardianSigned<T> {
-    /// Move out the payload WITHOUT verifying the signature. The node uses this
-    /// on guardian responses it has already authenticated over TLS; the ed25519
-    /// signing key is verified only by KPs/monitors on the S3 audit logs.
-    pub fn into_data_unchecked(self) -> T {
-        self.data
     }
 }

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -3,9 +3,10 @@
 
 //! The guardian-signed envelope and its intent-based domain separation.
 //!
-//! `IntentType` is a registry: each signable type maps to exactly one intent
-//! value, and `GuardianSigned::{new,verify}` mix that value into the signed
-//! bytes so a signature over one type can never be replayed as another.
+//! `GuardianSigningIntentType` is a registry: each signable type maps to
+//! exactly one intent value, and `GuardianSigned::{sign,authenticate}` mix that
+//! value into the signed bytes so a signature over one type can never be
+//! replayed as another.
 
 use super::CryptoVerificationError;
 use super::CryptoVerificationResult;
@@ -34,7 +35,7 @@ use std::path::Path;
 /// Using an enum ensures no two types can accidentally share the same intent value.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum IntentType {
+pub enum GuardianSigningIntentType {
     /// Intent for key-bound guardian log records.
     LogMessage = 0,
     /// Intent for SetupNewKeyResponse
@@ -49,34 +50,32 @@ pub enum IntentType {
     ProvisionerRotateCertResponse = 5,
 }
 
-/// Trait for serializable types that can be signed with intent-based domain
-/// separation.
-pub trait SigningIntent: Serialize {
-    const INTENT: IntentType;
+/// Guardian-signed payloads and their intent-based domain separation.
+pub trait GuardianSigningIntent: Serialize {
+    const INTENT: GuardianSigningIntentType;
+}
 
-    /// Canonical bytes covered by this guardian signature. Most payloads use
-    /// the standard `(intent, data, timestamp)` layout; routing-sensitive
-    /// payloads may override this while retaining the central intent registry.
-    fn signing_bytes(&self, timestamp_ms: UnixMillis) -> Vec<u8> {
-        bcs::to_bytes(&(Self::INTENT, self, timestamp_ms)).expect("serialization should not fail")
-    }
+fn guardian_signing_bytes<T: GuardianSigningIntent>(data: &T, timestamp_ms: UnixMillis) -> Vec<u8> {
+    bcs::to_bytes(&(T::INTENT, data, timestamp_ms)).expect("serialization should not fail")
+}
 
-    /// Signs this payload's canonical intent-bound bytes.
-    fn sign(&self, timestamp_ms: UnixMillis, signing_key: &SigningKey) -> GuardianSignature {
-        signing_key.sign(&self.signing_bytes(timestamp_ms))
-    }
+pub(crate) fn sign_guardian_payload<T: GuardianSigningIntent>(
+    data: &T,
+    timestamp_ms: UnixMillis,
+    signing_key: &SigningKey,
+) -> GuardianSignature {
+    signing_key.sign(&guardian_signing_bytes(data, timestamp_ms))
+}
 
-    /// Verifies a signature over this payload's canonical intent-bound bytes.
-    fn verify_signature(
-        &self,
-        timestamp_ms: UnixMillis,
-        signature: &GuardianSignature,
-        pub_key: &VerificationKey,
-    ) -> CryptoVerificationResult<()> {
-        pub_key
-            .verify(signature, &self.signing_bytes(timestamp_ms))
-            .map_err(|_| CryptoVerificationError::new("signature invalid"))
-    }
+pub(crate) fn verify_guardian_payload_signature<T: GuardianSigningIntent>(
+    data: &T,
+    timestamp_ms: UnixMillis,
+    signature: &GuardianSignature,
+    pub_key: &VerificationKey,
+) -> CryptoVerificationResult<()> {
+    pub_key
+        .verify(signature, &guardian_signing_bytes(data, timestamp_ms))
+        .map_err(|_| CryptoVerificationError::new("signature invalid"))
 }
 
 /// All possible KP signing intent types.
@@ -94,29 +93,30 @@ pub enum KpSigningIntentType {
     ProvisionerRotateCertRequest = 1,
 }
 
-/// Trait for KP-submitted request payloads that need detached signatures.
-pub trait KpSigningIntent {
+/// KP-signed payloads and their intent-based domain separation.
+pub trait KpSigningIntent: Serialize {
     const INTENT: KpSigningIntentType;
 }
 
-impl SigningIntent for SetupNewKeyResponse {
-    const INTENT: IntentType = IntentType::SetupNewKeyResponse;
+impl GuardianSigningIntent for SetupNewKeyResponse {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::SetupNewKeyResponse;
 }
 
-impl SigningIntent for StandardWithdrawalResponse {
-    const INTENT: IntentType = IntentType::StandardWithdrawalResponse;
+impl GuardianSigningIntent for StandardWithdrawalResponse {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::StandardWithdrawalResponse;
 }
 
-impl SigningIntent for GuardianInfo {
-    const INTENT: IntentType = IntentType::GuardianInfo;
+impl GuardianSigningIntent for GuardianInfo {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::GuardianInfo;
 }
 
-impl SigningIntent for RotateKpsResponse {
-    const INTENT: IntentType = IntentType::RotateKpsResponse;
+impl GuardianSigningIntent for RotateKpsResponse {
+    const INTENT: GuardianSigningIntentType = GuardianSigningIntentType::RotateKpsResponse;
 }
 
-impl SigningIntent for ProvisionerRotateCertResponse {
-    const INTENT: IntentType = IntentType::ProvisionerRotateCertResponse;
+impl GuardianSigningIntent for ProvisionerRotateCertResponse {
+    const INTENT: GuardianSigningIntentType =
+        GuardianSigningIntentType::ProvisionerRotateCertResponse;
 }
 
 impl KpSigningIntent for SingleProvisionerInitRequest {
@@ -145,12 +145,10 @@ pub struct GuardianSigned<T> {
     pub signature: GuardianSignature,
 }
 
-/// Methods for `Signed<T>` wrapper - signing and verification
-impl<T: SigningIntent> GuardianSigned<T> {
-    /// Create a new signed payload (used by enclave)
-    /// Includes intent byte for domain separation to prevent cross-type signature attacks
-    pub fn new(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
-        let signature = data.sign(timestamp_ms, signing_key);
+impl<T: GuardianSigningIntent> GuardianSigned<T> {
+    /// Sign a payload with intent-based domain separation.
+    pub fn sign(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
+        let signature = sign_guardian_payload(&data, timestamp_ms, signing_key);
         Self {
             data,
             timestamp_ms,
@@ -158,20 +156,26 @@ impl<T: SigningIntent> GuardianSigned<T> {
         }
     }
 
-    /// Verify signature and extract payload
-    /// Checks intent byte to ensure signature is for the correct type
-    pub fn verify(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
-        self.data
-            .verify_signature(self.timestamp_ms, &self.signature, pub_key)?;
+    /// Verify the Guardian signature without consuming the signed payload.
+    pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()> {
+        verify_guardian_payload_signature(&self.data, self.timestamp_ms, &self.signature, pub_key)
+    }
+
+    /// Authenticate the Guardian signer and extract the payload.
+    ///
+    /// The caller remains responsible for authorizing the signing key for the
+    /// requested operation and current state.
+    pub fn authenticate(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T> {
+        self.verify_signature(pub_key)?;
         Ok(self.data)
     }
 }
 
-impl<T: Serialize + KpSigningIntent> KpSigned<T> {
-    /// Create a new signed KP payload by invoking `gpg --detach-sign` for the
+impl<T: KpSigningIntent> KpSigned<T> {
+    /// Sign a KP payload by invoking `gpg --detach-sign` for the
     /// signer certificate's fingerprint. Includes the KP intent in the signed
     /// bytes; payload types carry any request-specific replay-binding fields.
-    pub fn new(
+    pub fn sign(
         data: T,
         signer_cert: PgpPublicCert,
         gpg_home: Option<&Path>,
@@ -204,8 +208,11 @@ impl<T: Serialize + KpSigningIntent> KpSigned<T> {
         Ok(())
     }
 
-    /// Verify the signature and extract the payload.
-    pub fn verify(self) -> CryptoVerificationResult<T> {
+    /// Authenticate the KP signer and extract the payload.
+    ///
+    /// The caller remains responsible for authorizing the signer fingerprint
+    /// for the requested operation and current state.
+    pub fn authenticate(self) -> CryptoVerificationResult<T> {
         self.verify_signature()?;
         Ok(self.data)
     }

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -59,25 +59,6 @@ fn guardian_signing_bytes<T: GuardianSigningIntent>(data: &T, timestamp_ms: Unix
     bcs::to_bytes(&(T::INTENT, data, timestamp_ms)).expect("serialization should not fail")
 }
 
-pub(crate) fn sign_guardian_payload<T: GuardianSigningIntent>(
-    data: &T,
-    timestamp_ms: UnixMillis,
-    signing_key: &SigningKey,
-) -> GuardianSignature {
-    signing_key.sign(&guardian_signing_bytes(data, timestamp_ms))
-}
-
-pub(crate) fn verify_guardian_payload_signature<T: GuardianSigningIntent>(
-    data: &T,
-    timestamp_ms: UnixMillis,
-    signature: &GuardianSignature,
-    pub_key: &VerificationKey,
-) -> CryptoVerificationResult<()> {
-    pub_key
-        .verify(signature, &guardian_signing_bytes(data, timestamp_ms))
-        .map_err(|_| CryptoVerificationError::new("signature invalid"))
-}
-
 /// All possible KP signing intent types.
 ///
 /// These signatures are detached OpenPGP signatures produced by KPs, not
@@ -148,7 +129,7 @@ pub struct GuardianSigned<T> {
 impl<T: GuardianSigningIntent> GuardianSigned<T> {
     /// Sign a payload with intent-based domain separation.
     pub fn sign(data: T, signing_key: &SigningKey, timestamp_ms: UnixMillis) -> Self {
-        let signature = sign_guardian_payload(&data, timestamp_ms, signing_key);
+        let signature = signing_key.sign(&guardian_signing_bytes(&data, timestamp_ms));
         Self {
             data,
             timestamp_ms,
@@ -158,7 +139,12 @@ impl<T: GuardianSigningIntent> GuardianSigned<T> {
 
     /// Verify the Guardian signature without consuming the signed payload.
     pub fn verify_signature(&self, pub_key: &VerificationKey) -> CryptoVerificationResult<()> {
-        verify_guardian_payload_signature(&self.data, self.timestamp_ms, &self.signature, pub_key)
+        pub_key
+            .verify(
+                &self.signature,
+                &guardian_signing_bytes(&self.data, self.timestamp_ms),
+            )
+            .map_err(|_| CryptoVerificationError::new("signature invalid"))
     }
 
     /// Authenticate the Guardian signer and extract the payload.

--- a/crates/hashi-types/src/guardian/signing.rs
+++ b/crates/hashi-types/src/guardian/signing.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The guardian-signed envelope and its intent-based domain separation.
+//! Guardian- and KP-signed envelopes with intent-based domain separation.
 //!
-//! `GuardianSigningIntentType` is a registry: each signable type maps to
-//! exactly one intent value, and `GuardianSigned::{sign,authenticate}` mix that
-//! value into the signed bytes so a signature over one type can never be
-//! replayed as another.
+//! [`GuardianSigned`] uses Ed25519 signatures produced by the Guardian, while
+//! [`KpSigned`] uses detached OpenPGP signatures produced by key provisioners.
+//! Both serialize a payload together with its signing intent so a signature for
+//! one payload type cannot be replayed as another.
 
 use super::CryptoVerificationError;
 use super::CryptoVerificationResult;
@@ -37,17 +37,17 @@ use std::path::Path;
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GuardianSigningIntentType {
-    /// Intent for key-bound guardian log records.
+    /// Intent for LogEntry.
     LogMessage = 0,
-    /// Intent for SetupNewKeyResponse
+    /// Intent for SetupNewKeyResponse.
     SetupNewKeyResponse = 1,
-    /// Intent for StandardWithdrawalResponse
+    /// Intent for StandardWithdrawalResponse.
     StandardWithdrawalResponse = 2,
-    /// Intent for GuardianInfo
+    /// Intent for GuardianInfo.
     GuardianInfo = 3,
-    /// Intent for RotateKpsResponse
+    /// Intent for RotateKpsResponse.
     RotateKpsResponse = 4,
-    /// Intent for ProvisionerRotateCertResponse
+    /// Intent for ProvisionerRotateCertResponse.
     ProvisionerRotateCertResponse = 5,
 }
 
@@ -65,15 +65,46 @@ pub trait GuardianSigningIntent: Serialize {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum KpSigningIntentType {
-    /// One KP's share submission to the provisioning relay.
-    ProvisionerInitRelaySubmission = 0,
-    /// One KP's request to replace one certificate wrapping its committed share.
+    /// Intent for SingleProvisionerInitRequest.
+    SingleProvisionerInitRequest = 0,
+    /// Intent for ProvisionerRotateCertRequest.
     ProvisionerRotateCertRequest = 1,
 }
 
 /// KP-signed payloads and their intent-based domain separation.
 pub trait KpSigningIntent: Serialize {
     const INTENT: KpSigningIntentType;
+}
+
+/// KP-signed wrapper - adds signer cert and detached OpenPGP signature to any
+/// KP-submitted request payload.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct KpSigned<T> {
+    pub data: T,
+    pub signer_cert: PgpPublicCert,
+    pub signature: String,
+}
+
+/// A timestamped response produced by the Guardian.
+///
+/// The timestamp is response metadata rather than a property of every
+/// Guardian-signed payload. Wrapping this value in [`GuardianSigned`] keeps the
+/// timestamp authenticated.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GuardianResponse<T> {
+    pub response: T,
+    /// Milliseconds since Unix epoch.
+    pub timestamp_ms: UnixMillis,
+}
+
+/// A signed, timestamped response produced by the Guardian.
+pub type GuardianSignedResponse<T> = GuardianSigned<GuardianResponse<T>>;
+
+/// Guardian-signed wrapper - adds a signature to any signable payload.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GuardianSigned<T> {
+    pub data: T,
+    pub signature: GuardianSignature,
 }
 
 impl GuardianSigningIntent for LogEntry {
@@ -102,32 +133,11 @@ impl GuardianSigningIntent for ProvisionerRotateCertResponse {
 }
 
 impl KpSigningIntent for SingleProvisionerInitRequest {
-    const INTENT: KpSigningIntentType = KpSigningIntentType::ProvisionerInitRelaySubmission;
+    const INTENT: KpSigningIntentType = KpSigningIntentType::SingleProvisionerInitRequest;
 }
 
 impl KpSigningIntent for ProvisionerRotateCertRequest {
     const INTENT: KpSigningIntentType = KpSigningIntentType::ProvisionerRotateCertRequest;
-}
-
-/// KP-signed wrapper - adds signer cert and detached OpenPGP signature to any
-/// KP-submitted request payload.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct KpSigned<T> {
-    pub data: T,
-    pub signer_cert: PgpPublicCert,
-    pub signature: String,
-}
-
-/// A timestamped response produced by the Guardian.
-///
-/// The timestamp is response metadata rather than a property of every
-/// Guardian-signed payload. Wrapping this value in [`GuardianSigned`] keeps the
-/// timestamp authenticated.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct GuardianResponse<T> {
-    pub response: T,
-    /// Milliseconds since Unix epoch.
-    pub timestamp_ms: UnixMillis,
 }
 
 impl<T> GuardianResponse<T> {
@@ -145,16 +155,6 @@ impl<T> GuardianResponse<T> {
 
 impl<T: GuardianSigningIntent> GuardianSigningIntent for GuardianResponse<T> {
     const INTENT: GuardianSigningIntentType = T::INTENT;
-}
-
-/// A signed, timestamped response produced by the Guardian.
-pub type GuardianSignedResponse<T> = GuardianSigned<GuardianResponse<T>>;
-
-/// Guardian-signed wrapper - adds a signature to any signable payload.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct GuardianSigned<T> {
-    pub data: T,
-    pub signature: GuardianSignature,
 }
 
 impl<T> GuardianSigned<T> {
@@ -182,18 +182,6 @@ impl<T> GuardianSigned<T> {
         pub_key
             .verify(&self.signature, &Self::signed_bytes(&self.data))
             .map_err(|_| CryptoVerificationError::new("signature invalid"))
-    }
-
-    /// Authenticate the Guardian signer and extract the payload.
-    ///
-    /// The caller remains responsible for authorizing the signing key for the
-    /// requested operation and current state.
-    pub fn authenticate(self, pub_key: &VerificationKey) -> CryptoVerificationResult<T>
-    where
-        T: GuardianSigningIntent,
-    {
-        self.verify_signature(pub_key)?;
-        Ok(self.data)
     }
 
     /// Move out the payload WITHOUT verifying the signature. The node uses this
@@ -239,15 +227,6 @@ impl<T: KpSigningIntent> KpSigned<T> {
             CryptoVerificationError::new(format!("KP signature verification failed: {e}"))
         })?;
         Ok(())
-    }
-
-    /// Authenticate the KP signer and extract the payload.
-    ///
-    /// The caller remains responsible for authorizing the signer fingerprint
-    /// for the requested operation and current state.
-    pub fn authenticate(self) -> CryptoVerificationResult<T> {
-        self.verify_signature()?;
-        Ok(self.data)
     }
 
     pub fn signer_fingerprint(&self) -> Fingerprint {

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -107,7 +107,7 @@ impl GetGuardianInfoResponse {
         GetGuardianInfoResponse::new(
             NitroAttestation::new("abcd".as_bytes().to_vec()),
             signing_pub_key,
-            GuardianSigned::new(info, &signing_key, 1234),
+            GuardianSigned::sign(info, &signing_key, 1234),
         )
     }
 }
@@ -167,7 +167,7 @@ impl GuardianSigned<SetupNewKeyResponse> {
         };
 
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::new(resp, &signing_kp, 0)
+        GuardianSigned::sign(resp, &signing_kp, 0)
     }
 }
 
@@ -177,7 +177,7 @@ impl GuardianSigned<RotateKpsResponse> {
             encrypted_shares: dummy_encrypted_shares(),
         };
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::new(resp, &signing_kp, 0)
+        GuardianSigned::sign(resp, &signing_kp, 0)
     }
 }
 
@@ -192,7 +192,7 @@ impl GuardianSigned<ProvisionerRotateCertResponse> {
                 .expect("dummy shares should be non-empty"),
         };
         let signing_key = SigningKey::from([1u8; 32]);
-        GuardianSigned::new(response, &signing_key, 0)
+        GuardianSigned::sign(response, &signing_key, 0)
     }
 }
 
@@ -409,7 +409,7 @@ impl GuardianSigned<StandardWithdrawalResponse> {
         let resp = StandardWithdrawalResponse { enclave_signatures };
 
         let signing_kp = SigningKey::from([4u8; 32]);
-        GuardianSigned::new(resp, &signing_kp, 0)
+        GuardianSigned::sign(resp, &signing_kp, 0)
     }
 }
 

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -6,7 +6,9 @@ use super::Ciphertext;
 use super::GetGuardianInfoResponse;
 use super::GuardianEncryptedShare;
 use super::GuardianInfo;
+use super::GuardianResponse;
 use super::GuardianSigned;
+use super::GuardianSignedResponse;
 use super::HashiCommittee;
 use super::HashiCommitteeMember;
 use super::HashiSigned;
@@ -107,7 +109,7 @@ impl GetGuardianInfoResponse {
         GetGuardianInfoResponse::new(
             NitroAttestation::new("abcd".as_bytes().to_vec()),
             signing_pub_key,
-            GuardianSigned::sign(info, &signing_key, 1234),
+            GuardianSigned::sign(GuardianResponse::new(info, 1234), &signing_key),
         )
     }
 }
@@ -156,7 +158,7 @@ fn dummy_encrypted_shares() -> KPEncryptedSharesRoster {
     .unwrap()
 }
 
-impl GuardianSigned<SetupNewKeyResponse> {
+impl GuardianSignedResponse<SetupNewKeyResponse> {
     pub fn mock_for_testing() -> Self {
         let resp = SetupNewKeyResponse {
             encrypted_shares: dummy_encrypted_shares(),
@@ -167,21 +169,21 @@ impl GuardianSigned<SetupNewKeyResponse> {
         };
 
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(resp, &signing_kp, 0)
+        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
     }
 }
 
-impl GuardianSigned<RotateKpsResponse> {
+impl GuardianSignedResponse<RotateKpsResponse> {
     pub fn mock_for_testing() -> Self {
         let resp = RotateKpsResponse {
             encrypted_shares: dummy_encrypted_shares(),
         };
         let signing_kp = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(resp, &signing_kp, 0)
+        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
     }
 }
 
-impl GuardianSigned<ProvisionerRotateCertResponse> {
+impl GuardianSignedResponse<ProvisionerRotateCertResponse> {
     pub fn mock_for_testing() -> Self {
         let response = ProvisionerRotateCertResponse {
             cert_seq: 7,
@@ -192,7 +194,7 @@ impl GuardianSigned<ProvisionerRotateCertResponse> {
                 .expect("dummy shares should be non-empty"),
         };
         let signing_key = SigningKey::from([1u8; 32]);
-        GuardianSigned::sign(response, &signing_key, 0)
+        GuardianSigned::sign(GuardianResponse::new(response, 0), &signing_key)
     }
 }
 
@@ -400,7 +402,7 @@ impl StandardWithdrawalRequest {
     }
 }
 
-impl GuardianSigned<StandardWithdrawalResponse> {
+impl GuardianSignedResponse<StandardWithdrawalResponse> {
     pub fn mock_for_testing() -> Self {
         let kp = create_btc_keypair_for_test(&[3u8; 32]);
         let msg = Message::from_digest([5u8; 32]);
@@ -409,7 +411,7 @@ impl GuardianSigned<StandardWithdrawalResponse> {
         let resp = StandardWithdrawalResponse { enclave_signatures };
 
         let signing_kp = SigningKey::from([4u8; 32]);
-        GuardianSigned::sign(resp, &signing_kp, 0)
+        GuardianSigned::sign(GuardianResponse::new(resp, 0), &signing_kp)
     }
 }
 

--- a/crates/hashi/src/leader/guardian.rs
+++ b/crates/hashi/src/leader/guardian.rs
@@ -11,7 +11,7 @@ use hashi_types::committee::MemberSignature;
 use hashi_types::committee::SignedMessage;
 use hashi_types::committee::certificate_threshold;
 use hashi_types::guardian::CommitteeTransitionRequest;
-use hashi_types::guardian::GuardianSigned;
+use hashi_types::guardian::GuardianSignedResponse;
 use hashi_types::guardian::StandardWithdrawalRequest;
 use hashi_types::guardian::StandardWithdrawalResponse;
 use hashi_types::guardian::proto_conversions::signed_committee_transition_to_pb;
@@ -105,7 +105,7 @@ impl LeaderService {
             anyhow::anyhow!("Guardian rejected withdrawal: {}", status.message())
         })?;
 
-        let signed_response: GuardianSigned<StandardWithdrawalResponse> = response_pb
+        let signed_response: GuardianSignedResponse<StandardWithdrawalResponse> = response_pb
             .try_into()
             .inspect_err(|_| {
                 Self::record_guardian_rpc_outcome(
@@ -118,7 +118,7 @@ impl LeaderService {
         // Authenticated by TLS; the per-input BTC witness signatures below only
         // spend the 2-of-2 if they verify against the on-chain guardian BTC key
         // (enforced by Bitcoin), so the response itself isn't signature-checked.
-        let response = signed_response.into_data_unchecked();
+        let response = signed_response.into_data_unchecked().into_response();
 
         anyhow::ensure!(
             response.enclave_signatures.len() == txn.inputs.len(),


### PR DESCRIPTION
## Summary

- move withdrawal and heartbeat cursor construction onto S3HourScopedDirectory
- update reader, monitor, and log-key callers to use the associated constructors
- normalize s3_reader comments around build selection, record verification, and S3 immutability

## Testing

- make fmt

Stacked on #909.