### PR TITLE
[guardian] add a guardian-tools image for the CI ceremony binaries

### DIFF
--- a/docker/hashi-guardian-tools/Containerfile
+++ b/docker/hashi-guardian-tools/Containerfile
@@ -1,0 +1,100 @@
+# syntax=docker/dockerfile:1
+
+# The guardian binaries the deploy pipeline's CI ceremony runs, built once here
+# instead of three times from a cold cargo cache on GitHub runners
+# (sui-operations scripts/hashi/{guardian-ceremony,bootstrap-guardian}.sh).
+#
+# Both carry `non-enclave-dev`: the guardian emits a mock attestation document
+# and init accepts one, which is what lets a runner-local ceremony verify
+# against dev stacks whose EIF sets eif-features=non-enclave-dev. That is the
+# ONLY thing this image is for — the `-dev` suffix on the packaged names is
+# deliberate, so these can never be mistaken for enclave-grade builds in the
+# bucket they share with the real hashi CLI.
+#
+# Deliberately separate from docker/hashi/Containerfile rather than another
+# stage in it. Cargo unifies features per invocation, so building these
+# alongside the `hashi` CLI would silently ship a CLI whose attestation
+# verification is a no-op. Separate images make that impossible.
+#
+# The sibling docker/hashi-guardian/Containerfile is the Nitro enclave build
+# and produces an EIF, not a runnable binary — do not conflate the two.
+
+FROM stagex/pallet-rust@sha256:abe9b95c93a5afa271f69fcd5eb18c8cd405fe5df6491a63c9418e3a170573dc AS pallet-rust
+FROM stagex/busybox@sha256:3d128909dbc8e7b6c4b8c3c31f4583f01a307907ea179934bb42c4ef056c7efd AS busybox
+FROM stagex/core-filesystem@sha256:da28831927652291b0fa573092fd41c8c96ca181ea224df7bff40e1833c3db13 AS core-filesystem
+
+#
+# Deps stage: fetch and compile external dependencies (cached until Cargo.toml/Cargo.lock change)
+#
+FROM pallet-rust AS deps
+
+# Shell needed by cc-based build scripts (blst, ring, etc.)
+COPY --from=busybox . /
+
+# Copy only manifests. hashi-guardian-init pulls in hashi and hashi-guardian,
+# so all four members are needed for the workspace glob to resolve.
+COPY Cargo.toml Cargo.lock /src/
+COPY crates/hashi/Cargo.toml /src/crates/hashi/Cargo.toml
+COPY crates/hashi-types/Cargo.toml /src/crates/hashi-types/Cargo.toml
+COPY crates/hashi-guardian/Cargo.toml /src/crates/hashi-guardian/Cargo.toml
+COPY crates/hashi-guardian-init/Cargo.toml /src/crates/hashi-guardian-init/Cargo.toml
+
+WORKDIR /src
+
+# Create stub source files so cargo can resolve and compile all external deps
+RUN mkdir -p crates/hashi/src \
+ && echo 'fn main(){}' > crates/hashi/src/main.rs \
+ && touch crates/hashi/src/lib.rs \
+ && mkdir -p crates/hashi-types/src \
+ && touch crates/hashi-types/src/lib.rs \
+ && mkdir -p crates/hashi-guardian/src \
+ && echo 'fn main(){}' > crates/hashi-guardian/src/main.rs \
+ && touch crates/hashi-guardian/src/lib.rs \
+ && mkdir -p crates/hashi-guardian-init/src \
+ && echo 'fn main(){}' > crates/hashi-guardian-init/src/main.rs
+
+ENV TARGET=x86_64-unknown-linux-musl
+ENV OPENSSL_STATIC=true
+ENV CARGO_INCREMENTAL=0
+ENV RUSTFLAGS="-C target-feature=+crt-static -C relocation-model=static -C target-cpu=x86-64"
+
+# One invocation for both binaries: they want the same feature, so unification
+# is intended here and the shared tree compiles once. Features are named
+# per-package because more than one package is selected. ENV rather than ARG so
+# the build stage below inherits it — ARG scope is per-stage.
+ENV CARGO_BUILD_ARGS="\
+    -p hashi-guardian -p hashi-guardian-init \
+    --features hashi-guardian/non-enclave-dev,hashi-guardian-init/non-enclave-dev \
+    --bin hashi-guardian --bin hashi-guardian-init"
+
+RUN cargo fetch
+RUN --network=none cargo build --release --frozen --target "$TARGET" ${CARGO_BUILD_ARGS}
+
+#
+# Build stage: compile with real source (only local crates recompile)
+#
+FROM deps AS build
+
+ARG GIT_REVISION=unknown
+ENV GIT_REVISION=${GIT_REVISION}
+
+COPY crates/hashi /src/crates/hashi
+COPY crates/hashi-types /src/crates/hashi-types
+COPY crates/hashi-guardian /src/crates/hashi-guardian
+COPY crates/hashi-guardian-init /src/crates/hashi-guardian-init
+
+# Touch source files to invalidate cargo's fingerprint cache for local crates
+RUN find crates/ -name "*.rs" -exec touch {} +
+
+RUN --network=none cargo build --release --frozen --target "$TARGET" ${CARGO_BUILD_ARGS}
+
+#
+# Package stage: nothing runs this image — it exists so the mp3 binary uploader
+# can extract these two paths to gs://mysten-hashi-binaries/<sha>/.
+#
+FROM core-filesystem
+# CA bundle for the AWS SDK's S3 TLS verification and Sui RPC; core-filesystem
+# ships none.
+COPY --from=build /etc/ssl/cert.pem /etc/ssl/cert.pem
+COPY --from=build /src/target/x86_64-unknown-linux-musl/release/hashi-guardian /opt/hashi/bin/hashi-guardian-dev
+COPY --from=build /src/target/x86_64-unknown-linux-musl/release/hashi-guardian-init /opt/hashi/bin/hashi-guardian-init-dev

