### PR TITLE
[btc-monitor] Wait for bitcoind to reach the start height

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ sui-transaction-builder = { git = "https://github.com/MystenLabs/sui-rust-sdk.gi
 sui-http = "0.3.1"
 bitcoin = { version = "0.32.8", features =["serde"] }
 corepc-client = { version = "0.10.0", features = ["client-sync"] }
-jsonrpc = "0.18.0"
+# `minreq_http` is named directly by the btc monitor's retry predicate.
+jsonrpc = { version = "0.18.0", features = ["minreq_http"] }
 kyoto = { package = "bip157", version = "0.6.3" }
 # Direct dependency only to turn on minreq's rustls-based `https` feature for
 # the bitcoind JSON-RPC transport (jsonrpc's `minreq_http` does not expose it,

--- a/crates/hashi/Cargo.toml
+++ b/crates/hashi/Cargo.toml
@@ -18,7 +18,8 @@ bitcoin.workspace = true
 corepc-client.workspace = true
 jsonrpc.workspace = true
 kyoto.workspace = true
-# Unused directly; enables minreq's `https` feature for the bitcoind RPC client.
+# Enables minreq's `https` feature for the bitcoind RPC client; the monitor
+# also matches on its error type.
 minreq.workspace = true
 lru.workspace = true
 

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -29,6 +29,9 @@ pub struct MonitorConfig {
 
     /// bitcoind JSON-RPC server auth config
     pub bitcoind_rpc_auth: corepc_client::client_sync::Auth,
+
+    /// Directory for storing BTC light client data
+    pub data_dir: Option<PathBuf>,
 }
 
 impl Default for MonitorConfig {
@@ -39,6 +42,7 @@ impl Default for MonitorConfig {
             start_height: DEFAULT_START_HEIGHT,
             bitcoind_rpc_url: "http://localhost:8332".to_string(),
             bitcoind_rpc_auth: corepc_client::client_sync::Auth::None,
+            data_dir: None,
         }
     }
 }
@@ -58,6 +62,7 @@ pub struct MonitorConfigBuilder {
     start_height: u32,
     bitcoind_rpc_url: Option<String>,
     bitcoind_rpc_auth: Option<corepc_client::client_sync::Auth>,
+    data_dir: Option<PathBuf>,
 }
 
 impl MonitorConfigBuilder {
@@ -91,6 +96,12 @@ impl MonitorConfigBuilder {
         self
     }
 
+    /// Set the directory for storing BTC light client data.
+    pub fn data_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.data_dir = Some(path.into());
+        self
+    }
+
     pub fn build(self) -> MonitorConfig {
         let default = MonitorConfig::default();
 
@@ -100,6 +111,7 @@ impl MonitorConfigBuilder {
             start_height: self.start_height,
             bitcoind_rpc_url: self.bitcoind_rpc_url.unwrap_or(default.bitcoind_rpc_url),
             bitcoind_rpc_auth: self.bitcoind_rpc_auth.unwrap_or(default.bitcoind_rpc_auth),
+            data_dir: self.data_dir,
         }
     }
 }

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -191,10 +191,13 @@ const DEFAULT_START_HEIGHT: u32 = 800_000;
 /// Only ever lower this; deposits below the anchor are never seen.
 const SIGNET_DEFAULT_START_HEIGHT: u32 = 300_000;
 
+/// Networks without a deployment anchor start at genesis, which is always valid
+/// and cheap on the short chains (regtest, testnet4) that reach this arm.
 pub fn default_start_height(network: Network) -> u32 {
     match network {
+        Network::Bitcoin => DEFAULT_START_HEIGHT,
         Network::Signet => SIGNET_DEFAULT_START_HEIGHT,
-        _ => DEFAULT_START_HEIGHT,
+        _ => 0,
     }
 }
 
@@ -230,7 +233,7 @@ mod tests {
     fn default_start_height_is_network_aware() {
         assert_eq!(default_start_height(Network::Signet), 300_000);
         assert_eq!(default_start_height(Network::Bitcoin), 800_000);
-        assert_eq!(default_start_height(Network::Testnet4), 800_000);
-        assert_eq!(default_start_height(Network::Regtest), 800_000);
+        assert_eq!(default_start_height(Network::Testnet4), 0);
+        assert_eq!(default_start_height(Network::Regtest), 0);
     }
 }

--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -29,9 +29,6 @@ pub struct MonitorConfig {
 
     /// bitcoind JSON-RPC server auth config
     pub bitcoind_rpc_auth: corepc_client::client_sync::Auth,
-
-    /// Directory for storing BTC light client data
-    pub data_dir: Option<PathBuf>,
 }
 
 impl Default for MonitorConfig {
@@ -42,7 +39,6 @@ impl Default for MonitorConfig {
             start_height: DEFAULT_START_HEIGHT,
             bitcoind_rpc_url: "http://localhost:8332".to_string(),
             bitcoind_rpc_auth: corepc_client::client_sync::Auth::None,
-            data_dir: None,
         }
     }
 }
@@ -62,7 +58,6 @@ pub struct MonitorConfigBuilder {
     start_height: u32,
     bitcoind_rpc_url: Option<String>,
     bitcoind_rpc_auth: Option<corepc_client::client_sync::Auth>,
-    data_dir: Option<PathBuf>,
 }
 
 impl MonitorConfigBuilder {
@@ -96,12 +91,6 @@ impl MonitorConfigBuilder {
         self
     }
 
-    /// Set the directory for storing BTC light client data.
-    pub fn data_dir(mut self, path: impl Into<PathBuf>) -> Self {
-        self.data_dir = Some(path.into());
-        self
-    }
-
     pub fn build(self) -> MonitorConfig {
         let default = MonitorConfig::default();
 
@@ -111,7 +100,6 @@ impl MonitorConfigBuilder {
             start_height: self.start_height,
             bitcoind_rpc_url: self.bitcoind_rpc_url.unwrap_or(default.bitcoind_rpc_url),
             bitcoind_rpc_auth: self.bitcoind_rpc_auth.unwrap_or(default.bitcoind_rpc_auth),
-            data_dir: self.data_dir,
         }
     }
 }

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -242,6 +242,8 @@ impl Monitor {
             .maximum_connection_time(Duration::MAX)
             .chain_state(kyoto::ChainState::Checkpoint(checkpoint));
 
+        // No-op as of bip157 0.6.3: the builder takes the path and `Node::new`
+        // discards it. Kept for when upstream implements persistence.
         if let Some(data_dir) = &config.data_dir {
             builder = builder.data_dir(data_dir.clone());
         }
@@ -263,19 +265,22 @@ impl Monitor {
             bitcoin::Network::Bitcoin if config.start_height > 481_823 => {
                 HashCheckpoint::segwit_activation()
             }
-            network => Self::checkpoint_at_height(bitcoind_rpc, config.start_height, network).await,
+            _ => Self::checkpoint_at_height(bitcoind_rpc, config.start_height).await,
         }
     }
 
