### PR TITLE
fix(docs): correct phase count in withdraw.mdx

### DIFF
--- a/design/docs/withdraw.mdx
+++ b/design/docs/withdraw.mdx
@@ -5,7 +5,7 @@ keywords: [ withdraw, hBTC, BTC, signing, MPC, Bitcoin transaction, Schnorr ]
 ---
 
 A withdrawal allows a user to redeem their `hBTC` on Sui for native BTC,
-sent to a user-specified address on Bitcoin. The process has four phases:
+sent to a user-specified address on Bitcoin. The process has five phases:
 
 ```mermaid
 graph LR


### PR DESCRIPTION
The document lists 5 distinct phases (`Request` > `Approve` > `Build TX` > `Sign` > `Broadcast`) but the introductory text incorrectly states "four phases". 