### PR TITLE
feat(versioning): active-version resolution + graceful degrade

### DIFF
--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -220,9 +220,15 @@ async fn test_upgrade_v1_to_v2() -> Result<()> {
     let v1_result = executors[0].execute(builder).await;
     assert!(v1_result.is_err(), "v1 should be rejected after disable");
     let err_msg = v1_result.unwrap_err().to_string();
+    // Rejected at either layer: with v1 disabled the only enabled on-chain
+    // version is v2, which this binary (SUPPORTED_PACKAGE_VERSIONS = [1]) does
+    // not support, so the node-side executor guard refuses to submit; had it
+    // reached chain, `assert_version_enabled` would abort with EVersionDisabled.
     assert!(
-        err_msg.contains("EVersionDisabled") || err_msg.contains("assert_version_enabled"),
-        "expected EVersionDisabled, got: {err_msg}"
+        err_msg.contains("EVersionDisabled")
+            || err_msg.contains("assert_version_enabled")
+            || err_msg.contains("supports no enabled on-chain package version"),
+        "expected a version-disabled rejection, got: {err_msg}"
     );
     info!("v1 entry point correctly rejected");
 

--- a/crates/hashi/src/constants.rs
+++ b/crates/hashi/src/constants.rs
@@ -23,6 +23,21 @@ pub const BITCOIN_REGTEST_CHAIN_ID: &str =
 /// `initial_pool_size / PRESIG_REFILL_DIVISOR`.
 pub const PRESIG_REFILL_DIVISOR: usize = 2;
 
+/// The `hashi::versioning` package versions whose on-chain semantics this
+/// binary implements.
+///
+/// The node computes an *active* version as
+/// `max(enabled_versions ∩ published_versions ∩ SUPPORTED_PACKAGE_VERSIONS)`
+/// and gates autonomous work on it (see `onchain::version`). If every
+/// enabled+published on-chain version is beyond this set — the chain has moved
+/// ahead of this binary — the node halts autonomous mutations and signals for
+/// an upgrade rather than acting on data it cannot interpret.
+///
+/// Add the next version here in the same change that teaches this binary to
+/// run it (e.g. a package upgrade); never list a version whose semantics this
+/// build does not implement.
+pub const SUPPORTED_PACKAGE_VERSIONS: &[u64] = &[1];
+
 pub fn is_production_sui_chain(chain_id: &str) -> bool {
     chain_id == SUI_MAINNET_CHAIN_ID || chain_id == SUI_TESTNET_CHAIN_ID
 }

--- a/crates/hashi/src/grpc/mod.rs
+++ b/crates/hashi/src/grpc/mod.rs
@@ -191,6 +191,19 @@ async fn health() -> impl axum::response::IntoResponse {
 
 async fn ready(hashi: Arc<Hashi>) -> impl axum::response::IntoResponse {
     let onchain_state = hashi.onchain_state();
+    // If the chain has moved past what this binary supports, report not-ready so
+    // operators/orchestration surface it — the node has halted autonomous work
+    // (see leader gate) and needs a binary upgrade. Details are in the
+    // `hashi_package_version_unsupported` metric and the leader log.
+    if matches!(
+        onchain_state.autonomous_halt_reason(),
+        Some(crate::onchain::HaltReason::BinaryUnsupported { .. })
+    ) {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "binary does not support the enabled on-chain package version(s) — upgrade required",
+        );
+    }
     let epoch = onchain_state.epoch();
     // Treat genesis (no committee formed yet) as ready so OrderedReady can bring
     // up the rest of the StatefulSet to register keys and run the initial DKG.

--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -310,10 +310,13 @@ impl LeaderService {
     }
 
     fn check_halt_deposit_processing(&mut self) -> bool {
-        // Evaluate both predicates from one consistent state snapshot.
+        // Evaluate all predicates from one consistent state snapshot.
         let halt = {
             let state = self.inner.onchain_state().state();
             state.hashi().config.paused()
+                || state
+                    .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
+                    .must_halt()
                 || state.hashi().committees.pending_epoch_change().is_some()
         };
         if !halt {

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -382,9 +382,24 @@ impl LeaderService {
     /// tasks can re-check leadership mid-flight and stop driving work that
     /// has rotated to another node.
     pub(super) fn node_is_leader(inner: &Arc<Hashi>, checkpoint_height: u64) -> bool {
-        if inner.onchain_state().state().hashi().config.paused() {
-            debug!("Bridge is paused, not acting as leader");
-            return false;
+        match inner.onchain_state().autonomous_halt_reason() {
+            None => {}
+            Some(crate::onchain::HaltReason::Paused) => {
+                debug!("Bridge is paused, not acting as leader");
+                return false;
+            }
+            Some(crate::onchain::HaltReason::BinaryUnsupported {
+                supported_max,
+                live_max,
+            }) => {
+                warn!(
+                    supported_max,
+                    live_max,
+                    "binary supports no live on-chain package version; not acting as leader — \
+                     upgrade required"
+                );
+                return false;
+            }
         }
 
         match inner.config.force_run_as_leader() {

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -47,6 +47,16 @@ use x509_parser::nom::AsBytes;
 const NUM_CONSECUTIVE_LEADER_CHECKPOINTS: u64 = 100;
 const LEADER_TASK_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Throttle for the "binary unsupported for the on-chain version" leader
+/// warning. `node_is_leader` runs every checkpoint (and from re-checking
+/// tasks), so an unthrottled `warn!` would flood logs for the whole time the
+/// chain sits ahead of this binary; the `hashi_package_version_unsupported`
+/// metric is the durable signal, so we log on first detection and then only
+/// periodically. Stores the last checkpoint height it warned at (0 = never).
+static LAST_UNSUPPORTED_WARN_CHECKPOINT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+const UNSUPPORTED_WARN_EVERY_CHECKPOINTS: u64 = 240;
+
 pub(crate) struct LeaderService {
     // Shared application state and external service clients used by leader jobs.
     inner: Arc<Hashi>,
@@ -392,12 +402,23 @@ impl LeaderService {
                 supported_max,
                 live_max,
             }) => {
-                warn!(
-                    supported_max,
-                    live_max,
-                    "binary supports no live on-chain package version; not acting as leader — \
-                     upgrade required"
-                );
+                // Throttle: loud on first detection, then periodic (the metric
+                // carries the steady-state signal).
+                use std::sync::atomic::Ordering;
+                let last = LAST_UNSUPPORTED_WARN_CHECKPOINT.load(Ordering::Relaxed);
+                if last == 0
+                    || checkpoint_height.saturating_sub(last) >= UNSUPPORTED_WARN_EVERY_CHECKPOINTS
+                {
+                    LAST_UNSUPPORTED_WARN_CHECKPOINT
+                        .store(checkpoint_height.max(1), Ordering::Relaxed);
+                    warn!(
+                        supported_max,
+                        live_max,
+                        checkpoint_height,
+                        "binary supports no live on-chain package version; not acting as leader — \
+                         upgrade required"
+                    );
+                }
                 return false;
             }
         }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -94,6 +94,12 @@ pub struct Metrics {
     num_consumed_presigs: IntGauge,
     treasury_supply: IntGaugeVec,
     package_version_enabled: IntGaugeVec,
+    /// The package version this binary is operating at (0 when none is
+    /// supported — see `package_version_unsupported`).
+    package_version_active: IntGauge,
+    /// 1 when this binary supports no live on-chain package version (chain
+    /// ahead of the binary); autonomous mutations are halted. 0 otherwise.
+    package_version_unsupported: IntGauge,
 
     pub deposits_confirmed_total: IntCounter,
     pub deposits_rejected_utxo_spent: IntCounter,
@@ -641,6 +647,18 @@ impl Metrics {
                 "hashi_package_version_enabled",
                 "enabled package versions (1 = enabled)",
                 &["version", "package_id"],
+                registry,
+            )
+            .unwrap(),
+            package_version_active: register_int_gauge_with_registry!(
+                "hashi_package_version_active",
+                "package version this binary is operating at (0 = none supported)",
+                registry,
+            )
+            .unwrap(),
+            package_version_unsupported: register_int_gauge_with_registry!(
+                "hashi_package_version_unsupported",
+                "1 = binary supports no live on-chain version (mutations halted), 0 = ok",
                 registry,
             )
             .unwrap(),
@@ -1295,6 +1313,12 @@ impl Metrics {
                 .with_label_values(&[&version_str, &package_id_str])
                 .set(1);
         }
+
+        let support = guard.version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS);
+        self.package_version_active
+            .set(support.active_version().map(|v| v as i64).unwrap_or(0));
+        self.package_version_unsupported
+            .set(i64::from(support.must_halt()));
     }
 }
 

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -77,11 +77,22 @@ mod apply;
 mod mirror;
 mod route;
 pub mod types;
+pub mod version;
 mod watcher;
 
 fn parse_encryption_public_key(bytes: &[u8]) -> Option<crate::mpc::EncryptionGroupElement> {
     let array: [u8; 32] = bytes.try_into().ok()?;
     crate::mpc::EncryptionGroupElement::from_byte_array(&array).ok()
+}
+
+/// Why a node must not initiate autonomous on-chain mutations right now.
+#[derive(Debug, Clone, Copy)]
+pub enum HaltReason {
+    /// The bridge is governance-paused (`config.paused()`).
+    Paused,
+    /// This binary supports no live on-chain package version — typically the
+    /// chain has upgraded past this build. Fields are for diagnostics/logging.
+    BinaryUnsupported { supported_max: u64, live_max: u64 },
 }
 
 #[derive(Clone)]
@@ -278,6 +289,40 @@ impl OnchainState {
 
     pub fn state(&self) -> RwLockReadGuard<'_, State> {
         self.0.state.read().unwrap()
+    }
+
+    /// How this binary's [`crate::constants::SUPPORTED_PACKAGE_VERSIONS`]
+    /// relate to the current on-chain enabled+published versions.
+    pub fn version_support(&self) -> version::VersionSupport {
+        self.state()
+            .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
+    }
+
+    /// The on-chain package version this binary should operate at, or `None`
+    /// when the chain is ahead of / incompatible with this build.
+    pub fn active_package_version(&self) -> Option<u64> {
+        self.version_support().active_version()
+    }
+
+    /// Reason autonomous on-chain work must halt (governance pause, or an
+    /// unsupported on-chain version), or `None` to proceed. Reads state once so
+    /// callers get a single consistent snapshot. Mirrors — and subsumes — the
+    /// existing `config.paused()` gate.
+    pub fn autonomous_halt_reason(&self) -> Option<HaltReason> {
+        let state = self.state();
+        if state.hashi().config.paused() {
+            return Some(HaltReason::Paused);
+        }
+        match state.version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS) {
+            version::VersionSupport::Unsupported {
+                supported_max,
+                live_max,
+            } => Some(HaltReason::BinaryUnsupported {
+                supported_max,
+                live_max,
+            }),
+            version::VersionSupport::Active(_) | version::VersionSupport::NotReady => None,
+        }
     }
 
     // NOTE: This function must remain private to this module so that only this module and its
@@ -961,6 +1006,18 @@ impl State {
 
     pub fn hashi(&self) -> &types::Hashi {
         &self.hashi
+    }
+
+    /// Resolve version support from this snapshot against `supported` (the
+    /// binary's [`crate::constants::SUPPORTED_PACKAGE_VERSIONS`]). Kept on
+    /// `State` so callers that already hold a read guard resolve without
+    /// re-locking or racing a second snapshot.
+    pub fn version_support(&self, supported: &[u64]) -> version::VersionSupport {
+        version::resolve_version_support(
+            &self.hashi.config.enabled_versions,
+            &self.package_versions,
+            supported,
+        )
     }
 
     async fn scrape(

--- a/crates/hashi/src/onchain/version.rs
+++ b/crates/hashi/src/onchain/version.rs
@@ -75,7 +75,26 @@ pub fn resolve_version_support(
         .collect();
 
     let Some(&live_max) = live.iter().next_back() else {
-        // Nothing enabled+published visible yet.
+        // Nothing enabled+published visible yet. Distinguish plain genesis
+        // (nothing on either side) from a chain that was fresh-published from
+        // a source tree whose `PACKAGE_VERSION` is ahead of its Sui sequence:
+        // there the genesis `create()` enabled {const} while the package
+        // history numbers the publish 1, so the two sets exist but never
+        // intersect and this state is permanent. Warn loudly instead of
+        // leaving an indistinguishable NotReady — the fix is to boot dev
+        // chains via snapshot + upgrade, not fresh-publish a mid-cycle tree.
+        if let (Some(&enabled_max), Some((&published_max, _))) = (
+            enabled.iter().next_back(),
+            published.versions().iter().next_back(),
+        ) {
+            tracing::warn!(
+                enabled_max,
+                published_max,
+                "no on-chain version is both enabled and published; the chain \
+                 appears fresh-published from a source tree ahead of its Sui \
+                 sequence — boot dev chains via snapshot + upgrade"
+            );
+        }
         return VersionSupport::NotReady;
     };
 
@@ -177,6 +196,18 @@ mod tests {
         // Empty everything.
         assert_eq!(
             resolve_version_support(&enabled(&[]), &published(&[]), &[1]),
+            VersionSupport::NotReady
+        );
+    }
+
+    #[test]
+    fn source_ahead_fresh_publish_is_not_ready_not_unsupported() {
+        // A mid-cycle tree (const = 2) fresh-published: genesis enabled {2},
+        // but the package history numbers the publish 1. Permanently disjoint
+        // sets must stay NotReady (the warn path), not halt as Unsupported —
+        // the binary is not behind the chain, the chain is misbooted.
+        assert_eq!(
+            resolve_version_support(&enabled(&[2]), &published(&[1]), &[1, 2]),
             VersionSupport::NotReady
         );
     }

--- a/crates/hashi/src/onchain/version.rs
+++ b/crates/hashi/src/onchain/version.rs
@@ -1,0 +1,209 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Package-version support resolution.
+//!
+//! The on-chain `hashi::versioning` module tracks which package versions are
+//! *enabled* (governance) and, separately, which have been *published* (an
+//! upgrade mints a new package id). This binary declares the versions whose
+//! semantics it implements in [`crate::constants::SUPPORTED_PACKAGE_VERSIONS`].
+//!
+//! [`resolve_version_support`] combines the three to decide how this binary
+//! should behave: operate at the highest mutually-live version, or — if the
+//! chain has moved entirely beyond what this build understands — halt
+//! autonomous mutations and signal for an upgrade rather than act on data it
+//! cannot safely interpret. The on-chain `assert_version_enabled` gate is the
+//! ultimate backstop (a stale binary's writes abort); this is the node-side
+//! fail-safe that avoids acting on misreads and surfaces the condition loudly.
+
+use std::collections::BTreeSet;
+
+use hashi_types::move_types::PackageVersions;
+
+/// How this binary's supported versions relate to the on-chain state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionSupport {
+    /// This binary supports the highest enabled+published on-chain version;
+    /// operate at `.0`.
+    Active(u64),
+    /// No enabled+published version is one this binary supports — typically the
+    /// chain has upgraded past this build. Halt autonomous mutations and signal
+    /// for a binary upgrade. `supported_max`/`live_max` are for diagnostics.
+    Unsupported { supported_max: u64, live_max: u64 },
+    /// No version is both enabled and published yet (pre-genesis or an
+    /// incomplete scrape). NOT a halt condition — normal genesis/startup gating
+    /// applies.
+    NotReady,
+}
+
+impl VersionSupport {
+    /// The version to operate at, if this binary supports the chain.
+    pub fn active_version(self) -> Option<u64> {
+        match self {
+            VersionSupport::Active(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Whether autonomous work must halt: only [`VersionSupport::Unsupported`].
+    /// [`VersionSupport::NotReady`] deliberately does NOT halt, so startup /
+    /// pre-genesis states aren't blocked spuriously.
+    pub fn must_halt(self) -> bool {
+        matches!(self, VersionSupport::Unsupported { .. })
+    }
+}
+
+/// Resolve version support from the enabled set (governance), the published
+/// version map (on-chain package history), and this binary's supported set.
+///
+/// The active version is `max(enabled ∩ published ∩ supported)`. A version that
+/// is enabled but not yet published (governance can enable ahead of a deploy)
+/// is excluded, so the ABI is never switched on before the package is live.
+///
+/// Pure over its inputs for exhaustive unit testing; [`super::OnchainState`]
+/// wraps it against live state.
+pub fn resolve_version_support(
+    enabled: &BTreeSet<u64>,
+    published: &PackageVersions,
+    supported: &[u64],
+) -> VersionSupport {
+    // Versions that are both governance-enabled and actually published.
+    let live: BTreeSet<u64> = enabled
+        .iter()
+        .copied()
+        .filter(|v| published.get(*v).is_some())
+        .collect();
+
+    let Some(&live_max) = live.iter().next_back() else {
+        // Nothing enabled+published visible yet.
+        return VersionSupport::NotReady;
+    };
+
+    // Highest version that is live AND supported by this binary.
+    match live.iter().rev().copied().find(|v| supported.contains(v)) {
+        Some(active) => VersionSupport::Active(active),
+        None => VersionSupport::Unsupported {
+            supported_max: supported.iter().copied().max().unwrap_or(0),
+            live_max,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use sui_sdk_types::Address;
+
+    /// Build a `PackageVersions` from version numbers; the mapped ids are
+    /// distinct but otherwise irrelevant to resolution (only presence matters).
+    fn published(versions: &[u64]) -> PackageVersions {
+        let map: BTreeMap<u64, Address> = versions
+            .iter()
+            .map(|v| (*v, Address::new([*v as u8; 32])))
+            .collect();
+        PackageVersions::new(map)
+    }
+
+    fn enabled(versions: &[u64]) -> BTreeSet<u64> {
+        versions.iter().copied().collect()
+    }
+
+    #[test]
+    fn v1_only_is_active() {
+        assert_eq!(
+            resolve_version_support(&enabled(&[1]), &published(&[1]), &[1]),
+            VersionSupport::Active(1)
+        );
+    }
+
+    #[test]
+    fn both_enabled_picks_highest_supported() {
+        // Post-upgrade steady state: chain has {1,2}, binary supports {1,2}.
+        assert_eq!(
+            resolve_version_support(&enabled(&[1, 2]), &published(&[1, 2]), &[1, 2]),
+            VersionSupport::Active(2)
+        );
+    }
+
+    #[test]
+    fn old_binary_on_upgraded_chain_uses_highest_it_supports() {
+        // Chain enabled {1,2}, both published, but this binary only supports v1:
+        // it keeps operating at v1 (v1 is still live).
+        assert_eq!(
+            resolve_version_support(&enabled(&[1, 2]), &published(&[1, 2]), &[1]),
+            VersionSupport::Active(1)
+        );
+    }
+
+    #[test]
+    fn chain_fully_ahead_is_unsupported() {
+        // v1 retired: only v2 enabled+published, binary supports only v1.
+        assert_eq!(
+            resolve_version_support(&enabled(&[2]), &published(&[2]), &[1]),
+            VersionSupport::Unsupported {
+                supported_max: 1,
+                live_max: 2
+            }
+        );
+    }
+
+    #[test]
+    fn enabled_but_unpublished_version_is_ignored() {
+        // Governance pre-enabled v2 before the package is published: v2 is not
+        // live, so the ABI stays at v1 (guards against switching on too early).
+        assert_eq!(
+            resolve_version_support(&enabled(&[1, 2]), &published(&[1]), &[1, 2]),
+            VersionSupport::Active(1)
+        );
+    }
+
+    #[test]
+    fn enabled_gap_ignores_unpublished_higher_version() {
+        // {1,3} enabled but only 1 published; supports {1,2}. Live∩supported = {1}.
+        assert_eq!(
+            resolve_version_support(&enabled(&[1, 3]), &published(&[1]), &[1, 2]),
+            VersionSupport::Active(1)
+        );
+    }
+
+    #[test]
+    fn nothing_live_is_not_ready() {
+        // Enabled version not yet published, and nothing else live.
+        assert_eq!(
+            resolve_version_support(&enabled(&[2]), &published(&[]), &[1, 2]),
+            VersionSupport::NotReady
+        );
+        // Empty everything.
+        assert_eq!(
+            resolve_version_support(&enabled(&[]), &published(&[]), &[1]),
+            VersionSupport::NotReady
+        );
+    }
+
+    #[test]
+    fn only_live_version_unsupported_by_this_binary_halts() {
+        // Misconfiguration: binary dropped v1 support (supports only {2}) while
+        // the chain's sole live version is v1. No mutual version -> halt.
+        assert_eq!(
+            resolve_version_support(&enabled(&[1]), &published(&[1]), &[2]),
+            VersionSupport::Unsupported {
+                supported_max: 2,
+                live_max: 1
+            }
+        );
+    }
+
+    #[test]
+    fn must_halt_only_on_unsupported() {
+        assert!(
+            VersionSupport::Unsupported {
+                supported_max: 1,
+                live_max: 2
+            }
+            .must_halt()
+        );
+        assert!(!VersionSupport::Active(1).must_halt());
+        assert!(!VersionSupport::NotReady.must_halt());
+    }
+}

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -428,6 +428,12 @@ pub struct SuiTxExecutor {
     signer: SimpleKeypair,
     hashi_ids: HashiIds,
     timeout: Duration,
+    /// Present for node-internal executors (built via [`SuiTxExecutor::from_config`]
+    /// / [`SuiTxExecutor::from_hashi`]); used to refuse submitting when this
+    /// binary supports no live on-chain package version. `None` for CLI/ad-hoc
+    /// executors built via [`SuiTxExecutor::new`], which are operator-driven and
+    /// intentionally not version-gated.
+    onchain_state: Option<OnchainState>,
 }
 
 impl SuiTxExecutor {
@@ -438,19 +444,21 @@ impl SuiTxExecutor {
             signer,
             hashi_ids,
             timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+            onchain_state: None,
         }
     }
 
     /// Create a new executor from config and onchain state.
     ///
-    /// This is a convenience constructor for use within the Hashi system.
+    /// This is a convenience constructor for use within the Hashi system. The
+    /// executor retains the [`OnchainState`] so [`SuiTxExecutor::execute`] can
+    /// refuse to submit when this binary supports no live on-chain package
+    /// version.
     pub fn from_config(config: &Config, onchain_state: &OnchainState) -> anyhow::Result<Self> {
         let signer = config.operator_private_key()?;
-        Ok(Self::new(
-            onchain_state.client(),
-            signer,
-            config.hashi_ids(),
-        ))
+        let mut executor = Self::new(onchain_state.client(), signer, config.hashi_ids());
+        executor.onchain_state = Some(onchain_state.clone());
+        Ok(executor)
     }
 
     /// Create a new executor from an `Arc<Hashi>`.
@@ -504,6 +512,21 @@ impl SuiTxExecutor {
         &mut self,
         builder: TransactionBuilder,
     ) -> anyhow::Result<ExecuteTransactionResponse> {
+        // Node-internal executors refuse to submit when the chain is running
+        // package versions this binary doesn't support — fail fast rather than
+        // burn a doomed transaction (the on-chain `assert_version_enabled` would
+        // reject it) or act on state we can't interpret. Operator/CLI executors
+        // (built via `new`, no `onchain_state`) are exempt.
+        if let Some(onchain_state) = &self.onchain_state {
+            let support = onchain_state.version_support();
+            if support.must_halt() {
+                anyhow::bail!(
+                    "refusing to submit hashi transaction: this binary supports no enabled \
+                     on-chain package version ({support:?}) — a binary upgrade is required"
+                );
+            }
+        }
+
         let outcome = finalize(
             &mut self.client,
             Some(&self.signer),


### PR DESCRIPTION
**PR 1 of the dynamic package-version management framework** (PR 2 = the decode rewire will stack on this; #841 re-lands on top). Branches off `main` — independent of the #913/#916/#921 test-infra stack.

## Why

The reverted #841 exposed that the node has no principled version gating: a single hardcoded per-feature flag (`enabled_versions.contains(&2)`, forward-broken at `{3}`/`{2,3}`) and **no notion of which package versions this binary understands** — so a binary running against a chain ahead of it would silently misparse/mis-sign rather than fail safe. For a BTC threshold signer, "halt when I don't understand the chain" beats "act on a misread."

## What

- **`SUPPORTED_PACKAGE_VERSIONS`** (`constants.rs`, currently `&[1]`) — the versions whose semantics this build implements.
- **`onchain::version`** — a pure `resolve_version_support(enabled, published, supported)` returning `Active(v)` / `Unsupported{..}` / `NotReady`. Active = `max(enabled ∩ published ∩ supported)`; an enabled-but-**unpublished** version is excluded so the ABI is never switched on before its package is live. Exhaustively unit-tested (9 cases).
- **Graceful degrade** — a combined `OnchainState::autonomous_halt_reason()` (subsumes the existing `config.paused()` check, reads one snapshot) gates `node_is_leader` and the deposit-processing halt. On `Unsupported` the node stops all leader-driven mutations, sets `hashi_package_version_unsupported=1`, and `/ready` returns 503 — signalling for a binary upgrade. `NotReady` (pre-genesis/incomplete scrape) deliberately does **not** halt.
- **Metrics** — `hashi_package_version_active` + `hashi_package_version_unsupported`.

The on-chain `assert_version_enabled` remains the ultimate backstop (a stale binary's writes abort on-chain).

## Scope note

Gates **leader-driven** mutations (the bulk). **MPC-participation gating is intentionally deferred to the #841 re-land**, which rewrites that code: today the MPC path isn't `paused()`-gated either, a stale binary's MPC writes already abort via `assert_version_enabled`, and the loud metric/readiness signal prompts the upgrade. Gating MPC participation also has committee-availability tradeoffs mid-rollout that deserve deliberate design.

## Follow-up

An e2e "chain ahead of binary" test (upgrade the chain past a test-only supported set via #916's snapshot harness) would exercise the halt end-to-end; kept out of this PR to avoid coupling to the test-infra stack. The resolver logic is fully unit-covered here.

## Test

`cargo test -p hashi --lib onchain` (37 pass, incl. 9 resolver cases); `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean.