### PR TITLE
[Monitor] [2/2] Run batch and continuous testnet audits

### DIFF
--- a/crates/hashi-monitor/README.md
+++ b/crates/hashi-monitor/README.md
@@ -19,27 +19,64 @@ Audits the cross-system bridge flow on two parallel tracks.
 - **Predecessor existence**: every successor event has a matching predecessor with consistent txid / wid.
 - **Successor existence**: for each non-terminal event, the configured next-event delay bound must hold.
 
+Findings are tagged as:
+- **liveness** when a successor is late or still missing after its deadline;
+- **safety** for a contradictory event, a late predecessor, or a predecessor
+  still missing after its source cursor passes the deadline.
+
+For withdrawals, a predecessor lookback that is too short can produce a false
+safety finding for a missing E1. Reconcile older Sui history before treating
+such a finding as conclusive.
+
 ### Modes
 1. **Batch**: one-time audit over a guardian time range `[start, end]`.
 2. **Continuous**: long-running monitor that polls Sui, Guardian S3, and BTC RPC on fixed intervals and reports findings as they appear.
 
 ### Timeline semantics (withdrawals)
 - User-provided `start` / `end` are interpreted on the **guardian (E2)** timeline.
-- Sui events are polled in a relaxed range to validate E2 predecessor constraints.
+- Sui withdrawal events are polled from `withdrawal_predecessor_lookback`
+  seconds before the guardian window to validate E2 predecessor constraints.
 - Orphan E1 findings are currently still reported when E1 falls in the user window.
-- Deposits are not gated by the audit window — there is no false-positive risk.
+- Deposits are audited over the derived Sui range rather than gated by the
+  withdrawal audit-window logic.
 
 ## Usage
 
+### Active testnet
+
+`audit.testnet.yaml` contains the active Hashi Guardian testnet deployment
+identifiers and PCR allowlist. Supply AWS credentials through the default
+credential chain and keep the Signet provider URI in the environment:
+
+```bash
+export AWS_PROFILE=guardian-s3-testnet
+export HASHI_SKIP_S3_OBJECT_LOCK_CHECK=1
+export HASHI_BITCOIN_RPC_URL="https://your-signet-json-rpc-endpoint"
+
+cargo run -p hashi-monitor -- continuous \
+  --config audit.testnet.yaml \
+  --start 2026-08-04T19:00:00Z
+```
+
+Run this from `crates/hashi-monitor`, or prefix the configuration path with
+`crates/hashi-monitor/` when running from the repository root. The object-lock
+bypass is temporary and is described below.
+
 ### Batch audit
 ```bash
-cargo run -p hashi-monitor -- batch --config audit.sample.yaml --start 1700000000 --end 1700003600
+cargo run -p hashi-monitor -- batch \
+  --config audit.sample.yaml \
+  --start 2026-08-04T18:00:00Z \
+  --end 2026-08-04T19:00:00Z
 ```
-`--end` defaults to the current time if omitted.
+CLI timestamps use whole-second UTC RFC 3339 (`YYYY-MM-DDTHH:MM:SSZ`). `--end`
+defaults to the current time if omitted.
 
 ### Continuous monitoring
 ```bash
-cargo run -p hashi-monitor -- continuous --config audit.sample.yaml --start 1700000000
+cargo run -p hashi-monitor -- continuous \
+  --config audit.sample.yaml \
+  --start 2026-08-04T19:00:00Z
 ```
 
 ## Config
@@ -54,22 +91,25 @@ next_event_delays:
 # Optional: clock skew tolerance (default: 300s)
 # clock_skew: 300
 
-guardian:
-  access_key: "AWS_ACCESS_KEY_ID"
-  secret_key: "AWS_SECRET_ACCESS_KEY"
-  session_token:
-  bucket_info:
-    bucket: "hashi-guardian-logs"
-    region: "us-east-1"
+# Optional: Sui withdrawal history before the guardian window (default: 1 hour)
+# withdrawal_predecessor_lookback: 3600
+
+guardian_s3:
+  bucket: "hashi-guardian-logs"
+  region: "us-east-1"
+  # Omit both keys to use the AWS default credential chain.
+  # access_key: "..."
+  # secret_key: "..."
   retention_environment: "testnet"
 
 sui:
   rpc_url: "https://fullnode.testnet.sui.io:443"