--- a/docker/hashi-guardian-tools/build.sh
+++ b/docker/hashi-guardian-tools/build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright (c), Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Builds the non-enclave-dev guardian binaries the deploy pipeline's CI
+# ceremony downloads. Local parity with what mp3 publishes to
+# gs://mysten-hashi-binaries/<sha>/.
+#
+# Usage:
+#   bash docker/hashi-guardian-tools/build.sh
+#   bash docker/hashi-guardian-tools/build.sh --no-cache
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+IMAGE_NAME="${IMAGE_NAME:-hashi-guardian-tools}"
+GIT_REVISION="${GIT_REVISION:-$(git -C "$REPO_ROOT" describe --always --exclude '*' --dirty --abbrev=8)}"
+IMAGE_TAG="${IMAGE_TAG:-${GIT_REVISION}}"
+OUT_DIR="${OUT_DIR:-${REPO_ROOT}/out}"
+
+EXTRA_ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --no-cache) EXTRA_ARGS+=("--no-cache") ;;
+        *) echo "Unknown argument: $arg"; exit 1 ;;
+    esac
+done
+
+mkdir -p "${OUT_DIR}"
+
+echo "Building ${IMAGE_NAME}:${IMAGE_TAG} (revision: ${GIT_REVISION})"
+
+docker build \
+    -f "${SCRIPT_DIR}/Containerfile" \
+    --platform linux/amd64 \
+    --build-arg "GIT_REVISION=${GIT_REVISION}" \
+    --provenance=false \
+    ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
+    -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+    -t "${IMAGE_NAME}:latest" \
+    "${REPO_ROOT}"
+
+echo "Successfully built ${IMAGE_NAME}:${IMAGE_TAG}"
+
+CID=$(docker create "${IMAGE_NAME}:${IMAGE_TAG}")
+trap 'docker rm "${CID}" > /dev/null' EXIT
+for bin in hashi-guardian-dev hashi-guardian-init-dev; do
+    docker cp "${CID}:/opt/hashi/bin/${bin}" "${OUT_DIR}/${bin}"
+    echo "${bin}: ${OUT_DIR}/${bin} (SHA-256 $(sha256sum "${OUT_DIR}/${bin}" | awk '{print $1}'))"
+done


### PR DESCRIPTION
## Summary

sui-operations' deploy pipeline builds `hashi-guardian` and `hashi-guardian-init` from scratch in two separate jobs, on 2-vCPU runners with no cargo cache — about 45 minutes per full redeploy for a tree that includes blst, fastcrypto, sequoia-openpgp and kyoto. This packages both so mp3 can build them once, on its warm cache, and publish them to `gs://mysten-hashi-binaries` alongside the hashi CLI.

Both are `non-enclave-dev` builds: the guardian emits a mock attestation document and init accepts one, which is what lets a runner-local ceremony verify against dev stacks whose EIF sets `eif-features=non-enclave-dev`. They are packaged as `hashi-guardian-dev` and `hashi-guardian-init-dev` so that can never be mistaken for an enclave-grade build in the bucket they share with the CLI.

Deliberately its own Containerfile rather than another stage in `docker/hashi/Containerfile`. Cargo unifies features per invocation, so building these next to the hashi CLI would silently ship a CLI whose attestation verification is a no-op — separate images make that impossible.

Verified on the built artifacts: `hashi-guardian-dev` contains the mock attestation document and `hashi-guardian-init-dev` the disabled-verification warning, while `cargo tree -f '{p} :: {f}'` shows hashi-types resolving *without* `non-enclave-dev` under the CLI's own selection. Both are static musl x86-64 and `--help` runs.

## Changes

- `docker/hashi-guardian-tools/Containerfile` — deps/build/package stages mirroring `docker/hashi-guardian-k8s`, emitting both binaries under `/opt/hashi/bin`
- `docker/hashi-guardian-tools/build.sh` — local build helper

Consumed by MystenLabs/sui-operations#8628, which needs this merged and one image build first.
