### PR TITLE
Label hashi_sui_balance with the operator address

### DIFF
--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -1096,10 +1096,6 @@ impl Hashi {
     fn start_sui_balance_metric(self: Arc<Self>) -> Service {
         const BALANCE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
         Service::new().spawn_aborting(async move {
-            // -1 = never sampled; keeps a `0 <= balance < threshold` alert
-            // from firing on nodes where this poller is disabled or has not
-            // yet succeeded (the gauge would otherwise read a false 0).
-            self.metrics.sui_balance.set(-1);
             let owner = match self.config.operator_private_key() {
                 Ok(key) => key.verifying_key().derive_address(),
                 Err(e) => {
@@ -1107,6 +1103,16 @@ impl Hashi {
                     return Ok(());
                 }
             };
+            // The address labels the series, so the gauge can only be
+            // published once the operator key resolves.
+            let balance = self
+                .metrics
+                .sui_balance
+                .with_label_values(&[&owner.to_string()]);
+            // -1 = never sampled; keeps a `0 <= balance < threshold` alert
+            // from firing before the first poll succeeds (the gauge would
+            // otherwise read a false 0).
+            balance.set(-1);
             let request = sui_rpc::proto::sui::rpc::v2::GetBalanceRequest::default()
                 .with_owner(owner)
                 .with_coin_type(sui_sdk_types::StructTag::sui());
@@ -1117,11 +1123,8 @@ impl Hashi {
                 interval.tick().await;
                 match client.state_client().get_balance(request.clone()).await {
                     Ok(response) => {
-                        if let Some(balance) = response.into_inner().balance.and_then(|b| b.balance)
-                        {
-                            self.metrics
-                                .sui_balance
-                                .set(balance.min(i64::MAX as u64) as i64);
+                        if let Some(sats) = response.into_inner().balance.and_then(|b| b.balance) {
+                            balance.set(sats.min(i64::MAX as u64) as i64);
                         }
                     }
                     Err(e) => tracing::debug!("failed to fetch operator SUI balance: {e}"),

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -102,7 +102,7 @@ pub struct Metrics {
     pub withdrawals_finalized_total: IntCounter,
     pub presig_pool_remaining: IntGauge,
     pub sui_tx_submissions_total: IntCounterVec,
-    pub sui_balance: IntGauge,
+    pub sui_balance: IntGaugeVec,
 
     pub is_leader: IntGauge,
     pub leader_retries_total: IntCounterVec,
@@ -668,10 +668,13 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
-            sui_balance: register_int_gauge_with_registry!(
+            sui_balance: register_int_gauge_vec_with_registry!(
                 "hashi_sui_balance",
                 "Operator gas wallet SUI balance in MIST, totaled across owned \
-                 coins and the address balance",
+                 coins and the address balance. Labeled with the operator \
+                 address that pays gas, so a low-balance alert names the \
+                 wallet to top up. One series per node.",
+                &["address"],
                 registry,
             )
             .unwrap(),

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -928,7 +928,7 @@ Notes:
 | `hashi_mpc_sign_failures_total` | counter | MPC signing failures. Investigate if increasing. |
 | `hashi_mpc_reconfig_total_duration_seconds` | histogram | DKG/rotation duration. |
 | `hashi_sui_tx_submissions_total` | counter | Sui tx submissions (by operation, status). |
-| `hashi_sui_balance` | gauge | Operator gas wallet SUI balance in MIST (owned coins + address balance). `-1` until the first successful sample. |
+| `hashi_sui_balance` | gauge | Operator gas wallet SUI balance in MIST (owned coins + address balance), labeled `address` with the operator address paying gas. `-1` until the first successful sample. |
 | `hashi_leader_retries_total` | counter | Leader operation retries (by operation, error kind). |
 
 > **Is `hashi_kyoto_connected_peers = 1` healthy? Yes.** The embedded light client runs in whitelist-only mode and connects **only** to the peers listed in `bitcoin-trusted-peers` (see [1.5](#15-bitcoin-node)), so it never discovers peers through DNS seeds or address gossip. The count therefore cannot exceed the number of trusted peers you configured, and `1` is the expected steady-state value for the common single-self-hosted-node setup. What matters is that the value is **non-zero and stable**: the alert in [8.4](#84-suggested-alerts) fires on `== 0`, not on a low count. If you want redundancy here, add more entries to `bitcoin-trusted-peers` rather than expecting the number to grow on its own.
@@ -952,7 +952,7 @@ hashi committee -c hashi-cli.toml epoch           # current epoch info
 | `hashi_kyoto_synced == 0` for > 5 min | Warning | Light client lost sync. Check Bitcoin RPC and P2P connectivity. |
 | `hashi_kyoto_connected_peers == 0` | Warning | No Bitcoin P2P peers. Check `bitcoin-trusted-peers` and reachability. |
 | `hashi_mpc_sign_failures_total` increasing | Warning | Investigate MPC protocol errors in logs. |
-| `hashi_sui_balance < 1e9 and hashi_sui_balance >= 0` (below 1 SUI) | Warning | Gas wallet running low; the node stops landing Sui transactions when it empties. Top up the operator address. (`-1` means not yet sampled, not empty.) |
+| `hashi_sui_balance < 1e9 and hashi_sui_balance >= 0` (below 1 SUI) | Warning | Gas wallet running low; the node stops landing Sui transactions when it empties. Top up the `address` named in the alert's labels. (`-1` means not yet sampled, not empty.) |
 | `up == 0` (Prometheus target down) | Critical | Node is down. Restart and check logs. |
 
 > **Coming soon:** A metrics **push** service for centralized collection. Details follow once it lands.


### PR DESCRIPTION
## Summary

Validator feedback from the operator channel:

> a small feedback on the `hashi_sui_balance` - it would be helpful to add the operator address label for this metric for better visibility and alerting.

Agreed — today the alert tells you a gas wallet is draining but not which address to fund. The pushed series carries the node's `host` label, and the operator address isn't derivable from it, so responding to the alert means going and looking it up.

## Change

- `hashi_sui_balance` becomes an `IntGaugeVec` with an `address` label holding the operator address that pays gas. One series per node, so there's no cardinality cost.
- The `-1` (never-sampled) sentinel now gets set after the operator key resolves, since the address labels the series. Side effect worth noting: a node with no operator key configured now publishes **no** series rather than an unlabeled `-1`.
- Runbook: metric table and the low-balance alert row now reference the label ("top up the `address` named in the alert's labels").

## Testing

Build + clippy clean, existing tests pass. Verified against the live fleet that the metric is currently unlabeled beyond `host`, which is what motivated the request.

Credit to the operator who raised it.