### PR TITLE
[Guardian] Support monitor reads from testnet S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,8 +3054,6 @@ name = "hashi-guardian-init"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "aws-config",
- "aws-credential-types",
  "bitcoin",
  "clap",
  "hashi",

--- a/crates/hashi-guardian-init/Cargo.toml
+++ b/crates/hashi-guardian-init/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
-aws-config.workspace = true
-aws-credential-types.workspace = true
 bitcoin.workspace = true
 clap.workspace = true
 hashi = { path = "../hashi" }

--- a/crates/hashi-guardian-init/guardian-init.sample.yaml
+++ b/crates/hashi-guardian-init/guardian-init.sample.yaml
@@ -35,7 +35,7 @@ guardian_s3:
   access_key:
   secret_key:
   # S3 object-lock retention class. One of: devnet, mainnet, testnet.
-  # TODO(s3-retention): Should this be replaced by, or derived from, a
+  # TODO: Should this be replaced by, or derived from, a
   # repository-wide Hashi network identifier?
   retention_environment: "testnet"
 

--- a/crates/hashi-guardian-init/src/config.rs
+++ b/crates/hashi-guardian-init/src/config.rs
@@ -5,14 +5,11 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Context;
-use aws_credential_types::provider::ProvideCredentials;
 use bitcoin::Network;
 use hashi::config::HashiIds;
 use hashi::onchain::OnchainState;
 use hashi_types::guardian::LimiterConfig;
-use hashi_types::guardian::S3BucketInfo;
-use hashi_types::guardian::S3Config;
-use hashi_types::guardian::S3RetentionEnvironment;
+use hashi_types::guardian::UnresolvedS3Config;
 use serde::Deserialize;
 
 use crate::kp_roster::KpRosterConfig;
