### PR TITLE
test(e2e): deployed bytecode snapshot -> current source upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,8 @@ dependencies = [
  "hashi-guardian",
  "hashi-screener",
  "hashi-types",
+ "move-binary-format",
+ "move-core-types",
  "nix",
  "prometheus",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,8 @@ fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = 
 bin-version = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
 prometheus-closure-metric = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
 sui-futures = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
+move-binary-format = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
+move-core-types = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
 
 # Metrics push
 snap = "1"

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -27,10 +27,9 @@ sui-crypto.workspace = true
 sui-sdk-types.workspace = true
 sui-transaction-builder.workspace = true
 # Needed by src/snapshot.rs to deserialize/rebase/re-serialize the checked-in
-# Move bytecode snapshot before publishing it. Pinned to the same sui rev as the
-# hashi crate's move-binary-format/move-core-types dev-deps.
-move-binary-format = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
-move-core-types = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
+# Move bytecode snapshot before publishing it.
+move-binary-format.workspace = true
+move-core-types.workspace = true
 base64ct.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -26,6 +26,11 @@ sui-rpc.workspace = true
 sui-crypto.workspace = true
 sui-sdk-types.workspace = true
 sui-transaction-builder.workspace = true
+# Needed by src/snapshot.rs to deserialize/rebase/re-serialize the checked-in
+# Move bytecode snapshot before publishing it. Pinned to the same sui rev as the
+# hashi crate's move-binary-format/move-core-types dev-deps.
+move-binary-format = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
+move-core-types = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
 base64ct.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -24,6 +24,7 @@ pub mod e2e_flow;
 pub mod guardian_harness;
 pub mod hashi_network;
 mod publish;
+pub mod snapshot;
 pub mod sui_network;
 pub mod tcp_proxy;
 pub mod test_helpers;
@@ -133,6 +134,12 @@ pub struct TestNetworksBuilder {
     /// When set, publish + point nodes at this external guardian instead of the
     /// in-process harness (and skip its finalize). See [`ExternalGuardian`].
     external_guardian: Option<ExternalGuardian>,
+    /// When set, bootstrap the local net by publishing the deployed **bytecode
+    /// snapshot** in this directory as v1, instead of a fresh source build of
+    /// `packages/hashi`. Enables the "deployed v1 → current source" upgrade
+    /// e2e test. `None` (default) keeps the source-publish behavior. See
+    /// [`crate::snapshot`].
+    v1_snapshot_dir: Option<std::path::PathBuf>,
 }
 
 impl TestNetworksBuilder {
@@ -151,7 +158,25 @@ impl TestNetworksBuilder {
             bitcoin_builder: BitcoinNodeBuilder::new(),
             onchain_config_overrides,
             external_guardian: None,
+            v1_snapshot_dir: None,
         }
+    }
+
+    /// Bootstrap the local net by publishing the deployed **bytecode snapshot**
+    /// as v1 instead of a fresh source build of `packages/hashi`.
+    ///
+    /// The snapshot directory holds the `*.mv` files of the deployed package
+    /// (self-addressed at its runtime id); [`crate::snapshot`] rebases them to
+    /// `0x0` and publishes them through the normal publish path. The rest of
+    /// the bootstrap (genesis, DKG, committee formation) is unchanged, so a
+    /// subsequent [`crate::upgrade_flow::execute_full_upgrade`] exercises a
+    /// real "deployed bytecode → current source" upgrade.
+    ///
+    /// Pass [`crate::snapshot::default_snapshot_dir`] for the checked-in
+    /// testnet v1 snapshot.
+    pub fn with_v1_from_snapshot(mut self, snapshot_dir: impl Into<std::path::PathBuf>) -> Self {
+        self.v1_snapshot_dir = Some(snapshot_dir.into());
+        self
     }
 
     /// Publish + point the nodes at an externally-run guardian (the dockerized
@@ -322,12 +347,18 @@ impl TestNetworksBuilder {
             .unwrap_or(hashi_builder.num_nodes)
             > 0;
 
-        let publish_output = publish(
-            dir.as_ref(),
-            &mut sui_network.client,
-            sui_network.user_keys.first().unwrap(),
-        )
-        .await?;
+        let publisher_key = sui_network.user_keys.first().unwrap();
+        let publish_output = match &self.v1_snapshot_dir {
+            Some(snapshot_dir) => {
+                tracing::info!(
+                    dir = %snapshot_dir.display(),
+                    "bootstrapping v1 from checked-in bytecode snapshot"
+                );
+                snapshot::publish_snapshot(snapshot_dir, &mut sui_network.client, publisher_key)
+                    .await?
+            }
+            None => publish(dir.as_ref(), &mut sui_network.client, publisher_key).await?,
+        };
 
         let hashi_network = hashi_builder
             .build(

--- a/crates/e2e-tests/src/snapshot.rs
+++ b/crates/e2e-tests/src/snapshot.rs
@@ -1,0 +1,197 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Publish a checked-in Move *bytecode snapshot* into a local Sui network.
+//!
+//! Hashi keeps a checked-in bytecode snapshot of the deployed package
+//! (`crates/hashi/tests/move_upgrade_snapshots/<network>/v<version>/`) so the
+//! upgrade-compatibility CI gate can run hermetically. This module reuses that
+//! same snapshot for a *stronger* test: publish the deployed v1 bytecode into a
+//! fresh local net and then upgrade it to the current source, proving the real
+//! "deployed bytecode → current source" upgrade end-to-end (not just the static
+//! compatibility check).
+//!
+//! ## Mechanism
+//!
+//! 1. Read every `*.mv` in the snapshot directory.
+//! 2. Rebase each module's self-address from the package's *runtime* id to
+//!    `0x0`. This is the **inverse** of the compat test's
+//!    `substitute_self_address`: the on-chain `module_map` (and thus the
+//!    snapshot) stores modules self-addressed at the runtime id, while a fresh
+//!    `publish` on Sui assigns a brand-new object id and expects the incoming
+//!    modules to be self-addressed at `0x0` (what a source build of an
+//!    upgradeable package emits).
+//! 3. Re-serialize at each module's *original* binary version (via
+//!    `serialize_with_version`, NOT `serialize()` — the latter forces
+//!    `VERSION_MAX`, which could exceed what the local net accepts).
+//! 4. Build a `Publish { modules, dependencies: [0x1, 0x2, 0x3] }` — the
+//!    framework-only deps present on any local net, per the on-chain linkage
+//!    table.
+//! 5. Publish via the production `hashi::publish::publish_package` path, which
+//!    also extracts the `Hashi` shared object + `UpgradeCap` — a strong signal
+//!    the snapshot published as a real, init-run package.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use hashi::publish::PublishOutput;
+use move_binary_format::CompiledModule;
+use move_core_types::account_address::AccountAddress;
+use sui_crypto::ed25519::Ed25519PrivateKey;
+use sui_rpc::Client;
+use sui_sdk_types::Address;
+
+/// Default snapshot directory, resolved relative to the `e2e-tests` crate:
+/// `../hashi/tests/move_upgrade_snapshots/testnet/v1`. This is the same
+/// snapshot the compat CI gate checks against.
+pub fn default_snapshot_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("hashi")
+        .join("tests")
+        .join("move_upgrade_snapshots")
+        .join("testnet")
+        .join("v1")
+}
+
+/// The self-address a module declares in its bytecode.
+fn module_self_address(module: &CompiledModule) -> Result<AccountAddress> {
+    let idx = module.self_handle().address;
+    module
+        .address_identifiers
+        .get(idx.0 as usize)
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("module has an invalid self-address index"))
+}
+
+/// Rebase a module's self-address from `runtime` to `0x0`.
+///
+/// INVERSE of the compat test's `substitute_self_address` (which rebases
+/// `0x0` → runtime for comparison). Here we go the other way because we are
+/// *publishing* the snapshot as a brand-new package: the adapter assigns a
+/// fresh object id and requires the incoming modules to be `0x0`-addressed.
+fn rebase_runtime_to_zero(module: &mut CompiledModule, runtime: AccountAddress) -> Result<()> {
+    let self_addr_idx = module.self_handle().address;
+    let name = module.identifier_at(module.self_handle().name).to_string();
+
+    let addr = module
+        .address_identifiers
+        .get_mut(self_addr_idx.0 as usize)
+        .ok_or_else(|| anyhow::anyhow!("module `{name}` has an invalid self-address index"))?;
+
+    anyhow::ensure!(
+        *addr == runtime,
+        "module `{name}` self-address is {addr}, expected snapshot runtime id {runtime}"
+    );
+
+    *addr = AccountAddress::ZERO;
+    Ok(())
+}
+
+/// Read the snapshot's runtime package id.
+///
+/// Every snapshot module is self-addressed at the deployed package's
+/// runtime/original id. We derive it from the first module's bytecode
+/// (matching `MovePackage::original_package_id`) rather than trusting the
+/// manifest, then assert every module agrees.
+fn read_runtime_id(modules: &[CompiledModule]) -> Result<AccountAddress> {
+    let runtime = module_self_address(
+        modules
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("snapshot has no modules"))?,
+    )?;
+    anyhow::ensure!(
+        runtime != AccountAddress::ZERO,
+        "snapshot modules unexpectedly carry a 0x0 self-address"
+    );
+    Ok(runtime)
+}
+
+/// Load every `*.mv` in `snapshot_dir`, rebase each module's self-address from
+/// the runtime id to `0x0`, re-serialize at its original binary version, and
+/// return a `Publish` payload with framework-only dependencies (`[0x1, 0x2,
+/// 0x3]`) ready to hand to `hashi::publish::publish_package`.
+pub fn load_snapshot_publish(snapshot_dir: &Path) -> Result<sui_sdk_types::Publish> {
+    anyhow::ensure!(
+        snapshot_dir.is_dir(),
+        "snapshot dir missing: {}",
+        snapshot_dir.display()
+    );
+
+    let mut mv_paths: Vec<PathBuf> = std::fs::read_dir(snapshot_dir)
+        .with_context(|| format!("reading snapshot directory {}", snapshot_dir.display()))?
+        .map(|e| e.map(|e| e.path()).map_err(anyhow::Error::from))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("mv"))
+        .collect();
+    mv_paths.sort();
+    anyhow::ensure!(
+        !mv_paths.is_empty(),
+        "no .mv files in {}",
+        snapshot_dir.display()
+    );
+
+    // Deserialize first so we can derive the runtime id from the bytecode.
+    let mut modules: Vec<CompiledModule> = mv_paths
+        .iter()
+        .map(|path| {
+            let raw = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+            CompiledModule::deserialize_with_defaults(&raw)
+                .map_err(|e| anyhow::anyhow!("deserialize {}: {e:?}", path.display()))
+        })
+        .collect::<Result<_>>()?;
+
+    let runtime = read_runtime_id(&modules)?;
+
+    let mut serialized = Vec::with_capacity(modules.len());
+    for module in &mut modules {
+        rebase_runtime_to_zero(module, runtime)?;
+
+        // Preserve the binary version the snapshot was serialized at (do NOT
+        // bump to VERSION_MAX — that could exceed what the local net accepts).
+        let version = module.version;
+        let mut bytes = Vec::new();
+        module
+            .serialize_with_version(version, &mut bytes)
+            .map_err(|e| anyhow::anyhow!("re-serialize module: {e:?}"))?;
+        serialized.push(bytes);
+    }
+
+    // Dependencies = the sui framework, per the on-chain linkage table. These
+    // three are present on any local net.
+    let dependencies: Vec<Address> = vec![
+        Address::from_static("0x1"),
+        Address::from_static("0x2"),
+        Address::from_static("0x3"),
+    ];
+
+    Ok(sui_sdk_types::Publish {
+        modules: serialized,
+        dependencies,
+    })
+}
+
+/// Publish the bytecode snapshot at `snapshot_dir` as a fresh package, driven
+/// by `private_key`. Mirrors [`crate::publish`] but sources the modules from a
+/// checked-in bytecode snapshot instead of a source build.
+///
+/// Like the source-build path, the `UpgradeCap` is transferred to the sender
+/// and left there until `hashi::finish_publish` (the launch switch) hands it
+/// into on-chain custody — so the returned [`PublishOutput`] slots directly
+/// into the normal genesis/launch sequencing.
+pub async fn publish_snapshot(
+    snapshot_dir: &Path,
+    client: &mut Client,
+    private_key: &Ed25519PrivateKey,
+) -> Result<PublishOutput> {
+    let publish = load_snapshot_publish(snapshot_dir)?;
+    tracing::info!(
+        modules = publish.modules.len(),
+        dir = %snapshot_dir.display(),
+        "publishing bytecode snapshot (runtime -> 0x0 rebased)"
+    );
+    hashi::publish::publish_package(client, &private_key.clone().into(), publish).await
+}

