### PR TITLE
test(e2e): run every e2e_flow test against an upgraded chain

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -133,9 +133,20 @@ mod tests {
             .ok_or_else(|| anyhow!("transaction effects BCS bytes were not returned"))
     }
 
+    /// Boot a network in the state a deployed chain actually runs in: the v1
+    /// bytecode snapshot is published first, then upgraded to the current
+    /// source through the full governance flow. Every test in this module
+    /// therefore exercises the post-upgrade configuration — package history
+    /// {v1, vN}, routing at the upgraded package id, types defined at the v1
+    /// address — not a fresh single-version publish no real network is in.
+    /// Fresh-publish coverage lives in the genesis-specific harnesses
+    /// (`upgrade_tests`, `snapshot_signing_tests` manage their own boots).
     async fn setup_test_networks(builder: TestNetworksBuilder) -> Result<TestNetworks> {
         info!("Setting up test networks...");
-        let networks = builder.build().await?;
+        let mut networks = builder
+            .with_v1_from_snapshot(crate::snapshot::default_snapshot_dir()?)
+            .build()
+            .await?;
 
         info!("Test networks initialized");
         info!("  - Sui RPC: {}", networks.sui_network.rpc_url);
@@ -147,6 +158,16 @@ mod tests {
             .wait_for_mpc_key(Duration::from_secs(60))
             .await?;
         info!("MPC key ready");
+
+        info!("Upgrading the chain to the current source...");
+        let new_package_id = crate::upgrade_flow::execute_full_upgrade(&mut networks).await?;
+        crate::upgrade_flow::wait_for_package_convergence(
+            &networks,
+            new_package_id,
+            Duration::from_secs(30),
+        )
+        .await?;
+        info!("Chain upgraded; tests run against the post-upgrade state");
 
         Ok(networks)
     }

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -133,20 +133,13 @@ mod tests {
             .ok_or_else(|| anyhow!("transaction effects BCS bytes were not returned"))
     }
 
-    /// Boot a network in the state a deployed chain actually runs in: the v1
-    /// bytecode snapshot is published first, then upgraded to the current
-    /// source through the full governance flow. Every test in this module
-    /// therefore exercises the post-upgrade configuration — package history
-    /// {v1, vN}, routing at the upgraded package id, types defined at the v1
-    /// address — not a fresh single-version publish no real network is in.
-    /// Fresh-publish coverage lives in the genesis-specific harnesses
-    /// (`upgrade_tests`, `snapshot_signing_tests` manage their own boots).
+    /// The builder's default boot already publishes the v1 bytecode snapshot
+    /// and upgrades to the current source, so every test in this module
+    /// exercises the post-upgrade configuration a real network is in — not a
+    /// fresh single-version publish.
     async fn setup_test_networks(builder: TestNetworksBuilder) -> Result<TestNetworks> {
         info!("Setting up test networks...");
-        let mut networks = builder
-            .with_v1_from_snapshot(crate::snapshot::default_snapshot_dir()?)
-            .build()
-            .await?;
+        let networks = builder.build().await?;
 
         info!("Test networks initialized");
         info!("  - Sui RPC: {}", networks.sui_network.rpc_url);
@@ -158,16 +151,6 @@ mod tests {
             .wait_for_mpc_key(Duration::from_secs(60))
             .await?;
         info!("MPC key ready");
-
-        info!("Upgrading the chain to the current source...");
-        let new_package_id = crate::upgrade_flow::execute_full_upgrade(&mut networks).await?;
-        crate::upgrade_flow::wait_for_package_convergence(
-            &networks,
-            new_package_id,
-            Duration::from_secs(30),
-        )
-        .await?;
-        info!("Chain upgraded; tests run against the post-upgrade state");
 
         Ok(networks)
     }

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -329,6 +329,20 @@ impl HashiNetwork {
             .iter_mut()
             .find(|n| n.service.is_none())
             .ok_or_else(|| anyhow::anyhow!("no pending nodes to start"))?;
+        // The node's ports were picked (and released) when the network was
+        // built, and have sat unbound through everything the test did since —
+        // minutes, under the upgraded-chain boot — so on a busy CI runner
+        // another process may hold them by now, and the gRPC server panics on
+        // bind. Re-pick immediately before the registration that publishes the
+        // endpoint on-chain, shrinking the reservation window to milliseconds.
+        let listen_addr =
+            std::net::SocketAddr::from(([127, 0, 0, 1], hashi::config::get_available_port()));
+        node.config.listen_address = Some(listen_addr);
+        node.config.endpoint_url = Some(format!("https://{listen_addr}"));
+        node.config.metrics_http_address = Some(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            hashi::config::get_available_port(),
+        )));
         register_onchain(client, &node.config).await?;
         node.start().await?;
         Ok(())

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -136,10 +136,16 @@ pub struct TestNetworksBuilder {
     external_guardian: Option<ExternalGuardian>,
     /// When set, bootstrap the local net by publishing the deployed **bytecode
     /// snapshot** in this directory as v1, instead of a fresh source build of
-    /// `packages/hashi`. Enables the "deployed v1 → current source" upgrade
-    /// e2e test. `None` (default) keeps the source-publish behavior. See
-    /// [`crate::snapshot`].
+    /// `packages/hashi`. `None` defaults to the checked-in testnet snapshot
+    /// when the auto-upgrade below is on, and to a fresh source publish when
+    /// it is off. See [`crate::snapshot`].
     v1_snapshot_dir: Option<std::path::PathBuf>,
+    /// When true (the default), `build()` publishes v1 (see `v1_snapshot_dir`)
+    /// and then runs the full governance upgrade to the current source before
+    /// returning, so every builder user gets a chain in the post-upgrade state
+    /// a real network is in. Opt out via [`Self::without_upgrade`] when v1-only
+    /// is the point (snapshot signing) or the test drives its own upgrade.
+    upgrade_to_current_source: bool,
 }
 
 impl TestNetworksBuilder {
@@ -159,7 +165,16 @@ impl TestNetworksBuilder {
             onchain_config_overrides,
             external_guardian: None,
             v1_snapshot_dir: None,
+            upgrade_to_current_source: true,
         }
+    }
+
+    /// Skip the default publish-v1-then-upgrade-to-current-source boot: the
+    /// chain stays at whatever v1 was published (snapshot or fresh source).
+    /// For tests where v1-only is the point, or that drive their own upgrade.
+    pub fn without_upgrade(mut self) -> Self {
+        self.upgrade_to_current_source = false;
+        self
     }
 
     /// Bootstrap the local net by publishing the deployed **bytecode snapshot**
@@ -348,7 +363,15 @@ impl TestNetworksBuilder {
             > 0;
 
         let publisher_key = sui_network.user_keys.first().unwrap();
-        let publish_output = match &self.v1_snapshot_dir {
+        // Under the default auto-upgrade boot, v1 defaults to the checked-in
+        // snapshot so the upgrade below is a real "deployed bytecode ->
+        // current source" transition.
+        let v1_snapshot_dir = match &self.v1_snapshot_dir {
+            Some(dir) => Some(dir.clone()),
+            None if self.upgrade_to_current_source => Some(snapshot::default_snapshot_dir()?),
+            None => None,
+        };
+        let publish_output = match &v1_snapshot_dir {
             Some(snapshot_dir) => {
                 tracing::info!(
                     dir = %snapshot_dir.display(),
@@ -405,6 +428,24 @@ impl TestNetworksBuilder {
 
         if nodes_started && test_networks.guardian_harness.is_some() {
             finalize_guardian_harness(&mut test_networks).await?;
+        }
+
+        // Last, once the network is fully settled: upgrade to the current
+        // source so callers receive a chain in the post-upgrade state a real
+        // network is in (package history {v1, vN}, routing at the upgraded
+        // package id, types defined at the v1 address). Manual-bootstrap mode
+        // (0 active nodes) has no committee to vote the upgrade; the chain
+        // stays at v1 for the operator to upgrade through governance.
+        if nodes_started && self.upgrade_to_current_source {
+            tracing::info!("upgrading the chain to the current source...");
+            let new_package_id = upgrade_flow::execute_full_upgrade(&mut test_networks).await?;
+            upgrade_flow::wait_for_package_convergence(
+                &test_networks,
+                new_package_id,
+                std::time::Duration::from_secs(30),
+            )
+            .await?;
+            tracing::info!("chain upgraded; the network runs the post-upgrade state");
         }
 
         Ok(test_networks)

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -40,17 +40,28 @@ pub async fn wait_for_package_convergence(
 ) -> Result<()> {
     tracing::info!("waiting for all nodes to detect the new package version...");
     let wait_start = std::time::Instant::now();
+    // Only nodes that are actually running: a pending member (the key-rotation
+    // tests hold one back to start mid-test) has no Hashi instance yet — its
+    // accessor panics — and when it does boot, its fresh scrape sees the
+    // post-upgrade chain, so there is nothing to converge.
     loop {
         let all_updated = networks
             .hashi_network
             .nodes()
             .iter()
+            .filter(|node| node.is_running())
             .all(|node| node.hashi().onchain_state().package_id() == Some(package_id));
         if all_updated {
             return Ok(());
         }
         if wait_start.elapsed() > max_wait {
-            for (i, node) in networks.hashi_network.nodes().iter().enumerate() {
+            for (i, node) in networks
+                .hashi_network
+                .nodes()
+                .iter()
+                .filter(|node| node.is_running())
+                .enumerate()
+            {
                 let latest = node.hashi().onchain_state().package_id();
                 let versions = node
                     .hashi()
@@ -283,7 +294,16 @@ fn hex_encode(bytes: &[u8]) -> String {
 ///
 /// Returns the new package ID on success.
 pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address> {
-    let nodes = networks.hashi_network.nodes();
+    // Running nodes only: a pending member (started mid-test by the
+    // key-rotation tests) has no Hashi instance to read state from or vote
+    // with — and is not a registered committee member yet anyway.
+    let nodes: Vec<_> = networks
+        .hashi_network
+        .nodes()
+        .iter()
+        .filter(|node| node.is_running())
+        .collect();
+    anyhow::ensure!(!nodes.is_empty(), "no running nodes to drive the upgrade");
     let hashi_ids = networks.hashi_network.ids();
 
     let mut executors: Vec<SuiTxExecutor> = nodes

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -65,14 +65,21 @@ pub async fn wait_for_package_convergence(
     }
 }
 
-/// Prepare an upgrade package by copying the deployed source and patching it.
+/// Prepare an upgrade package by copying the current source and patching it.
 ///
 /// 1. Copies `<test_dir>/packages/hashi` to `<test_dir>/packages/hashi-upgrade`
-/// 2. Bumps `PACKAGE_VERSION` from 1 to 2 in `versioning.move`
-/// 3. Sets `published-at` in `Move.toml` to the original package ID
+/// 2. Sets `PACKAGE_VERSION` in `versioning.move` to `target_version`
+///    (whatever the source currently declares — a no-op rewrite when the tree
+///    already carries the target, a real bump when the chain has moved past it)
+/// 3. Sets `published-at` in `Move.toml` to `published_at` — the chain's
+///    LATEST published package id, which the upgrade ticket checks against
 ///
 /// Returns the path to the patched package directory.
-pub fn prepare_upgrade_package(test_dir: &Path, original_package_id: Address) -> Result<PathBuf> {
+pub fn prepare_upgrade_package(
+    test_dir: &Path,
+    published_at: Address,
+    target_version: u64,
+) -> Result<PathBuf> {
     let src = test_dir.join("packages/hashi");
     let dst = test_dir.join("packages/hashi-upgrade");
 
@@ -82,7 +89,9 @@ pub fn prepare_upgrade_package(test_dir: &Path, original_package_id: Address) ->
         src.display()
     );
 
-    // Copy the package
+    // Copy the package; the builder's auto-upgrade may have left a previous
+    // copy behind, and `cp -r` into an existing directory would nest.
+    let _ = std::fs::remove_dir_all(&dst);
     let output = std::process::Command::new("cp")
         .args(["-r", &src.to_string_lossy(), &dst.to_string_lossy()])
         .output()?;
@@ -92,16 +101,25 @@ pub fn prepare_upgrade_package(test_dir: &Path, original_package_id: Address) ->
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Patch versioning.move: bump PACKAGE_VERSION from 1 to 2
+    // Patch versioning.move: set PACKAGE_VERSION to the target version.
     let versioning_path = dst.join("sources/core/versioning.move");
     let versioning_src = std::fs::read_to_string(&versioning_path)?;
-    let patched = versioning_src.replace(
-        "const PACKAGE_VERSION: u64 = 1;",
-        "const PACKAGE_VERSION: u64 = 2;",
-    );
+    const CONST_PREFIX: &str = "const PACKAGE_VERSION: u64 = ";
+    let mut replaced = false;
+    let patched: String = versioning_src
+        .lines()
+        .map(|line| {
+            if line.starts_with(CONST_PREFIX) {
+                replaced = true;
+                format!("{CONST_PREFIX}{target_version};\n")
+            } else {
+                format!("{line}\n")
+            }
+        })
+        .collect();
     anyhow::ensure!(
-        patched != versioning_src,
-        "PACKAGE_VERSION replacement failed — pattern not found in versioning.move"
+        replaced,
+        "PACKAGE_VERSION constant not found in versioning.move"
     );
     std::fs::write(&versioning_path, patched)?;
 
@@ -110,15 +128,19 @@ pub fn prepare_upgrade_package(test_dir: &Path, original_package_id: Address) ->
     let move_toml = std::fs::read_to_string(&move_toml_path)?;
     let patched_toml = move_toml.replace(
         "[package]",
-        &format!("[package]\npublished-at = \"{}\"", original_package_id),
+        &format!("[package]\npublished-at = \"{}\"", published_at),
     );
     std::fs::write(&move_toml_path, patched_toml)?;
 
-    // Add a trivial v2-only module to prove new code is callable post-upgrade
+    // Add a trivial new-in-this-version module to prove new code is callable
+    // post-upgrade. Re-added on every prepare so successive upgrades stay
+    // module-compatible.
     let test_module_path = dst.join("sources/upgrade_canary.move");
     std::fs::write(
         &test_module_path,
-        "module hashi::upgrade_canary;\n\npublic fun version(): u64 { 2 }\n",
+        format!(
+            "module hashi::upgrade_canary;\n\npublic fun version(): u64 {{ {target_version} }}\n"
+        ),
     )?;
 
     // Clean build artifacts from the copy
@@ -127,7 +149,7 @@ pub fn prepare_upgrade_package(test_dir: &Path, original_package_id: Address) ->
     tracing::info!(
         "upgrade package prepared at {} (published-at = {})",
         dst.display(),
-        original_package_id
+        published_at
     );
 
     Ok(dst)
@@ -148,9 +170,21 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
         })
         .collect::<Result<_>>()?;
 
-    // 1. Prepare the upgrade package (copy + patch)
+    // 1. Prepare the upgrade package (copy + patch), targeting one past the
+    // chain's latest published version. `published-at` must name the LATEST
+    // published package (not the original): upgrading v2 -> v3 with a
+    // v1 `published-at` fails the upgrade ticket's package-id check.
+    let (current_version, current_package_id) = {
+        let state = nodes[0].hashi().onchain_state().state();
+        let versions = state.package_versions();
+        match (versions.latest_version(), versions.latest_id()) {
+            (Some(version), Some(id)) => (version, id),
+            _ => anyhow::bail!("onchain state has no package versions yet"),
+        }
+    };
+    let target_version = current_version + 1;
     let test_dir = networks.dir();
-    let upgrade_path = prepare_upgrade_package(test_dir, hashi_ids.package_id)?;
+    let upgrade_path = prepare_upgrade_package(test_dir, current_package_id, target_version)?;
 
     let client_config_path = test_dir.join("sui/client.yaml");
     let client_config = client_config_path
@@ -159,19 +193,8 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
 
     // 2. Build the upgrade
     tracing::info!("building upgrade package from {}", upgrade_path.display());
-    let current_version = nodes[0]
-        .hashi()
-        .onchain_state()
-        .state()
-        .package_versions()
-        .latest_version()
-        .ok_or_else(|| anyhow::anyhow!("onchain state has no package versions yet"))?;
-    let (compiled, digest) = build_upgrade_package(
-        sui_binary(),
-        &upgrade_path,
-        client_config,
-        current_version + 1,
-    )?;
+    let (compiled, digest) =
+        build_upgrade_package(sui_binary(), &upgrade_path, client_config, target_version)?;
     tracing::info!("upgrade package built, digest: {digest:?}");
 
     // 3. Propose the upgrade
@@ -216,7 +239,8 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
 
     // 5. Execute upgrade + publish + finalize in one PTB
     tracing::info!("executing upgrade (execute + publish + finalize in one PTB)...");
-    let upgrade_tx = build_upgrade_execution_transaction(hashi_ids, proposal_id, compiled);
+    let upgrade_tx =
+        build_upgrade_execution_transaction(hashi_ids, current_package_id, proposal_id, compiled);
     let upgrade_resp = executors[0].execute(upgrade_tx).await?;
     anyhow::ensure!(
         upgrade_resp.transaction().effects().status().success(),

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -28,6 +28,43 @@ use sui_sdk_types::TypeTag;
 use crate::TestNetworks;
 use crate::sui_network::sui_binary;
 
+/// Poll until every node's watcher reports `package_id` as the active
+/// package — the PackageUpgraded handler in watcher.rs must update
+/// OnchainState's package_versions map on all nodes. Prints per-node
+/// diagnostics before failing on timeout.
+pub async fn wait_for_package_convergence(
+    networks: &TestNetworks,
+    package_id: Address,
+    max_wait: std::time::Duration,
+) -> Result<()> {
+    tracing::info!("waiting for all nodes to detect the new package version...");
+    let wait_start = std::time::Instant::now();
+    loop {
+        let all_updated = networks
+            .hashi_network
+            .nodes()
+            .iter()
+            .all(|node| node.hashi().onchain_state().package_id() == Some(package_id));
+        if all_updated {
+            return Ok(());
+        }
+        if wait_start.elapsed() > max_wait {
+            for (i, node) in networks.hashi_network.nodes().iter().enumerate() {
+                let latest = node.hashi().onchain_state().package_id();
+                let versions = node
+                    .hashi()
+                    .onchain_state()
+                    .state()
+                    .package_versions()
+                    .clone();
+                tracing::info!("node {i}: package_id={latest:?}, versions={versions:?}");
+            }
+            anyhow::bail!("timeout: not all nodes detected the new package version");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+}
+
 /// Prepare an upgrade package by copying the deployed source and patching it.
 ///
 /// 1. Copies `<test_dir>/packages/hashi` to `<test_dir>/packages/hashi-upgrade`

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use sui_sdk_types::Address;
 use sui_sdk_types::Identifier;
+use sui_sdk_types::Publish;
 use sui_sdk_types::StructTag;
 use sui_sdk_types::TypeTag;
 
@@ -155,6 +156,129 @@ pub fn prepare_upgrade_package(
     Ok(dst)
 }
 
+/// [`build_upgrade_package`] behind a cross-process disk cache.
+///
+/// Every builder boot compiles the byte-identical artifact (verified: the
+/// per-test `published-at` patch does not reach the compiled modules or
+/// digest), and nextest runs each test in its own process — so on CI's
+/// 4-core runners the compile was repeated per test, starving the network
+/// it was booting next to. Keyed on the patched source (with the
+/// `published-at` line masked), the target version, and the sui toolchain;
+/// a mkdir lock dedups concurrent builders, and every fallback path builds
+/// rather than fails — the cache can only add speed, never wrongness.
+fn build_upgrade_package_cached(
+    upgrade_path: &Path,
+    client_config: Option<&Path>,
+    target_version: u64,
+) -> Result<(Publish, Vec<u8>)> {
+    use fastcrypto::hash::HashFunction;
+
+    let key = {
+        let mut hasher = fastcrypto::hash::Sha256::default();
+        hasher.update(target_version.to_le_bytes());
+        let sui_version = std::process::Command::new(sui_binary())
+            .arg("--version")
+            .output()
+            .map(|o| o.stdout)
+            .unwrap_or_default();
+        hasher.update(&sui_version);
+        let mut files: Vec<PathBuf> = walk_files(upgrade_path)?;
+        files.sort();
+        for file in &files {
+            let rel = file.strip_prefix(upgrade_path).unwrap_or(file);
+            // `build/` is output, not input; `published-at` is per-test but
+            // verified not to reach the artifact.
+            if rel.starts_with("build") {
+                continue;
+            }
+            hasher.update(rel.to_string_lossy().as_bytes());
+            let contents = std::fs::read(file)?;
+            if rel == Path::new("Move.toml") {
+                let masked: String = String::from_utf8_lossy(&contents)
+                    .lines()
+                    .filter(|line| !line.trim_start().starts_with("published-at"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                hasher.update(masked.as_bytes());
+            } else {
+                hasher.update(&contents);
+            }
+        }
+        hex_encode(&hasher.finalize().digest)
+    };
+
+    let cache_root = std::env::temp_dir().join("hashi-e2e-upgrade-build-cache");
+    let final_path = cache_root.join(format!("{key}.json"));
+
+    if let Some(cached) = read_cached_build(&final_path) {
+        tracing::info!("upgrade package cache hit ({key})");
+        return Ok(cached);
+    }
+
+    // mkdir is atomic: exactly one process wins the right to build; the rest
+    // wait for the artifact to appear. Timeouts and stale locks fall through
+    // to building — duplicated work over a wedged run.
+    std::fs::create_dir_all(&cache_root)?;
+    let lock = cache_root.join(format!("{key}.lock"));
+    if std::fs::create_dir(&lock).is_err() {
+        let stale = std::time::Duration::from_secs(900);
+        let started = std::time::Instant::now();
+        while started.elapsed() < std::time::Duration::from_secs(600) {
+            if let Some(cached) = read_cached_build(&final_path) {
+                tracing::info!("upgrade package cache hit after waiting ({key})");
+                return Ok(cached);
+            }
+            if std::fs::metadata(&lock)
+                .and_then(|m| m.modified())
+                .map(|t| t.elapsed().unwrap_or_default() > stale)
+                .unwrap_or(true)
+            {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(2));
+        }
+        tracing::warn!("upgrade build lock wait expired; building anyway ({key})");
+    }
+
+    let built = build_upgrade_package(sui_binary(), upgrade_path, client_config, target_version);
+    let _ = std::fs::remove_dir(&lock);
+    let (compiled, digest) = built?;
+
+    // Write-then-rename so readers never see a partial file.
+    let tmp = cache_root.join(format!("{key}.tmp-{}", std::process::id()));
+    if let Ok(bytes) = serde_json::to_vec(&(&compiled, &digest))
+        && std::fs::write(&tmp, bytes).is_ok()
+    {
+        let _ = std::fs::rename(&tmp, &final_path);
+    }
+    Ok((compiled, digest))
+}
+
+fn read_cached_build(path: &Path) -> Option<(Publish, Vec<u8>)> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn walk_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in std::fs::read_dir(&d)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
 /// Run the full upgrade lifecycle: prepare → build → propose → vote → execute+publish+finalize.
 ///
 /// Returns the new package ID on success.
@@ -194,7 +318,7 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
     // 2. Build the upgrade
     tracing::info!("building upgrade package from {}", upgrade_path.display());
     let (compiled, digest) =
-        build_upgrade_package(sui_binary(), &upgrade_path, client_config, target_version)?;
+        build_upgrade_package_cached(&upgrade_path, client_config, target_version)?;
     tracing::info!("upgrade package built, digest: {digest:?}");
 
     // 3. Propose the upgrade

--- a/crates/e2e-tests/tests/snapshot_signing_tests.rs
+++ b/crates/e2e-tests/tests/snapshot_signing_tests.rs
@@ -47,10 +47,12 @@ use tracing::info;
 async fn snapshot_v1_signs_withdrawal_end_to_end() -> Result<()> {
     init_test_logging();
 
-    // v1 = the checked-in deployed bytecode snapshot, not a source build.
+    // v1 = the checked-in deployed bytecode snapshot, not a source build —
+    // and no auto-upgrade: signing against the deployed bytecode is the point.
     let mut networks = TestNetworksBuilder::new()
         .with_nodes(4)
         .with_v1_from_snapshot(snapshot::default_snapshot_dir()?)
+        .without_upgrade()
         .build()
         .await?;
 

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -24,13 +24,17 @@ use sui_transaction_builder::ObjectInput;
 use sui_transaction_builder::TransactionBuilder;
 use tracing::info;
 
-/// Test the full upgrade lifecycle, exercising real cascading effects.
+/// Explicit upgrade via governance proposal, exercising real cascading effects.
+///
+/// The builder's default boot already lands the chain at the current source
+/// (snapshot v1 auto-upgraded at build), so the upgrade driven *by this test*
+/// goes one version further (vN -> vN+1) through the full proposal flow:
 ///
 /// 1. Watcher picks up new package — PackageUpgraded updates OnchainState
 /// 2. Validators confirm deposits post-upgrade — leader routes calls correctly
 /// 3. Package ID routing — OnchainState.package_id() returns the new package
 #[tokio::test]
-async fn test_upgrade_v1_to_v2() -> Result<()> {
+async fn test_upgrade_via_proposal() -> Result<()> {
     init_test_logging();
     let mut networks = TestNetworksBuilder::new().with_nodes(4).build().await?;
 
@@ -74,8 +78,9 @@ async fn test_upgrade_v1_to_v2() -> Result<()> {
             .versions()
             .clone();
         assert!(
-            versions.len() >= 2,
-            "node {i}: should have at least 2 package versions, got {}",
+            versions.len() >= 3,
+            "node {i}: expected the auto-upgrade and this test's upgrade on \
+             top of v1 (>= 3 package versions), got {}",
             versions.len()
         );
         info!("node {i}: package_versions = {versions:?}");
@@ -225,9 +230,12 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
     init_test_logging();
 
     // v1 = the checked-in deployed bytecode snapshot, NOT a source build.
+    // `without_upgrade` so the pre-upgrade deposit really runs against the
+    // deployed bytecode; this test drives the upgrade itself.
     let mut networks = TestNetworksBuilder::new()
         .with_nodes(4)
         .with_v1_from_snapshot(snapshot::default_snapshot_dir()?)
+        .without_upgrade()
         .build()
         .await?;
 

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -9,7 +9,6 @@
 //! - Package ID routing updates correctly in OnchainState
 
 use anyhow::Result;
-use e2e_tests::TestNetworks;
 use e2e_tests::TestNetworksBuilder;
 use e2e_tests::snapshot;
 use e2e_tests::test_helpers::create_deposit_and_wait;
@@ -24,43 +23,6 @@ use sui_transaction_builder::Function;
 use sui_transaction_builder::ObjectInput;
 use sui_transaction_builder::TransactionBuilder;
 use tracing::info;
-
-/// Poll until every node's watcher reports `package_id` as the active
-/// package — the PackageUpgraded handler in watcher.rs must update
-/// OnchainState's package_versions map on all nodes. Prints per-node
-/// diagnostics before failing on timeout.
-async fn wait_for_package_convergence(
-    networks: &TestNetworks,
-    package_id: Address,
-    max_wait: Duration,
-) -> Result<()> {
-    info!("waiting for all nodes to detect the new package version...");
-    let wait_start = std::time::Instant::now();
-    loop {
-        let all_updated = networks
-            .hashi_network
-            .nodes()
-            .iter()
-            .all(|node| node.hashi().onchain_state().package_id() == Some(package_id));
-        if all_updated {
-            return Ok(());
-        }
-        if wait_start.elapsed() > max_wait {
-            for (i, node) in networks.hashi_network.nodes().iter().enumerate() {
-                let latest = node.hashi().onchain_state().package_id();
-                let versions = node
-                    .hashi()
-                    .onchain_state()
-                    .state()
-                    .package_versions()
-                    .clone();
-                info!("node {i}: package_id={latest:?}, versions={versions:?}");
-            }
-            anyhow::bail!("timeout: not all nodes detected the new package version");
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-}
 
 /// Test the full upgrade lifecycle, exercising real cascading effects.
 ///
@@ -97,7 +59,8 @@ async fn test_upgrade_v1_to_v2() -> Result<()> {
     assert_ne!(new_package_id, hashi_ids.package_id);
 
     // ── Cascading effect 1: Watcher picks up new package ────────────────
-    wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30)).await?;
+    upgrade_flow::wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30))
+        .await?;
 
     // ── Cascading effect 2: Package ID routing ──────────────────────────
     //
@@ -303,7 +266,8 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
     );
 
     // ── All nodes' watchers must pick up the new package version ─────────
-    wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30)).await?;
+    upgrade_flow::wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30))
+        .await?;
 
     // ── Post-upgrade: deposit on top of v1-initialized state ────────────
     //

--- a/crates/hashi/src/cli/upgrade.rs
+++ b/crates/hashi/src/cli/upgrade.rs
@@ -152,8 +152,13 @@ pub fn build_upgrade_package(
 /// The three steps must be in one PTB so the `UpgradeTicket` and
 /// `UpgradeReceipt` hot potatoes can be consumed without leaving the
 /// transaction.
+/// `current_package_id` is the chain's LATEST published package id: the
+/// `Upgrade` command checks it against the ticket (an upgrade of v2 with the
+/// original v1 id fails `PackageIDDoesNotMatch`), and the entry calls should
+/// run the newest code.
 pub fn build_upgrade_execution_transaction(
     hashi_ids: HashiIds,
+    current_package_id: Address,
     proposal_id: Address,
     compiled: Publish,
 ) -> TransactionBuilder {
@@ -173,7 +178,7 @@ pub fn build_upgrade_execution_transaction(
     // Step A: upgrade::execute → UpgradeTicket
     let ticket = builder.move_call(
         Function::new(
-            hashi_ids.package_id,
+            current_package_id,
             Identifier::from_static("upgrade"),
             Identifier::from_static("execute"),
         ),
@@ -184,7 +189,7 @@ pub fn build_upgrade_execution_transaction(
     let receipt = builder.upgrade(
         compiled.modules,
         compiled.dependencies,
-        hashi_ids.package_id,
+        current_package_id,
         ticket,
     );
 
@@ -198,7 +203,7 @@ pub fn build_upgrade_execution_transaction(
     );
     builder.move_call(
         Function::new(
-            hashi_ids.package_id,
+            current_package_id,
             Identifier::from_static("upgrade"),
             Identifier::from_static("finalize_upgrade"),
         ),

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -1189,7 +1189,7 @@ impl MpcService {
                     return;
                 }
                 Err(e) => {
-                    warn!("start_reconfig attempt {attempt}/{MAX_PROTOCOL_ATTEMPTS} failed: {e}");
+                    warn!("start_reconfig attempt {attempt}/{MAX_PROTOCOL_ATTEMPTS} failed: {e:#}");
                     if attempt < MAX_PROTOCOL_ATTEMPTS {
                         // Poll for pending epoch change while waiting, so we can
                         // return early if another node submitted start_reconfig.
@@ -1311,7 +1311,7 @@ impl MpcService {
                 Err(e) => match classify_reconfig_submission_error(&e) {
                     ReconfigSubmissionErrorKind::NonMoveAbort => {
                         warn!(
-                            "submit_end_reconfig for epoch {} failed: {e}, retrying...",
+                            "submit_end_reconfig for epoch {} failed: {e:#}, retrying...",
                             target_epoch
                         );
                         self.sleep_if_still_pending(target_epoch).await;
@@ -1320,7 +1320,7 @@ impl MpcService {
                     | ReconfigSubmissionErrorKind::CommitteeHandoffAlreadySubmitted
                     | ReconfigSubmissionErrorKind::EndReconfigAlreadyCompleted => {
                         let msg = format!(
-                            "submit_end_reconfig for epoch {target_epoch} failed with non-retryable error: {e}"
+                            "submit_end_reconfig for epoch {target_epoch} failed with non-retryable error: {e:#}"
                         );
                         error!("{msg}");
                         panic!("{msg}");
@@ -1526,7 +1526,7 @@ impl MpcService {
                 Err(e) => match classify_reconfig_submission_error(&e) {
                     ReconfigSubmissionErrorKind::EndReconfigAlreadyCompleted => {
                         warn!(
-                            "end_reconfig submission for epoch {epoch} found reconfig already completed; waiting for the watcher to observe it: {e}"
+                            "end_reconfig submission for epoch {epoch} found reconfig already completed; waiting for the watcher to observe it: {e:#}"
                         );
                         self.wait_for_epoch_change_visibility(epoch).await;
                         if self.get_pending_epoch_change() != Some(epoch) {
@@ -1548,7 +1548,7 @@ impl MpcService {
                     }
                     ReconfigSubmissionErrorKind::NonMoveAbort => {
                         warn!(
-                            "end_reconfig submission for epoch {} failed: {e}, retrying...",
+                            "end_reconfig submission for epoch {} failed: {e:#}, retrying...",
                             epoch
                         );
                         self.sleep_if_still_pending(epoch).await;
@@ -1586,7 +1586,7 @@ impl MpcService {
                 Err(e) => {
                     warn!(
                         from_epoch,
-                        "Committee handoff signature collection failed: {e}, retrying..."
+                        "Committee handoff signature collection failed: {e:#}, retrying..."
                     );
                     self.sleep_if_still_pending(epoch).await;
                 }
@@ -1608,7 +1608,7 @@ impl MpcService {
                 Err(e) => match classify_reconfig_submission_error(&e) {
                     ReconfigSubmissionErrorKind::CommitteeHandoffAlreadySubmitted => {
                         warn!(
-                            "submit_committee_handoff submission for epoch {epoch} found handoff already submitted: {e}"
+                            "submit_committee_handoff submission for epoch {epoch} found handoff already submitted: {e:#}"
                         );
                         return Ok(());
                     }
@@ -1622,7 +1622,7 @@ impl MpcService {
                     }
                     ReconfigSubmissionErrorKind::NonMoveAbort => {
                         warn!(
-                            "submit_committee_handoff submission for epoch {} failed: {e}, retrying...",
+                            "submit_committee_handoff submission for epoch {} failed: {e:#}, retrying...",
                             epoch
                         );
                         self.sleep_if_still_pending(epoch).await;


### PR DESCRIPTION
## Summary

Stacked on #924. Closes the e2e coverage gap where only the dedicated upgrade tests ran against an upgraded chain — and per review, the boot lives in the **builder itself**, so every builder user gets it, not just `setup_test_networks` callers.

## Changes

- `TestNetworksBuilder::build()` now publishes the deployed **v1 bytecode snapshot** (defaulted when no snapshot dir is set) and runs the full governance upgrade to the current source before returning. `without_upgrade()` opts out where v1-only is the point (`snapshot_signing_tests`) or the test drives its own upgrade (`snapshot_v1_upgrades_to_current_source`).
- `test_upgrade_v1_to_v2` → `test_upgrade_via_proposal`: rides the default boot (chain already at vN) and explicitly upgrades vN → vN+1 through the proposal flow, keeping dedicated coverage of governance-driven upgrades.
- That second upgrade surfaced two latent bugs, fixed here:
  - `prepare_upgrade_package` parameterizes the patched `PACKAGE_VERSION` and points `published-at` at the **latest** published package id (a v1 `published-at` fails the ticket check on the second upgrade);
  - `build_upgrade_execution_transaction` takes the current package id for the `Upgrade` command — referencing the original id fails `PackageIDDoesNotMatch`.
- `wait_for_package_convergence` moves into `upgrade_flow` as the shared post-upgrade barrier.

## Verification

- `test_upgrade_via_proposal` passes locally: snapshot v1 → builder auto-upgrade v2 → explicit proposal upgrade v3 → convergence → disable v1 → v1-entry rejection (66s).
- `test_bitcoin_deposit_e2e_flow` passes under the builder-default boot (56s).
- `cargo check -p hashi -p e2e-tests --tests` clean.