### PR TITLE
[limiter] adopt the guardian's limiter policy on rotation

### DIFF
--- a/crates/hashi/src/guardian_limiter.rs
+++ b/crates/hashi/src/guardian_limiter.rs
@@ -11,9 +11,22 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::sync::RwLock;
 
+/// The mirrored policy and the position under it. Capacity is a function of
+/// both, so they are read as a pair.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LimiterView {
+    pub config: LimiterConfig,
+    pub state: LimiterState,
+}
+
+impl LimiterView {
+    pub fn capacity_at(&self, timestamp_secs: u64) -> u64 {
+        project_capacity(&self.config, &self.state, timestamp_secs)
+    }
+}
+
 pub struct LocalLimiter {
-    config: LimiterConfig,
-    state: RwLock<LimiterState>,
+    view: RwLock<LimiterView>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -30,8 +43,10 @@ pub enum LocalLimiterError {
 
 impl fmt::Debug for LocalLimiter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `try_read` like std's own `RwLock` impl: never block to format.
+        let config = self.view.try_read().ok().map(|view| view.config);
         f.debug_struct("LocalLimiter")
-            .field("config", &self.config)
+            .field("config", &config)
             .finish_non_exhaustive()
     }
 }
@@ -39,26 +54,30 @@ impl fmt::Debug for LocalLimiter {
 impl LocalLimiter {
     pub fn new(config: LimiterConfig, state: LimiterState) -> Self {
         Self {
-            config,
-            state: RwLock::new(state),
+            view: RwLock::new(LimiterView { config, state }),
         }
     }
 
-    pub fn config(&self) -> &LimiterConfig {
-        &self.config
+    /// Both halves under one lock; two accessors could straddle an
+    /// [`Self::adopt_config`].
+    pub fn view(&self) -> LimiterView {
+        *self.view.read().unwrap()
+    }
+
+    pub fn config(&self) -> LimiterConfig {
+        self.view.read().unwrap().config
     }
 
     pub fn snapshot(&self) -> LimiterState {
-        *self.state.read().unwrap()
+        self.view.read().unwrap().state
     }
 
     pub fn capacity_at(&self, timestamp_secs: u64) -> u64 {
-        let state = *self.state.read().unwrap();
-        project_capacity(&self.config, &state, timestamp_secs)
+        self.view().capacity_at(timestamp_secs)
     }
 
     pub fn next_seq(&self) -> u64 {
-        self.state.read().unwrap().next_seq
+        self.view.read().unwrap().state.next_seq
     }
 
     /// Validate a consume; does not mutate state.
@@ -68,20 +87,20 @@ impl LocalLimiter {
         timestamp_secs: u64,
         amount_sats: u64,
     ) -> Result<(), LocalLimiterError> {
-        let state = *self.state.read().unwrap();
-        if expected_seq != state.next_seq {
+        let view = *self.view.read().unwrap();
+        if expected_seq != view.state.next_seq {
             return Err(LocalLimiterError::SeqMismatch {
-                local: state.next_seq,
+                local: view.state.next_seq,
                 incoming: expected_seq,
             });
         }
-        if timestamp_secs < state.last_updated_at {
+        if timestamp_secs < view.state.last_updated_at {
             return Err(LocalLimiterError::StaleTimestamp {
-                local_last: state.last_updated_at,
+                local_last: view.state.last_updated_at,
                 incoming: timestamp_secs,
             });
         }
-        let capacity = project_capacity(&self.config, &state, timestamp_secs);
+        let capacity = view.capacity_at(timestamp_secs);
         if capacity < amount_sats {
             return Err(LocalLimiterError::InsufficientCapacity {
                 needed: amount_sats,
@@ -99,53 +118,78 @@ impl LocalLimiter {
         timestamp_secs: u64,
         amount_sats: u64,
     ) -> Result<(), LocalLimiterError> {
-        let mut guard = self.state.write().unwrap();
-        if applied_seq != guard.next_seq {
+        let mut guard = self.view.write().unwrap();
+        if applied_seq != guard.state.next_seq {
             return Err(LocalLimiterError::SeqMismatch {
-                local: guard.next_seq,
+                local: guard.state.next_seq,
                 incoming: applied_seq,
             });
         }
-        if timestamp_secs < guard.last_updated_at {
+        if timestamp_secs < guard.state.last_updated_at {
             return Err(LocalLimiterError::StaleTimestamp {
-                local_last: guard.last_updated_at,
+                local_last: guard.state.last_updated_at,
                 incoming: timestamp_secs,
             });
         }
-        let capacity = project_capacity(&self.config, &guard, timestamp_secs);
+        let capacity = guard.capacity_at(timestamp_secs);
         if capacity < amount_sats {
             return Err(LocalLimiterError::InsufficientCapacity {
                 needed: amount_sats,
                 available: capacity,
             });
         }
-        guard.num_tokens_available = capacity - amount_sats;
-        guard.last_updated_at = timestamp_secs;
-        guard.next_seq += 1;
+        guard.state.num_tokens_available = capacity - amount_sats;
+        guard.state.last_updated_at = timestamp_secs;
+        guard.state.next_seq += 1;
         Ok(())
+    }
+
+    /// Take the guardian's current policy, capping tokens to the new ceiling as
+    /// the guardian's own activation recovery does. Returns the replaced policy
+    /// if it changed.
+    ///
+    /// A rotation re-provisions the enclave, so the policy can move under a
+    /// running mirror; reconciling state cannot correct that, since both sides
+    /// are then projected through a capacity function that no longer matches.
+    /// No seq guard is needed: `next_seq` is untouched and tokens only move
+    /// down, so this can neither double-count an in-flight withdrawal nor
+    /// invent capacity.
+    pub fn adopt_config(&self, config: LimiterConfig) -> Option<LimiterConfig> {
+        let mut guard = self.view.write().unwrap();
+        let previous = guard.config;
+        if previous == config {
+            return None;
+        }
+        guard.config = config;
+        guard.state.num_tokens_available = guard
+            .state
+            .num_tokens_available
+            .min(config.max_bucket_capacity);
+        Some(previous)
     }
 
     /// Overwrite local state with the guardian's authoritative `state`.
     pub fn reconcile_to(&self, state: LimiterState) {
-        *self.state.write().unwrap() = state;
+        self.view.write().unwrap().state = state;
     }
 
     /// Snap the mirror to the guardian's `state` on genuine drift, only at a matching
     /// `next_seq` (so a racing `apply_consume` isn't clobbered). A pure refill-timing
     /// difference — same bucket line, different snapshot instant — isn't drift (equal
     /// projected capacity at a common time); clobbering it would stall the refill.
+    /// Callers must [`Self::adopt_config`] first: both sides project through
+    /// the mirror's own policy, so a stale ceiling saturates them into a
+    /// false match.
     pub fn reconcile_token_drift(&self, state: LimiterState) -> bool {
-        let mut guard = self.state.write().unwrap();
-        if guard.next_seq != state.next_seq {
+        let mut guard = self.view.write().unwrap();
+        if guard.state.next_seq != state.next_seq {
             return false;
         }
-        let common = guard.last_updated_at.max(state.last_updated_at);
-        if project_capacity(&self.config, &guard, common)
-            == project_capacity(&self.config, &state, common)
-        {
+        let common = guard.state.last_updated_at.max(state.last_updated_at);
+        if guard.capacity_at(common) == project_capacity(&guard.config, &state, common) {
             return false;
         }
-        *guard = state;
+        guard.state = state;
         true
     }
 }
@@ -454,6 +498,83 @@ mod tests {
         assert!(!mirror.reconcile_token_drift(guardian));
         assert_eq!(mirror.snapshot().num_tokens_available, 600_000);
         assert_eq!(mirror.snapshot().last_updated_at, 1_100);
+    }
+
+    /// What a rotated guardian installs below: 10x `make_limiter`'s policy.
+    fn raised_config() -> LimiterConfig {
+        LimiterConfig {
+            refill_rate: 10_000,
+            max_bucket_capacity: 20_000_000,
+        }
+    }
+
+    #[test]
+    fn adopt_config_is_a_noop_when_the_policy_is_unchanged() {
+        let limiter = make_limiter(1_500, 40, 3);
+        let before = limiter.snapshot();
+        assert!(limiter.adopt_config(limiter.config()).is_none());
+        assert_eq!(limiter.snapshot(), before);
+    }
+
+    #[test]
+    fn adopt_config_raises_the_ceiling_without_inventing_tokens() {
+        let limiter = make_limiter(1_000_000, 0, 4);
+        let previous = limiter.adopt_config(raised_config()).unwrap();
+        assert_eq!(previous.max_bucket_capacity, 2_000_000);
+        // Tokens carry over; only the ceiling and the refill move.
+        assert_eq!(limiter.snapshot().num_tokens_available, 1_000_000);
+        assert_eq!(limiter.capacity_at(1_000), 11_000_000);
+    }
+
+    #[test]
+    fn adopt_config_caps_tokens_when_the_ceiling_drops() {
+        let limiter = make_limiter(1_800_000, 500, 9);
+        limiter
+            .adopt_config(LimiterConfig {
+                refill_rate: 1_000,
+                max_bucket_capacity: 1_000_000,
+            })
+            .unwrap();
+        // Capped, but the position must not look like a consume.
+        assert_eq!(
+            limiter.snapshot(),
+            LimiterState {
+                num_tokens_available: 1_000_000,
+                last_updated_at: 500,
+                next_seq: 9,
+            }
+        );
+    }
+
+    #[test]
+    fn stale_policy_rejects_a_withdrawal_the_rotated_guardian_would_allow() {
+        let limiter = make_limiter(2_000_000, 0, 3);
+        let stale = limiter.validate_consume(3, 1_000, 5_000_000).unwrap_err();
+        assert!(matches!(
+            stale,
+            LocalLimiterError::InsufficientCapacity {
+                available: 2_000_000,
+                ..
+            }
+        ));
+        limiter.adopt_config(raised_config()).unwrap();
+        limiter.validate_consume(3, 1_000, 5_000_000).unwrap();
+    }
+
+    #[test]
+    fn adopt_config_unmasks_drift_hidden_by_a_stale_ceiling() {
+        // Under the stale ceiling both sides saturate at it and read as in sync.
+        let guardian = LimiterState {
+            num_tokens_available: 15_000_000,
+            last_updated_at: 1_000,
+            next_seq: 7,
+        };
+        let mirror = make_limiter(2_000_000, 1_000, 7);
+        assert!(!mirror.reconcile_token_drift(guardian));
+
+        mirror.adopt_config(raised_config()).unwrap();
+        assert!(mirror.reconcile_token_drift(guardian));
+        assert_eq!(mirror.snapshot(), guardian);
     }
 
     #[test]

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -490,8 +490,10 @@ impl LeaderService {
         // the full batching window.
         let (batch, at_capacity) = if let Some(limiter) = self.inner.local_limiter() {
             let timestamp_secs = checkpoint_timestamp_ms / 1000;
-            let max_bucket = limiter.config().max_bucket_capacity;
-            let capacity = limiter.capacity_at(timestamp_secs);
+            // One read: a rotation landing mid-loop must not mix the two.
+            let view = limiter.view();
+            let max_bucket = view.config.max_bucket_capacity;
+            let capacity = view.capacity_at(timestamp_secs);
 
             let mut batch: Vec<WithdrawalRequest> = Vec::new();
             let mut cumulative = 0u64;

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -1000,9 +1000,20 @@ impl Hashi {
         if !self.verify_and_pin_guardian_btc_pubkey(info.enclave_btc_pubkey) {
             return None;
         }
-        let config = info.limiter_config?;
-        let state = info.limiter_state?;
-        Some((limiter, config, state))
+        match (info.limiter_config, info.limiter_state) {
+            (Some(config), Some(state)) => Some((limiter, config, state)),
+            // The enclave installs the config at operator_init and builds the
+            // limiter from it at operator_activate, so state can never outrun
+            // config. Say so rather than stalling every reconcile in silence.
+            (None, Some(_)) => {
+                tracing::warn!(
+                    "Guardian reported limiter state without a config; skipping reconcile"
+                );
+                None
+            }
+            // Provisioned but not yet activated — ordinary mid-rotation.
+            _ => None,
+        }
     }
 
     /// Adopt the guardian's limiter policy when a re-provision changed it. The

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -985,12 +985,14 @@ impl Hashi {
         Ok(info)
     }
 
-    /// Fetch the guardian's authoritative `LimiterState` and the live local
-    /// limiter handle. `None` if not seeded, the RPC fails, or pubkey mismatches.
+    /// Fetch the guardian's authoritative limiter policy and state, plus the
+    /// live local limiter handle. `None` if not seeded, the RPC fails, the
+    /// pubkey mismatches, or the guardian has no limiter yet.
     async fn guardian_limiter_and_state(
         &self,
     ) -> Option<(
         Arc<guardian_limiter::LocalLimiter>,
+        hashi_types::guardian::LimiterConfig,
         hashi_types::guardian::LimiterState,
     )> {
         let limiter = self.local_limiter()?;
@@ -998,8 +1000,31 @@ impl Hashi {
         if !self.verify_and_pin_guardian_btc_pubkey(info.enclave_btc_pubkey) {
             return None;
         }
+        let config = info.limiter_config?;
         let state = info.limiter_state?;
-        Some((limiter, state))
+        Some((limiter, config, state))
+    }
+
+    /// Adopt the guardian's limiter policy when a re-provision changed it. The
+    /// policy is pinned per enclave session, so a rotation can move it under a
+    /// running mirror. It rides the same `GetGuardianInfo` response already
+    /// trusted for `LimiterState`, so this widens nothing.
+    fn adopt_guardian_limiter_config(
+        &self,
+        limiter: &guardian_limiter::LocalLimiter,
+        config: hashi_types::guardian::LimiterConfig,
+    ) {
+        let Some(previous) = limiter.adopt_config(config) else {
+            return;
+        };
+        self.metrics.guardian_limiter_config_changed_total.inc();
+        let view = limiter.view();
+        self.metrics.record_limiter_state(&view.state, &view.config);
+        tracing::warn!(
+            ?previous,
+            ?config,
+            "Guardian limiter config changed; local mirror adopted it",
+        );
     }
 
     /// Cross-check the live guardian's BTC pubkey against the on-chain pin and
@@ -1039,7 +1064,7 @@ impl Hashi {
         state: hashi_types::guardian::LimiterState,
     ) {
         self.metrics.guardian_limiter_reconciled_total.inc();
-        self.metrics.record_limiter_state(&state, limiter.config());
+        self.metrics.record_limiter_state(&state, &limiter.config());
     }
 
     /// Snap the local limiter to the guardian once `tracker` confirms the
@@ -1048,9 +1073,11 @@ impl Hashi {
         &self,
         tracker: &mut guardian_limiter::LimiterStallTracker,
     ) {
-        let Some((limiter, state)) = self.guardian_limiter_and_state().await else {
+        let Some((limiter, config, state)) = self.guardian_limiter_and_state().await else {
             return;
         };
+        // Before the state comparison below, which projects through this policy.
+        self.adopt_guardian_limiter_config(&limiter, config);
         let local_seq = limiter.next_seq();
         if tracker.observe(local_seq, state.next_seq) {
             tracing::warn!(
@@ -1078,9 +1105,10 @@ impl Hashi {
     /// again). So only re-align the bucket at a matching seq; seq drift is
     /// left to the stall tick.
     async fn reconcile_guardian_limiter_on_rebootstrap(&self) {
-        let Some((limiter, state)) = self.guardian_limiter_and_state().await else {
+        let Some((limiter, config, state)) = self.guardian_limiter_and_state().await else {
             return;
         };
+        self.adopt_guardian_limiter_config(&limiter, config);
         if limiter.reconcile_token_drift(state) {
             self.record_limiter_reconcile(&limiter, state);
             tracing::debug!(

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -51,6 +51,7 @@ pub struct Metrics {
     pub guardian_limiter_batch_stuck_head_total: IntCounter,
     pub guardian_finalize_deferred_total: IntCounter,
     pub guardian_limiter_reconciled_total: IntCounter,
+    pub guardian_limiter_config_changed_total: IntCounter,
     pub guardian_rpc_total: IntCounterVec,
     pub guardian_rpc_duration_seconds: HistogramVec,
 
@@ -442,6 +443,13 @@ impl Metrics {
             guardian_limiter_reconciled_total: register_int_counter_with_registry!(
                 "hashi_guardian_limiter_reconciled_total",
                 "Local limiter reconciled to the guardian after a stall (recovers events dropped across a checkpoint-subscription reconnect)",
+                registry,
+            )
+            .unwrap(),
+            guardian_limiter_config_changed_total: register_int_counter_with_registry!(
+                "hashi_guardian_limiter_config_changed_total",
+                "Times the local limiter adopted a changed guardian limiter policy, i.e. a \
+                 guardian re-provision installed a different refill rate or bucket capacity",
                 registry,
             )
             .unwrap(),

--- a/crates/hashi/src/onchain/mirror.rs
+++ b/crates/hashi/src/onchain/mirror.rs
@@ -515,7 +515,8 @@ fn withdrawal_txn_fully_signed(
         Ok(()) => {
             if let Some(metrics) = state.metrics() {
                 metrics.guardian_limiter_anchor_events_total.inc();
-                metrics.record_limiter_state(&limiter.snapshot(), limiter.config());
+                let view = limiter.view();
+                metrics.record_limiter_state(&view.state, &view.config);
             }
             tracing::info!(
                 seq,


### PR DESCRIPTION
## Summary

As of now, the local limiter in the hashi node, is only reconciling the limiter state (nonce + current limit), however changes to config are not reconciled.

With this, we area also syncing the limiter config to the local limiter config.

## Changes

- `guardian_limiter.rs`: config moves under the same lock as state as a `LimiterView`; adds `adopt_config`, and `view()` so callers needing both read them together
- `lib.rs`: the reconcile loop pulls `limiter_config` off `GetGuardianInfo` and adopts it before comparing state
- `withdrawal_request_flow.rs`, `mirror.rs`: one `view()` read in place of paired accessors
- `metrics.rs`: adds `hashi_guardian_limiter_config_changed_total`. the existing capacity/refill gauges now follow a rotation instead of reporting boot-time values forever