--- a/crates/e2e-tests/src/snapshot.rs
+++ b/crates/e2e-tests/src/snapshot.rs
@@ -43,17 +43,32 @@ use sui_crypto::ed25519::Ed25519PrivateKey;
 use sui_rpc::Client;
 use sui_sdk_types::Address;
 
-/// Default snapshot directory, resolved relative to the `e2e-tests` crate:
-/// `../hashi/tests/move_upgrade_snapshots/testnet/v1`. This is the same
-/// snapshot the compat CI gate checks against.
-pub fn default_snapshot_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+/// Default snapshot directory: the deployed `testnet` package's snapshot,
+/// `../hashi/tests/move_upgrade_snapshots/testnet/v<version>`, with the
+/// version taken from `packages/hashi/Published.toml` — the same source of
+/// truth the compat CI gate derives its snapshot locations from. A deployment
+/// bumps `Published.toml`, so this test follows it to the new snapshot
+/// instead of silently exercising stale bytecode.
+pub fn default_snapshot_dir() -> Result<PathBuf> {
+    let crates_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+    let published = crates_dir
         .join("..")
+        .join("packages")
+        .join("hashi")
+        .join("Published.toml");
+    let entries = hashi::published::published_entries(&published)?;
+    let entry = entries.get("testnet").ok_or_else(|| {
+        anyhow::anyhow!(
+            "no `testnet` entry in {} — the snapshot tests exercise the testnet deployment",
+            published.display()
+        )
+    })?;
+    Ok(crates_dir
         .join("hashi")
         .join("tests")
         .join("move_upgrade_snapshots")
         .join("testnet")
-        .join("v1")
+        .join(format!("v{}", entry.version)))
 }
 
 /// The self-address a module declares in its bytecode.

