### PR TITLE
[Guardian] [2/3] Preserve versioned log records

### DIFF
--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -240,8 +240,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         enclave_current_committee_epoch.is_none(),
         "Guardian has current_committee_epoch => operator activation already ran"
     );
-    let oi_info = verified_session.info;
-    ensure_oi_info_matches_post_init(&oi_info, &guardian_info)
+    ensure_oi_info_matches_post_init(verified_session.info(), &guardian_info)
         .with_context(|| format!("S3 GuardianInfo mismatch for session {session_id}"))?;
     anyhow::ensure!(
         &master_g == enclave_mpc_master_g,

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -118,11 +118,11 @@ pub async fn run(
         .get_session_info(&session_id, BuildPolicy::Current)
         .await?;
     anyhow::ensure!(
-        verified_session.signing_pubkey == signing_pub_key,
+        verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
     anyhow::ensure!(
-        verified_session.info.bucket_info.as_ref() == Some(endpoint_bucket_info),
+        verified_session.info().bucket_info.as_ref() == Some(endpoint_bucket_info),
         "guardian S3 session bucket info differs from live GuardianInfo"
     );
     let endpoint_btc_pubkey = endpoint_verified

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -128,10 +128,10 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         .get_session_info(&session_id, BuildPolicy::Current)
         .await?;
     ensure!(
-        verified_session.signing_pubkey == signing_pub_key,
+        verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
-    verify_oi_info_matches_provisioned_standby(&verified_session.info, &pre_info)?;
+    verify_oi_info_matches_provisioned_standby(verified_session.info(), &pre_info)?;
     info!(
         phase = "attestation pin",
         session_id = %session_id,

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -142,9 +142,9 @@ pub async fn run(cfg: Config) -> Result<()> {
     let verified_session = reader
         .get_session_info(&session_id, BuildPolicy::Current)
         .await?;
-    let attested_signing_pub_key = verified_session.signing_pubkey;
+    let attested_signing_pub_key = verified_session.signing_pubkey();
     ensure!(
-        attested_signing_pub_key == signing_pub_key,
+        attested_signing_pub_key == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
     info!(

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -244,11 +244,10 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         .get_session_info(&session_id, BuildPolicy::Current)
         .await?;
     ensure!(
-        verified_session.signing_pubkey == signing_pub_key,
+        verified_session.signing_pubkey() == &signing_pub_key,
         "guardian S3 attestation signing pubkey differs from gRPC signing pubkey"
     );
-    let oi_info = verified_session.info;
-    ensure_oi_info_matches_post_init(&oi_info, &post.info)?;
+    ensure_oi_info_matches_post_init(verified_session.info(), &post.info)?;
     info!(
         phase = "attestation pin",
         session_id = %session_id,

--- a/crates/hashi-guardian-proxy/src/widlog.rs
+++ b/crates/hashi-guardian-proxy/src/widlog.rs
@@ -20,9 +20,12 @@
 use crate::metrics::ProxyMetrics;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::log::S3_DIR_WITHDRAW;
-use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::GuardianError::InvalidS3Log;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::StandardWithdrawalResponse;
+use hashi_types::guardian::VersionedLogMessage;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::WithdrawalLogMessage;
 use tracing::warn;
@@ -166,9 +169,22 @@ fn parse_success_seq(key: &str) -> Option<u64> {
 
 fn parse_success(bytes: &[u8], wid: &WithdrawalID) -> anyhow::Result<FoundSuccess> {
     let record: LogRecord = serde_json::from_slice(bytes)?;
-    let (_, timestamp_ms, message) = record.into_current_unchecked()?;
-    let LogMessage::Withdrawal(message) = message else {
-        anyhow::bail!("not a withdrawal record");
+    if let LogRecord::Unsigned(entry) = &record {
+        let message = if entry.message().is_allowed_unsigned() {
+            "expected signed log record but message is unsigned"
+        } else {
+            "missing log signature"
+        };
+        return Err(InvalidS3Log(message.into()).into());
+    }
+    let entry = record.into_entry_unchecked();
+    let timestamp_ms = entry.timestamp_ms();
+    let message = match entry.into_message() {
+        VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,
+        VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) => message,
+        VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+            anyhow::bail!("not a withdrawal record");
+        }
     };
     let WithdrawalLogMessage::Success {
         request_data,
@@ -298,6 +314,7 @@ pub(crate) mod test_store {
     use bitcoin::hashes::Hash as _;
     use bitcoin::Network;
     use hashi_types::guardian::GuardianSignKeyPair;
+    use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::StandardWithdrawalRequestWire;

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -135,7 +135,7 @@ mod tests {
     use hashi_types::guardian::test_utils::mock_kp_certs_roster;
     use hashi_types::guardian::GuardianError::InvalidInputs;
     use hashi_types::guardian::GuardianError::LifecycleMismatch;
-    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;
     use k256::SecretKey;
@@ -254,7 +254,7 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Ceremony(ceremony)) = record.message() else {
             panic!("expected V2 Ceremony variant");
         };
         let CeremonyLogMessage::Rotate {
@@ -300,7 +300,7 @@ mod tests {
             "expected sharing_seq=1 cert_seq=0, got key {shares_key}"
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message()
+        let VersionedLogMessage::V2(LogMessageV2::KpShareState(shares)) = shares_record.message()
         else {
             panic!("expected V2 KpShareState variant");
         };

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -97,7 +97,7 @@ mod tests {
     use crate::test_utils::decrypt_kp_shares;
     use crate::test_utils::mock_kp_certs_roster_with_secrets;
     use hashi_types::guardian::crypto::combine_shares;
-    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;
 
@@ -162,7 +162,7 @@ mod tests {
         );
 
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Ceremony(ceremony)) = record.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Ceremony(ceremony)) = record.message() else {
             panic!("expected V2 Ceremony variant");
         };
         let CeremonyLogMessage::NewKey {
@@ -197,7 +197,7 @@ mod tests {
             )
         );
         let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessage::KpShareState(shares)) = shares_record.message()
+        let VersionedLogMessage::V2(LogMessageV2::KpShareState(shares)) = shares_record.message()
         else {
             panic!("expected V2 KpShareState variant");
         };

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -271,12 +271,12 @@ mod tests {
         let attestation: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert!(matches!(
             attestation.message(),
-            VersionedLogMessage::V2(LogMessage::Init(message))
+            VersionedLogMessage::V2(LogMessageV2::Init(message))
                 if matches!(message.as_ref(), OIAttestationUnsigned { .. })
         ));
 
         let guardian_info: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Init(message)) = guardian_info.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Init(message)) = guardian_info.message() else {
             panic!("expected V2 init record");
         };
         let OIGuardianInfo(info) = message.as_ref() else {

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -23,9 +23,6 @@ use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianError::S3Error;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::InitLogMessage;
-use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::VerifiedSessionInfo;
 use serde::Serialize;
 use tracing::info;
 use tracing::warn;
@@ -623,61 +620,6 @@ impl GuardianS3Client {
         self.get_log_record_inner(key, LockCheck::Required, HistoryCheck::Required)
             .await
     }
-
-    /// Resolve a session's [`VerifiedSessionInfo`]: read the AWS-self-signed
-    /// attestation (anchoring the signing pubkey), then the signed `GuardianInfo`,
-    /// and pin the attestation's PCR0 against the `allowlist` entry named by the
-    /// info's reported build. No caller needs the raw attestation bytes.
-    pub(crate) async fn get_verified_session_info(
-        &self,
-        session_id: &str,
-        allowlist: &PcrAllowlist,
-    ) -> GuardianResult<VerifiedSessionInfo> {
-        // 1. Attestation (unsigned: authenticated by AWS, not the enclave key) →
-        //    the signing pubkey it commits to.
-        let att_key = InitLogMessage::attestation_object_key(session_id);
-        let attestation_record = self.get_log_record(&att_key).await?;
-        let (_, _, attestation_message) = attestation_record.validate(None)?;
-        let (attestation, signing_pubkey) = attestation_message
-            .into_init_log()
-            .and_then(|x| match x {
-                InitLogMessage::OIAttestationUnsigned {
-                    attestation,
-                    signing_public_key,
-                } => Some((attestation, signing_public_key)),
-                _ => None,
-            })
-            .ok_or_else(|| {
-                InvalidS3Log(format!("expected OIAttestationUnsigned at key {att_key}"))
-            })?;
-
-        // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
-        let info_key = InitLogMessage::guardian_info_object_key(session_id);
-        let info_record = self.get_log_record(&info_key).await?;
-        let (_, _, info_message) = info_record.validate(Some(&signing_pubkey))?;
-        let info = info_message
-            .into_init_log()
-            .and_then(|x| match x {
-                InitLogMessage::OIGuardianInfo(info) => Some(*info),
-                _ => None,
-            })
-            .ok_or_else(|| InvalidS3Log(format!("expected OIGuardianInfo at key {info_key}")))?;
-
-        // 3. Anchor the pubkey and pin PCR0 to the allowlist entry for the
-        //    reported build. This replays a logged attestation whose short-lived
-        //    leaf cert has typically expired, so the chain is checked at the
-        //    document's own signed timestamp, not now.
-        let build_pcrs = allowlist.resolve(&info.untrusted_git_revision)?.clone();
-        attestation
-            .verify_replay(&signing_pubkey, &build_pcrs)
-            .map_err(|e| InvalidS3Log(format!("attestation at key {att_key}: {e}")))?;
-
-        Ok(VerifiedSessionInfo {
-            signing_pubkey,
-            info,
-            build_pcrs,
-        })
-    }
 }
 
 // TODO(testnet-wipe): Once legacy seven-day logs are gone, also verify that the
@@ -703,6 +645,7 @@ mod tests {
     use aws_smithy_mocks::RuleMode;
     use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::HeartbeatLogMessage;
+    use hashi_types::guardian::InitLogMessage;
     use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::NitroAttestation;
     use hashi_types::guardian::SessionID;

--- a/crates/hashi-guardian/src/s3_reader.rs
+++ b/crates/hashi-guardian/src/s3_reader.rs
@@ -15,7 +15,6 @@ use crate::s3_client::GuardianS3Client;
 use crate::s3_client::HistoryCheck;
 use crate::s3_client::LockCheck;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
-use hashi_types::guardian::time_utils::UnixMillis;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::CeremonyLogMessage;
@@ -26,12 +25,13 @@ use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::KpShareStateLogMessage;
-use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3Config;
 use hashi_types::guardian::SessionID;
-use hashi_types::guardian::VerifiedSessionInfo;
+use hashi_types::guardian::VersionedLogMessage;
 use hashi_types::guardian::S3_DIR_CEREMONY;
 use hashi_types::guardian::S3_DIR_COMMITTEE_UPDATE;
 use hashi_types::guardian::S3_DIR_GENESIS;
@@ -43,61 +43,10 @@ use tracing::info;
 
 mod heartbeat_checks;
 mod limiter_recovery;
+mod verified;
 
-/// A log record whose message signature and writing session's attestation/PCRs
-/// have both been verified. Its message is normalized to the current schema.
-/// If a future schema cannot be converted losslessly, this type should retain
-/// the versioned message and leave version acceptance to callers instead.
-#[derive(Debug)]
-pub struct VerifiedLogRecord {
-    object_key: String,
-    session_id: SessionID,
-    timestamp_ms: UnixMillis,
-    message: LogMessage,
-    build_pcrs: BuildPcrs,
-}
-
-impl VerifiedLogRecord {
-    fn new(
-        object_key: String,
-        session_id: SessionID,
-        timestamp_ms: UnixMillis,
-        message: LogMessage,
-        build_pcrs: BuildPcrs,
-    ) -> Self {
-        Self {
-            object_key,
-            session_id,
-            timestamp_ms,
-            message,
-            build_pcrs,
-        }
-    }
-
-    pub fn object_key(&self) -> &str {
-        &self.object_key
-    }
-
-    pub fn session_id(&self) -> &SessionID {
-        &self.session_id
-    }
-
-    pub fn timestamp_ms(&self) -> UnixMillis {
-        self.timestamp_ms
-    }
-
-    pub fn message(&self) -> &LogMessage {
-        &self.message
-    }
-
-    pub fn build_pcrs(&self) -> &BuildPcrs {
-        &self.build_pcrs
-    }
-
-    pub fn into_message(self) -> LogMessage {
-        self.message
-    }
-}
+pub use verified::VerifiedLogRecord;
+pub use verified::VerifiedSessionInfo;
 
 /// Open an hour-scoped cursor at `start` over the `withdraw/` stream. Advance/
 /// retreat with [`S3HourScopedDirectory::next_dir`]/`prev_dir`, gate on
@@ -197,7 +146,7 @@ impl GuardianReader {
             .get_or_load_session_info(&self.s3, session_id)
             .await?
             .clone();
-        self.enforce_build_policy(build_policy, &session_info.build_pcrs)?;
+        self.enforce_build_policy(build_policy, session_info.build_pcrs())?;
         Ok(session_info)
     }
 
@@ -207,7 +156,10 @@ impl GuardianReader {
         session_id: &str,
         build_policy: BuildPolicy,
     ) -> GuardianResult<GuardianInfo> {
-        Ok(self.get_session_info(session_id, build_policy).await?.info)
+        Ok(self
+            .get_session_info(session_id, build_policy)
+            .await?
+            .into_info())
     }
 
     /// The latest ceremony from `ceremony/` — the max-`sharing_seq` (lex-last)
@@ -229,11 +181,14 @@ impl GuardianReader {
         };
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        let build_pcrs = record.build_pcrs.clone();
-        self.enforce_build_policy(build_policy, &build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::Ceremony(msg) = record.message else {
-            return Err(InvalidS3Log(format!("expected a ceremony log at {key}")));
+        self.enforce_build_policy(build_policy, record.build_pcrs())?;
+        let session_id = record.entry().session_id().clone();
+        let msg = match record.into_entry().into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Ceremony(msg)) => msg,
+            VersionedLogMessage::V2(LogMessageV2::Ceremony(msg)) => msg,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!("expected a ceremony log at {key}")));
+            }
         };
         log_verified_read(&key, &session_id);
         Ok(Some(*msg))
@@ -309,13 +264,19 @@ impl GuardianReader {
             .get_log_record_inner(key, LockCheck::Skipped, history_check)
             .await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::KpShareState(msg) = record.message else {
-            return Err(InvalidS3Log(format!("expected a kp-shares log at {key}")));
+        self.enforce_build_policy(build_policy, record.build_pcrs())?;
+        let session_id = record.entry().session_id().clone();
+        let msg = match record.into_entry().into_message() {
+            VersionedLogMessage::V1(LogMessageV1::KpShareState(msg)) => (*msg)
+                .try_into()
+                .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?,
+            VersionedLogMessage::V2(LogMessageV2::KpShareState(msg)) => *msg,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!("expected a kp-shares log at {key}")));
+            }
         };
         log_verified_read(key, &session_id);
-        Ok(*msg)
+        Ok(msg)
     }
 
     /// Read the latest ceremony together with the latest KP share state for its
@@ -375,12 +336,16 @@ impl GuardianReader {
         };
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::CommitteeUpdate(msg) = record.message else {
-            return Err(InvalidS3Log(format!(
-                "expected a committee-update log at {key}"
-            )));
+        self.enforce_build_policy(build_policy, record.build_pcrs())?;
+        let session_id = record.entry().session_id().clone();
+        let msg = match record.into_entry().into_message() {
+            VersionedLogMessage::V1(LogMessageV1::CommitteeUpdate(msg)) => msg,
+            VersionedLogMessage::V2(LogMessageV2::CommitteeUpdate(msg)) => msg,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!(
+                    "expected a committee-update log at {key}"
+                )));
+            }
         };
         let committee = match *msg {
             CommitteeUpdateLogMessage::Success { new_committee, .. } => new_committee,
@@ -415,10 +380,14 @@ impl GuardianReader {
         }
         let record = self.s3.get_log_record(&key).await?;
         let record = self.cache.verify_record(&self.s3, record).await?;
-        self.enforce_build_policy(build_policy, &record.build_pcrs)?;
-        let session_id = record.session_id;
-        let LogMessage::Genesis(msg) = record.message else {
-            return Err(InvalidS3Log(format!("expected a genesis log at {key}")));
+        self.enforce_build_policy(build_policy, record.build_pcrs())?;
+        let session_id = record.entry().session_id().clone();
+        let msg = match record.into_entry().into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Genesis(msg)) => msg,
+            VersionedLogMessage::V2(LogMessageV2::Genesis(msg)) => msg,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(format!("expected a genesis log at {key}")));
+            }
         };
         log_verified_read(&key, &session_id);
         Ok(Some(*msg))
@@ -453,9 +422,7 @@ impl GuardianSessionCache {
         session_id: &str,
     ) -> GuardianResult<&VerifiedSessionInfo> {
         if !self.sessions.contains_key(session_id) {
-            let session_info = s3
-                .get_verified_session_info(session_id, &self.allowlist)
-                .await?;
+            let session_info = VerifiedSessionInfo::new(s3, session_id, &self.allowlist).await?;
             self.sessions.insert(session_id.into(), session_info);
         }
         Ok(&self.sessions[session_id])
@@ -467,19 +434,9 @@ impl GuardianSessionCache {
         s3: &GuardianS3Client,
         record: LogRecord,
     ) -> GuardianResult<VerifiedLogRecord> {
-        let object_key = record.object_key().to_owned();
         let session_id = record.session_id().clone();
         let session_info = self.get_or_load_session_info(s3, &session_id).await?;
-        let signing_pubkey = session_info.signing_pubkey;
-        let build_pcrs = session_info.build_pcrs.clone();
-        let (session_id, timestamp_ms, message) = record.validate(Some(&signing_pubkey))?;
-        Ok(VerifiedLogRecord::new(
-            object_key,
-            session_id,
-            timestamp_ms,
-            message,
-            build_pcrs,
-        ))
+        VerifiedLogRecord::new(record, session_info)
     }
 }
 

--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -14,8 +14,10 @@ use hashi_types::guardian::GuardianError::CurrentSessionHeartbeatNotLive;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianError::PriorSessionHeartbeatStillRecent;
 use hashi_types::guardian::GuardianResult;
-use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::SessionID;
+use hashi_types::guardian::VersionedLogMessage;
 use std::collections::BTreeMap;
 use tracing::info;
 
@@ -79,14 +81,20 @@ fn summarize_heartbeats_by_session(
     let mut map: BTreeMap<SessionID, (UnixSeconds, UnixSeconds)> = BTreeMap::new();
 
     for log in logs {
-        if !matches!(log.message, LogMessage::Heartbeat(..)) {
-            return Err(InvalidS3Log(
-                "non-heartbeat log found under the heartbeat prefix".into(),
-            ));
+        let entry = log.into_entry();
+        let session_id = entry.session_id().clone();
+        let ts = unix_millis_to_seconds(entry.timestamp_ms());
+        match entry.into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Heartbeat(..))
+            | VersionedLogMessage::V2(LogMessageV2::Heartbeat(..)) => {}
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                return Err(InvalidS3Log(
+                    "non-heartbeat log found under the heartbeat prefix".into(),
+                ));
+            }
         }
 
-        let ts = unix_millis_to_seconds(log.timestamp_ms);
-        map.entry(log.session_id)
+        map.entry(session_id)
             .and_modify(|(first, last)| {
                 *first = (*first).min(ts);
                 *last = (*last).max(ts);
@@ -150,37 +158,47 @@ fn validate_session_live_and_others_quiet(
 mod tests {
     use super::*;
     use hashi_types::guardian::BuildPcrs;
+    use hashi_types::guardian::GuardianSignKeyPair;
     use hashi_types::guardian::HeartbeatLogMessage;
     use hashi_types::guardian::InitLogMessage;
+    use hashi_types::guardian::LogMessage;
 
     fn build_pcrs() -> BuildPcrs {
         BuildPcrs::new("current", vec![0])
     }
 
     fn heartbeat_log(session_id: &str, timestamp_secs: UnixSeconds) -> VerifiedLogRecord {
-        VerifiedLogRecord {
-            object_key: format!("heartbeat/{session_id}.json"),
-            session_id: session_id.into(),
-            timestamp_ms: timestamp_secs * 1_000,
-            message: LogMessage::Heartbeat(HeartbeatLogMessage::new(0)),
-            build_pcrs: build_pcrs(),
-        }
+        verified_log(
+            session_id,
+            timestamp_secs * 1_000,
+            LogMessage::Heartbeat(HeartbeatLogMessage::new(0)),
+        )
     }
 
     fn non_heartbeat_log() -> VerifiedLogRecord {
-        VerifiedLogRecord {
-            object_key: "init/test-session/03-pi-enclave-fully-initialized.json".to_string(),
-            session_id: "test-session".into(),
-            timestamp_ms: 0,
-            message: LogMessage::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
+        verified_log(
+            "test-session",
+            0,
+            LogMessage::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
                 sharing_seq: 0,
                 share_ids: vec![],
                 enclave_btc_pubkey: hashi_types::bitcoin::create_btc_keypair_for_test(&[1; 32])
                     .x_only_public_key()
                     .0,
             })),
-            build_pcrs: build_pcrs(),
-        }
+        )
+    }
+
+    fn verified_log(session_id: &str, timestamp_ms: u64, message: LogMessage) -> VerifiedLogRecord {
+        let signing_key = GuardianSignKeyPair::from([7u8; 32]);
+        let entry = hashi_types::guardian::LogRecord::new_at_timestamp(
+            session_id.into(),
+            message,
+            &signing_key,
+            timestamp_ms,
+        )
+        .into_entry_unchecked();
+        VerifiedLogRecord::new_for_test(entry, build_pcrs())
     }
 
     #[test]

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -32,7 +32,9 @@ use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::LimiterState;
-use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
+use hashi_types::guardian::VersionedLogMessage;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::S3_DIR_WITHDRAW;
 use tracing::info;
@@ -132,8 +134,10 @@ async fn hour_bucket_has_success(
 fn bucket_max_post_state(logs: Vec<VerifiedLogRecord>) -> Option<LimiterState> {
     logs.into_iter()
         .filter_map(|log| {
-            let LogMessage::Withdrawal(boxed) = log.message else {
-                return None;
+            let boxed = match log.into_entry().into_message() {
+                VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,
+                VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) => message,
+                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => return None,
             };
             match *boxed {
                 WithdrawalLogMessage::Success { post_state, .. } => Some(post_state),
@@ -161,6 +165,9 @@ mod tests {
     use bitcoin::Txid;
     use hashi_types::guardian::BuildPcrs;
     use hashi_types::guardian::GuardianError;
+    use hashi_types::guardian::GuardianSignKeyPair;
+    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::StandardWithdrawalRequestWire;
     use hashi_types::guardian::StandardWithdrawalResponse;
@@ -187,13 +194,7 @@ mod tests {
             response: StandardWithdrawalResponse::mock_for_testing(),
             post_state: state_with_seq(next_seq),
         };
-        VerifiedLogRecord {
-            object_key: format!("withdraw/success-{next_seq}.json"),
-            session_id: "test-session".into(),
-            timestamp_ms: 0,
-            message: LogMessage::Withdrawal(Box::new(msg)),
-            build_pcrs: build_pcrs(),
-        }
+        verified_withdrawal_log(msg)
     }
 
     fn withdrawal_failure_log() -> VerifiedLogRecord {
@@ -204,13 +205,19 @@ mod tests {
             request_sign,
             error: GuardianError::RateLimitExceeded.to_string(),
         };
-        VerifiedLogRecord {
-            object_key: "withdraw/failure.json".to_string(),
-            session_id: "test-session".into(),
-            timestamp_ms: 0,
-            message: LogMessage::Withdrawal(Box::new(msg)),
-            build_pcrs: build_pcrs(),
-        }
+        verified_withdrawal_log(msg)
+    }
+
+    fn verified_withdrawal_log(message: WithdrawalLogMessage) -> VerifiedLogRecord {
+        let signing_key = GuardianSignKeyPair::from([7u8; 32]);
+        let entry = LogRecord::new_at_timestamp(
+            "test-session".into(),
+            LogMessage::Withdrawal(Box::new(message)),
+            &signing_key,
+            0,
+        )
+        .into_entry_unchecked();
+        VerifiedLogRecord::new_for_test(entry, build_pcrs())
     }
 
     #[test]

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::s3_client::GuardianS3Client;
+use hashi_types::guardian::BuildPcrs;
+use hashi_types::guardian::GuardianError::InvalidS3Log;
+use hashi_types::guardian::GuardianInfo;
+use hashi_types::guardian::GuardianPubKey;
+use hashi_types::guardian::GuardianResult;
+use hashi_types::guardian::InitLogMessage;
+use hashi_types::guardian::LogEntry;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
+use hashi_types::guardian::LogRecord;
+use hashi_types::guardian::PcrAllowlist;
+use hashi_types::guardian::VersionedLogMessage;
+
+/// A session's verified guardian info: the attestation-anchored signing key,
+/// the signed [`GuardianInfo`], and the build PCRs proven by attestation.
+#[derive(Debug, Clone)]
+pub struct VerifiedSessionInfo {
+    signing_pubkey: GuardianPubKey,
+    info: GuardianInfo,
+    build_pcrs: BuildPcrs,
+}
+
+impl VerifiedSessionInfo {
+    pub(super) async fn new(
+        s3: &GuardianS3Client,
+        session_id: &str,
+        allowlist: &PcrAllowlist,
+    ) -> GuardianResult<Self> {
+        // 1. Attestation (unsigned: authenticated by AWS, not the enclave key) →
+        //    the signing pubkey it commits to.
+        let att_key = InitLogMessage::attestation_object_key(session_id);
+        let attestation_record = s3.get_log_record(&att_key).await?;
+        let attestation_message =
+            match validate_into_entry(attestation_record, None)?.into_message() {
+                VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
+                VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
+                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                    return Err(InvalidS3Log(format!(
+                        "expected OIAttestationUnsigned at key {att_key}"
+                    )));
+                }
+            };
+        let InitLogMessage::OIAttestationUnsigned {
+            attestation,
+            signing_public_key: signing_pubkey,
+        } = *attestation_message
+        else {
+            return Err(InvalidS3Log(format!(
+                "expected OIAttestationUnsigned at key {att_key}"
+            )));
+        };
+
+        // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
+        let info_key = InitLogMessage::guardian_info_object_key(session_id);
+        let info_record = s3.get_log_record(&info_key).await?;
+        let info_message =
+            match validate_into_entry(info_record, Some(&signing_pubkey))?.into_message() {
+                VersionedLogMessage::V1(LogMessageV1::Init(message)) => message,
+                VersionedLogMessage::V2(LogMessageV2::Init(message)) => message,
+                VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                    return Err(InvalidS3Log(format!(
+                        "expected OIGuardianInfo at key {info_key}"
+                    )));
+                }
+            };
+        let InitLogMessage::OIGuardianInfo(info) = *info_message else {
+            return Err(InvalidS3Log(format!(
+                "expected OIGuardianInfo at key {info_key}"
+            )));
+        };
+        let info = *info;
+
+        // 3. Anchor the pubkey and pin PCR0 to the allowlist entry for the
+        //    reported build. This replays a logged attestation whose short-lived
+        //    leaf cert has typically expired, so the chain is checked at the
+        //    document's own signed timestamp, not now.
+        let build_pcrs = allowlist.resolve(&info.untrusted_git_revision)?.clone();
+        attestation
+            .verify_replay(&signing_pubkey, &build_pcrs)
+            .map_err(|e| InvalidS3Log(format!("attestation at key {att_key}: {e}")))?;
+
+        Ok(Self {
+            signing_pubkey,
+            info,
+            build_pcrs,
+        })
+    }
+
+    pub fn signing_pubkey(&self) -> &GuardianPubKey {
+        &self.signing_pubkey
+    }
+
+    pub fn info(&self) -> &GuardianInfo {
+        &self.info
+    }
+
+    pub fn build_pcrs(&self) -> &BuildPcrs {
+        &self.build_pcrs
+    }
+
+    pub fn into_info(self) -> GuardianInfo {
+        self.info
+    }
+}
+
+/// A log record whose message signature and writing session's attestation/PCRs
+/// have both been verified. The exact versioned entry is retained so callers
+/// can choose which schema versions they accept and how to interpret them.
+#[derive(Debug)]
+pub struct VerifiedLogRecord {
+    entry: LogEntry,
+    build_pcrs: BuildPcrs,
+}
+
+impl VerifiedLogRecord {
+    pub(super) fn new(
+        record: LogRecord,
+        session_info: &VerifiedSessionInfo,
+    ) -> GuardianResult<Self> {
+        let entry = validate_into_entry(record, Some(&session_info.signing_pubkey))?;
+        Ok(Self {
+            entry,
+            build_pcrs: session_info.build_pcrs.clone(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn new_for_test(entry: LogEntry, build_pcrs: BuildPcrs) -> Self {
+        Self { entry, build_pcrs }
+    }
+
+    pub fn entry(&self) -> &LogEntry {
+        &self.entry
+    }
+
+    pub fn build_pcrs(&self) -> &BuildPcrs {
+        &self.build_pcrs
+    }
+
+    pub fn into_entry(self) -> LogEntry {
+        self.entry
+    }
+}
+
+fn validate_into_entry(
+    record: LogRecord,
+    signing_public_key: Option<&GuardianPubKey>,
+) -> GuardianResult<LogEntry> {
+    record.validate(signing_public_key)?;
+    Ok(record.into_entry_unchecked())
+}

--- a/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
@@ -64,7 +64,7 @@ impl HeartbeatWriter {
 mod tests {
     use super::*;
     use crate::OperatorInitTestArgs;
-    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::VersionedLogMessage;
 
@@ -90,7 +90,7 @@ mod tests {
         assert_eq!(captured.len(), 1, "heartbeat tick should write one record");
         let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert_eq!(captured[0].0, record.object_key());
-        let VersionedLogMessage::V2(LogMessage::Heartbeat(message)) = record.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Heartbeat(message)) = record.message() else {
             panic!("expected V2 heartbeat record");
         };
         assert_eq!(message.seq, 0);

--- a/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/provisioner_init.rs
@@ -414,7 +414,7 @@ mod tests {
             "provisioner init should write one record"
         );
         let record: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
-        let VersionedLogMessage::V2(LogMessage::Init(message)) = record.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Init(message)) = record.message() else {
             panic!("expected V2 init record");
         };
         assert_eq!(

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -174,7 +174,7 @@ mod tests {
     use hashi_types::guardian::InitConfig;
     use hashi_types::guardian::LimiterConfig;
     use hashi_types::guardian::LimiterState;
-    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::LogMessageV2;
     use hashi_types::guardian::LogRecord;
     use hashi_types::guardian::StandardWithdrawalRequest;
     use hashi_types::guardian::VersionedLogMessage;
@@ -293,7 +293,7 @@ mod tests {
         );
         let success: LogRecord = serde_json::from_slice(&captured[0].1).unwrap();
         assert_eq!(captured[0].0, success.object_key());
-        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = success.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) = success.message() else {
             panic!("expected V2 withdrawal record");
         };
         let WithdrawalLogMessage::Success {
@@ -310,7 +310,7 @@ mod tests {
 
         let failure: LogRecord = serde_json::from_slice(&captured[1].1).unwrap();
         assert_eq!(captured[1].0, failure.object_key());
-        let VersionedLogMessage::V2(LogMessage::Withdrawal(message)) = failure.message() else {
+        let VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) = failure.message() else {
             panic!("expected V2 withdrawal record");
         };
         let WithdrawalLogMessage::Failure {

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -9,7 +9,9 @@ use crate::domain::WithdrawalEventType;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_guardian::s3_reader::VerifiedLogRecord;
 use hashi_guardian::s3_reader::withdraw_cursor;
-use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogMessageV1;
+use hashi_types::guardian::LogMessageV2;
+use hashi_types::guardian::VersionedLogMessage;
 use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::guardian::s3_utils::S3HourScopedDirectory;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -27,9 +29,14 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
     type Error = anyhow::Error;
 
     fn try_from(log: VerifiedLogRecord) -> Result<Self, Self::Error> {
-        let timestamp_ms = log.timestamp_ms();
-        let LogMessage::Withdrawal(withdrawal_message) = log.into_message() else {
-            anyhow::bail!("non-withdrawal logs found");
+        let entry = log.into_entry();
+        let timestamp_ms = entry.timestamp_ms();
+        let withdrawal_message = match entry.into_message() {
+            VersionedLogMessage::V1(LogMessageV1::Withdrawal(message)) => message,
+            VersionedLogMessage::V2(LogMessageV2::Withdrawal(message)) => message,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                anyhow::bail!("non-withdrawal logs found");
+            }
         };
 
         match *withdrawal_message {

--- a/crates/hashi-types/src/guardian/attestation.rs
+++ b/crates/hashi-types/src/guardian/attestation.rs
@@ -8,7 +8,6 @@ use std::collections::BTreeSet;
 #[cfg(not(any(test, feature = "non-enclave-dev")))]
 use super::CryptoVerificationError;
 use super::CryptoVerificationResult;
-use super::GuardianInfo;
 use super::GuardianPubKey;
 use super::GuardianResult;
 use super::errors::GuardianError::BuildNotAllowlisted;
@@ -133,15 +132,6 @@ impl NitroAttestation {
 enum VerifyTime {
     Now,
     DocumentTimestamp,
-}
-
-/// A session's verified guardian info: the attestation-anchored signing pubkey,
-/// the signed `GuardianInfo`, and the build PCRs proven by attestation.
-#[derive(Debug, Clone)]
-pub struct VerifiedSessionInfo {
-    pub signing_pubkey: GuardianPubKey,
-    pub info: GuardianInfo,
-    pub build_pcrs: BuildPcrs,
 }
 
 /// One enclave build: its git revision and known-good Nitro measurement. A build is

--- a/crates/hashi-types/src/guardian/log/messages/kp_share.rs
+++ b/crates/hashi-types/src/guardian/log/messages/kp_share.rs
@@ -23,8 +23,7 @@ pub struct KpShareStateLogMessageV2 {
     pub encrypted_shares: KPEncryptedSharesRoster,
 }
 
-/// The current normalized KP-share state exposed to writers and verified
-/// readers.
+/// The KP-share state emitted by writers and returned by ceremony readers.
 pub type KpShareStateLogMessage = KpShareStateLogMessageV2;
 
 /// V1 encrypted share state: exactly one certificate and ciphertext per KP.
@@ -90,9 +89,13 @@ impl KpShareStateLogMessageV1 {
             self.cert_seq,
         ))
     }
+}
 
-    pub fn into_current(self) -> Result<KpShareStateLogMessageV2, GuardianError> {
-        let shares = self
+impl TryFrom<KpShareStateLogMessageV1> for KpShareStateLogMessageV2 {
+    type Error = GuardianError;
+
+    fn try_from(message: KpShareStateLogMessageV1) -> Result<Self, Self::Error> {
+        let shares = message
             .encrypted_shares
             .0
             .into_iter()
@@ -104,9 +107,9 @@ impl KpShareStateLogMessageV1 {
                 )]),
             })
             .collect();
-        Ok(KpShareStateLogMessageV2::new(
-            self.sharing_seq,
-            self.cert_seq,
+        Ok(Self::new(
+            message.sharing_seq,
+            message.cert_seq,
             KPEncryptedSharesRoster::new(shares)?,
         ))
     }

--- a/crates/hashi-types/src/guardian/log/record.rs
+++ b/crates/hashi-types/src/guardian/log/record.rs
@@ -1,14 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The `LogRecord` written to S3: it wraps a `super::schema::LogMessage` with
-//! its routing context and, for signed logs, a guardian signature.
+//! The `LogRecord` written to S3: it wraps a
+//! `super::schema::VersionedLogMessage` with its routing context and, for
+//! signed logs, a guardian signature.
 //! The object key and lock duration are derived from the wrapped message.
 
 use super::ObjectKeyPattern;
 use super::retention::S3ObjectLockPolicy;
 use super::schema::LogMessage;
 use super::schema::LogMessageV1;
+use super::schema::LogMessageV2;
 use super::schema::VersionedLogMessage;
 use crate::guardian::GuardianError::InvalidS3Log;
 use crate::guardian::GuardianPubKey;
@@ -42,7 +44,7 @@ pub struct LogEntry {
 
 /// Write: `LogMessage` -> `LogRecord` -> JSON body.
 /// Read: actual S3 key + JSON body -> untrusted `LogRecord`; the reader layer
-/// authenticates it before exposing its contents.
+/// fully verifies it before exposing its contents.
 #[derive(Debug)]
 pub enum LogRecord {
     Signed(GuardianSigned<LogEntry>),
@@ -117,7 +119,7 @@ impl<'de> Deserialize<'de> for LogRecord {
                     .map_err(D::Error::custom)?
             }
             VersionedLogMessage::SCHEMA_VERSION_V2 => {
-                serde_json::from_value::<LogMessage>(raw.message)
+                serde_json::from_value::<LogMessageV2>(raw.message)
                     .map(VersionedLogMessage::V2)
                     .map_err(D::Error::custom)?
             }
@@ -143,12 +145,28 @@ impl<'de> Deserialize<'de> for LogRecord {
 }
 
 impl LogEntry {
-    fn into_current(self) -> GuardianResult<(SessionID, LogMessage)> {
-        let message = self
-            .message
-            .into_current()
-            .map_err(|e| InvalidS3Log(format!("log schema conversion failed: {e}")))?;
-        Ok((self.session_id, message))
+    pub fn schema_version(&self) -> u64 {
+        self.schema_version
+    }
+
+    pub fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub fn session_id(&self) -> &SessionID {
+        &self.session_id
+    }
+
+    pub fn timestamp_ms(&self) -> UnixMillis {
+        self.timestamp_ms
+    }
+
+    pub fn message(&self) -> &VersionedLogMessage {
+        &self.message
+    }
+
+    pub fn into_message(self) -> VersionedLogMessage {
+        self.message
     }
 
     fn validate_object_key(&self) -> GuardianResult<()> {
@@ -186,7 +204,7 @@ impl LogEntry {
 
     /// Validate an unsigned OI-attestation entry. The Nitro attestation itself
     /// must be authenticated separately.
-    fn validate_unsigned(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    fn validate_unsigned(&self) -> GuardianResult<()> {
         if !self.message.is_allowed_unsigned() {
             return Err(InvalidS3Log(
                 "expected unsigned log record but message requires a signature".into(),
@@ -195,8 +213,10 @@ impl LogEntry {
         self.validate_object_key()?;
         let init = match &self.message {
             VersionedLogMessage::V1(LogMessageV1::Init(init)) => init,
-            VersionedLogMessage::V2(LogMessage::Init(init)) => init,
-            _ => unreachable!("is_allowed_unsigned only permits an init message"),
+            VersionedLogMessage::V2(LogMessageV2::Init(init)) => init,
+            VersionedLogMessage::V1(_) | VersionedLogMessage::V2(_) => {
+                unreachable!("is_allowed_unsigned only permits an init message")
+            }
         };
         let super::messages::InitLogMessage::OIAttestationUnsigned {
             signing_public_key, ..
@@ -205,9 +225,7 @@ impl LogEntry {
             unreachable!("is_allowed_unsigned only permits OIAttestationUnsigned");
         };
         self.validate_session_id(signing_public_key)?;
-        let timestamp_ms = self.timestamp_ms;
-        let (session_id, message) = self.into_current()?;
-        Ok((session_id, timestamp_ms, message))
+        Ok(())
     }
 
     /// Validate signed-log routing context.
@@ -264,7 +282,7 @@ impl LogRecord {
         &self.data().message
     }
 
-    /// Validate a record and normalize its message to the current schema.
+    /// Validate a record without consuming it.
     ///
     /// Validation checks record-local invariants and verifies a signed record
     /// against the caller-supplied key. It does not establish that the key
@@ -274,21 +292,16 @@ impl LogRecord {
     /// Signed records require `Some(signing_public_key)`; the one permitted
     /// unsigned record kind requires `None`. The caller is responsible for
     /// authenticating the Nitro attestation carried by an unsigned record.
-    pub fn validate(
-        self,
-        signing_public_key: Option<&GuardianPubKey>,
-    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    pub fn validate(&self, signing_public_key: Option<&GuardianPubKey>) -> GuardianResult<()> {
         match (self, signing_public_key) {
             (Self::Signed(signed), Some(signing_public_key)) => {
-                let timestamp_ms = signed.data_unchecked().timestamp_ms;
                 signed
                     .data_unchecked()
                     .validate_signed(signing_public_key)?;
-                let data = signed
-                    .verify_into_data(signing_public_key)
-                    .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))?;
-                let (session_id, message) = data.into_current()?;
-                Ok((session_id, timestamp_ms, message))
+                signed
+                    .verify_signature(signing_public_key)
+                    .map(|_| ())
+                    .map_err(|e| InvalidS3Log(format!("invalid log signature: {e}")))
             }
             (Self::Unsigned(unsigned), None) => unsigned.validate_unsigned(),
             (Self::Unsigned(unsigned), Some(_)) if unsigned.message.is_allowed_unsigned() => Err(
@@ -312,20 +325,11 @@ impl LogRecord {
         policy.duration_for(self.data().message.log_type())
     }
 
-    /// Extract and normalize a signed record without authenticating its
-    /// Guardian signature. This is only for callers that independently
-    /// authenticate the extracted payload.
-    pub fn into_current_unchecked(self) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    /// Extract the entry without validating the record.
+    pub fn into_entry_unchecked(self) -> LogEntry {
         match self {
-            Self::Signed(signed) => {
-                let timestamp_ms = signed.data_unchecked().timestamp_ms;
-                let (session_id, message) = signed.into_data_unchecked().into_current()?;
-                Ok((session_id, timestamp_ms, message))
-            }
-            Self::Unsigned(unsigned) if unsigned.message.is_allowed_unsigned() => Err(
-                InvalidS3Log("expected signed log record but message is unsigned".into()),
-            ),
-            Self::Unsigned(_) => Err(InvalidS3Log("missing log signature".into())),
+            Self::Signed(signed) => signed.into_data_unchecked(),
+            Self::Unsigned(unsigned) => unsigned,
         }
     }
 
@@ -395,7 +399,6 @@ mod tests {
     use crate::guardian::KPEncryptedSharesRoster;
     use crate::guardian::KpShareStateLogMessage;
     use crate::guardian::LimiterState;
-    use crate::guardian::LogMessageV2;
     use crate::guardian::MAINNET_S3_OBJECT_LOCK_POLICY;
     use crate::guardian::NitroAttestation;
     use crate::guardian::RotateKpsResponse;
@@ -429,14 +432,14 @@ mod tests {
         (object_key, record, signing_key)
     }
 
-    fn authenticate_signed(
-        record: LogRecord,
+    fn validate_signed(
+        record: &LogRecord,
         signing_public_key: &GuardianPubKey,
-    ) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    ) -> GuardianResult<()> {
         record.validate(Some(signing_public_key))
     }
 
-    fn validate_unsigned(record: LogRecord) -> GuardianResult<(SessionID, UnixMillis, LogMessage)> {
+    fn validate_unsigned(record: &LogRecord) -> GuardianResult<()> {
         record.validate(None)
     }
 
@@ -453,7 +456,7 @@ mod tests {
         let body = serde_json::to_vec(&log).unwrap();
         let record_read_from_s3: LogRecord = serde_json::from_slice(&body).unwrap();
         assert_eq!(record_read_from_s3.object_key(), writer_key);
-        authenticate_signed(record_read_from_s3, &signing_key.verification_key())
+        validate_signed(&record_read_from_s3, &signing_key.verification_key())
             .expect("the serialized record must verify at the key used by the writer");
     }
 
@@ -623,17 +626,17 @@ mod tests {
                 "{name} did not preserve its object key"
             );
             if decoded.message().is_allowed_unsigned() {
-                validate_unsigned(decoded)
+                validate_unsigned(&decoded)
                     .unwrap_or_else(|error| panic!("{name} failed validation: {error}"));
             } else {
-                authenticate_signed(decoded, &signing_key.verification_key())
+                validate_signed(&decoded, &signing_key.verification_key())
                     .unwrap_or_else(|error| panic!("{name} failed verification: {error}"));
             }
         }
     }
 
     #[test]
-    fn deployed_v1_kp_share_state_verifies_and_normalizes() {
+    fn deployed_v1_kp_share_state_verifies_and_is_retained() {
         let fixture = r#"{"schema_version":1,"object_key":"kp-shares/00000000000000000000/00000000000000000000-916c711a5e81c2b0.json","session_id":"916c711a5e81c2b0","timestamp_ms":1784219535816,"message":{"KpShareState":{"sharing_seq":0,"cert_seq":0,"encrypted_shares":[{"id":1,"recipient_fingerprint":"010AFFD5514AE454CA0D56DAA40FE24388998D2A","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DT5hsKqzbvdwSAQdACnLThsK4Jq+u0g98VJzmYXrG05xLKgM1ki4FSGrOljkw\ndnHArbGaerEC8lBXZPVNhxMB8rOAfvgqxOUtt7SIMmjGIZMy7tzwfbM1YL45wgac\n0lkBE7TsICEPN/B/EwheDv/Ooid3NTDsoIsUGGuqtzUPCVYJTGPR+LWVY+F2xZxb\nHaLZO65VgrA3pcnyLsUy8iN3giOrIxmiZy/GjQBUwkeSCbVuopTZ2mpxPg==\n=7m3k\n-----END PGP MESSAGE-----\n"},{"id":2,"recipient_fingerprint":"69A798B4CD1FE3F7C827381BC56DF2575EC846C3","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DIHt6s8jZpqASAQdALWbHtxu0R/ANnNighIV7VtFgkIX3CGJzfW51GkSJkBQw\n7Ec2Y2wBmo4sDM2VGmxqK5ADvGVSYgLvIlByRdRV2NaJ1xkjHUoA39PDTqCvwCOK\n0lkBOZPrJPrBInDax3ceQwDkC/rkJrQXT8oVWGxNjxp244q66jhMdOBZSEc8T/oZ\noAdjEccCcDLYt+S+bEVZeuNhZowDSx14soiALI16hrzbDqJq04e7K9W0uQ==\n=tfbb\n-----END PGP MESSAGE-----\n"},{"id":3,"recipient_fingerprint":"8D798722C24B2A15C15036A1DEFA2C01C4350A31","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DZcZnV1kFupoSAQdA4X4hRbapAgL8eAouMEM0aRE4frVwmQZVHsXB6aOOxgkw\nsc2w0UU8bLzgt3aCe4HqBA9/v3jlKqK4STYVRFzG6o8fa+tb2qX94g6bCcIE07x4\n0lkBeTRYLlUlg7Jl2s7X9d9Ns60O8A2DQKwSYtQZV1pEwX44UQPz8Od/C9nIPeLP\nQEIA1BYRghu0ePQaqsfKohRXUunOrgVpYSCNFoupOKoVTl0qFgeDz5dw7Q==\n=giUp\n-----END PGP MESSAGE-----\n"},{"id":4,"recipient_fingerprint":"5551B442C80AB4D9CF3C95B90DA471909B35BFE9","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DJ51dk/19HSASAQdAgq4QrNM43HykXcLxDfRtHHRtd4BdVJBirC2esDoXEjkw\nF7YLVWrMoXUtwOxFqXGkoUhEhfPAzdLG3WyuZQDnOdPBl0r/2qxmlmZIjFFBGXVc\n0lkBLfdxmJ8BOQYcaiEhBODpY7o2xO13agT28X6Uyv3rc5qw5km1WDw5+AlTLKZj\nw7aathIK+Qof15Tj7VxzSzRmo/pIf/Plcz9JoBNOYPgz/ewuzsPzDQ9+Qw==\n=iAGD\n-----END PGP MESSAGE-----\n"},{"id":5,"recipient_fingerprint":"354807E1940BFC2763D15EBB8E7048E384EBBC7A","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4D6mDrwWj9BrASAQdAazktC+Jd2EMtE8Gav7ROlkVmL+Ty1duA3RttbKQ5eAEw\nbKIxkq1Jp9J4ZqcvjfxcBzVOfZPQwdhxXxDv2pOUG7ioZuDTRlGNNbsiyodvmlgy\n0lkB8eaGI0/LBZ++1vbGsZ/uQ7phGVFkPdcZzXm0pyD1poDKhTTyiHpAgDub2yph\nAAWsEIYzjLQWJvuOw0JXzwu1HBy+z5QTY4nK+wKrh6ojcLKjjyRVehhtTw==\n=m9Mm\n-----END PGP MESSAGE-----\n"},{"id":6,"recipient_fingerprint":"CB27C30ABAAC7EEDE92E71C6017C4627E937F5B0","armored_ciphertext":"-----BEGIN PGP MESSAGE-----\n\nwV4DuqwfDzk48aQSAQdAoJevGCVjo+1pD/WVPkWza4qGxBU9tsXbqE/kaSynsGYw\nskjzNOD5oY+/S0CMeH+6xspbLUZ9uZFy98fWOKMi9nbftH1nWXtKRdCNweaaCAPu\n0lkBR4DxLFCydQKfFzENlKRl9qc4m5NkVnjWaGR+cgK1U2UAPf/p82eRggyf6Obp\nNcdOnAfu0aLB70FESJEHtDFj36QCyC0SwTdtZwXUfCOo0AykDph9rTYVpA==\n=DQ4F\n-----END PGP MESSAGE-----\n"}]}},"signature":"2895193893f1feaea65fb6b441c011815c937df33cde136e4721f4173db86c1fe44a2095a6f8753fecbdaa5c99b744a22368f41ab8ca01edff99fafb6710a304"}"#;
         let record: LogRecord = serde_json::from_str(fixture).unwrap();
         assert!(matches!(
@@ -645,14 +648,17 @@ mod tests {
             hex::decode("916c711a5e81c2b032f15952b515205a20ef2a16f8a88da504885f392e314dca")
                 .unwrap();
         let signing_pubkey = GuardianPubKey::try_from(signing_pubkey.as_slice()).unwrap();
-        let (session_id, timestamp_ms, LogMessageV2::KpShareState(message)) =
-            authenticate_signed(record, &signing_pubkey)
-                .expect("the deployed V1 signature must verify before normalization")
+        validate_signed(&record, &signing_pubkey).expect("the deployed V1 signature must verify");
+        let entry = record.into_entry_unchecked();
+        assert_eq!(entry.session_id().as_str(), "916c711a5e81c2b0");
+        assert_eq!(entry.timestamp_ms(), 1_784_219_535_816);
+        let VersionedLogMessage::V1(LogMessageV1::KpShareState(message)) = entry.into_message()
         else {
-            panic!("expected normalized KP share state");
+            panic!("expected the exact V1 KP share state");
         };
-        assert_eq!(session_id.as_str(), "916c711a5e81c2b0");
-        assert_eq!(timestamp_ms, 1_784_219_535_816);
+        let message: KpShareStateLogMessage = (*message)
+            .try_into()
+            .expect("the deployed V1 KP share state must convert");
         assert_eq!(message.sharing_seq, 0);
         assert_eq!(message.cert_seq, 0);
         assert_eq!(message.encrypted_shares.share_count(), 6);
@@ -722,13 +728,13 @@ mod tests {
     fn signed_log_verifies_at_canonical_object_key() {
         let (_, log, signing_key) = signed_heartbeat(1_700_000_000_000);
 
-        let (_, timestamp_ms, message) = authenticate_signed(log, &signing_key.verification_key())
+        validate_signed(&log, &signing_key.verification_key())
             .expect("record should verify at its intended S3 key");
 
-        assert_eq!(timestamp_ms, 1_700_000_000_000);
+        assert_eq!(log.timestamp_ms(), 1_700_000_000_000);
         assert!(matches!(
-            message,
-            LogMessage::Heartbeat(HeartbeatLogMessage { seq: 42 })
+            log.message(),
+            VersionedLogMessage::V2(LogMessageV2::Heartbeat(HeartbeatLogMessage { seq: 42 }))
         ));
     }
 
@@ -750,7 +756,7 @@ mod tests {
         assert!(serde_json::from_value::<LogRecord>(malformed).is_err());
 
         let from_s3: LogRecord = serde_json::from_value(json).unwrap();
-        authenticate_signed(from_s3, &signing_key.verification_key())
+        validate_signed(&from_s3, &signing_key.verification_key())
             .expect("serialized object key should be covered by the signature");
     }
 
@@ -809,7 +815,7 @@ mod tests {
             heartbeat_session_id()
         );
 
-        let err = authenticate_signed(tampered, &signing_key.verification_key())
+        let err = validate_signed(&tampered, &signing_key.verification_key())
             .expect_err("signature must cover the canonical object key and message");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -839,7 +845,7 @@ mod tests {
         let mut record_read_from_s3: LogRecord =
             serde_json::from_slice(&serde_json::to_vec(&log).unwrap()).unwrap();
         record_read_from_s3.data_mut().object_key = relocated_key;
-        let err = authenticate_signed(record_read_from_s3, &signing_key.verification_key())
+        let err = validate_signed(&record_read_from_s3, &signing_key.verification_key())
             .expect_err("the signature must authenticate the random failure suffix");
 
         assert!(format!("{err:?}").contains("signature invalid"));
@@ -867,7 +873,7 @@ mod tests {
         aliased.data_mut().session_id = "aliased-session".into();
         aliased.data_mut().object_key = GenesisLogMessage::object_key();
 
-        let err = authenticate_signed(aliased, &signing_key.verification_key())
+        let err = validate_signed(&aliased, &signing_key.verification_key())
             .expect_err("session ID must be part of the signed routing context");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -888,7 +894,7 @@ mod tests {
         );
 
         log.data_mut().object_key = "init/copied-attestation.json".to_string();
-        let err = validate_unsigned(log)
+        let err = validate_unsigned(&log)
             .expect_err("unsigned record copied to another S3 key must be rejected");
 
         assert!(format!("{err:?}").contains("non-canonical S3 object key"));
@@ -906,7 +912,7 @@ mod tests {
             &signing_key,
             1_700_000_000_000,
         );
-        let err = validate_unsigned(log)
+        let err = validate_unsigned(&log)
             .expect_err("attestation session ID must come from its signing public key");
 
         assert!(format!("{err:?}").contains("session ID mismatch"));
@@ -969,7 +975,7 @@ mod tests {
         assert_eq!(message["config_hash"], hex::encode([0xcd; 32]));
 
         let from_json: LogRecord = serde_json::from_value(json).unwrap();
-        authenticate_signed(from_json, &signing_key.verification_key()).unwrap();
+        validate_signed(&from_json, &signing_key.verification_key()).unwrap();
     }
 
     #[test]

--- a/crates/hashi-types/src/guardian/log/schema.rs
+++ b/crates/hashi-types/src/guardian/log/schema.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The versioned `LogMessage` family the enclave emits and conversion into the
-//! current message shape. The `LogRecord` wrapper that carries these to S3 lives
-//! in `super::record`.
+//! The versioned `LogMessage` family the enclave emits. The `LogRecord` wrapper
+//! that carries these to S3 lives in `super::record`.
 
 use super::LogType;
 use super::ObjectKeyPattern;
@@ -15,7 +14,6 @@ use super::messages::InitLogMessage;
 use super::messages::KpShareStateLogMessageV1;
 use super::messages::KpShareStateLogMessageV2;
 use super::messages::WithdrawalLogMessage;
-use crate::guardian::GuardianError;
 use crate::guardian::UnixMillis;
 use serde::Deserialize;
 use serde::Serialize;
@@ -23,6 +21,9 @@ use serde::Serialize;
 /// The wire message stored in a [`super::LogRecord`]. Its version is serialized
 /// as the record's sibling `schema_version` field rather than as an additional
 /// JSON enum layer.
+///
+/// Readers match these variants exhaustively at their consumption boundary so
+/// adding a schema version requires each reader to opt in explicitly.
 #[derive(Debug)]
 pub enum VersionedLogMessage {
     V1(LogMessageV1),
@@ -67,7 +68,7 @@ pub enum LogMessageV1 {
     Genesis(Box<GenesisLogMessage>),
 }
 
-/// Current log schema emitted by the guardian enclave.
+/// Schema-version-2 log messages emitted by the guardian enclave.
 /// Uses an enum discriminator for automatic domain separation between variants.
 // TODO(testnet-wipe): Collapse the V1/V2 compatibility layer into a single log
 // schema once existing testnet records no longer need to be read.
@@ -82,8 +83,7 @@ pub enum LogMessageV2 {
     Genesis(Box<GenesisLogMessage>),
 }
 
-/// The current normalized log-message shape exposed to writers and verified
-/// readers. Wire-version handling remains internal to [`VersionedLogMessage`].
+/// Writer-facing alias for the log-message schema emitted by guardians.
 pub type LogMessage = LogMessageV2;
 
 trait LogMessageSchema {
@@ -146,31 +146,6 @@ macro_rules! impl_log_message_schema {
 impl_log_message_schema!(LogMessageV1);
 impl_log_message_schema!(LogMessageV2);
 
-impl LogMessageV1 {
-    fn into_current(self) -> Result<LogMessage, GuardianError> {
-        Ok(match self {
-            LogMessageV1::Heartbeat(message) => LogMessage::Heartbeat(message),
-            LogMessageV1::Init(message) => LogMessage::Init(message),
-            LogMessageV1::Withdrawal(message) => LogMessage::Withdrawal(message),
-            LogMessageV1::Ceremony(message) => LogMessage::Ceremony(message),
-            LogMessageV1::KpShareState(message) => {
-                LogMessage::KpShareState(Box::new((*message).into_current()?))
-            }
-            LogMessageV1::CommitteeUpdate(message) => LogMessage::CommitteeUpdate(message),
-            LogMessageV1::Genesis(message) => LogMessage::Genesis(message),
-        })
-    }
-}
-
-impl LogMessageV2 {
-    pub fn into_init_log(self) -> Option<InitLogMessage> {
-        match self {
-            Self::Init(init_message) => Some(*init_message),
-            _ => None,
-        }
-    }
-}
-
 impl VersionedLogMessage {
     pub const SCHEMA_VERSION_V1: u64 = 1;
     pub const SCHEMA_VERSION_V2: u64 = 2;
@@ -208,13 +183,6 @@ impl VersionedLogMessage {
         match self {
             Self::V1(message) => message.object_key_pattern(session_id, timestamp_ms),
             Self::V2(message) => message.object_key_pattern(session_id, timestamp_ms),
-        }
-    }
-
-    pub fn into_current(self) -> Result<LogMessage, GuardianError> {
-        match self {
-            Self::V1(message) => message.into_current(),
-            Self::V2(message) => Ok(message),
         }
     }
 }

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -20,7 +20,6 @@ pub use attestation::BuildPcrs;
 pub use attestation::GitRevision;
 pub use attestation::NitroAttestation;
 pub use attestation::PcrAllowlist;
-pub use attestation::VerifiedSessionInfo;
 pub use lifecycle::*;
 pub use limiter::LimiterConfig;
 pub use limiter::LimiterState;


### PR DESCRIPTION
Stacked on #904.

## Summary

- Preserve each record’s exact `LogEntry` and `VersionedLogMessage` through validation and `VerifiedLogRecord` instead of normalizing verified logs to the writer-facing schema.
- Remove the broad V1-to-V2 conversion APIs. Readers accept `LogMessageV1` and `LogMessageV2` explicitly at their consumption boundaries; only the genuinely different legacy KP-share payload keeps a narrow conversion.
- Make `LogRecord::validate` non-consuming and keep unchecked entry extraction explicit.
- Co-locate verified session and record types with the S3 reader so verified records can retain their exact versioned entries.
- Update guardian, proxy, and monitor consumers to handle versioned entries explicitly.

## Local validation

- `make fmt`