### PR TITLE
test: pin the package-version bump policy in CI

### DIFF
--- a/crates/hashi/tests/version_policy_tests.rs
+++ b/crates/hashi/tests/version_policy_tests.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pins the package-version bump policy in CI.
+//!
+//! The source tree always declares the *next* package version: exactly one
+//! past the deployed testnet package recorded in `Published.toml`. The e2e
+//! harness patches the constant when building upgrade artifacts, so no test
+//! that runs the code would notice a missed or doubled bump — the first
+//! thing that would is the real upgrade build on deploy day
+//! (`build_upgrade_package`'s `declared == published + 1` check). This test
+//! moves that failure to the PR that should have carried the bump:
+//!
+//! - after deploying an upgrade, bump `PACKAGE_VERSION` in the same change
+//!   that records the deployment (Published.toml + snapshot capture);
+//! - mid-cycle Move changes never touch it.
+
+use std::path::PathBuf;
+
+#[test]
+fn source_declares_one_past_the_deployed_testnet_version() -> anyhow::Result<()> {
+    let packages_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packages/hashi");
+
+    let versioning = std::fs::read_to_string(packages_dir.join("sources/core/versioning.move"))?;
+    const PREFIX: &str = "const PACKAGE_VERSION: u64 = ";
+    let declared: u64 = versioning
+        .lines()
+        .find_map(|line| line.strip_prefix(PREFIX))
+        .and_then(|rest| rest.strip_suffix(';'))
+        .ok_or_else(|| anyhow::anyhow!("PACKAGE_VERSION constant not found in versioning.move"))?
+        .parse()?;
+
+    let entries = hashi::published::published_entries(&packages_dir.join("Published.toml"))?;
+    let deployed = entries
+        .get("testnet")
+        .ok_or_else(|| anyhow::anyhow!("no `testnet` entry in Published.toml"))?
+        .version;
+
+    assert_eq!(
+        declared,
+        deployed + 1,
+        "versioning.move declares PACKAGE_VERSION = {declared}, but the deployed testnet \
+         package (Published.toml) is version {deployed}. The tree must declare exactly one \
+         past the deployment: bump the constant in the change that records a new deployment, \
+         and never in mid-cycle Move changes."
+    );
+    Ok(())
+}

--- a/packages/hashi/sources/core/versioning.move
+++ b/packages/hashi/sources/core/versioning.move
@@ -14,9 +14,10 @@ use sui::{package::{Self, UpgradeCap, UpgradeTicket, UpgradeReceipt}, vec_set::{
 
 // ~~~~~~~ Constants ~~~~~~~
 
-/// The package version this tree ships as: the deployed version while the
-/// tree matches a deployment, bumped to the next version when a release
-/// cycle's changes begin landing. A mid-cycle tree must reach a chain as an
+/// The package version this tree ships as: always one past the deployed
+/// testnet package, bumped in the same change that records a deployment
+/// (Published.toml + snapshot capture) and never in mid-cycle Move changes.
+/// CI pins this (`version_policy_tests`). The tree must reach a chain as an
 /// upgrade (snapshot v1 + upgrade in every dev harness), never as a fresh
 /// publish — `create` enables this constant, and a fresh publish is Sui
 /// sequence version 1, so a mid-cycle fresh publish can never activate.


### PR DESCRIPTION
## Summary

Stacked on #976 (→ #975 → #924 → #923). Closes the enforcement gap discussed on the stack: the e2e harness patches `PACKAGE_VERSION` when building upgrade artifacts, so no running test notices a missed or doubled bump — the first failure would be the real upgrade build on deploy day (`build_upgrade_package`'s `declared == published + 1` check).

## Changes

- `crates/hashi/tests/version_policy_tests.rs`: a plain test (runs in the existing `test` CI job, no workflow wiring) asserting `versioning.move` declares exactly one past `Published.toml`'s deployed testnet version — the same source of truth the compat gate and snapshot boots key off.
- Sharpens the policy stated on the constant: the bump rides the change that records a deployment (Published.toml + snapshot capture); mid-cycle Move changes never touch it. The assertion message says exactly that, so the failing PR knows what to do.

## Verification

- Test passes at the current state (declared 2, deployed 1).
- Flipping either side locally fails with the policy message.