### PR TITLE
[hashi-monitor][2/2] Add Sui polling for active testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,8 +2999,6 @@ name = "hashi-guardian-init"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "aws-config",
- "aws-credential-types",
  "bitcoin",
  "clap",
  "hashi",
@@ -3048,17 +3046,23 @@ name = "hashi-monitor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64ct",
  "bitcoin",
  "clap",
- "corepc-client",
  "e2e-tests",
+ "futures",
  "hashi-guardian",
  "hashi-types",
- "jsonrpc",
+ "minreq",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "sui-rpc",
+ "sui-sdk-types",
  "tempfile",
+ "time",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/hashi-guardian-init/Cargo.toml
+++ b/crates/hashi-guardian-init/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
-aws-config.workspace = true
-aws-credential-types.workspace = true
 bitcoin.workspace = true
 clap.workspace = true
 hashi = { path = "../hashi" }

--- a/crates/hashi-guardian-init/src/config.rs
+++ b/crates/hashi-guardian-init/src/config.rs
@@ -5,14 +5,11 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Context;
-use aws_credential_types::provider::ProvideCredentials;
 use bitcoin::Network;
 use hashi::config::HashiIds;
 use hashi::onchain::OnchainState;
 use hashi_types::guardian::LimiterConfig;
-use hashi_types::guardian::S3BucketInfo;
-use hashi_types::guardian::S3Config;
-use hashi_types::guardian::S3RetentionEnvironment;
+use hashi_types::guardian::UnresolvedS3Config;
 use serde::Deserialize;
 
 use crate::kp_roster::KpRosterConfig;
