### PR TITLE
test(e2e): sign a withdrawal end-to-end against the deployed v1 bytecode snapshot

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -29,12 +29,14 @@ mod tests {
 
     use crate::test_helpers::BackgroundMiner;
     use crate::test_helpers::create_deposit_and_wait;
+    use crate::test_helpers::extract_witness_program;
     use crate::test_helpers::get_hbtc_balance;
     use crate::test_helpers::init_test_logging;
     use crate::test_helpers::lookup_vout;
     use crate::test_helpers::txid_to_address;
     use crate::test_helpers::wait_for_deposit_confirmation;
     use crate::test_helpers::wait_for_spent_utxo_cleanup;
+    use crate::test_helpers::wait_for_withdrawal_confirmation;
 
     const MAX_TX_SIZE_BYTES: usize = 131_072;
     const MAX_SERIALIZED_TX_EFFECTS_SIZE_BYTES: usize = 524_288;
@@ -238,87 +240,6 @@ mod tests {
             deposit_request.approval_cert.is_none(),
             "brand-new deposit should not be approved by epoch-change stale-cert processing"
         );
-    }
-
-    async fn wait_for_withdrawal_confirmation(
-        sui_client: &mut sui_rpc::Client,
-        timeout: Duration,
-    ) -> Result<WithdrawalConfirmed> {
-        info!("Waiting for withdrawal confirmation...");
-
-        let start = std::time::Instant::now();
-        let subscription_read_mask = FieldMask::from_paths([Checkpoint::path_builder()
-            .transactions()
-            .events()
-            .events()
-            .contents()
-            .finish()]);
-        let mut subscription = sui_client
-            .subscription_client()
-            .subscribe_checkpoints(
-                SubscribeCheckpointsRequest::default().with_read_mask(subscription_read_mask),
-            )
-            .await?
-            .into_inner();
-
-        while let Some(item) = subscription.next().await {
-            if start.elapsed() > timeout {
-                return Err(anyhow!(
-                    "Timeout waiting for withdrawal confirmation after {:?}",
-                    timeout
-                ));
-            }
-
-            let checkpoint = match item {
-                Ok(checkpoint) => checkpoint,
-                Err(e) => {
-                    debug!("Error in checkpoint stream: {}", e);
-                    continue;
-                }
-            };
-
-            debug!(
-                "Received checkpoint {}, checking for WithdrawalConfirmed...",
-                checkpoint.cursor()
-            );
-
-            for txn in checkpoint.checkpoint().transactions() {
-                for event in txn.events().events() {
-                    let event_type = event.contents().name();
-
-                    if event_type.contains("WithdrawalConfirmed") {
-                        match WithdrawalConfirmed::from_bcs(event.contents().value()) {
-                            Ok(event_data) => {
-                                info!(
-                                    withdrawal_txn_id = %event_data.withdrawal_txn_id,
-                                    txid = %event_data.txid,
-                                    "Withdrawal confirmed!"
-                                );
-                                return Ok(event_data);
-                            }
-                            Err(e) => {
-                                debug!("Failed to parse WithdrawalConfirmed: {}", e);
-                            }
-                        }
-                    }
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-
-        Err(anyhow!("Checkpoint subscription ended unexpectedly"))
-    }
-
-    fn extract_witness_program(address: &BitcoinAddress) -> Result<Vec<u8>> {
-        let script = address.script_pubkey();
-        let bytes = script.as_bytes();
-        match bytes {
-            [0x00, 0x14, rest @ ..] if rest.len() == 20 => Ok(rest.to_vec()),
-            [0x51, 0x20, rest @ ..] if rest.len() == 32 => Ok(rest.to_vec()),
-            _ => Err(anyhow!(
-                "Unsupported script pubkey for withdrawal: {script}"
-            )),
-        }
     }
 
     /// Wait for a withdrawal transaction to be confirmed on the Bitcoin chain.

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -33,10 +33,10 @@ mod tests {
     use crate::test_helpers::get_hbtc_balance;
     use crate::test_helpers::init_test_logging;
     use crate::test_helpers::lookup_vout;
+    use crate::test_helpers::subscribe_withdrawal_confirmations;
     use crate::test_helpers::txid_to_address;
     use crate::test_helpers::wait_for_deposit_confirmation;
     use crate::test_helpers::wait_for_spent_utxo_cleanup;
-    use crate::test_helpers::wait_for_withdrawal_confirmation;
 
     const MAX_TX_SIZE_BYTES: usize = 131_072;
     const MAX_SERIALIZED_TX_EFFECTS_SIZE_BYTES: usize = 524_288;
@@ -516,6 +516,9 @@ mod tests {
             withdrawal_amount_sats, btc_destination
         );
 
+        let confirmations =
+            subscribe_withdrawal_confirmations(&mut networks.sui_network.client).await?;
+
         let mut withdrawal_executor =
             SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())?
                 .with_signer(user_key.clone().into());
@@ -526,11 +529,9 @@ mod tests {
 
         let miner = BackgroundMiner::start(&networks.bitcoin_node);
 
-        let confirmed_event = wait_for_withdrawal_confirmation(
-            &mut networks.sui_network.client,
-            Duration::from_secs(60),
-        )
-        .await?;
+        let confirmed_event = confirmations
+            .wait_for(withdrawal_request_id, Duration::from_secs(60))
+            .await?;
         info!("Withdrawal confirmed on Sui");
 
         drop(miner);
@@ -615,19 +616,19 @@ mod tests {
     ) -> Result<()> {
         let btc_destination = networks.bitcoin_node.get_new_address()?;
         let destination_bytes = extract_witness_program(&btc_destination)?;
+        let confirmations =
+            subscribe_withdrawal_confirmations(&mut networks.sui_network.client).await?;
         let mut executor = SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())?
             .with_signer(signer.into());
-        executor
+        let withdrawal_request_id = executor
             .execute_create_withdrawal_request(withdrawal_amount_sats, destination_bytes)
             .await?;
 
         let miner = BackgroundMiner::start(&networks.bitcoin_node);
 
-        let confirmed = wait_for_withdrawal_confirmation(
-            &mut networks.sui_network.client,
-            Duration::from_secs(60),
-        )
-        .await?;
+        let confirmed = confirmations
+            .wait_for(withdrawal_request_id, Duration::from_secs(60))
+            .await?;
 
         drop(miner);
 
@@ -1071,10 +1072,13 @@ mod tests {
             .current_epoch()
             .ok_or_else(|| anyhow!("no current Hashi epoch"))?;
 
+        let confirmations =
+            subscribe_withdrawal_confirmations(&mut networks.sui_network.client).await?;
+
         let mut withdrawal_executor =
             SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())?
                 .with_signer(user_key.clone().into());
-        withdrawal_executor
+        let withdrawal_request_id = withdrawal_executor
             .execute_create_withdrawal_request(withdrawal_amount_sats, destination_bytes)
             .await?;
 
@@ -1098,11 +1102,9 @@ mod tests {
         }
 
         let miner = BackgroundMiner::start(&networks.bitcoin_node);
-        wait_for_withdrawal_confirmation(
-            &mut networks.sui_network.client,
-            Duration::from_secs(180),
-        )
-        .await?;
+        confirmations
+            .wait_for(withdrawal_request_id, Duration::from_secs(180))
+            .await?;
         drop(miner);
 
         Ok(())

--- a/crates/e2e-tests/src/test_helpers.rs
+++ b/crates/e2e-tests/src/test_helpers.rs
@@ -16,6 +16,7 @@ use futures::StreamExt;
 use hashi::sui_tx_executor::SuiTxExecutor;
 use hashi_types::bitcoin::BitcoinAddress;
 use hashi_types::move_types::DepositConfirmed;
+use hashi_types::move_types::WithdrawalConfirmed;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -196,6 +197,133 @@ pub async fn create_deposit_and_wait(
     info!("Deposit confirmed on Sui");
 
     Ok(hbtc_recipient)
+}
+
+/// Extract the witness program (the bytes after the segwit version +
+/// push-length prefix) from a P2WPKH (`0x00 0x14 …20`) or P2TR
+/// (`0x51 0x20 …32`) address. This is the destination form the withdrawal
+/// entry function expects.
+pub fn extract_witness_program(address: &BitcoinAddress) -> Result<Vec<u8>> {
+    let script = address.script_pubkey();
+    let bytes = script.as_bytes();
+    match bytes {
+        [0x00, 0x14, rest @ ..] if rest.len() == 20 => Ok(rest.to_vec()),
+        [0x51, 0x20, rest @ ..] if rest.len() == 32 => Ok(rest.to_vec()),
+        _ => Err(anyhow!(
+            "Unsupported script pubkey for withdrawal: {script}"
+        )),
+    }
+}
+
+/// Subscribe to checkpoints and return the first `WithdrawalConfirmed` event,
+/// or error on timeout. Confirmation is the terminal on-chain milestone of a
+/// withdrawal: it fires only after the committee has generated presignatures,
+/// threshold-signed the BTC transaction, the guardian co-signed, and the leader
+/// observed the mined tx — so waiting on it exercises the whole signing path.
+pub async fn wait_for_withdrawal_confirmation(
+    sui_client: &mut sui_rpc::Client,
+    timeout: Duration,
+) -> Result<WithdrawalConfirmed> {
+    info!("Waiting for withdrawal confirmation...");
+
+    let start = std::time::Instant::now();
+    let subscription_read_mask = FieldMask::from_paths([Checkpoint::path_builder()
+        .transactions()
+        .events()
+        .events()
+        .contents()
+        .finish()]);
+    let mut subscription = sui_client
+        .subscription_client()
+        .subscribe_checkpoints(
+            SubscribeCheckpointsRequest::default().with_read_mask(subscription_read_mask),
+        )
+        .await?
+        .into_inner();
+
+    while let Some(item) = subscription.next().await {
+        if start.elapsed() > timeout {
+            return Err(anyhow!(
+                "Timeout waiting for withdrawal confirmation after {:?}",
+                timeout
+            ));
+        }
+
+        let checkpoint = match item {
+            Ok(checkpoint) => checkpoint,
+            Err(e) => {
+                debug!("Error in checkpoint stream: {}", e);
+                continue;
+            }
+        };
+
+        debug!(
+            "Received checkpoint {}, checking for WithdrawalConfirmed...",
+            checkpoint.cursor()
+        );
+
+        for txn in checkpoint.checkpoint().transactions() {
+            for event in txn.events().events() {
+                let event_type = event.contents().name();
+
+                if event_type.contains("WithdrawalConfirmed") {
+                    match WithdrawalConfirmed::from_bcs(event.contents().value()) {
+                        Ok(event_data) => {
+                            info!(
+                                withdrawal_txn_id = %event_data.withdrawal_txn_id,
+                                txid = %event_data.txid,
+                                "Withdrawal confirmed!"
+                            );
+                            return Ok(event_data);
+                        }
+                        Err(e) => {
+                            debug!("Failed to parse WithdrawalConfirmed: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(anyhow!("Checkpoint subscription ended unexpectedly"))
+}
+
+/// Request a withdrawal of `amount_sats` to a fresh regtest address and wait
+/// for it to be confirmed on Sui, returning the `WithdrawalConfirmed` event.
+///
+/// Mirrors [`create_deposit_and_wait`] for the withdrawal side: it drives the
+/// full presignature-generation + threshold-signing path, mining Bitcoin blocks
+/// in the background so the signed transaction confirms and the leader reports
+/// `WithdrawalConfirmed`.
+pub async fn create_withdrawal_and_wait(
+    networks: &mut TestNetworks,
+    amount_sats: u64,
+) -> Result<WithdrawalConfirmed> {
+    let hashi = networks.hashi_network.nodes()[0].hashi().clone();
+    let user_key = networks.sui_network.user_keys.first().unwrap();
+    let btc_destination = networks.bitcoin_node.get_new_address()?;
+    let destination_bytes = extract_witness_program(&btc_destination)?;
+    info!("Requesting withdrawal of {amount_sats} sats to {btc_destination}");
+
+    let mut executor = SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())?
+        .with_signer(user_key.clone().into());
+    let withdrawal_request_id = executor
+        .execute_create_withdrawal_request(amount_sats, destination_bytes)
+        .await?;
+    info!("Withdrawal request created: {withdrawal_request_id}");
+
+    // Mine in the background so the signed BTC transaction confirms and the
+    // leader's block-driven loop reports the withdrawal on Sui.
+    let _miner = BackgroundMiner::start(&networks.bitcoin_node);
+    let confirmed = wait_for_withdrawal_confirmation(
+        &mut networks.sui_network.client,
+        Duration::from_secs(300),
+    )
+    .await?;
+    info!("Withdrawal confirmed on Sui");
+
+    Ok(confirmed)
 }
 
 /// Wait until every node's object mirror shows the spent withdrawal

--- a/crates/e2e-tests/src/test_helpers.rs
+++ b/crates/e2e-tests/src/test_helpers.rs
@@ -26,6 +26,7 @@ use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2::Checkpoint;
 use sui_rpc::proto::sui::rpc::v2::GetBalanceRequest;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
+use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsResponse;
 use sui_sdk_types::Address;
 use sui_sdk_types::StructTag;
 use sui_sdk_types::bcs::FromBcs;
@@ -215,66 +216,95 @@ pub fn extract_witness_program(address: &BitcoinAddress) -> Result<Vec<u8>> {
     }
 }
 
-/// Subscribe to checkpoints and return the first `WithdrawalConfirmed` event,
-/// or error on timeout. Confirmation is the terminal on-chain milestone of a
-/// withdrawal: it fires only after the committee has generated presignatures,
-/// threshold-signed the BTC transaction, the guardian co-signed, and the leader
-/// observed the mined tx — so waiting on it exercises the whole signing path.
-pub async fn wait_for_withdrawal_confirmation(
-    sui_client: &mut sui_rpc::Client,
-    timeout: Duration,
-) -> Result<WithdrawalConfirmed> {
-    info!("Waiting for withdrawal confirmation...");
+/// A live checkpoint subscription to be consumed by
+/// [`WithdrawalConfirmations::wait_for`].
+///
+/// Two-phase on purpose: open the subscription with
+/// [`subscribe_withdrawal_confirmations`] BEFORE kicking off whatever
+/// produces the confirmation (the background miner), so an early event
+/// cannot land in the gap before the stream exists and be missed.
+pub struct WithdrawalConfirmations {
+    subscription: tonic::Streaming<SubscribeCheckpointsResponse>,
+}
 
-    let start = std::time::Instant::now();
+/// Open a checkpoint subscription for awaiting `WithdrawalConfirmed` events.
+pub async fn subscribe_withdrawal_confirmations(
+    sui_client: &mut sui_rpc::Client,
+) -> Result<WithdrawalConfirmations> {
     let subscription_read_mask = FieldMask::from_paths([Checkpoint::path_builder()
         .transactions()
         .events()
         .events()
         .contents()
         .finish()]);
-    let mut subscription = sui_client
+    let subscription = sui_client
         .subscription_client()
         .subscribe_checkpoints(
             SubscribeCheckpointsRequest::default().with_read_mask(subscription_read_mask),
         )
         .await?
         .into_inner();
+    Ok(WithdrawalConfirmations { subscription })
+}
 
-    while let Some(item) = subscription.next().await {
-        if start.elapsed() > timeout {
-            return Err(anyhow!(
-                "Timeout waiting for withdrawal confirmation after {:?}",
-                timeout
-            ));
-        }
+impl WithdrawalConfirmations {
+    /// Return the `WithdrawalConfirmed` event covering `request_id`, or error
+    /// on timeout. Confirmation is the terminal on-chain milestone of a
+    /// withdrawal: it fires only after the committee has generated
+    /// presignatures, threshold-signed the BTC transaction, the guardian
+    /// co-signed, and the leader observed the mined tx — so waiting on it
+    /// exercises the whole signing path. Confirmations for other requests are
+    /// skipped, so concurrent withdrawals cannot satisfy the wait.
+    pub async fn wait_for(
+        mut self,
+        request_id: Address,
+        timeout: Duration,
+    ) -> Result<WithdrawalConfirmed> {
+        info!("Waiting for confirmation of withdrawal request {request_id}...");
 
-        let checkpoint = match item {
-            Ok(checkpoint) => checkpoint,
-            Err(e) => {
-                debug!("Error in checkpoint stream: {}", e);
-                continue;
-            }
-        };
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            // Deadline the stream read itself: a stalled subscription must
+            // fail the wait, not hang it.
+            let item = tokio::time::timeout_at(deadline, self.subscription.next())
+                .await
+                .map_err(|_| {
+                    anyhow!("Timeout waiting for withdrawal confirmation after {timeout:?}")
+                })?
+                .ok_or_else(|| anyhow!("Checkpoint subscription ended unexpectedly"))?;
 
-        debug!(
-            "Received checkpoint {}, checking for WithdrawalConfirmed...",
-            checkpoint.cursor()
-        );
+            let checkpoint = match item {
+                Ok(checkpoint) => checkpoint,
+                Err(e) => {
+                    debug!("Error in checkpoint stream: {}", e);
+                    continue;
+                }
+            };
 
-        for txn in checkpoint.checkpoint().transactions() {
-            for event in txn.events().events() {
-                let event_type = event.contents().name();
+            debug!(
+                "Received checkpoint {}, checking for WithdrawalConfirmed...",
+                checkpoint.cursor()
+            );
 
-                if event_type.contains("WithdrawalConfirmed") {
+            for txn in checkpoint.checkpoint().transactions() {
+                for event in txn.events().events() {
+                    if !event.contents().name().contains("WithdrawalConfirmed") {
+                        continue;
+                    }
                     match WithdrawalConfirmed::from_bcs(event.contents().value()) {
-                        Ok(event_data) => {
+                        Ok(event_data) if event_data.request_ids.contains(&request_id) => {
                             info!(
                                 withdrawal_txn_id = %event_data.withdrawal_txn_id,
                                 txid = %event_data.txid,
                                 "Withdrawal confirmed!"
                             );
                             return Ok(event_data);
+                        }
+                        Ok(event_data) => {
+                            debug!(
+                                withdrawal_txn_id = %event_data.withdrawal_txn_id,
+                                "WithdrawalConfirmed for other requests, still waiting"
+                            );
                         }
                         Err(e) => {
                             debug!("Failed to parse WithdrawalConfirmed: {}", e);
@@ -283,10 +313,7 @@ pub async fn wait_for_withdrawal_confirmation(
                 }
             }
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
-
-    Err(anyhow!("Checkpoint subscription ended unexpectedly"))
 }
 
 /// Request a withdrawal of `amount_sats` to a fresh regtest address and wait
@@ -306,6 +333,11 @@ pub async fn create_withdrawal_and_wait(
     let destination_bytes = extract_witness_program(&btc_destination)?;
     info!("Requesting withdrawal of {amount_sats} sats to {btc_destination}");
 
+    // Subscribe before creating the request or mining, so the confirmation
+    // cannot land before the stream exists.
+    let confirmations =
+        subscribe_withdrawal_confirmations(&mut networks.sui_network.client).await?;
+
     let mut executor = SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())?
         .with_signer(user_key.clone().into());
     let withdrawal_request_id = executor
@@ -316,11 +348,9 @@ pub async fn create_withdrawal_and_wait(
     // Mine in the background so the signed BTC transaction confirms and the
     // leader's block-driven loop reports the withdrawal on Sui.
     let _miner = BackgroundMiner::start(&networks.bitcoin_node);
-    let confirmed = wait_for_withdrawal_confirmation(
-        &mut networks.sui_network.client,
-        Duration::from_secs(300),
-    )
-    .await?;
+    let confirmed = confirmations
+        .wait_for(withdrawal_request_id, Duration::from_secs(300))
+        .await?;
     info!("Withdrawal confirmed on Sui");
 
     Ok(confirmed)

--- a/crates/e2e-tests/tests/snapshot_signing_tests.rs
+++ b/crates/e2e-tests/tests/snapshot_signing_tests.rs
@@ -1,0 +1,117 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Signing lifecycle against the deployed **v1 bytecode snapshot**.
+//!
+//! Boots a local net by publishing the checked-in deployed testnet package
+//! bytecode as v1 (via [`TestNetworksBuilder::with_v1_from_snapshot`]) and then
+//! drives a full deposit → withdrawal cycle. The withdrawal forces the
+//! committee to generate presignatures and threshold-sign a Bitcoin
+//! transaction end to end.
+//!
+//! Why this is distinct from the source-built withdrawal e2e (`e2e_flow`):
+//! every other harness publishes the *current* `packages/hashi` source, so the
+//! binary always runs against a package built from the same tree. This test
+//! runs the current binary against the **actually-deployed** (older) Move
+//! bytecode — the real rollout-window configuration, where the node binary is
+//! rolled out before the on-chain package is upgraded. A full withdrawal here
+//! proves that configuration can still sign.
+//!
+//! Forward note: once the version-gated stamped nonce-cert path re-lands (the
+//! reverted #841 line of work), a v1-only snapshot chain is exactly the *bare*
+//! cert path (`supports_stamped_nonce_certs() == false`, timestamps synthesized
+//! to `0`) that no fresh-publish harness exercises — the marked assertion below
+//! should then also pin this test to that path.
+
+use anyhow::Result;
+use e2e_tests::TestNetworksBuilder;
+use e2e_tests::snapshot;
+use e2e_tests::test_helpers::create_deposit_and_wait;
+use e2e_tests::test_helpers::create_withdrawal_and_wait;
+use e2e_tests::test_helpers::get_hbtc_balance;
+use e2e_tests::test_helpers::init_test_logging;
+use std::time::Duration;
+use tracing::info;
+
+/// Deposit then withdraw on a chain published from the deployed v1 bytecode
+/// snapshot, proving the committee generates presignatures and threshold-signs
+/// a withdrawal end-to-end against the deployed (pre-upgrade) package.
+///
+/// Asserts:
+/// - the snapshot chain is a single-version (v1) package — no upgrade has run,
+///   so signing happens against the deployed bytecode;
+/// - a deposit credits hBTC;
+/// - a withdrawal reaches `WithdrawalConfirmed` and burns the hBTC — i.e. the
+///   presig + signing path completed, not merely that a request was accepted.
+#[tokio::test]
+async fn snapshot_v1_signs_withdrawal_end_to_end() -> Result<()> {
+    init_test_logging();
+
+    // v1 = the checked-in deployed bytecode snapshot, not a source build.
+    let mut networks = TestNetworksBuilder::new()
+        .with_nodes(4)
+        .with_v1_from_snapshot(snapshot::default_snapshot_dir()?)
+        .build()
+        .await?;
+
+    let hashi_ids = networks.hashi_network.ids();
+    info!("snapshot-published v1 package ID: {}", hashi_ids.package_id);
+
+    // Committee/DKG must complete before anything can be signed.
+    networks.hashi_network.nodes()[0]
+        .wait_for_mpc_key(Duration::from_secs(120))
+        .await?;
+
+    // The snapshot chain is a single-version v1 package (no upgrade has run),
+    // so the committee signs against the deployed bytecode. When the
+    // version-gated stamped nonce-cert path re-lands, also assert
+    // `!node0.onchain_state().supports_stamped_nonce_certs()` here to pin this
+    // to the *bare* cert path.
+    let node0 = networks.hashi_network.nodes()[0].hashi().clone();
+    assert_eq!(
+        node0
+            .onchain_state()
+            .state()
+            .package_versions()
+            .versions()
+            .len(),
+        1,
+        "snapshot chain should be a single-version (v1) package before any upgrade"
+    );
+
+    // ── Deposit ─────────────────────────────────────────────────────────
+    let deposit_sats = 100_000u64;
+    let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_sats).await?;
+    assert_eq!(
+        get_hbtc_balance(
+            &mut networks.sui_network.client,
+            hashi_ids.package_id,
+            hbtc_recipient,
+        )
+        .await?,
+        deposit_sats,
+        "pre-withdrawal deposit should have credited hBTC",
+    );
+
+    // ── Withdraw — forces presig generation + threshold signing ──────────
+    let withdrawal_sats = 30_000u64;
+    let confirmed = create_withdrawal_and_wait(&mut networks, withdrawal_sats).await?;
+    info!(
+        "withdrawal confirmed on Sui against deployed v1: txid={}",
+        confirmed.txid
+    );
+
+    assert_eq!(
+        get_hbtc_balance(
+            &mut networks.sui_network.client,
+            hashi_ids.package_id,
+            hbtc_recipient,
+        )
+        .await?,
+        deposit_sats - withdrawal_sats,
+        "withdrawal did not complete (hBTC not burned) against the deployed v1 package",
+    );
+
+    info!("=== V1 SNAPSHOT SIGNING TEST PASSED ===");
+    Ok(())
+}


### PR DESCRIPTION
Stacked on #916 (which is stacked on #913). **Review/merge order: #913 → #916 → this.**

## What

Publishes the checked-in deployed testnet package **bytecode snapshot** as v1 (via `with_v1_from_snapshot`, from #916) and drives a full **deposit → withdrawal** cycle. The withdrawal forces the committee to generate presignatures and threshold-sign a Bitcoin transaction end to end.

## Why

Every other e2e harness publishes the *current* `packages/hashi` source, so the node binary always runs against a package built from the same tree. This test runs the **current binary against the actually-deployed (older) Move bytecode** — the real rollout-window configuration, where the binary is rolled out *before* the on-chain package is upgraded. #916 proves the upgrade *mechanism*; this proves the deployed-package config can still **sign**, which #916 never exercises (DKG + upgrade only, no withdrawal).

## What it does / doesn't cover

- ✅ Full presig-generation + threshold-signing lifecycle against the deployed v1 bytecode.
- ✅ Reusable withdrawal harness: extracts `extract_witness_program` / `wait_for_withdrawal_confirmation` out of `e2e_flow` into public `test_helpers`, adds `create_withdrawal_and_wait` (mirrors `create_deposit_and_wait`).
- ⏳ Forward note: once the version-gated stamped nonce-cert path re-lands (the reverted #841 work), a v1-only snapshot chain is exactly the *bare* cert path. The test carries a marked assertion to also pin `!supports_stamped_nonce_certs()` at that point.

## Test

`snapshot_v1_signs_withdrawal_end_to_end` — passes locally (deposit → withdrawal reaches `WithdrawalConfirmed`, hBTC burned), ~60s.