### PR TITLE
[btc-monitor] upgrade kyoto to 0.6.3 and replenish its peer whitelist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "bip157"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0baddc6c57202ec7bb76d2232aa243f8f529c4450bb873d55349f4d55ce94a2"
+checksum = "cf76493aa2ead2603d435280f4a7bb2413610ff16ddb34f7ec24b090fff51236"
 dependencies = [
  "bip324",
  "bitcoin",
@@ -2393,7 +2393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3463,7 +3463,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3777,7 +3777,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4288,7 +4288,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5076,7 +5076,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5113,7 +5113,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5529,7 +5529,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6524,7 +6524,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6533,7 +6533,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7375,7 +7375,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ sui-http = "0.3.1"
 bitcoin = { version = "0.32.8", features =["serde"] }
 corepc-client = { version = "0.10.0", features = ["client-sync"] }
 jsonrpc = "0.18.0"
-kyoto = { package = "bip157", version = "0.6.0" }
+kyoto = { package = "bip157", version = "0.6.3" }
 # Direct dependency only to turn on minreq's rustls-based `https` feature for
 # the bitcoind JSON-RPC transport (jsonrpc's `minreq_http` does not expose it,
 # and without it any https:// bitcoin-rpc URL fails at runtime).

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -17,9 +17,8 @@ pub struct MonitorConfig {
     pub network: Network,
 
     /// Peers for P2P connections, identified by hostname (or IP) and port.
-    /// Hostnames are resolved at connection time; the monitor's supervisor
-    /// rebuilds the kyoto node on disconnect, which re-resolves them so IP
-    /// changes (e.g. Kubernetes pod rotation) are followed.
+    /// Hostnames are resolved at each connection attempt, so IP changes
+    /// (e.g. Kubernetes pod rotation) are followed.
     pub trusted_peers: Vec<kyoto::TrustedPeer>,
 
     /// Starting block height for synchronization

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -211,6 +211,8 @@ pub struct Monitor {
     rpc_workers: JoinSet<()>,
     deposit_lookup_cache: SharedDepositLookupCache,
     deposit_observation_cache: HashMap<bitcoin::OutPoint, CachedDepositEntry>,
+    /// Endless rotation of `config.trusted_peers`; yields `None` when it's empty.
+    trusted_peer_rotation: std::iter::Cycle<std::vec::IntoIter<kyoto::TrustedPeer>>,
 }
 
 /// Offload a blocking Bitcoin Core RPC call to the tokio blocking thread pool.
@@ -234,8 +236,8 @@ impl Monitor {
             .add_peers(config.trusted_peers.iter().cloned())
             // Only connect to the configured trusted peers. Prevents Kyoto from
             // discovering additional peers via DNS seeding or addr gossip.
-            // If all peers disconnect, the node exits with NoReachablePeers
-            // and the supervision loop rebuilds it.
+            // `replenish_trusted_peers` keeps the whitelist stocked; if it still
+            // drains, the node exits and the supervision loop rebuilds it.
             .whitelist_only()
             .maximum_connection_time(Duration::MAX)
             .chain_state(kyoto::ChainState::Checkpoint(checkpoint));
@@ -325,6 +327,7 @@ impl Monitor {
 
                 let start_checkpoint = Self::resolve_start_checkpoint(&bitcoind_rpc, &config).await;
                 let (kyoto_node, kyoto_client) = Self::build_kyoto_node(&config, start_checkpoint);
+                let trusted_peer_rotation = config.trusted_peers.clone().into_iter().cycle();
 
                 let mut monitor = Monitor {
                     config,
@@ -340,6 +343,7 @@ impl Monitor {
                     rpc_workers: JoinSet::new(),
                     deposit_lookup_cache: SharedDepositLookupCache::new(metrics),
                     deposit_observation_cache: HashMap::new(),
+                    trusted_peer_rotation,
                 };
 
                 monitor
@@ -433,6 +437,18 @@ impl Monitor {
         }
     }
 
+    /// Kyoto pops a whitelist entry per dial and never refills it, so a
+    /// `whitelist_only` node eventually exits with `NoReachablePeers`. It warns
+    /// once per dial, so one peer per warning refills it at the rate it drains.
+    fn replenish_trusted_peers(&mut self) {
+        let Some(peer) = self.trusted_peer_rotation.next() else {
+            return;
+        };
+        if let Err(e) = self.requester.add_peer(peer) {
+            debug!("Could not return a trusted peer to Kyoto's whitelist: {e}");
+        }
+    }
+
     /// Map a Kyoto `Warning` variant to a short label for metrics.
     fn warning_label(warning: &Warning) -> &'static str {
         match warning {
@@ -485,6 +501,7 @@ impl Monitor {
                     if let Warning::NeedConnections { connected, required } = &warning {
                         self.metrics.kyoto_connected_peers.set(*connected as i64);
                         required_peers = *required;
+                        self.replenish_trusted_peers();
                     }
 
                     let is_connectivity_failure = matches!(

--- a/docker/hashi-guardian/enclave-Cargo.lock
+++ b/docker/hashi-guardian/enclave-Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "bip157"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0baddc6c57202ec7bb76d2232aa243f8f529c4450bb873d55349f4d55ce94a2"
+checksum = "cf76493aa2ead2603d435280f4a7bb2413610ff16ddb34f7ec24b090fff51236"
 dependencies = [
  "bip324",
  "bitcoin",
@@ -2325,7 +2325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3349,7 +3349,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3623,7 +3623,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4067,7 +4067,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4784,7 +4784,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4821,7 +4821,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5205,7 +5205,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6149,7 +6149,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6158,7 +6158,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6960,7 +6960,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `bip157` 0.6.0 → 0.6.3 and stops the kyoto node from dying when its peer whitelist runs dry.

Upgrade changes:

- **0.6.1** — kyoto sends `getheaders` on `inv` block announcements instead of dropping them. Core falls back to `inv` on >8-block bursts and reorgs, so we went deaf until the 30-minute stale-tip timer disconnected every peer.
- **0.6.2** — `bitcoin` no longer pinned to `=0.32.8`.
- **0.6.3** — info messages are a best-effort send, so a slow consumer can't stall the node loop that also serves `get_block` and `height_of_hash`.