### PR TITLE
[guardian] Make the enclave EIF reproducible, and measurable for a deployment

### DIFF
--- a/.github/workflows/guardian-enclave.yml
+++ b/.github/workflows/guardian-enclave.yml
@@ -113,6 +113,7 @@ jobs:
           path: |
             docker/hashi-guardian/out/kernel.config
             docker/hashi-guardian/out/bzImage
+            docker/hashi-guardian/out/rootfs.cpio
 
       - name: Upload PCRs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
@@ -176,9 +177,38 @@ jobs:
             echo "| features | \`${{ inputs.features }}\`${{ inputs.features == '' && ' (real attestation)' || ' — MOCK attestation, not provenance' }} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # A bare "the PCRs differ" costs whoever sees it a long investigation:
+      # PCR0 covers everything, so it only says the build moved. These are the
+      # inputs eif_build consumed, and naming the one that moved is most of the
+      # diagnosis. The last time this fired, the answer was the kernel — it was
+      # stamping its built-in initramfs with the wall clock.
+      - name: Download build inputs (only when the PCRs disagree)
+        if: steps.compare.outputs.match != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # pin@v8.0.1
+        with:
+          pattern: build-inputs-*
+          path: inputs
+
       - name: Fail if PCRs differ
         if: steps.compare.outputs.match != 'true'
         run: |
           echo "PCRs differ across platforms!"
-          diff pcrs-latest/nitro.pcrs pcrs-22/nitro.pcrs
+          diff pcrs-latest/nitro.pcrs pcrs-22/nitro.pcrs || true
+          echo
+          echo "Which build input moved:"
+          for f in rootfs.cpio bzImage kernel.config; do
+            a="$(sha256sum "inputs/build-inputs-ubuntu-latest/$f" 2>/dev/null | cut -d' ' -f1)"
+            b="$(sha256sum "inputs/build-inputs-ubuntu-22.04/$f" 2>/dev/null | cut -d' ' -f1)"
+            if [ -z "$a" ] || [ -z "$b" ]; then
+              printf '  %-14s ?  (artifact missing)\n' "$f"
+            elif [ "$a" = "$b" ]; then
+              printf '  %-14s same\n' "$f"
+            else
+              printf '  %-14s DIFFERS\n    ubuntu-latest %s\n    ubuntu-22.04  %s\n' "$f" "$a" "$b"
+            fi
+          done
+          echo
+          echo "rootfs.cpio is the app ramdisk; bzImage the kernel. If only bzImage moved,"
+          echo "suspect something the kernel build absorbs from its environment — a clock"
+          echo "reaching the built-in initramfs is the failure mode that has happened before."
           exit 1

--- a/.github/workflows/guardian-enclave.yml
+++ b/.github/workflows/guardian-enclave.yml
@@ -41,6 +41,10 @@ on:
         description: 'Extra cargo features. Leave EMPTY for anything whose PCR0 is provenance; non-enclave-dev builds mock attestation.'
         required: false
         default: ''
+      git_revision:
+        description: 'Commit to build and stamp. Defaults to the dispatched ref. Set it to measure a commit that predates this workflow — an already-deployed guardian, or the ceremony build an allowlist has to keep trusting.'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -51,17 +55,32 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
+    outputs:
+      git_revision: ${{ steps.rev.outputs.git_revision }}
 
     steps:
+      # The SOURCE measured is git_revision's, not the dispatched ref's — the
+      # ref only supplies this workflow file. GIT_REVISION is compiled into the
+      # guardian, so the two must name the same commit or the EIF measures a
+      # build that never existed.
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.git_revision || github.sha }}
+
+      - name: Resolve the revision being measured
+        id: rev
+        shell: bash
+        run: |
+          REV="$(git rev-parse HEAD)"
+          echo "GIT_REVISION=$REV" >> "$GITHUB_ENV"
+          echo "git_revision=$REV" >> "$GITHUB_OUTPUT"
 
       - name: Build enclave EIF
         working-directory: docker/hashi-guardian
         env:
           BUCKET_NAME: ${{ inputs.bucket_name }}
           AWS_REGION: ${{ inputs.aws_region }}
-          GIT_REVISION: ${{ github.sha }}
           FEATURES: ${{ inputs.features }}
           # The Makefile takes "true"/empty, not the friendlier input wording.
           CEREMONY_MODE: ${{ inputs.ceremony_mode == 'ceremony' && 'true' || '' }}
