### PR TITLE
[Guardian] Organize S3 reader module

### DIFF
--- a/crates/hashi-guardian/src/s3_reader/mod.rs
+++ b/crates/hashi-guardian/src/s3_reader/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Verified reads of the guardian's S3 logs.
+//! Verified reads from the guardian's S3 logs.
 //!
 //! [`GuardianReader`] applies each log stream's S3 immutability policy, verifies
 //! records with their writing session's attestation-anchored key, and caches the


### PR DESCRIPTION
Stacked on #908.

## Summary

- Move the S3 reader module root from `s3_reader.rs` to `s3_reader/mod.rs` so it lives alongside its focused submodules.
- Leave `s3_client.rs` and all public APIs unchanged.

## Local validation

- `make fmt`