### PR TITLE
[metrics] widen withdrawal_duration_seconds histogram buckets

### DIFF
--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -184,6 +184,12 @@ const LATENCY_SEC_BUCKETS: &[f64] = &[
     300., 600., 1200.,
 ];
 
+// Hours-scale: sign_to_confirm waits on Bitcoin confirmations, unlike LATENCY_SEC_BUCKETS.
+const WITHDRAWAL_PHASE_SEC_BUCKETS: &[f64] = &[
+    10., 30., 60., 120., 300., 600., 1200., 1800., 2700., 3600., 5400., 7200., 10800., 14400.,
+    21600., 32400., 43200., 64800., 86400., 172800.,
+];
+
 pub const MPC_LABEL_DKG: &str = "dkg";
 pub const MPC_LABEL_KEY_ROTATION: &str = "key_rotation";
 pub const MPC_LABEL_NONCE_GENERATION: &str = "nonce_generation";
@@ -1058,7 +1064,7 @@ impl Metrics {
                 "hashi_withdrawal_duration_seconds",
                 "Duration of withdrawal lifecycle phases.",
                 &["phase"],
-                LATENCY_SEC_BUCKETS.to_vec(),
+                WITHDRAWAL_PHASE_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Summary

- `hashi_withdrawal_duration_seconds` reused `LATENCY_SEC_BUCKETS`, which stops at 1200s
- `sign_to_confirm` runs to hours, so 1355 of 1367 observations (99.1%) landed in the overflow bucket
- `histogram_quantile` clamps to the top finite bucket, so p50 and p95 both read a flat 1200s — panel said 20min, real mean was 6.8h (7d) and 20h (worst 6h window)

## Changes

- Add `WITHDRAWAL_PHASE_SEC_BUCKETS`: 20 buckets, 10s–48h
- Point `hashi_withdrawal_duration_seconds` at it
- `LATENCY_SEC_BUCKETS` untouched — still correct for the RPC paths
- `pick_to_sign` (p95 82s) was in range already, unaffected