@@ -129,7 +148,7 @@ jobs:
             echo ""
             echo "| Input | Value |"
             echo "|-------|-------|"
-            echo "| commit | \`${{ github.sha }}\` |"
+            echo "| commit | \`${{ needs.build.outputs.git_revision }}\` |"
             echo "| bucket | \`${{ inputs.bucket_name }}\` |"
             echo "| region | \`${{ inputs.aws_region }}\` |"
             echo "| mode | \`${{ inputs.ceremony_mode }}\` |"

--- a/.github/workflows/guardian-enclave.yml
+++ b/.github/workflows/guardian-enclave.yml
@@ -93,6 +93,27 @@ jobs:
         working-directory: docker/hashi-guardian
         run: cat out/nitro.pcrs
 
+      # PCR0 covers everything, so a mismatch between runners says only "the
+      # build moved". These say which half: rootfs.cpio is the app ramdisk
+      # (PCR2), bzImage the kernel (PCR1). Plus the host facts a from-source
+      # kernel build can leak — core count reaches it through `make -j$(nproc)`.
+      - name: Provenance of the build inputs
+        working-directory: docker/hashi-guardian
+        run: |
+          echo "runner        : ${{ matrix.os }}"
+          echo "nproc         : $(nproc)"
+          echo "docker        : $(docker version --format '{{.Server.Version}}')"
+          echo "buildx        : $(docker buildx version)"
+          sha256sum out/rootfs.cpio out/bzImage out/kernel.config
+
+      - name: Upload build-input hashes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
+        with:
+          name: build-inputs-${{ matrix.os }}
+          path: |
+            docker/hashi-guardian/out/kernel.config
+            docker/hashi-guardian/out/bzImage
+
       - name: Upload PCRs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
         with:

--- a/.github/workflows/guardian-enclave.yml
+++ b/.github/workflows/guardian-enclave.yml
@@ -1,12 +1,46 @@
 name: Guardian Enclave Build
 
+# Measures the guardian EIF for a deployment.
+#
+# PCR0 is a hash of the built image, and the build takes BUCKET_NAME, AWS_REGION
+# and CEREMONY_MODE as inputs — they are substituted into run.sh, which goes in
+# the ramdisk the measurement covers. So a PCR0 only means something next to the
+# deployment it was built for: pass the same values that stack's enclave hosts
+# build with (pulumi/services/hashi-guardian-enclave/Pulumi.<stack>.yaml in
+# sui-operations, rendered into user-data by enclave.go), and dispatch this on
+# the commit the hosts pin.
+#
+# This is the ONLY sanctioned source for the eif-pcr0 / eif-pcr0-b /
+# ceremony-pcr0 config values and for the rotate workflow's hashi_pcr0 input.
+# Reading a measurement off the host being verified would make the check
+# circular: it would confirm the host runs whatever it runs.
+#
+# Both runners must agree, or the build is not reproducible and no measurement
+# from it can be trusted.
+
 on:
   workflow_dispatch:
     inputs:
       bucket_name:
-        description: 'S3 bucket name for the build'
+        description: 'S3 bucket the guardian logs to (must match the target stack exactly)'
         required: true
         default: 'guardian-test-bucket'
+      aws_region:
+        description: 'Region of that bucket. Every deployed stack is us-west-2; the Makefile default is not.'
+        required: true
+        default: 'us-west-2'
+      ceremony_mode:
+        description: 'Enclave boot mode: withdraw (serving) or ceremony (one-time key ceremony, a different PCR0 at the same commit)'
+        type: choice
+        options:
+          - withdraw
+          - ceremony
+        required: true
+        default: withdraw
+      features:
+        description: 'Extra cargo features. Leave EMPTY for anything whose PCR0 is provenance; non-enclave-dev builds mock attestation.'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -25,9 +59,16 @@ jobs:
       - name: Build enclave EIF
         working-directory: docker/hashi-guardian
         env:
-          BUCKET_NAME: ${{ inputs.bucket_name || 'guardian-test-bucket' }}
+          BUCKET_NAME: ${{ inputs.bucket_name }}
+          AWS_REGION: ${{ inputs.aws_region }}
           GIT_REVISION: ${{ github.sha }}