@@ -20,7 +17,7 @@ use crate::kp_roster::KpRosterConfig;
 #[derive(Deserialize)]
 pub struct Config {
     pub hashi: HashiOnchainConfig,
-    pub guardian_s3: GuardianInitS3Config,
+    pub guardian_s3: UnresolvedS3Config,
     #[serde(deserialize_with = "deserialize_network")]
     pub bitcoin_network: Network,
     pub kp_roster: KpRosterConfig,
@@ -109,64 +106,5 @@ impl HashiOnchainConfig {
             .await
             .with_context(|| format!("failed to connect to Sui RPC at {}", self.sui_rpc))?;
         Ok(state)
-    }
-}
-
-#[derive(Deserialize)]
-pub struct GuardianInitS3Config {
-    pub bucket: String,
-    pub region: String,
-    pub access_key: Option<String>,
-    pub secret_key: Option<String>,
-    // TODO(s3-retention): Should this be replaced by, or derived from, a
-    // repository-wide Hashi network identifier?
-    pub retention_environment: S3RetentionEnvironment,
-}
-
-impl GuardianInitS3Config {
-    pub async fn resolve(&self) -> anyhow::Result<S3Config> {
-        let access_key = self
-            .access_key
-            .as_deref()
-            .filter(|value| !value.trim().is_empty());
-        let secret_key = self
-            .secret_key
-            .as_deref()
-            .filter(|value| !value.trim().is_empty());
-
-        let (access_key, secret_key, session_token) = match (access_key, secret_key) {
-            (Some(access_key), Some(secret_key)) => {
-                (access_key.to_string(), secret_key.to_string(), None)
-            }
-            (None, None) => {
-                let provider =
-                    aws_config::default_provider::credentials::DefaultCredentialsChain::builder()
-                        .build()
-                        .await;
-                let creds = provider
-                    .provide_credentials()
-                    .await
-                    .context("failed to resolve AWS credentials from the default provider chain")?;
-                (
-                    creds.access_key_id().to_string(),
-                    creds.secret_access_key().to_string(),
-                    creds.session_token().map(ToOwned::to_owned),
-                )
-            }
-            _ => anyhow::bail!(
-                "guardian_s3 access_key and secret_key must either both be set or both be omitted"
-            ),
-        };
-
-        Ok(S3Config {
-            access_key,
-            secret_key,
-            session_token,
-            bucket_info: S3BucketInfo {
-                bucket: self.bucket.clone(),
-                region: self.region.clone(),
-            },
-            retention_environment: self.retention_environment,
-        })
     }
 }

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -27,7 +27,7 @@ use crate::kp_roster::load_kp_cert;
 /// separately written to disk by this flow.
 pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
 
     info!(
         phase = "setup",

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -59,7 +59,7 @@ use crate::kp_roster::load_kp_cert;
 
 pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
 
     info!(
         phase = "setup",

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -31,7 +31,7 @@ pub async fn run(
     new_kp_pgp_cert_path: PathBuf,
 ) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
     let allowlist = cfg.kp_roster.pcr_allowlist();
     let certs_roster = cfg.kp_roster.load_certs_roster()?;
 

--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -17,7 +17,7 @@ use hashi_types::guardian::GuardianResult;
 use hashi_types::guardian::HashiCommittee;
 use hashi_types::guardian::InitConfig;
 use hashi_types::guardian::OperatorActivateRequest;
-use hashi_types::guardian::S3Config;
+use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::VerifiedGuardianInfo;
 use hashi_types::guardian::WithdrawStage;
 use hashi_types::guardian::proto_conversions::operator_activate_request_to_pb;
@@ -48,7 +48,7 @@ const ACTIVATION_HEARTBEAT_WAIT_BUFFER: Duration = Duration::from_mins(5);
 /// Activate a provisioner-initialized standby guardian.
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
     let allowlist = cfg.kp_roster.pcr_allowlist();
 
     info!(
@@ -294,7 +294,7 @@ struct StandbyChecks {
 
 fn verify_provisioned_standby_info(
     info: &GuardianInfo,
-    guardian_s3: &S3Config,
+    guardian_s3: &ResolvedS3Config,
     cfg: &Config,
     allowlist: &hashi_types::guardian::PcrAllowlist,
     master_g: &hashi_types::bitcoin::HashiMasterG,

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -37,7 +37,7 @@ use crate::guardian_info::verified_live_guardian_info;
 /// See the module docs for the full step-by-step flow. Each step is logged via
 /// `tracing` so the operator can follow exactly what is happening.
 pub async fn run(cfg: Config) -> Result<()> {
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
     let retention_environment = guardian_s3.retention_environment;
 
     info!(

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -9,7 +9,7 @@ use hashi_types::guardian::GenesisState;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::InitConfig;
 use hashi_types::guardian::OperatorInitRequest;
-use hashi_types::guardian::S3Config;
+use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::SecretSharingInstance;
 use hashi_types::guardian::WithdrawStage;
 use hashi_types::guardian::proto_conversions::operator_init_request_to_pb;
@@ -23,7 +23,7 @@ use crate::guardian_info::verified_live_guardian_info;
 /// Initialize a fresh withdraw-mode guardian with operator-supplied stable config.
 pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
     cfg.kp_roster.validate()?;
-    let guardian_s3 = cfg.guardian_s3.resolve().await?;
+    let guardian_s3 = hashi_guardian::resolve_s3_config(&cfg.guardian_s3).await?;
     let retention_environment = guardian_s3.retention_environment;
     let allowlist = cfg.kp_roster.pcr_allowlist();
 
@@ -322,7 +322,7 @@ fn ensure_uninitialized(info: &GuardianInfo) -> anyhow::Result<()> {
 
 fn verify_initialized_info(
     info: GuardianInfo,
-    guardian_s3: &S3Config,
+    guardian_s3: &ResolvedS3Config,
     expected_instance: &SecretSharingInstance,
     expected_config: &InitConfig,
     expected_config_hash: [u8; 32],

--- a/crates/hashi-guardian/src/lib.rs
+++ b/crates/hashi-guardian/src/lib.rs
@@ -34,6 +34,7 @@ pub mod withdraw_mode;
 pub mod test_utils;
 
 pub use enclave::Enclave;
+pub use s3_client::resolve_s3_config;
 pub use s3_client::GuardianS3Client;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::MAX_S3_WRITE_FAILURE_INTERVAL;
+use anyhow::Context;
+use aws_credential_types::provider::ProvideCredentials;
 use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_credential_types::CredentialsBuilder;
 use aws_sdk_s3::error::DisplayErrorContext;
 use hashi_types::guardian::LogRecord;
+use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::S3BucketInfo;
-use hashi_types::guardian::S3Config;
 use hashi_types::guardian::S3ObjectLockPolicy;
+use hashi_types::guardian::UnresolvedS3Config;
 use std::collections::BTreeSet;
 use std::sync::Once;
 use std::time::Duration;
@@ -37,10 +40,58 @@ const S3_WRITE_RETRY_INTERVAL: Duration = Duration::from_secs(10);
 const SKIP_S3_OBJECT_LOCK_CHECK_ENV: &str = "HASHI_SKIP_S3_OBJECT_LOCK_CHECK";
 static SKIP_S3_OBJECT_LOCK_CHECK_WARNING: Once = Once::new();
 
+/// Resolve explicit credentials or, when both are omitted, use AWS's default
+/// provider chain.
+pub async fn resolve_s3_config(config: &UnresolvedS3Config) -> anyhow::Result<ResolvedS3Config> {
+    let access_key = config
+        .access_key
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+    let secret_key = config
+        .secret_key
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+
+    let (access_key, secret_key, session_token) = match (access_key, secret_key) {
+        (Some(access_key), Some(secret_key)) => {
+            (access_key.to_string(), secret_key.to_string(), None)
+        }
+        (None, None) => {
+            let provider =
+                aws_config::default_provider::credentials::DefaultCredentialsChain::builder()
+                    .build()
+                    .await;
+            let credentials = provider
+                .provide_credentials()
+                .await
+                .context("failed to resolve AWS credentials from the default provider chain")?;
+            (
+                credentials.access_key_id().to_string(),
+                credentials.secret_access_key().to_string(),
+                credentials.session_token().map(ToOwned::to_owned),
+            )
+        }
+        _ => anyhow::bail!(
+            "guardian_s3 access_key and secret_key must either both be set or both be omitted"
+        ),
+    };
+
+    Ok(ResolvedS3Config {
+        access_key,
+        secret_key,
+        session_token,
+        bucket_info: S3BucketInfo {
+            bucket: config.bucket.clone(),
+            region: config.region.clone(),
+        },
+        retention_environment: config.retention_environment,
+    })
+}
+
 #[derive(Clone)]
 pub struct GuardianS3Client {
     /// S3 connection and retention config.
-    config: S3Config,
+    config: ResolvedS3Config,
     /// S3 client
     client: S3Client,
     /// Expected object-lock policy for this Guardian deployment.
@@ -52,7 +103,7 @@ impl GuardianS3Client {
     // Constructors
     // ========================================================================
 
-    pub async fn new(config: &S3Config) -> Self {
+    pub async fn new(config: &ResolvedS3Config) -> Self {
         info!("S3 Configuration:");
         info!("   Bucket: {}", config.bucket_name());
         info!("   Region: {}", config.region());
@@ -88,7 +139,7 @@ impl GuardianS3Client {
         }
     }
 
-    pub async fn new_checked(config: &S3Config) -> GuardianResult<Self> {
+    pub async fn new_checked(config: &ResolvedS3Config) -> GuardianResult<Self> {
         let logger = Self::new(config).await;
         logger.test_s3_connectivity().await?;
         Ok(logger)
@@ -97,7 +148,7 @@ impl GuardianS3Client {
     /// Construct an `GuardianS3Client` from an already-configured S3 client.
     /// This is intended for unit tests that use a mock S3 Client.
     /// This is not put behind cfg(test) as tests in the enclave crate also use it.
-    pub fn from_client_for_tests(config: S3Config, client: S3Client) -> Self {
+    pub fn from_client_for_tests(config: ResolvedS3Config, client: S3Client) -> Self {
         let object_lock_policy = S3ObjectLockPolicy::for_environment(config.retention_environment);
         Self {
             client,
@@ -554,7 +605,16 @@ impl GuardianS3Client {
         dir: &S3HourScopedDirectory,
     ) -> GuardianResult<Vec<LogRecord>> {
         let prefix = dir.to_string();
-        let keys = self.list_keys(&prefix, true).await?;
+        self.list_all_log_records_with_prefix(&prefix).await
+    }
+
+    /// Batch read all immutable log records whose keys begin with `prefix`.
+    /// The prefix history is validated before any records are fetched.
+    pub(crate) async fn list_all_log_records_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> GuardianResult<Vec<LogRecord>> {
+        let keys = self.list_keys(prefix, true).await?;
         let mut out = Vec::with_capacity(keys.len());
         for key in keys {
             // The prefix history was checked above. Immutable batch logs also
@@ -689,7 +749,7 @@ mod tests {
     use hashi_types::guardian::SessionID;
 
     fn mk_logger_with_client(client: Client) -> GuardianS3Client {
-        let config = S3Config {
+        let config = ResolvedS3Config {
             access_key: "test-access-key".to_string(),
             secret_key: "test-secret-key".to_string(),
             session_token: None,

--- a/crates/hashi-guardian/src/s3_reader/mod.rs
+++ b/crates/hashi-guardian/src/s3_reader/mod.rs
@@ -22,10 +22,11 @@ use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::S3Config;
+use hashi_types::guardian::ResolvedS3Config;
 use hashi_types::guardian::SessionID;
 use hashi_types::guardian::VersionedLogMessage::V1;
 use hashi_types::guardian::VersionedLogMessage::V2;
+use hashi_types::guardian::WithdrawalLogMessage;
 use hashi_types::move_types::Committee;
 use std::collections::HashMap;
 use tracing::info;
@@ -69,7 +70,7 @@ pub struct GuardianReader {
 
 impl GuardianReader {
     /// Create a reader after checking S3 connectivity and object-lock support.
-    pub async fn new(config: &S3Config, allowlist: PcrAllowlist) -> GuardianResult<Self> {
+    pub async fn new(config: &ResolvedS3Config, allowlist: PcrAllowlist) -> GuardianResult<Self> {
         let s3 = GuardianS3Client::new_checked(config).await?;
         Ok(Self::from_s3_client(s3, allowlist))
     }
@@ -119,7 +120,15 @@ impl GuardianReader {
         &mut self,
         dir: &S3HourScopedDirectory,
     ) -> GuardianResult<Vec<VerifiedLogRecord>> {
-        let all_logs = self.s3.list_all_log_records_in_dir(dir).await?;
+        let prefix = dir.to_string();
+        self.read_logs_with_prefix(&prefix).await
+    }
+
+    async fn read_logs_with_prefix(
+        &mut self,
+        prefix: &str,
+    ) -> GuardianResult<Vec<VerifiedLogRecord>> {
+        let all_logs = self.s3.list_all_log_records_with_prefix(prefix).await?;
 
         let mut out = Vec::with_capacity(all_logs.len());
         for record in all_logs {
@@ -127,6 +136,18 @@ impl GuardianReader {
             out.push(verified_record);
         }
         Ok(out)
+    }
+
+    /// Read and verify successful withdrawal records in `dir`.
+    ///
+    /// This excludes rejected withdrawal requests, which do not represent
+    /// Guardian approval events and are not inputs to the monitor state machine.
+    pub async fn read_successful_withdrawals_in_dir(
+        &mut self,
+        dir: &S3HourScopedDirectory,
+    ) -> GuardianResult<Vec<VerifiedLogRecord>> {
+        let prefix = format!("{dir}{}", WithdrawalLogMessage::SUCCESS_OBJECT_KEY_PREFIX);
+        self.read_logs_with_prefix(&prefix).await
     }
 
     /// Return verified session info after requiring the attested PCRs to match

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -35,11 +35,11 @@ pub fn mock_logger() -> GuardianS3Client {
     use aws_smithy_mocks::mock;
     use aws_smithy_mocks::mock_client;
     use aws_smithy_mocks::RuleMode;
-    use hashi_types::guardian::S3Config;
+    use hashi_types::guardian::ResolvedS3Config;
 
     let put_ok = mock!(Client::put_object).then_output(|| PutObjectOutput::builder().build());
     let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_ok]);
-    GuardianS3Client::from_client_for_tests(S3Config::mock_for_testing(), client)
+    GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client)
 }
 
 /// Captured `(key, body)` pairs from a `mock_logger_capturing()` logger.
@@ -126,7 +126,7 @@ pub fn mock_logger_capturing() -> (GuardianS3Client, CapturedPuts) {
     use aws_smithy_mocks::mock;
     use aws_smithy_mocks::mock_client;
     use aws_smithy_mocks::RuleMode;
-    use hashi_types::guardian::S3Config;
+    use hashi_types::guardian::ResolvedS3Config;
 
     let captures: CapturedPuts = Arc::new(std::sync::Mutex::new(Vec::new()));
     let captures_w = captures.clone();
@@ -144,7 +144,8 @@ pub fn mock_logger_capturing() -> (GuardianS3Client, CapturedPuts) {
         })
         .then_output(|| PutObjectOutput::builder().build());
     let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_ok]);
-    let logger = GuardianS3Client::from_client_for_tests(S3Config::mock_for_testing(), client);
+    let logger =
+        GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client);
     (logger, captures)
 }
 
@@ -167,7 +168,7 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
     use aws_smithy_mocks::mock;
     use aws_smithy_mocks::mock_client;
     use aws_smithy_mocks::RuleMode;
-    use hashi_types::guardian::S3Config;
+    use hashi_types::guardian::ResolvedS3Config;
     use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::sync::Mutex;
@@ -236,7 +237,7 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
         RuleMode::MatchAny,
         &[&list_v2, &list_versions, &put_ok]
     );
-    GuardianS3Client::from_client_for_tests(S3Config::mock_for_testing(), client)
+    GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client)
 }
 
 /// Args for arming a withdraw-mode test enclave. `config` is the stable

--- a/crates/hashi-monitor/audit.sample.yaml
+++ b/crates/hashi-monitor/audit.sample.yaml
@@ -8,13 +8,12 @@ next_event_delays:
 # Clock skew tolerance: E_{i+1} can occur up to clock_skew seconds before E_i (default: 300s)
 # clock_skew: 300
 
-guardian:
-  access_key: "AWS_ACCESS_KEY_ID"
-  secret_key: "AWS_SECRET_ACCESS_KEY"
-  session_token:
-  bucket_info:
-    bucket: "hashi-guardian-logs"
-    region: "us-east-1"
+guardian_s3:
+  bucket: "hashi-guardian-logs"
+  region: "us-east-1"
+  # Omit both keys to use the AWS default credential chain.
+  # access_key: "..."
+  # secret_key: "..."
   retention_environment: "testnet"
 
 # Expected enclave build: git revision + PCR0 (hex). The live guardian must

--- a/crates/hashi-monitor/src/config.rs
+++ b/crates/hashi-monitor/src/config.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use anyhow::anyhow;
 use corepc_client::client_sync::Auth;
 use hashi_types::guardian::PcrAllowlist;
-use hashi_types::guardian::S3Config;
+use hashi_types::guardian::UnresolvedS3Config;
 use serde::Deserialize;
 
 use crate::domain::WithdrawalEventType;
@@ -23,7 +23,7 @@ pub struct Config {
     #[serde(default = "default_clock_skew")]
     pub clock_skew: u64,
 
-    pub guardian: S3Config,
+    pub guardian_s3: UnresolvedS3Config,
     #[serde(flatten)]
     pub pcr_allowlist: PcrAllowlist,
     pub sui: SuiConfig,

--- a/crates/hashi-monitor/src/rpc/btc.rs
+++ b/crates/hashi-monitor/src/rpc/btc.rs
@@ -116,7 +116,13 @@ mod tests {
             ])
             .expect("valid next event delays"),
             clock_skew: 10,
-            guardian: hashi_types::guardian::S3Config::mock_for_testing(),
+            guardian_s3: hashi_types::guardian::UnresolvedS3Config {
+                bucket: "bucket".to_string(),
+                region: "us-east-1".to_string(),
+                access_key: Some("access-key".to_string()),
+                secret_key: Some("secret-key".to_string()),
+                retention_environment: hashi_types::guardian::S3RetentionEnvironment::Testnet,
+            },
             pcr_allowlist: hashi_types::guardian::PcrAllowlist::new(
                 hashi_types::guardian::BuildPcrs::new("", vec![]),
                 vec![],

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -17,14 +17,8 @@ use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::unix_millis_to_seconds;
 use tracing::debug;
-use tracing::info;
 
-enum VerifiedWithdrawal {
-    Success(MonitorWithdrawalEvent),
-    Failure,
-}
-
-impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
+impl TryFrom<VerifiedLogRecord> for MonitorWithdrawalEvent {
     type Error = anyhow::Error;
 
     fn try_from(log: VerifiedLogRecord) -> Result<Self, Self::Error> {
@@ -47,16 +41,15 @@ impl TryFrom<VerifiedLogRecord> for VerifiedWithdrawal {
                     txid = %txid,
                     "successful guardian withdrawal log"
                 );
-                Ok(VerifiedWithdrawal::Success(MonitorWithdrawalEvent {
+                Ok(MonitorWithdrawalEvent {
                     event_type: WithdrawalEventType::E2GuardianApproved,
                     wid: request_data.wid,
                     timestamp_secs: unix_millis_to_seconds(timestamp_ms),
                     btc_txid: txid,
-                }))
+                })
             }
-            failure @ WithdrawalLogMessage::Failure { .. } => {
-                info!(?failure, "failed guardian withdrawal log");
-                Ok(VerifiedWithdrawal::Failure)
+            WithdrawalLogMessage::Failure { .. } => {
+                anyhow::bail!("failure log found under successful-withdrawal prefix")
             }
         }
     }
@@ -74,8 +67,9 @@ pub struct GuardianWithdrawalsPoller {
 impl GuardianWithdrawalsPoller {
     // Note: Throws an error if there is a S3 connectivity issue
     pub async fn new(config: &Config, start: UnixSeconds) -> anyhow::Result<Self> {
+        let guardian_s3 = hashi_guardian::resolve_s3_config(&config.guardian_s3).await?;
         Ok(Self {
-            reader: GuardianReader::new(&config.guardian, config.pcr_allowlist()).await?,
+            reader: GuardianReader::new(&guardian_s3, config.pcr_allowlist()).await?,
             cursor: S3HourScopedDirectory::withdraw(start),
         })
     }
@@ -91,20 +85,20 @@ impl GuardianWithdrawalsPoller {
             return Ok(PollOutcome::CursorUnmoved);
         }
 
-        let verified_logs = self.reader.read_logs_in_dir(&self.cursor).await?;
+        let verified_logs = self
+            .reader
+            .read_successful_withdrawals_in_dir(&self.cursor)
+            .await?;
         // Withdrawal polling may replay historical buckets during an upgrade, so
         // this caller accepts any record whose session build verifies against the
         // configured allowlist. Add a cursor/cutoff policy here if tailing must
         // require the current build after the upgrade window.
         let withdrawal_events = verified_logs
             .into_iter()
-            .map(VerifiedWithdrawal::try_from)
+            .map(MonitorWithdrawalEvent::try_from)
             .collect::<anyhow::Result<Vec<_>>>()?
             .into_iter()
-            .filter_map(|e| match e {
-                VerifiedWithdrawal::Success(event) => Some(MonitorEvent::Withdrawal(event)),
-                VerifiedWithdrawal::Failure => None,
-            })
+            .map(MonitorEvent::Withdrawal)
             .collect::<Vec<MonitorEvent>>();
 
         self.cursor = self.cursor.next_dir();

--- a/crates/hashi-monitor/src/state_machine.rs
+++ b/crates/hashi-monitor/src/state_machine.rs
@@ -395,7 +395,7 @@ mod tests {
     use crate::config::NextEventDelays;
     use crate::config::SuiConfig;
     use bitcoin::hashes::Hash as _;
-    use hashi_types::guardian::S3Config;
+    use hashi_types::guardian::UnresolvedS3Config;
 
     struct TestWindow {
         start: UnixSeconds,
@@ -416,7 +416,13 @@ mod tests {
             ])
             .expect("valid intra-event delays"),
             clock_skew: 10,
-            guardian: S3Config::mock_for_testing(),
+            guardian_s3: UnresolvedS3Config {
+                bucket: "bucket".to_string(),
+                region: "us-east-1".to_string(),
+                access_key: Some("access-key".to_string()),
+                secret_key: Some("secret-key".to_string()),
+                retention_environment: hashi_types::guardian::S3RetentionEnvironment::Testnet,
+            },
             pcr_allowlist: hashi_types::guardian::PcrAllowlist::new(
                 hashi_types::guardian::BuildPcrs::new("", vec![]),
                 vec![],

--- a/crates/hashi-types/src/guardian/log/messages/withdrawal.rs
+++ b/crates/hashi-types/src/guardian/log/messages/withdrawal.rs
@@ -34,6 +34,9 @@ pub enum WithdrawalLogMessage {
 }
 
 impl WithdrawalLogMessage {
+    /// Prefix shared by all successful withdrawal object names within an hour.
+    pub const SUCCESS_OBJECT_KEY_PREFIX: &'static str = "success-";
+
     /// Success keys lead with `success-{seq:020}` so that lexicographic listing
     /// within an hour bucket is also seq-sorted — the last key is the max-seq
     /// log, which the KP reads to recover limiter state. Failures don't have a
@@ -47,8 +50,10 @@ impl WithdrawalLogMessage {
         let directory = S3HourScopedDirectory::withdraw(unix_millis_to_seconds(timestamp_ms));
         match self {
             Self::Success { request_data, .. } => ObjectKeyPattern::Fixed(format!(
-                "{directory}success-{:020}-{session_id}-wid{}.json",
-                request_data.seq, request_data.wid,
+                "{directory}{}{:020}-{session_id}-wid{}.json",
+                Self::SUCCESS_OBJECT_KEY_PREFIX,
+                request_data.seq,
+                request_data.wid,
             )),
             Self::Failure { request_data, .. } => ObjectKeyPattern::RandomSuffix(format!(
                 "{directory}failure-{session_id}-wid{}-",

--- a/crates/hashi-types/src/guardian/log/retention.rs
+++ b/crates/hashi-types/src/guardian/log/retention.rs
@@ -30,7 +30,7 @@ pub struct S3ObjectLockPolicy {
     pub short_lived: Duration,
 }
 
-// TODO(s3-retention): Retire this enum once the repository has a canonical
+// TODO: Retire this enum once the repository has a canonical
 // Hashi network enum from which the retention policy can be derived.
 /// Hashi deployment class used to select an S3 object-lock policy.
 ///

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -390,8 +390,7 @@ pub struct UnresolvedS3Config {
     pub region: String,
     pub access_key: Option<String>,
     pub secret_key: Option<String>,
-    // TODO: Should this be replaced by, or derived from, a
-    // repository-wide Hashi network identifier?
+    /// Hashi deployment class used to select the Guardian S3 object-lock policy.
     pub retention_environment: S3RetentionEnvironment,
 }
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -75,7 +75,7 @@ use std::ops::Deref;
 /// `InitConfig` whose digest KPs authenticate during provisioner init.
 #[derive(Debug, Clone, PartialEq)]
 pub struct OperatorInitRequest {
-    s3_config: S3Config,
+    s3_config: ResolvedS3Config,
     init_config: Option<InitConfig>,
     genesis_state: Option<GenesisState>,
 }
@@ -382,8 +382,22 @@ impl fmt::Display for SessionID {
     }
 }
 
+/// S3 configuration as supplied by a config file, before AWS credentials have
+/// been resolved.
+#[derive(Clone, Debug, Deserialize)]
+pub struct UnresolvedS3Config {
+    pub bucket: String,
+    pub region: String,
+    pub access_key: Option<String>,
+    pub secret_key: Option<String>,
+    // TODO: Should this be replaced by, or derived from, a
+    // repository-wide Hashi network identifier?
+    pub retention_environment: S3RetentionEnvironment,
+}
+
+/// Runtime S3 configuration with concrete credentials.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct S3Config {
+pub struct ResolvedS3Config {
     pub access_key: String,
     pub secret_key: String,
     pub session_token: Option<String>,
@@ -401,7 +415,7 @@ pub struct S3BucketInfo {
 //          Helper impl's
 // ---------------------------------
 
-impl S3Config {
+impl ResolvedS3Config {
     pub fn bucket_name(&self) -> &str {
         &self.bucket_info.bucket
     }
@@ -450,7 +464,7 @@ impl SetupNewKeyRequest {
 
 impl OperatorInitRequest {
     /// Build a ceremony-mode request (S3 only).
-    pub fn new_ceremony_mode(s3_config: S3Config) -> Self {
+    pub fn new_ceremony_mode(s3_config: ResolvedS3Config) -> Self {
         Self {
             s3_config,
             init_config: None,
@@ -460,7 +474,7 @@ impl OperatorInitRequest {
 
     /// Build a withdraw-mode request carrying the stable operator config.
     pub fn new_withdraw_mode(
-        s3_config: S3Config,
+        s3_config: ResolvedS3Config,
         init_config: InitConfig,
         genesis_state: Option<GenesisState>,
     ) -> Self {
@@ -471,7 +485,7 @@ impl OperatorInitRequest {
         }
     }
 
-    pub fn s3_config(&self) -> &S3Config {
+    pub fn s3_config(&self) -> &ResolvedS3Config {
         &self.s3_config
     }
 
@@ -497,7 +511,7 @@ impl OperatorInitRequest {
         }
     }
 
-    pub fn into_parts(self) -> (S3Config, Option<InitConfig>, Option<GenesisState>) {
+    pub fn into_parts(self) -> (ResolvedS3Config, Option<InitConfig>, Option<GenesisState>) {
         (self.s3_config, self.init_config, self.genesis_state)
     }
 }

--- a/crates/hashi-types/src/guardian/proto_conversions.rs
+++ b/crates/hashi-types/src/guardian/proto_conversions.rs
@@ -182,7 +182,7 @@ impl TryFrom<pb::OperatorInitRequest> for OperatorInitRequest {
 
     fn try_from(req: pb::OperatorInitRequest) -> Result<Self, Self::Error> {
         let s3_config =
-            super::S3Config::try_from(req.s3_config.ok_or_else(|| missing("s3_config"))?)?;
+            super::ResolvedS3Config::try_from(req.s3_config.ok_or_else(|| missing("s3_config"))?)?;
         let genesis_state = req
             .genesis_state
             .map(|state| {
@@ -1108,7 +1108,7 @@ fn share_id_to_pb(id: ShareID) -> pb::GuardianShareId {
     }
 }
 
-impl TryFrom<pb::S3Config> for super::S3Config {
+impl TryFrom<pb::S3Config> for super::ResolvedS3Config {
     type Error = GuardianError;
 
     fn try_from(cfg: pb::S3Config) -> Result<Self, Self::Error> {
@@ -1132,7 +1132,7 @@ impl TryFrom<pb::S3Config> for super::S3Config {
     }
 }
 
-fn s3_config_to_pb(cfg: super::S3Config) -> pb::S3Config {
+fn s3_config_to_pb(cfg: super::ResolvedS3Config) -> pb::S3Config {
     pb::S3Config {
         access_key: Some(cfg.access_key),
         secret_key: Some(cfg.secret_key),

--- a/crates/hashi-types/src/guardian/test_utils.rs
+++ b/crates/hashi-types/src/guardian/test_utils.rs
@@ -25,9 +25,9 @@ use super::PcrAllowlist;
 use super::ProvisionerInitRequest;
 use super::ProvisionerRotateCertRequest;
 use super::ProvisionerRotateCertResponse;
+use super::ResolvedS3Config;
 use super::RotateKpsResponse;
 use super::S3BucketInfo;
-use super::S3Config;
 use super::SecretSharingInstance;
 use super::SessionID;
 use super::SetupNewKeyRequest;
@@ -233,7 +233,7 @@ impl GuardianSignedResponse<ProvisionerRotateCertResponse> {
 
 impl OperatorInitRequest {
     pub fn mock_for_testing() -> Self {
-        let s3_config = super::S3Config {
+        let s3_config = super::ResolvedS3Config {
             access_key: "ak".into(),
             secret_key: "sk".into(),
             session_token: Some("token".into()),
@@ -482,7 +482,7 @@ impl S3BucketInfo {
     }
 }
 
-impl S3Config {
+impl ResolvedS3Config {
     /// Convenience helper for tests.
     pub fn mock_for_testing() -> Self {
         Self {


### PR DESCRIPTION
Splits the Guardian/S3 integration prerequisite out of the original combined monitor PR.

This PR:
- shares unresolved and resolved S3 configuration between Guardian and the monitor
- resolves the AWS default credential chain in the Guardian crate
- reads only successful withdrawal records for monitor audits
- supports the temporary testnet object-lock bypass until the next testnet wipe

Monitor stack:
- prerequisite: this PR
- [1/2]: #949
- [2/2]: #950

Keep as draft pending approval.

Local verification:
- `make fmt`
- `cargo check`