### PR TITLE
[guardian] Gate the enclave workspace resolve in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,19 @@ jobs:
 
       - run: make is-dirty
 
+  # guardian-enclave-lock resolves on this runner, where #960's failure does not
+  # reproduce. Resolve in the enclave's own toolchain instead; it fails before
+  # compiling anything, so this costs a minute rather than an EIF build.
+  guardian-enclave-resolve:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Resolve the enclave workspace
+        run: make -C docker/hashi-guardian resolve-check
+
   docs:
     runs-on: ubuntu-latest
 

--- a/docker/hashi-guardian/Containerfile
+++ b/docker/hashi-guardian/Containerfile
@@ -124,23 +124,10 @@ COPY --from=core-llvm . /
 COPY --from=core-libffi . /
 COPY --from=core-gcc . /
 COPY --from=user-cpio . /
-COPY --from=kernel /bzImage .
-COPY --from=kernel /kernel.config .
 
-FROM base AS build
-ARG BUCKET_NAME
-ARG AWS_REGION=us-east-1
-ARG GIT_REVISION
-# Extra cargo features for the guardian build. Empty (the default) is the real
-# enclave build — leave it empty for anything whose PCR0 must match provenance.
-# Dev deploys pass `non-enclave-dev` so a runner-local mock ceremony verifies.
-ARG FEATURES=""
-# Enclave boot mode, baked into run.sh below (see guardian main.rs). Empty (the
-# default) => withdraw; "true" => ceremony. A ceremony enclave is intentionally a
-# distinct, separately-attested EIF with its own PCR0.
-ARG CEREMONY_MODE=""
-RUN [ -n "$GIT_REVISION" ] || { echo "GIT_REVISION build-arg must be set"; exit 1; }
-ENV GIT_REVISION=${GIT_REVISION}
+# The pruned workspace the enclave compiles, split out so `resolve` below gates
+# this exact tree. The kernel moves to `build` so resolving does not wait on it.
+FROM base AS workspace
 COPY crates /crates
 COPY Cargo.toml /Cargo.toml
 # Keep test-only code out of the enclave build. `-p hashi-guardian` does not
@@ -163,6 +150,29 @@ RUN rm -rf /crates/e2e-tests /crates/hashi-monitor \
 # the workspace resolves to. Regenerate with `make enclave-lock` and keep it in
 # sync; CI (guardian-enclave-lock) fails if it drifts.
 COPY docker/hashi-guardian/enclave-Cargo.lock /Cargo.lock
+
+# Resolution only: where a dependency this cargo cannot resolve fails (#960),
+# reached in a minute instead of the hour a full EIF takes.
+FROM workspace AS resolve
+WORKDIR /
+RUN cargo metadata --locked --format-version 1 >/dev/null
+
+FROM workspace AS build
+COPY --from=kernel /bzImage /bzImage
+COPY --from=kernel /kernel.config /kernel.config
+ARG BUCKET_NAME
+ARG AWS_REGION=us-east-1
+ARG GIT_REVISION
+# Extra cargo features for the guardian build. Empty (the default) is the real
+# enclave build — leave it empty for anything whose PCR0 must match provenance.
+# Dev deploys pass `non-enclave-dev` so a runner-local mock ceremony verifies.
+ARG FEATURES=""
+# Enclave boot mode, baked into run.sh below (see guardian main.rs). Empty (the
+# default) => withdraw; "true" => ceremony. A ceremony enclave is intentionally a
+# distinct, separately-attested EIF with its own PCR0.
+ARG CEREMONY_MODE=""
+RUN [ -n "$GIT_REVISION" ] || { echo "GIT_REVISION build-arg must be set"; exit 1; }
+ENV GIT_REVISION=${GIT_REVISION}
 
 WORKDIR /
 ENV OPENSSL_STATIC=true

--- a/docker/hashi-guardian/Makefile
+++ b/docker/hashi-guardian/Makefile
@@ -54,6 +54,17 @@ run-debug: out/nitro.eif
 enclave-lock:
 	./scripts/gen-enclave-lock.sh
 
+# Reproduce the resolution the EIF build performs, without building it.
+.PHONY: resolve-check
+resolve-check:
+	docker build \
+		--pull \
+		--progress=plain \
+		--platform linux/amd64 \
+		--target resolve \
+		-f Containerfile \
+		../..
+
 .PHONY: clean
 clean:
 	rm -rf out/


### PR DESCRIPTION
## Summary

`guardian-enclave-lock` regenerates the lock on a GitHub runner, where resolution succeeds — so it would not have caught #960, whose failure was specific to the enclave's own cargo. This adds a CI job that resolves the pruned workspace in that toolchain instead. It fails before compiling anything, so it costs a minute rather than an EIF build.

## Changes

- Split the Containerfile's pruned tree into a `workspace` stage, with a `resolve` stage on top that only runs `cargo metadata --locked`.
- Moved the kernel copy from `base` into `build`, so resolving doesn't wait on the kernel.
- Added `make -C docker/hashi-guardian resolve-check` and a `guardian-enclave-resolve` CI job that runs it.

PCR0 is unaffected — `eif_build` still measures the same kernel, ramdisk and cmdline.