-        run: make BUCKET_NAME=$BUCKET_NAME GIT_REVISION=$GIT_REVISION
+          FEATURES: ${{ inputs.features }}
+          # The Makefile takes "true"/empty, not the friendlier input wording.
+          CEREMONY_MODE: ${{ inputs.ceremony_mode == 'ceremony' && 'true' || '' }}
+        run: |
+          make BUCKET_NAME="$BUCKET_NAME" AWS_REGION="$AWS_REGION" \
+               GIT_REVISION="$GIT_REVISION" FEATURES="$FEATURES" \
+               CEREMONY_MODE="$CEREMONY_MODE"
 
       - name: Print PCRs
         working-directory: docker/hashi-guardian
@@ -58,8 +99,6 @@ jobs:
       - name: Compare PCRs
         id: compare
         run: |
-          LATEST=$(cat pcrs-latest/nitro.pcrs)
-          OLDER=$(cat pcrs-22/nitro.pcrs)
           if diff pcrs-latest/nitro.pcrs pcrs-22/nitro.pcrs > /dev/null; then
             echo "match=true" >> "$GITHUB_OUTPUT"
           else
@@ -75,16 +114,27 @@ jobs:
 
       - name: Print results
         run: |
-          echo "## Guardian Enclave PCR Measurements" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| PCR | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| PCR0 | \`${{ steps.compare.outputs.pcr0 }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| PCR1 | \`${{ steps.compare.outputs.pcr1 }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| PCR2 | \`${{ steps.compare.outputs.pcr2 }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Cross-platform check**: ${{ steps.compare.outputs.match == 'true' && 'Reproducible' || 'MISMATCH' }} (ubuntu-latest vs ubuntu-22.04)" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Bucket**: \`${{ inputs.bucket_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Guardian Enclave PCR Measurements"
+            echo ""
+            echo "| PCR | Value |"
+            echo "|-----|-------|"
+            echo "| PCR0 | \`${{ steps.compare.outputs.pcr0 }}\` |"
+            echo "| PCR1 | \`${{ steps.compare.outputs.pcr1 }}\` |"
+            echo "| PCR2 | \`${{ steps.compare.outputs.pcr2 }}\` |"
+            echo ""
+            echo "**Cross-platform check**: ${{ steps.compare.outputs.match == 'true' && 'Reproducible' || 'MISMATCH' }} (ubuntu-latest vs ubuntu-22.04)"
+            echo ""
+            echo "Measured build — a PCR0 is only valid for this exact combination:"
+            echo ""
+            echo "| Input | Value |"
+            echo "|-------|-------|"
+            echo "| commit | \`${{ github.sha }}\` |"
+            echo "| bucket | \`${{ inputs.bucket_name }}\` |"
+            echo "| region | \`${{ inputs.aws_region }}\` |"
+            echo "| mode | \`${{ inputs.ceremony_mode }}\` |"
+            echo "| features | \`${{ inputs.features }}\`${{ inputs.features == '' && ' (real attestation)' || ' — MOCK attestation, not provenance' }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if PCRs differ
         if: steps.compare.outputs.match != 'true'

--- a/docker/hashi-guardian/Containerfile
+++ b/docker/hashi-guardian/Containerfile
@@ -92,9 +92,21 @@ FROM kernel-toolchain AS kernel
 ADD --checksum=sha256:de9999b784d2293f00d39c62d8f92a08ab8a54bc4e80ffd250a0c09cb07a0f98 \
 	https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.0.14.tar.xz /linux.tar.xz
 COPY --from=user-linux-nitro /linux.config /config
-ENV SOURCE_DATE_EPOCH=1 KBUILD_BUILD_TIMESTAMP=1 KBUILD_BUILD_USER=stagex KBUILD_BUILD_HOST=stagex
+# KBUILD_BUILD_TIMESTAMP must be something `date -d` PARSES, not just a fixed
+# string. usr/Makefile forwards it to gen_initramfs.sh, which does
+# `timestamp="$(date -d"$1" +%s || :)"` — and that `|| :` means an unparseable
+# value is silently dropped, leaving gen_init_cpio to stamp the built-in
+# initramfs with the wall clock. `1` does not parse (this toolchain's date is
+# busybox: `date: invalid date '1'`), so every build embedded its own build
+# time, which is what made PCR0 differ between two identical builds. `@1` parses
+# and is timezone-proof, unlike a bare `1970-01-01 00:00:00`.
+ENV SOURCE_DATE_EPOCH=1 KBUILD_BUILD_TIMESTAMP=@1 KBUILD_BUILD_USER=stagex KBUILD_BUILD_HOST=stagex
 RUN <<-EOF
 	set -eux
+	# gen_initramfs.sh drops an unparseable -d on the floor (`|| :`) and stamps
+	# the built-in initramfs with the wall clock instead, so the only symptom of
+	# getting this wrong is a PCR0 that quietly differs per build. Fail loudly.
+	date -d"\$KBUILD_BUILD_TIMESTAMP" +%s
 	tar -xf /linux.tar.xz
 	cd linux-7.0.14
 	cp /config .config

--- a/docker/hashi-guardian/Containerfile
+++ b/docker/hashi-guardian/Containerfile
@@ -222,6 +222,13 @@ WORKDIR /rootfs
 COPY --from=build /nitro.eif .
 COPY --from=build /nitro.pcrs .
 COPY --from=build /build_cpio/rootfs.cpio .
+# Exported for provenance triage only — none of these is an EIF input, they are
+# the inputs eif_build consumed. When two builds of one commit disagree on PCR0,
+# hashing these says WHICH half moved: rootfs.cpio is PCR2 (the app), bzImage is
+# PCR1 (the kernel), and the kernel is the half we compile rather than pull from
+# a digest-pinned image.
+COPY --from=build /bzImage .
+COPY --from=build /kernel.config .
 
 FROM scratch AS package
 COPY --from=install /rootfs .

--- a/docker/hashi-guardian/Containerfile
+++ b/docker/hashi-guardian/Containerfile
@@ -106,7 +106,7 @@ RUN <<-EOF
 	# gen_initramfs.sh drops an unparseable -d on the floor (`|| :`) and stamps
 	# the built-in initramfs with the wall clock instead, so the only symptom of
 	# getting this wrong is a PCR0 that quietly differs per build. Fail loudly.
-	date -d"\$KBUILD_BUILD_TIMESTAMP" +%s
+	date -d"$KBUILD_BUILD_TIMESTAMP" +%s
 	tar -xf /linux.tar.xz
 	cd linux-7.0.14
 	cp /config .config


### PR DESCRIPTION
Two builds of the same commit produced different PCR0s, so no measurement could be pinned in a `PcrAllowlist` — a PCR0 that only describes the machine that produced it cannot reject anything. That blocks a guardian rotation, which has to name the build it is moving to.

**Root cause.** Of the 32MB decompressed vmlinux, 29 bytes differed: the `mtime` field of the built-in initramfs cpio header, plus the `.note.gnu.build-id` that follows from it. The values decoded to each run's wall clock.

`KBUILD_BUILD_TIMESTAMP` was already set, to `1`. `usr/Makefile` forwards it to `gen_initramfs.sh` as `-d 1`, which runs `date -d"1" +%s || :` — and `1` is not a date the kernel-toolchain's busybox can parse (that stage has no coreutils), so the `|| :` swallowed the failure and `gen_init_cpio` fell back to the current time. Setting it had never done anything.

`@1` parses, matches `SOURCE_DATE_EPOCH`, and is timezone-proof, which a bare `1970-01-01 00:00:00` is not. The kernel stage now runs the same `date -d` up front so an unparseable value fails the build loudly.

**Verified** on one native host, `--no-cache` throughout:

```
BASE1 (-j14, ts=1):  70394360…787be2
BASE2 (-j14, ts=1):  6313216f…94ecd8   differs — the bug, on one machine
FIX1  (-j14, ts=@1): 8d42d8cf…84babe
FIX2  (-j14, ts=@1): 8d42d8cf…84babe
FIX3  (-j4,  ts=@1): 8d42d8cf…84babe   identical at a different -j
```

The `-j` result is the one that matters operationally: CI builds on 4 cores and an enclave host on 14 (96 on the rotation builder), so had core count reached the output, a CI measurement could never have matched a host.

**The measurement workflow also could not describe a real deployment.** PCR0 covers `run.sh`, into which the build substitutes the bucket, region and boot mode — so it only means something next to the deployment it was built for. The workflow passed neither region (taking the Makefile's `us-east-1` while every stack is `us-west-2`) nor ceremony mode, so it could not produce a usable `eif-pcr0` or a `ceremony-pcr0` at all. It also gains `git_revision`, so an allowlist can name builds older than this workflow — the guardian being replaced, and the ceremony build whose records every later session still reads.

**Diagnosis, kept.** `bzImage` / `rootfs.cpio` / `kernel.config` are exported and hashed per runner, and on a PCR mismatch the verify job names which one moved. Working that out by hand this time meant a byte-level diff of two decompressed kernels.

Note this changes PCR0 for every build, including rebuilds of old commits. Previously recorded measurements stay valid for the guardians that produced them; they simply cannot be reproduced, which is the defect.