+  package_id: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 btc:
-  rpc_url: "http://localhost:8332"
-  rpc_auth:
-    type: none
+  rpc_url: "env:BITCOIN_RPC_URL"
+  # http_headers:
+  #   Origin: "https://example.com"
 ```
 
 ## Status
@@ -77,9 +117,8 @@ btc:
   - Domain model and withdrawal / deposit state-machine checks.
   - Batch and continuous auditor loops (cursor advancement, BTC fetch, violation detection, GC, progress watermarks).
   - Guardian S3 withdrawal log polling with attestation and signature verification.
-  - BTC confirmation lookup via Bitcoin Core RPC.
-- Not yet implemented:
-  - Sui event polling — `AuditorCore::poll_sui` is a stub that returns `CursorUnmoved`, so E1 (withdrawal) and the deposit pipeline currently see no Sui input.
+  - Checkpoint-bounded, resumable Sui polling for withdrawal and deposit events.
+  - Batched BTC confirmation lookup over HTTP JSON-RPC.
 
 ## Temporary testnet object-lock bypass
 

--- a/crates/hashi-monitor/audit.sample.yaml
+++ b/crates/hashi-monitor/audit.sample.yaml
@@ -8,6 +8,9 @@ next_event_delays:
 # Clock skew tolerance: E_{i+1} can occur up to clock_skew seconds before E_i (default: 300s)
 # clock_skew: 300
 
+# Sui withdrawal history searched before the guardian audit start (default: 1 hour)
+# withdrawal_predecessor_lookback: 3600
+
 guardian_s3:
   bucket: "hashi-guardian-logs"
   region: "us-east-1"
@@ -31,10 +34,10 @@ prev_builds: []
 
 sui:
   rpc_url: "https://fullnode.testnet.sui.io:443"
-  package_id: "0x..."
+  package_id: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 btc:
-  # Prefix with env: to keep provider API keys out of YAML.
-  rpc_url: "env:HASHI_BITCOIN_RPC_URL"
-  # Optional provider-specific headers.
-  http_headers: {}
+  rpc_url: "env:BITCOIN_RPC_URL"
+  # Optional headers for hosted JSON-RPC providers:
+  # http_headers:
+  #   Origin: "https://example.com"

--- a/crates/hashi-monitor/audit.testnet.yaml
+++ b/crates/hashi-monitor/audit.testnet.yaml
@@ -1,0 +1,35 @@
+# Active Hashi Guardian testnet configuration for `hashi-monitor`.
+#
+# This file contains only public deployment identifiers and enclave build
+# measurements. AWS credentials come from the default credential chain, and
+# the Signet JSON-RPC endpoint comes from HASHI_BITCOIN_RPC_URL.
+
+next_event_delays:
+  # Active-testnet Guardian approvals normally arrive 13-15 minutes after E1.
+  - [E1HashiApproved, 1200]
+  - [E2GuardianApproved, 86400]
+
+clock_skew: 300
+withdrawal_predecessor_lookback: 3600
+
+guardian_s3:
+  bucket: "mysten-hashi-guardian-enclave-testnet-3"
+  region: "us-west-2"
+  retention_environment: "testnet"
+
+current_build:
+  git_revision: "ae3fc68200a80fcef2dd5dbea5c4fd18a4ec8f0e"
+  pcr0: "2b32834f124e5d626fdbeb79d9b3bec20dc46365e3418508f794e31ce188d737f92dc0a89110530c027e22cec7741489"
+
+# Add older withdrawal-mode builds here only when auditing across an upgrade.
+# Ceremony-mode builds are not needed by the monitor's withdrawal log reader.
+prev_builds: []
+
+sui:
+  rpc_url: "https://fullnode.testnet.sui.io:443"
+  package_id: "0xfcea10cadbb553c4874201584abf68771592678952efd957b2e82c010c7f4360"
+
+btc:
+  rpc_url: "env:HASHI_BITCOIN_RPC_URL"
+  http_headers:
+    Origin: "https://testnet.hashi.sui.io"

--- a/crates/hashi-monitor/src/audit/batch.rs
+++ b/crates/hashi-monitor/src/audit/batch.rs
@@ -8,19 +8,19 @@ use crate::config::Config;
 use crate::domain::Cursors;
 use crate::domain::MonitorEvent;
 use crate::domain::PollOutcome;
-use crate::domain::WithdrawalEventType;
 use crate::domain::now_unix_seconds;
+use crate::domain::utc_timestamp;
 use hashi_types::guardian::time_utils::UnixSeconds;
 
 const NUM_ITERATIONS_BEFORE_FAIL: u8 = 5;
 
-/// the exact amount of time to look back or ahead to identify all the potentially interesting events
+/// User and derived source ranges for one batch audit.
 #[derive(Clone, Copy, Debug)]
 pub struct BatchAuditWindow {
-    /// time range input by user
+    /// Guardian time range supplied by the user.
     user_start: UnixSeconds,
     user_end: UnixSeconds,
-    /// relaxed time ranges used to pull logs from sui & guardian
+    /// Derived source ranges used to poll Sui and Guardian.
     sui_start: UnixSeconds,
     sui_end: UnixSeconds,
     guardian_start: UnixSeconds,
@@ -29,11 +29,8 @@ pub struct BatchAuditWindow {
 
 impl BatchAuditWindow {
     pub fn new(cfg: &Config, start: UnixSeconds, end: UnixSeconds, cur_time: UnixSeconds) -> Self {
-        let e1_e2_delay_secs = cfg
-            .next_event_delay(WithdrawalEventType::E1HashiApproved)
-            .expect("should be Some");
         // Guardian timeline is authoritative. We still fetch Sui in a relaxed range to validate E2 -> E1.
-        let sui_start = start.saturating_sub(e1_e2_delay_secs); // guardian_e2@{start} might match sui_e1@{start-e1_e2_delay_secs}
+        let sui_start = start.saturating_sub(cfg.withdrawal_predecessor_lookback);
         let sui_end = end.saturating_add(cfg.clock_skew).min(cur_time); // guardian_e2@{end} might match sui_e1@{end+clock_skew}
 
         // User [start, end] is interpreted as guardian timestamps.
@@ -61,16 +58,19 @@ impl AuditWindow for BatchAuditWindow {
 ///
 /// It functions as follows:
 ///     - fetch guardian events from `[t1, t2]` (authoritative timeline)
-///     - fetch sui events from `[t1 - e1_e2_delay_secs, t2 + clock_skew]` (for E2 predecessor checks)
-///     - fetch btc tx & perform checks for withdrawals anchored by guardian events in `[t1, t2]`
-/// Finally, it outputs a timestamp `verified_up_to` to be used as `t1` in the next audit.
+///     - fetch withdrawal and deposit events from
+///       `[t1 - withdrawal_predecessor_lookback, t2 + clock_skew]`
+///     - fetch BTC data for in-scope withdrawals and deposits found in the Sui range
+/// Finally, it logs progress watermarks that identify a safe start for the next audit.
 ///
 /// Notes:
-/// 1) A successful batch audit guarantees that guardian events emitted in `[t1, verified_up_to)` are cross-verified.
+/// 1) If no findings are emitted, Guardian events in the verified withdrawal
+///    range were cross-checked against their Sui and Bitcoin neighbors.
 /// 2) We currently also report orphan E1 findings if they fall in the user window.
 ///    TODO: If desired, this can be relaxed later to strict guardian-anchored scope.
-/// 3) Events emitted towards the end of the time range may not be fully verified, e.g., if t2 is current or if there is
-///    some issue with RPC. This info is captured by the `verified_up_to` timestamp.
+/// 3) Events near the end may remain unresolved because their successors are
+///    not yet due or observed. The progress watermarks capture a safe restart;
+///    infrastructure failures return an error instead of a partial audit.
 /// 4) The current approach is fetch-then-check. An alternate streaming auditor can be implemented in the future if needed.
 pub struct BatchAuditor {
     pub inner: AuditorCore,
@@ -82,12 +82,16 @@ impl BatchAuditor {
     pub async fn new(cfg: &Config, start: UnixSeconds, end: UnixSeconds) -> anyhow::Result<Self> {
         anyhow::ensure!(
             start <= end,
-            "invalid time range: start={start} > end={end}"
+            "invalid time range: start={} > end={}",
+            utc_timestamp(start),
+            utc_timestamp(end),
         );
         let cur_time = now_unix_seconds();
         anyhow::ensure!(
             end <= cur_time,
-            "end is in the future: end={end} > cur_time={cur_time}"
+            "end is in the future: end={} > current_time={}",
+            utc_timestamp(end),
+            utc_timestamp(cur_time),
         );
 
         let audit_window = BatchAuditWindow::new(cfg, start, end, cur_time);
@@ -95,6 +99,15 @@ impl BatchAuditor {
             sui: audit_window.sui_start,
             guardian: audit_window.guardian_start,
         };
+        tracing::info!(
+            "starting batch audit:\n  requested_start={}\n  requested_end={}\n  sui_start={}\n  sui_target_end={}\n  guardian_start={}\n  guardian_target_end={}",
+            utc_timestamp(audit_window.user_start),
+            utc_timestamp(audit_window.user_end),
+            utc_timestamp(audit_window.sui_start),
+            utc_timestamp(audit_window.sui_end),
+            utc_timestamp(audit_window.guardian_start),
+            utc_timestamp(audit_window.guardian_end),
+        );
         Ok(Self {
             inner: AuditorCore::new(cfg, cursors).await?,
             audit_window,
@@ -126,7 +139,8 @@ impl BatchAuditor {
 
             let mut sui_cursor_moved = false;
             if should_poll_sui
-                && let PollOutcome::CursorAdvanced(events) = self.inner.poll_sui().await?
+                && let PollOutcome::CursorAdvanced(events) =
+                    self.inner.poll_sui(self.audit_window.sui_end).await?
             {
                 self.ingest_batch(events);
                 sui_cursor_moved = true;
@@ -140,21 +154,40 @@ impl BatchAuditor {
                 guardian_cursor_moved = true;
             }
 
+            if should_poll_guardian && !guardian_cursor_moved {
+                let ready_at = self.inner.get_guardian_next_partition_ready_at();
+                if now_unix_seconds() < ready_at {
+                    anyhow::bail!(
+                        "Guardian data is not finalized for the requested batch range:\n  \
+                         guardian_complete_through={}\n  requested_end={}\n  \
+                         next_partition_ready_at={}\nRerun at or after {}, or choose an end \
+                         time at or before {}.",
+                        utc_timestamp(self.inner.get_guardian_cursor()),
+                        utc_timestamp(self.audit_window.guardian_end),
+                        utc_timestamp(ready_at),
+                        utc_timestamp(ready_at),
+                        utc_timestamp(self.inner.get_guardian_cursor()),
+                    );
+                }
+            }
+
             if !sui_cursor_moved && !guardian_cursor_moved {
                 stalled_iterations = stalled_iterations.saturating_add(1);
                 if stalled_iterations >= NUM_ITERATIONS_BEFORE_FAIL {
-                    tracing::warn!(
-                        "batch polling cursors did not advance fully (sui={}, guardian={})",
-                        self.inner.get_sui_cursor(),
-                        self.inner.get_guardian_cursor()
+                    anyhow::bail!(
+                        "batch polling stalled:\n  sui_cursor={}\n  sui_target={}\n  \
+                         guardian_cursor={}\n  guardian_target={}",
+                        utc_timestamp(self.inner.get_sui_cursor()),
+                        utc_timestamp(self.audit_window.sui_end),
+                        utc_timestamp(self.inner.get_guardian_cursor()),
+                        utc_timestamp(self.audit_window.guardian_end),
                     );
-                    return Ok(());
                 }
             } else {
                 stalled_iterations = 0;
             }
         }
-        tracing::info!("all desired cursor endpoints reached");
+        tracing::info!("all Sui and Guardian cursor endpoints reached");
         Ok(())
     }
 
@@ -163,15 +196,15 @@ impl BatchAuditor {
         self.fetch_all_sui_guardian_events().await?;
 
         tracing::info!(
-            start = self.audit_window.user_start,
-            end = self.audit_window.user_end,
-            sui_start = self.audit_window.sui_start,
-            sui_target_end = self.audit_window.sui_end,
-            sui_cursor = self.inner.get_sui_cursor(),
-            guardian_start = self.audit_window.guardian_start,
-            guardian_target_end = self.audit_window.guardian_end,
-            guardian_cursor = self.inner.get_guardian_cursor(),
-            "finished batch polling"
+            "finished batch polling:\n  start={}\n  end={}\n  sui_start={}\n  sui_target_end={}\n  sui_cursor={}\n  guardian_start={}\n  guardian_target_end={}\n  guardian_cursor={}",
+            utc_timestamp(self.audit_window.user_start),
+            utc_timestamp(self.audit_window.user_end),
+            utc_timestamp(self.audit_window.sui_start),
+            utc_timestamp(self.audit_window.sui_end),
+            utc_timestamp(self.inner.get_sui_cursor()),
+            utc_timestamp(self.audit_window.guardian_start),
+            utc_timestamp(self.audit_window.guardian_end),
+            utc_timestamp(self.inner.get_guardian_cursor()),
         );
 
         // Fetch all BTC info
@@ -191,14 +224,17 @@ impl BatchAuditor {
         let progress = self.inner.progress_watermarks(&self.audit_window);
 
         tracing::info!(
-            verified_up_to_withdrawals = progress.verified_up_to_withdrawals,
-            verified_up_to_deposits = progress.verified_up_to_deposits,
-            next_start = progress.restart_start,
-            "batch progress watermarks"
+            "batch progress watermarks:\n  verified_up_to_withdrawals={}\n  verified_up_to_deposits={}\n  next_start={}",
+            utc_timestamp(progress.verified_up_to_withdrawals),
+            utc_timestamp(progress.verified_up_to_deposits),
+            utc_timestamp(progress.restart_start),
         );
 
         if !self.violation_found {
-            tracing::info!("audit passed. run next audit at {}", progress.restart_start);
+            tracing::info!(
+                "audit passed. run next audit at {}",
+                utc_timestamp(progress.restart_start)
+            );
         } else {
             tracing::warn!("audit produced findings: see logs");
         }

--- a/crates/hashi-monitor/src/audit/batch.rs
+++ b/crates/hashi-monitor/src/audit/batch.rs
@@ -224,8 +224,9 @@ impl BatchAuditor {
         let progress = self.inner.progress_watermarks(&self.audit_window);
 
         tracing::info!(
-            "batch progress watermarks:\n  verified_up_to_withdrawals={}\n  verified_up_to_deposits={}\n  next_start={}",
+            "batch progress watermarks:\n  verified_up_to_withdrawals={}\n  withdrawal_blockers={}\n  verified_up_to_deposits={}\n  next_start={}",
             utc_timestamp(progress.verified_up_to_withdrawals),
+            progress.withdrawal_blockers_summary(),
             utc_timestamp(progress.verified_up_to_deposits),
             utc_timestamp(progress.restart_start),
         );

--- a/crates/hashi-monitor/src/audit/continuous.rs
+++ b/crates/hashi-monitor/src/audit/continuous.rs
@@ -113,10 +113,11 @@ impl ContinuousAuditor {
 
         let progress = self.inner.progress_watermarks(&self.window);
         tracing::info!(
-            "continuous progress checkpoint:\n  guardian_cursor={}\n  sui_cursor={}\n  verified_up_to_withdrawals={}\n  verified_up_to_deposits={}\n  restart_start={}",
+            "continuous progress checkpoint:\n  guardian_cursor={}\n  sui_cursor={}\n  verified_up_to_withdrawals={}\n  withdrawal_blockers={}\n  verified_up_to_deposits={}\n  restart_start={}",
             utc_timestamp(self.inner.get_guardian_cursor()),
             utc_timestamp(self.inner.get_sui_cursor()),
             utc_timestamp(progress.verified_up_to_withdrawals),
+            progress.withdrawal_blockers_summary(),
             utc_timestamp(progress.verified_up_to_deposits),
             utc_timestamp(progress.restart_start),
         );

--- a/crates/hashi-monitor/src/audit/continuous.rs
+++ b/crates/hashi-monitor/src/audit/continuous.rs
@@ -10,8 +10,8 @@ use crate::config::Config;
 use crate::domain::Cursors;
 use crate::domain::MonitorEvent;
 use crate::domain::PollOutcome;
-use crate::domain::WithdrawalEventType;
 use crate::domain::now_unix_seconds;
+use crate::domain::utc_timestamp;
 use hashi_types::guardian::time_utils::UnixSeconds;
 
 // TODO: Consider switching to a streaming API
@@ -29,7 +29,8 @@ pub struct ContinuousAuditWindow {
 }
 
 /// A continuous auditor that runs indefinitely processing events as they arrive.
-/// Constructors accept a start time as input that acts as a starting point for the auditor.
+/// Its start time is on the Guardian timeline; Sui polling begins at the
+/// configured predecessor lookback before that boundary.
 pub struct ContinuousAuditor {
     pub inner: AuditorCore,
     pub window: ContinuousAuditWindow,
@@ -43,10 +44,7 @@ impl AuditWindow for ContinuousAuditWindow {
 
 impl ContinuousAuditWindow {
     pub fn new(cfg: &Config, start: UnixSeconds) -> Self {
-        let e1_e2_delay_secs = cfg
-            .next_event_delay(WithdrawalEventType::E1HashiApproved)
-            .expect("should be Some");
-        let sui_start = start.saturating_sub(e1_e2_delay_secs); // guardian_e2@{start} might match sui_e1@{start-e1_e2_delay_secs}
+        let sui_start = start.saturating_sub(cfg.withdrawal_predecessor_lookback);
         let guardian_start = start;
 
         Self {
@@ -62,7 +60,9 @@ impl ContinuousAuditor {
         let cur_time = now_unix_seconds();
         anyhow::ensure!(
             start <= cur_time,
-            "start is in the future: start={start} > cur_time={cur_time}"
+            "start is in the future: start={} > current_time={}",
+            utc_timestamp(start),
+            utc_timestamp(cur_time),
         );
         let audit_window = ContinuousAuditWindow::new(cfg, start);
         let cursors = Cursors {
@@ -82,14 +82,15 @@ impl ContinuousAuditor {
     }
 
     async fn tick_sui(&mut self) -> anyhow::Result<()> {
-        if let PollOutcome::CursorAdvanced(events) = self.inner.poll_sui().await? {
+        let up_to = now_unix_seconds();
+        while let PollOutcome::CursorAdvanced(events) = self.inner.poll_sui(up_to).await? {
             self.ingest_batch(events);
         }
         Ok(())
     }
 
     async fn tick_guardian(&mut self) -> anyhow::Result<()> {
-        if let PollOutcome::CursorAdvanced(events) = self.inner.poll_guardian().await? {
+        while let PollOutcome::CursorAdvanced(events) = self.inner.poll_guardian().await? {
             self.ingest_batch(events);
         }
         Ok(())
@@ -112,16 +113,66 @@ impl ContinuousAuditor {
 
         let progress = self.inner.progress_watermarks(&self.window);
         tracing::info!(
-            guardian_cursor = self.inner.get_guardian_cursor(),
-            sui_cursor = self.inner.get_sui_cursor(),
-            verified_up_to_withdrawals = progress.verified_up_to_withdrawals,
-            verified_up_to_deposits = progress.verified_up_to_deposits,
-            restart_start = progress.restart_start,
-            "continuous progress checkpoint"
+            "continuous progress checkpoint:\n  guardian_cursor={}\n  sui_cursor={}\n  verified_up_to_withdrawals={}\n  verified_up_to_deposits={}\n  restart_start={}",
+            utc_timestamp(self.inner.get_guardian_cursor()),
+            utc_timestamp(self.inner.get_sui_cursor()),
+            utc_timestamp(progress.verified_up_to_withdrawals),
+            utc_timestamp(progress.verified_up_to_deposits),
+            utc_timestamp(progress.restart_start),
         );
     }
 
     pub async fn run(&mut self) -> anyhow::Result<()> {
+        tracing::info!(
+            "starting continuous audit:\n  requested_start={}\n  sui_start={}\n  guardian_start={}",
+            utc_timestamp(self.window.user_start),
+            utc_timestamp(self.window.sui_start),
+            utc_timestamp(self.window.guardian_start),
+        );
+        tracing::info!(
+            cursor = %utc_timestamp(self.inner.get_sui_cursor()),
+            "starting initial Sui catch-up"
+        );
+        if let Err(error) = self.tick_sui().await {
+            tracing::warn!(
+                source = "sui",
+                ?error,
+                "initial catch-up failed; continuing"
+            );
+        } else {
+            tracing::info!(
+                cursor = %utc_timestamp(self.inner.get_sui_cursor()),
+                "finished initial Sui catch-up"
+            );
+        }
+        tracing::info!(
+            cursor = %utc_timestamp(self.inner.get_guardian_cursor()),
+            "starting initial Guardian catch-up"
+        );
+        if let Err(error) = self.tick_guardian().await {
+            tracing::warn!(
+                source = "guardian",
+                ?error,
+                "initial catch-up failed; continuing"
+            );
+        } else {
+            tracing::info!(
+                cursor = %utc_timestamp(self.inner.get_guardian_cursor()),
+                "finished initial Guardian catch-up"
+            );
+        }
+        tracing::info!("starting initial Bitcoin confirmation lookups");
+        if let Err(error) = self.tick_btc() {
+            tracing::warn!(
+                source = "btc",
+                ?error,
+                "initial catch-up failed; continuing"
+            );
+        } else {
+            tracing::info!("finished initial Bitcoin confirmation lookups");
+        }
+        self.tick_state_checks_and_gc();
+
         let mut sui_ticker = tokio::time::interval(POLL_INTERVAL);
         let mut guardian_ticker = tokio::time::interval(POLL_INTERVAL);
         let mut btc_ticker = tokio::time::interval(POLL_INTERVAL);
@@ -132,7 +183,8 @@ impl ContinuousAuditor {
         btc_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         state_checks_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-        // Consume the immediate first tick and then run on a stable cadence.
+        // The initial catch-up above handled startup; consume each immediate
+        // interval tick so the next pass runs on the configured cadence.
         sui_ticker.tick().await;
         guardian_ticker.tick().await;
         btc_ticker.tick().await;

--- a/crates/hashi-monitor/src/audit/mod.rs
+++ b/crates/hashi-monitor/src/audit/mod.rs
@@ -12,15 +12,20 @@
 //!         - call `if wsm.is_in_audit_window() { wsm.violations(&cursors) }` to identify errors.
 //!     - Currently we also report orphan E1 findings when they fall in the user window.
 //!
-//! Note that we do not use audit window gating for deposits because there is no risk of false violation flagging.
+//! Deposits are checked over the derived Sui polling range rather than gated by
+//! the withdrawal audit window.
 
 use crate::domain::Cursors;
+use crate::domain::DepositId;
 use crate::domain::MonitorDepositEvent;
 use crate::domain::MonitorEvent;
 use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
+use crate::domain::human_timestamp_delta;
+use crate::domain::utc_timestamp;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 
 pub mod batch;
@@ -31,11 +36,11 @@ use crate::findings::FindingCategory;
 use crate::findings::MonitorFinding;
 use crate::rpc::btc::BtcRpcClient;
 use crate::rpc::guardian::GuardianWithdrawalsPoller;
+use crate::rpc::sui::SuiEventsPoller;
 use crate::state_machine::BtcFetchOutcome;
 use crate::state_machine::DepositStateMachine;
 use crate::state_machine::WithdrawalStateMachine;
 pub use batch::BatchAuditor;
-use bitcoin::Txid;
 pub use continuous::ContinuousAuditor;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -53,7 +58,7 @@ pub fn log_findings(source: &'static str, phase: &'static str, findings: &[Monit
                 phase,
                 %category,
                 total = findings.len(),
-                ?finding,
+                finding = %finding,
                 "monitor finding"
             ),
             FindingCategory::Liveness => tracing::warn!(
@@ -61,7 +66,7 @@ pub fn log_findings(source: &'static str, phase: &'static str, findings: &[Monit
                 phase,
                 %category,
                 total = findings.len(),
-                ?finding,
+                finding = %finding,
                 "monitor finding"
             ),
         }
@@ -80,11 +85,10 @@ pub struct AuditorCore {
     cfg: Config,
     // mutable
     pending_withdrawals: HashMap<WithdrawalID, WithdrawalStateMachine>,
-    pending_deposits: HashMap<(Txid, u32), DepositStateMachine>,
+    pending_deposits: HashMap<DepositId, DepositStateMachine>,
     guardian_poller: GuardianWithdrawalsPoller,
+    sui_poller: SuiEventsPoller,
     btc_client: BtcRpcClient,
-    // placeholder until we implement sui rpc
-    sui_cursor: UnixSeconds,
 }
 
 impl AuditorCore {
@@ -94,8 +98,8 @@ impl AuditorCore {
             pending_withdrawals: HashMap::new(),
             pending_deposits: HashMap::new(),
             guardian_poller: GuardianWithdrawalsPoller::new(cfg, cursors.guardian).await?,
+            sui_poller: SuiEventsPoller::new(&cfg.sui, cursors.sui)?,
             btc_client: BtcRpcClient::new(cfg)?,
-            sui_cursor: cursors.sui,
         })
     }
 
@@ -118,8 +122,8 @@ impl AuditorCore {
     }
 
     fn ingest_deposit(&mut self, event: MonitorDepositEvent) -> Vec<MonitorFinding> {
-        let outpoint = (event.btc_txid, event.btc_vout);
-        match self.pending_deposits.entry(outpoint) {
+        let deposit_id = event.deposit_id;
+        match self.pending_deposits.entry(deposit_id) {
             Entry::Occupied(entry) => {
                 if entry.get().hashi_deposit_event() != &event {
                     return vec![MonitorFinding::InvalidEventAdded(
@@ -149,6 +153,42 @@ impl AuditorCore {
         &mut self,
         window: &impl AuditWindow,
     ) -> anyhow::Result<Vec<MonitorFinding>> {
+        self.btc_client.clear_confirmation_cache();
+        let withdrawal_count = self
+            .pending_withdrawals
+            .values()
+            .filter(|sm| {
+                sm.is_in_audit_window(window) && sm.expects(WithdrawalEventType::E3BtcConfirmed)
+            })
+            .count();
+        let deposit_count = self
+            .pending_deposits
+            .values()
+            .filter(|sm| sm.is_expecting_events())
+            .count();
+        let unique_txids = self
+            .pending_withdrawals
+            .values()
+            .filter(|sm| {
+                sm.is_in_audit_window(window) && sm.expects(WithdrawalEventType::E3BtcConfirmed)
+            })
+            .map(WithdrawalStateMachine::btc_txid)
+            .chain(
+                self.pending_deposits
+                    .values()
+                    .filter(|sm| sm.is_expecting_events())
+                    .map(DepositStateMachine::btc_txid),
+            )
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        tracing::info!(
+            withdrawal_count,
+            deposit_count,
+            unique_txids = unique_txids.len(),
+            "starting bitcoin confirmation lookups"
+        );
+        self.btc_client.prefetch_confirmations(&unique_txids)?;
         let mut findings = Vec::new();
         for sm in self.pending_withdrawals.values_mut() {
             if !sm.is_in_audit_window(window) {
@@ -205,7 +245,24 @@ impl AuditorCore {
                 continue;
             }
             if !sm.is_expecting_events() {
-                tracing::info!(%wid, "withdrawal flow is complete");
+                let e1 = sm
+                    .get(WithdrawalEventType::E1HashiApproved)
+                    .expect("completed withdrawal has E1");
+                let e2 = sm
+                    .get(WithdrawalEventType::E2GuardianApproved)
+                    .expect("completed withdrawal has E2");
+                let e3 = sm
+                    .get(WithdrawalEventType::E3BtcConfirmed)
+                    .expect("completed withdrawal has E3");
+                tracing::info!(
+                    %wid,
+                    e1_at = %utc_timestamp(e1.timestamp_secs),
+                    e2_at = %utc_timestamp(e2.timestamp_secs),
+                    e3_at = %utc_timestamp(e3.timestamp_secs),
+                    e1_to_e2 = %human_timestamp_delta(e2.timestamp_secs, e1.timestamp_secs),
+                    e2_to_e3 = %human_timestamp_delta(e3.timestamp_secs, e2.timestamp_secs),
+                    "withdrawal flow is complete"
+                );
                 completed_withdrawals.push(*wid);
             }
         }
@@ -215,15 +272,15 @@ impl AuditorCore {
         }
 
         let mut completed_deposits = Vec::new();
-        for ((txid, vout), sm) in &mut self.pending_deposits {
+        for (deposit_id, sm) in &mut self.pending_deposits {
             if !sm.is_expecting_events() {
-                tracing::debug!(%txid, vout, "deposit flow is complete");
-                completed_deposits.push((*txid, *vout));
+                tracing::debug!(%deposit_id, "deposit flow is complete");
+                completed_deposits.push(*deposit_id);
             }
         }
 
-        for outpoint in completed_deposits {
-            self.pending_deposits.remove(&outpoint);
+        for deposit_id in completed_deposits {
+            self.pending_deposits.remove(&deposit_id);
         }
     }
 
@@ -237,7 +294,7 @@ impl AuditorCore {
             if let Some(e2) = sm.get(WithdrawalEventType::E2GuardianApproved) {
                 verified_up_to_withdrawals = verified_up_to_withdrawals.min(e2.timestamp_secs);
             } else {
-                tracing::warn!(
+                tracing::debug!(
                     wid = %sm.wid(),
                     "in-window withdrawal missing guardian anchor; skipping in verified_up_to computation"
                 );
@@ -261,15 +318,14 @@ impl AuditorCore {
         }
     }
 
-    /// Polls one hour worth of guardian events
-    /// TODO: Provide an option to poll more aggressively if we are lagging behind
+    /// Advance the Guardian cursor by one hourly S3 directory. Callers may loop
+    /// to catch up multiple directories in one tick.
     pub async fn poll_guardian(&mut self) -> anyhow::Result<PollOutcome> {
         self.guardian_poller.poll_one_hour().await
     }
 
-    pub async fn poll_sui(&mut self) -> anyhow::Result<PollOutcome> {
-        // TODO: Implement me
-        Ok(PollOutcome::CursorUnmoved)
+    pub async fn poll_sui(&mut self, up_to: UnixSeconds) -> anyhow::Result<PollOutcome> {
+        self.sui_poller.poll(up_to).await
     }
 
     fn get_cursors(&self) -> Cursors {
@@ -279,10 +335,14 @@ impl AuditorCore {
         }
     }
     fn get_sui_cursor(&self) -> UnixSeconds {
-        self.sui_cursor
+        self.sui_poller.cursor_seconds()
     }
 
     fn get_guardian_cursor(&self) -> UnixSeconds {
         self.guardian_poller.cursor_seconds()
+    }
+
+    fn get_guardian_next_partition_ready_at(&self) -> UnixSeconds {
+        self.guardian_poller.next_partition_ready_at()
     }
 }

--- a/crates/hashi-monitor/src/audit/mod.rs
+++ b/crates/hashi-monitor/src/audit/mod.rs
@@ -41,9 +41,11 @@ use crate::state_machine::BtcFetchOutcome;
 use crate::state_machine::DepositStateMachine;
 use crate::state_machine::WithdrawalStateMachine;
 pub use batch::BatchAuditor;
+use bitcoin::Txid;
 pub use continuous::ContinuousAuditor;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::time_utils::UnixSeconds;
+use std::fmt;
 
 pub trait AuditWindow {
     fn in_window(&self, timestamp_secs: UnixSeconds) -> bool;
@@ -73,11 +75,47 @@ pub fn log_findings(source: &'static str, phase: &'static str, findings: &[Monit
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct ProgressWatermarks {
     pub verified_up_to_withdrawals: UnixSeconds,
     pub verified_up_to_deposits: UnixSeconds,
     pub restart_start: UnixSeconds,
+    withdrawal_blockers: Vec<WithdrawalProgressBlocker>,
+}
+
+impl ProgressWatermarks {
+    fn withdrawal_blockers_summary(&self) -> String {
+        if self.withdrawal_blockers.is_empty() {
+            return "none".to_string();
+        }
+
+        self.withdrawal_blockers
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+}
+
+#[derive(Clone, Debug)]
+struct WithdrawalProgressBlocker {
+    wid: WithdrawalID,
+    btc_txid: Txid,
+    guardian_approved_at: UnixSeconds,
+    waiting_for: Vec<WithdrawalEventType>,
+}
+
+impl fmt::Display for WithdrawalProgressBlocker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "wid={}, btc_txid={}, guardian_approved_at={}, waiting_for={:?}",
+            self.wid,
+            self.btc_txid,
+            utc_timestamp(self.guardian_approved_at),
+            self.waiting_for,
+        )
+    }
 }
 
 pub struct AuditorCore {
@@ -286,13 +324,25 @@ impl AuditorCore {
 
     pub fn progress_watermarks(&self, window: &impl AuditWindow) -> ProgressWatermarks {
         let mut verified_up_to_withdrawals = self.get_guardian_cursor();
+        let mut withdrawal_blockers = Vec::new();
         for sm in self.pending_withdrawals.values() {
             if !sm.is_in_audit_window(window) || !sm.is_expecting_events() {
                 continue;
             }
 
             if let Some(e2) = sm.get(WithdrawalEventType::E2GuardianApproved) {
-                verified_up_to_withdrawals = verified_up_to_withdrawals.min(e2.timestamp_secs);
+                if e2.timestamp_secs < verified_up_to_withdrawals {
+                    verified_up_to_withdrawals = e2.timestamp_secs;
+                    withdrawal_blockers.clear();
+                }
+                if e2.timestamp_secs == verified_up_to_withdrawals {
+                    withdrawal_blockers.push(WithdrawalProgressBlocker {
+                        wid: sm.wid(),
+                        btc_txid: sm.btc_txid(),
+                        guardian_approved_at: e2.timestamp_secs,
+                        waiting_for: sm.expected_event_types(),
+                    });
+                }
             } else {
                 tracing::debug!(
                     wid = %sm.wid(),
@@ -315,6 +365,7 @@ impl AuditorCore {
             verified_up_to_withdrawals,
             verified_up_to_deposits,
             restart_start: verified_up_to_withdrawals.min(verified_up_to_deposits),
+            withdrawal_blockers,
         }
     }
 

--- a/crates/hashi-monitor/src/config.rs
+++ b/crates/hashi-monitor/src/config.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::domain::WithdrawalEventType;
 
-/// Configuration for the cursorless batch auditor.
+/// Configuration shared by the batch and continuous monitor modes.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     /// Maximum allowed delay between consecutive events.
@@ -22,6 +22,11 @@ pub struct Config {
     #[serde(default = "default_clock_skew")]
     pub clock_skew: u64,
 
+    /// How far before the guardian audit start to search Sui for withdrawal
+    /// predecessor events (default: 1 hour).
+    #[serde(default = "default_withdrawal_predecessor_lookback")]
+    pub withdrawal_predecessor_lookback: u64,
+
     pub guardian_s3: UnresolvedS3Config,
     #[serde(flatten)]
     pub pcr_allowlist: PcrAllowlist,
@@ -29,7 +34,7 @@ pub struct Config {
     pub btc: BtcConfig,
 }
 
-/// The maximum allowed delay between an event and it's successor in seconds.
+/// The maximum allowed delay between an event and its successor, in seconds.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(try_from = "Vec<(WithdrawalEventType, u64)>")]
 pub struct NextEventDelays(Vec<(WithdrawalEventType, u64)>);
@@ -73,6 +78,10 @@ impl BtcConfig {
 
 fn default_clock_skew() -> u64 {
     300
+}
+
+fn default_withdrawal_predecessor_lookback() -> u64 {
+    60 * 60
 }
 
 impl NextEventDelays {

--- a/crates/hashi-monitor/src/domain.rs
+++ b/crates/hashi-monitor/src/domain.rs
@@ -6,9 +6,10 @@
 //! We model the cross-system withdrawal flow as a sequence of events:
 //! - E1 or E_hashi: Hashi approval event on sui (corresponds to WithdrawalPickedForProcessing)
 //! - E2 or E_guardian: Guardian approval event on S3 (corresponds to NormalWithdrawalSuccess)
-//! - E3 or E_btc: BTC tx broadcast
+//! - E3 or E_btc: BTC transaction confirmed
 //!
-//! Predecessor checks: for every E_{i+1}, there exists a corresponding E_i within a small clock skew.
+//! Predecessor checks: every E_{i+1} has a corresponding E_i, and E_i does not
+//! occur more than `clock_skew` after E_{i+1}.
 //! Successor checks: for every E_i, there exists a corresponding E_{i+1} within time `t`.
 //!
 //! Note: IOP-203 matches the withdrawal destination & amount that a user inputs with that in E_hashi.
@@ -18,6 +19,7 @@ use std::fmt;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use bitcoin::OutPoint;
 use bitcoin::Txid;
 use hashi_types::guardian::WithdrawalID;
 use hashi_types::guardian::time_utils::UnixSeconds;
@@ -60,10 +62,143 @@ impl fmt::Display for UtcTimestamp {
     }
 }
 
+/// Seconds rendered as a compact human-readable duration.
+pub struct HumanDuration(UnixSeconds);
+
+pub fn human_duration(seconds: UnixSeconds) -> HumanDuration {
+    HumanDuration(seconds)
+}
+
+impl fmt::Display for HumanDuration {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hours = self.0 / 3_600;
+        let minutes = (self.0 % 3_600) / 60;
+        let seconds = self.0 % 60;
+
+        if hours > 0 {
+            write!(formatter, "{hours}h")?;
+        }
+        if minutes > 0 || hours > 0 {
+            write!(formatter, "{minutes}m")?;
+        }
+        write!(formatter, "{seconds}s")
+    }
+}
+
+/// Signed difference between two Unix timestamps, rendered compactly.
+pub struct HumanTimestampDelta(i128);
+
+pub fn human_timestamp_delta(later: UnixSeconds, earlier: UnixSeconds) -> HumanTimestampDelta {
+    HumanTimestampDelta(i128::from(later) - i128::from(earlier))
+}
+
+impl fmt::Display for HumanTimestampDelta {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0 < 0 {
+            formatter.write_str("-")?;
+        }
+
+        let total_seconds = self.0.unsigned_abs();
+        let hours = total_seconds / 3_600;
+        let minutes = (total_seconds % 3_600) / 60;
+        let seconds = total_seconds % 60;
+
+        if hours > 0 {
+            write!(formatter, "{hours}h")?;
+        }
+        if minutes > 0 || hours > 0 {
+            write!(formatter, "{minutes}m")?;
+        }
+        write!(formatter, "{seconds}s")
+    }
+}
+
+/// Parse the monitor's sole public timestamp format: whole-second UTC RFC 3339.
+pub fn parse_utc_timestamp(value: &str) -> Result<UnixSeconds, String> {
+    if !value.ends_with('Z') {
+        return Err(
+            "timestamp must be UTC and end in `Z` (for example, 2026-08-04T19:00:00Z)".to_string(),
+        );
+    }
+
+    let datetime =
+        time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+            .map_err(|error| format!("invalid UTC timestamp `{value}`: {error}"))?;
+    let timestamp = UnixSeconds::try_from(datetime.unix_timestamp())
+        .map_err(|_| "timestamp must not precede 1970-01-01T00:00:00Z".to_string())?;
+    if utc_timestamp(timestamp).to_string() != value {
+        return Err(
+            "timestamp must use exactly `YYYY-MM-DDTHH:MM:SSZ` with no fractional seconds"
+                .to_string(),
+        );
+    }
+
+    Ok(timestamp)
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MonitorEvent {
     Withdrawal(MonitorWithdrawalEvent),
     Deposit(MonitorDepositEvent),
+}
+
+impl fmt::Display for MonitorEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Withdrawal(event) => write!(
+                formatter,
+                "Withdrawal(type={:?}, wid={}, timestamp={}, btc_txid={})",
+                event.event_type,
+                event.wid,
+                utc_timestamp(event.timestamp_secs),
+                event.btc_txid,
+            ),
+            Self::Deposit(event) => write!(
+                formatter,
+                "Deposit(type={:?}, deposit_id={}, timestamp={})",
+                event.event_type,
+                event.deposit_id,
+                utc_timestamp(event.timestamp_secs),
+            ),
+        }
+    }
+}
+
+/// Stable identifier for a monitored deposit: its Bitcoin outpoint.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct DepositId(OutPoint);
+
+impl DepositId {
+    pub fn new(txid: Txid, vout: u32) -> Self {
+        Self(OutPoint { txid, vout })
+    }
+
+    pub fn txid(self) -> Txid {
+        self.0.txid
+    }
+}
+
+impl fmt::Display for DepositId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Correlation identifier for an event in the monitor's withdrawal or deposit model.
+/// This is not a chain-native event ID.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MonitorEventId {
+    Withdrawal(WithdrawalID),
+    Deposit(DepositId),
+}
+
+impl fmt::Display for MonitorEventId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Withdrawal(wid) => write!(formatter, "wid={wid}"),
+            Self::Deposit(deposit_id) => write!(formatter, "deposit_id={deposit_id}"),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -80,7 +215,7 @@ pub struct MonitorWithdrawalEvent {
     /// Stable withdrawal identifier.
     pub wid: WithdrawalID,
 
-    /// Unix timestamp of sui checkpoint / s3 log / btc block
+    /// Unix timestamp embedded in the Sui event / S3 log / BTC block.
     pub timestamp_secs: UnixSeconds,
 
     /// btc txid
@@ -103,8 +238,7 @@ pub enum WithdrawalEventType {
 pub struct MonitorDepositEvent {
     pub event_type: DepositEventType,
     pub timestamp_secs: UnixSeconds,
-    pub btc_txid: Txid,
-    pub btc_vout: u32,
+    pub deposit_id: DepositId,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -169,4 +303,31 @@ impl Cursors {
 pub enum PollOutcome {
     CursorAdvanced(Vec<MonitorEvent>),
     CursorUnmoved,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utc_timestamp_round_trip() {
+        let input = "2026-08-04T19:45:38Z";
+        let timestamp = parse_utc_timestamp(input).unwrap();
+        assert_eq!(utc_timestamp(timestamp).to_string(), input);
+    }
+
+    #[test]
+    fn timestamp_parser_requires_canonical_utc_format() {
+        assert!(parse_utc_timestamp("1785872738").is_err());
+        assert!(parse_utc_timestamp("2026-08-04T19:45:38+00:00").is_err());
+        assert!(parse_utc_timestamp("2026-08-04T19:45:38.000Z").is_err());
+    }
+
+    #[test]
+    fn duration_uses_compact_human_readable_format() {
+        assert_eq!(human_duration(0).to_string(), "0s");
+        assert_eq!(human_duration(191).to_string(), "3m11s");
+        assert_eq!(human_duration(4_028).to_string(), "1h7m8s");
+        assert_eq!(human_timestamp_delta(100, 120).to_string(), "-20s");
+    }
 }

--- a/crates/hashi-monitor/src/findings.rs
+++ b/crates/hashi-monitor/src/findings.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::domain::MonitorEvent;
+use crate::domain::MonitorEventId;
 use crate::domain::MonitorEventType;
+use crate::domain::human_duration;
+use crate::domain::utc_timestamp;
 use hashi_types::guardian::time_utils::UnixSeconds;
 use std::fmt;
 
@@ -38,6 +41,7 @@ pub enum MonitorFinding {
         occurred_at: UnixSeconds, // same as event.timestamp
     },
     ExpectedEventMissing {
+        event_id: MonitorEventId,
         event_type: MonitorEventType,
         relation: EventRelation,
         deadline: UnixSeconds,
@@ -67,6 +71,34 @@ impl MonitorFinding {
 
 impl fmt::Display for MonitorFinding {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
+        match self {
+            Self::InvalidEventAdded(message) => {
+                write!(f, "InvalidEventAdded(message={message})")
+            }
+            Self::EventOccurredAfterDeadline {
+                event,
+                relation,
+                deadline,
+                occurred_at,
+            } => write!(
+                f,
+                "EventOccurredAfterDeadline(event={event}, relation={relation:?}, deadline={}, occurred_at={}, late_by={})",
+                utc_timestamp(*deadline),
+                utc_timestamp(*occurred_at),
+                human_duration(occurred_at.saturating_sub(*deadline)),
+            ),
+            Self::ExpectedEventMissing {
+                event_id,
+                event_type,
+                relation,
+                deadline,
+                cursor,
+            } => write!(
+                f,
+                "ExpectedEventMissing({event_id}, event_type={event_type:?}, relation={relation:?}, deadline={}, cursor={})",
+                utc_timestamp(*deadline),
+                utc_timestamp(*cursor),
+            ),
+        }
     }
 }

--- a/crates/hashi-monitor/src/main.rs
+++ b/crates/hashi-monitor/src/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap::Subcommand;
 use hashi_monitor::domain::now_unix_seconds;
+use hashi_monitor::domain::parse_utc_timestamp;
 
 #[derive(Debug, Parser)]
 #[command(name = "hashi-monitor")]
@@ -23,12 +24,12 @@ enum Command {
         #[arg(long)]
         config: PathBuf,
 
-        /// Start of guardian audit window, as unix seconds.
-        #[arg(long)]
+        /// Start of guardian audit window as UTC, for example 2026-08-04T19:00:00Z.
+        #[arg(long, value_parser = parse_utc_timestamp)]
         start: u64,
 
-        /// End of guardian audit window, as unix seconds. Defaults to current time.
-        #[arg(long)]
+        /// End of guardian audit window as UTC. Defaults to the current time.
+        #[arg(long, value_parser = parse_utc_timestamp)]
         end: Option<u64>,
     },
     /// Run continuous monitoring on guardian timeline.
@@ -37,8 +38,8 @@ enum Command {
         #[arg(long)]
         config: PathBuf,
 
-        /// Start of guardian audit period, as unix seconds.
-        #[arg(long)]
+        /// Start of guardian audit period as UTC, for example 2026-08-04T19:00:00Z.
+        #[arg(long, value_parser = parse_utc_timestamp)]
         start: u64,
     },
 }
@@ -57,10 +58,7 @@ async fn main() -> anyhow::Result<()> {
             let cfg = hashi_monitor::config::Config::load_yaml(&config)?;
             let end = end.unwrap_or_else(now_unix_seconds);
             let mut auditor = hashi_monitor::audit::BatchAuditor::new(&cfg, start, end).await?;
-            auditor
-                .run()
-                .await
-                .unwrap_or_else(|e| panic!("infra failure: {e:#}"));
+            auditor.run().await?;
         }
         Command::Continuous { config, start } => {
             let cfg = hashi_monitor::config::Config::load_yaml(&config)?;

--- a/crates/hashi-monitor/src/rpc/btc.rs
+++ b/crates/hashi-monitor/src/rpc/btc.rs
@@ -456,6 +456,7 @@ mod tests {
             ])
             .expect("valid next event delays"),
             clock_skew: 10,
+            withdrawal_predecessor_lookback: 60 * 60,
             guardian_s3: UnresolvedS3Config {
                 bucket: "bucket".to_string(),
                 region: "us-east-1".to_string(),

--- a/crates/hashi-monitor/src/rpc/guardian.rs
+++ b/crates/hashi-monitor/src/rpc/guardian.rs
@@ -6,6 +6,7 @@ use crate::domain::MonitorEvent;
 use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::PollOutcome;
 use crate::domain::WithdrawalEventType;
+use crate::domain::utc_timestamp;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_guardian::s3_reader::VerifiedLogRecord;
 use hashi_types::guardian::LogMessageV1;
@@ -17,7 +18,6 @@ use hashi_types::guardian::time_utils::UnixSeconds;
 use hashi_types::guardian::time_utils::now_timestamp_secs;
 use hashi_types::guardian::unix_millis_to_seconds;
 use tracing::debug;
-
 impl TryFrom<VerifiedLogRecord> for MonitorWithdrawalEvent {
     type Error = anyhow::Error;
 
@@ -78,13 +78,20 @@ impl GuardianWithdrawalsPoller {
         self.cursor.to_unix_seconds()
     }
 
-    /// Polls the Guardian S3 bucket for one hour worth of events.
-    /// A more aggressive fetch, e.g., one day at a time, can also be done if needed.
+    /// Time after which the next unread hourly partition is considered complete.
+    pub fn next_partition_ready_at(&self) -> UnixSeconds {
+        self.cursor.write_completion_time()
+    }
+
+    /// Poll one hourly Guardian S3 directory and advance to the next directory.
     pub async fn poll_one_hour(&mut self) -> anyhow::Result<PollOutcome> {
         if now_timestamp_secs() < self.cursor.write_completion_time() {
             return Ok(PollOutcome::CursorUnmoved);
         }
 
+        let start = self.cursor.to_unix_seconds();
+        let next_cursor = self.cursor.next_dir();
+        let end = next_cursor.to_unix_seconds();
         let verified_logs = self
             .reader
             .read_successful_withdrawals_in_dir(&self.cursor)
@@ -101,7 +108,14 @@ impl GuardianWithdrawalsPoller {
             .map(MonitorEvent::Withdrawal)
             .collect::<Vec<MonitorEvent>>();
 
-        self.cursor = self.cursor.next_dir();
+        self.cursor = next_cursor;
+        tracing::info!(
+            start = %utc_timestamp(start),
+            end = %utc_timestamp(end),
+            cursor = %utc_timestamp(self.cursor.to_unix_seconds()),
+            events = withdrawal_events.len(),
+            "completed Guardian event range"
+        );
         Ok(PollOutcome::CursorAdvanced(withdrawal_events))
     }
 }

--- a/crates/hashi-monitor/src/rpc/sui.rs
+++ b/crates/hashi-monitor/src/rpc/sui.rs
@@ -28,6 +28,7 @@ use sui_sdk_types::Address;
 
 use crate::config::SuiConfig;
 use crate::domain::DepositEventType;
+use crate::domain::DepositId;
 use crate::domain::MonitorDepositEvent;
 use crate::domain::MonitorEvent;
 use crate::domain::MonitorWithdrawalEvent;
@@ -465,8 +466,7 @@ impl SuiEventsPoller {
                     // ListTransactions supplies the containing checkpoint's
                     // timestamp alongside the nested events.
                     timestamp_secs: transaction_timestamp_secs,
-                    btc_txid: event.utxo.id.txid.into(),
-                    btc_vout: event.utxo.id.vout,
+                    deposit_id: DepositId::new(event.utxo.id.txid.into(), event.utxo.id.vout),
                 }))
             }
             Some(_) | None => None,

--- a/crates/hashi-monitor/src/state_machine.rs
+++ b/crates/hashi-monitor/src/state_machine.rs
@@ -7,8 +7,10 @@ use crate::audit::AuditWindow;
 use crate::config::Config;
 use crate::domain::Cursors;
 use crate::domain::DepositEventType;
+use crate::domain::DepositId;
 use crate::domain::MonitorDepositEvent;
 use crate::domain::MonitorEvent;
+use crate::domain::MonitorEventId;
 use crate::domain::MonitorEventType;
 use crate::domain::MonitorWithdrawalEvent;
 use crate::domain::WithdrawalEventType;
@@ -257,9 +259,8 @@ impl WithdrawalStateMachine {
                 WithdrawalEventType::E3BtcConfirmed => match self.btc_checked_at {
                     Some(checked_at) => checked_at,
                     None => {
-                        tracing::warn!(
-                            "callers should avoid reaching this branch by calling try_fetch_btc_tx before"
-                        );
+                        // Bitcoin and state checks have independent schedules.
+                        // Wait for the first lookup before evaluating absence.
                         continue;
                     }
                 },
@@ -267,6 +268,7 @@ impl WithdrawalStateMachine {
             };
             if *deadline <= cursor {
                 out.push(MonitorFinding::ExpectedEventMissing {
+                    event_id: MonitorEventId::Withdrawal(self.wid),
                     event_type: MonitorEventType::Withdrawal(*event_type),
                     relation: *relation,
                     deadline: *deadline,
@@ -305,7 +307,11 @@ impl DepositStateMachine {
     }
 
     pub fn btc_txid(&self) -> Txid {
-        self.hashi_deposit_event.btc_txid
+        self.hashi_deposit_event.deposit_id.txid()
+    }
+
+    pub fn deposit_id(&self) -> DepositId {
+        self.hashi_deposit_event.deposit_id
     }
 
     pub fn hashi_deposit_event(&self) -> &MonitorDepositEvent {
@@ -325,7 +331,8 @@ impl DepositStateMachine {
         }
 
         let deadline = self.btc_event_expected_at;
-        let btc_txid = self.hashi_deposit_event.btc_txid;
+        let deposit_id = self.hashi_deposit_event.deposit_id;
+        let btc_txid = deposit_id.txid();
         let cur_time = now_unix_seconds();
 
         match btc_rpc_client.lookup_confirmation(btc_txid) {
@@ -333,8 +340,7 @@ impl DepositStateMachine {
                 self.btc_checked_at = Some(cur_time);
                 let e_btc = MonitorDepositEvent {
                     event_type: DepositEventType::E1BtcConfirmed,
-                    btc_txid,
-                    btc_vout: self.hashi_deposit_event.btc_vout,
+                    deposit_id,
                     timestamp_secs: block_time,
                 };
 
@@ -366,10 +372,8 @@ impl DepositStateMachine {
 
         // btc event not yet found
         let Some(cursor) = self.btc_checked_at else {
-            tracing::warn!(
-                txid = %self.hashi_deposit_event.btc_txid,
-                "callers should avoid this branch by calling try_fetch_btc_tx before violations"
-            );
+            // Bitcoin and state checks have independent schedules. Wait for
+            // the first lookup before evaluating absence.
             return Vec::new();
         };
 
@@ -379,6 +383,7 @@ impl DepositStateMachine {
         }
 
         vec![MonitorFinding::ExpectedEventMissing {
+            event_id: MonitorEventId::Deposit(self.hashi_deposit_event.deposit_id),
             event_type: MonitorEventType::Deposit(DepositEventType::E1BtcConfirmed),
             relation: EventRelation::Predecessor,
             deadline,
@@ -417,6 +422,7 @@ mod tests {
             ])
             .expect("valid intra-event delays"),
             clock_skew: 10,
+            withdrawal_predecessor_lookback: 60 * 60,
             guardian_s3: UnresolvedS3Config {
                 bucket: "bucket".to_string(),
                 region: "us-east-1".to_string(),
@@ -462,8 +468,7 @@ mod tests {
         MonitorDepositEvent {
             event_type: DepositEventType::E2HashiDeposited,
             timestamp_secs: timestamp,
-            btc_txid: txid(fill),
-            btc_vout: 0,
+            deposit_id: DepositId::new(txid(fill), 0),
         }
     }
 
@@ -613,6 +618,7 @@ mod tests {
         assert_eq!(
             violations[0],
             MonitorFinding::ExpectedEventMissing {
+                event_id: MonitorEventId::Withdrawal(WithdrawalID::new([1; 32])),
                 event_type: MonitorEventType::Withdrawal(WithdrawalEventType::E2GuardianApproved),
                 relation: EventRelation::Successor,
                 deadline: 200,
@@ -681,6 +687,7 @@ mod tests {
         assert_eq!(
             violations[0],
             MonitorFinding::ExpectedEventMissing {
+                event_id: MonitorEventId::Deposit(DepositId::new(txid(8), 0)),
                 event_type: MonitorEventType::Deposit(DepositEventType::E1BtcConfirmed),
                 relation: EventRelation::Predecessor,
                 deadline: 110,

--- a/crates/hashi-monitor/src/state_machine.rs
+++ b/crates/hashi-monitor/src/state_machine.rs
@@ -107,6 +107,13 @@ impl WithdrawalStateMachine {
         !self.expected_events.is_empty()
     }
 
+    pub fn expected_event_types(&self) -> Vec<WithdrawalEventType> {
+        self.expected_events
+            .iter()
+            .map(|(event_type, _, _)| *event_type)
+            .collect()
+    }
+
     // TODO: If we fully move to strict guardian-led audits, this can be relaxed to only include
     // withdrawals with guardian E2 in the user window.
     pub fn is_in_audit_window(&self, window: &impl AuditWindow) -> bool {


### PR DESCRIPTION
Builds on the chain polling support merged in #949; this is the audit-runtime and observability half of the monitor stack.

This PR:
- wires the Sui, Guardian, and Bitcoin sources into batch and continuous audit modes
- implements initial catch-up and ongoing cursor advancement
- reports safety findings as errors and liveness findings as warnings
- adds human-readable timestamps, progress logs, finding identifiers, timing deltas, and withdrawal progress blockers
- adds the active testnet YAML and run documentation

Monitor stack:
- [1/2]: #949 (merged)
- [2/2]: this PR

Local verification:
- `make fmt`
- `cargo check`
- live 10-minute testnet batch audit: 2,510 confirmed deposits and one withdrawal ingested, 551 unique Bitcoin transactions checked, and the audit passed