--- a/crates/e2e-tests/src/snapshot.rs
+++ b/crates/e2e-tests/src/snapshot.rs
@@ -110,7 +110,7 @@ fn rebase_runtime_to_zero(module: &mut CompiledModule, runtime: AccountAddress) 
 /// Every snapshot module is self-addressed at the deployed package's
 /// runtime/original id. We derive it from the first module's bytecode
 /// (matching `MovePackage::original_package_id`) rather than trusting the
-/// manifest, then assert every module agrees.
+/// manifest, and assert every module agrees.
 fn read_runtime_id(modules: &[CompiledModule]) -> Result<AccountAddress> {
     let runtime = module_self_address(
         modules
@@ -121,6 +121,14 @@ fn read_runtime_id(modules: &[CompiledModule]) -> Result<AccountAddress> {
         runtime != AccountAddress::ZERO,
         "snapshot modules unexpectedly carry a 0x0 self-address"
     );
+    for module in modules {
+        let addr = module_self_address(module)?;
+        anyhow::ensure!(
+            addr == runtime,
+            "module `{}` self-address is {addr}, expected snapshot runtime id {runtime}",
+            module.identifier_at(module.self_handle().name),
+        );
+    }
     Ok(runtime)
 }
 

--- a/crates/e2e-tests/src/snapshot.rs
+++ b/crates/e2e-tests/src/snapshot.rs
@@ -175,7 +175,7 @@ pub fn load_snapshot_publish(snapshot_dir: &Path) -> Result<sui_sdk_types::Publi
 }
 
 /// Publish the bytecode snapshot at `snapshot_dir` as a fresh package, driven