+    /// Wait for bitcoind to have the block at `height`. A node still in initial
+    /// block download reports the same "out of range" error as a height past the
+    /// tip, so giving up would anchor Kyoto far below `height` permanently.
     async fn checkpoint_at_height(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         height: u32,
-        network: bitcoin::Network,
     ) -> HashCheckpoint {
-        const MAX_ATTEMPTS: u32 = 5;
         const RETRY_DELAY: Duration = Duration::from_secs(2);
+        const LOG_EVERY: u32 = 15;
 
-        for attempt in 1..=MAX_ATTEMPTS {
+        let mut attempt: u32 = 0;
+        loop {
             match btc_rpc_call(bitcoind_rpc, move |rpc| rpc.get_block_hash(height as u64)).await {
                 Ok(raw) => match raw.into_model() {
                     Ok(model) => {
@@ -284,29 +289,32 @@ impl Monitor {
                     }
                     Err(e) => error!("Failed to parse getblockhash({height}) response: {e}"),
                 },
-                // RPC error -8 "block height out of range": start_height is beyond
-                // the node's tip — permanent, so anchor at genesis instead of retrying.
-                Err(corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(
-                    ref e,
-                ))) if e.code == -8 => {
-                    warn!(
-                        "Start height {height} is beyond bitcoind's tip; anchoring Kyoto at genesis"
-                    );
-                    return HashCheckpoint::from_genesis(network);
+                Err(e) => {
+                    if attempt.is_multiple_of(LOG_EVERY) {
+                        match Self::bitcoind_height(bitcoind_rpc).await {
+                            Some(blocks) => warn!(
+                                "Waiting for bitcoind to reach start height {height}; it is at {blocks}"
+                            ),
+                            None => warn!(
+                                "Waiting for a block at start height {height} from bitcoind: {e}"
+                            ),
+                        }
+                    }
                 }
-                Err(e) => warn!(
-                    "Failed to fetch block hash at start height {height} \
-                     (attempt {attempt}/{MAX_ATTEMPTS}): {e}"
-                ),
             }
+            attempt = attempt.wrapping_add(1);
             tokio::time::sleep(RETRY_DELAY).await;
         }
+    }
 
-        warn!(
-            "Could not resolve a checkpoint at start height {height}; falling back to genesis. \
-             Kyoto will sync the entire chain from genesis."
-        );
-        HashCheckpoint::from_genesis(network)
+    async fn bitcoind_height(
+        bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
+    ) -> Option<u32> {
+        btc_rpc_call(bitcoind_rpc, |rpc| rpc.get_blockchain_info())
+            .await
+            .ok()
+            .and_then(|info| info.into_model().ok())
+            .map(|info| info.blocks)
     }
 
     /// Run a BTC monitor with the given configuration.
@@ -1431,6 +1439,86 @@ mod tests {
             Monitor::resolve_start_checkpoint(&rpc, &between_segwit_and_taproot).await,
             HashCheckpoint::segwit_activation(),
         );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_at_height_waits_out_a_lagging_bitcoind() {
+        use std::sync::atomic::AtomicU32;
+        use std::sync::atomic::Ordering;
+        use tokio::io::AsyncReadExt;
+        use tokio::io::AsyncWriteExt;
+
+        const HASH: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+        // `getblockhash` replies "out of range" this many times before the block lands.
+        const LAGGING_REPLIES: u32 = 2;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let block_hash_calls = Arc::new(AtomicU32::new(0));
+
+        tokio::spawn({
+            let block_hash_calls = block_hash_calls.clone();
+            async move {
+                while let Ok((mut sock, _)) = listener.accept().await {
+                    let block_hash_calls = block_hash_calls.clone();
+                    tokio::spawn(async move {
+                        let mut buf = [0u8; 4096];
+                        while let Ok(n) = sock.read(&mut buf).await {
+                            if n == 0 {
+                                return;
+                            }
+                            let req = String::from_utf8_lossy(&buf[..n]).into_owned();
+                            let id = req
+                                .rsplit_once("\"id\":")
+                                .and_then(|(_, rest)| rest.split([',', '}']).next())
+                                .unwrap_or("0")
+                                .to_string();
+                            let out_of_range = |id: &str| {
+                                format!(
+                                    r#"{{"result":null,"error":{{"code":-8,"message":"Block height out of range"}},"id":{id}}}"#
+                                )
+                            };
+                            let body = if req.contains("\"getblockhash\"") {
+                                if block_hash_calls.fetch_add(1, Ordering::SeqCst) < LAGGING_REPLIES
+                                {
+                                    out_of_range(&id)
+                                } else {
+                                    format!(r#"{{"result":"{HASH}","error":null,"id":{id}}}"#)
+                                }
+                            } else {
+                                // The progress-logging `getblockchaininfo`; failing it
+                                // exercises the branch that logs without a height.
+                                out_of_range(&id)
+                            };
+                            let resp = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                                 Content-Length: {}\r\n\r\n{body}",
+                                body.len()
+                            );
+                            if sock.write_all(resp.as_bytes()).await.is_err() {
+                                return;
+                            }
+                        }
+                    });
+                }
+            }
+        });
+
+        let rpc = Arc::new(corepc_client::client_sync::v29::Client::new(&format!(
+            "http://{addr}"
+        )));
+
+        // The old "-8 is permanent" path returned a genesis checkpoint on the first reply.
+        let checkpoint = tokio::time::timeout(
+            Duration::from_secs(60),
+            Monitor::checkpoint_at_height(&rpc, 300_000),
+        )
+        .await
+        .expect("checkpoint_at_height gave up instead of waiting for bitcoind");
+
+        assert_eq!(checkpoint.height, 300_000);
+        assert_eq!(checkpoint.hash.to_string(), HASH);
+        assert!(block_hash_calls.load(Ordering::SeqCst) > LAGGING_REPLIES);
     }
 
     #[test]

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -64,10 +64,11 @@ const MAX_PENDING_DEPOSIT_CHECKS_PER_OUTPOINT: usize = 100;
 // and overflowing it fails calls outright ("Work queue depth exceeded").
 const UTXO_HEIGHT_LOOKUP_CONCURRENCY: usize = 16;
 
-/// Ceiling on a single round-trip through the monitor loop. Above the 60s
-/// timeout corepc puts on its RPC transport, so this only fires when the loop
-/// never picked the request up — never on an RPC that is still in flight.
-const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
+/// Ceiling on a round trip through the monitor loop: corepc's 60s transport
+/// timeout plus the longest stretch the loop is alive but not receiving (a
+/// Kyoto restart, up to 35s), with margin. It can only fire on a request the
+/// loop never dispatched, which the workers' `is_closed` guards then drop.
+const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 fn next_restart_delay() -> Duration {
     let jitter = Duration::from_millis(
@@ -292,7 +293,9 @@ pub struct Monitor {
 }
 
 /// bitcoind is still catching up (-8 out of range, -28 warming up), overloaded,
-/// or briefly unreachable; anything else will not clear by waiting.
+/// or briefly unreachable; anything else will not clear by waiting. Transport
+/// blips are safe to wait out because `verify_bitcoind_network` already proved
+/// a reachable node with working credentials before the loop starts.
 fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
     use jsonrpc::http::minreq_http::Error as TransportError;
 
@@ -302,10 +305,10 @@ fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
     match e {
         jsonrpc::error::Error::Rpc(e) => matches!(e.code, -8 | -28),
         jsonrpc::error::Error::Transport(e) => match e.downcast_ref::<TransportError>() {
-            // A refused connection and an HTTP error status arrive alike, but
-            // only 503 (bitcoind's RPC work queue is full) is worth waiting
-            // out; 401 and 403 mean the credentials are wrong.
-            Some(TransportError::Http(e)) => e.status_code == 503,
+            // A refused connection and an HTTP error status arrive alike. A 5xx
+            // is the server's problem (503: bitcoind's RPC work queue is full);
+            // a 4xx is ours: wrong credentials or an RPC whitelist.
+            Some(TransportError::Http(e)) => e.status_code >= 500,
             Some(_) => true,
             None => false,
         },
@@ -2478,22 +2481,26 @@ mod tests {
         );
     }
 
-    fn rpc_id(req: &str) -> &str {
-        req.rsplit_once("\"id\":")
-            .and_then(|(_, rest)| rest.split([',', '}']).next())
-            .unwrap_or("0")
+    /// Answer a JSON-RPC request, echoing its id.
+    fn rpc_reply(req: &str, result: serde_json::Value, error: serde_json::Value) -> String {
+        let body = req.split_once("\r\n\r\n").map_or("", |(_, body)| body);
+        let id = serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .and_then(|req| req.get("id").cloned())
+            .unwrap_or_default();
+        serde_json::json!({ "result": result, "error": error, "id": id }).to_string()
     }
 
     fn rpc_error(req: &str, code: i32, message: &str) -> String {
-        let id = rpc_id(req);
-        format!(r#"{{"result":null,"error":{{"code":{code},"message":"{message}"}},"id":{id}}}"#)
+        rpc_reply(
+            req,
+            serde_json::Value::Null,
+            serde_json::json!({ "code": code, "message": message }),
+        )
     }
 
     fn rpc_ok(req: &str, result: &str) -> String {
-        format!(
-            r#"{{"result":"{result}","error":null,"id":{}}}"#,
-            rpc_id(req)
-        )
+        rpc_reply(req, serde_json::json!(result), serde_json::Value::Null)
     }
 
     /// Serve JSON-RPC over loopback, answering each request body with `reply`.
@@ -2602,6 +2609,7 @@ mod tests {
             )))
         };
         assert!(is_transient_rpc_error(&http(503)));
+        assert!(is_transient_rpc_error(&http(502)));
         assert!(!is_transient_rpc_error(&http(401)));
         assert!(!is_transient_rpc_error(&http(403)));
 

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -611,6 +611,8 @@ impl Monitor {
             .maximum_connection_time(Duration::MAX)
             .chain_state(kyoto::ChainState::Checkpoint(checkpoint));
 
+        // No-op as of bip157 0.6.3: the builder takes the path and `Node::new`
+        // discards it. Kept for when upstream implements persistence.
         if let Some(data_dir) = &config.data_dir {
             builder = builder.data_dir(data_dir.clone());
         }
@@ -632,19 +634,22 @@ impl Monitor {
             bitcoin::Network::Bitcoin if config.start_height > 481_823 => {
                 HashCheckpoint::segwit_activation()
             }
-            network => Self::checkpoint_at_height(bitcoind_rpc, config.start_height, network).await,
+            _ => Self::checkpoint_at_height(bitcoind_rpc, config.start_height).await,
         }
     }
 
+    /// Wait for bitcoind to have the block at `height`. A node still in initial
+    /// block download reports the same "out of range" error as a height past the
+    /// tip, so giving up would anchor Kyoto far below `height` permanently.
     async fn checkpoint_at_height(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         height: u32,
-        network: bitcoin::Network,
     ) -> HashCheckpoint {
-        const MAX_ATTEMPTS: u32 = 5;
         const RETRY_DELAY: Duration = Duration::from_secs(2);
+        const LOG_EVERY: u32 = 15;
 
-        for attempt in 1..=MAX_ATTEMPTS {
+        let mut attempt: u32 = 0;
+        loop {
             match btc_rpc_call(bitcoind_rpc, move |rpc| rpc.get_block_hash(height as u64)).await {
                 Ok(raw) => match raw.into_model() {
                     Ok(model) => {
@@ -653,29 +658,32 @@ impl Monitor {
                     }
                     Err(e) => error!("Failed to parse getblockhash({height}) response: {e}"),
                 },
-                // RPC error -8 "block height out of range": start_height is beyond
-                // the node's tip — permanent, so anchor at genesis instead of retrying.
-                Err(corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(
-                    ref e,
-                ))) if e.code == -8 => {
-                    warn!(
-                        "Start height {height} is beyond bitcoind's tip; anchoring Kyoto at genesis"
-                    );
-                    return HashCheckpoint::from_genesis(network);
+                Err(e) => {
+                    if attempt.is_multiple_of(LOG_EVERY) {
+                        match Self::bitcoind_height(bitcoind_rpc).await {
+                            Some(blocks) => warn!(
+                                "Waiting for bitcoind to reach start height {height}; it is at {blocks}"
+                            ),
+                            None => warn!(
+                                "Waiting for a block at start height {height} from bitcoind: {e}"
+                            ),
+                        }
+                    }
                 }
-                Err(e) => warn!(
-                    "Failed to fetch block hash at start height {height} \
-                     (attempt {attempt}/{MAX_ATTEMPTS}): {e}"
-                ),
             }
+            attempt = attempt.wrapping_add(1);
             tokio::time::sleep(RETRY_DELAY).await;
         }
+    }
 
-        warn!(
-            "Could not resolve a checkpoint at start height {height}; falling back to genesis. \
-             Kyoto will sync the entire chain from genesis."
-        );
-        HashCheckpoint::from_genesis(network)
+    async fn bitcoind_height(
+        bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
+    ) -> Option<u32> {
+        btc_rpc_call(bitcoind_rpc, |rpc| rpc.get_blockchain_info())
+            .await
+            .ok()
+            .and_then(|info| info.into_model().ok())
+            .map(|info| info.blocks)
     }
 
     /// Run a BTC monitor with the given configuration.
@@ -2409,6 +2417,86 @@ mod tests {
             Monitor::resolve_start_checkpoint(&rpc, &between_segwit_and_taproot).await,
             HashCheckpoint::segwit_activation(),
         );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_at_height_waits_out_a_lagging_bitcoind() {
+        use std::sync::atomic::AtomicU32;
+        use std::sync::atomic::Ordering;
+        use tokio::io::AsyncReadExt;
+        use tokio::io::AsyncWriteExt;
+
+        const HASH: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+        // `getblockhash` replies "out of range" this many times before the block lands.
+        const LAGGING_REPLIES: u32 = 2;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let block_hash_calls = Arc::new(AtomicU32::new(0));
+
+        tokio::spawn({
+            let block_hash_calls = block_hash_calls.clone();
+            async move {
+                while let Ok((mut sock, _)) = listener.accept().await {
+                    let block_hash_calls = block_hash_calls.clone();
+                    tokio::spawn(async move {
+                        let mut buf = [0u8; 4096];
+                        while let Ok(n) = sock.read(&mut buf).await {
+                            if n == 0 {
+                                return;
+                            }
+                            let req = String::from_utf8_lossy(&buf[..n]).into_owned();
+                            let id = req
+                                .rsplit_once("\"id\":")
+                                .and_then(|(_, rest)| rest.split([',', '}']).next())
+                                .unwrap_or("0")
+                                .to_string();
+                            let out_of_range = |id: &str| {
+                                format!(
+                                    r#"{{"result":null,"error":{{"code":-8,"message":"Block height out of range"}},"id":{id}}}"#
+                                )
+                            };
+                            let body = if req.contains("\"getblockhash\"") {
+                                if block_hash_calls.fetch_add(1, Ordering::SeqCst) < LAGGING_REPLIES
+                                {
+                                    out_of_range(&id)
+                                } else {
+                                    format!(r#"{{"result":"{HASH}","error":null,"id":{id}}}"#)
+                                }
+                            } else {
+                                // The progress-logging `getblockchaininfo`; failing it
+                                // exercises the branch that logs without a height.
+                                out_of_range(&id)
+                            };
+                            let resp = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                                 Content-Length: {}\r\n\r\n{body}",
+                                body.len()
+                            );
+                            if sock.write_all(resp.as_bytes()).await.is_err() {
+                                return;
+                            }
+                        }
+                    });
+                }
+            }
+        });
+
+        let rpc = Arc::new(corepc_client::client_sync::v29::Client::new(&format!(
+            "http://{addr}"
+        )));
+
+        // The old "-8 is permanent" path returned a genesis checkpoint on the first reply.
+        let checkpoint = tokio::time::timeout(
+            Duration::from_secs(60),
+            Monitor::checkpoint_at_height(&rpc, 300_000),
+        )
+        .await
+        .expect("checkpoint_at_height gave up instead of waiting for bitcoind");
+
+        assert_eq!(checkpoint.height, 300_000);
+        assert_eq!(checkpoint.hash.to_string(), HASH);
+        assert!(block_hash_calls.load(Ordering::SeqCst) > LAGGING_REPLIES);
     }
 
     #[test]

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -289,6 +289,18 @@ pub struct Monitor {
     trusted_peer_rotation: std::iter::Cycle<std::vec::IntoIter<kyoto::TrustedPeer>>,
 }
 
+/// bitcoind is still catching up (-8 out of range, -28 warming up) or briefly
+/// unreachable; anything else will not resolve by waiting.
+fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
+    match e {
+        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Transport(_)) => true,
+        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(e)) => {
+            matches!(e.code, -8 | -28)
+        }
+        _ => false,
+    }
+}
+
 /// Offload a blocking Bitcoin Core RPC call to the tokio blocking thread pool.
 async fn btc_rpc_call<F, T>(client: &Arc<corepc_client::client_sync::v29::Client>, f: F) -> T
 where
@@ -623,16 +635,16 @@ impl Monitor {
     async fn resolve_start_checkpoint(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         config: &MonitorConfig,
-    ) -> HashCheckpoint {
-        match config.network {
+    ) -> Result<HashCheckpoint> {
+        Ok(match config.network {
             bitcoin::Network::Bitcoin if config.start_height > 709_631 => {
                 HashCheckpoint::taproot_activation()
             }
             bitcoin::Network::Bitcoin if config.start_height > 481_823 => {
                 HashCheckpoint::segwit_activation()
             }
-            _ => Self::checkpoint_at_height(bitcoind_rpc, config.start_height).await,
-        }
+            _ => Self::checkpoint_at_height(bitcoind_rpc, config.start_height).await?,
+        })
     }
 
     /// Wait for bitcoind to have the block at `height`. A node still in initial
@@ -641,20 +653,25 @@ impl Monitor {
     async fn checkpoint_at_height(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         height: u32,
-    ) -> HashCheckpoint {
+    ) -> Result<HashCheckpoint> {
         const RETRY_DELAY: Duration = Duration::from_secs(2);
         const LOG_INTERVAL: Duration = Duration::from_secs(30);
 
         let mut next_log = Instant::now();
         loop {
             match btc_rpc_call(bitcoind_rpc, move |rpc| rpc.get_block_hash(height as u64)).await {
-                Ok(raw) => match raw.into_model() {
-                    Ok(model) => {
-                        info!("Anchoring Kyoto at start height {height} ({})", model.0);
-                        return HashCheckpoint::new(height, model.0);
-                    }
-                    Err(e) => error!("Failed to parse getblockhash({height}) response: {e}"),
-                },
+                Ok(raw) => {
+                    let model = raw.into_model().map_err(|e| {
+                        anyhow::anyhow!("Failed to parse getblockhash({height}) response: {e}")
+                    })?;
+                    info!("Anchoring Kyoto at start height {height} ({})", model.0);
+                    return Ok(HashCheckpoint::new(height, model.0));
+                }
+                Err(e) if !is_transient_rpc_error(&e) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to fetch the block at start height {height}: {e}"
+                    ));
+                }
                 Err(e) => {
                     if Instant::now() >= next_log {
                         next_log = Instant::now() + LOG_INTERVAL;
@@ -707,7 +724,8 @@ impl Monitor {
             async move {
                 let bitcoind_rpc = Arc::new(bitcoind_rpc);
 
-                let start_checkpoint = Self::resolve_start_checkpoint(&bitcoind_rpc, &config).await;
+                let start_checkpoint =
+                    Self::resolve_start_checkpoint(&bitcoind_rpc, &config).await?;
                 let (kyoto_node, kyoto_client) = Self::build_kyoto_node(&config, start_checkpoint);
                 let trusted_peer_rotation = config.trusted_peers.clone().into_iter().cycle();
 
@@ -1164,6 +1182,10 @@ impl Monitor {
         conf_target: u16,
         result_tx: oneshot::Sender<Result<FeeRate>>,
     ) {
+        if result_tx.is_closed() {
+            return;
+        }
+
         // ECONOMICAL tracks spot fees more closely than the default
         // CONSERVATIVE, which blends in a long-horizon max.
         let result = btc_rpc_call(&bitcoind_rpc, move |rpc| {
@@ -1203,6 +1225,12 @@ impl Monitor {
         tx: bitcoin::Transaction,
         result_tx: oneshot::Sender<Result<()>>,
     ) {
+        // The caller stopped waiting, so don't put the transaction on the wire
+        // behind its back.
+        if result_tx.is_closed() {
+            return;
+        }
+
         // Broadcast via the bitcoind RPC, not kyoto's P2P submit_package, which
         // dropped its response or hung under load.
         let txid = tx.compute_txid();
@@ -1232,6 +1260,10 @@ impl Monitor {
         txid: bitcoin::Txid,
         result_tx: oneshot::Sender<Result<TxStatus>>,
     ) {
+        if result_tx.is_closed() {
+            return;
+        }
+
         let rpc_result = btc_rpc_call(&bitcoind_rpc, move |rpc| {
             rpc.get_raw_transaction_verbose(txid)
         })
@@ -2415,7 +2447,9 @@ mod tests {
             ..MonitorConfig::default()
         };
         assert_eq!(
-            Monitor::resolve_start_checkpoint(&rpc, &above_taproot).await,
+            Monitor::resolve_start_checkpoint(&rpc, &above_taproot)
+                .await
+                .unwrap(),
             HashCheckpoint::taproot_activation(),
         );
 
@@ -2425,77 +2459,93 @@ mod tests {
             ..MonitorConfig::default()
         };
         assert_eq!(
-            Monitor::resolve_start_checkpoint(&rpc, &between_segwit_and_taproot).await,
+            Monitor::resolve_start_checkpoint(&rpc, &between_segwit_and_taproot)
+                .await
+                .unwrap(),
             HashCheckpoint::segwit_activation(),
         );
+    }
+
+    fn rpc_id(req: &str) -> &str {
+        req.rsplit_once("\"id\":")
+            .and_then(|(_, rest)| rest.split([',', '}']).next())
+            .unwrap_or("0")
+    }
+
+    fn rpc_error(req: &str, code: i32, message: &str) -> String {
+        let id = rpc_id(req);
+        format!(r#"{{"result":null,"error":{{"code":{code},"message":"{message}"}},"id":{id}}}"#)
+    }
+
+    fn rpc_ok(req: &str, result: &str) -> String {
+        format!(
+            r#"{{"result":"{result}","error":null,"id":{}}}"#,
+            rpc_id(req)
+        )
+    }
+
+    /// Serve JSON-RPC over loopback, answering each request body with `reply`.
+    async fn stub_bitcoind(
+        reply: impl Fn(&str) -> String + Send + Sync + 'static,
+    ) -> Arc<corepc_client::client_sync::v29::Client> {
+        use tokio::io::AsyncReadExt;
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let reply = Arc::new(reply);
+
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = listener.accept().await {
+                let reply = reply.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    while let Ok(n) = sock.read(&mut buf).await {
+                        if n == 0 {
+                            return;
+                        }
+                        let body = reply(&String::from_utf8_lossy(&buf[..n]));
+                        let resp = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                             Content-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        );
+                        if sock.write_all(resp.as_bytes()).await.is_err() {
+                            return;
+                        }
+                    }
+                });
+            }
+        });
+
+        Arc::new(corepc_client::client_sync::v29::Client::new(&format!(
+            "http://{addr}"
+        )))
     }
 
     #[tokio::test]
     async fn checkpoint_at_height_waits_out_a_lagging_bitcoind() {
         use std::sync::atomic::AtomicU32;
         use std::sync::atomic::Ordering;
-        use tokio::io::AsyncReadExt;
-        use tokio::io::AsyncWriteExt;
 
         const HASH: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
         // `getblockhash` replies "out of range" this many times before the block lands.
         const LAGGING_REPLIES: u32 = 2;
 
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
         let block_hash_calls = Arc::new(AtomicU32::new(0));
-
-        tokio::spawn({
+        let rpc = stub_bitcoind({
             let block_hash_calls = block_hash_calls.clone();
-            async move {
-                while let Ok((mut sock, _)) = listener.accept().await {
-                    let block_hash_calls = block_hash_calls.clone();
-                    tokio::spawn(async move {
-                        let mut buf = [0u8; 4096];
-                        while let Ok(n) = sock.read(&mut buf).await {
-                            if n == 0 {
-                                return;
-                            }
-                            let req = String::from_utf8_lossy(&buf[..n]).into_owned();
-                            let id = req
-                                .rsplit_once("\"id\":")
-                                .and_then(|(_, rest)| rest.split([',', '}']).next())
-                                .unwrap_or("0")
-                                .to_string();
-                            let out_of_range = |id: &str| {
-                                format!(
-                                    r#"{{"result":null,"error":{{"code":-8,"message":"Block height out of range"}},"id":{id}}}"#
-                                )
-                            };
-                            let body = if req.contains("\"getblockhash\"") {
-                                if block_hash_calls.fetch_add(1, Ordering::SeqCst) < LAGGING_REPLIES
-                                {
-                                    out_of_range(&id)
-                                } else {
-                                    format!(r#"{{"result":"{HASH}","error":null,"id":{id}}}"#)
-                                }
-                            } else {
-                                // The progress-logging `getblockchaininfo`; failing it
-                                // exercises the branch that logs without a height.
-                                out_of_range(&id)
-                            };
-                            let resp = format!(
-                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
-                                 Content-Length: {}\r\n\r\n{body}",
-                                body.len()
-                            );
-                            if sock.write_all(resp.as_bytes()).await.is_err() {
-                                return;
-                            }
-                        }
-                    });
+            move |req| {
+                if req.contains("\"getblockhash\"")
+                    && block_hash_calls.fetch_add(1, Ordering::SeqCst) >= LAGGING_REPLIES
+                {
+                    rpc_ok(req, HASH)
+                } else {
+                    rpc_error(req, -8, "Block height out of range")
                 }
             }
-        });
-
-        let rpc = Arc::new(corepc_client::client_sync::v29::Client::new(&format!(
-            "http://{addr}"
-        )));
+        })
+        .await;
 
         // The old "-8 is permanent" path returned a genesis checkpoint on the first reply.
         let checkpoint = tokio::time::timeout(
@@ -2503,11 +2553,27 @@ mod tests {
             Monitor::checkpoint_at_height(&rpc, 300_000),
         )
         .await
-        .expect("checkpoint_at_height gave up instead of waiting for bitcoind");
+        .expect("checkpoint_at_height gave up instead of waiting for bitcoind")
+        .unwrap();
 
         assert_eq!(checkpoint.height, 300_000);
         assert_eq!(checkpoint.hash.to_string(), HASH);
         assert!(block_hash_calls.load(Ordering::SeqCst) > LAGGING_REPLIES);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_at_height_gives_up_on_a_permanent_rpc_error() {
+        let rpc = stub_bitcoind(|req| rpc_error(req, -32601, "Method not found")).await;
+
+        let err = tokio::time::timeout(
+            Duration::from_secs(60),
+            Monitor::checkpoint_at_height(&rpc, 300_000),
+        )
+        .await
+        .expect("checkpoint_at_height retried an error that will never clear")
+        .unwrap_err();
+
+        assert!(err.to_string().contains("start height 300000"), "{err}");
     }
 
     #[test]

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -41,8 +41,10 @@ const KYOTO_MAX_RESTART_DELAY_JITTER: Duration = Duration::from_secs(30);
 /// refreshed before it's dropped from the confirmation-metrics cache.
 const STALE_OBSERVATION_BLOCKS: u32 = 10;
 
-/// Ceiling on a single round-trip through the monitor loop.
-const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Ceiling on a single round-trip through the monitor loop. Above the 60s
+/// timeout corepc puts on its RPC transport, so this only fires when the loop
+/// never picked the request up — never on an RPC that is still in flight.
+const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
 
 fn next_restart_delay() -> Duration {
     let jitter = Duration::from_millis(
@@ -219,14 +221,24 @@ pub struct Monitor {
     trusted_peer_rotation: std::iter::Cycle<std::vec::IntoIter<kyoto::TrustedPeer>>,
 }
 
-/// bitcoind is still catching up (-8 out of range, -28 warming up) or briefly
-/// unreachable; anything else will not resolve by waiting.
+/// bitcoind is still catching up (-8 out of range, -28 warming up), overloaded,
+/// or briefly unreachable; anything else will not clear by waiting.
 fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
+    use jsonrpc::http::minreq_http::Error as TransportError;
+
+    let corepc_client::client_sync::Error::JsonRpc(e) = e else {
+        return false;
+    };
     match e {
-        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Transport(_)) => true,
-        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(e)) => {
-            matches!(e.code, -8 | -28)
-        }
+        jsonrpc::error::Error::Rpc(e) => matches!(e.code, -8 | -28),
+        jsonrpc::error::Error::Transport(e) => match e.downcast_ref::<TransportError>() {
+            // A refused connection and an HTTP error status arrive alike, but
+            // only 503 (bitcoind's RPC work queue is full) is worth waiting
+            // out; 401 and 403 mean the credentials are wrong.
+            Some(TransportError::Http(e)) => e.status_code == 503,
+            Some(_) => true,
+            None => false,
+        },
         _ => false,
     }
 }
@@ -260,9 +272,9 @@ impl Monitor {
             .build()
     }
 
-    /// Kyoto re-syncs from its checkpoint on every build, so anchoring at genesis
-    /// replays the whole chain. Anchor non-mainnet at `start_height`; mainnet
-    /// keeps the soft-fork activation anchors.
+    /// Kyoto re-syncs from its checkpoint on every build, so anchor as high as
+    /// possible without passing `start_height`: mainnet reuses the soft-fork
+    /// activation heights, everything else resolves the exact block.
     async fn resolve_start_checkpoint(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         config: &MonitorConfig,
@@ -1596,6 +1608,35 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("start height 300000"), "{err}");
+    }
+
+    #[test]
+    fn only_recoverable_transport_errors_are_retried() {
+        use jsonrpc::http::minreq_http::Error as TransportError;
+        use jsonrpc::http::minreq_http::HttpError;
+
+        let http = |status_code| {
+            corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Transport(Box::new(
+                TransportError::Http(HttpError {
+                    status_code,
+                    body: String::new(),
+                }),
+            )))
+        };
+        assert!(is_transient_rpc_error(&http(503)));
+        assert!(!is_transient_rpc_error(&http(401)));
+        assert!(!is_transient_rpc_error(&http(403)));
+
+        // Against a port nothing is listening on, so the retryable branch is
+        // exercised on a real error rather than a hand-built one.
+        let addr = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap();
+        let refused = corepc_client::client_sync::v29::Client::new(&format!("http://{addr}"))
+            .get_blockchain_info()
+            .unwrap_err();
+        assert!(is_transient_rpc_error(&refused), "{refused}");
     }
 
     #[test]

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -6,6 +6,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
+use std::time::Instant;
 
 use anyhow::Result;
 use kyoto::FeeRate;
@@ -39,6 +40,9 @@ const KYOTO_MAX_RESTART_DELAY_JITTER: Duration = Duration::from_secs(30);
 /// How many Bitcoin blocks a deposit observation can go without being
 /// refreshed before it's dropped from the confirmation-metrics cache.
 const STALE_OBSERVATION_BLOCKS: u32 = 10;
+
+/// Ceiling on a single round-trip through the monitor loop.
+const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn next_restart_delay() -> Duration {
     let jitter = Duration::from_millis(
@@ -232,7 +236,7 @@ impl Monitor {
         config: &MonitorConfig,
         checkpoint: HashCheckpoint,
     ) -> (kyoto::Node, kyoto::Client) {
-        let mut builder = kyoto::Builder::new(config.network)
+        kyoto::Builder::new(config.network)
             .add_peers(config.trusted_peers.iter().cloned())
             // Only connect to the configured trusted peers. Prevents Kyoto from
             // discovering additional peers via DNS seeding or addr gossip.
@@ -240,15 +244,8 @@ impl Monitor {
             // drains, the node exits and the supervision loop rebuilds it.
             .whitelist_only()
             .maximum_connection_time(Duration::MAX)
-            .chain_state(kyoto::ChainState::Checkpoint(checkpoint));
-
-        // No-op as of bip157 0.6.3: the builder takes the path and `Node::new`
-        // discards it. Kept for when upstream implements persistence.
-        if let Some(data_dir) = &config.data_dir {
-            builder = builder.data_dir(data_dir.clone());
-        }
-
-        builder.build()
+            .chain_state(kyoto::ChainState::Checkpoint(checkpoint))
+            .build()
     }
 
     /// Kyoto re-syncs from its checkpoint on every build, so anchoring at genesis
@@ -277,9 +274,9 @@ impl Monitor {
         height: u32,
     ) -> HashCheckpoint {
         const RETRY_DELAY: Duration = Duration::from_secs(2);
-        const LOG_EVERY: u32 = 15;
+        const LOG_INTERVAL: Duration = Duration::from_secs(30);
 
-        let mut attempt: u32 = 0;
+        let mut next_log = Instant::now();
         loop {
             match btc_rpc_call(bitcoind_rpc, move |rpc| rpc.get_block_hash(height as u64)).await {
                 Ok(raw) => match raw.into_model() {
@@ -290,19 +287,17 @@ impl Monitor {
                     Err(e) => error!("Failed to parse getblockhash({height}) response: {e}"),
                 },
                 Err(e) => {
-                    if attempt.is_multiple_of(LOG_EVERY) {
+                    if Instant::now() >= next_log {
+                        next_log = Instant::now() + LOG_INTERVAL;
                         match Self::bitcoind_height(bitcoind_rpc).await {
                             Some(blocks) => warn!(
                                 "Waiting for bitcoind to reach start height {height}; it is at {blocks}"
                             ),
-                            None => warn!(
-                                "Waiting for a block at start height {height} from bitcoind: {e}"
-                            ),
+                            None => warn!("Waiting for a block at start height {height}: {e}"),
                         }
                     }
                 }
             }
-            attempt = attempt.wrapping_add(1);
             tokio::time::sleep(RETRY_DELAY).await;
         }
     }
@@ -1222,31 +1217,47 @@ impl MonitorClient {
         })?
     }
 
-    pub async fn get_recent_fee_rate(&self, conf_target: u16) -> Result<FeeRate> {
+    /// Round-trip a request through the monitor loop, bounded so callers fail
+    /// rather than block while the loop is still resolving its start checkpoint.
+    async fn request<T>(
+        &self,
+        message: impl FnOnce(oneshot::Sender<Result<T>>) -> MonitorMessage,
+        what: &str,
+    ) -> Result<T> {
         let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(MonitorMessage::GetRecentFeeRate(conf_target, tx))
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?;
-        rx.await.map_err(|e| anyhow::anyhow!(e))?
+        tokio::time::timeout(MONITOR_REQUEST_TIMEOUT, async {
+            self.tx
+                .send(message(tx))
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            rx.await.map_err(|e| anyhow::anyhow!(e))?
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("{what} timed out waiting for the Bitcoin monitor"))?
+    }
+
+    pub async fn get_recent_fee_rate(&self, conf_target: u16) -> Result<FeeRate> {
+        self.request(
+            |tx| MonitorMessage::GetRecentFeeRate(conf_target, tx),
+            "get_recent_fee_rate",
+        )
+        .await
     }
 
     pub async fn broadcast_transaction(&self, transaction: bitcoin::Transaction) -> Result<()> {
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(MonitorMessage::BroadcastTransaction(transaction, tx))
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?;
-        rx.await.map_err(|e| anyhow::anyhow!(e))?
+        self.request(
+            |tx| MonitorMessage::BroadcastTransaction(transaction, tx),
+            "broadcast_transaction",
+        )
+        .await
     }
 
     pub async fn get_transaction_status(&self, txid: bitcoin::Txid) -> Result<TxStatus> {
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(MonitorMessage::GetTransactionStatus(txid, tx))
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?;
-        rx.await.map_err(|e| anyhow::anyhow!(e))?
+        self.request(
+            |tx| MonitorMessage::GetTransactionStatus(txid, tx),
+            "get_transaction_status",
+        )
+        .await
     }
 }
 

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -628,7 +628,7 @@ impl Monitor {
         config: &MonitorConfig,
         checkpoint: HashCheckpoint,
     ) -> (kyoto::Node, kyoto::Client) {
-        kyoto::Builder::new(config.network)
+        let mut builder = kyoto::Builder::new(config.network)
             .add_peers(config.trusted_peers.iter().cloned())
             // Only connect to the configured trusted peers. Prevents Kyoto from
             // discovering additional peers via DNS seeding or addr gossip.
@@ -636,8 +636,13 @@ impl Monitor {
             // drains, the node exits and the supervision loop rebuilds it.
             .whitelist_only()
             .maximum_connection_time(Duration::MAX)
-            .chain_state(kyoto::ChainState::Checkpoint(checkpoint))
-            .build()
+            .chain_state(kyoto::ChainState::Checkpoint(checkpoint));
+
+        if let Some(data_dir) = &config.data_dir {
+            builder = builder.data_dir(data_dir.clone());
+        }
+
+        builder.build()
     }
 
     /// Kyoto re-syncs from its checkpoint on every build, so anchor as high as

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -64,8 +64,10 @@ const MAX_PENDING_DEPOSIT_CHECKS_PER_OUTPOINT: usize = 100;
 // and overflowing it fails calls outright ("Work queue depth exceeded").
 const UTXO_HEIGHT_LOOKUP_CONCURRENCY: usize = 16;
 
-/// Ceiling on a single round-trip through the monitor loop.
-const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Ceiling on a single round-trip through the monitor loop. Above the 60s
+/// timeout corepc puts on its RPC transport, so this only fires when the loop
+/// never picked the request up — never on an RPC that is still in flight.
+const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
 
 fn next_restart_delay() -> Duration {
     let jitter = Duration::from_millis(
@@ -289,14 +291,24 @@ pub struct Monitor {
     trusted_peer_rotation: std::iter::Cycle<std::vec::IntoIter<kyoto::TrustedPeer>>,
 }
 
-/// bitcoind is still catching up (-8 out of range, -28 warming up) or briefly
-/// unreachable; anything else will not resolve by waiting.
+/// bitcoind is still catching up (-8 out of range, -28 warming up), overloaded,
+/// or briefly unreachable; anything else will not clear by waiting.
 fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
+    use jsonrpc::http::minreq_http::Error as TransportError;
+
+    let corepc_client::client_sync::Error::JsonRpc(e) = e else {
+        return false;
+    };
     match e {
-        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Transport(_)) => true,
-        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(e)) => {
-            matches!(e.code, -8 | -28)
-        }
+        jsonrpc::error::Error::Rpc(e) => matches!(e.code, -8 | -28),
+        jsonrpc::error::Error::Transport(e) => match e.downcast_ref::<TransportError>() {
+            // A refused connection and an HTTP error status arrive alike, but
+            // only 503 (bitcoind's RPC work queue is full) is worth waiting
+            // out; 401 and 403 mean the credentials are wrong.
+            Some(TransportError::Http(e)) => e.status_code == 503,
+            Some(_) => true,
+            None => false,
+        },
         _ => false,
     }
 }
@@ -629,9 +641,9 @@ impl Monitor {
             .build()
     }
 
-    /// Kyoto re-syncs from its checkpoint on every build, so anchoring at genesis
-    /// replays the whole chain. Anchor non-mainnet at `start_height`; mainnet
-    /// keeps the soft-fork activation anchors.
+    /// Kyoto re-syncs from its checkpoint on every build, so anchor as high as
+    /// possible without passing `start_height`: mainnet reuses the soft-fork
+    /// activation heights, everything else resolves the exact block.
     async fn resolve_start_checkpoint(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         config: &MonitorConfig,
@@ -2574,6 +2586,35 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("start height 300000"), "{err}");
+    }
+
+    #[test]
+    fn only_recoverable_transport_errors_are_retried() {
+        use jsonrpc::http::minreq_http::Error as TransportError;
+        use jsonrpc::http::minreq_http::HttpError;
+
+        let http = |status_code| {
+            corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Transport(Box::new(
+                TransportError::Http(HttpError {
+                    status_code,
+                    body: String::new(),
+                }),
+            )))
+        };
+        assert!(is_transient_rpc_error(&http(503)));
+        assert!(!is_transient_rpc_error(&http(401)));
+        assert!(!is_transient_rpc_error(&http(403)));
+
+        // Against a port nothing is listening on, so the retryable branch is
+        // exercised on a real error rather than a hand-built one.
+        let addr = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap();
+        let refused = corepc_client::client_sync::v29::Client::new(&format!("http://{addr}"))
+            .get_blockchain_info()
+            .unwrap_err();
+        assert!(is_transient_rpc_error(&refused), "{refused}");
     }
 
     #[test]

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -13,6 +13,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use anyhow::Result;
 use futures::FutureExt;
@@ -62,6 +63,9 @@ const MAX_PENDING_DEPOSIT_CHECKS_PER_OUTPOINT: usize = 100;
 // At most 16 concurrent txid lookups: bitcoind's default rpcworkqueue is 16,
 // and overflowing it fails calls outright ("Work queue depth exceeded").
 const UTXO_HEIGHT_LOOKUP_CONCURRENCY: usize = 16;
+
+/// Ceiling on a single round-trip through the monitor loop.
+const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn next_restart_delay() -> Duration {
     let jitter = Duration::from_millis(
@@ -601,7 +605,7 @@ impl Monitor {
         config: &MonitorConfig,
         checkpoint: HashCheckpoint,
     ) -> (kyoto::Node, kyoto::Client) {
-        let mut builder = kyoto::Builder::new(config.network)
+        kyoto::Builder::new(config.network)
             .add_peers(config.trusted_peers.iter().cloned())
             // Only connect to the configured trusted peers. Prevents Kyoto from
             // discovering additional peers via DNS seeding or addr gossip.
@@ -609,15 +613,8 @@ impl Monitor {
             // drains, the node exits and the supervision loop rebuilds it.
             .whitelist_only()
             .maximum_connection_time(Duration::MAX)
-            .chain_state(kyoto::ChainState::Checkpoint(checkpoint));
-
-        // No-op as of bip157 0.6.3: the builder takes the path and `Node::new`
-        // discards it. Kept for when upstream implements persistence.
-        if let Some(data_dir) = &config.data_dir {
-            builder = builder.data_dir(data_dir.clone());
-        }
-
-        builder.build()
+            .chain_state(kyoto::ChainState::Checkpoint(checkpoint))
+            .build()
     }
 
     /// Kyoto re-syncs from its checkpoint on every build, so anchoring at genesis
@@ -646,9 +643,9 @@ impl Monitor {
         height: u32,
     ) -> HashCheckpoint {
         const RETRY_DELAY: Duration = Duration::from_secs(2);
-        const LOG_EVERY: u32 = 15;
+        const LOG_INTERVAL: Duration = Duration::from_secs(30);
 
-        let mut attempt: u32 = 0;
+        let mut next_log = Instant::now();
         loop {
             match btc_rpc_call(bitcoind_rpc, move |rpc| rpc.get_block_hash(height as u64)).await {
                 Ok(raw) => match raw.into_model() {
@@ -659,19 +656,17 @@ impl Monitor {
                     Err(e) => error!("Failed to parse getblockhash({height}) response: {e}"),
                 },
                 Err(e) => {
-                    if attempt.is_multiple_of(LOG_EVERY) {
+                    if Instant::now() >= next_log {
+                        next_log = Instant::now() + LOG_INTERVAL;
                         match Self::bitcoind_height(bitcoind_rpc).await {
                             Some(blocks) => warn!(
                                 "Waiting for bitcoind to reach start height {height}; it is at {blocks}"
                             ),
-                            None => warn!(
-                                "Waiting for a block at start height {height} from bitcoind: {e}"
-                            ),
+                            None => warn!("Waiting for a block at start height {height}: {e}"),
                         }
                     }
                 }
             }
-            attempt = attempt.wrapping_add(1);
             tokio::time::sleep(RETRY_DELAY).await;
         }
     }
@@ -1759,31 +1754,47 @@ impl MonitorClient {
         rx.await.map_err(|e| anyhow::anyhow!(e))?
     }
 
-    pub async fn get_recent_fee_rate(&self, conf_target: u16) -> Result<FeeRate> {
+    /// Round-trip a request through the monitor loop, bounded so callers fail
+    /// rather than block while the loop is still resolving its start checkpoint.
+    async fn request<T>(
+        &self,
+        message: impl FnOnce(oneshot::Sender<Result<T>>) -> MonitorMessage,
+        what: &str,
+    ) -> Result<T> {
         let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(MonitorMessage::GetRecentFeeRate(conf_target, tx))
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?;
-        rx.await.map_err(|e| anyhow::anyhow!(e))?
+        tokio::time::timeout(MONITOR_REQUEST_TIMEOUT, async {
+            self.tx
+                .send(message(tx))
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            rx.await.map_err(|e| anyhow::anyhow!(e))?
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("{what} timed out waiting for the Bitcoin monitor"))?
+    }
+
+    pub async fn get_recent_fee_rate(&self, conf_target: u16) -> Result<FeeRate> {
+        self.request(
+            |tx| MonitorMessage::GetRecentFeeRate(conf_target, tx),
+            "get_recent_fee_rate",
+        )
+        .await
     }
 
     pub async fn broadcast_transaction(&self, transaction: bitcoin::Transaction) -> Result<()> {
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(MonitorMessage::BroadcastTransaction(transaction, tx))
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?;
-        rx.await.map_err(|e| anyhow::anyhow!(e))?
+        self.request(
+            |tx| MonitorMessage::BroadcastTransaction(transaction, tx),
+            "broadcast_transaction",
+        )
+        .await
     }
 
     pub async fn get_transaction_status(&self, txid: bitcoin::Txid) -> Result<TxStatus> {
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(MonitorMessage::GetTransactionStatus(txid, tx))
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?;
-        rx.await.map_err(|e| anyhow::anyhow!(e))?
+        self.request(
+            |tx| MonitorMessage::GetTransactionStatus(txid, tx),
+            "get_transaction_status",
+        )
+        .await
     }
 }
 

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -64,10 +64,15 @@ const MAX_PENDING_DEPOSIT_CHECKS_PER_OUTPOINT: usize = 100;
 // and overflowing it fails calls outright ("Work queue depth exceeded").
 const UTXO_HEIGHT_LOOKUP_CONCURRENCY: usize = 16;
 
-/// Bound on a round trip through the monitor loop, above corepc's 60s RPC
-/// timeout plus a Kyoto restart gap, so it only fires on a request the loop
-/// never dispatched; the workers' `is_closed` checks then drop that request.
+/// Budget for one bitcoind RPC: corepc's fixed 60s transport timeout, which
+/// minreq enforces around the whole request, plus a scheduling margin.
+const BITCOIND_RPC_BUDGET: Duration = Duration::from_secs(65);
+
+/// How long a `MonitorClient` call waits for the loop. A worker starts an RPC
+/// only if its budget fits before this deadline, so a caller that times out
+/// never has one in flight.
 const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const _: () = assert!(MONITOR_REQUEST_TIMEOUT.as_secs() > BITCOIND_RPC_BUDGET.as_secs());
 
 fn next_restart_delay() -> Duration {
     let jitter = Duration::from_millis(
@@ -305,8 +310,15 @@ fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
             // A refused connection and an HTTP error status arrive alike; 5xx
             // clears by waiting (503 is a full RPC work queue), 4xx never will.
             Some(TransportError::Http(e)) => e.status_code >= 500,
-            Some(_) => true,
-            None => false,
+            // Connection-level only; a malformed reply, a protocol error or a
+            // bad TLS or proxy setup will not fix itself.
+            Some(TransportError::Minreq(e)) => {
+                matches!(
+                    e,
+                    minreq::Error::IoError(_) | minreq::Error::AddressNotFound
+                )
+            }
+            _ => false,
         },
         _ => false,
     }
@@ -322,6 +334,43 @@ where
     tokio::task::spawn_blocking(move || f(&client))
         .await
         .expect("btc_rpc_call: spawn_blocking task panicked")
+}
+
+/// A `MonitorClient` caller's reply channel and the instant it stops waiting.
+struct Caller<T> {
+    deadline: Instant,
+    result_tx: oneshot::Sender<Result<T>>,
+}
+
+impl<T> Caller<T> {
+    /// Run `f` on the blocking pool only if the caller is still waiting and
+    /// `BITCOIND_RPC_BUDGET` fits before its deadline; `None` means skipped.
+    async fn rpc<F, R>(
+        &self,
+        client: &Arc<corepc_client::client_sync::v29::Client>,
+        f: F,
+    ) -> Option<R>
+    where
+        F: FnOnce(&corepc_client::client_sync::v29::Client) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        if self.result_tx.is_closed() {
+            return None;
+        }
+        let deadline = self.deadline;
+        let client = Arc::clone(client);
+        // Checked on the blocking thread: a busy pool can hold the closure
+        // back, and the caller's deadline does not wait for it.
+        tokio::task::spawn_blocking(move || {
+            (Instant::now() + BITCOIND_RPC_BUDGET <= deadline).then(|| f(&client))
+        })
+        .await
+        .expect("Caller::rpc: spawn_blocking task panicked")
+    }
+
+    fn reply(self, result: Result<T>) {
+        let _ = self.result_tx.send(result);
+    }
 }
 
 impl Monitor {
@@ -1134,26 +1183,26 @@ impl Monitor {
                         context, txids, result_tx,
                     ));
             }
-            MonitorMessage::GetRecentFeeRate(conf_target, result_tx) => {
+            MonitorMessage::GetRecentFeeRate(conf_target, caller) => {
                 self.rpc_workers.spawn(Self::get_recent_fee_rate(
                     self.bitcoind_rpc.clone(),
                     self.metrics.clone(),
                     conf_target,
-                    result_tx,
+                    caller,
                 ));
             }
-            MonitorMessage::BroadcastTransaction(tx, result_tx) => {
+            MonitorMessage::BroadcastTransaction(tx, caller) => {
                 self.rpc_workers.spawn(Self::broadcast_transaction(
                     self.bitcoind_rpc.clone(),
                     tx,
-                    result_tx,
+                    caller,
                 ));
             }
-            MonitorMessage::GetTransactionStatus(txid, result_tx) => {
+            MonitorMessage::GetTransactionStatus(txid, caller) => {
                 self.rpc_workers.spawn(Self::get_transaction_status(
                     self.bitcoind_rpc.clone(),
                     txid,
-                    result_tx,
+                    caller,
                 ));
             }
         }
@@ -1195,64 +1244,71 @@ impl Monitor {
         bitcoind_rpc: Arc<corepc_client::client_sync::v29::Client>,
         metrics: Arc<Metrics>,
         conf_target: u16,
-        result_tx: oneshot::Sender<Result<FeeRate>>,
+        caller: Caller<FeeRate>,
     ) {
-        if result_tx.is_closed() {
-            return;
-        }
-
         // ECONOMICAL tracks spot fees more closely than the default
         // CONSERVATIVE, which blends in a long-horizon max.
-        let result = btc_rpc_call(&bitcoind_rpc, move |rpc| {
-            rpc.call::<corepc_client::types::v29::EstimateSmartFee>(
-                "estimatesmartfee",
-                &[
-                    serde_json::json!(conf_target as u32),
-                    serde_json::json!("ECONOMICAL"),
-                ],
-            )
-        })
-        .await
-        .map_err(anyhow::Error::from)
-        .and_then(|res| Ok(res.into_model()?))
-        .map(|res| {
-            let sat_per_kwu = match res.fee_rate {
-                Some(fee_rate) => fee_rate.to_sat_per_kwu(),
-                None => {
-                    warn!(
-                        conf_target,
-                        fallback_sat_per_kwu = FALLBACK_FEE_RATE_SAT_PER_KWU,
-                        "Node could not estimate fee rate; falling back to minimum relay fee"
-                    );
-                    FALLBACK_FEE_RATE_SAT_PER_KWU
-                }
-            };
-            metrics
-                .btc_fee_rate_sat_per_kvb
-                .set((sat_per_kwu * 4) as i64);
-            FeeRate::from_sat_per_kwu(sat_per_kwu)
-        });
-        let _ = result_tx.send(result);
+        let rpc_result = caller
+            .rpc(&bitcoind_rpc, move |rpc| {
+                rpc.call::<corepc_client::types::v29::EstimateSmartFee>(
+                    "estimatesmartfee",
+                    &[
+                        serde_json::json!(conf_target as u32),
+                        serde_json::json!("ECONOMICAL"),
+                    ],
+                )
+            })
+            .await;
+        let Some(rpc_result) = rpc_result else {
+            caller.reply(Err(anyhow::anyhow!(
+                "Fee estimate expired before its bitcoind RPC could start"
+            )));
+            return;
+        };
+        let result = rpc_result
+            .map_err(anyhow::Error::from)
+            .and_then(|res| Ok(res.into_model()?))
+            .map(|res| {
+                let sat_per_kwu = match res.fee_rate {
+                    Some(fee_rate) => fee_rate.to_sat_per_kwu(),
+                    None => {
+                        warn!(
+                            conf_target,
+                            fallback_sat_per_kwu = FALLBACK_FEE_RATE_SAT_PER_KWU,
+                            "Node could not estimate fee rate; falling back to minimum relay fee"
+                        );
+                        FALLBACK_FEE_RATE_SAT_PER_KWU
+                    }
+                };
+                metrics
+                    .btc_fee_rate_sat_per_kvb
+                    .set((sat_per_kwu * 4) as i64);
+                FeeRate::from_sat_per_kwu(sat_per_kwu)
+            });
+        caller.reply(result);
     }
 
     async fn broadcast_transaction(
         bitcoind_rpc: Arc<corepc_client::client_sync::v29::Client>,
         tx: bitcoin::Transaction,
-        result_tx: oneshot::Sender<Result<()>>,
+        caller: Caller<()>,
     ) {
-        // The caller gave up; don't broadcast behind its back.
-        if result_tx.is_closed() {
-            return;
-        }
-
         // Broadcast via the bitcoind RPC, not kyoto's P2P submit_package, which
         // dropped its response or hung under load.
         let txid = tx.compute_txid();
-        let result = btc_rpc_call(&bitcoind_rpc, move |rpc| rpc.send_raw_transaction(&tx)).await;
+        let Some(result) = caller
+            .rpc(&bitcoind_rpc, move |rpc| rpc.send_raw_transaction(&tx))
+            .await
+        else {
+            caller.reply(Err(anyhow::anyhow!(
+                "Broadcast of {txid} expired before its bitcoind RPC could start"
+            )));
+            return;
+        };
         match result {
             Ok(_) => {
                 info!("Transaction {txid} broadcast via Bitcoin Core RPC");
-                let _ = result_tx.send(Ok(()));
+                caller.reply(Ok(()));
             }
             Err(corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(ref e)))
                 if e.code == -27 =>
@@ -1260,11 +1316,11 @@ impl Monitor {
                 // RPC error -27: tx already confirmed on-chain ("outputs already in utxo
                 // set"), so the broadcast succeeded. (A mempool duplicate returns Ok.)
                 debug!("Transaction {txid} already confirmed on-chain");
-                let _ = result_tx.send(Ok(()));
+                caller.reply(Ok(()));
             }
             Err(e) => {
                 error!("Failed to broadcast transaction {txid}: {e}");
-                let _ = result_tx.send(Err(anyhow::anyhow!(e)));
+                caller.reply(Err(anyhow::anyhow!(e)));
             }
         }
     }
@@ -1272,16 +1328,19 @@ impl Monitor {
     async fn get_transaction_status(
         bitcoind_rpc: Arc<corepc_client::client_sync::v29::Client>,
         txid: bitcoin::Txid,
-        result_tx: oneshot::Sender<Result<TxStatus>>,
+        caller: Caller<TxStatus>,
     ) {
-        if result_tx.is_closed() {
+        let rpc_result = caller
+            .rpc(&bitcoind_rpc, move |rpc| {
+                rpc.get_raw_transaction_verbose(txid)
+            })
+            .await;
+        let Some(rpc_result) = rpc_result else {
+            caller.reply(Err(anyhow::anyhow!(
+                "Status lookup for {txid} expired before its bitcoind RPC could start"
+            )));
             return;
-        }
-
-        let rpc_result = btc_rpc_call(&bitcoind_rpc, move |rpc| {
-            rpc.get_raw_transaction_verbose(txid)
-        })
-        .await;
+        };
         let result = match rpc_result {
             Ok(tx_info) => match tx_info.into_model() {
                 Ok(tx_info) => {
@@ -1302,7 +1361,7 @@ impl Monitor {
             }
             Err(e) => Err(anyhow::anyhow!("Failed to query transaction status: {e}")),
         };
-        let _ = result_tx.send(result);
+        caller.reply(result);
     }
 }
 
@@ -1800,17 +1859,21 @@ impl MonitorClient {
         rx.await.map_err(|e| anyhow::anyhow!(e))?
     }
 
-    /// Round-trip a request through the monitor loop, bounded so callers fail
-    /// rather than block while the loop is still resolving its start checkpoint.
+    /// Round-trip a request through the monitor loop. The deadline travels with
+    /// it, so a worker never starts an RPC the caller will not wait out.
     async fn request<T>(
         &self,
-        message: impl FnOnce(oneshot::Sender<Result<T>>) -> MonitorMessage,
+        message: impl FnOnce(Caller<T>) -> MonitorMessage,
         what: &str,
     ) -> Result<T> {
-        let (tx, rx) = oneshot::channel();
-        tokio::time::timeout(MONITOR_REQUEST_TIMEOUT, async {
+        let (result_tx, rx) = oneshot::channel();
+        let deadline = Instant::now() + MONITOR_REQUEST_TIMEOUT;
+        tokio::time::timeout_at(tokio::time::Instant::from_std(deadline), async {
             self.tx
-                .send(message(tx))
+                .send(message(Caller {
+                    deadline,
+                    result_tx,
+                }))
                 .await
                 .map_err(|e| anyhow::anyhow!(e))?;
             rx.await.map_err(|e| anyhow::anyhow!(e))?
@@ -1821,7 +1884,7 @@ impl MonitorClient {
 
     pub async fn get_recent_fee_rate(&self, conf_target: u16) -> Result<FeeRate> {
         self.request(
-            |tx| MonitorMessage::GetRecentFeeRate(conf_target, tx),
+            |caller| MonitorMessage::GetRecentFeeRate(conf_target, caller),
             "get_recent_fee_rate",
         )
         .await
@@ -1829,7 +1892,7 @@ impl MonitorClient {
 
     pub async fn broadcast_transaction(&self, transaction: bitcoin::Transaction) -> Result<()> {
         self.request(
-            |tx| MonitorMessage::BroadcastTransaction(transaction, tx),
+            |caller| MonitorMessage::BroadcastTransaction(transaction, caller),
             "broadcast_transaction",
         )
         .await
@@ -1837,7 +1900,7 @@ impl MonitorClient {
 
     pub async fn get_transaction_status(&self, txid: bitcoin::Txid) -> Result<TxStatus> {
         self.request(
-            |tx| MonitorMessage::GetTransactionStatus(txid, tx),
+            |caller| MonitorMessage::GetTransactionStatus(txid, caller),
             "get_transaction_status",
         )
         .await
@@ -1855,13 +1918,13 @@ enum MonitorMessage {
     ),
 
     // Returns an estimated fee rate targeting confirmation within `conf_target` blocks.
-    GetRecentFeeRate(u16, oneshot::Sender<Result<FeeRate>>),
+    GetRecentFeeRate(u16, Caller<FeeRate>),
 
     // Broadcast a transaction to the network.
-    BroadcastTransaction(bitcoin::Transaction, oneshot::Sender<Result<()>>),
+    BroadcastTransaction(bitcoin::Transaction, Caller<()>),
 
     // Query the status of a transaction (confirmed, in mempool, or not found).
-    GetTransactionStatus(bitcoin::Txid, oneshot::Sender<Result<TxStatus>>),
+    GetTransactionStatus(bitcoin::Txid, Caller<TxStatus>),
 }
 
 #[cfg(test)]
@@ -2594,6 +2657,50 @@ mod tests {
         assert!(err.to_string().contains("start height 300000"), "{err}");
     }
 
+    #[tokio::test]
+    async fn checkpoint_at_height_gives_up_on_a_malformed_reply() {
+        let rpc = stub_bitcoind(|_| "<html>not json</html>".to_string()).await;
+
+        let err = tokio::time::timeout(
+            Duration::from_secs(60),
+            Monitor::checkpoint_at_height(&rpc, 300_000),
+        )
+        .await
+        .expect("checkpoint_at_height retried a reply that will never parse")
+        .unwrap_err();
+
+        assert!(err.to_string().contains("start height 300000"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn caller_rpc_only_starts_inside_the_deadline() {
+        let rpc = Arc::new(corepc_client::client_sync::v29::Client::new(
+            "http://127.0.0.1:1",
+        ));
+
+        let (result_tx, _rx) = oneshot::channel::<Result<()>>();
+        let fits = Caller {
+            deadline: Instant::now() + MONITOR_REQUEST_TIMEOUT,
+            result_tx,
+        };
+        assert_eq!(fits.rpc(&rpc, |_| 1).await, Some(1));
+
+        let (result_tx, _rx) = oneshot::channel::<Result<()>>();
+        let too_late = Caller {
+            deadline: Instant::now() + BITCOIND_RPC_BUDGET / 2,
+            result_tx,
+        };
+        assert_eq!(too_late.rpc(&rpc, |_| 1).await, None);
+
+        let (result_tx, rx) = oneshot::channel::<Result<()>>();
+        drop(rx);
+        let gone = Caller {
+            deadline: Instant::now() + MONITOR_REQUEST_TIMEOUT,
+            result_tx,
+        };
+        assert_eq!(gone.rpc(&rpc, |_| 1).await, None);
+    }
+
     #[test]
     fn only_recoverable_transport_errors_are_retried() {
         use jsonrpc::http::minreq_http::Error as TransportError;
@@ -2611,6 +2718,15 @@ mod tests {
         assert!(is_transient_rpc_error(&http(502)));
         assert!(!is_transient_rpc_error(&http(401)));
         assert!(!is_transient_rpc_error(&http(403)));
+
+        // A 200 whose body is not JSON-RPC is a transport error too, and permanent.
+        let malformed =
+            corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Transport(Box::new(
+                TransportError::Minreq(minreq::Error::SerdeJsonError(
+                    serde_json::from_str::<serde_json::Value>("nope").unwrap_err(),
+                )),
+            )));
+        assert!(!is_transient_rpc_error(&malformed));
 
         // Against a port nothing is listening on, so the retryable branch is
         // exercised on a real error rather than a hand-built one.

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -219,6 +219,18 @@ pub struct Monitor {
     trusted_peer_rotation: std::iter::Cycle<std::vec::IntoIter<kyoto::TrustedPeer>>,
 }
 
+/// bitcoind is still catching up (-8 out of range, -28 warming up) or briefly
+/// unreachable; anything else will not resolve by waiting.
+fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
+    match e {
+        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Transport(_)) => true,
+        corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(e)) => {
+            matches!(e.code, -8 | -28)
+        }
+        _ => false,
+    }
+}
+
 /// Offload a blocking Bitcoin Core RPC call to the tokio blocking thread pool.
 async fn btc_rpc_call<F, T>(client: &Arc<corepc_client::client_sync::v29::Client>, f: F) -> T
 where
@@ -254,16 +266,16 @@ impl Monitor {
     async fn resolve_start_checkpoint(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         config: &MonitorConfig,
-    ) -> HashCheckpoint {
-        match config.network {
+    ) -> Result<HashCheckpoint> {
+        Ok(match config.network {
             bitcoin::Network::Bitcoin if config.start_height > 709_631 => {
                 HashCheckpoint::taproot_activation()
             }
             bitcoin::Network::Bitcoin if config.start_height > 481_823 => {
                 HashCheckpoint::segwit_activation()
             }
-            _ => Self::checkpoint_at_height(bitcoind_rpc, config.start_height).await,
-        }
+            _ => Self::checkpoint_at_height(bitcoind_rpc, config.start_height).await?,
+        })
     }
 
     /// Wait for bitcoind to have the block at `height`. A node still in initial
@@ -272,20 +284,25 @@ impl Monitor {
     async fn checkpoint_at_height(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         height: u32,
-    ) -> HashCheckpoint {
+    ) -> Result<HashCheckpoint> {
         const RETRY_DELAY: Duration = Duration::from_secs(2);
         const LOG_INTERVAL: Duration = Duration::from_secs(30);
 
         let mut next_log = Instant::now();
         loop {
             match btc_rpc_call(bitcoind_rpc, move |rpc| rpc.get_block_hash(height as u64)).await {
-                Ok(raw) => match raw.into_model() {
-                    Ok(model) => {
-                        info!("Anchoring Kyoto at start height {height} ({})", model.0);
-                        return HashCheckpoint::new(height, model.0);
-                    }
-                    Err(e) => error!("Failed to parse getblockhash({height}) response: {e}"),
-                },
+                Ok(raw) => {
+                    let model = raw.into_model().map_err(|e| {
+                        anyhow::anyhow!("Failed to parse getblockhash({height}) response: {e}")
+                    })?;
+                    info!("Anchoring Kyoto at start height {height} ({})", model.0);
+                    return Ok(HashCheckpoint::new(height, model.0));
+                }
+                Err(e) if !is_transient_rpc_error(&e) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to fetch the block at start height {height}: {e}"
+                    ));
+                }
                 Err(e) => {
                     if Instant::now() >= next_log {
                         next_log = Instant::now() + LOG_INTERVAL;
@@ -328,7 +345,8 @@ impl Monitor {
             async move {
                 let bitcoind_rpc = Arc::new(bitcoind_rpc);
 
-                let start_checkpoint = Self::resolve_start_checkpoint(&bitcoind_rpc, &config).await;
+                let start_checkpoint =
+                    Self::resolve_start_checkpoint(&bitcoind_rpc, &config).await?;
                 let (kyoto_node, kyoto_client) = Self::build_kyoto_node(&config, start_checkpoint);
                 let trusted_peer_rotation = config.trusted_peers.clone().into_iter().cycle();
 
@@ -764,6 +782,10 @@ impl Monitor {
         conf_target: u16,
         result_tx: oneshot::Sender<Result<FeeRate>>,
     ) {
+        if result_tx.is_closed() {
+            return;
+        }
+
         // ECONOMICAL tracks spot fees more closely than the default
         // CONSERVATIVE, which blends in a long-horizon max.
         let result = btc_rpc_call(&bitcoind_rpc, move |rpc| {
@@ -803,6 +825,12 @@ impl Monitor {
         tx: bitcoin::Transaction,
         result_tx: oneshot::Sender<Result<()>>,
     ) {
+        // The caller stopped waiting, so don't put the transaction on the wire
+        // behind its back.
+        if result_tx.is_closed() {
+            return;
+        }
+
         // Broadcast via the bitcoind RPC, not kyoto's P2P submit_package, which
         // dropped its response or hung under load.
         let txid = tx.compute_txid();
@@ -832,6 +860,10 @@ impl Monitor {
         txid: bitcoin::Txid,
         result_tx: oneshot::Sender<Result<TxStatus>>,
     ) {
+        if result_tx.is_closed() {
+            return;
+        }
+
         let rpc_result = btc_rpc_call(&bitcoind_rpc, move |rpc| {
             rpc.get_raw_transaction_verbose(txid)
         })
@@ -1437,7 +1469,9 @@ mod tests {
             ..MonitorConfig::default()
         };
         assert_eq!(
-            Monitor::resolve_start_checkpoint(&rpc, &above_taproot).await,
+            Monitor::resolve_start_checkpoint(&rpc, &above_taproot)
+                .await
+                .unwrap(),
             HashCheckpoint::taproot_activation(),
         );
 
@@ -1447,77 +1481,93 @@ mod tests {
             ..MonitorConfig::default()
         };
         assert_eq!(
-            Monitor::resolve_start_checkpoint(&rpc, &between_segwit_and_taproot).await,
+            Monitor::resolve_start_checkpoint(&rpc, &between_segwit_and_taproot)
+                .await
+                .unwrap(),
             HashCheckpoint::segwit_activation(),
         );
+    }
+
+    fn rpc_id(req: &str) -> &str {
+        req.rsplit_once("\"id\":")
+            .and_then(|(_, rest)| rest.split([',', '}']).next())
+            .unwrap_or("0")
+    }
+
+    fn rpc_error(req: &str, code: i32, message: &str) -> String {
+        let id = rpc_id(req);
+        format!(r#"{{"result":null,"error":{{"code":{code},"message":"{message}"}},"id":{id}}}"#)
+    }
+
+    fn rpc_ok(req: &str, result: &str) -> String {
+        format!(
+            r#"{{"result":"{result}","error":null,"id":{}}}"#,
+            rpc_id(req)
+        )
+    }
+
+    /// Serve JSON-RPC over loopback, answering each request body with `reply`.
+    async fn stub_bitcoind(
+        reply: impl Fn(&str) -> String + Send + Sync + 'static,
+    ) -> Arc<corepc_client::client_sync::v29::Client> {
+        use tokio::io::AsyncReadExt;
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let reply = Arc::new(reply);
+
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = listener.accept().await {
+                let reply = reply.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    while let Ok(n) = sock.read(&mut buf).await {
+                        if n == 0 {
+                            return;
+                        }
+                        let body = reply(&String::from_utf8_lossy(&buf[..n]));
+                        let resp = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                             Content-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        );
+                        if sock.write_all(resp.as_bytes()).await.is_err() {
+                            return;
+                        }
+                    }
+                });
+            }
+        });
+
+        Arc::new(corepc_client::client_sync::v29::Client::new(&format!(
+            "http://{addr}"
+        )))
     }
 
     #[tokio::test]
     async fn checkpoint_at_height_waits_out_a_lagging_bitcoind() {
         use std::sync::atomic::AtomicU32;
         use std::sync::atomic::Ordering;
-        use tokio::io::AsyncReadExt;
-        use tokio::io::AsyncWriteExt;
 
         const HASH: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
         // `getblockhash` replies "out of range" this many times before the block lands.
         const LAGGING_REPLIES: u32 = 2;
 
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
         let block_hash_calls = Arc::new(AtomicU32::new(0));
-
-        tokio::spawn({
+        let rpc = stub_bitcoind({
             let block_hash_calls = block_hash_calls.clone();
-            async move {
-                while let Ok((mut sock, _)) = listener.accept().await {
-                    let block_hash_calls = block_hash_calls.clone();
-                    tokio::spawn(async move {
-                        let mut buf = [0u8; 4096];
-                        while let Ok(n) = sock.read(&mut buf).await {
-                            if n == 0 {
-                                return;
-                            }
-                            let req = String::from_utf8_lossy(&buf[..n]).into_owned();
-                            let id = req
-                                .rsplit_once("\"id\":")
-                                .and_then(|(_, rest)| rest.split([',', '}']).next())
-                                .unwrap_or("0")
-                                .to_string();
-                            let out_of_range = |id: &str| {
-                                format!(
-                                    r#"{{"result":null,"error":{{"code":-8,"message":"Block height out of range"}},"id":{id}}}"#
-                                )
-                            };
-                            let body = if req.contains("\"getblockhash\"") {
-                                if block_hash_calls.fetch_add(1, Ordering::SeqCst) < LAGGING_REPLIES
-                                {
-                                    out_of_range(&id)
-                                } else {
-                                    format!(r#"{{"result":"{HASH}","error":null,"id":{id}}}"#)
-                                }
-                            } else {
-                                // The progress-logging `getblockchaininfo`; failing it
-                                // exercises the branch that logs without a height.
-                                out_of_range(&id)
-                            };
-                            let resp = format!(
-                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
-                                 Content-Length: {}\r\n\r\n{body}",
-                                body.len()
-                            );
-                            if sock.write_all(resp.as_bytes()).await.is_err() {
-                                return;
-                            }
-                        }
-                    });
+            move |req| {
+                if req.contains("\"getblockhash\"")
+                    && block_hash_calls.fetch_add(1, Ordering::SeqCst) >= LAGGING_REPLIES
+                {
+                    rpc_ok(req, HASH)
+                } else {
+                    rpc_error(req, -8, "Block height out of range")
                 }
             }
-        });
-
-        let rpc = Arc::new(corepc_client::client_sync::v29::Client::new(&format!(
-            "http://{addr}"
-        )));
+        })
+        .await;
 
         // The old "-8 is permanent" path returned a genesis checkpoint on the first reply.
         let checkpoint = tokio::time::timeout(
@@ -1525,11 +1575,27 @@ mod tests {
             Monitor::checkpoint_at_height(&rpc, 300_000),
         )
         .await
-        .expect("checkpoint_at_height gave up instead of waiting for bitcoind");
+        .expect("checkpoint_at_height gave up instead of waiting for bitcoind")
+        .unwrap();
 
         assert_eq!(checkpoint.height, 300_000);
         assert_eq!(checkpoint.hash.to_string(), HASH);
         assert!(block_hash_calls.load(Ordering::SeqCst) > LAGGING_REPLIES);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_at_height_gives_up_on_a_permanent_rpc_error() {
+        let rpc = stub_bitcoind(|req| rpc_error(req, -32601, "Method not found")).await;
+
+        let err = tokio::time::timeout(
+            Duration::from_secs(60),
+            Monitor::checkpoint_at_height(&rpc, 300_000),
+        )
+        .await
+        .expect("checkpoint_at_height retried an error that will never clear")
+        .unwrap_err();
+
+        assert!(err.to_string().contains("start height 300000"), "{err}");
     }
 
     #[test]

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -64,10 +64,9 @@ const MAX_PENDING_DEPOSIT_CHECKS_PER_OUTPOINT: usize = 100;
 // and overflowing it fails calls outright ("Work queue depth exceeded").
 const UTXO_HEIGHT_LOOKUP_CONCURRENCY: usize = 16;
 
-/// Ceiling on a round trip through the monitor loop: corepc's 60s transport
-/// timeout plus the longest stretch the loop is alive but not receiving (a
-/// Kyoto restart, up to 35s), with margin. It can only fire on a request the
-/// loop never dispatched, which the workers' `is_closed` guards then drop.
+/// Bound on a round trip through the monitor loop, above corepc's 60s RPC
+/// timeout plus a Kyoto restart gap, so it only fires on a request the loop
+/// never dispatched; the workers' `is_closed` checks then drop that request.
 const MONITOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 fn next_restart_delay() -> Duration {
@@ -293,9 +292,7 @@ pub struct Monitor {
 }
 
 /// bitcoind is still catching up (-8 out of range, -28 warming up), overloaded,
-/// or briefly unreachable; anything else will not clear by waiting. Transport
-/// blips are safe to wait out because `verify_bitcoind_network` already proved
-/// a reachable node with working credentials before the loop starts.
+/// or briefly unreachable; anything else will not clear by waiting.
 fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
     use jsonrpc::http::minreq_http::Error as TransportError;
 
@@ -305,9 +302,8 @@ fn is_transient_rpc_error(e: &corepc_client::client_sync::Error) -> bool {
     match e {
         jsonrpc::error::Error::Rpc(e) => matches!(e.code, -8 | -28),
         jsonrpc::error::Error::Transport(e) => match e.downcast_ref::<TransportError>() {
-            // A refused connection and an HTTP error status arrive alike. A 5xx
-            // is the server's problem (503: bitcoind's RPC work queue is full);
-            // a 4xx is ours: wrong credentials or an RPC whitelist.
+            // A refused connection and an HTTP error status arrive alike; 5xx
+            // clears by waiting (503 is a full RPC work queue), 4xx never will.
             Some(TransportError::Http(e)) => e.status_code >= 500,
             Some(_) => true,
             None => false,
@@ -651,20 +647,19 @@ impl Monitor {
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         config: &MonitorConfig,
     ) -> Result<HashCheckpoint> {
-        Ok(match config.network {
+        match config.network {
             bitcoin::Network::Bitcoin if config.start_height > 709_631 => {
-                HashCheckpoint::taproot_activation()
+                Ok(HashCheckpoint::taproot_activation())
             }
             bitcoin::Network::Bitcoin if config.start_height > 481_823 => {
-                HashCheckpoint::segwit_activation()
+                Ok(HashCheckpoint::segwit_activation())
             }
-            _ => Self::checkpoint_at_height(bitcoind_rpc, config.start_height).await?,
-        })
+            _ => Self::checkpoint_at_height(bitcoind_rpc, config.start_height).await,
+        }
     }
 
     /// Wait for bitcoind to have the block at `height`. A node still in initial
-    /// block download reports the same "out of range" error as a height past the
-    /// tip, so giving up would anchor Kyoto far below `height` permanently.
+    /// block download reports it "out of range" just like a height past the tip.
     async fn checkpoint_at_height(
         bitcoind_rpc: &Arc<corepc_client::client_sync::v29::Client>,
         height: u32,
@@ -682,12 +677,7 @@ impl Monitor {
                     info!("Anchoring Kyoto at start height {height} ({})", model.0);
                     return Ok(HashCheckpoint::new(height, model.0));
                 }
-                Err(e) if !is_transient_rpc_error(&e) => {
-                    return Err(anyhow::anyhow!(
-                        "Failed to fetch the block at start height {height}: {e}"
-                    ));
-                }
-                Err(e) => {
+                Err(e) if is_transient_rpc_error(&e) => {
                     if Instant::now() >= next_log {
                         next_log = Instant::now() + LOG_INTERVAL;
                         match Self::bitcoind_height(bitcoind_rpc).await {
@@ -697,6 +687,11 @@ impl Monitor {
                             None => warn!("Waiting for a block at start height {height}: {e}"),
                         }
                     }
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to fetch the block at start height {height}: {e}"
+                    ));
                 }
             }
             tokio::time::sleep(RETRY_DELAY).await;
@@ -1240,8 +1235,7 @@ impl Monitor {
         tx: bitcoin::Transaction,
         result_tx: oneshot::Sender<Result<()>>,
     ) {
-        // The caller stopped waiting, so don't put the transaction on the wire
-        // behind its back.
+        // The caller gave up; don't broadcast behind its back.
         if result_tx.is_closed() {
             return;
         }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -792,6 +792,13 @@ impl Hashi {
                 self.config.bitcoin_rpc_auth(),
             )
             .trusted_peers(self.config.bitcoin_trusted_peers()?)
+            .data_dir(
+                self.config
+                    .db
+                    .as_deref()
+                    .expect("Db path is not set")
+                    .join("btc-monitor"),
+            )
             .build();
         let (client, service) = crate::btc_monitor::monitor::Monitor::run_with_tracker(
             monitor_config,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -792,13 +792,6 @@ impl Hashi {
                 self.config.bitcoin_rpc_auth(),
             )
             .trusted_peers(self.config.bitcoin_trusted_peers()?)
-            .data_dir(
-                self.config
-                    .db
-                    .as_deref()
-                    .expect("Db path is not set")
-                    .join("btc-monitor"),
-            )
             .build();
         let (client, service) = crate::btc_monitor::monitor::Monitor::run_with_tracker(
             monitor_config,

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -725,13 +725,6 @@ impl Hashi {
                 self.config.bitcoin_rpc_auth(),
             )
             .trusted_peers(self.config.bitcoin_trusted_peers()?)
-            .data_dir(
-                self.config
-                    .db
-                    .as_deref()
-                    .expect("Db path is not set")
-                    .join("btc-monitor"),
-            )
             .build();
         let (client, service) =
             crate::btc_monitor::monitor::Monitor::run(monitor_config, self.metrics.clone())

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -244,7 +244,7 @@ bitcoin-trusted-peers = ["127.0.0.1:38333"]       # host:port (port is mandatory
 UserPass = ["YOUR_RPC_USER", "YOUR_STRONG_RPC_PASSWORD"]
 ```
 
-> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `300000` on Signet (below the Testnet deployment, so the light client anchors under the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor.
+> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `300000` on Signet (below the Testnet deployment, so the light client anchors under the first bridge deposit) and a post-Taproot height on Mainnet; override it only if you need a different anchor.
 
 **Verify your node:**
 
@@ -1294,15 +1294,15 @@ Lost connectivity to Bitcoin peers after 15 consecutive failures. Restarting Kyo
 
 ---
 
-**Symptom:** `hashi_kyoto_best_height` sits far below your Bitcoin node's height, restarting from near zero after each light client restart. The log shows:
+**Symptom:** `hashi_kyoto_best_height` stays at `0` and the log repeats:
 
 ```
-Start height 800000 is beyond bitcoind's tip; anchoring Kyoto at genesis
+Waiting for bitcoind to reach start height 300000; it is at 214173
 ```
 
-**Likely cause:** the light client could not read a block at `bitcoin-start-height`, so it anchored at genesis and replays the whole chain on every rebuild. Either the height is past your node's tip, or the node is still syncing. No deposits are missed; genesis is the conservative fallback.
+**Likely cause:** the light client anchors at `bitcoin-start-height` and cannot start until your Bitcoin node has that block. Either the node is still syncing, or the height is past its tip.
 
-**Fix:** leave `bitcoin-start-height` unset to take the per-network default, or set it at or below your first relevant deposit, as noted in [1.5](#15-bitcoin-node). If your Bitcoin node is still syncing, restart Hashi once it passes that height — the anchor is resolved once at startup.
+**Fix:** none needed while the node is syncing — the height in the log climbs, and Hashi anchors and carries on by itself once it arrives, with no restart. If the height is not climbing, set `bitcoin-start-height` at or below your node's tip, as noted in [1.5](#15-bitcoin-node).
 
 ---
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -244,7 +244,7 @@ bitcoin-trusted-peers = ["127.0.0.1:38333"]       # host:port (port is mandatory
 UserPass = ["YOUR_RPC_USER", "YOUR_STRONG_RPC_PASSWORD"]
 ```
 
-> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `300000` on Signet (below the Testnet deployment, so the light client anchors under the first bridge deposit instead of re-syncing from genesis) and a post-Taproot height on Mainnet; override it only if you need a different anchor.
+> Notes: ports `38332` (RPC) / `38333` (P2P) are Bitcoin Core **Signet** defaults. Hashi does not default to them (its default `bitcoin-rpc` is `http://localhost:8332`), so set them explicitly. The light client runs in *whitelist-only* mode and connects **only** to `bitcoin-trusted-peers`, so that list must be correct and reachable. `bitcoin-start-height` defaults per network — `300000` on Signet (below the Testnet deployment, so the light client anchors under the first bridge deposit) and a post-Taproot height on Mainnet; override it only if you need a different anchor.
 
 **Verify your node:**
 
@@ -1304,15 +1304,15 @@ Lost connectivity to Bitcoin peers after 15 consecutive failures. Restarting Kyo
 
 ---
 
-**Symptom:** `hashi_kyoto_best_height` sits far below your Bitcoin node's height, restarting from near zero after each light client restart. The log shows:
+**Symptom:** `hashi_kyoto_best_height` stays at `0` and the log repeats:
 
 ```
-Start height 800000 is beyond bitcoind's tip; anchoring Kyoto at genesis
+Waiting for bitcoind to reach start height 300000; it is at 214173
 ```
 
-**Likely cause:** the light client could not read a block at `bitcoin-start-height`, so it anchored at genesis and replays the whole chain on every rebuild. Either the height is past your node's tip, or the node is still syncing. No deposits are missed; genesis is the conservative fallback.
+**Likely cause:** the light client anchors at `bitcoin-start-height` and cannot start until your Bitcoin node has that block. Either the node is still syncing, or the height is past its tip.
 
-**Fix:** leave `bitcoin-start-height` unset to take the per-network default, or set it at or below your first relevant deposit, as noted in [1.5](#15-bitcoin-node). If your Bitcoin node is still syncing, restart Hashi once it passes that height — the anchor is resolved once at startup.
+**Fix:** none needed while the node is syncing — the height in the log climbs, and Hashi anchors and carries on by itself once it arrives, with no restart. If the height is not climbing, set `bitcoin-start-height` at or below your node's tip, as noted in [1.5](#15-bitcoin-node).
 
 ---
 


### PR DESCRIPTION
## Summary

A node started next to a bitcoind that is still syncing anchored Kyoto at genesis for the life of the process: `getblockhash` returns `-8` for any height above the node's current tip, and we treated that as permanent. Every Kyoto rebuild then replayed the whole chain. The anchor is a floor the light client can't see below, so it can never be raised later; the right move is to wait for the block. Fixes #963.

The unused Kyoto `data_dir` cleanup that used to ride along here is now its own PR, #1090.

## Changes

- `checkpoint_at_height` retries until bitcoind has the block, logging its height every 30s. The `-8` special case and the genesis fallbacks are gone.
- Only errors that can clear are retried: `-8`, `-28`, connection-level I/O failures, HTTP 5xx. Anything else, including a reply that does not parse, fails the monitor, which exits the node.
- `default_start_height` is `0` for networks without a deployment anchor. The e2e harness needs this: regtest with no start height took the `800000` default.
- Each `MonitorClient` call carries one deadline. The caller times out on it, and the worker starts the bitcoind RPC only if corepc's fixed timeout, plus a margin, still fits before it, checked on the blocking thread. A caller that times out never has an RPC in flight; a request that can no longer fit gets an immediate error.
- The workspace declares `jsonrpc/minreq_http`, which the retry predicate names.
- Tests for the wait, a permanent RPC error, a malformed reply, the transport predicate against real errors, and the deadline check. Runbook §11 rewritten for the new log line.
