### PR TITLE
feat(versioning): self-describing decode of version-divergent dynamic-field values

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -89,15 +89,13 @@ impl PackageVersions {
 ///    with the version that introduced them; existing types keep theirs
 ///    forever — never renumber (a Move type's defining address never
 ///    changes across upgrades).
-/// 3. To identify tags: use [`matches`] where a [`PackageVersions`] is in
-///    hand (event routing); use [`MODULE_NAME`] for name-keyed dispatch
-///    where the chain already reports a value's concrete type — see
-///    `hashi::onchain::versioned_decode`, and read its module doc before
-///    adding an address check there.
+/// 3. To identify tags, use [`matches`]: the full tag — defining package
+///    address included — must match the mirror, so a same-name type from a
+///    foreign package is rejected rather than trusted.
 /// 4. If the new type replaces what a dynamic-field slot holds (a v2 type
-///    in the same bucket), wire its name into the `versioned_decode`
-///    dispatch. Readers fail loudly on names they do not implement; they
-///    never guess a layout.
+///    in the same bucket), wire it into the dispatch in
+///    `hashi::onchain::versioned_decode`. Readers fail loudly on types they
+///    do not implement; they never guess a layout.
 ///
 /// The package-wide version the *tree* ships as is a separate axis: see the
 /// `PACKAGE_VERSION` doc in `packages/hashi/sources/core/versioning.move`
@@ -105,7 +103,6 @@ impl PackageVersions {
 ///
 /// [`PACKAGE_VERSION`]: MoveType::PACKAGE_VERSION
 /// [`matches`]: MoveType::matches
-/// [`MODULE_NAME`]: MoveType::MODULE_NAME
 pub trait MoveType {
     /// The hashi package version that first defined this struct. A
     /// type keeps its defining package's address through upgrades, so

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -879,6 +879,23 @@ pub struct EpochCertsV1 {
     pub certs: LinkedTable<Address>,
 }
 
+impl MoveType for EpochCertsV1 {
+    const MODULE: &'static str = "tob";
+    const NAME: &'static str = "EpochCertsV1";
+}
+
+/// Marker for the Move hashi::tob::StampedEpochCertsV1 type, which the v2
+/// package introduces (the stamped nonce-cert line of work). Identification
+/// only: this build recognizes the type but does not decode its stamped
+/// linked-table nodes; the mirror gains fields when that support lands.
+pub struct StampedEpochCertsV1;
+
+impl MoveType for StampedEpochCertsV1 {
+    const PACKAGE_VERSION: u64 = 2;
+    const MODULE: &'static str = "tob";
+    const NAME: &'static str = "StampedEpochCertsV1";
+}
+
 /// Rust version of the Move sui::linked_table::LinkedTable type.
 #[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct LinkedTable<K> {

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -72,6 +72,40 @@ impl PackageVersions {
 
 /// A Rust mirror of a Move struct, identified by its defining package
 /// version, module, and name.
+///
+/// # Adding a new Move type that Rust reads
+///
+/// Mirrors are written by hand; nothing is generated. The path for a new
+/// Move struct whose bytes Rust decodes (an event, a dynamic-field value,
+/// a container node):
+///
+/// 1. Add the struct in `packages/hashi/`. An upgrade can only *add* types
+///    — it can never change an existing struct's layout (the CI compat gate
+///    enforces this) — so a layout change is a *new* type with a *new* name
+///    (`FooV2`, `StampedFoo`, …).
+/// 2. Mirror it in this module with serde derives whose field order matches
+///    the Move declaration exactly (BCS is positional), and `impl MoveType`.
+///    Types introduced by an upgraded package override [`PACKAGE_VERSION`]
+///    with the version that introduced them; existing types keep theirs
+///    forever — never renumber (a Move type's defining address never
+///    changes across upgrades).
+/// 3. To identify tags: use [`matches`] where a [`PackageVersions`] is in
+///    hand (event routing); use [`MODULE_NAME`] for name-keyed dispatch
+///    where the chain already reports a value's concrete type — see
+///    `hashi::onchain::versioned_decode`, and read its module doc before
+///    adding an address check there.
+/// 4. If the new type replaces what a dynamic-field slot holds (a v2 type
+///    in the same bucket), wire its name into the `versioned_decode`
+///    dispatch. Readers fail loudly on names they do not implement; they
+///    never guess a layout.
+///
+/// The package-wide version the *tree* ships as is a separate axis: see the
+/// `PACKAGE_VERSION` doc in `packages/hashi/sources/core/versioning.move`
+/// and `SUPPORTED_PACKAGE_VERSIONS` in the `hashi` crate's `constants`.
+///
+/// [`PACKAGE_VERSION`]: MoveType::PACKAGE_VERSION
+/// [`matches`]: MoveType::matches
+/// [`MODULE_NAME`]: MoveType::MODULE_NAME
 pub trait MoveType {
     /// The hashi package version that first defined this struct. A
     /// type keeps its defining package's address through upgrades, so

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -78,6 +78,7 @@ mod mirror;
 mod route;
 pub mod types;
 pub mod version;
+mod versioned_decode;
 mod watcher;
 
 fn parse_encryption_public_key(bytes: &[u8]) -> Option<crate::mpc::EncryptionGroupElement> {
@@ -885,11 +886,26 @@ impl OnchainState {
                     .with_read_mask(FieldMask::from_paths([
                         DynamicField::path_builder().name().finish(),
                         DynamicField::path_builder().value().finish(),
+                        DynamicField::path_builder().value_type(),
                     ])),
             )
             .pipe(Box::pin);
         while let Some(field) = stream.try_next().await? {
             if field.name().value() == key_bcs.as_slice() {
+                // Decode by the layout the chain reports (self-describing),
+                // rather than assuming `EpochCertsV1`. The bucket structs are
+                // BCS-identical, but a stamped bucket implies stamped node
+                // values this build cannot decode — so fail cleanly here
+                // instead of misparsing the linked-table nodes downstream.
+                let value_type = versioned_decode::field_value_type(&field)?;
+                match versioned_decode::TobCertLayout::from_struct_tag(&value_type)? {
+                    versioned_decode::TobCertLayout::Bare => {}
+                    versioned_decode::TobCertLayout::Stamped => anyhow::bail!(
+                        "TOB bucket (epoch {epoch}, batch {batch_index:?}, {protocol_type:?}) uses \
+                         the stamped cert layout, which this binary does not support — upgrade \
+                         required"
+                    ),
+                }
                 let epoch_certs: move_types::EpochCertsV1 = field.value().deserialize()?;
                 return Ok(Some(epoch_certs));
             }

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -890,6 +890,10 @@ impl OnchainState {
                     ])),
             )
             .pipe(Box::pin);
+        // Cloned once up front: the guard must not be held across the stream's
+        // await points, and identification below resolves defining addresses
+        // through this map.
+        let packages = self.state().package_versions().clone();
         while let Some(field) = stream.try_next().await? {
             if field.name().value() == key_bcs.as_slice() {
                 // Decode by the layout the chain reports (self-describing),
@@ -898,7 +902,7 @@ impl OnchainState {
                 // values this build cannot decode — so fail cleanly here
                 // instead of misparsing the linked-table nodes downstream.
                 let value_type = versioned_decode::field_value_type(&field)?;
-                match versioned_decode::TobCertLayout::from_struct_tag(&value_type)? {
+                match versioned_decode::TobCertLayout::from_struct_tag(&packages, &value_type)? {
                     versioned_decode::TobCertLayout::Bare => {}
                     versioned_decode::TobCertLayout::Stamped => anyhow::bail!(
                         "TOB bucket (epoch {epoch}, batch {batch_index:?}, {protocol_type:?}) uses \

--- a/crates/hashi/src/onchain/versioned_decode.rs
+++ b/crates/hashi/src/onchain/versioned_decode.rs
@@ -18,13 +18,21 @@
 //! the [`super::version`] active-version gate: that halts *writes* when the
 //! chain is ahead; this makes *reads* fail loud rather than wrong.
 //!
-//! Identification keys on `(module, name)` only. A Move type keeps its module
-//! and name across upgrades, and a divergent layout must be a *new* type with a
-//! new name (an upgrade cannot change an existing struct's layout — the compat
-//! gate enforces this), so the name is an authoritative layout discriminator.
+//! Identification keys on `(module, name)` only — [`MoveType::MODULE_NAME`],
+//! so the Rust mirrors stay the single source of truth for type identity. A
+//! Move type keeps its module and name across upgrades, and a divergent layout
+//! must be a *new* type with a new name (an upgrade cannot change an existing
+//! struct's layout — the compat gate enforces this), so the name is an
+//! authoritative layout discriminator. Deliberately not the address-checking
+//! [`MoveType::matches`]: the field's `value_type` is already authoritative
+//! here, and address-keyed dispatch would reintroduce the mid-upgrade lag this
+//! module exists to avoid.
 
 use anyhow::Context;
 use anyhow::Result;
+use hashi_types::move_types::EpochCertsV1;
+use hashi_types::move_types::MoveType;
+use hashi_types::move_types::StampedEpochCertsV1;
 use sui_rpc::proto::sui::rpc::v2::DynamicField;
 use sui_sdk_types::StructTag;
 
@@ -37,10 +45,6 @@ pub fn field_value_type(field: &DynamicField) -> Result<StructTag> {
     raw.parse::<StructTag>()
         .with_context(|| format!("parsing dynamic field value_type {raw:?}"))
 }
-
-const TOB_MODULE: &str = "tob";
-const EPOCH_CERTS_V1: &str = "EpochCertsV1";
-const STAMPED_EPOCH_CERTS_V1: &str = "StampedEpochCertsV1";
 
 /// The layout family of a TOB certificate bucket, identified by its on-chain
 /// value type.
@@ -63,15 +67,10 @@ pub enum TobCertLayout {
 impl TobCertLayout {
     /// Identify the bucket layout from its on-chain value type.
     pub fn from_struct_tag(tag: &StructTag) -> Result<Self> {
-        anyhow::ensure!(
-            tag.module() == TOB_MODULE,
-            "unexpected TOB bucket module: {}::{}",
-            tag.module(),
-            tag.name()
-        );
-        if tag.name() == EPOCH_CERTS_V1 {
+        let key = (tag.module().as_str(), tag.name().as_str());
+        if key == EpochCertsV1::MODULE_NAME {
             Ok(Self::Bare)
-        } else if tag.name() == STAMPED_EPOCH_CERTS_V1 {
+        } else if key == StampedEpochCertsV1::MODULE_NAME {
             Ok(Self::Stamped)
         } else {
             anyhow::bail!(

--- a/crates/hashi/src/onchain/versioned_decode.rs
+++ b/crates/hashi/src/onchain/versioned_decode.rs
@@ -18,20 +18,21 @@
 //! the [`super::version`] active-version gate: that halts *writes* when the
 //! chain is ahead; this makes *reads* fail loud rather than wrong.
 //!
-//! Identification keys on `(module, name)` only — [`MoveType::MODULE_NAME`],
-//! so the Rust mirrors stay the single source of truth for type identity. A
-//! Move type keeps its module and name across upgrades, and a divergent layout
-//! must be a *new* type with a new name (an upgrade cannot change an existing
-//! struct's layout — the compat gate enforces this), so the name is an
-//! authoritative layout discriminator. Deliberately not the address-checking
-//! [`MoveType::matches`]: the field's `value_type` is already authoritative
-//! here, and address-keyed dispatch would reintroduce the mid-upgrade lag this
-//! module exists to avoid.
+//! Identification is [`MoveType::matches`] against the Rust mirrors — the full
+//! tag, defining package address included, so the mirrors stay the single
+//! source of truth for type identity and a same-name type from a foreign
+//! package is rejected rather than trusted. The defining address is resolved
+//! through the version that introduced the type ([`MoveType::PACKAGE_VERSION`]),
+//! which never moves across upgrades. A tag whose introducing version this
+//! node has not yet observed in the package history fails the match and
+//! surfaces as a clean unknown-type error — loud and retryable, never a
+//! misdecode.
 
 use anyhow::Context;
 use anyhow::Result;
 use hashi_types::move_types::EpochCertsV1;
 use hashi_types::move_types::MoveType;
+use hashi_types::move_types::PackageVersions;
 use hashi_types::move_types::StampedEpochCertsV1;
 use sui_rpc::proto::sui::rpc::v2::DynamicField;
 use sui_sdk_types::StructTag;
@@ -51,7 +52,7 @@ pub fn field_value_type(field: &DynamicField) -> Result<StructTag> {
 ///
 /// The bucket structs (`EpochCertsV1` / `StampedEpochCertsV1`) are BCS-identical
 /// — the divergence is in the `LinkedTable` node values they hold
-/// (`DealerSubmissionV1` vs the stamped variant). So the bucket's type name is
+/// (`DealerSubmissionV1` vs the stamped variant). So the bucket's type is
 /// what tells a reader which node layout to expect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TobCertLayout {
@@ -65,16 +66,17 @@ pub enum TobCertLayout {
 }
 
 impl TobCertLayout {
-    /// Identify the bucket layout from its on-chain value type.
-    pub fn from_struct_tag(tag: &StructTag) -> Result<Self> {
-        let key = (tag.module().as_str(), tag.name().as_str());
-        if key == EpochCertsV1::MODULE_NAME {
+    /// Identify the bucket layout from its on-chain value type: the tag must
+    /// fully match one of the known mirrors via [`MoveType::matches`].
+    pub fn from_struct_tag(packages: &PackageVersions, tag: &StructTag) -> Result<Self> {
+        if EpochCertsV1::matches(packages, tag) {
             Ok(Self::Bare)
-        } else if key == StampedEpochCertsV1::MODULE_NAME {
+        } else if StampedEpochCertsV1::matches(packages, tag) {
             Ok(Self::Stamped)
         } else {
             anyhow::bail!(
-                "unknown TOB cert bucket type: {}::{}",
+                "unknown TOB cert bucket type: {}::{}::{}",
+                tag.address(),
                 tag.module(),
                 tag.name()
             )
@@ -85,29 +87,67 @@ impl TobCertLayout {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+    use sui_sdk_types::Address;
+
+    /// v1 published at 0x7, v2 at 0x9.
+    fn packages() -> PackageVersions {
+        PackageVersions::new(BTreeMap::from([
+            (1, Address::from_bytes([0x7; 32]).unwrap()),
+            (2, Address::from_bytes([0x9; 32]).unwrap()),
+        ]))
+    }
 
     fn tag(s: &str) -> StructTag {
         s.parse().unwrap()
     }
 
+    fn addr_tag(byte: u8, rest: &str) -> StructTag {
+        format!("{}::{rest}", Address::from_bytes([byte; 32]).unwrap())
+            .parse()
+            .unwrap()
+    }
+
     #[test]
-    fn identifies_bare_and_stamped_by_name() {
+    fn identifies_bare_and_stamped_at_their_defining_addresses() {
         assert_eq!(
-            TobCertLayout::from_struct_tag(&tag("0x7::tob::EpochCertsV1")).unwrap(),
+            TobCertLayout::from_struct_tag(&packages(), &addr_tag(0x7, "tob::EpochCertsV1"))
+                .unwrap(),
             TobCertLayout::Bare
         );
-        // Distinct package address (a v2 upgrade) — dispatch is by name, so the
-        // address is irrelevant to which layout it is.
+        // Introduced by v2, so its defining address is the v2 package.
         assert_eq!(
-            TobCertLayout::from_struct_tag(&tag("0x9::tob::StampedEpochCertsV1")).unwrap(),
+            TobCertLayout::from_struct_tag(&packages(), &addr_tag(0x9, "tob::StampedEpochCertsV1"))
+                .unwrap(),
             TobCertLayout::Stamped
         );
     }
 
     #[test]
     fn rejects_unknown_name_and_wrong_module() {
-        assert!(TobCertLayout::from_struct_tag(&tag("0x7::tob::SomethingElse")).is_err());
-        assert!(TobCertLayout::from_struct_tag(&tag("0x7::other::EpochCertsV1")).is_err());
+        assert!(
+            TobCertLayout::from_struct_tag(&packages(), &addr_tag(0x7, "tob::SomethingElse"))
+                .is_err()
+        );
+        assert!(
+            TobCertLayout::from_struct_tag(&packages(), &addr_tag(0x7, "other::EpochCertsV1"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_a_known_name_at_a_foreign_address() {
+        // Right module::name, wrong defining package: a same-name type from a
+        // package outside the history must not be trusted.
+        assert!(
+            TobCertLayout::from_struct_tag(&packages(), &tag("0x42::tob::EpochCertsV1")).is_err()
+        );
+        // A known name at the *other* version's address is also rejected: the
+        // defining address of a type never moves.
+        assert!(
+            TobCertLayout::from_struct_tag(&packages(), &addr_tag(0x9, "tob::EpochCertsV1"))
+                .is_err()
+        );
     }
 
     #[test]
@@ -115,10 +155,14 @@ mod tests {
         let missing = DynamicField::default();
         assert!(field_value_type(&missing).is_err());
 
-        let present = DynamicField::default().with_value_type("0x7::tob::EpochCertsV1");
+        let bare = format!(
+            "{}::tob::EpochCertsV1",
+            Address::from_bytes([0x7; 32]).unwrap()
+        );
+        let present = DynamicField::default().with_value_type(bare);
         let parsed = field_value_type(&present).unwrap();
         assert_eq!(
-            TobCertLayout::from_struct_tag(&parsed).unwrap(),
+            TobCertLayout::from_struct_tag(&packages(), &parsed).unwrap(),
             TobCertLayout::Bare
         );
     }

--- a/crates/hashi/src/onchain/versioned_decode.rs
+++ b/crates/hashi/src/onchain/versioned_decode.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Self-describing decode of version-divergent dynamic-field values.
+//!
+//! When a package upgrade changes the *type* stored in a dynamic-field slot — a
+//! v2 replaces type A with type B in the same bucket, e.g. the TOB nonce-cert
+//! buckets gaining stamped variants — a reader must decide which layout to
+//! BCS-decode the bytes as. Rather than infer that from a global version flag
+//! (which can lag the actual on-chain state mid-upgrade and mis-decode a
+//! straggler field written before the flip), we read the field's own on-chain
+//! `value_type` (`DynamicField.value_type`) and decode exactly what the chain
+//! reports.
+//!
+//! This is transition-safe: during an upgrade a mix of old- and new-layout
+//! fields is each decoded correctly, and a layout this binary does not implement
+//! fails cleanly (a clear error) instead of silently misparsing. It complements
+//! the [`super::version`] active-version gate: that halts *writes* when the
+//! chain is ahead; this makes *reads* fail loud rather than wrong.
+//!
+//! Identification keys on `(module, name)` only. A Move type keeps its module
+//! and name across upgrades, and a divergent layout must be a *new* type with a
+//! new name (an upgrade cannot change an existing struct's layout — the compat
+//! gate enforces this), so the name is an authoritative layout discriminator.
+
+use anyhow::Context;
+use anyhow::Result;
+use sui_rpc::proto::sui::rpc::v2::DynamicField;
+use sui_sdk_types::StructTag;
+
+/// The concrete Move type a dynamic field's value carries on chain. Requires
+/// `value_type` in the `list_dynamic_fields` read mask.
+pub fn field_value_type(field: &DynamicField) -> Result<StructTag> {
+    let raw = field
+        .value_type_opt()
+        .context("dynamic field is missing value_type (add it to the read mask)")?;
+    raw.parse::<StructTag>()
+        .with_context(|| format!("parsing dynamic field value_type {raw:?}"))
+}
+
+const TOB_MODULE: &str = "tob";
+const EPOCH_CERTS_V1: &str = "EpochCertsV1";
+const STAMPED_EPOCH_CERTS_V1: &str = "StampedEpochCertsV1";
+
+/// The layout family of a TOB certificate bucket, identified by its on-chain
+/// value type.
+///
+/// The bucket structs (`EpochCertsV1` / `StampedEpochCertsV1`) are BCS-identical
+/// — the divergence is in the `LinkedTable` node values they hold
+/// (`DealerSubmissionV1` vs the stamped variant). So the bucket's type name is
+/// what tells a reader which node layout to expect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TobCertLayout {
+    /// `tob::EpochCertsV1` — nodes are `DealerSubmissionV1`.
+    Bare,
+    /// `tob::StampedEpochCertsV1` — nodes carry a timestamp. Decoding it
+    /// requires binary support for the stamped types (the nonce dealer-cert
+    /// window work); a build without them identifies the layout but must not
+    /// attempt to decode its nodes.
+    Stamped,
+}
+
+impl TobCertLayout {
+    /// Identify the bucket layout from its on-chain value type.
+    pub fn from_struct_tag(tag: &StructTag) -> Result<Self> {
+        anyhow::ensure!(
+            tag.module() == TOB_MODULE,
+            "unexpected TOB bucket module: {}::{}",
+            tag.module(),
+            tag.name()
+        );
+        if tag.name() == EPOCH_CERTS_V1 {
+            Ok(Self::Bare)
+        } else if tag.name() == STAMPED_EPOCH_CERTS_V1 {
+            Ok(Self::Stamped)
+        } else {
+            anyhow::bail!(
+                "unknown TOB cert bucket type: {}::{}",
+                tag.module(),
+                tag.name()
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tag(s: &str) -> StructTag {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn identifies_bare_and_stamped_by_name() {
+        assert_eq!(
+            TobCertLayout::from_struct_tag(&tag("0x7::tob::EpochCertsV1")).unwrap(),
+            TobCertLayout::Bare
+        );
+        // Distinct package address (a v2 upgrade) — dispatch is by name, so the
+        // address is irrelevant to which layout it is.
+        assert_eq!(
+            TobCertLayout::from_struct_tag(&tag("0x9::tob::StampedEpochCertsV1")).unwrap(),
+            TobCertLayout::Stamped
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_name_and_wrong_module() {
+        assert!(TobCertLayout::from_struct_tag(&tag("0x7::tob::SomethingElse")).is_err());
+        assert!(TobCertLayout::from_struct_tag(&tag("0x7::other::EpochCertsV1")).is_err());
+    }
+
+    #[test]
+    fn field_value_type_requires_the_mask_field() {
+        let missing = DynamicField::default();
+        assert!(field_value_type(&missing).is_err());
+
+        let present = DynamicField::default().with_value_type("0x7::tob::EpochCertsV1");
+        let parsed = field_value_type(&present).unwrap();
+        assert_eq!(
+            TobCertLayout::from_struct_tag(&parsed).unwrap(),
+            TobCertLayout::Bare
+        );
+    }
+}


### PR DESCRIPTION
**PR 2 of the dynamic package-version framework**, stacked on #923 (PR 1).

## What

Makes the node's decode of on-chain dynamic-field values **version-aware** wherever a slot's stored type can change across package upgrades — starting with the TOB nonce-cert buckets (`EpochCertsV1` → `StampedEpochCertsV1`).

- **`onchain::versioned_decode`** — reads a dynamic field's on-chain `value_type` and identifies its layout (`TobCertLayout::{Bare, Stamped}`) instead of assuming a single Rust type. Decode follows what the chain actually reports.
- **Gated in `fetch_epoch_certs`** — adds `value_type` to the read mask and checks the layout before decoding. The bucket structs are BCS-identical, so this single gate covers every cert protocol type; a `Stamped` bucket is rejected with a clear "upgrade required" error instead of misparsing its stamped linked-table nodes downstream.

## Why value-type dispatch

Decoding by the field's actual on-chain type — rather than a global "are we on v2 yet" flag — is **self-describing and transition-safe**: during an upgrade a mix of pre- and post-flip bucket layouts is each decoded correctly, with no dependency on a flag staying in lockstep with per-bucket reality. It complements PR 1: the active-version gate halts *writes* when the chain is ahead of the binary; this makes *reads* fail loud rather than wrong.

## How the nonce-cert window work plugs in

The reverted #841 re-lands on top: its `StampedEpochCertsV1` maps to `TobCertLayout::Stamped`, and the re-land fills in the node-level stamped decode (against real data) and declares its types at `PACKAGE_VERSION = 2`. `MoveType::PACKAGE_VERSION` remains the per-type version marker used on the write side.

## Test

`cargo test -p hashi --lib onchain` (40 pass, incl. 3 new dispatch cases); `clippy --all-targets -D warnings` and `fmt --check` clean.