-/// by `private_key`. Mirrors [`crate::publish`] but sources the modules from a
+/// by `private_key`. Mirrors the `publish` module but sources the modules from a
 /// checked-in bytecode snapshot instead of a source build.
 ///
 /// Like the source-build path, the `UpgradeCap` is transferred to the sender

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -9,6 +9,7 @@
 //! - Package ID routing updates correctly in OnchainState
 
 use anyhow::Result;
+use e2e_tests::TestNetworks;
 use e2e_tests::TestNetworksBuilder;
 use e2e_tests::snapshot;
 use e2e_tests::test_helpers::create_deposit_and_wait;
@@ -23,6 +24,43 @@ use sui_transaction_builder::Function;
 use sui_transaction_builder::ObjectInput;
 use sui_transaction_builder::TransactionBuilder;
 use tracing::info;
+
+/// Poll until every node's watcher reports `package_id` as the active
+/// package — the PackageUpgraded handler in watcher.rs must update
+/// OnchainState's package_versions map on all nodes. Prints per-node
+/// diagnostics before failing on timeout.
+async fn wait_for_package_convergence(
+    networks: &TestNetworks,
+    package_id: Address,
+    max_wait: Duration,
+) -> Result<()> {
+    info!("waiting for all nodes to detect the new package version...");
+    let wait_start = std::time::Instant::now();
+    loop {
+        let all_updated = networks
+            .hashi_network
+            .nodes()
+            .iter()
+            .all(|node| node.hashi().onchain_state().package_id() == Some(package_id));
+        if all_updated {
+            return Ok(());
+        }
+        if wait_start.elapsed() > max_wait {
+            for (i, node) in networks.hashi_network.nodes().iter().enumerate() {
+                let latest = node.hashi().onchain_state().package_id();
+                let versions = node
+                    .hashi()
+                    .onchain_state()
+                    .state()
+                    .package_versions()
+                    .clone();
+                info!("node {i}: package_id={latest:?}, versions={versions:?}");
+            }
+            anyhow::bail!("timeout: not all nodes detected the new package version");
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
 
 /// Test the full upgrade lifecycle, exercising real cascading effects.
 ///
@@ -59,38 +97,7 @@ async fn test_upgrade_v1_to_v2() -> Result<()> {
     assert_ne!(new_package_id, hashi_ids.package_id);
 
     // ── Cascading effect 1: Watcher picks up new package ────────────────
-    //
-    // The PackageUpgraded handler in watcher.rs should update
-    // OnchainState's package_versions map. Poll until all nodes see the
-    // new package — this proves the watcher correctly processes the event.
-    info!("waiting for all nodes to detect the new package version...");
-    let wait_start = std::time::Instant::now();
-    let max_wait = Duration::from_secs(30);
-    loop {
-        let all_updated = networks
-            .hashi_network
-            .nodes()
-            .iter()
-            .all(|node| node.hashi().onchain_state().package_id() == Some(new_package_id));
-        if all_updated {
-            break;
-        }
-        if wait_start.elapsed() > max_wait {
-            // Print diagnostic info before failing
-            for (i, node) in networks.hashi_network.nodes().iter().enumerate() {
-                let latest = node.hashi().onchain_state().package_id();
-                let versions = node
-                    .hashi()
-                    .onchain_state()
-                    .state()
-                    .package_versions()
-                    .clone();
-                info!("node {i}: package_id={latest:?}, versions={versions:?}");
-            }
-            anyhow::bail!("timeout: not all nodes detected the new package version");
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
+    wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30)).await?;
 
     // ── Cascading effect 2: Package ID routing ──────────────────────────
     //
@@ -269,27 +276,7 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
     );
 
     // ── All nodes' watchers must pick up the new package version ─────────
-    info!("waiting for all nodes to detect the new package version...");
-    let wait_start = std::time::Instant::now();
-    let max_wait = Duration::from_secs(30);
-    loop {
-        let all_updated = networks
-            .hashi_network
-            .nodes()
-            .iter()
-            .all(|node| node.hashi().onchain_state().package_id() == Some(new_package_id));
-        if all_updated {
-            break;
-        }
-        if wait_start.elapsed() > max_wait {
-            for (i, node) in networks.hashi_network.nodes().iter().enumerate() {
-                let latest = node.hashi().onchain_state().package_id();
-                info!("node {i}: package_id={latest:?}");
-            }
-            anyhow::bail!("timeout: not all nodes detected the new package version");
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
+    wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30)).await?;
 
     // ── v2-only canary module must be callable post-upgrade ─────────────
     //

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -10,6 +10,7 @@
 
 use anyhow::Result;
 use e2e_tests::TestNetworksBuilder;
+use e2e_tests::snapshot;
 use e2e_tests::test_helpers::create_deposit_and_wait;
 use e2e_tests::test_helpers::get_hbtc_balance;
 use e2e_tests::test_helpers::init_test_logging;
@@ -219,5 +220,104 @@ async fn test_upgrade_v1_to_v2() -> Result<()> {
     info!("v1 entry point correctly rejected");
 
     info!("=== UPGRADE TEST PASSED ===");
+    Ok(())
+}
+
+/// The real "deployed bytecode → current source" upgrade test.
+///
+/// Bootstraps the local net by publishing the checked-in **bytecode snapshot**
+/// of the deployed testnet package as v1 (via
+/// [`TestNetworksBuilder::with_v1_from_snapshot`]), then runs the ordinary
+/// governance-gated upgrade flow ([`upgrade_flow::execute_full_upgrade`]) to
+/// upgrade it to the current `packages/hashi` source. This proves — end to
+/// end, against a running Sui net — that the deployed bytecode can actually be
+/// upgraded to what's in the tree today, a strictly stronger claim than the
+/// static compatibility gate (which only normalizes-and-diffs the modules).
+///
+/// Asserts:
+/// - v1 publishes from the snapshot and forms a committee (DKG completes).
+/// - the governance upgrade to current source succeeds (effects success).
+/// - the new package id differs from v1's.
+/// - all nodes' watchers pick up the new package version.
+/// - a v2-only module (`upgrade_canary::version`) is callable post-upgrade.
+#[tokio::test]
+async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
+    init_test_logging();
+
+    // v1 = the checked-in deployed bytecode snapshot, NOT a source build.
+    let mut networks = TestNetworksBuilder::new()
+        .with_nodes(4)
+        .with_v1_from_snapshot(snapshot::default_snapshot_dir())
+        .build()
+        .await?;
+
+    let hashi_ids = networks.hashi_network.ids();
+    info!("snapshot-published v1 package ID: {}", hashi_ids.package_id);
+
+    // Committee must be formed (DKG done) before the upgrade proposal can be
+    // voted through at the required 100% quorum.
+    networks.hashi_network.nodes()[0]
+        .wait_for_mpc_key(Duration::from_secs(120))
+        .await?;
+
+    // ── Upgrade the deployed bytecode to the current source ─────────────
+    let new_package_id = upgrade_flow::execute_full_upgrade(&mut networks).await?;
+    info!("upgraded snapshot v1 -> current source: new package {new_package_id}");
+    assert_ne!(
+        new_package_id, hashi_ids.package_id,
+        "upgrade should mint a new package id"
+    );
+
+    // ── All nodes' watchers must pick up the new package version ─────────
+    info!("waiting for all nodes to detect the new package version...");
+    let wait_start = std::time::Instant::now();
+    let max_wait = Duration::from_secs(30);
+    loop {
+        let all_updated = networks
+            .hashi_network
+            .nodes()
+            .iter()
+            .all(|node| node.hashi().onchain_state().package_id() == Some(new_package_id));
+        if all_updated {
+            break;
+        }
+        if wait_start.elapsed() > max_wait {
+            for (i, node) in networks.hashi_network.nodes().iter().enumerate() {
+                let latest = node.hashi().onchain_state().package_id();
+                info!("node {i}: package_id={latest:?}");
+            }
+            anyhow::bail!("timeout: not all nodes detected the new package version");
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // ── v2-only canary module must be callable post-upgrade ─────────────
+    //
+    // `execute_full_upgrade` adds an `upgrade_canary` module to the patched
+    // source; being callable proves the new code (not just a new object id)
+    // is live on the upgraded package.
+    info!("calling v2-only upgrade_canary::version()...");
+    let user_key = networks.sui_network.user_keys.first().unwrap();
+    let hashi = networks.hashi_network.nodes()[0].hashi().clone();
+    let mut executor = SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())?
+        .with_signer(user_key.clone().into());
+
+    let mut builder = TransactionBuilder::new();
+    builder.move_call(
+        Function::new(
+            new_package_id,
+            Identifier::from_static("upgrade_canary"),
+            Identifier::from_static("version"),
+        ),
+        vec![],
+    );
+    let canary_resp = executor.execute(builder).await?;
+    assert!(
+        canary_resp.transaction().effects().status().success(),
+        "v2-only canary module should be callable after upgrading the deployed bytecode"
+    );
+    info!("v2 canary module call succeeded");
+
+    info!("=== SNAPSHOT UPGRADE TEST PASSED ===");
     Ok(())
 }

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -247,7 +247,7 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
     // v1 = the checked-in deployed bytecode snapshot, NOT a source build.
     let mut networks = TestNetworksBuilder::new()
         .with_nodes(4)
-        .with_v1_from_snapshot(snapshot::default_snapshot_dir())
+        .with_v1_from_snapshot(snapshot::default_snapshot_dir()?)
         .build()
         .await?;
 

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -243,9 +243,13 @@ async fn test_upgrade_v1_to_v2() -> Result<()> {
 ///
 /// Asserts:
 /// - v1 publishes from the snapshot and forms a committee (DKG completes).
+/// - a deposit confirms against the snapshot bytecode, establishing real
+///   v1-initialized on-chain state before the upgrade.
 /// - the governance upgrade to current source succeeds (effects success).
 /// - the new package id differs from v1's.
 /// - all nodes' watchers pick up the new package version.
+/// - a post-upgrade deposit confirms through the full validator path, on top
+///   of the state the snapshot bytecode initialized.
 /// - a v2-only module (`upgrade_canary::version`) is callable post-upgrade.
 #[tokio::test]
 async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
@@ -267,6 +271,23 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
         .wait_for_mpc_key(Duration::from_secs(120))
         .await?;
 
+    // ── Pre-upgrade: deposit against the snapshot bytecode ──────────────
+    //
+    // Establishes real on-chain state *initialized by the deployed v1
+    // bytecode* (UTXO pool entries, deposit records, hBTC supply), so the
+    // post-upgrade assertions below exercise the upgraded package against
+    // v1-created state — not a fresh object graph.
+    info!("depositing 100k sats against the snapshot bytecode...");
+    let hbtc_recipient = create_deposit_and_wait(&mut networks, 100_000).await?;
+    let balance_before = get_hbtc_balance(
+        &mut networks.sui_network.client,
+        hashi_ids.package_id,
+        hbtc_recipient,
+    )
+    .await?;
+    assert_eq!(balance_before, 100_000);
+    info!("pre-upgrade balance: {balance_before} sats");
+
     // ── Upgrade the deployed bytecode to the current source ─────────────
     let new_package_id = upgrade_flow::execute_full_upgrade(&mut networks).await?;
     info!("upgraded snapshot v1 -> current source: new package {new_package_id}");
@@ -277,6 +298,25 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
 
     // ── All nodes' watchers must pick up the new package version ─────────
     wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30)).await?;
+
+    // ── Post-upgrade: deposit on top of v1-initialized state ────────────
+    //
+    // The full validator confirmation path (observe DepositRequested, build
+    // the BLS certificate, approve, time-delay, confirm) must work against
+    // the upgraded package operating on state the snapshot bytecode created.
+    info!("depositing 50k sats post-upgrade (full validator confirmation path)...");
+    create_deposit_and_wait(&mut networks, 50_000).await?;
+    let balance_after = get_hbtc_balance(
+        &mut networks.sui_network.client,
+        hashi_ids.package_id,
+        hbtc_recipient,
+    )
+    .await?;
+    assert_eq!(
+        balance_after, 150_000,
+        "post-upgrade deposit should confirm on top of snapshot-initialized state"
+    );
+    info!("post-upgrade deposit confirmed, balance: {balance_after} sats");
 
     // ── v2-only canary module must be callable post-upgrade ─────────────
     //

--- a/crates/hashi/Cargo.toml
+++ b/crates/hashi/Cargo.toml
@@ -93,5 +93,5 @@ tracing-test = "0.2"
 http-body = "1"
 # Paused-clock tests (`start_paused`) for deadline/cooldown behavior.
 tokio = { workspace = true, features = ["test-util"] }
-move-binary-format = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
-move-core-types = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }
+move-binary-format.workspace = true
+move-core-types.workspace = true

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -30,6 +30,7 @@ pub mod metrics_push;
 pub mod mpc;
 pub mod onchain;
 pub mod publish;
+pub mod published;
 pub mod storage;
 pub mod sui_rpc_client;
 pub mod sui_tx_executor;

--- a/crates/hashi/src/published.rs
+++ b/crates/hashi/src/published.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parse `packages/hashi/Published.toml` — the Move tooling's record of
+//! where (and at what version) the package is deployed per network.
+//!
+//! This file is the source of truth both the upgrade-compatibility CI gate
+//! (`crates/hashi/tests/move_upgrade_compat.rs`) and the e2e bytecode-snapshot
+//! tests (`crates/e2e-tests/src/snapshot.rs`) derive their snapshot locations
+//! from, so a version bump there without a matching snapshot capture fails
+//! those checks instead of silently exercising an obsolete package.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::Context;
+use anyhow::Result;
+
+/// One `[published.<network>]` entry of `Published.toml`.
+#[derive(serde_derive::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct PublishedEntry {
+    /// Storage id of the deployed package object (the id a snapshot capture
+    /// is fetched from).
+    pub published_at: String,
+    /// Runtime/original id the deployed modules are self-addressed at.
+    pub original_id: String,
+    /// Deployed package version (`v<version>` names the snapshot directory).
+    pub version: u64,
+}
+
+#[derive(serde_derive::Deserialize)]
+struct PublishedFile {
+    published: BTreeMap<String, PublishedEntry>,
+}
+
+/// Parse the `Published.toml` at `path` into its per-network entries.
+/// Fails on a missing/unparsable file or one declaring no environments.
+pub fn published_entries(path: &Path) -> Result<BTreeMap<String, PublishedEntry>> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let parsed: PublishedFile =
+        toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
+    anyhow::ensure!(
+        !parsed.published.is_empty(),
+        "{} declares no published environments",
+        path.display()
+    );
+    Ok(parsed.published)
+}

