### PR TITLE
[guardian] Refresh the enclave lock after the guardian-init aws drop

### DIFF
--- a/docker/hashi-guardian/enclave-Cargo.lock
+++ b/docker/hashi-guardian/enclave-Cargo.lock
@@ -2960,8 +2960,6 @@ name = "hashi-guardian-init"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "aws-config",
- "aws-credential-types",
  "bitcoin",
  "clap",
  "hashi",


### PR DESCRIPTION
#948 dropped `aws-config` and `aws-credential-types` from `hashi-guardian-init` without regenerating `docker/hashi-guardian/enclave-Cargo.lock`. CI only runs on `pull_request` and the nightly cron, so nothing caught it at merge time and `guardian-enclave-lock` is now failing on every open PR.

This is just `make -C docker/hashi-guardian enclave-lock` committed.