### PR TITLE
versioning: source carries the next package version

### DIFF
--- a/packages/hashi/sources/core/versioning.move
+++ b/packages/hashi/sources/core/versioning.move
@@ -14,7 +14,13 @@ use sui::{package::{Self, UpgradeCap, UpgradeTicket, UpgradeReceipt}, vec_set::{
 
 // ~~~~~~~ Constants ~~~~~~~
 
-const PACKAGE_VERSION: u64 = 1;
+/// The package version this tree ships as: the deployed version while the
+/// tree matches a deployment, bumped to the next version when a release
+/// cycle's changes begin landing. A mid-cycle tree must reach a chain as an
+/// upgrade (snapshot v1 + upgrade in every dev harness), never as a fresh
+/// publish — `create` enables this constant, and a fresh publish is Sui
+/// sequence version 1, so a mid-cycle fresh publish can never activate.
+const PACKAGE_VERSION: u64 = 2;
 
 // ~~~~~~~ Errors ~~~~~~~
 

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -746,11 +746,12 @@ fun test_enable_version_proposal() {
     let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
     let clock = clock::create_for_testing(ctx);
 
-    // Create enable version proposal for version 2
+    // Enable a version that is not already enabled (genesis enables
+    // PACKAGE_VERSION itself, so use the one after it).
     let proposal_id = test_utils::create_enable_version_proposal(
         &mut hashi,
         VOTER1,
-        2,
+        3,
         &clock,
         ctx,
     );
@@ -772,21 +773,21 @@ fun test_disable_version_proposal() {
     let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
     let clock = clock::create_for_testing(ctx);
 
-    // First enable version 2
+    // First enable a version that is not the current PACKAGE_VERSION
     let enable_id = test_utils::create_enable_version_proposal(
         &mut hashi,
         VOTER1,
-        2,
+        3,
         &clock,
         ctx,
     );
     hashi::enable_version::execute(&mut hashi, enable_id, &clock);
 
-    // Now disable version 2 (not the current version)
+    // Now disable it (disabling the current version is rejected)
     let disable_id = test_utils::create_disable_version_proposal(
         &mut hashi,
         VOTER1,
-        2,
+        3,
         &clock,
         ctx,
     );
@@ -807,11 +808,11 @@ fun test_disable_current_version_fails() {
     let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
     let clock = clock::create_for_testing(ctx);
 
-    // Try to disable version 1 (current version) - should fail
+    // Try to disable the current PACKAGE_VERSION - should fail
     let proposal_id = test_utils::create_disable_version_proposal(
         &mut hashi,
         VOTER1,
-        1, // current package version
+        2, // current package version
         &clock,
         ctx,
     );
@@ -832,11 +833,12 @@ fun test_enable_already_enabled_version_fails() {
     let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
     let clock = clock::create_for_testing(ctx);
 
-    // Try to enable version 1 (already enabled by default) - should fail
+    // Try to enable the current PACKAGE_VERSION (already enabled by the
+    // genesis `create`) - should fail
     let proposal_id = test_utils::create_enable_version_proposal(
         &mut hashi,
         VOTER1,
-        1, // already enabled
+        2, // already enabled
         &clock,
         ctx,
     );


### PR DESCRIPTION
## Summary

Stacked on #975 (→ #924 → #923). `PACKAGE_VERSION` in source declares the version the tree *ships as*, bumped at cycle start rather than patched into artifacts at build time.

## Changes

- `versioning.move`: `PACKAGE_VERSION = 2` with the policy documented (a mid-cycle tree must land as an upgrade, never a fresh publish — genesis `create()` enables `{const}` while a fresh publish is Sui sequence version 1, permanently disjoint).
- With #975's builder-owned snapshot→upgrade boot, no harness or localnet changes are needed here: the harness version patch becomes a no-op rewrite of the same value, so tests upgrade to the literal artifact a deployment would publish, and `build_upgrade_package`'s `declared == published+1` check enforces the policy end to end. Manual-mode localnet (no committee at build) stays on snapshot v1 for the operator to upgrade through governance.
- Move tests that assumed const = 1 pin to versions relative to the current const (enable/disable 3; current-version guards use 2).

## Verification

- `sui move test`: 148/148.
- `test_upgrade_via_proposal` passes at const = 2: builder auto-upgrade patches 2→2 (no-op), explicit upgrade goes 2→3 (66s).

## Notes

- `SUPPORTED_PACKAGE_VERSIONS` stays `[1]`; it grows to `[1, 2]` with the change that implements v2 semantics (#841 re-land).
- On #923 in this stack: a permanently disjoint enabled/published state (mid-cycle tree fresh-published) now warns loudly instead of an indistinguishable `NotReady`.