--- a/crates/hashi/tests/move_upgrade_compat.rs
+++ b/crates/hashi/tests/move_upgrade_compat.rs
@@ -66,6 +66,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::Result;
+use hashi::published::PublishedEntry;
 use move_binary_format::CompiledModule;
 use move_binary_format::compatibility::Compatibility;
 use move_binary_format::normalized;
@@ -290,37 +291,12 @@ fn write_throwaway_client_config() -> Result<(tempfile::TempDir, PathBuf)> {
     Ok((dir, client_yaml))
 }
 
-/// One `[published.<network>]` entry of `packages/hashi/Published.toml` —
-/// the Move tooling's record of where (and at what version) the package is
-/// deployed. This is the source of truth the gate derives its snapshot
-/// locations from, so bumping the version there without capturing a matching
-/// snapshot fails the gate instead of silently checking an obsolete package.
-#[derive(serde_derive::Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct PublishedEntry {
-    published_at: String,
-    original_id: String,
-    version: u64,
-}
-
-#[derive(serde_derive::Deserialize)]
-struct PublishedFile {
-    published: std::collections::BTreeMap<String, PublishedEntry>,
-}
-
-/// Parse `packages/hashi/Published.toml` into its per-network entries.
+/// Parse `packages/hashi/Published.toml` into its per-network entries. This
+/// is the source of truth the gate derives its snapshot locations from, so
+/// bumping the version there without capturing a matching snapshot fails the
+/// gate instead of silently checking an obsolete package.
 fn published_entries() -> Result<std::collections::BTreeMap<String, PublishedEntry>> {
-    let path = workspace_package_path().join("Published.toml");
-    let text =
-        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-    let parsed: PublishedFile =
-        toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
-    anyhow::ensure!(
-        !parsed.published.is_empty(),
-        "{} declares no published environments — the gate has nothing to check against",
-        path.display()
-    );
-    Ok(parsed.published)
+    hashi::published::published_entries(&workspace_package_path().join("Published.toml"))
 }
 
 /// Root of the checked-in snapshots: `tests/move_upgrade_snapshots/`.