@@ -20,7 +17,7 @@ use crate::kp_roster::KpRosterConfig;
 #[derive(Deserialize)]
 pub struct Config {
     pub hashi: HashiOnchainConfig,
-    pub guardian_s3: GuardianInitS3Config,
+    pub guardian_s3: UnresolvedS3Config,
     #[serde(deserialize_with = "deserialize_network")]
     pub bitcoin_network: Network,
     pub kp_roster: KpRosterConfig,
@@ -109,64 +106,5 @@ impl HashiOnchainConfig {
             .await
             .with_context(|| format!("failed to connect to Sui RPC at {}", self.sui_rpc))?;
         Ok(state)
-    }
-}
-
-#[derive(Deserialize)]
-pub struct GuardianInitS3Config {
-    pub bucket: String,
-    pub region: String,
-    pub access_key: Option<String>,
-    pub secret_key: Option<String>,
-    // TODO(s3-retention): Should this be replaced by, or derived from, a
-    // repository-wide Hashi network identifier?
-    pub retention_environment: S3RetentionEnvironment,
-}
-
-impl GuardianInitS3Config {
-    pub async fn resolve(&self) -> anyhow::Result<S3Config> {
-        let access_key = self
-            .access_key
-            .as_deref()
-            .filter(|value| !value.trim().is_empty());
-        let secret_key = self
-            .secret_key
-            .as_deref()
-            .filter(|value| !value.trim().is_empty());
-
-        let (access_key, secret_key, session_token) = match (access_key, secret_key) {
-            (Some(access_key), Some(secret_key)) => {
-                (access_key.to_string(), secret_key.to_string(), None)
-            }
-            (None, None) => {
-                let provider =
-                    aws_config::default_provider::credentials::DefaultCredentialsChain::builder()
-                        .build()
-                        .await;
-                let creds = provider
-                    .provide_credentials()
-                    .await
-                    .context("failed to resolve AWS credentials from the default provider chain")?;
-                (
-                    creds.access_key_id().to_string(),
-                    creds.secret_access_key().to_string(),
-                    creds.session_token().map(ToOwned::to_owned),
-                )
-            }
-            _ => anyhow::bail!(
-                "guardian_s3 access_key and secret_key must either both be set or both be omitted"
-            ),
-        };
-
-        Ok(S3Config {
-            access_key,
-            secret_key,
-            session_token,
-            bucket_info: S3BucketInfo {
-                bucket: self.bucket.clone(),
-                region: self.region.clone(),
-            },
-            retention_environment: self.retention_environment,
-        })
     }
 }

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -28,7 +28,7 @@ use crate::kp_roster::load_kp_cert;
 /// separately written to disk by this flow.
 pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
 
     info!(
         phase = "setup",

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -60,7 +60,7 @@ use crate::kp_roster::load_kp_cert;
 
 pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
 
     info!(
         phase = "setup",

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -32,7 +32,7 @@ pub async fn run(
     new_kp_pgp_cert_path: PathBuf,
 ) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
     let allowlist = cfg.kp_roster.pcr_allowlist();
     let certs_roster = cfg.kp_roster.load_certs_roster()?;
 

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -18,7 +18,7 @@ use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::HashiCommittee;
 use hashi_types::guardian::InitConfig;
 use hashi_types::guardian::OperatorActivateRequest;
-use hashi_types::guardian::S3Config;
+use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::VerifiedGuardianInfo;
 use hashi_types::guardian::WithdrawStage;
 use hashi_types::guardian::proto_conversions::operator_activate_request_to_pb;
@@ -49,7 +49,7 @@ const ACTIVATION_HEARTBEAT_WAIT_BUFFER: Duration = Duration::from_mins(5);
 /// Activate a provisioner-initialized standby guardian.
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
     let allowlist = cfg.kp_roster.pcr_allowlist();
 
     info!(
@@ -297,7 +297,7 @@ struct StandbyChecks {
 
 fn verify_provisioned_standby_info(
     info: &GuardianInfo,
-    guardian_s3: &S3Config,
+    guardian_s3: &ResolvedS3Config,
     cfg: &Config,
     allowlist: &hashi_types::guardian::PcrAllowlist,
     master_g: &hashi_types::bitcoin::HashiMasterG,

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -38,7 +38,7 @@ use crate::guardian_info::verified_live_guardian_info;
 /// See the module docs for the full step-by-step flow. Each step is logged via
 /// `tracing` so the operator can follow exactly what is happening.
 pub async fn run(cfg: Config) -> Result<()> {
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
     let retention_environment = guardian_s3.retention_environment;
 
     info!(

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -10,7 +10,7 @@ use hashi_types::guardian::GenesisState;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::InitConfig;
 use hashi_types::guardian::OperatorInitRequest;
-use hashi_types::guardian::S3Config;
+use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::WithdrawStage;
 use hashi_types::guardian::proto_conversions::operator_init_request_to_pb;
@@ -24,7 +24,7 @@ use crate::guardian_info::verified_live_guardian_info;
 /// Initialize a fresh withdraw-mode guardian with operator-supplied stable config.
 pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
     let retention_environment = guardian_s3.retention_environment;
     let allowlist = cfg.kp_roster.pcr_allowlist();
 
@@ -328,7 +328,7 @@ fn ensure_uninitialized(info: &GuardianInfo) -> anyhow::Result<()> {
 
 fn verify_initialized_info(
     info: GuardianInfo,
-    guardian_s3: &S3Config,
+    guardian_s3: &ResolvedS3Config,
     expected_instance: &SecretSharingInstance,
     expected_config: &InitConfig,
     expected_config_hash: [u8; 32],

--- a/crates/hashi-guardian/src/lib.rs
+++ b/crates/hashi-guardian/src/lib.rs
@@ -34,6 +34,7 @@ pub mod withdraw_mode;
 pub mod test_utils;
 
 pub use enclave::Enclave;
+pub use s3_client::resolve_s3_config;
 pub use s3_client::GuardianS3Client;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::MAX_S3_WRITE_FAILURE_INTERVAL;
+use anyhow::Context;
+use aws_credential_types::provider::ProvideCredentials;
 use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_credential_types::CredentialsBuilder;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::LogRecord;
+use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::S3BucketInfo;
-use hashi_types::guardian::S3Config;
 use hashi_types::guardian::S3ObjectLockPolicy;
+use hashi_types::guardian::UnresolvedS3Config;
 use std::collections::BTreeSet;
 use std::sync::Once;
 use std::time::Duration;
@@ -40,10 +43,58 @@ const S3_WRITE_RETRY_INTERVAL: Duration = Duration::from_secs(10);
 const SKIP_S3_OBJECT_LOCK_CHECK_ENV: &str = "HASHI_SKIP_S3_OBJECT_LOCK_CHECK";
 static SKIP_S3_OBJECT_LOCK_CHECK_WARNING: Once = Once::new();
 
+/// Resolve explicit credentials or, when both are omitted, use AWS's default
+/// provider chain.
+pub async fn resolve_s3_config(config: &UnresolvedS3Config) -> anyhow::Result<ResolvedS3Config> {
+    let access_key = config
+        .access_key
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+    let secret_key = config
+        .secret_key
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+
+    let (access_key, secret_key, session_token) = match (access_key, secret_key) {
+        (Some(access_key), Some(secret_key)) => {
+            (access_key.to_string(), secret_key.to_string(), None)
+        }
+        (None, None) => {
+            let provider =
+                aws_config::default_provider::credentials::DefaultCredentialsChain::builder()
+                    .build()
+                    .await;
+            let credentials = provider
+                .provide_credentials()
+                .await
+                .context("failed to resolve AWS credentials from the default provider chain")?;
+            (
+                credentials.access_key_id().to_string(),
+                credentials.secret_access_key().to_string(),
+                credentials.session_token().map(ToOwned::to_owned),
+            )
+        }
+        _ => anyhow::bail!(
+            "guardian_s3 access_key and secret_key must either both be set or both be omitted"
+        ),
+    };
+
+    Ok(ResolvedS3Config {
+        access_key,
+        secret_key,
+        session_token,
+        bucket_info: S3BucketInfo {
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+        },
+        retention_environment: config.retention_environment,
+    })
+}
+
 #[derive(Clone)]
 pub struct GuardianS3Client {
     /// S3 connection and retention config.
-    config: S3Config,
+    config: ResolvedS3Config,
     /// S3 client
     client: S3Client,
     /// Expected object-lock policy for this Guardian deployment.
@@ -55,7 +106,7 @@ impl GuardianS3Client {
     // Constructors
     // ========================================================================
 
-    pub async fn new(config: &S3Config) -> Self {
+    pub async fn new(config: &ResolvedS3Config) -> Self {
         info!("S3 Configuration:");
         info!("   Bucket: {}", config.bucket_name());
         info!("   Region: {}", config.region());
@@ -91,7 +142,7 @@ impl GuardianS3Client {
         }
     }
 
-    pub async fn new_checked(config: &S3Config) -> GuardianResult<Self> {
+    pub async fn new_checked(config: &ResolvedS3Config) -> GuardianResult<Self> {
         let logger = Self::new(config).await;
         logger.test_s3_connectivity().await?;
         Ok(logger)
@@ -100,7 +151,7 @@ impl GuardianS3Client {
     /// Construct an `GuardianS3Client` from an already-configured S3 client.
     /// This is intended for unit tests that use a mock S3 Client.
     /// This is not put behind cfg(test) as tests in the enclave crate also use it.
-    pub fn from_client_for_tests(config: S3Config, client: S3Client) -> Self {
+    pub fn from_client_for_tests(config: ResolvedS3Config, client: S3Client) -> Self {
         let object_lock_policy = S3ObjectLockPolicy::for_environment(config.retention_environment);
         Self {
             client,
@@ -730,7 +781,7 @@ mod tests {
     use hashi_types::guardian::SessionID;
 
     fn mk_logger_with_client(client: Client) -> GuardianS3Client {
-        let config = S3Config {
+        let config = ResolvedS3Config {
             access_key: "test-access-key".to_string(),
             secret_key: "test-secret-key".to_string(),
             session_token: None,

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -591,7 +591,16 @@ impl GuardianS3Client {
         dir: &S3HourScopedDirectory,
     ) -> GuardianResult<Vec<LogRecord>> {
         let prefix = dir.to_string();
-        let keys = self.validate_prefix_history_and_list_keys(&prefix).await?;
+        self.list_all_log_records_with_prefix(&prefix).await
+    }
+
+    /// Batch read all immutable log records whose keys begin with `prefix`.
+    /// The prefix history is validated before any records are fetched.
+    pub(crate) async fn list_all_log_records_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> GuardianResult<Vec<LogRecord>> {
+        let keys = self.validate_prefix_history_and_list_keys(prefix).await?;
         let mut out = Vec::with_capacity(keys.len());
         for key in keys {
             // The prefix history was checked above. Immutable batch logs also

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -32,6 +32,7 @@ use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::SessionID;
 use hashi_types::guardian::VerifiedSessionInfo;
+use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
 use hashi_types::guardian::S3_DIR_GENESIS;
@@ -175,13 +176,33 @@ impl GuardianReader {
         &mut self,
         dir: &S3HourScopedDirectory,
     ) -> GuardianResult<Vec<VerifiedLogRecord>> {
-        let all_logs = self.s3.list_all_log_records_in_dir(dir).await?;
+        let prefix = dir.to_string();
+        self.read_logs_with_prefix(&prefix).await
+    }
+
+    async fn read_logs_with_prefix(
+        &mut self,
+        prefix: &str,
+    ) -> GuardianResult<Vec<VerifiedLogRecord>> {
+        let all_logs = self.s3.list_all_log_records_with_prefix(prefix).await?;
 
         let mut out = Vec::with_capacity(all_logs.len());
         for log in all_logs {
             out.push(self.cache.verify_record(&self.s3, log).await?);
         }
         Ok(out)
+    }
+
+    /// Read and verify successful withdrawal records in `dir`.
+    ///
+    /// This excludes rejected withdrawal requests, which do not represent
+    /// Guardian approval events and are not inputs to the monitor state machine.
+    pub async fn read_successful_withdrawals_in_dir(
+        &mut self,
+        dir: &S3HourScopedDirectory,
+    ) -> GuardianResult<Vec<VerifiedLogRecord>> {
+        let prefix = format!("{dir}{}", WithdrawalLogMessage::SUCCESS_OBJECT_KEY_PREFIX);
+        self.read_logs_with_prefix(&prefix).await
     }
 
     /// The session's verified guardian info. Served from the session cache, which

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -29,7 +29,7 @@ use hashi_types::guardian::KpShareStateLogMessage;
 use hashi_types::guardian::LogMessage;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::S3Config;
+use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::SessionID;
 use hashi_types::guardian::VerifiedSessionInfo;
 use hashi_types::guardian::S3_DIR_CEREMONY;
@@ -138,7 +138,7 @@ pub struct GuardianReader {
 }
 
 impl GuardianReader {
-    pub async fn new(config: &S3Config, allowlist: PcrAllowlist) -> GuardianResult<Self> {
+    pub async fn new(config: &ResolvedS3Config, allowlist: PcrAllowlist) -> GuardianResult<Self> {
         let s3 = GuardianS3Client::new_checked(config).await?;
         Ok(Self::from_s3_client(s3, allowlist))
     }

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -35,11 +35,11 @@ pub fn mock_logger() -> GuardianS3Client {
     use aws_smithy_mocks::mock;
     use aws_smithy_mocks::mock_client;
     use aws_smithy_mocks::RuleMode;
-    use hashi_types::guardian::S3Config;
+    use hashi_types::guardian::ResolvedS3Config;
 
     let put_ok = mock!(Client::put_object).then_output(|| PutObjectOutput::builder().build());
     let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_ok]);
-    GuardianS3Client::from_client_for_tests(S3Config::mock_for_testing(), client)
+    GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client)
 }
 
 /// Captured `(key, body)` pairs from a `mock_logger_capturing()` logger.
@@ -126,7 +126,7 @@ pub fn mock_logger_capturing() -> (GuardianS3Client, CapturedPuts) {
     use aws_smithy_mocks::mock;
     use aws_smithy_mocks::mock_client;
     use aws_smithy_mocks::RuleMode;
-    use hashi_types::guardian::S3Config;
+    use hashi_types::guardian::ResolvedS3Config;
 
     let captures: CapturedPuts = Arc::new(std::sync::Mutex::new(Vec::new()));
     let captures_w = captures.clone();
@@ -144,7 +144,8 @@ pub fn mock_logger_capturing() -> (GuardianS3Client, CapturedPuts) {
         })
         .then_output(|| PutObjectOutput::builder().build());
     let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_ok]);
-    let logger = GuardianS3Client::from_client_for_tests(S3Config::mock_for_testing(), client);
+    let logger =
+        GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client);
     (logger, captures)
 }
 
@@ -167,7 +168,7 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
     use aws_smithy_mocks::mock;
     use aws_smithy_mocks::mock_client;
     use aws_smithy_mocks::RuleMode;
-    use hashi_types::guardian::S3Config;
+    use hashi_types::guardian::ResolvedS3Config;
     use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::sync::Mutex;
@@ -236,7 +237,7 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
         RuleMode::MatchAny,
         &[&list_v2, &list_versions, &put_ok]
     );
-    GuardianS3Client::from_client_for_tests(S3Config::mock_for_testing(), client)
+    GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client)
 }
 
 /// Args for arming a withdraw-mode test enclave. `config` is the stable

--- a/crates/hashi-monitor/Cargo.toml
+++ b/crates/hashi-monitor/Cargo.toml
@@ -17,7 +17,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 sui-rpc.workspace = true
 sui-sdk-types.workspace = true
-time = "0.3"
+time = { version = "0.3", features = ["parsing"] }
 tokio.workspace = true
 tower.workspace = true
 tracing.workspace = true

--- a/crates/hashi-monitor/Cargo.toml
+++ b/crates/hashi-monitor/Cargo.toml
@@ -6,19 +6,25 @@ edition = "2024"
 [dependencies]
 anyhow.workspace = true
 bitcoin.workspace = true
-corepc-client.workspace = true
-jsonrpc.workspace = true
 clap.workspace = true
+futures.workspace = true
 hashi-types = { path = "../hashi-types" }
 # guardian imported for s3 logger
 hashi-guardian = { path = "../hashi-guardian" }
+minreq = { workspace = true, features = ["json-using-serde"] }
 serde.workspace = true
+serde_json.workspace = true
 serde_yaml.workspace = true
+sui-rpc.workspace = true
+sui-sdk-types.workspace = true
+time = "0.3"
 tokio.workspace = true
+tower.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
+base64ct.workspace = true
 e2e-tests = { path = "../e2e-tests" }
 hashi-guardian = { path = "../hashi-guardian", features = ["test-utils"] }
 tempfile.workspace = true

--- a/crates/hashi-monitor/README.md
+++ b/crates/hashi-monitor/README.md
@@ -17,17 +17,49 @@ Audits the cross-system bridge flow on two parallel tracks.
 - **Predecessor existence**: every successor event has a matching predecessor with consistent txid / wid.
 - **Successor existence**: for each non-terminal event, the configured next-event delay bound must hold.
 
+Findings are tagged as:
+- **liveness** when a successor is late or still missing after its deadline;
+- **safety** for a contradictory event, a late predecessor, or a predecessor
+  still missing after its source cursor passes the deadline.
+
+For withdrawals, a predecessor lookback that is too short can produce a false
+safety finding for a missing E1. Reconcile older Sui history before treating
+such a finding as conclusive.
+
 ### Modes
 1. **Batch**: one-time audit over a guardian time range `[start, end]`.
 2. **Continuous**: long-running monitor that polls Sui, Guardian S3, and BTC RPC on fixed intervals and reports findings as they appear.
 
 ### Timeline semantics (withdrawals)
 - User-provided `start` / `end` are interpreted on the **guardian (E2)** timeline.
-- Sui events are polled in a relaxed range to validate E2 predecessor constraints.
+- Sui withdrawal events are polled from `withdrawal_predecessor_lookback`
+  seconds before the guardian window to validate E2 predecessor constraints.
+- Deposit events are polled only from the start of the guardian window.
 - Orphan E1 findings are currently still reported when E1 falls in the user window.
-- Deposits are not gated by the audit window — there is no false-positive risk.
+- Deposits are audited over the derived Sui range rather than gated by the
+  withdrawal audit-window logic.
 
 ## Usage
+
+### Active testnet
+
+`audit.testnet.yaml` contains the active Hashi Guardian testnet deployment
+identifiers and PCR allowlist. Supply AWS credentials through the default
+credential chain and keep the Signet provider URI in the environment:
+
+```bash
+export AWS_PROFILE=guardian-s3-testnet
+export HASHI_SKIP_S3_OBJECT_LOCK_CHECK=1
+export HASHI_BITCOIN_RPC_URL="https://your-signet-json-rpc-endpoint"
+
+cargo run -p hashi-monitor -- continuous \
+  --config audit.testnet.yaml \
+  --start "$(($(date +%s) - 3600))"
+```
+
+Run this from `crates/hashi-monitor`, or prefix the configuration path with
+`crates/hashi-monitor/` when running from the repository root. The object-lock
+bypass is temporary and is described below.
 
 ### Batch audit
 ```bash
@@ -52,22 +84,25 @@ next_event_delays:
 # Optional: clock skew tolerance (default: 300s)
 # clock_skew: 300
 
-guardian:
-  access_key: "AWS_ACCESS_KEY_ID"
-  secret_key: "AWS_SECRET_ACCESS_KEY"
-  session_token:
-  bucket_info:
-    bucket: "hashi-guardian-logs"
-    region: "us-east-1"
+# Optional: Sui withdrawal history before the guardian window (default: 1 hour)
+# withdrawal_predecessor_lookback: 3600
+
+guardian_s3:
+  bucket: "hashi-guardian-logs"
+  region: "us-east-1"
+  # Omit both keys to use the AWS default credential chain.
+  # access_key: "..."
+  # secret_key: "..."
   retention_environment: "testnet"
 
 sui:
   rpc_url: "https://fullnode.testnet.sui.io:443"
+  package_id: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 btc:
-  rpc_url: "http://localhost:8332"
-  rpc_auth:
-    type: none
+  rpc_url: "env:BITCOIN_RPC_URL"
+  # http_headers:
+  #   Origin: "https://example.com"
 ```
 
 ## Status
@@ -75,9 +110,8 @@ btc:
   - Domain model and withdrawal / deposit state-machine checks.
   - Batch and continuous auditor loops (cursor advancement, BTC fetch, violation detection, GC, progress watermarks).
   - Guardian S3 withdrawal log polling with attestation and signature verification.
-  - BTC confirmation lookup via Bitcoin Core RPC.
-- Not yet implemented:
-  - Sui event polling — `AuditorCore::poll_sui` is a stub that returns `CursorUnmoved`, so E1 (withdrawal) and the deposit pipeline currently see no Sui input.
+  - Checkpoint-bounded, resumable Sui polling for withdrawal and deposit events.
+  - Batched BTC confirmation lookup over HTTP JSON-RPC.
 
 ## Temporary testnet object-lock bypass
 

--- a/crates/hashi-monitor/README.md
+++ b/crates/hashi-monitor/README.md
@@ -34,7 +34,6 @@ such a finding as conclusive.
 - User-provided `start` / `end` are interpreted on the **guardian (E2)** timeline.
 - Sui withdrawal events are polled from `withdrawal_predecessor_lookback`
   seconds before the guardian window to validate E2 predecessor constraints.
-- Deposit events are polled only from the start of the guardian window.
 - Orphan E1 findings are currently still reported when E1 falls in the user window.
 - Deposits are audited over the derived Sui range rather than gated by the
   withdrawal audit-window logic.
@@ -54,7 +53,7 @@ export HASHI_BITCOIN_RPC_URL="https://your-signet-json-rpc-endpoint"
 
 cargo run -p hashi-monitor -- continuous \
   --config audit.testnet.yaml \
-  --start "$(($(date +%s) - 3600))"
+  --start 2026-08-04T19:00:00Z
 ```
 
 Run this from `crates/hashi-monitor`, or prefix the configuration path with
@@ -63,13 +62,19 @@ bypass is temporary and is described below.
 
 ### Batch audit
 ```bash
-cargo run -p hashi-monitor -- batch --config audit.sample.yaml --start 1700000000 --end 1700003600
+cargo run -p hashi-monitor -- batch \
+  --config audit.sample.yaml \
+  --start 2026-08-04T18:00:00Z \
+  --end 2026-08-04T19:00:00Z
 ```
-`--end` defaults to the current time if omitted.
+CLI timestamps use whole-second UTC RFC 3339 (`YYYY-MM-DDTHH:MM:SSZ`). `--end`
+defaults to the current time if omitted.
 
 ### Continuous monitoring
 ```bash
-cargo run -p hashi-monitor -- continuous --config audit.sample.yaml --start 1700000000
+cargo run -p hashi-monitor -- continuous \
+  --config audit.sample.yaml \
+  --start 2026-08-04T19:00:00Z
 ```
 
 ## Config

--- a/crates/hashi-monitor/audit.sample.yaml
+++ b/crates/hashi-monitor/audit.sample.yaml
@@ -8,13 +8,15 @@ next_event_delays:
 # Clock skew tolerance: E_{i+1} can occur up to clock_skew seconds before E_i (default: 300s)
 # clock_skew: 300
 
-guardian:
-  access_key: "AWS_ACCESS_KEY_ID"
-  secret_key: "AWS_SECRET_ACCESS_KEY"
-  session_token:
-  bucket_info:
-    bucket: "hashi-guardian-logs"
-    region: "us-east-1"
+# Sui withdrawal history searched before the guardian audit start (default: 1 hour)
+# withdrawal_predecessor_lookback: 3600
+
+guardian_s3:
+  bucket: "hashi-guardian-logs"
+  region: "us-east-1"
+  # Omit both keys to use the AWS default credential chain.
+  # access_key: "..."
+  # secret_key: "..."
   retention_environment: "testnet"
 
 # Expected enclave build: git revision + PCR0 (hex). The live guardian must
@@ -32,13 +34,10 @@ prev_builds: []
 
 sui:
   rpc_url: "https://fullnode.testnet.sui.io:443"
+  package_id: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 btc:
-  rpc_url: "http://localhost:8332"
-  rpc_auth:
-    type: none
-    # type: user_pass
-    # username: "rpcuser"
-    # password: "rpcpassword"
-    # type: cookie_file
-    # path: "/path/to/.cookie"
+  rpc_url: "env:BITCOIN_RPC_URL"
+  # Optional headers for hosted JSON-RPC providers:
+  # http_headers:
+  #   Origin: "https://example.com"

--- a/crates/hashi-monitor/audit.testnet.yaml
+++ b/crates/hashi-monitor/audit.testnet.yaml
@@ -1,0 +1,34 @@
+# Active Hashi Guardian testnet configuration for `hashi-monitor`.
+#
+# This file contains only public deployment identifiers and enclave build
+# measurements. AWS credentials come from the default credential chain, and
+# the Signet JSON-RPC endpoint comes from HASHI_BITCOIN_RPC_URL.
+
+next_event_delays:
+  - [E1HashiApproved, 600]
+  - [E2GuardianApproved, 86400]
+
+clock_skew: 300
+withdrawal_predecessor_lookback: 3600
+
+guardian_s3:
+  bucket: "mysten-hashi-guardian-enclave-testnet-3"
+  region: "us-west-2"
+  retention_environment: "testnet"
+
+current_build:
+  git_revision: "ae3fc68200a80fcef2dd5dbea5c4fd18a4ec8f0e"
+  pcr0: "2b32834f124e5d626fdbeb79d9b3bec20dc46365e3418508f794e31ce188d737f92dc0a89110530c027e22cec7741489"
+
+# Add older withdrawal-mode builds here only when auditing across an upgrade.
+# Ceremony-mode builds are not needed by the monitor's withdrawal log reader.
+prev_builds: []
+
+sui:
+  rpc_url: "https://fullnode.testnet.sui.io:443"
+  package_id: "0xfcea10cadbb553c4874201584abf68771592678952efd957b2e82c010c7f4360"
+
+btc:
+  rpc_url: "env:HASHI_BITCOIN_RPC_URL"
+  http_headers:
+    Origin: "https://testnet.hashi.sui.io"

--- a/crates/hashi-monitor/audit.testnet.yaml
+++ b/crates/hashi-monitor/audit.testnet.yaml
@@ -5,7 +5,8 @@
 # the Signet JSON-RPC endpoint comes from HASHI_BITCOIN_RPC_URL.
 
 next_event_delays:
-  - [E1HashiApproved, 600]
+  # Active-testnet Guardian approvals normally arrive 13-15 minutes after E1.
+  - [E1HashiApproved, 1200]
   - [E2GuardianApproved, 86400]
 
 clock_skew: 300

--- a/crates/hashi-monitor/src/audit/batch.rs
+++ b/crates/hashi-monitor/src/audit/batch.rs
@@ -9,7 +9,7 @@ use crate::domain::Cursors;
 use crate::domain::MonitorEvent;
 use crate::domain::PollOutcome;
 use crate::domain::now_unix_seconds;
-use crate::domain::readable_unix_seconds;
+use crate::domain::utc_timestamp;
 use hashi_types::guardian::time_utils::UnixSeconds;
 
 const NUM_ITERATIONS_BEFORE_FAIL: u8 = 5;
@@ -82,12 +82,16 @@ impl BatchAuditor {
     pub async fn new(cfg: &Config, start: UnixSeconds, end: UnixSeconds) -> anyhow::Result<Self> {
         anyhow::ensure!(
             start <= end,
-            "invalid time range: start={start} > end={end}"
+            "invalid time range: start={} > end={}",
+            utc_timestamp(start),
+            utc_timestamp(end),
         );
         let cur_time = now_unix_seconds();
         anyhow::ensure!(
             end <= cur_time,
-            "end is in the future: end={end} > cur_time={cur_time}"
+            "end is in the future: end={} > current_time={}",
+            utc_timestamp(end),
+            utc_timestamp(cur_time),
         );
 
         let audit_window = BatchAuditWindow::new(cfg, start, end, cur_time);
@@ -95,6 +99,15 @@ impl BatchAuditor {
             sui: audit_window.sui_start,
             guardian: audit_window.guardian_start,
         };
+        tracing::info!(
+            "starting batch audit:\n  requested_start={}\n  requested_end={}\n  sui_start={}\n  sui_target_end={}\n  guardian_start={}\n  guardian_target_end={}",
+            utc_timestamp(audit_window.user_start),
+            utc_timestamp(audit_window.user_end),
+            utc_timestamp(audit_window.sui_start),
+            utc_timestamp(audit_window.sui_end),
+            utc_timestamp(audit_window.guardian_start),
+            utc_timestamp(audit_window.guardian_end),
+        );
         Ok(Self {
             inner: AuditorCore::new(cfg, cursors).await?,
             audit_window,
@@ -141,23 +154,40 @@ impl BatchAuditor {
                 guardian_cursor_moved = true;
             }
 
+            if should_poll_guardian && !guardian_cursor_moved {
+                let ready_at = self.inner.get_guardian_next_partition_ready_at();
+                if now_unix_seconds() < ready_at {
+                    anyhow::bail!(
+                        "Guardian data is not finalized for the requested batch range:\n  \
+                         guardian_complete_through={}\n  requested_end={}\n  \
+                         next_partition_ready_at={}\nRerun at or after {}, or choose an end \
+                         time at or before {}.",
+                        utc_timestamp(self.inner.get_guardian_cursor()),
+                        utc_timestamp(self.audit_window.guardian_end),
+                        utc_timestamp(ready_at),
+                        utc_timestamp(ready_at),
+                        utc_timestamp(self.inner.get_guardian_cursor()),
+                    );
+                }
+            }
+
             if !sui_cursor_moved && !guardian_cursor_moved {
                 stalled_iterations = stalled_iterations.saturating_add(1);
                 if stalled_iterations >= NUM_ITERATIONS_BEFORE_FAIL {
                     anyhow::bail!(
-                        "batch polling cursors did not reach their targets \
-                         (sui={}/{}, guardian={}/{})",
-                        self.inner.get_sui_cursor(),
-                        self.audit_window.sui_end,
-                        self.inner.get_guardian_cursor(),
-                        self.audit_window.guardian_end,
+                        "batch polling stalled:\n  sui_cursor={}\n  sui_target={}\n  \
+                         guardian_cursor={}\n  guardian_target={}",
+                        utc_timestamp(self.inner.get_sui_cursor()),
+                        utc_timestamp(self.audit_window.sui_end),
+                        utc_timestamp(self.inner.get_guardian_cursor()),
+                        utc_timestamp(self.audit_window.guardian_end),
                     );
                 }
             } else {
                 stalled_iterations = 0;
             }
         }
-        tracing::info!("all desired cursor endpoints reached");
+        tracing::info!("all Sui and Guardian cursor endpoints reached");
         Ok(())
     }
 
@@ -167,14 +197,14 @@ impl BatchAuditor {
 
         tracing::info!(
             "finished batch polling:\n  start={}\n  end={}\n  sui_start={}\n  sui_target_end={}\n  sui_cursor={}\n  guardian_start={}\n  guardian_target_end={}\n  guardian_cursor={}",
-            readable_unix_seconds(self.audit_window.user_start),
-            readable_unix_seconds(self.audit_window.user_end),
-            readable_unix_seconds(self.audit_window.sui_start),
-            readable_unix_seconds(self.audit_window.sui_end),
-            readable_unix_seconds(self.inner.get_sui_cursor()),
-            readable_unix_seconds(self.audit_window.guardian_start),
-            readable_unix_seconds(self.audit_window.guardian_end),
-            readable_unix_seconds(self.inner.get_guardian_cursor()),
+            utc_timestamp(self.audit_window.user_start),
+            utc_timestamp(self.audit_window.user_end),
+            utc_timestamp(self.audit_window.sui_start),
+            utc_timestamp(self.audit_window.sui_end),
+            utc_timestamp(self.inner.get_sui_cursor()),
+            utc_timestamp(self.audit_window.guardian_start),
+            utc_timestamp(self.audit_window.guardian_end),
+            utc_timestamp(self.inner.get_guardian_cursor()),
         );
 
         // Fetch all BTC info
@@ -195,15 +225,15 @@ impl BatchAuditor {
 
         tracing::info!(
             "batch progress watermarks:\n  verified_up_to_withdrawals={}\n  verified_up_to_deposits={}\n  next_start={}",
-            readable_unix_seconds(progress.verified_up_to_withdrawals),
-            readable_unix_seconds(progress.verified_up_to_deposits),
-            readable_unix_seconds(progress.restart_start),
+            utc_timestamp(progress.verified_up_to_withdrawals),
+            utc_timestamp(progress.verified_up_to_deposits),
+            utc_timestamp(progress.restart_start),
         );
 
         if !self.violation_found {
             tracing::info!(
                 "audit passed. run next audit at {}",
-                readable_unix_seconds(progress.restart_start)
+                utc_timestamp(progress.restart_start)
             );
         } else {
             tracing::warn!("audit produced findings: see logs");

--- a/crates/hashi-monitor/src/audit/batch.rs
+++ b/crates/hashi-monitor/src/audit/batch.rs
@@ -8,19 +8,19 @@ use crate::config::Config;
 use crate::domain::Cursors;
 use crate::domain::MonitorEvent;
 use crate::domain::PollOutcome;
-use crate::domain::WithdrawalEventType;
 use crate::domain::now_unix_seconds;
+use crate::domain::readable_unix_seconds;
 use hashi_types::guardian::time_utils::UnixSeconds;
 
 const NUM_ITERATIONS_BEFORE_FAIL: u8 = 5;
 
-/// the exact amount of time to look back or ahead to identify all the potentially interesting events
+/// User and derived source ranges for one batch audit.
 #[derive(Clone, Copy, Debug)]
 pub struct BatchAuditWindow {
-    /// time range input by user
+    /// Guardian time range supplied by the user.
     user_start: UnixSeconds,
     user_end: UnixSeconds,
-    /// relaxed time ranges used to pull logs from sui & guardian
+    /// Derived source ranges used to poll Sui and Guardian.
     sui_start: UnixSeconds,
     sui_end: UnixSeconds,
     guardian_start: UnixSeconds,
@@ -29,11 +29,8 @@ pub struct BatchAuditWindow {
 
 impl BatchAuditWindow {
     pub fn new(cfg: &Config, start: UnixSeconds, end: UnixSeconds, cur_time: UnixSeconds) -> Self {
-        let e1_e2_delay_secs = cfg
-            .next_event_delay(WithdrawalEventType::E1HashiApproved)
-            .expect("should be Some");
         // Guardian timeline is authoritative. We still fetch Sui in a relaxed range to validate E2 -> E1.
-        let sui_start = start.saturating_sub(e1_e2_delay_secs); // guardian_e2@{start} might match sui_e1@{start-e1_e2_delay_secs}
+        let sui_start = start.saturating_sub(cfg.withdrawal_predecessor_lookback);
         let sui_end = end.saturating_add(cfg.clock_skew).min(cur_time); // guardian_e2@{end} might match sui_e1@{end+clock_skew}
 
         // User [start, end] is interpreted as guardian timestamps.
@@ -61,16 +58,19 @@ impl AuditWindow for BatchAuditWindow {
 ///
 /// It functions as follows:
 ///     - fetch guardian events from `[t1, t2]` (authoritative timeline)
-///     - fetch sui events from `[t1 - e1_e2_delay_secs, t2 + clock_skew]` (for E2 predecessor checks)
-///     - fetch btc tx & perform checks for withdrawals anchored by guardian events in `[t1, t2]`
-/// Finally, it outputs a timestamp `verified_up_to` to be used as `t1` in the next audit.
+///     - fetch withdrawal and deposit events from
+///       `[t1 - withdrawal_predecessor_lookback, t2 + clock_skew]`
+///     - fetch BTC data for in-scope withdrawals and deposits found in the Sui range
+/// Finally, it logs progress watermarks that identify a safe start for the next audit.
 ///
 /// Notes:
-/// 1) A successful batch audit guarantees that guardian events emitted in `[t1, verified_up_to)` are cross-verified.
+/// 1) If no findings are emitted, Guardian events in the verified withdrawal
+///    range were cross-checked against their Sui and Bitcoin neighbors.
 /// 2) We currently also report orphan E1 findings if they fall in the user window.
 ///    TODO: If desired, this can be relaxed later to strict guardian-anchored scope.
-/// 3) Events emitted towards the end of the time range may not be fully verified, e.g., if t2 is current or if there is
-///    some issue with RPC. This info is captured by the `verified_up_to` timestamp.
+/// 3) Events near the end may remain unresolved because their successors are
+///    not yet due or observed. The progress watermarks capture a safe restart;
+///    infrastructure failures return an error instead of a partial audit.
 /// 4) The current approach is fetch-then-check. An alternate streaming auditor can be implemented in the future if needed.
 pub struct BatchAuditor {
     pub inner: AuditorCore,
@@ -126,7 +126,8 @@ impl BatchAuditor {
 
             let mut sui_cursor_moved = false;
             if should_poll_sui
-                && let PollOutcome::CursorAdvanced(events) = self.inner.poll_sui().await?
+                && let PollOutcome::CursorAdvanced(events) =
+                    self.inner.poll_sui(self.audit_window.sui_end).await?
             {
                 self.ingest_batch(events);
                 sui_cursor_moved = true;
@@ -143,12 +144,14 @@ impl BatchAuditor {
             if !sui_cursor_moved && !guardian_cursor_moved {
                 stalled_iterations = stalled_iterations.saturating_add(1);
                 if stalled_iterations >= NUM_ITERATIONS_BEFORE_FAIL {
-                    tracing::warn!(
-                        "batch polling cursors did not advance fully (sui={}, guardian={})",
+                    anyhow::bail!(
+                        "batch polling cursors did not reach their targets \
+                         (sui={}/{}, guardian={}/{})",
                         self.inner.get_sui_cursor(),
-                        self.inner.get_guardian_cursor()
+                        self.audit_window.sui_end,
+                        self.inner.get_guardian_cursor(),
+                        self.audit_window.guardian_end,
                     );
-                    return Ok(());
                 }
             } else {
                 stalled_iterations = 0;
@@ -163,15 +166,15 @@ impl BatchAuditor {
         self.fetch_all_sui_guardian_events().await?;
 
         tracing::info!(
-            start = self.audit_window.user_start,
-            end = self.audit_window.user_end,
-            sui_start = self.audit_window.sui_start,
-            sui_target_end = self.audit_window.sui_end,
-            sui_cursor = self.inner.get_sui_cursor(),
-            guardian_start = self.audit_window.guardian_start,
-            guardian_target_end = self.audit_window.guardian_end,
-            guardian_cursor = self.inner.get_guardian_cursor(),
-            "finished batch polling"
+            "finished batch polling:\n  start={}\n  end={}\n  sui_start={}\n  sui_target_end={}\n  sui_cursor={}\n  guardian_start={}\n  guardian_target_end={}\n  guardian_cursor={}",
+            readable_unix_seconds(self.audit_window.user_start),
+            readable_unix_seconds(self.audit_window.user_end),
+            readable_unix_seconds(self.audit_window.sui_start),
+            readable_unix_seconds(self.audit_window.sui_end),
+            readable_unix_seconds(self.inner.get_sui_cursor()),
+            readable_unix_seconds(self.audit_window.guardian_start),
+            readable_unix_seconds(self.audit_window.guardian_end),
+            readable_unix_seconds(self.inner.get_guardian_cursor()),
         );
 
         // Fetch all BTC info
@@ -191,14 +194,17 @@ impl BatchAuditor {
         let progress = self.inner.progress_watermarks(&self.audit_window);
 
         tracing::info!(
-            verified_up_to_withdrawals = progress.verified_up_to_withdrawals,
-            verified_up_to_deposits = progress.verified_up_to_deposits,
-            next_start = progress.restart_start,
-            "batch progress watermarks"
+            "batch progress watermarks:\n  verified_up_to_withdrawals={}\n  verified_up_to_deposits={}\n  next_start={}",
+            readable_unix_seconds(progress.verified_up_to_withdrawals),
+            readable_unix_seconds(progress.verified_up_to_deposits),
+            readable_unix_seconds(progress.restart_start),
         );
 
         if !self.violation_found {
-            tracing::info!("audit passed. run next audit at {}", progress.restart_start);
+            tracing::info!(
+                "audit passed. run next audit at {}",
+                readable_unix_seconds(progress.restart_start)
+            );
         } else {
             tracing::warn!("audit produced findings: see logs");
         }

--- a/crates/hashi-monitor/src/audit/continuous.rs
+++ b/crates/hashi-monitor/src/audit/continuous.rs
@@ -10,8 +10,8 @@ use crate::config::Config;
 use crate::domain::Cursors;
 use crate::domain::MonitorEvent;
 use crate::domain::PollOutcome;
-use crate::domain::WithdrawalEventType;
 use crate::domain::now_unix_seconds;
+use crate::domain::readable_unix_seconds;
 use hashi_types::guardian::time_utils::UnixSeconds;
 
 // TODO: Consider switching to a streaming API
@@ -29,7 +29,8 @@ pub struct ContinuousAuditWindow {
 }
 
 /// A continuous auditor that runs indefinitely processing events as they arrive.
-/// Constructors accept a start time as input that acts as a starting point for the auditor.
+/// Its start time is on the Guardian timeline; Sui polling begins at the
+/// configured predecessor lookback before that boundary.
 pub struct ContinuousAuditor {
     pub inner: AuditorCore,
     pub window: ContinuousAuditWindow,
@@ -43,10 +44,7 @@ impl AuditWindow for ContinuousAuditWindow {
 
 impl ContinuousAuditWindow {
     pub fn new(cfg: &Config, start: UnixSeconds) -> Self {
-        let e1_e2_delay_secs = cfg
-            .next_event_delay(WithdrawalEventType::E1HashiApproved)
-            .expect("should be Some");
-        let sui_start = start.saturating_sub(e1_e2_delay_secs); // guardian_e2@{start} might match sui_e1@{start-e1_e2_delay_secs}
+        let sui_start = start.saturating_sub(cfg.withdrawal_predecessor_lookback);
         let guardian_start = start;
 
         Self {
@@ -82,14 +80,15 @@ impl ContinuousAuditor {
     }
 
     async fn tick_sui(&mut self) -> anyhow::Result<()> {
-        if let PollOutcome::CursorAdvanced(events) = self.inner.poll_sui().await? {
+        let up_to = now_unix_seconds();
+        while let PollOutcome::CursorAdvanced(events) = self.inner.poll_sui(up_to).await? {
             self.ingest_batch(events);
         }
         Ok(())
     }
 
     async fn tick_guardian(&mut self) -> anyhow::Result<()> {
-        if let PollOutcome::CursorAdvanced(events) = self.inner.poll_guardian().await? {
+        while let PollOutcome::CursorAdvanced(events) = self.inner.poll_guardian().await? {
             self.ingest_batch(events);
         }
         Ok(())
@@ -112,16 +111,39 @@ impl ContinuousAuditor {
 
         let progress = self.inner.progress_watermarks(&self.window);
         tracing::info!(
-            guardian_cursor = self.inner.get_guardian_cursor(),
-            sui_cursor = self.inner.get_sui_cursor(),
-            verified_up_to_withdrawals = progress.verified_up_to_withdrawals,
-            verified_up_to_deposits = progress.verified_up_to_deposits,
-            restart_start = progress.restart_start,
-            "continuous progress checkpoint"
+            "continuous progress checkpoint:\n  guardian_cursor={}\n  sui_cursor={}\n  verified_up_to_withdrawals={}\n  verified_up_to_deposits={}\n  restart_start={}",
+            readable_unix_seconds(self.inner.get_guardian_cursor()),
+            readable_unix_seconds(self.inner.get_sui_cursor()),
+            readable_unix_seconds(progress.verified_up_to_withdrawals),
+            readable_unix_seconds(progress.verified_up_to_deposits),
+            readable_unix_seconds(progress.restart_start),
         );
     }
 
     pub async fn run(&mut self) -> anyhow::Result<()> {
+        if let Err(error) = self.tick_sui().await {
+            tracing::warn!(
+                source = "sui",
+                ?error,
+                "initial catch-up failed; continuing"
+            );
+        }
+        if let Err(error) = self.tick_guardian().await {
+            tracing::warn!(
+                source = "guardian",
+                ?error,
+                "initial catch-up failed; continuing"
+            );
+        }
+        if let Err(error) = self.tick_btc() {
+            tracing::warn!(
+                source = "btc",
+                ?error,
+                "initial catch-up failed; continuing"
+            );
+        }
+        self.tick_state_checks_and_gc();
+
         let mut sui_ticker = tokio::time::interval(POLL_INTERVAL);
         let mut guardian_ticker = tokio::time::interval(POLL_INTERVAL);
         let mut btc_ticker = tokio::time::interval(POLL_INTERVAL);
@@ -132,7 +154,8 @@ impl ContinuousAuditor {
         btc_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         state_checks_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-        // Consume the immediate first tick and then run on a stable cadence.
+        // The initial catch-up above handled startup; consume each immediate
+        // interval tick so the next pass runs on the configured cadence.
         sui_ticker.tick().await;
         guardian_ticker.tick().await;
         btc_ticker.tick().await;

--- a/crates/hashi-monitor/src/audit/continuous.rs
+++ b/crates/hashi-monitor/src/audit/continuous.rs
@@ -123,26 +123,53 @@ impl ContinuousAuditor {
     }
 
     pub async fn run(&mut self) -> anyhow::Result<()> {
+        tracing::info!(
+            "starting continuous audit:\n  requested_start={}\n  sui_start={}\n  guardian_start={}",
+            utc_timestamp(self.window.user_start),
+            utc_timestamp(self.window.sui_start),
+            utc_timestamp(self.window.guardian_start),
+        );
+        tracing::info!(
+            cursor = %utc_timestamp(self.inner.get_sui_cursor()),
+            "starting initial Sui catch-up"
+        );
         if let Err(error) = self.tick_sui().await {
             tracing::warn!(
                 source = "sui",
                 ?error,
                 "initial catch-up failed; continuing"
             );
+        } else {
+            tracing::info!(
+                cursor = %utc_timestamp(self.inner.get_sui_cursor()),
+                "finished initial Sui catch-up"
+            );
         }
+        tracing::info!(
+            cursor = %utc_timestamp(self.inner.get_guardian_cursor()),
+            "starting initial Guardian catch-up"
+        );
         if let Err(error) = self.tick_guardian().await {
             tracing::warn!(
                 source = "guardian",
                 ?error,
                 "initial catch-up failed; continuing"
             );
+        } else {
+            tracing::info!(
+                cursor = %utc_timestamp(self.inner.get_guardian_cursor()),
+                "finished initial Guardian catch-up"
+            );
         }
+        tracing::info!("starting initial Bitcoin confirmation lookups");
         if let Err(error) = self.tick_btc() {
             tracing::warn!(
                 source = "btc",
                 ?error,
                 "initial catch-up failed; continuing"
             );
+        } else {
+            tracing::info!("finished initial Bitcoin confirmation lookups");
         }
         self.tick_state_checks_and_gc();
 

--- a/crates/hashi-monitor/src/audit/continuous.rs
+++ b/crates/hashi-monitor/src/audit/continuous.rs
@@ -11,7 +11,7 @@ use crate::domain::Cursors;
 use crate::domain::MonitorEvent;
 use crate::domain::PollOutcome;
 use crate::domain::now_unix_seconds;
-use crate::domain::readable_unix_seconds;
+use crate::domain::utc_timestamp;
 use hashi_types::guardian::time_utils::UnixSeconds;
 
 // TODO: Consider switching to a streaming API
@@ -60,7 +60,9 @@ impl ContinuousAuditor {
         let cur_time = now_unix_seconds();
         anyhow::ensure!(
             start <= cur_time,
-            "start is in the future: start={start} > cur_time={cur_time}"
+            "start is in the future: start={} > current_time={}",
+            utc_timestamp(start),
+            utc_timestamp(cur_time),
         );
         let audit_window = ContinuousAuditWindow::new(cfg, start);
         let cursors = Cursors {
@@ -112,11 +114,11 @@ impl ContinuousAuditor {
         let progress = self.inner.progress_watermarks(&self.window);
         tracing::info!(
             "continuous progress checkpoint:\n  guardian_cursor={}\n  sui_cursor={}\n  verified_up_to_withdrawals={}\n  verified_up_to_deposits={}\n  restart_start={}",
-            readable_unix_seconds(self.inner.get_guardian_cursor()),
-            readable_unix_seconds(self.inner.get_sui_cursor()),
-            readable_unix_seconds(progress.verified_up_to_withdrawals),
-            readable_unix_seconds(progress.verified_up_to_deposits),
-            readable_unix_seconds(progress.restart_start),
+            utc_timestamp(self.inner.get_guardian_cursor()),
+            utc_timestamp(self.inner.get_sui_cursor()),
+            utc_timestamp(progress.verified_up_to_withdrawals),
+            utc_timestamp(progress.verified_up_to_deposits),
+            utc_timestamp(progress.restart_start),
         );
     }
 

--- a/crates/hashi-monitor/src/audit/mod.rs
+++ b/crates/hashi-monitor/src/audit/mod.rs
@@ -16,6 +16,7 @@
 //! the withdrawal audit window.
 
 use crate::domain::Cursors;
+use crate::domain::DepositId;
 use crate::domain::MonitorDepositEvent;
 use crate::domain::MonitorEvent;
 use crate::domain::MonitorWithdrawalEvent;
@@ -40,7 +41,6 @@ use crate::state_machine::BtcFetchOutcome;
 use crate::state_machine::DepositStateMachine;
 use crate::state_machine::WithdrawalStateMachine;
 pub use batch::BatchAuditor;
-use bitcoin::Txid;
 pub use continuous::ContinuousAuditor;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -85,7 +85,7 @@ pub struct AuditorCore {
     cfg: Config,
     // mutable
     pending_withdrawals: HashMap<WithdrawalID, WithdrawalStateMachine>,
-    pending_deposits: HashMap<(Txid, u32), DepositStateMachine>,
+    pending_deposits: HashMap<DepositId, DepositStateMachine>,
     guardian_poller: GuardianWithdrawalsPoller,
     sui_poller: SuiEventsPoller,
     btc_client: BtcRpcClient,
@@ -122,12 +122,15 @@ impl AuditorCore {
     }
 
     fn ingest_deposit(&mut self, event: MonitorDepositEvent) -> Vec<MonitorFinding> {
-        let outpoint = (event.btc_txid, event.btc_vout);
-        match self.pending_deposits.entry(outpoint) {
-            // Duplicate DepositApproved events are legitimate: a pending deposit
-            // must be approved again after committee rotation. Sui events arrive
-            // in ascending order, so retain the first approval; it gives the
-            // strictest check that Bitcoin preceded the committee approval.
+        let deposit_id = event.deposit_id;
+        match self.pending_deposits.entry(deposit_id) {
+            // Multiple DepositApproved events may legitimately share an outpoint:
+            // one request can be reapproved after committee rotation, and the
+            // anti-griefing design permits distinct pending requests for the same
+            // UTXO. This monitor checks only the shared Bitcoin evidence, so one
+            // state machine per deposit ID is sufficient. Sui events arrive in
+            // ascending order; retaining the first approval gives the strictest
+            // check that Bitcoin preceded committee approval.
             // Restore duplicate detection if this monitor returns to the unique
             // DepositConfirmed event.
             Entry::Occupied(_) => {}
@@ -271,15 +274,15 @@ impl AuditorCore {
         }
 
         let mut completed_deposits = Vec::new();
-        for ((txid, vout), sm) in &mut self.pending_deposits {
+        for (deposit_id, sm) in &mut self.pending_deposits {
             if !sm.is_expecting_events() {
-                tracing::debug!(%txid, vout, "deposit flow is complete");
-                completed_deposits.push((*txid, *vout));
+                tracing::debug!(%deposit_id, "deposit flow is complete");
+                completed_deposits.push(*deposit_id);
             }
         }
 
-        for outpoint in completed_deposits {
-            self.pending_deposits.remove(&outpoint);
+        for deposit_id in completed_deposits {
+            self.pending_deposits.remove(&deposit_id);
         }
     }
 
@@ -293,7 +296,7 @@ impl AuditorCore {
             if let Some(e2) = sm.get(WithdrawalEventType::E2GuardianApproved) {
                 verified_up_to_withdrawals = verified_up_to_withdrawals.min(e2.timestamp_secs);
             } else {
-                tracing::warn!(
+                tracing::debug!(
                     wid = %sm.wid(),
                     "in-window withdrawal missing guardian anchor; skipping in verified_up_to computation"
                 );

--- a/crates/hashi-monitor/src/audit/mod.rs
+++ b/crates/hashi-monitor/src/audit/mod.rs
@@ -56,7 +56,7 @@ pub fn log_findings(source: &'static str, phase: &'static str, findings: &[Monit
                 phase,
                 %category,
                 total = findings.len(),
-                ?finding,
+                finding = %finding,
                 "monitor finding"
             ),
             FindingCategory::Liveness => tracing::warn!(
@@ -64,7 +64,7 @@ pub fn log_findings(source: &'static str, phase: &'static str, findings: &[Monit
                 phase,
                 %category,
                 total = findings.len(),
-                ?finding,
+                finding = %finding,
                 "monitor finding"
             ),
         }
@@ -320,5 +320,9 @@ impl AuditorCore {
 
     fn get_guardian_cursor(&self) -> UnixSeconds {
         self.guardian_poller.cursor_seconds()
+    }
+
+    fn get_guardian_next_partition_ready_at(&self) -> UnixSeconds {
+        self.guardian_poller.next_partition_ready_at()
     }
 }

--- a/crates/hashi-monitor/src/audit/mod.rs
+++ b/crates/hashi-monitor/src/audit/mod.rs
@@ -21,6 +21,8 @@ use crate::domain::MonitorEvent;
 use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
+use crate::domain::human_timestamp_delta;
+use crate::domain::utc_timestamp;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::hash_map::Entry;
@@ -242,7 +244,24 @@ impl AuditorCore {
                 continue;
             }
             if !sm.is_expecting_events() {
-                tracing::info!(%wid, "withdrawal flow is complete");
+                let e1 = sm
+                    .get(WithdrawalEventType::E1HashiApproved)
+                    .expect("completed withdrawal has E1");
+                let e2 = sm
+                    .get(WithdrawalEventType::E2GuardianApproved)
+                    .expect("completed withdrawal has E2");
+                let e3 = sm
+                    .get(WithdrawalEventType::E3BtcConfirmed)
+                    .expect("completed withdrawal has E3");
+                tracing::info!(
+                    %wid,
+                    e1_at = %utc_timestamp(e1.timestamp_secs),
+                    e2_at = %utc_timestamp(e2.timestamp_secs),
+                    e3_at = %utc_timestamp(e3.timestamp_secs),
+                    e1_to_e2 = %human_timestamp_delta(e2.timestamp_secs, e1.timestamp_secs),
+                    e2_to_e3 = %human_timestamp_delta(e3.timestamp_secs, e2.timestamp_secs),
+                    "withdrawal flow is complete"
+                );
                 completed_withdrawals.push(*wid);
             }
         }

--- a/crates/hashi-monitor/src/audit/mod.rs
+++ b/crates/hashi-monitor/src/audit/mod.rs
@@ -12,7 +12,8 @@
 //!         - call `if wsm.is_in_audit_window() { wsm.violations(&cursors) }` to identify errors.
 //!     - Currently we also report orphan E1 findings when they fall in the user window.
 //!
-//! Note that we do not use audit window gating for deposits because there is no risk of false violation flagging.
+//! Deposits are checked over the derived Sui polling range rather than gated by
+//! the withdrawal audit window.
 
 use crate::domain::Cursors;
 use crate::domain::MonitorDepositEvent;
@@ -21,6 +22,7 @@ use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 
 pub mod batch;
@@ -31,6 +33,7 @@ use crate::findings::FindingCategory;
 use crate::findings::MonitorFinding;
 use crate::rpc::btc::BtcRpcClient;
 use crate::rpc::guardian::GuardianWithdrawalsPoller;
+use crate::rpc::sui::SuiEventsPoller;
 use crate::state_machine::BtcFetchOutcome;
 use crate::state_machine::DepositStateMachine;
 use crate::state_machine::WithdrawalStateMachine;
@@ -82,9 +85,8 @@ pub struct AuditorCore {
     pending_withdrawals: HashMap<WithdrawalID, WithdrawalStateMachine>,
     pending_deposits: HashMap<(Txid, u32), DepositStateMachine>,
     guardian_poller: GuardianWithdrawalsPoller,
+    sui_poller: SuiEventsPoller,
     btc_client: BtcRpcClient,
-    // placeholder until we implement sui rpc
-    sui_cursor: UnixSeconds,
 }
 
 impl AuditorCore {
@@ -94,8 +96,8 @@ impl AuditorCore {
             pending_withdrawals: HashMap::new(),
             pending_deposits: HashMap::new(),
             guardian_poller: GuardianWithdrawalsPoller::new(cfg, cursors.guardian).await?,
+            sui_poller: SuiEventsPoller::new(&cfg.sui, cursors.sui)?,
             btc_client: BtcRpcClient::new(cfg)?,
-            sui_cursor: cursors.sui,
         })
     }
 
@@ -148,6 +150,42 @@ impl AuditorCore {
         &mut self,
         window: &impl AuditWindow,
     ) -> anyhow::Result<Vec<MonitorFinding>> {
+        self.btc_client.clear_confirmation_cache();
+        let withdrawal_count = self
+            .pending_withdrawals
+            .values()
+            .filter(|sm| {
+                sm.is_in_audit_window(window) && sm.expects(WithdrawalEventType::E3BtcConfirmed)
+            })
+            .count();
+        let deposit_count = self
+            .pending_deposits
+            .values()
+            .filter(|sm| sm.is_expecting_events())
+            .count();
+        let unique_txids = self
+            .pending_withdrawals
+            .values()
+            .filter(|sm| {
+                sm.is_in_audit_window(window) && sm.expects(WithdrawalEventType::E3BtcConfirmed)
+            })
+            .map(WithdrawalStateMachine::btc_txid)
+            .chain(
+                self.pending_deposits
+                    .values()
+                    .filter(|sm| sm.is_expecting_events())
+                    .map(DepositStateMachine::btc_txid),
+            )
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        tracing::info!(
+            withdrawal_count,
+            deposit_count,
+            unique_txids = unique_txids.len(),
+            "starting bitcoin confirmation lookups"
+        );
+        self.btc_client.prefetch_confirmations(&unique_txids)?;
         let mut findings = Vec::new();
         for sm in self.pending_withdrawals.values_mut() {
             if !sm.is_in_audit_window(window) {
@@ -260,15 +298,14 @@ impl AuditorCore {
         }
     }
 
-    /// Polls one hour worth of guardian events
-    /// TODO: Provide an option to poll more aggressively if we are lagging behind
+    /// Advance the Guardian cursor by one hourly S3 directory. Callers may loop
+    /// to catch up multiple directories in one tick.
     pub async fn poll_guardian(&mut self) -> anyhow::Result<PollOutcome> {
         self.guardian_poller.poll_one_hour().await
     }
 
-    pub async fn poll_sui(&mut self) -> anyhow::Result<PollOutcome> {
-        // TODO: Implement me
-        Ok(PollOutcome::CursorUnmoved)
+    pub async fn poll_sui(&mut self, up_to: UnixSeconds) -> anyhow::Result<PollOutcome> {
+        self.sui_poller.poll(up_to).await
     }
 
     fn get_cursors(&self) -> Cursors {
@@ -278,7 +315,7 @@ impl AuditorCore {
         }
     }
     fn get_sui_cursor(&self) -> UnixSeconds {
-        self.sui_cursor
+        self.sui_poller.cursor_seconds()
     }
 
     fn get_guardian_cursor(&self) -> UnixSeconds {

--- a/crates/hashi-monitor/src/config.rs
+++ b/crates/hashi-monitor/src/config.rs
@@ -1,19 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
 use std::path::Path;
-use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::anyhow;
-use corepc_client::client_sync::Auth;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::S3Config;
+use hashi_types::guardian::UnresolvedS3Config;
 use serde::Deserialize;
 
 use crate::domain::WithdrawalEventType;
 
-/// Configuration for the cursorless batch auditor.
+/// Configuration shared by the batch and continuous monitor modes.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     /// Maximum allowed delay between consecutive events.
@@ -23,14 +22,19 @@ pub struct Config {
     #[serde(default = "default_clock_skew")]
     pub clock_skew: u64,
 
-    pub guardian: S3Config,
+    /// How far before the guardian audit start to search Sui for withdrawal
+    /// predecessor events (default: 1 hour).
+    #[serde(default = "default_withdrawal_predecessor_lookback")]
+    pub withdrawal_predecessor_lookback: u64,
+
+    pub guardian_s3: UnresolvedS3Config,
     #[serde(flatten)]
     pub pcr_allowlist: PcrAllowlist,
     pub sui: SuiConfig,
     pub btc: BtcConfig,
 }
 
-/// The maximum allowed delay between an event and it's successor in seconds.
+/// The maximum allowed delay between an event and its successor, in seconds.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(try_from = "Vec<(WithdrawalEventType, u64)>")]
 pub struct NextEventDelays(Vec<(WithdrawalEventType, u64)>);
@@ -39,46 +43,45 @@ pub struct NextEventDelays(Vec<(WithdrawalEventType, u64)>);
 pub struct SuiConfig {
     /// Sui RPC endpoint.
     pub rpc_url: String,
+
+    /// Currently deployed Hashi package.
+    pub package_id: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct BtcConfig {
-    /// Bitcoin Core RPC endpoint.
+    /// Bitcoin JSON-RPC endpoint.
+    ///
+    /// Prefix with `env:` to read the URL from an environment variable, which
+    /// keeps provider API keys out of YAML.
     pub rpc_url: String,
 
-    /// Bitcoin Core RPC auth.
+    /// Optional HTTP headers for the JSON-RPC provider.
     #[serde(default)]
-    pub rpc_auth: BtcRpcAuth,
+    pub http_headers: BTreeMap<String, String>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum BtcRpcAuth {
-    #[default]
-    None,
-    UserPass {
-        username: String,
-        password: String,
-    },
-    CookieFile {
-        path: PathBuf,
-    },
-}
-
-impl BtcRpcAuth {
-    pub fn to_corepc_auth(&self) -> Auth {
-        match self {
-            BtcRpcAuth::None => Auth::None,
-            BtcRpcAuth::UserPass { username, password } => {
-                Auth::UserPass(username.clone(), password.clone())
-            }
-            BtcRpcAuth::CookieFile { path } => Auth::CookieFile(path.clone()),
+impl BtcConfig {
+    pub fn resolve_rpc_url(&self) -> anyhow::Result<String> {
+        if let Some(variable) = self.rpc_url.strip_prefix("env:") {
+            anyhow::ensure!(
+                !variable.is_empty(),
+                "bitcoin rpc_url environment variable name is empty"
+            );
+            return std::env::var(variable).with_context(|| {
+                format!("bitcoin RPC environment variable {variable} is not set")
+            });
         }
+        Ok(self.rpc_url.clone())
     }
 }
 
 fn default_clock_skew() -> u64 {
     300
+}
+
+fn default_withdrawal_predecessor_lookback() -> u64 {
+    60 * 60
 }
 
 impl NextEventDelays {

--- a/crates/hashi-monitor/src/domain.rs
+++ b/crates/hashi-monitor/src/domain.rs
@@ -61,6 +61,57 @@ impl fmt::Display for UtcTimestamp {
     }
 }
 
+/// Seconds rendered as a compact human-readable duration.
+pub struct HumanDuration(UnixSeconds);
+
+pub fn human_duration(seconds: UnixSeconds) -> HumanDuration {
+    HumanDuration(seconds)
+}
+
+impl fmt::Display for HumanDuration {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hours = self.0 / 3_600;
+        let minutes = (self.0 % 3_600) / 60;
+        let seconds = self.0 % 60;
+
+        if hours > 0 {
+            write!(formatter, "{hours}h")?;
+        }
+        if minutes > 0 || hours > 0 {
+            write!(formatter, "{minutes}m")?;
+        }
+        write!(formatter, "{seconds}s")
+    }
+}
+
+/// Signed difference between two Unix timestamps, rendered compactly.
+pub struct HumanTimestampDelta(i128);
+
+pub fn human_timestamp_delta(later: UnixSeconds, earlier: UnixSeconds) -> HumanTimestampDelta {
+    HumanTimestampDelta(i128::from(later) - i128::from(earlier))
+}
+
+impl fmt::Display for HumanTimestampDelta {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0 < 0 {
+            formatter.write_str("-")?;
+        }
+
+        let total_seconds = self.0.unsigned_abs();
+        let hours = total_seconds / 3_600;
+        let minutes = (total_seconds % 3_600) / 60;
+        let seconds = total_seconds % 60;
+
+        if hours > 0 {
+            write!(formatter, "{hours}h")?;
+        }
+        if minutes > 0 || hours > 0 {
+            write!(formatter, "{minutes}m")?;
+        }
+        write!(formatter, "{seconds}s")
+    }
+}
+
 /// Parse the monitor's sole public timestamp format: whole-second UTC RFC 3339.
 pub fn parse_utc_timestamp(value: &str) -> Result<UnixSeconds, String> {
     if !value.ends_with('Z') {
@@ -238,5 +289,13 @@ mod tests {
         assert!(parse_utc_timestamp("1785872738").is_err());
         assert!(parse_utc_timestamp("2026-08-04T19:45:38+00:00").is_err());
         assert!(parse_utc_timestamp("2026-08-04T19:45:38.000Z").is_err());
+    }
+
+    #[test]
+    fn duration_uses_compact_human_readable_format() {
+        assert_eq!(human_duration(0).to_string(), "0s");
+        assert_eq!(human_duration(191).to_string(), "3m11s");
+        assert_eq!(human_duration(4_028).to_string(), "1h7m8s");
+        assert_eq!(human_timestamp_delta(100, 120).to_string(), "-20s");
     }
 }

--- a/crates/hashi-monitor/src/domain.rs
+++ b/crates/hashi-monitor/src/domain.rs
@@ -6,14 +6,16 @@
 //! We model the cross-system withdrawal flow as a sequence of events:
 //! - E1 or E_hashi: Hashi approval event on sui (corresponds to WithdrawalPickedForProcessing)
 //! - E2 or E_guardian: Guardian approval event on S3 (corresponds to NormalWithdrawalSuccess)
-//! - E3 or E_btc: BTC tx broadcast
+//! - E3 or E_btc: BTC transaction confirmed
 //!
-//! Predecessor checks: for every E_{i+1}, there exists a corresponding E_i within a small clock skew.
+//! Predecessor checks: every E_{i+1} has a corresponding E_i, and E_i does not
+//! occur more than `clock_skew` after E_{i+1}.
 //! Successor checks: for every E_i, there exists a corresponding E_{i+1} within time `t`.
 //!
 //! Note: IOP-203 matches the withdrawal destination & amount that a user inputs with that in E_hashi.
 //! The monitor is insecure without this check as a malicious hashi committee can include an arbitrary destination address.
 
+use std::fmt;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -29,6 +31,35 @@ pub fn now_unix_seconds() -> UnixSeconds {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+/// Unix seconds rendered together with their UTC wall-clock time.
+pub struct ReadableUnixSeconds(UnixSeconds);
+
+pub fn readable_unix_seconds(timestamp: UnixSeconds) -> ReadableUnixSeconds {
+    ReadableUnixSeconds(timestamp)
+}
+
+impl fmt::Display for ReadableUnixSeconds {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Ok(timestamp) = i64::try_from(self.0)
+            && let Ok(datetime) = time::OffsetDateTime::from_unix_timestamp(timestamp)
+        {
+            return write!(
+                formatter,
+                "{}({:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z)",
+                self.0,
+                datetime.year(),
+                u8::from(datetime.month()),
+                datetime.day(),
+                datetime.hour(),
+                datetime.minute(),
+                datetime.second(),
+            );
+        }
+
+        self.0.fmt(formatter)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -51,7 +82,7 @@ pub struct MonitorWithdrawalEvent {
     /// Stable withdrawal identifier.
     pub wid: WithdrawalID,
 
-    /// Unix timestamp of sui checkpoint / s3 log / btc block
+    /// Unix timestamp embedded in the Sui event / S3 log / BTC block.
     pub timestamp_secs: UnixSeconds,
 
     /// btc txid

--- a/crates/hashi-monitor/src/domain.rs
+++ b/crates/hashi-monitor/src/domain.rs
@@ -19,6 +19,7 @@ use std::fmt;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use bitcoin::OutPoint;
 use bitcoin::Txid;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -154,12 +155,48 @@ impl fmt::Display for MonitorEvent {
             ),
             Self::Deposit(event) => write!(
                 formatter,
-                "Deposit(type={:?}, timestamp={}, btc_txid={}, btc_vout={})",
+                "Deposit(type={:?}, deposit_id={}, timestamp={})",
                 event.event_type,
+                event.deposit_id,
                 utc_timestamp(event.timestamp_secs),
-                event.btc_txid,
-                event.btc_vout,
             ),
+        }
+    }
+}
+
+/// Stable identifier for a monitored deposit: its Bitcoin outpoint.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct DepositId(OutPoint);
+
+impl DepositId {
+    pub fn new(txid: Txid, vout: u32) -> Self {
+        Self(OutPoint { txid, vout })
+    }
+
+    pub fn txid(self) -> Txid {
+        self.0.txid
+    }
+}
+
+impl fmt::Display for DepositId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Correlation identifier for an event in the monitor's withdrawal or deposit model.
+/// This is not a chain-native event ID.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MonitorEventId {
+    Withdrawal(WithdrawalID),
+    Deposit(DepositId),
+}
+
+impl fmt::Display for MonitorEventId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Withdrawal(wid) => write!(formatter, "wid={wid}"),
+            Self::Deposit(deposit_id) => write!(formatter, "deposit_id={deposit_id}"),
         }
     }
 }
@@ -201,8 +238,7 @@ pub enum WithdrawalEventType {
 pub struct MonitorDepositEvent {
     pub event_type: DepositEventType,
     pub timestamp_secs: UnixSeconds,
-    pub btc_txid: Txid,
-    pub btc_vout: u32,
+    pub deposit_id: DepositId,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]

--- a/crates/hashi-monitor/src/domain.rs
+++ b/crates/hashi-monitor/src/domain.rs
@@ -33,22 +33,21 @@ pub fn now_unix_seconds() -> UnixSeconds {
         .as_secs()
 }
 
-/// Unix seconds rendered together with their UTC wall-clock time.
-pub struct ReadableUnixSeconds(UnixSeconds);
+/// Unix seconds rendered in the monitor's canonical UTC timestamp format.
+pub struct UtcTimestamp(UnixSeconds);
 
-pub fn readable_unix_seconds(timestamp: UnixSeconds) -> ReadableUnixSeconds {
-    ReadableUnixSeconds(timestamp)
+pub fn utc_timestamp(timestamp: UnixSeconds) -> UtcTimestamp {
+    UtcTimestamp(timestamp)
 }
 
-impl fmt::Display for ReadableUnixSeconds {
+impl fmt::Display for UtcTimestamp {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(timestamp) = i64::try_from(self.0)
             && let Ok(datetime) = time::OffsetDateTime::from_unix_timestamp(timestamp)
         {
             return write!(
                 formatter,
-                "{}({:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z)",
-                self.0,
+                "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
                 datetime.year(),
                 u8::from(datetime.month()),
                 datetime.day(),
@@ -58,14 +57,60 @@ impl fmt::Display for ReadableUnixSeconds {
             );
         }
 
-        self.0.fmt(formatter)
+        formatter.write_str("<invalid UTC timestamp>")
     }
+}
+
+/// Parse the monitor's sole public timestamp format: whole-second UTC RFC 3339.
+pub fn parse_utc_timestamp(value: &str) -> Result<UnixSeconds, String> {
+    if !value.ends_with('Z') {
+        return Err(
+            "timestamp must be UTC and end in `Z` (for example, 2026-08-04T19:00:00Z)".to_string(),
+        );
+    }
+
+    let datetime =
+        time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+            .map_err(|error| format!("invalid UTC timestamp `{value}`: {error}"))?;
+    let timestamp = UnixSeconds::try_from(datetime.unix_timestamp())
+        .map_err(|_| "timestamp must not precede 1970-01-01T00:00:00Z".to_string())?;
+    if utc_timestamp(timestamp).to_string() != value {
+        return Err(
+            "timestamp must use exactly `YYYY-MM-DDTHH:MM:SSZ` with no fractional seconds"
+                .to_string(),
+        );
+    }
+
+    Ok(timestamp)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MonitorEvent {
     Withdrawal(MonitorWithdrawalEvent),
     Deposit(MonitorDepositEvent),
+}
+
+impl fmt::Display for MonitorEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Withdrawal(event) => write!(
+                formatter,
+                "Withdrawal(type={:?}, wid={}, timestamp={}, btc_txid={})",
+                event.event_type,
+                event.wid,
+                utc_timestamp(event.timestamp_secs),
+                event.btc_txid,
+            ),
+            Self::Deposit(event) => write!(
+                formatter,
+                "Deposit(type={:?}, timestamp={}, btc_txid={}, btc_vout={})",
+                event.event_type,
+                utc_timestamp(event.timestamp_secs),
+                event.btc_txid,
+                event.btc_vout,
+            ),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -175,4 +220,23 @@ impl Cursors {
 pub enum PollOutcome {
     CursorAdvanced(Vec<MonitorEvent>),
     CursorUnmoved,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utc_timestamp_round_trip() {
+        let input = "2026-08-04T19:45:38Z";
+        let timestamp = parse_utc_timestamp(input).unwrap();
+        assert_eq!(utc_timestamp(timestamp).to_string(), input);
+    }
+
+    #[test]
+    fn timestamp_parser_requires_canonical_utc_format() {
+        assert!(parse_utc_timestamp("1785872738").is_err());
+        assert!(parse_utc_timestamp("2026-08-04T19:45:38+00:00").is_err());
+        assert!(parse_utc_timestamp("2026-08-04T19:45:38.000Z").is_err());
+    }
 }

--- a/crates/hashi-monitor/src/findings.rs
+++ b/crates/hashi-monitor/src/findings.rs
@@ -3,6 +3,7 @@
 
 use crate::domain::MonitorEvent;
 use crate::domain::MonitorEventType;
+use crate::domain::utc_timestamp;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use std::fmt;
 
@@ -67,6 +68,32 @@ impl MonitorFinding {
 
 impl fmt::Display for MonitorFinding {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
+        match self {
+            Self::InvalidEventAdded(message) => {
+                write!(f, "InvalidEventAdded(message={message})")
+            }
+            Self::EventOccurredAfterDeadline {
+                event,
+                relation,
+                deadline,
+                occurred_at,
+            } => write!(
+                f,
+                "EventOccurredAfterDeadline(event={event}, relation={relation:?}, deadline={}, occurred_at={})",
+                utc_timestamp(*deadline),
+                utc_timestamp(*occurred_at),
+            ),
+            Self::ExpectedEventMissing {
+                event_type,
+                relation,
+                deadline,
+                cursor,
+            } => write!(
+                f,
+                "ExpectedEventMissing(event_type={event_type:?}, relation={relation:?}, deadline={}, cursor={})",
+                utc_timestamp(*deadline),
+                utc_timestamp(*cursor),
+            ),
+        }
     }
 }

--- a/crates/hashi-monitor/src/findings.rs
+++ b/crates/hashi-monitor/src/findings.rs
@@ -3,27 +3,10 @@
 
 use crate::domain::MonitorEvent;
 use crate::domain::MonitorEventType;
+use crate::domain::human_duration;
 use crate::domain::utc_timestamp;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use std::fmt;
-
-struct HumanDuration(UnixSeconds);
-
-impl fmt::Display for HumanDuration {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let hours = self.0 / 3_600;
-        let minutes = (self.0 % 3_600) / 60;
-        let seconds = self.0 % 60;
-
-        if hours > 0 {
-            write!(f, "{hours}h")?;
-        }
-        if minutes > 0 || hours > 0 {
-            write!(f, "{minutes}m")?;
-        }
-        write!(f, "{seconds}s")
-    }
-}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum EventRelation {
@@ -100,7 +83,7 @@ impl fmt::Display for MonitorFinding {
                 "EventOccurredAfterDeadline(event={event}, relation={relation:?}, deadline={}, occurred_at={}, late_by={})",
                 utc_timestamp(*deadline),
                 utc_timestamp(*occurred_at),
-                HumanDuration(occurred_at.saturating_sub(*deadline)),
+                human_duration(occurred_at.saturating_sub(*deadline)),
             ),
             Self::ExpectedEventMissing {
                 event_type,

--- a/crates/hashi-monitor/src/findings.rs
+++ b/crates/hashi-monitor/src/findings.rs
@@ -7,6 +7,24 @@ use crate::domain::utc_timestamp;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use std::fmt;
 
+struct HumanDuration(UnixSeconds);
+
+impl fmt::Display for HumanDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hours = self.0 / 3_600;
+        let minutes = (self.0 % 3_600) / 60;
+        let seconds = self.0 % 60;
+
+        if hours > 0 {
+            write!(f, "{hours}h")?;
+        }
+        if minutes > 0 || hours > 0 {
+            write!(f, "{minutes}m")?;
+        }
+        write!(f, "{seconds}s")
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum EventRelation {
     Predecessor,
@@ -79,9 +97,10 @@ impl fmt::Display for MonitorFinding {
                 occurred_at,
             } => write!(
                 f,
-                "EventOccurredAfterDeadline(event={event}, relation={relation:?}, deadline={}, occurred_at={})",
+                "EventOccurredAfterDeadline(event={event}, relation={relation:?}, deadline={}, occurred_at={}, late_by={})",
                 utc_timestamp(*deadline),
                 utc_timestamp(*occurred_at),
+                HumanDuration(occurred_at.saturating_sub(*deadline)),
             ),
             Self::ExpectedEventMissing {
                 event_type,

--- a/crates/hashi-monitor/src/findings.rs
+++ b/crates/hashi-monitor/src/findings.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::domain::MonitorEvent;
+use crate::domain::MonitorEventId;
 use crate::domain::MonitorEventType;
 use crate::domain::human_duration;
 use crate::domain::utc_timestamp;
@@ -40,6 +41,7 @@ pub enum MonitorFinding {
         occurred_at: UnixSeconds, // same as event.timestamp
     },
     ExpectedEventMissing {
+        event_id: MonitorEventId,
         event_type: MonitorEventType,
         relation: EventRelation,
         deadline: UnixSeconds,
@@ -86,13 +88,14 @@ impl fmt::Display for MonitorFinding {
                 human_duration(occurred_at.saturating_sub(*deadline)),
             ),
             Self::ExpectedEventMissing {
+                event_id,
                 event_type,
                 relation,
                 deadline,
                 cursor,
             } => write!(
                 f,
-                "ExpectedEventMissing(event_type={event_type:?}, relation={relation:?}, deadline={}, cursor={})",
+                "ExpectedEventMissing({event_id}, event_type={event_type:?}, relation={relation:?}, deadline={}, cursor={})",
                 utc_timestamp(*deadline),
                 utc_timestamp(*cursor),
             ),

--- a/crates/hashi-monitor/src/main.rs
+++ b/crates/hashi-monitor/src/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap::Subcommand;
 use hashi_monitor::domain::now_unix_seconds;
+use hashi_monitor::domain::parse_utc_timestamp;
 
 #[derive(Debug, Parser)]
 #[command(name = "hashi-monitor")]
@@ -23,12 +24,12 @@ enum Command {
         #[arg(long)]
         config: PathBuf,
 
-        /// Start of guardian audit window, as unix seconds.
-        #[arg(long)]
+        /// Start of guardian audit window as UTC, for example 2026-08-04T19:00:00Z.
+        #[arg(long, value_parser = parse_utc_timestamp)]
         start: u64,
 
-        /// End of guardian audit window, as unix seconds. Defaults to current time.
-        #[arg(long)]
+        /// End of guardian audit window as UTC. Defaults to the current time.
+        #[arg(long, value_parser = parse_utc_timestamp)]
         end: Option<u64>,
     },
     /// Run continuous monitoring on guardian timeline.
@@ -37,8 +38,8 @@ enum Command {
         #[arg(long)]
         config: PathBuf,
 
-        /// Start of guardian audit period, as unix seconds.
-        #[arg(long)]
+        /// Start of guardian audit period as UTC, for example 2026-08-04T19:00:00Z.
+        #[arg(long, value_parser = parse_utc_timestamp)]
         start: u64,
     },
 }

--- a/crates/hashi-monitor/src/main.rs
+++ b/crates/hashi-monitor/src/main.rs
@@ -57,10 +57,7 @@ async fn main() -> anyhow::Result<()> {
             let cfg = hashi_monitor::config::Config::load_yaml(&config)?;
             let end = end.unwrap_or_else(now_unix_seconds);
             let mut auditor = hashi_monitor::audit::BatchAuditor::new(&cfg, start, end).await?;
-            auditor
-                .run()
-                .await
-                .unwrap_or_else(|e| panic!("infra failure: {e:#}"));
+            auditor.run().await?;
         }
         Command::Continuous { config, start } => {
             let cfg = hashi_monitor::config::Config::load_yaml(&config)?;

--- a/crates/hashi-monitor/src/rpc/btc.rs
+++ b/crates/hashi-monitor/src/rpc/btc.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 use crate::config::Config;
 
 const HTTP_JSON_RPC_BATCH_SIZE: usize = 20;
-const HTTP_JSON_RPC_BATCH_DELAY: Duration = Duration::from_millis(250);
+const HTTP_JSON_RPC_BATCH_DELAY: Duration = Duration::from_millis(200);
 const MAX_RATE_LIMIT_RETRIES: usize = 6;
 
 pub struct BtcRpcClient {

--- a/crates/hashi-monitor/src/rpc/btc.rs
+++ b/crates/hashi-monitor/src/rpc/btc.rs
@@ -223,7 +223,7 @@ impl HttpJsonRpcTransport {
         for (batch_index, chunk) in txids.chunks(HTTP_JSON_RPC_BATCH_SIZE).enumerate() {
             confirmations.extend(self.lookup_confirmation_batch(chunk)?);
             let processed_txids = ((batch_index + 1) * HTTP_JSON_RPC_BATCH_SIZE).min(txids.len());
-            if processed_txids % 200 == 0 || processed_txids == txids.len() {
+            if processed_txids.is_multiple_of(200) || processed_txids == txids.len() {
                 info!(
                     processed_txids,
                     total_txids = txids.len(),

--- a/crates/hashi-monitor/src/rpc/btc.rs
+++ b/crates/hashi-monitor/src/rpc/btc.rs
@@ -1,31 +1,84 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::thread;
+use std::time::Duration;
+
 use anyhow::Context;
+use bitcoin::BlockHash;
 use bitcoin::Txid;
 use hashi_types::guardian::time_utils::UnixSeconds;
+use serde::Deserialize;
+use serde_json::Value;
 use tracing::debug;
 use tracing::warn;
 
 use crate::config::Config;
 
+const HTTP_JSON_RPC_BATCH_SIZE: usize = 20;
+const HTTP_JSON_RPC_BATCH_DELAY: Duration = Duration::from_millis(250);
+const MAX_RATE_LIMIT_RETRIES: usize = 6;
+
 pub struct BtcRpcClient {
-    client: corepc_client::client_sync::v29::Client,
+    transport: HttpJsonRpcTransport,
+    confirmation_cache: RefCell<HashMap<Txid, Option<UnixSeconds>>>,
+}
+
+struct HttpJsonRpcTransport {
+    rpc_url: String,
+    headers: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcEnvelope {
+    id: Value,
+    result: Option<Value>,
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct RawTransactionInfo {
+    blockhash: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawBlockHeader {
+    time: u64,
 }
 
 impl BtcRpcClient {
     pub fn new(cfg: &Config) -> anyhow::Result<Self> {
-        let auth = cfg.btc.rpc_auth.to_corepc_auth();
-        let client = match auth {
-            corepc_client::client_sync::Auth::None => {
-                corepc_client::client_sync::v29::Client::new(&cfg.btc.rpc_url)
-            }
-            auth => corepc_client::client_sync::v29::Client::new_with_auth(&cfg.btc.rpc_url, auth)
-                .with_context(|| {
-                    format!("failed to connect to bitcoin rpc at {}", cfg.btc.rpc_url)
-                })?,
-        };
-        Ok(Self { client })
+        Ok(Self {
+            transport: HttpJsonRpcTransport {
+                rpc_url: cfg.btc.resolve_rpc_url()?,
+                headers: cfg.btc.http_headers.clone(),
+            },
+            confirmation_cache: RefCell::new(HashMap::new()),
+        })
+    }
+
+    /// Start a fresh lookup cycle. Confirmed and unconfirmed results are shared
+    /// by all outpoints from the same transaction within one audit tick, while
+    /// later ticks still retry transactions that were previously unconfirmed.
+    pub fn clear_confirmation_cache(&self) {
+        self.confirmation_cache.borrow_mut().clear();
+    }
+
+    pub fn prefetch_confirmations(&self, txids: &[Txid]) -> anyhow::Result<()> {
+        let confirmations = self.transport.lookup_confirmations(txids)?;
+        self.confirmation_cache.borrow_mut().extend(confirmations);
+        Ok(())
     }
 
     /// Query BTC RPC to check if a transaction is confirmed.
@@ -34,53 +87,311 @@ impl BtcRpcClient {
     /// - `Ok(None)` if txid is not seen or txid is seen but not confirmed,
     /// - `Err(...)` for all other errors
     pub fn lookup_confirmation(&self, txid: Txid) -> anyhow::Result<Option<UnixSeconds>> {
-        // Note: rpc returns Ok(...) even for unconfirmed txid in the mempool.
-        let tx_info = match self.client.get_raw_transaction_verbose(txid) {
-            Ok(tx_info) => tx_info
-                .into_model()
-                .with_context(|| format!("failed to parse transaction info for {txid}"))?,
-            Err(e) if txid_not_found(&e) => {
-                debug!(%txid, "bitcoin tx not found in mempool or chain yet");
-                return Ok(None);
-            }
-            Err(e) => {
-                warn!(%txid, error = %e, "failed to fetch bitcoin tx from rpc");
-                anyhow::bail!("failed to fetch bitcoin tx {} from rpc: {}", txid, e)
-            }
-        };
-
-        let Some(block_hash) = tx_info.block_hash else {
-            debug!(%txid, "bitcoin tx found but not mined yet");
-            return Ok(None);
-        };
-
-        let block_header = self
-            .client
-            .get_block_header_verbose(&block_hash)
-            .with_context(|| format!("failed to fetch block header for {}", block_hash))?
-            .into_model()
-            .with_context(|| format!("failed to parse block header for {}", block_hash))?;
-
-        let block_time = u64::from(block_header.time);
-
-        Ok(Some(block_time))
+        if let Some(result) = self.confirmation_cache.borrow().get(&txid) {
+            return Ok(*result);
+        }
+        let result = self.transport.lookup_confirmation(txid)?;
+        self.confirmation_cache.borrow_mut().insert(txid, result);
+        Ok(result)
     }
 }
 
-// https://github.com/bitcoin/bitcoin/blob/v25.0/src/rpc/protocol.h#L41
-fn txid_not_found(error: &corepc_client::client_sync::Error) -> bool {
-    matches!(
-        error,
-        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(rpc_error))
-            if rpc_error.code == -5
-    )
+impl HttpJsonRpcTransport {
+    fn call(&self, method: &str, params: Value) -> anyhow::Result<JsonRpcEnvelope> {
+        let body = serde_json::json!({
+            "jsonrpc": "1.0",
+            "id": "hashi-monitor",
+            "method": method,
+            "params": params,
+        });
+        serde_json::from_value(self.post_json(&body)?)
+            .context("failed to decode bitcoin JSON-RPC response")
+    }
+
+    fn call_batch(&self, body: &[Value]) -> anyhow::Result<Vec<JsonRpcEnvelope>> {
+        let body = Value::Array(body.to_vec());
+        serde_json::from_value(self.post_json(&body)?)
+            .context("failed to decode bitcoin JSON-RPC batch response")
+    }
+
+    /// Pace requests so a historical audit does not exhaust a provider's
+    /// rolling throughput bucket, and retry the standard HTTP/JSON-RPC 429
+    /// responses with bounded exponential backoff.
+    fn post_json(&self, body: &Value) -> anyhow::Result<Value> {
+        for attempt in 0..=MAX_RATE_LIMIT_RETRIES {
+            let response = minreq::post(&self.rpc_url)
+                .with_timeout(60)
+                .with_headers(self.headers.clone())
+                .with_json(body)
+                .context("failed to encode bitcoin JSON-RPC request")?
+                .send()
+                .context("bitcoin JSON-RPC request failed")?;
+
+            if response.status_code == 429 {
+                Self::wait_before_rate_limit_retry(attempt)?;
+                continue;
+            }
+
+            let response_body: Value = response
+                .json()
+                .context("failed to decode bitcoin JSON-RPC response")?;
+            if json_rpc_rate_limited(&response_body) {
+                Self::wait_before_rate_limit_retry(attempt)?;
+                continue;
+            }
+
+            thread::sleep(HTTP_JSON_RPC_BATCH_DELAY);
+            return Ok(response_body);
+        }
+
+        unreachable!("rate-limit retry loop either returns or errors")
+    }
+
+    fn wait_before_rate_limit_retry(attempt: usize) -> anyhow::Result<()> {
+        if attempt == MAX_RATE_LIMIT_RETRIES {
+            anyhow::bail!(
+                "bitcoin JSON-RPC remained rate limited after {MAX_RATE_LIMIT_RETRIES} retries"
+            );
+        }
+
+        let delay = Duration::from_secs(1 << attempt.min(5));
+        warn!(
+            retry = attempt + 1,
+            max_retries = MAX_RATE_LIMIT_RETRIES,
+            delay_secs = delay.as_secs(),
+            "bitcoin JSON-RPC rate limited; retrying"
+        );
+        thread::sleep(delay);
+        Ok(())
+    }
+
+    fn lookup_confirmation(&self, txid: Txid) -> anyhow::Result<Option<UnixSeconds>> {
+        let response = self.call(
+            "getrawtransaction",
+            serde_json::json!([txid.to_string(), true]),
+        )?;
+        if let Some(error) = response.error {
+            if error.code == -5 {
+                debug!(%txid, "bitcoin tx not found in mempool or chain yet");
+                return Ok(None);
+            }
+            anyhow::bail!(
+                "bitcoin getrawtransaction failed for {txid}: {} ({})",
+                error.message,
+                error.code
+            );
+        }
+        let tx_info: RawTransactionInfo = serde_json::from_value(
+            response
+                .result
+                .context("bitcoin getrawtransaction response is missing its result")?,
+        )
+        .with_context(|| format!("failed to parse transaction info for {txid}"))?;
+        let Some(block_hash) = tx_info.blockhash else {
+            debug!(%txid, "bitcoin tx found but not mined yet");
+            return Ok(None);
+        };
+        let block_hash = BlockHash::from_str(&block_hash)
+            .with_context(|| format!("invalid bitcoin block hash for {txid}"))?;
+
+        let response = self.call(
+            "getblockheader",
+            serde_json::json!([block_hash.to_string(), true]),
+        )?;
+        if let Some(error) = response.error {
+            anyhow::bail!(
+                "bitcoin getblockheader failed for {block_hash}: {} ({})",
+                error.message,
+                error.code
+            );
+        }
+        let header: RawBlockHeader = serde_json::from_value(
+            response
+                .result
+                .context("bitcoin getblockheader response is missing its result")?,
+        )
+        .with_context(|| format!("failed to parse block header for {block_hash}"))?;
+        Ok(Some(header.time))
+    }
+
+    fn lookup_confirmations(
+        &self,
+        txids: &[Txid],
+    ) -> anyhow::Result<HashMap<Txid, Option<UnixSeconds>>> {
+        let mut confirmations = HashMap::with_capacity(txids.len());
+        for chunk in txids.chunks(HTTP_JSON_RPC_BATCH_SIZE) {
+            confirmations.extend(self.lookup_confirmation_batch(chunk)?);
+        }
+        Ok(confirmations)
+    }
+
+    fn lookup_confirmation_batch(
+        &self,
+        txids: &[Txid],
+    ) -> anyhow::Result<HashMap<Txid, Option<UnixSeconds>>> {
+        let requests = txids
+            .iter()
+            .enumerate()
+            .map(|(id, txid)| {
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": "getrawtransaction",
+                    "params": [txid.to_string(), true],
+                })
+            })
+            .collect::<Vec<_>>();
+        let responses = self.call_batch(&requests)?;
+        let mut seen = HashSet::with_capacity(txids.len());
+        let mut block_hashes = HashMap::with_capacity(txids.len());
+
+        for response in responses {
+            let index = response_index(&response, txids.len())?;
+            anyhow::ensure!(
+                seen.insert(index),
+                "duplicate bitcoin getrawtransaction batch response ID {index}"
+            );
+            let txid = txids[index];
+            if let Some(error) = response.error {
+                if error.code == -5 {
+                    block_hashes.insert(txid, None);
+                    continue;
+                }
+                anyhow::bail!(
+                    "bitcoin getrawtransaction failed for {txid}: {} ({})",
+                    error.message,
+                    error.code
+                );
+            }
+            let info: RawTransactionInfo = serde_json::from_value(
+                response
+                    .result
+                    .context("bitcoin getrawtransaction batch response is missing its result")?,
+            )
+            .with_context(|| format!("failed to parse transaction info for {txid}"))?;
+            let block_hash = info
+                .blockhash
+                .map(|hash| {
+                    BlockHash::from_str(&hash)
+                        .with_context(|| format!("invalid bitcoin block hash for {txid}"))
+                })
+                .transpose()?;
+            block_hashes.insert(txid, block_hash);
+        }
+        anyhow::ensure!(
+            seen.len() == txids.len(),
+            "bitcoin getrawtransaction batch returned {}/{} responses",
+            seen.len(),
+            txids.len()
+        );
+
+        let unique_block_hashes = block_hashes
+            .values()
+            .flatten()
+            .copied()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let mut block_times = HashMap::with_capacity(unique_block_hashes.len());
+        for hashes in unique_block_hashes.chunks(HTTP_JSON_RPC_BATCH_SIZE) {
+            let requests = hashes
+                .iter()
+                .enumerate()
+                .map(|(id, hash)| {
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "method": "getblockheader",
+                        "params": [hash.to_string(), true],
+                    })
+                })
+                .collect::<Vec<_>>();
+            let responses = self.call_batch(&requests)?;
+            let mut seen = HashSet::with_capacity(hashes.len());
+            for response in responses {
+                let index = response_index(&response, hashes.len())?;
+                anyhow::ensure!(
+                    seen.insert(index),
+                    "duplicate bitcoin getblockheader batch response ID {index}"
+                );
+                let block_hash = hashes[index];
+                if let Some(error) = response.error {
+                    anyhow::bail!(
+                        "bitcoin getblockheader failed for {block_hash}: {} ({})",
+                        error.message,
+                        error.code
+                    );
+                }
+                let header: RawBlockHeader = serde_json::from_value(
+                    response
+                        .result
+                        .context("bitcoin getblockheader batch response is missing its result")?,
+                )
+                .with_context(|| format!("failed to parse block header for {block_hash}"))?;
+                block_times.insert(block_hash, header.time);
+            }
+            anyhow::ensure!(
+                seen.len() == hashes.len(),
+                "bitcoin getblockheader batch returned {}/{} responses",
+                seen.len(),
+                hashes.len()
+            );
+        }
+
+        block_hashes
+            .into_iter()
+            .map(|(txid, block_hash)| {
+                let confirmation = block_hash
+                    .map(|hash| {
+                        block_times
+                            .get(&hash)
+                            .copied()
+                            .with_context(|| format!("missing block time for {hash}"))
+                    })
+                    .transpose()?;
+                Ok((txid, confirmation))
+            })
+            .collect()
+    }
+}
+
+fn json_rpc_rate_limited(response: &Value) -> bool {
+    let is_rate_limited = |envelope: &Value| {
+        envelope
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64)
+            == Some(429)
+    };
+
+    match response {
+        Value::Array(envelopes) => envelopes.iter().any(is_rate_limited),
+        envelope => is_rate_limited(envelope),
+    }
+}
+
+fn response_index(response: &JsonRpcEnvelope, batch_len: usize) -> anyhow::Result<usize> {
+    let index = response
+        .id
+        .as_u64()
+        .context("bitcoin JSON-RPC batch response ID is not an integer")?;
+    let index =
+        usize::try_from(index).context("bitcoin JSON-RPC batch response ID is too large")?;
+    anyhow::ensure!(
+        index < batch_len,
+        "bitcoin JSON-RPC batch response ID {index} is outside batch of {batch_len}"
+    );
+    Ok(index)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::sync::Once;
 
     use anyhow::Result;
+    use base64ct::Base64;
+    use base64ct::Encoding as _;
     use bitcoin::Amount;
     use bitcoin::Txid;
     use bitcoin::hashes::Hash as _;
@@ -91,11 +402,11 @@ mod tests {
 
     use super::BtcRpcClient;
     use crate::config::BtcConfig;
-    use crate::config::BtcRpcAuth;
     use crate::config::Config;
     use crate::config::NextEventDelays;
     use crate::config::SuiConfig;
     use crate::domain::WithdrawalEventType;
+    use hashi_types::guardian::UnresolvedS3Config;
 
     static TRACING_INIT: Once = Once::new();
 
@@ -116,7 +427,14 @@ mod tests {
             ])
             .expect("valid next event delays"),
             clock_skew: 10,
-            guardian: hashi_types::guardian::S3Config::mock_for_testing(),
+            withdrawal_predecessor_lookback: 60 * 60,
+            guardian_s3: UnresolvedS3Config {
+                bucket: "bucket".to_string(),
+                region: "us-east-1".to_string(),
+                access_key: Some("access-key".to_string()),
+                secret_key: Some("secret-key".to_string()),
+                retention_environment: hashi_types::guardian::S3RetentionEnvironment::Testnet,
+            },
             pcr_allowlist: hashi_types::guardian::PcrAllowlist::new(
                 hashi_types::guardian::BuildPcrs::new("", vec![]),
                 vec![],
@@ -124,13 +442,17 @@ mod tests {
             .expect("valid PCR allowlist"),
             sui: SuiConfig {
                 rpc_url: "http://sui".to_string(),
+                package_id: format!("0x{}", "11".repeat(32)),
             },
             btc: BtcConfig {
                 rpc_url,
-                rpc_auth: BtcRpcAuth::UserPass {
-                    username: RPC_USER.to_string(),
-                    password: RPC_PASSWORD.to_string(),
-                },
+                http_headers: BTreeMap::from([(
+                    "Authorization".to_string(),
+                    format!(
+                        "Basic {}",
+                        Base64::encode_string(format!("{RPC_USER}:{RPC_PASSWORD}").as_bytes())
+                    ),
+                )]),
             },
         }
     }
@@ -162,6 +484,7 @@ mod tests {
         assert!(unconfirmed.is_none(), "expected unconfirmed transaction");
 
         node.generate_blocks(1)?;
+        btc_rpc_client.clear_confirmation_cache();
 
         let confirmed = btc_rpc_client.lookup_confirmation(txid)?;
         assert!(confirmed.is_some(), "expected confirmed transaction");

--- a/crates/hashi-monitor/src/rpc/btc.rs
+++ b/crates/hashi-monitor/src/rpc/btc.rs
@@ -16,6 +16,7 @@ use hashi_types::guardian::time_utils::UnixSeconds;
 use serde::Deserialize;
 use serde_json::Value;
 use tracing::debug;
+use tracing::info;
 use tracing::warn;
 
 use crate::config::Config;
@@ -219,8 +220,16 @@ impl HttpJsonRpcTransport {
         txids: &[Txid],
     ) -> anyhow::Result<HashMap<Txid, Option<UnixSeconds>>> {
         let mut confirmations = HashMap::with_capacity(txids.len());
-        for chunk in txids.chunks(HTTP_JSON_RPC_BATCH_SIZE) {
+        for (batch_index, chunk) in txids.chunks(HTTP_JSON_RPC_BATCH_SIZE).enumerate() {
             confirmations.extend(self.lookup_confirmation_batch(chunk)?);
+            let processed_txids = ((batch_index + 1) * HTTP_JSON_RPC_BATCH_SIZE).min(txids.len());
+            if processed_txids % 200 == 0 || processed_txids == txids.len() {
+                info!(
+                    processed_txids,
+                    total_txids = txids.len(),
+                    "bitcoin confirmation lookup progress"
+                );
+            }
         }
         Ok(confirmations)
     }

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -17,14 +17,7 @@ use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::unix_millis_to_seconds;
 use tracing::debug;
-use tracing::info;
-
-enum VerifiedWithdrawal {
-    Success(MonitorWithdrawalEvent),
-    Failure,
-}
-
-impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
+impl TryFrom<VerifiedLogRecord> for MonitorWithdrawalEvent {
     type Error = anyhow::Error;
 
     fn try_from(log: VerifiedLogRecord) -> Result<Self, Self::Error> {
@@ -42,16 +35,15 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
                     txid = %txid,
                     "successful guardian withdrawal log"
                 );
-                Ok(VerifiedWithdrawal::Success(MonitorWithdrawalEvent {
+                Ok(MonitorWithdrawalEvent {
                     event_type: WithdrawalEventType::E2GuardianApproved,
                     wid: request_data.wid,
                     timestamp_secs: unix_millis_to_seconds(timestamp_ms),
                     btc_txid: txid,
-                }))
+                })
             }
-            failure @ WithdrawalLogMessage::Failure { .. } => {
-                info!(?failure, "failed guardian withdrawal log");
-                Ok(VerifiedWithdrawal::Failure)
+            WithdrawalLogMessage::Failure { .. } => {
+                anyhow::bail!("failure log found under successful-withdrawal prefix")
             }
         }
     }
@@ -94,20 +86,20 @@ impl GuardianWithdrawalsPoller {
         let start = self.cursor.to_unix_seconds();
         let next_cursor = self.cursor.next_dir();
         let end = next_cursor.to_unix_seconds();
-        let verified_logs = self.reader.read_logs_in_dir(&self.cursor).await?;
+        let verified_logs = self
+            .reader
+            .read_successful_withdrawals_in_dir(&self.cursor)
+            .await?;
         // Withdrawal polling may replay historical buckets during an upgrade, so
         // this caller accepts any record whose session build verifies against the
         // configured allowlist. Add a cursor/cutoff policy here if tailing must
         // require the current build after the upgrade window.
         let withdrawal_events = verified_logs
             .into_iter()
-            .map(VerifiedWithdrawal::try_from)
+            .map(MonitorWithdrawalEvent::try_from)
             .collect::<anyhow::Result<Vec<_>>>()?
             .into_iter()
-            .filter_map(|e| match e {
-                VerifiedWithdrawal::Success(event) => Some(MonitorEvent::Withdrawal(event)),
-                VerifiedWithdrawal::Failure => None,
-            })
+            .map(MonitorEvent::Withdrawal)
             .collect::<Vec<MonitorEvent>>();
 
         self.cursor = next_cursor;

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -68,8 +68,9 @@ pub struct GuardianWithdrawalsPoller {
 impl GuardianWithdrawalsPoller {
     // Note: Throws an error if there is a S3 connectivity issue
     pub async fn new(config: &Config, start: UnixSeconds) -> anyhow::Result<Self> {
+        let guardian_s3 = hashi_guardian::resolve_s3_config(&config.guardian_s3).await?;
         Ok(Self {
-            reader: GuardianReader::new(&config.guardian, config.pcr_allowlist()).await?,
+            reader: GuardianReader::new(&guardian_s3, config.pcr_allowlist()).await?,
             cursor: withdraw_cursor(start),
         })
     }
@@ -78,8 +79,7 @@ impl GuardianWithdrawalsPoller {
         self.cursor.to_unix_seconds()
     }
 
-    /// Polls the Guardian S3 bucket for one hour worth of events.
-    /// A more aggressive fetch, e.g., one day at a time, can also be done if needed.
+    /// Poll one hourly Guardian S3 directory and advance to the next directory.
     pub async fn poll_one_hour(&mut self) -> anyhow::Result<PollOutcome> {
         if now_timestamp_secs() < self.cursor.write_completion_time() {
             return Ok(PollOutcome::CursorUnmoved);

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -6,6 +6,7 @@ use crate::domain::MonitorEvent;
 use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
+use crate::domain::utc_timestamp;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_guardian::s3_reader::VerifiedLogRecord;
 use hashi_guardian::s3_reader::withdraw_cursor;
@@ -90,6 +91,9 @@ impl GuardianWithdrawalsPoller {
             return Ok(PollOutcome::CursorUnmoved);
         }
 
+        let start = self.cursor.to_unix_seconds();
+        let next_cursor = self.cursor.next_dir();
+        let end = next_cursor.to_unix_seconds();
         let verified_logs = self.reader.read_logs_in_dir(&self.cursor).await?;
         // Withdrawal polling may replay historical buckets during an upgrade, so
         // this caller accepts any record whose session build verifies against the
@@ -106,7 +110,14 @@ impl GuardianWithdrawalsPoller {
             })
             .collect::<Vec<MonitorEvent>>();
 
-        self.cursor = self.cursor.next_dir();
+        self.cursor = next_cursor;
+        tracing::info!(
+            start = %utc_timestamp(start),
+            end = %utc_timestamp(end),
+            cursor = %utc_timestamp(self.cursor.to_unix_seconds()),
+            events = withdrawal_events.len(),
+            "completed Guardian event range"
+        );
         Ok(PollOutcome::CursorAdvanced(withdrawal_events))
     }
 }

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -79,6 +79,11 @@ impl GuardianWithdrawalsPoller {
         self.cursor.to_unix_seconds()
     }
 
+    /// Time after which the next unread hourly partition is considered complete.
+    pub fn next_partition_ready_at(&self) -> UnixSeconds {
+        self.cursor.write_completion_time()
+    }
+
     /// Poll one hourly Guardian S3 directory and advance to the next directory.
     pub async fn poll_one_hour(&mut self) -> anyhow::Result<PollOutcome> {
         if now_timestamp_secs() < self.cursor.write_completion_time() {

--- a/crates/hashi-monitor/src/rpc/mod.rs
+++ b/crates/hashi-monitor/src/rpc/mod.rs
@@ -3,3 +3,4 @@
 
 pub mod btc;
 pub mod guardian;
+pub mod sui;

--- a/crates/hashi-monitor/src/rpc/sui.rs
+++ b/crates/hashi-monitor/src/rpc/sui.rs
@@ -29,6 +29,7 @@ use sui_sdk_types::Address;
 
 use crate::config::SuiConfig;
 use crate::domain::DepositEventType;
+use crate::domain::DepositId;
 use crate::domain::MonitorDepositEvent;
 use crate::domain::MonitorEvent;
 use crate::domain::MonitorWithdrawalEvent;
@@ -435,8 +436,7 @@ impl SuiEventsPoller {
                 Some(MonitorEvent::Deposit(MonitorDepositEvent {
                     event_type: DepositEventType::E2HashiApproved,
                     timestamp_secs: unix_millis_to_seconds(event.approved_timestamp_ms),
-                    btc_txid: event.utxo.id.txid.into(),
-                    btc_vout: event.utxo.id.vout,
+                    deposit_id: DepositId::new(event.utxo.id.txid.into(), event.utxo.id.vout),
                 }))
             }
             Some(_) | None => None,

--- a/crates/hashi-monitor/src/rpc/sui.rs
+++ b/crates/hashi-monitor/src/rpc/sui.rs
@@ -1,0 +1,424 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::Context;
+use futures::StreamExt;
+use hashi_types::guardian::time_utils::UnixSeconds;
+use hashi_types::guardian::unix_millis_to_seconds;
+use hashi_types::move_types::HashiEvent;
+use hashi_types::move_types::PackageVersions;
+use sui_rpc::field::FieldMask;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::proto_to_timestamp_ms;
+use sui_rpc::proto::sui::rpc::v2::Checkpoint;
+use sui_rpc::proto::sui::rpc::v2::Event;
+use sui_rpc::proto::sui::rpc::v2::EventFilter;
+use sui_rpc::proto::sui::rpc::v2::EventLiteral;
+use sui_rpc::proto::sui::rpc::v2::EventTerm;
+use sui_rpc::proto::sui::rpc::v2::EventTypeFilter;
+use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
+use sui_rpc::proto::sui::rpc::v2::ListEventsRequest;
+use sui_rpc::proto::sui::rpc::v2::Ordering;
+use sui_rpc::proto::sui::rpc::v2::QueryEndReason;
+use sui_rpc::proto::sui::rpc::v2::QueryOptions;
+use sui_sdk_types::Address;
+
+use crate::config::SuiConfig;
+use crate::domain::DepositEventType;
+use crate::domain::MonitorDepositEvent;
+use crate::domain::MonitorEvent;
+use crate::domain::MonitorWithdrawalEvent;
+use crate::domain::PollOutcome;
+use crate::domain::WithdrawalEventType;
+use crate::domain::readable_unix_seconds;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const PAGE_SIZE: u32 = 1_000;
+const MIN_CHECKPOINTS_PER_RETRY: u64 = 25;
+
+pub struct SuiEventsPoller {
+    /// Sui v2 gRPC client used for checkpoint and event requests.
+    client: sui_rpc::Client,
+    /// Deployed package versions used to decode Hashi event BCS.
+    package_versions: PackageVersions,
+    /// Current Hashi package used to construct server-side event type filters.
+    package_id: String,
+    /// Latest timestamp through which the poller has completely scanned events.
+    cursor_seconds: UnixSeconds,
+    /// First checkpoint not yet scanned, once the initial timestamp lookup completes.
+    next_checkpoint_to_scan: Option<u64>,
+    /// Checkpoint timestamps cached to avoid repeating `GetCheckpoint` requests.
+    checkpoint_timestamps: BTreeMap<u64, UnixSeconds>,
+    /// Most recently fetched chain head as `(sequence_number, timestamp_secs)`.
+    observed_chain_head: Option<(u64, UnixSeconds)>,
+}
+
+impl SuiEventsPoller {
+    pub fn new(config: &SuiConfig, start: UnixSeconds) -> anyhow::Result<Self> {
+        let package_id = Address::from_str(&config.package_id)
+            .with_context(|| format!("invalid Hashi package ID {}", config.package_id))?;
+
+        let package_versions = PackageVersions::new(BTreeMap::from([(1, package_id)]));
+        let client = sui_rpc::Client::new(&config.rpc_url)
+            .with_context(|| format!("invalid Sui RPC URL {}", config.rpc_url))?
+            .request_layer(tower::timeout::TimeoutLayer::new(REQUEST_TIMEOUT));
+
+        Ok(Self {
+            client,
+            package_versions,
+            package_id: config.package_id.clone(),
+            cursor_seconds: start,
+            next_checkpoint_to_scan: None,
+            checkpoint_timestamps: BTreeMap::new(),
+            observed_chain_head: None,
+        })
+    }
+
+    pub fn cursor_seconds(&self) -> UnixSeconds {
+        self.cursor_seconds
+    }
+
+    /// Scan through the checkpoint covering `up_to`, or the observed chain head.
+    ///
+    /// The timestamp cursor advances only after `ListEvents` reports that the
+    /// complete requested range was scanned. The server stream handles its own
+    /// item and scan limits with resumable cursors. A partial response caused by
+    /// an RPC failure is discarded; that range is retried and may be split.
+    pub async fn poll(&mut self, up_to: UnixSeconds) -> anyhow::Result<PollOutcome> {
+        if up_to <= self.cursor_seconds {
+            return Ok(PollOutcome::CursorUnmoved);
+        }
+
+        let start_checkpoint = match self.next_checkpoint_to_scan {
+            Some(checkpoint) => checkpoint,
+            None => self
+                .checkpoint_bracket(self.cursor_seconds)
+                .await?
+                .map(|(before, _)| before)
+                .context("Sui does not yet have a checkpoint at the poll start time")?,
+        };
+        let (mut latest_sequence, mut latest_timestamp) = self
+            .observed_chain_head
+            .context("latest Sui checkpoint was not resolved")?;
+        if start_checkpoint > latest_sequence {
+            (latest_sequence, latest_timestamp) = self.refresh_chain_head().await?;
+            if start_checkpoint > latest_sequence {
+                return Ok(PollOutcome::CursorUnmoved);
+            }
+        }
+
+        let (mut end_checkpoint, mut scanned_through_timestamp) = if latest_timestamp < up_to {
+            (latest_sequence.saturating_add(1), latest_timestamp)
+        } else {
+            let (_, boundary) = self
+                .checkpoint_bracket_from_head(up_to, (latest_sequence, latest_timestamp))
+                .await?
+                .context("Sui does not yet have a checkpoint at the poll end time")?;
+            let timestamp = self.checkpoint_timestamp(boundary).await?;
+            (boundary.saturating_add(1), timestamp)
+        };
+        if end_checkpoint <= start_checkpoint {
+            return Ok(PollOutcome::CursorUnmoved);
+        }
+
+        let mut retry_same_range = true;
+        let raw_events = loop {
+            match self
+                .list_events_in_range(start_checkpoint, end_checkpoint)
+                .await
+            {
+                Ok(events) => break events,
+                Err(error) if retry_same_range => {
+                    tracing::warn!(
+                        start_checkpoint,
+                        end_checkpoint,
+                        ?error,
+                        "Sui event scan failed; retrying range"
+                    );
+                    retry_same_range = false;
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+                Err(error) => {
+                    let checkpoint_count = end_checkpoint.saturating_sub(start_checkpoint);
+                    if checkpoint_count <= MIN_CHECKPOINTS_PER_RETRY {
+                        return Err(error).context("Sui event scan failed after retries");
+                    }
+                    end_checkpoint = start_checkpoint + checkpoint_count / 2;
+                    let scanned_through = end_checkpoint
+                        .checked_sub(1)
+                        .context("empty Sui checkpoint range after retry split")?;
+                    scanned_through_timestamp = self.checkpoint_timestamp(scanned_through).await?;
+                    tracing::warn!(
+                        start_checkpoint,
+                        end_checkpoint,
+                        ?error,
+                        "Sui event scan failed twice; retrying a smaller range"
+                    );
+                    retry_same_range = true;
+                }
+            }
+        };
+        let mut events = Vec::with_capacity(raw_events.len());
+        for event in raw_events {
+            if let Some(event) = self.parse_event(event)? {
+                events.push(event);
+            }
+        }
+
+        self.next_checkpoint_to_scan = Some(end_checkpoint);
+        self.cursor_seconds = self.cursor_seconds.max(scanned_through_timestamp);
+        tracing::info!(
+            start_checkpoint,
+            end_checkpoint,
+            cursor = %readable_unix_seconds(self.cursor_seconds),
+            events = events.len(),
+            "completed Sui event range"
+        );
+        Ok(PollOutcome::CursorAdvanced(events))
+    }
+
+    /// Find a safe checkpoint bracket `(before, at_or_after)` for a timestamp.
+    ///
+    /// Exponential probing finds a lower bound, then binary search resolves the
+    /// exact adjacent checkpoint boundary. When a predecessor checkpoint exists,
+    /// the lower bound is before the timestamp and the upper bound is at or after
+    /// it. At or before genesis, both bounds are checkpoint zero.
+    async fn checkpoint_bracket(
+        &mut self,
+        timestamp_secs: UnixSeconds,
+    ) -> anyhow::Result<Option<(u64, u64)>> {
+        let head = self.refresh_chain_head().await?;
+        self.checkpoint_bracket_from_head(timestamp_secs, head)
+            .await
+    }
+
+    async fn checkpoint_bracket_from_head(
+        &mut self,
+        timestamp_secs: UnixSeconds,
+        (latest_sequence, latest_timestamp): (u64, UnixSeconds),
+    ) -> anyhow::Result<Option<(u64, u64)>> {
+        if latest_timestamp < timestamp_secs {
+            return Ok(None);
+        }
+
+        let elapsed = latest_timestamp.saturating_sub(timestamp_secs);
+        let mut distance = elapsed.saturating_mul(6).max(1);
+        let mut low_sequence = loop {
+            let probe = latest_sequence.saturating_sub(distance);
+            let timestamp = self.checkpoint_timestamp(probe).await?;
+            if timestamp < timestamp_secs {
+                break probe;
+            }
+            if probe == 0 {
+                return Ok(Some((0, 0)));
+            }
+            distance = distance.saturating_mul(2);
+        };
+        let mut high_sequence = latest_sequence;
+
+        // Resolve the exact adjacent checkpoint boundary. A previously capped
+        // interpolation could leave a very wide but technically safe bracket
+        // for historical timestamps, forcing ListEvents to scan many unrelated
+        // checkpoint ranges. Binary search keeps the lookup logarithmic even
+        // when checkpoint production has varied over time.
+        while high_sequence > low_sequence.saturating_add(1) {
+            let midpoint = low_sequence + (high_sequence - low_sequence) / 2;
+            let midpoint_timestamp = self.checkpoint_timestamp(midpoint).await?;
+            if midpoint_timestamp < timestamp_secs {
+                low_sequence = midpoint;
+            } else {
+                high_sequence = midpoint;
+            }
+        }
+
+        Ok(Some((low_sequence, high_sequence)))
+    }
+
+    async fn refresh_chain_head(&mut self) -> anyhow::Result<(u64, UnixSeconds)> {
+        let latest = self.get_checkpoint(GetCheckpointRequest::latest()).await?;
+        self.observed_chain_head = Some(latest);
+        Ok(latest)
+    }
+
+    async fn checkpoint_timestamp(&mut self, sequence_number: u64) -> anyhow::Result<UnixSeconds> {
+        if let Some(timestamp) = self.checkpoint_timestamps.get(&sequence_number) {
+            return Ok(*timestamp);
+        }
+        let (actual_sequence, timestamp) = self
+            .get_checkpoint(GetCheckpointRequest::by_sequence_number(sequence_number))
+            .await?;
+        anyhow::ensure!(
+            actual_sequence == sequence_number,
+            "requested Sui checkpoint {sequence_number}, received {actual_sequence}"
+        );
+        self.checkpoint_timestamps
+            .insert(sequence_number, timestamp);
+        Ok(timestamp)
+    }
+
+    async fn get_checkpoint(
+        &mut self,
+        request: GetCheckpointRequest,
+    ) -> anyhow::Result<(u64, UnixSeconds)> {
+        let request = request.with_read_mask(FieldMask::from_paths([
+            "sequence_number",
+            "summary.timestamp",
+        ]));
+        let response = self
+            .client
+            .ledger_client()
+            .get_checkpoint(request)
+            .await
+            .context("failed to fetch Sui checkpoint")?
+            .into_inner();
+        let checkpoint = response.checkpoint.context("missing Sui checkpoint")?;
+        let (sequence_number, timestamp_secs) =
+            Self::checkpoint_sequence_and_timestamp(checkpoint)?;
+        self.checkpoint_timestamps
+            .insert(sequence_number, timestamp_secs);
+        Ok((sequence_number, timestamp_secs))
+    }
+
+    fn checkpoint_sequence_and_timestamp(
+        checkpoint: Checkpoint,
+    ) -> anyhow::Result<(u64, UnixSeconds)> {
+        let sequence_number = checkpoint
+            .sequence_number
+            .context("Sui checkpoint is missing sequence_number")?;
+        let timestamp = checkpoint
+            .summary
+            .and_then(|summary| summary.timestamp)
+            .context("Sui checkpoint is missing summary.timestamp")?;
+        let timestamp_ms =
+            proto_to_timestamp_ms(timestamp).context("invalid Sui checkpoint timestamp")?;
+        let timestamp_secs = timestamp_ms / 1_000;
+        Ok((sequence_number, timestamp_secs))
+    }
+
+    async fn list_events_in_range(
+        &mut self,
+        start_checkpoint: u64,
+        end_checkpoint: u64,
+    ) -> anyhow::Result<Vec<Event>> {
+        if start_checkpoint >= end_checkpoint {
+            return Ok(Vec::new());
+        }
+
+        let filter = self.event_filter();
+        let mut after = None;
+        let mut all_events = Vec::new();
+
+        loop {
+            let mut options = QueryOptions::default()
+                .with_limit(PAGE_SIZE)
+                .with_ordering(Ordering::Ascending);
+            if let Some(cursor) = after.clone() {
+                options = options.with_after(cursor);
+            }
+            let request = ListEventsRequest::default()
+                .with_read_mask(FieldMask::from_paths(["event_type", "contents"]))
+                .with_start_checkpoint(start_checkpoint)
+                .with_end_checkpoint(end_checkpoint)
+                .with_filter(filter.clone())
+                .with_options(options);
+
+            let mut stream = self
+                .client
+                .ledger_client()
+                .list_events(request)
+                .await
+                .context("failed to list Sui events")?
+                .into_inner();
+            let mut end_reason = None;
+            let mut page_cursor = None;
+
+            while let Some(frame) = stream.next().await {
+                let frame = frame.context("Sui ListEvents stream failed")?;
+                if let Some(watermark) = &frame.watermark
+                    && let Some(cursor) = watermark.cursor.clone()
+                {
+                    page_cursor = Some(cursor);
+                }
+                if let Some(event) = frame.event {
+                    all_events.push(event);
+                }
+                if let Some(end) = frame.end {
+                    end_reason = end
+                        .reason
+                        .and_then(|reason| QueryEndReason::try_from(reason).ok());
+                    break;
+                }
+            }
+
+            match end_reason.context("Sui ListEvents ended without QueryEnd")? {
+                QueryEndReason::CheckpointBound => return Ok(all_events),
+                QueryEndReason::ItemLimit | QueryEndReason::ScanLimit => {
+                    let next = page_cursor
+                        .context("Sui ListEvents reached a page limit without a resume cursor")?;
+                    anyhow::ensure!(
+                        after.as_ref() != Some(&next),
+                        "Sui ListEvents resume cursor did not advance"
+                    );
+                    after = Some(next);
+                }
+                reason => anyhow::bail!(
+                    "Sui ListEvents stopped before checkpoint {end_checkpoint}: {reason:?}"
+                ),
+            }
+        }
+    }
+
+    fn event_filter(&self) -> EventFilter {
+        let event_types = [
+            format!(
+                "{}::withdrawal_queue::WithdrawalPickedForProcessing",
+                self.package_id
+            ),
+            format!("{}::deposit::DepositApproved", self.package_id),
+        ];
+        EventFilter::default().with_terms(
+            event_types
+                .into_iter()
+                .map(|event_type| {
+                    EventTerm::default().with_literals(vec![
+                        EventLiteral::default().with_event_type(
+                            EventTypeFilter::default().with_event_type(event_type),
+                        ),
+                    ])
+                })
+                .collect(),
+        )
+    }
+
+    fn parse_event(&self, event: Event) -> anyhow::Result<Option<MonitorEvent>> {
+        let contents = event
+            .contents
+            .context("Sui event is missing BCS contents")?;
+        let event = HashiEvent::try_parse(&self.package_versions, &contents)
+            .context("failed to parse Hashi Sui event")?;
+
+        Ok(match event {
+            Some(HashiEvent::WithdrawalPickedForProcessing(event)) => {
+                Some(MonitorEvent::Withdrawal(MonitorWithdrawalEvent {
+                    event_type: WithdrawalEventType::E1HashiApproved,
+                    wid: event.withdrawal_txn_id,
+                    timestamp_secs: unix_millis_to_seconds(event.timestamp_ms),
+                    btc_txid: event.txid.into(),
+                }))
+            }
+            Some(HashiEvent::DepositApproved(event)) => {
+                Some(MonitorEvent::Deposit(MonitorDepositEvent {
+                    event_type: DepositEventType::E2HashiApproved,
+                    timestamp_secs: unix_millis_to_seconds(event.approved_timestamp_ms),
+                    btc_txid: event.utxo.id.txid.into(),
+                    btc_vout: event.utxo.id.vout,
+                }))
+            }
+            Some(_) | None => None,
+        })
+    }
+}

--- a/crates/hashi-monitor/src/rpc/sui.rs
+++ b/crates/hashi-monitor/src/rpc/sui.rs
@@ -34,7 +34,7 @@ use crate::domain::MonitorEvent;
 use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
-use crate::domain::readable_unix_seconds;
+use crate::domain::utc_timestamp;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 const PAGE_SIZE: u32 = 1_000;
@@ -174,7 +174,7 @@ impl SuiEventsPoller {
         tracing::info!(
             start_checkpoint,
             end_checkpoint,
-            cursor = %readable_unix_seconds(self.cursor_seconds),
+            cursor = %utc_timestamp(self.cursor_seconds),
             events = events.len(),
             "completed Sui event range"
         );

--- a/crates/hashi-monitor/src/rpc/sui.rs
+++ b/crates/hashi-monitor/src/rpc/sui.rs
@@ -201,6 +201,12 @@ impl SuiEventsPoller {
         timestamp_secs: UnixSeconds,
         (latest_sequence, latest_timestamp): (u64, UnixSeconds),
     ) -> anyhow::Result<Option<(u64, u64)>> {
+        tracing::info!(
+            target = %utc_timestamp(timestamp_secs),
+            latest_checkpoint = latest_sequence,
+            latest_timestamp = %utc_timestamp(latest_timestamp),
+            "resolving Sui checkpoint boundary"
+        );
         if latest_timestamp < timestamp_secs {
             return Ok(None);
         }
@@ -235,6 +241,12 @@ impl SuiEventsPoller {
             }
         }
 
+        tracing::info!(
+            target = %utc_timestamp(timestamp_secs),
+            before_checkpoint = low_sequence,
+            at_or_after_checkpoint = high_sequence,
+            "resolved Sui checkpoint boundary"
+        );
         Ok(Some((low_sequence, high_sequence)))
     }
 
@@ -311,6 +323,7 @@ impl SuiEventsPoller {
         let filter = self.event_filter();
         let mut after = None;
         let mut all_events = Vec::new();
+        tracing::info!(start_checkpoint, end_checkpoint, "starting Sui event scan");
 
         loop {
             let mut options = QueryOptions::default()
@@ -354,9 +367,17 @@ impl SuiEventsPoller {
                 }
             }
 
-            match end_reason.context("Sui ListEvents ended without QueryEnd")? {
+            let end_reason = end_reason.context("Sui ListEvents ended without QueryEnd")?;
+            match end_reason {
                 QueryEndReason::CheckpointBound => return Ok(all_events),
                 QueryEndReason::ItemLimit | QueryEndReason::ScanLimit => {
+                    tracing::info!(
+                        start_checkpoint,
+                        end_checkpoint,
+                        events = all_events.len(),
+                        ?end_reason,
+                        "Sui event scan progress"
+                    );
                     let next = page_cursor
                         .context("Sui ListEvents reached a page limit without a resume cursor")?;
                     anyhow::ensure!(

--- a/crates/hashi-monitor/src/state_machine.rs
+++ b/crates/hashi-monitor/src/state_machine.rs
@@ -259,11 +259,8 @@ impl WithdrawalStateMachine {
                 WithdrawalEventType::E3BtcConfirmed => match self.btc_checked_at {
                     Some(checked_at) => checked_at,
                     None => {
-                        tracing::debug!(
-                            wid = %self.wid,
-                            btc_txid = %self.btc_txid,
-                            "callers should avoid reaching this branch by calling try_fetch_btc_tx before"
-                        );
+                        // Bitcoin and state checks have independent schedules.
+                        // Wait for the first lookup before evaluating absence.
                         continue;
                     }
                 },
@@ -375,10 +372,8 @@ impl DepositStateMachine {
 
         // btc event not yet found
         let Some(cursor) = self.btc_checked_at else {
-            tracing::debug!(
-                deposit_id = %self.hashi_deposit_event.deposit_id,
-                "callers should avoid this branch by calling try_fetch_btc_tx before violations"
-            );
+            // Bitcoin and state checks have independent schedules. Wait for
+            // the first lookup before evaluating absence.
             return Vec::new();
         };
 

--- a/crates/hashi-monitor/src/state_machine.rs
+++ b/crates/hashi-monitor/src/state_machine.rs
@@ -389,13 +389,14 @@ impl DepositStateMachine {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use crate::config::BtcConfig;
-    use crate::config::BtcRpcAuth;
     use crate::config::NextEventDelays;
     use crate::config::SuiConfig;
     use bitcoin::hashes::Hash as _;
-    use hashi_types::guardian::S3Config;
+    use hashi_types::guardian::UnresolvedS3Config;
 
     struct TestWindow {
         start: UnixSeconds,
@@ -416,7 +417,14 @@ mod tests {
             ])
             .expect("valid intra-event delays"),
             clock_skew: 10,
-            guardian: S3Config::mock_for_testing(),
+            withdrawal_predecessor_lookback: 60 * 60,
+            guardian_s3: UnresolvedS3Config {
+                bucket: "bucket".to_string(),
+                region: "us-east-1".to_string(),
+                access_key: Some("access-key".to_string()),
+                secret_key: Some("secret-key".to_string()),
+                retention_environment: hashi_types::guardian::S3RetentionEnvironment::Testnet,
+            },
             pcr_allowlist: hashi_types::guardian::PcrAllowlist::new(
                 hashi_types::guardian::BuildPcrs::new("", vec![]),
                 vec![],
@@ -424,10 +432,11 @@ mod tests {
             .expect("valid PCR allowlist"),
             sui: SuiConfig {
                 rpc_url: "http://sui".to_string(),
+                package_id: format!("0x{}", "11".repeat(32)),
             },
             btc: BtcConfig {
                 rpc_url: "http://btc".to_string(),
-                rpc_auth: BtcRpcAuth::None,
+                http_headers: BTreeMap::new(),
             },
         }
     }

--- a/crates/hashi-monitor/src/state_machine.rs
+++ b/crates/hashi-monitor/src/state_machine.rs
@@ -7,8 +7,10 @@ use crate::audit::AuditWindow;
 use crate::config::Config;
 use crate::domain::Cursors;
 use crate::domain::DepositEventType;
+use crate::domain::DepositId;
 use crate::domain::MonitorDepositEvent;
 use crate::domain::MonitorEvent;
+use crate::domain::MonitorEventId;
 use crate::domain::MonitorEventType;
 use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::WithdrawalEventType;
@@ -257,7 +259,9 @@ impl WithdrawalStateMachine {
                 WithdrawalEventType::E3BtcConfirmed => match self.btc_checked_at {
                     Some(checked_at) => checked_at,
                     None => {
-                        tracing::warn!(
+                        tracing::debug!(
+                            wid = %self.wid,
+                            btc_txid = %self.btc_txid,
                             "callers should avoid reaching this branch by calling try_fetch_btc_tx before"
                         );
                         continue;
@@ -267,6 +271,7 @@ impl WithdrawalStateMachine {
             };
             if *deadline <= cursor {
                 out.push(MonitorFinding::ExpectedEventMissing {
+                    event_id: MonitorEventId::Withdrawal(self.wid),
                     event_type: MonitorEventType::Withdrawal(*event_type),
                     relation: *relation,
                     deadline: *deadline,
@@ -305,7 +310,11 @@ impl DepositStateMachine {
     }
 
     pub fn btc_txid(&self) -> Txid {
-        self.hashi_deposit_event.btc_txid
+        self.hashi_deposit_event.deposit_id.txid()
+    }
+
+    pub fn deposit_id(&self) -> DepositId {
+        self.hashi_deposit_event.deposit_id
     }
 
     pub fn hashi_deposit_event(&self) -> &MonitorDepositEvent {
@@ -325,7 +334,8 @@ impl DepositStateMachine {
         }
 
         let deadline = self.btc_event_expected_at;
-        let btc_txid = self.hashi_deposit_event.btc_txid;
+        let deposit_id = self.hashi_deposit_event.deposit_id;
+        let btc_txid = deposit_id.txid();
         let cur_time = now_unix_seconds();
 
         match btc_rpc_client.lookup_confirmation(btc_txid) {
@@ -333,8 +343,7 @@ impl DepositStateMachine {
                 self.btc_checked_at = Some(cur_time);
                 let e_btc = MonitorDepositEvent {
                     event_type: DepositEventType::E1BtcConfirmed,
-                    btc_txid,
-                    btc_vout: self.hashi_deposit_event.btc_vout,
+                    deposit_id,
                     timestamp_secs: block_time,
                 };
 
@@ -366,8 +375,8 @@ impl DepositStateMachine {
 
         // btc event not yet found
         let Some(cursor) = self.btc_checked_at else {
-            tracing::warn!(
-                txid = %self.hashi_deposit_event.btc_txid,
+            tracing::debug!(
+                deposit_id = %self.hashi_deposit_event.deposit_id,
                 "callers should avoid this branch by calling try_fetch_btc_tx before violations"
             );
             return Vec::new();
@@ -379,6 +388,7 @@ impl DepositStateMachine {
         }
 
         vec![MonitorFinding::ExpectedEventMissing {
+            event_id: MonitorEventId::Deposit(self.hashi_deposit_event.deposit_id),
             event_type: MonitorEventType::Deposit(DepositEventType::E1BtcConfirmed),
             relation: EventRelation::Predecessor,
             deadline,
@@ -463,8 +473,7 @@ mod tests {
         MonitorDepositEvent {
             event_type: DepositEventType::E2HashiApproved,
             timestamp_secs: timestamp,
-            btc_txid: txid(fill),
-            btc_vout: 0,
+            deposit_id: DepositId::new(txid(fill), 0),
         }
     }
 
@@ -614,6 +623,7 @@ mod tests {
         assert_eq!(
             violations[0],
             MonitorFinding::ExpectedEventMissing {
+                event_id: MonitorEventId::Withdrawal(WithdrawalID::new([1; 32])),
                 event_type: MonitorEventType::Withdrawal(WithdrawalEventType::E2GuardianApproved),
                 relation: EventRelation::Successor,
                 deadline: 200,
@@ -682,6 +692,7 @@ mod tests {
         assert_eq!(
             violations[0],
             MonitorFinding::ExpectedEventMissing {
+                event_id: MonitorEventId::Deposit(DepositId::new(txid(8), 0)),
                 event_type: MonitorEventType::Deposit(DepositEventType::E1BtcConfirmed),
                 relation: EventRelation::Predecessor,
                 deadline: 110,

--- a/crates/hashi-types/src/guardian/log/messages/withdrawal.rs
+++ b/crates/hashi-types/src/guardian/log/messages/withdrawal.rs
@@ -35,6 +35,9 @@ pub enum WithdrawalLogMessage {
 }
 
 impl WithdrawalLogMessage {
+    /// Prefix shared by all successful withdrawal object names within an hour.
+    pub const SUCCESS_OBJECT_KEY_PREFIX: &'static str = "success-";
+
     /// Success keys lead with `success-{seq:020}` so that lexicographic listing
     /// within an hour bucket is also seq-sorted — the last key is the max-seq
     /// log, which the KP reads to recover limiter state. Failures don't have a
@@ -49,8 +52,10 @@ impl WithdrawalLogMessage {
             S3HourScopedDirectory::new(S3_DIR_WITHDRAW, unix_millis_to_seconds(timestamp_ms));
         match self {
             Self::Success { request_data, .. } => ObjectKeyPattern::Fixed(format!(
-                "{directory}success-{:020}-{session_id}-wid{}.json",
-                request_data.seq, request_data.wid,
+                "{directory}{}{:020}-{session_id}-wid{}.json",
+                Self::SUCCESS_OBJECT_KEY_PREFIX,
+                request_data.seq,
+                request_data.wid,
             )),
             Self::Failure { request_data, .. } => ObjectKeyPattern::RandomSuffix(format!(
                 "{directory}failure-{session_id}-wid{}-",

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -76,7 +76,7 @@ use std::ops::Deref;
 /// `InitConfig` whose digest KPs authenticate during provisioner init.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OperatorInitRequest {
-    s3_config: S3Config,
+    s3_config: ResolvedS3Config,
     init_config: Option<InitConfig>,
     genesis_state: Option<GenesisState>,
 }
@@ -383,8 +383,22 @@ impl fmt::Display for SessionID {
     }
 }
 
+/// S3 configuration as supplied by a config file, before AWS credentials have
+/// been resolved.
+#[derive(Clone, Debug, Deserialize)]
+pub struct UnresolvedS3Config {
+    pub bucket: String,
+    pub region: String,
+    pub access_key: Option<String>,
+    pub secret_key: Option<String>,
+    // TODO: Should this be replaced by, or derived from, a
+    // repository-wide Hashi network identifier?
+    pub retention_environment: S3RetentionEnvironment,
+}
+
+/// Runtime S3 configuration with concrete credentials.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct S3Config {
+pub struct ResolvedS3Config {
     pub access_key: String,
     pub secret_key: String,
     pub session_token: Option<String>,
@@ -402,7 +416,7 @@ pub struct S3BucketInfo {
 //          Helper impl's
 // ---------------------------------
 
-impl S3Config {
+impl ResolvedS3Config {
     pub fn bucket_name(&self) -> &str {
         &self.bucket_info.bucket
     }
@@ -451,7 +465,7 @@ impl SetupNewKeyRequest {
 
 impl OperatorInitRequest {
     /// Build a ceremony-mode request (S3 only).
-    pub fn new_ceremony_mode(s3_config: S3Config) -> Self {
+    pub fn new_ceremony_mode(s3_config: ResolvedS3Config) -> Self {
         Self {
             s3_config,
             init_config: None,
@@ -461,7 +475,7 @@ impl OperatorInitRequest {
 
     /// Build a withdraw-mode request carrying the stable operator config.
     pub fn new_withdraw_mode(
-        s3_config: S3Config,
+        s3_config: ResolvedS3Config,
         init_config: InitConfig,
         genesis_state: Option<GenesisState>,
     ) -> Self {
@@ -472,7 +486,7 @@ impl OperatorInitRequest {
         }
     }
 
-    pub fn s3_config(&self) -> &S3Config {
+    pub fn s3_config(&self) -> &ResolvedS3Config {
         &self.s3_config
     }
 
@@ -498,7 +512,7 @@ impl OperatorInitRequest {
         }
     }
 
-    pub fn into_parts(self) -> (S3Config, Option<InitConfig>, Option<GenesisState>) {
+    pub fn into_parts(self) -> (ResolvedS3Config, Option<InitConfig>, Option<GenesisState>) {
         (self.s3_config, self.init_config, self.genesis_state)
     }
 }

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -182,7 +182,7 @@ impl TryFrom<pb::OperatorInitRequest> for OperatorInitRequest {
 
     fn try_from(req: pb::OperatorInitRequest) -> Result<Self, Self::Error> {
         let s3_config =
-            super::S3Config::try_from(req.s3_config.ok_or_else(|| missing("s3_config"))?)?;
+            super::ResolvedS3Config::try_from(req.s3_config.ok_or_else(|| missing("s3_config"))?)?;
         let genesis_state = req
             .genesis_state
             .map(|state| {
@@ -1108,7 +1108,7 @@ fn share_id_to_pb(id: ShareID) -> pb::GuardianShareId {
     }
 }
 
-impl TryFrom<pb::S3Config> for super::S3Config {
+impl TryFrom<pb::S3Config> for super::ResolvedS3Config {
     type Error = GuardianError;
 
     fn try_from(cfg: pb::S3Config) -> Result<Self, Self::Error> {
@@ -1132,7 +1132,7 @@ impl TryFrom<pb::S3Config> for super::S3Config {
     }
 }
 
-fn s3_config_to_pb(cfg: super::S3Config) -> pb::S3Config {
+fn s3_config_to_pb(cfg: super::ResolvedS3Config) -> pb::S3Config {
     pb::S3Config {
         access_key: Some(cfg.access_key),
         secret_key: Some(cfg.secret_key),

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -25,9 +25,9 @@ use super::PcrAllowlist;
 use super::ProvisionerInitRequest;
 use super::ProvisionerRotateCertRequest;
 use super::ProvisionerRotateCertResponse;
+use super::ResolvedS3Config;
 use super::RotateKpsResponse;
 use super::S3BucketInfo;
-use super::S3Config;
 use super::SecretSharingInstance;
 use super::SessionID;
 use super::SetupNewKeyRequest;
@@ -233,7 +233,7 @@ impl GuardianSignedResponse<ProvisionerRotateCertResponse> {
 
 impl OperatorInitRequest {
     pub fn mock_for_testing() -> Self {
-        let s3_config = super::S3Config {
+        let s3_config = super::ResolvedS3Config {
             access_key: "ak".into(),
             secret_key: "sk".into(),
             session_token: Some("token".into()),
@@ -482,7 +482,7 @@ impl S3BucketInfo {
     }
 }
 
-impl S3Config {
+impl ResolvedS3Config {
     /// Convenience helper for tests.
     pub fn mock_for_testing() -> Self {
         Self {


### PR DESCRIPTION
## Summary

- add checkpoint-bounded Sui v2 `ListEvents` polling with exact timestamp bracketing, resumable cursors, progress logs, retries, and smaller-range fallback
- decode withdrawal approvals and timestamped `DepositApproved` events according to the security policy established in #933
- search a configurable withdrawal-predecessor lookback while auditing deposits over the complete derived Sui range
- align monitor YAML and AWS credential resolution with Guardian Init, and include the active-testnet PCRs, deployment configuration, and runbook
- read only successful Guardian withdrawal records and log progress across the hourly S3 partitions
- support hosted Bitcoin JSON-RPC headers, bounded batching, rate-limit retries, progress logs, and per-pass confirmation caching
- make continuous mode catch up immediately and make batch runs fail if source boundaries are not reached
- use one UTC RFC 3339 format for CLI timestamps and monitor fields, including readable `late_by` durations and explicit diagnostics for unfinished Guardian hourly partitions
- log E1, E2, and E3 timestamps plus signed consecutive-event durations when a withdrawal flow completes
- identify missing withdrawal and deposit events by WID or Bitcoin outpoint, while keeping expected intermediate states out of warning-level logs
- tune the active-testnet predecessor lookback and withdrawal timing bounds from observed traffic

Builds on the security-critical state-machine, finding-classification, deposit-selection, reapproval, and temporary Object Lock bypass behavior merged in #933.

## Validation

- `make fmt`
- `cargo check`
- active-testnet batch audit completed across Sui, Guardian S3, and Bitcoin Signet
- continuous catch-up retained a late Guardian event, reported its liveness finding, confirmed Bitcoin, and completed the withdrawal
- transient Sui deadline retry and range splitting observed live
- seven-day continuous active-testnet catch-up launched on a persistent remote host