### PR DESCRIPTION
## What this adds

An e2e-test harness seam that publishes the **checked-in Move bytecode snapshot** of the deployed testnet package into a local Sui net as v1, then upgrades it to the current `packages/hashi` source through the ordinary governance flow. This is the real "deployed bytecode → current source upgrade works end-to-end" test.

It's a strictly stronger claim than the static compatibility gate on the base branch: that gate only normalizes-and-diffs the modules; this actually publishes the deployed bytecode and swaps in the current source against a running validator.

### Stacked on #913

Base branch is `move-compat-ci-gate` (#913). This PR reuses the same checked-in snapshot that #913's compat gate introduced (`crates/hashi/tests/move_upgrade_snapshots/testnet/v1/`). Review/merge #913 first.

## Changes

- **`crates/e2e-tests/src/snapshot.rs`** (new): reusable snapshot module.
  - `load_snapshot_publish(dir) -> Publish`: read every `*.mv`, derive the runtime id from the bytecode, rebase each module self-address `runtime -> 0x0`, re-serialize at each module's original binary version, deps `[0x1,0x2,0x3]`.
  - `publish_snapshot(dir, client, key) -> PublishOutput`: mirrors `publish.rs`, calls `hashi::publish::publish_package`.
  - `default_snapshot_dir()`: the checked-in testnet v1 snapshot.
- **`crates/e2e-tests/src/lib.rs`**: `TestNetworksBuilder::with_v1_from_snapshot(dir)` seam. When set, `build()` publishes v1 from the snapshot instead of a source build; everything else (genesis, DKG, committee, launch) is unchanged. Default behavior (source publish) is unchanged when the seam isn't used.
- **`crates/e2e-tests/tests/upgrade_tests.rs`**: new `snapshot_v1_upgrades_to_current_source` test — stands up a 4-node net with v1-from-snapshot, waits for DKG, runs `execute_full_upgrade` to the current source, asserts effects success, new package id, all nodes' watchers pick up the new version, and the v2-only `upgrade_canary::version()` is callable.
- **`crates/e2e-tests/Cargo.toml`**: add `move-binary-format` / `move-core-types` (pinned to the same sui rev `77a42de4…` as the hashi crate's dev-deps), needed to deserialize/rebase/re-serialize the snapshot.

## Mechanism (folded from a proven PoC)

The on-chain `module_map` (and thus the snapshot) stores modules self-addressed at the package's runtime id. A fresh `publish` on Sui assigns a brand-new object id and expects incoming modules to be `0x0`-addressed (what a source build of an upgradeable package emits) — so we rebase `runtime -> 0x0` (the inverse of the compat test's `substitute_self_address`). Re-serialization uses `serialize_with_version(module.version, ..)` to preserve the original binary version (not `serialize()`, which forces `VERSION_MAX`). The upgrade to v2 goes through the existing governance flow, whose digest is computed by `sui move build`, so no manual upgrade-digest is needed.

## Verify (local + hermetic; needs only the `sui` CLI)

- `cargo build -p e2e-tests` / `cargo test -p e2e-tests --no-run`: clean.
- `cargo fmt --check`: clean.
- `snapshot_v1_upgrades_to_current_source`: **PASSED** (47.6s). Real run:
  - v1 published from snapshot: `0x96e59206…73bf61bf` (fresh id, not the testnet runtime id)
  - DKG / committee formed, 4/4 nodes voted the upgrade proposal
  - upgrade execute+publish+finalize: effects success → new package `0xfdd64032…bef2d8cf`
  - all 4 nodes' watchers logged "package upgraded; version map extended … version=2"
  - v2-only `upgrade_canary::version()` call: effects success
- Regression: the pre-existing `test_upgrade_v1_to_v2` (source-publish path) still **PASSED** (67.2s), confirming the default behavior is unchanged.
