### PR TITLE
mpc: keep the avss rng off the verify-only paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,7 +2405,7 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 [[package]]
 name = "fastcrypto"
 version = "0.1.11"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=179ba6ca65f567efb297d0f8d449d78cdef6745c#179ba6ca65f567efb297d0f8d449d78cdef6745c"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d9ae33b1f5abfc2c09974c7682175f281f6f528f#d9ae33b1f5abfc2c09974c7682175f281f6f528f"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.4"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=179ba6ca65f567efb297d0f8d449d78cdef6745c#179ba6ca65f567efb297d0f8d449d78cdef6745c"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d9ae33b1f5abfc2c09974c7682175f281f6f528f#d9ae33b1f5abfc2c09974c7682175f281f6f528f"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2479,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=179ba6ca65f567efb297d0f8d449d78cdef6745c#179ba6ca65f567efb297d0f8d449d78cdef6745c"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d9ae33b1f5abfc2c09974c7682175f281f6f528f#d9ae33b1f5abfc2c09974c7682175f281f6f528f"
 dependencies = [
  "bcs",
  "digest 0.10.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,9 +87,13 @@ aws-config = "1.1.7"
 aws-credential-types = "1"
 aws-sdk-s3 = "1.12.0"
 
-# fastcrypto — pinned to a `main` rev.
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = "179ba6ca65f567efb297d0f8d449d78cdef6745c" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = "179ba6ca65f567efb297d0f8d449d78cdef6745c" }
+# fastcrypto — the merged avss verify_message/create_complaint split
+# (MystenLabs/fastcrypto#1002) on top of 179ba6c, hashi main's pinned rev. This
+# commit is kept reachable by SHA via the merged PR. fastcrypto main has since
+# diverged with unrelated breaking changes, so moving off this rev needs a
+# coordinated fastcrypto bump for the whole workspace, not just this PR.
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = "d9ae33b1f5abfc2c09974c7682175f281f6f528f" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto.git", rev = "d9ae33b1f5abfc2c09974c7682175f281f6f528f" }
 
 # Sui monorepo deps
 bin-version = { git = "https://github.com/MystenLabs/sui.git", rev = "77a42de4be99383b98518541e0c6002d720cafc8" }

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -378,7 +378,7 @@ impl MpcManager {
         Box::pin(async move { spawn_blocking(move || f(&mut mgr.write().unwrap())).await })
     }
 
-    /// The AVSS threshold parameters (`t`, `f`) for this manager's epoch.
+    /// Threshold parameters (`t`, `f`) for the current `mpc_config` epoch.
     pub(crate) fn params(&self) -> Parameters {
         Parameters {
             t: self.mpc_config.threshold,

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -96,6 +96,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::RwLock;
@@ -355,21 +356,24 @@ impl MpcManager {
     }
 
     /// Run `f` against a read-locked manager on a blocking thread.
-    pub(crate) async fn with_manager_blocking<T: Send + 'static>(
+    pub(crate) fn with_manager_blocking<T: Send + 'static>(
         mpc_manager: &Arc<RwLock<Self>>,
         f: impl FnOnce(&Self) -> T + Send + 'static,
-    ) -> T {
+    ) -> Pin<Box<dyn Future<Output = T> + Send>> {
         let mgr = Arc::clone(mpc_manager);
-        spawn_blocking(move || f(&mgr.read().unwrap())).await
+        // This is boxed to keep the future off the caller's stack. If inlined and deeply nested,
+        // it can overflow the worker stack.
+        Box::pin(async move { spawn_blocking(move || f(&mgr.read().unwrap())).await })
     }
 
     /// Run `f` against a write-locked manager on a blocking thread.
-    async fn with_manager_blocking_mut<T: Send + 'static>(
+    fn with_manager_blocking_mut<T: Send + 'static>(
         mpc_manager: &Arc<RwLock<Self>>,
         f: impl FnOnce(&mut Self) -> T + Send + 'static,
-    ) -> T {
+    ) -> Pin<Box<dyn Future<Output = T> + Send>> {
         let mgr = Arc::clone(mpc_manager);
-        spawn_blocking(move || f(&mut mgr.write().unwrap())).await
+        // Same as with_manager_blocking.
+        Box::pin(async move { spawn_blocking(move || f(&mut mgr.write().unwrap())).await })
     }
 
     /// The AVSS threshold parameters (`t`, `f`) for this manager's epoch.
@@ -6500,9 +6504,19 @@ fn consume_certified_nonce_outputs<T>(
 }
 
 /// Time an async operation on `metric[label]`, holding the timer until `f` completes.
-pub(crate) async fn time_async<F: Future>(metric: &HistogramVec, label: &str, f: F) -> F::Output {
-    let _timer = metric.with_label_values(&[label]).start_timer();
-    f.await
+pub(crate) fn time_async<'a, F>(
+    metric: &HistogramVec,
+    label: &str,
+    f: F,
+) -> Pin<Box<dyn Future<Output = F::Output> + Send + 'a>>
+where
+    F: Future + Send + 'a,
+{
+    let timer = metric.with_label_values(&[label]).start_timer();
+    Box::pin(async move {
+        let _timer = timer;
+        f.await
+    })
 }
 
 pub(crate) async fn spawn_blocking<F, T>(f: F) -> T

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -91,6 +91,8 @@ use hashi_types::committee::Committee;
 use hashi_types::committee::MemberSignature;
 use hashi_types::committee::ReducedWeight;
 use prometheus::HistogramVec;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -1246,11 +1248,11 @@ impl MpcManager {
         metrics: &Metrics,
     ) -> MpcResult<()> {
         // TODO(Optimization): Skip dealer phase if certificate is already on TOB
+        let mut rng = StdRng::from_entropy();
         let dealer_data = time_async(
             &metrics.mpc_dealer_crypto_duration_seconds,
             MPC_LABEL_DKG,
             Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
-                let mut rng = rand::thread_rng();
                 mgr.prepare_dkg_dealer_flow(&mut rng)
             }),
         )
@@ -1517,8 +1519,8 @@ impl MpcManager {
             .start_timer();
         let dealer_data = {
             let previous = previous.clone();
+            let mut rng = StdRng::from_entropy();
             Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
-                let mut rng = rand::thread_rng();
                 mgr.prepare_rotation_dealer_flow(&previous, &mut rng)
             })
             .await?
@@ -1813,11 +1815,11 @@ impl MpcManager {
         tob_channel: &mut impl OrderedBroadcastChannel<CertificateV1>,
         metrics: &Metrics,
     ) -> MpcResult<()> {
+        let mut rng = StdRng::from_entropy();
         let dealer_data = time_async(
             &metrics.mpc_dealer_crypto_duration_seconds,
             MPC_LABEL_NONCE_GENERATION,
             Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
-                let mut rng = rand::thread_rng();
                 mgr.prepare_nonce_dealer_flow(batch_index, &mut rng)
             }),
         )
@@ -2848,11 +2850,11 @@ impl MpcManager {
         tob_channel: &mut impl OrderedBroadcastChannel<CertificateV1>,
         metrics: &Metrics,
     ) -> MpcResult<()> {
+        let mut rng = StdRng::from_entropy();
         let mut dealer_data = time_async(
             &metrics.mpc_dealer_crypto_duration_seconds,
             MPC_LABEL_NONCE_GENERATION,
             Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
-                let mut rng = rand::thread_rng();
                 mgr.prepare_avid_nonce_dealer_flow(batch_index, &mut rng)
             }),
         )

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -363,8 +363,8 @@ impl MpcManager {
         f: impl FnOnce(&Self) -> T + Send + 'static,
     ) -> Pin<Box<dyn Future<Output = T> + Send>> {
         let mgr = Arc::clone(mpc_manager);
-        // This is boxed to keep the future off the caller's stack. If inlined and deeply nested,
-        // it can overflow the worker stack.
+        // Boxed so it isn't inlined into the enclosing future; deeply nested, the inlined
+        // layers can overflow the worker stack.
         Box::pin(async move { spawn_blocking(move || f(&mgr.read().unwrap())).await })
     }
 
@@ -6514,7 +6514,9 @@ pub(crate) fn time_async<'a, F>(
 where
     F: Future + Send + 'a,
 {
+    // Timer starts here, at call time, not on first poll of the returned future.
     let timer = metric.with_label_values(&[label]).start_timer();
+    // Boxed for the same reason as with_manager_blocking.
     Box::pin(async move {
         let _timer = timer;
         f.await

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -90,10 +90,12 @@ use hashi_types::committee::BlsSignatureAggregator;
 use hashi_types::committee::Committee;
 use hashi_types::committee::MemberSignature;
 use hashi_types::committee::ReducedWeight;
+use prometheus::HistogramVec;
 use rand::seq::SliceRandom;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::RwLock;
@@ -350,6 +352,24 @@ impl MpcManager {
         };
         manager.load_stored_messages()?;
         Ok(manager)
+    }
+
+    /// Run `f` against a read-locked manager on a blocking thread.
+    async fn with_manager_blocking<T: Send + 'static>(
+        mpc_manager: &Arc<RwLock<Self>>,
+        f: impl FnOnce(&Self) -> T + Send + 'static,
+    ) -> T {
+        let mgr = Arc::clone(mpc_manager);
+        spawn_blocking(move || f(&mgr.read().unwrap())).await
+    }
+
+    /// Run `f` against a write-locked manager on a blocking thread.
+    async fn with_manager_blocking_mut<T: Send + 'static>(
+        mpc_manager: &Arc<RwLock<Self>>,
+        f: impl FnOnce(&mut Self) -> T + Send + 'static,
+    ) -> T {
+        let mgr = Arc::clone(mpc_manager);
+        spawn_blocking(move || f(&mut mgr.write().unwrap())).await
     }
 
     // Only for devnet key recovery CLI tool
@@ -837,14 +857,12 @@ impl MpcManager {
         metrics: &Metrics,
     ) -> MpcResult<MpcOutput> {
         tracing::info!("run_key_rotation: starting prepare_previous_output");
-        let _timer = metrics
-            .mpc_rotation_prepare_previous_duration_seconds
-            .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-            .start_timer();
-        let (previous, is_member_of_previous_committee) =
-            Self::prepare_previous_output(mpc_manager, previous_certificates, p2p_channel, metrics)
-                .await?;
-        drop(_timer);
+        let (previous, is_member_of_previous_committee) = time_async(
+            &metrics.mpc_rotation_prepare_previous_duration_seconds,
+            MPC_LABEL_KEY_ROTATION,
+            Self::prepare_previous_output(mpc_manager, previous_certificates, p2p_channel, metrics),
+        )
+        .await?;
         tracing::info!(
             "run_key_rotation: prepare_previous_output complete, \
              is_member={is_member_of_previous_committee}",
@@ -1182,9 +1200,7 @@ impl MpcManager {
                     continue;
                 }
             };
-            let mgr = Arc::clone(mpc_manager);
-            let verification = spawn_blocking(move || {
-                let mgr = mgr.read().unwrap();
+            let verification = Self::with_manager_blocking(mpc_manager, move |mgr| {
                 mgr.verify_nonce_dealer_certificate(&dealer_cert)
                     .map_err(|e| {
                         let reason = mgr.rejection_reason(
@@ -1218,20 +1234,17 @@ impl MpcManager {
         metrics: &Metrics,
     ) -> MpcResult<()> {
         // TODO(Optimization): Skip dealer phase if certificate is already on TOB
-        let _timer = metrics
-            .mpc_dealer_crypto_duration_seconds
-            .with_label_values(&[MPC_LABEL_DKG])
-            .start_timer();
-        let dealer_data = {
-            let mgr = Arc::clone(mpc_manager);
+        let mgr = Arc::clone(mpc_manager);
+        let dealer_data = time_async(
+            &metrics.mpc_dealer_crypto_duration_seconds,
+            MPC_LABEL_DKG,
             spawn_blocking(move || {
                 let mut rng = rand::thread_rng();
                 let mut mgr = mgr.write().unwrap();
                 mgr.prepare_dkg_dealer_flow(&mut rng)
-            })
-            .await?
-        };
-        drop(_timer);
+            }),
+        )
+        .await?;
         let mut aggregator = BlsSignatureAggregator::new_reduced(
             &dealer_data.committee,
             dealer_data.messages_hash.clone(),
@@ -1298,15 +1311,13 @@ impl MpcManager {
             if dealer_weight_sum >= threshold {
                 break;
             }
-            let _timer = metrics
-                .mpc_tob_poll_duration_seconds
-                .with_label_values(&[MPC_LABEL_DKG])
-                .start_timer();
-            let cert = tob_channel
-                .receive()
-                .await
-                .map_err(|e| MpcError::BroadcastError(e.to_string()))?;
-            drop(_timer);
+            let cert = time_async(
+                &metrics.mpc_tob_poll_duration_seconds,
+                MPC_LABEL_DKG,
+                tob_channel.receive(),
+            )
+            .await
+            .map_err(|e| MpcError::BroadcastError(e.to_string()))?;
             let CertificateV1::Dkg(dkg_cert) = cert else {
                 continue;
             };
@@ -1316,18 +1327,15 @@ impl MpcManager {
                 continue;
             }
             {
-                let _timer = metrics
-                    .mpc_cert_verify_duration_seconds
-                    .with_label_values(&[MPC_LABEL_DKG])
-                    .start_timer();
-                let mgr = Arc::clone(mpc_manager);
                 let cert = dkg_cert.clone();
-                let verified = spawn_blocking(move || {
-                    let mgr = mgr.read().unwrap();
-                    mgr.verify_certificate(CertificateV1::Dkg(cert)).map(|_| ())
-                })
+                let verified = time_async(
+                    &metrics.mpc_cert_verify_duration_seconds,
+                    MPC_LABEL_DKG,
+                    Self::with_manager_blocking(mpc_manager, move |mgr| {
+                        mgr.verify_certificate(CertificateV1::Dkg(cert)).map(|_| ())
+                    }),
+                )
                 .await;
-                drop(_timer);
                 if let Err(e) = verified {
                     tracing::warn!("Rejected DKG cert from {:?}: {}", &dealer, e);
                     let reason = {
@@ -1358,21 +1366,20 @@ impl MpcManager {
                     "Certificate from dealer {:?} received but message missing or hash mismatch, retrieving from signers",
                     &dealer
                 );
-                let _timer = metrics
-                    .mpc_message_retrieval_duration_seconds
-                    .with_label_values(&[MPC_LABEL_DKG])
-                    .start_timer();
-                Self::retrieve_dealer_message(mpc_manager, message, &dkg_cert, p2p_channel)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(
-                            "Failed to retrieve message from any signer for dealer {:?}: {}. Certificate exists but message unavailable from all signers.",
-                            &dealer,
-                            e
-                        );
+                time_async(
+                    &metrics.mpc_message_retrieval_duration_seconds,
+                    MPC_LABEL_DKG,
+                    Self::retrieve_dealer_message(mpc_manager, message, &dkg_cert, p2p_channel),
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        "Failed to retrieve message from any signer for dealer {:?}: {}. Certificate exists but message unavailable from all signers.",
+                        &dealer,
                         e
-                    })?;
-                drop(_timer);
+                    );
+                    e
+                })?;
                 // Delete stale output from the RPC handler so the party phase
                 // reprocesses with the retrieved (certified) message.
                 mpc_manager
@@ -1381,14 +1388,10 @@ impl MpcManager {
                     .dealer_outputs
                     .remove(&DealerOutputsKey::Dkg(dealer));
             }
-            let _timer = metrics
-                .mpc_message_process_duration_seconds
-                .with_label_values(&[MPC_LABEL_DKG])
-                .start_timer();
-            let has_complaint = {
-                let mgr = Arc::clone(mpc_manager);
-                spawn_blocking(move || {
-                    let mut mgr = mgr.write().unwrap();
+            let has_complaint = time_async(
+                &metrics.mpc_message_process_duration_seconds,
+                MPC_LABEL_DKG,
+                Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
                     if !mgr
                         .dealer_outputs
                         .contains_key(&DealerOutputsKey::Dkg(dealer))
@@ -1402,10 +1405,9 @@ impl MpcManager {
                         mgr.complaints_to_process
                             .contains_key(&ComplaintsToProcessKey::Dkg(dealer)),
                     )
-                })
-                .await?
-            };
-            drop(_timer);
+                }),
+            )
+            .await?;
             if has_complaint {
                 tracing::info!(
                     "DKG complaint detected for dealer {:?}, recovering via Complain RPC",
@@ -1480,19 +1482,14 @@ impl MpcManager {
             dealer_weight_sum += dealer_weight as u32;
             certified_dealers.insert(dealer);
         }
-        let _timer = metrics
-            .mpc_completion_duration_seconds
-            .with_label_values(&[MPC_LABEL_DKG])
-            .start_timer();
-        let output = {
-            let mgr = Arc::clone(mpc_manager);
-            spawn_blocking(move || {
-                let mgr = mgr.read().unwrap();
+        let output = time_async(
+            &metrics.mpc_completion_duration_seconds,
+            MPC_LABEL_DKG,
+            Self::with_manager_blocking(mpc_manager, move |mgr| {
                 mgr.complete_dkg(certified_dealers.into_iter())
-            })
-            .await?
-        };
-        drop(_timer);
+            }),
+        )
+        .await?;
         Ok(output)
     }
 
@@ -1594,15 +1591,13 @@ impl MpcManager {
             if certified_share_indices.len() >= previous.threshold as usize {
                 break;
             }
-            let _timer = metrics
-                .mpc_tob_poll_duration_seconds
-                .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                .start_timer();
-            let cert = ordered_broadcast_channel
-                .receive()
-                .await
-                .map_err(|e| MpcError::BroadcastError(e.to_string()))?;
-            drop(_timer);
+            let cert = time_async(
+                &metrics.mpc_tob_poll_duration_seconds,
+                MPC_LABEL_KEY_ROTATION,
+                ordered_broadcast_channel.receive(),
+            )
+            .await
+            .map_err(|e| MpcError::BroadcastError(e.to_string()))?;
             let CertificateV1::Rotation(rotation_cert) = cert else {
                 continue;
             };
@@ -1612,19 +1607,16 @@ impl MpcManager {
                 continue;
             }
             {
-                let _timer = metrics
-                    .mpc_cert_verify_duration_seconds
-                    .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                    .start_timer();
-                let mgr = Arc::clone(mpc_manager);
                 let cert = rotation_cert.clone();
-                let verified = spawn_blocking(move || {
-                    let mgr = mgr.read().unwrap();
-                    mgr.verify_certificate(CertificateV1::Rotation(cert))
-                        .map(|_| ())
-                })
+                let verified = time_async(
+                    &metrics.mpc_cert_verify_duration_seconds,
+                    MPC_LABEL_KEY_ROTATION,
+                    Self::with_manager_blocking(mpc_manager, move |mgr| {
+                        mgr.verify_certificate(CertificateV1::Rotation(cert))
+                            .map(|_| ())
+                    }),
+                )
                 .await;
-                drop(_timer);
                 if let Err(e) = verified {
                     tracing::warn!("Rejected rotation cert from {:?}: {}", &dealer, e);
                     let reason = {
@@ -1677,21 +1669,25 @@ impl MpcManager {
                     "Rotation messages from dealer {:?} not available or hash mismatch, retrieving from signers",
                     dealer
                 );
-                let _timer = metrics
-                    .mpc_message_retrieval_duration_seconds
-                    .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                    .start_timer();
-                Self::retrieve_rotation_messages(mpc_manager, message, &rotation_cert, p2p_channel)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(
-                            "Failed to retrieve rotation messages for dealer {:?}: {}",
-                            dealer,
-                            e
-                        );
+                time_async(
+                    &metrics.mpc_message_retrieval_duration_seconds,
+                    MPC_LABEL_KEY_ROTATION,
+                    Self::retrieve_rotation_messages(
+                        mpc_manager,
+                        message,
+                        &rotation_cert,
+                        p2p_channel,
+                    ),
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        "Failed to retrieve rotation messages for dealer {:?}: {}",
+                        dealer,
                         e
-                    })?;
-                drop(_timer);
+                    );
+                    e
+                })?;
                 // Delete stale outputs from the RPC handler so the party phase
                 // reprocesses with the retrieved (certified) messages.
                 {
@@ -1706,11 +1702,9 @@ impl MpcManager {
                     .mpc_message_process_duration_seconds
                     .with_label_values(&[MPC_LABEL_KEY_ROTATION])
                     .start_timer();
-                let mgr = Arc::clone(mpc_manager);
                 let previous = previous.clone();
                 let share_indices = dealer_share_indices.clone();
-                spawn_blocking(move || {
-                    let mut mgr = mgr.write().unwrap();
+                Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
                     if share_indices.iter().any(|idx| {
                         !mgr.dealer_outputs
                             .contains_key(&DealerOutputsKey::Rotation(*idx))
@@ -1794,10 +1788,8 @@ impl MpcManager {
             .with_label_values(&[MPC_LABEL_KEY_ROTATION])
             .start_timer();
         let output = {
-            let mgr = Arc::clone(mpc_manager);
             let previous = previous.clone();
-            spawn_blocking(move || {
-                let mut mgr = mgr.write().unwrap();
+            Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
                 mgr.complete_key_rotation(&previous, &certified_share_indices)
             })
             .await?
@@ -1813,20 +1805,17 @@ impl MpcManager {
         tob_channel: &mut impl OrderedBroadcastChannel<CertificateV1>,
         metrics: &Metrics,
     ) -> MpcResult<()> {
-        let _timer = metrics
-            .mpc_dealer_crypto_duration_seconds
-            .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-            .start_timer();
-        let dealer_data = {
-            let mgr = Arc::clone(mpc_manager);
+        let mgr = Arc::clone(mpc_manager);
+        let dealer_data = time_async(
+            &metrics.mpc_dealer_crypto_duration_seconds,
+            MPC_LABEL_NONCE_GENERATION,
             spawn_blocking(move || {
                 let mut rng = rand::thread_rng();
                 let mut mgr = mgr.write().unwrap();
                 mgr.prepare_nonce_dealer_flow(batch_index, &mut rng)
-            })
-            .await?
-        };
-        drop(_timer);
+            }),
+        )
+        .await?;
         let mut aggregator = BlsSignatureAggregator::new_reduced(
             &dealer_data.committee,
             dealer_data.messages_hash.clone(),
@@ -1894,15 +1883,13 @@ impl MpcManager {
             if dealer_weight_sum >= required_weight {
                 break;
             }
-            let _timer = metrics
-                .mpc_tob_poll_duration_seconds
-                .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-                .start_timer();
-            let cert = tob_channel
-                .receive()
-                .await
-                .map_err(|e| MpcError::BroadcastError(e.to_string()))?;
-            drop(_timer);
+            let cert = time_async(
+                &metrics.mpc_tob_poll_duration_seconds,
+                MPC_LABEL_NONCE_GENERATION,
+                tob_channel.receive(),
+            )
+            .await
+            .map_err(|e| MpcError::BroadcastError(e.to_string()))?;
             let CertificateV1::NonceGeneration {
                 cert: nonce_cert, ..
             } = cert
@@ -1915,18 +1902,15 @@ impl MpcManager {
                 continue;
             }
             {
-                let _timer = metrics
-                    .mpc_cert_verify_duration_seconds
-                    .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-                    .start_timer();
-                let mgr = Arc::clone(mpc_manager);
                 let cert = nonce_cert.clone();
-                let verified = spawn_blocking(move || {
-                    let mgr = mgr.read().unwrap();
-                    mgr.verify_nonce_dealer_certificate(&cert).map(|_| ())
-                })
+                let verified = time_async(
+                    &metrics.mpc_cert_verify_duration_seconds,
+                    MPC_LABEL_NONCE_GENERATION,
+                    Self::with_manager_blocking(mpc_manager, move |mgr| {
+                        mgr.verify_nonce_dealer_certificate(&cert).map(|_| ())
+                    }),
+                )
                 .await;
-                drop(_timer);
                 if let Err(e) = verified {
                     tracing::warn!("Rejected nonce cert from {:?}: {}", &dealer, e);
                     let reason = {
@@ -1949,16 +1933,16 @@ impl MpcManager {
                     "Nonce message for dealer {:?} not found in memory or DB, retrieving from signers",
                     &dealer
                 );
-                let _timer = metrics
-                    .mpc_message_retrieval_duration_seconds
-                    .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-                    .start_timer();
-                Self::retrieve_nonce_message(
-                    mpc_manager,
-                    message,
-                    &nonce_cert,
-                    p2p_channel,
-                    batch_index,
+                time_async(
+                    &metrics.mpc_message_retrieval_duration_seconds,
+                    MPC_LABEL_NONCE_GENERATION,
+                    Self::retrieve_nonce_message(
+                        mpc_manager,
+                        message,
+                        &nonce_cert,
+                        p2p_channel,
+                        batch_index,
+                    ),
                 )
                 .await
                 .map_err(|e| {
@@ -1969,7 +1953,6 @@ impl MpcManager {
                     );
                     e
                 })?;
-                drop(_timer);
                 // Delete stale output from the RPC handler so the party phase
                 // reprocesses with the retrieved (certified) message.
                 mpc_manager
@@ -1978,14 +1961,10 @@ impl MpcManager {
                     .dealer_nonce_outputs
                     .remove(&(batch_index, dealer));
             }
-            let _timer = metrics
-                .mpc_message_process_duration_seconds
-                .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-                .start_timer();
-            let has_complaint = {
-                let mgr = Arc::clone(mpc_manager);
-                spawn_blocking(move || {
-                    let mut mgr = mgr.write().unwrap();
+            let has_complaint = time_async(
+                &metrics.mpc_message_process_duration_seconds,
+                MPC_LABEL_NONCE_GENERATION,
+                Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
                     if !mgr
                         .dealer_nonce_outputs
                         .contains_key(&(batch_index, dealer))
@@ -2004,10 +1983,9 @@ impl MpcManager {
                             dealer,
                         },
                     ))
-                })
-                .await?
-            };
-            drop(_timer);
+                }),
+            )
+            .await?;
             if has_complaint {
                 tracing::info!(
                     "Nonce gen complaint detected for dealer {:?}, recovering via Complain RPC",
@@ -2885,20 +2863,17 @@ impl MpcManager {
         tob_channel: &mut impl OrderedBroadcastChannel<CertificateV1>,
         metrics: &Metrics,
     ) -> MpcResult<()> {
-        let _timer = metrics
-            .mpc_dealer_crypto_duration_seconds
-            .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-            .start_timer();
-        let mut dealer_data = {
-            let mgr = Arc::clone(mpc_manager);
+        let mgr = Arc::clone(mpc_manager);
+        let mut dealer_data = time_async(
+            &metrics.mpc_dealer_crypto_duration_seconds,
+            MPC_LABEL_NONCE_GENERATION,
             spawn_blocking(move || {
                 let mut rng = rand::thread_rng();
                 let mut mgr = mgr.write().unwrap();
                 mgr.prepare_avid_nonce_dealer_flow(batch_index, &mut rng)
-            })
-            .await?
-        };
-        drop(_timer);
+            }),
+        )
+        .await?;
         let mut aggregator = BlsSignatureAggregator::new_reduced(
             &dealer_data.committee,
             dealer_data.confirm_target.clone(),
@@ -2963,15 +2938,11 @@ impl MpcManager {
         let confirm_cert = aggregator
             .finish()
             .expect("signatures should always be valid");
-        let _timer = metrics
-            .mpc_dealer_crypto_duration_seconds
-            .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-            .start_timer();
         let builder = dealer_data.builder;
-        let (vote_target, my_vote, recipient_dispersals) = {
-            let mgr = Arc::clone(mpc_manager);
-            spawn_blocking(move || -> MpcResult<_> {
-                let mut mgr = mgr.write().unwrap();
+        let (vote_target, my_vote, recipient_dispersals) = time_async(
+            &metrics.mpc_dealer_crypto_duration_seconds,
+            MPC_LABEL_NONCE_GENERATION,
+            Self::with_manager_blocking_mut(mpc_manager, move |mgr| -> MpcResult<_> {
                 let mut dispersals =
                     mgr.create_avid_nonce_dispersal_messages(&builder, confirm_cert, batch_index)?;
                 let own_index = dispersals
@@ -2996,10 +2967,9 @@ impl MpcManager {
                 };
                 let my_vote = MemberSignature::new(mgr.mpc_config.epoch, mgr.address, signature);
                 Ok((vote_target, my_vote, dispersals))
-            })
-            .await?
-        };
-        drop(_timer);
+            }),
+        )
+        .await?;
         let mut vote_aggregator = BlsSignatureAggregator::new_reduced(
             &dealer_data.committee,
             vote_target,
@@ -3165,9 +3135,7 @@ impl MpcManager {
         certified: Vec<(Address, CertificateV1)>,
         metrics: &Metrics,
     ) -> BTreeMap<Address, u32> {
-        let mgr = Arc::clone(mpc_manager);
-        let (verified, rejected) = spawn_blocking(move || {
-            let mgr = mgr.read().unwrap();
+        let (verified, rejected) = Self::with_manager_blocking(mpc_manager, move |mgr| {
             mgr.verified_dealer_weight(&certified)
         })
         .await;
@@ -3340,10 +3308,8 @@ impl MpcManager {
                 }
             })
             .collect();
-        let mgr = Arc::clone(mpc_manager);
         let nonce_cert = nonce_cert.clone();
-        let outcome = spawn_blocking(move || {
-            let mut mgr = mgr.write().unwrap();
+        let outcome = Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
             let digest = nonce_cert.message().messages_hash;
             let avid_vote = bundles.iter().find_map(|(_, b)| {
                 b.avid_vote
@@ -3590,15 +3556,13 @@ impl MpcManager {
             if dealer_weight_sum >= required_weight {
                 break;
             }
-            let _timer = metrics
-                .mpc_tob_poll_duration_seconds
-                .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-                .start_timer();
-            let cert = tob_channel
-                .receive()
-                .await
-                .map_err(|e| MpcError::BroadcastError(e.to_string()))?;
-            drop(_timer);
+            let cert = time_async(
+                &metrics.mpc_tob_poll_duration_seconds,
+                MPC_LABEL_NONCE_GENERATION,
+                tob_channel.receive(),
+            )
+            .await
+            .map_err(|e| MpcError::BroadcastError(e.to_string()))?;
             let CertificateV1::NonceGeneration {
                 cert: nonce_cert, ..
             } = cert
@@ -3610,24 +3574,21 @@ impl MpcManager {
                 continue;
             }
             let signer_weight = {
-                let _timer = metrics
-                    .mpc_cert_verify_duration_seconds
-                    .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-                    .start_timer();
-                let mgr = Arc::clone(mpc_manager);
                 let cert = nonce_cert.clone();
-                let result = spawn_blocking(move || {
-                    let mgr = mgr.read().unwrap();
-                    mgr.committee
-                        .verify_signature_and_reduced_weight(
-                            &cert,
-                            &mgr.mpc_config.nodes,
-                            vote_quorum_weight,
-                        )
-                        .map_err(|e| MpcError::InvalidCertificate(e.to_string()))
-                })
+                let result = time_async(
+                    &metrics.mpc_cert_verify_duration_seconds,
+                    MPC_LABEL_NONCE_GENERATION,
+                    Self::with_manager_blocking(mpc_manager, move |mgr| {
+                        mgr.committee
+                            .verify_signature_and_reduced_weight(
+                                &cert,
+                                &mgr.mpc_config.nodes,
+                                vote_quorum_weight,
+                            )
+                            .map_err(|e| MpcError::InvalidCertificate(e.to_string()))
+                    }),
+                )
                 .await;
-                drop(_timer);
                 match result {
                     Ok(weight) => weight,
                     Err(e) => {
@@ -3655,20 +3616,19 @@ impl MpcManager {
             let kind = match kind {
                 Some(kind) => kind,
                 None => {
-                    let _timer = metrics
-                        .mpc_message_retrieval_duration_seconds
-                        .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-                        .start_timer();
-                    let result = Self::pull_and_resolve_avid_cert(
-                        mpc_manager,
-                        dealer,
-                        batch_index,
-                        &nonce_cert,
-                        p2p_channel,
-                        metrics,
+                    let result = time_async(
+                        &metrics.mpc_message_retrieval_duration_seconds,
+                        MPC_LABEL_NONCE_GENERATION,
+                        Self::pull_and_resolve_avid_cert(
+                            mpc_manager,
+                            dealer,
+                            batch_index,
+                            &nonce_cert,
+                            p2p_channel,
+                            metrics,
+                        ),
                     )
                     .await;
-                    drop(_timer);
                     match result {
                         Ok(kind) => kind,
                         Err(e) => {
@@ -5446,18 +5406,17 @@ impl MpcManager {
         };
         let previous = if is_member_of_previous_committee && has_previous_key {
             let reconstruction_result = async {
-                let _retrieve_timer = metrics
-                    .mpc_prepare_previous_retrieve_duration_seconds
-                    .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                    .start_timer();
-                Self::retrieve_missing_previous_messages(
-                    mpc_manager,
-                    previous_certificates,
-                    p2p_channel,
-                    metrics,
+                time_async(
+                    &metrics.mpc_prepare_previous_retrieve_duration_seconds,
+                    MPC_LABEL_KEY_ROTATION,
+                    Self::retrieve_missing_previous_messages(
+                        mpc_manager,
+                        previous_certificates,
+                        p2p_channel,
+                        metrics,
+                    ),
                 )
                 .await;
-                drop(_retrieve_timer);
                 Self::reconstruct_with_complaint_recovery(
                     mpc_manager,
                     previous_certificates,
@@ -5523,19 +5482,16 @@ impl MpcManager {
     ) -> MpcResult<MpcOutput> {
         let mut complaint_cache: HashMap<DealerOutputsKey, avss::AvssOutput> = HashMap::new();
         loop {
-            let mgr = Arc::clone(mpc_manager);
             let certs = previous_certificates.to_vec();
             let cache_snapshot = complaint_cache.clone();
-            let _reconstruct_timer = metrics
-                .mpc_prepare_previous_reconstruct_duration_seconds
-                .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                .start_timer();
-            let outcome = spawn_blocking(move || {
-                let mgr = mgr.read().unwrap();
-                mgr.reconstruct_previous_output(&certs, &cache_snapshot)
-            })
+            let outcome = time_async(
+                &metrics.mpc_prepare_previous_reconstruct_duration_seconds,
+                MPC_LABEL_KEY_ROTATION,
+                Self::with_manager_blocking(mpc_manager, move |mgr| {
+                    mgr.reconstruct_previous_output(&certs, &cache_snapshot)
+                }),
+            )
             .await?;
-            drop(_reconstruct_timer);
             match outcome {
                 ReconstructionOutcome::Success(output) => return Ok(output),
                 ReconstructionOutcome::NeedsDkgComplaintRecovery {
@@ -5564,20 +5520,19 @@ impl MpcManager {
                         .mpc_prepare_previous_complaint_recovery_total
                         .with_label_values(&[MPC_LABEL_KEY_ROTATION])
                         .inc();
-                    let _recovery_timer = metrics
-                        .mpc_prepare_previous_complaint_recovery_duration_seconds
-                        .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                        .start_timer();
-                    let recovered = Self::recover_dkg_shares_via_complaint(
-                        mpc_manager,
-                        &dealer_address,
-                        &message,
-                        signers,
-                        p2p_channel,
-                        previous_epoch,
+                    let recovered = time_async(
+                        &metrics.mpc_prepare_previous_complaint_recovery_duration_seconds,
+                        MPC_LABEL_KEY_ROTATION,
+                        Self::recover_dkg_shares_via_complaint(
+                            mpc_manager,
+                            &dealer_address,
+                            &message,
+                            signers,
+                            p2p_channel,
+                            previous_epoch,
+                        ),
                     )
                     .await?;
-                    drop(_recovery_timer);
                     complaint_cache.insert(DealerOutputsKey::Dkg(dealer_address), recovered);
                     mpc_manager
                         .write()
@@ -5630,20 +5585,19 @@ impl MpcManager {
                         .mpc_prepare_previous_complaint_recovery_total
                         .with_label_values(&[MPC_LABEL_KEY_ROTATION])
                         .inc();
-                    let _recovery_timer = metrics
-                        .mpc_prepare_previous_complaint_recovery_duration_seconds
-                        .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                        .start_timer();
-                    let recovered = Self::recover_rotation_shares_via_complaints(
-                        mpc_manager,
-                        &dealer_address,
-                        &rotation_msgs,
-                        signers,
-                        p2p_channel,
-                        previous_epoch,
+                    let recovered = time_async(
+                        &metrics.mpc_prepare_previous_complaint_recovery_duration_seconds,
+                        MPC_LABEL_KEY_ROTATION,
+                        Self::recover_rotation_shares_via_complaints(
+                            mpc_manager,
+                            &dealer_address,
+                            &rotation_msgs,
+                            signers,
+                            p2p_channel,
+                            previous_epoch,
+                        ),
                     )
                     .await?;
-                    drop(_recovery_timer);
                     let mut mgr = mpc_manager.write().unwrap();
                     for (share_index, output) in recovered {
                         complaint_cache.insert(DealerOutputsKey::Rotation(share_index), output);
@@ -6539,12 +6493,12 @@ async fn publish_dealer_cert(
     protocol: &'static str,
     metrics: &Metrics,
 ) -> MpcResult<()> {
-    let _timer = metrics
-        .mpc_cert_publish_duration_seconds
-        .with_label_values(&[protocol])
-        .start_timer();
-    let result = with_timeout_and_retry(|| tob_channel.publish(cert.clone())).await;
-    drop(_timer);
+    let result = time_async(
+        &metrics.mpc_cert_publish_duration_seconds,
+        protocol,
+        with_timeout_and_retry(|| tob_channel.publish(cert.clone())),
+    )
+    .await;
     let outcome = match &result {
         Ok(PublishOutcome::Landed) => "ok",
         Ok(PublishOutcome::AlreadyPresent) => "already_present",
@@ -6597,6 +6551,12 @@ fn consume_certified_nonce_outputs<T>(
         }
     });
     (pre_filter, dealers, outputs)
+}
+
+/// Time an async operation on `metric[label]`; the timer stops when `fut` completes.
+async fn time_async<F: Future>(metric: &HistogramVec, label: &str, fut: F) -> F::Output {
+    let _timer = metric.with_label_values(&[label]).start_timer();
+    fut.await
 }
 
 pub(crate) async fn spawn_blocking<F, T>(f: F) -> T

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -379,7 +379,7 @@ impl MpcManager {
     }
 
     /// The AVSS threshold parameters (`t`, `f`) for this manager's epoch.
-    fn params(&self) -> Parameters {
+    pub(crate) fn params(&self) -> Parameters {
         Parameters {
             t: self.mpc_config.threshold,
             f: self.mpc_config.max_faulty,

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -372,6 +372,14 @@ impl MpcManager {
         spawn_blocking(move || f(&mut mgr.write().unwrap())).await
     }
 
+    /// The AVSS threshold parameters (`t`, `f`) for this manager's epoch.
+    fn params(&self) -> Parameters {
+        Parameters {
+            t: self.mpc_config.threshold,
+            f: self.mpc_config.max_faulty,
+        }
+    }
+
     // Only for devnet key recovery CLI tool
     pub fn handle_send_messages_request(
         &mut self,
@@ -2046,17 +2054,8 @@ impl MpcManager {
     ) -> avss::Message {
         let dealer_session_id = self.current_session_id().dealer_session_id(&self.address);
         let nodes = self.maybe_corrupt_nodes_for_testing(&self.mpc_config.nodes);
-        let dealer = avss::Dealer::new(
-            None,
-            nodes,
-            Parameters {
-                t: self.mpc_config.threshold,
-                f: self.mpc_config.max_faulty,
-            },
-            dealer_session_id.to_vec(),
-            rng,
-        )
-        .expect("checked threshold above");
+        let dealer = avss::Dealer::new(None, nodes, self.params(), dealer_session_id.to_vec(), rng)
+            .expect("checked threshold above");
         dealer.create_message(rng)
     }
 
@@ -2206,10 +2205,7 @@ impl MpcManager {
             &self.encryption_key,
             self.mpc_config.nodes.clone(),
             self.party_id,
-            Parameters {
-                t: self.mpc_config.threshold,
-                f: self.mpc_config.max_faulty,
-            },
+            self.params(),
             &dealer_session_id,
             message,
             None, // commitment: None for initial DKG
@@ -2351,10 +2347,7 @@ impl MpcManager {
             self.mpc_config.nodes.clone(),
             self.party_id,
             dealer_party_id,
-            Parameters {
-                t: self.mpc_config.threshold,
-                f: self.mpc_config.max_faulty,
-            },
+            self.params(),
             dealer_session_id.to_vec(),
             self.encryption_key.clone(),
             self.batch_size_per_weight,
@@ -2377,10 +2370,7 @@ impl MpcManager {
         let dealer = batch_avss_avid::Dealer::new(
             nodes,
             self.party_id,
-            Parameters {
-                t: self.mpc_config.threshold,
-                f: self.mpc_config.max_faulty,
-            },
+            self.params(),
             dealer_sid.to_vec(),
             self.batch_size_per_weight,
         )
@@ -2461,10 +2451,7 @@ impl MpcManager {
         let dealer = batch_avss_avid::Dealer::new(
             nodes,
             self.party_id,
-            Parameters {
-                t: self.mpc_config.threshold,
-                f: self.mpc_config.max_faulty,
-            },
+            self.params(),
             dealer_sid.to_vec(),
             self.batch_size_per_weight,
         )
@@ -3028,14 +3015,7 @@ impl MpcManager {
         epoch: u64,
     ) -> MpcResult<(&Committee, &Nodes<EncryptionGroupElement>, Parameters)> {
         if epoch == self.mpc_config.epoch {
-            return Ok((
-                &self.committee,
-                &self.mpc_config.nodes,
-                Parameters {
-                    t: self.mpc_config.threshold,
-                    f: self.mpc_config.max_faulty,
-                },
-            ));
+            return Ok((&self.committee, &self.mpc_config.nodes, self.params()));
         }
         if epoch != self.previous_epoch {
             return Err(MpcError::InvalidCertificate(format!(
@@ -3098,10 +3078,7 @@ impl MpcManager {
     }
 
     fn current_dealer_cert_quorum(&self) -> u32 {
-        Self::dealer_cert_quorum(Parameters {
-            t: self.mpc_config.threshold,
-            f: self.mpc_config.max_faulty,
-        })
+        Self::dealer_cert_quorum(self.params())
     }
 
     fn nonce_cert_quorum(&self, epoch: u64) -> MpcResult<u32> {
@@ -4634,17 +4611,9 @@ impl MpcManager {
             .map(|share| {
                 let sid = base_sid.rotation_session_id(&self.address, share.index);
                 let nodes = self.maybe_corrupt_nodes_for_testing(&self.mpc_config.nodes);
-                let dealer = avss::Dealer::new(
-                    Some(share.value),
-                    nodes,
-                    Parameters {
-                        t: self.mpc_config.threshold,
-                        f: self.mpc_config.max_faulty,
-                    },
-                    sid.to_vec(),
-                    rng,
-                )
-                .expect(EXPECT_THRESHOLD_VALIDATED);
+                let dealer =
+                    avss::Dealer::new(Some(share.value), nodes, self.params(), sid.to_vec(), rng)
+                        .expect(EXPECT_THRESHOLD_VALIDATED);
                 let message = dealer.create_message(rng);
                 (share.index, message)
             })
@@ -4728,10 +4697,7 @@ impl MpcManager {
                 &self.encryption_key,
                 self.mpc_config.nodes.clone(),
                 self.party_id,
-                Parameters {
-                    t: self.mpc_config.threshold,
-                    f: self.mpc_config.max_faulty,
-                },
+                self.params(),
                 &session_id,
                 message,
                 commitment,
@@ -5953,14 +5919,7 @@ impl MpcManager {
         epoch: u64,
     ) -> MpcResult<(Nodes<EncryptionGroupElement>, u16, Parameters)> {
         if epoch == self.mpc_config.epoch {
-            Ok((
-                self.mpc_config.nodes.clone(),
-                self.party_id,
-                Parameters {
-                    t: self.mpc_config.threshold,
-                    f: self.mpc_config.max_faulty,
-                },
-            ))
+            Ok((self.mpc_config.nodes.clone(), self.party_id, self.params()))
         } else if epoch == self.previous_epoch {
             let committee = self.previous_committee.as_ref().ok_or_else(|| {
                 MpcError::InvalidConfig("No previous committee for cross-epoch complaint".into())

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -355,7 +355,7 @@ impl MpcManager {
     }
 
     /// Run `f` against a read-locked manager on a blocking thread.
-    async fn with_manager_blocking<T: Send + 'static>(
+    pub(crate) async fn with_manager_blocking<T: Send + 'static>(
         mpc_manager: &Arc<RwLock<Self>>,
         f: impl FnOnce(&Self) -> T + Send + 'static,
     ) -> T {
@@ -1234,13 +1234,11 @@ impl MpcManager {
         metrics: &Metrics,
     ) -> MpcResult<()> {
         // TODO(Optimization): Skip dealer phase if certificate is already on TOB
-        let mgr = Arc::clone(mpc_manager);
         let dealer_data = time_async(
             &metrics.mpc_dealer_crypto_duration_seconds,
             MPC_LABEL_DKG,
-            spawn_blocking(move || {
+            Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
                 let mut rng = rand::thread_rng();
-                let mut mgr = mgr.write().unwrap();
                 mgr.prepare_dkg_dealer_flow(&mut rng)
             }),
         )
@@ -1506,11 +1504,9 @@ impl MpcManager {
             .with_label_values(&[MPC_LABEL_KEY_ROTATION])
             .start_timer();
         let dealer_data = {
-            let mgr = Arc::clone(mpc_manager);
             let previous = previous.clone();
-            spawn_blocking(move || {
+            Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
                 let mut rng = rand::thread_rng();
-                let mut mgr = mgr.write().unwrap();
                 mgr.prepare_rotation_dealer_flow(&previous, &mut rng)
             })
             .await?
@@ -1805,13 +1801,11 @@ impl MpcManager {
         tob_channel: &mut impl OrderedBroadcastChannel<CertificateV1>,
         metrics: &Metrics,
     ) -> MpcResult<()> {
-        let mgr = Arc::clone(mpc_manager);
         let dealer_data = time_async(
             &metrics.mpc_dealer_crypto_duration_seconds,
             MPC_LABEL_NONCE_GENERATION,
-            spawn_blocking(move || {
+            Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
                 let mut rng = rand::thread_rng();
-                let mut mgr = mgr.write().unwrap();
                 mgr.prepare_nonce_dealer_flow(batch_index, &mut rng)
             }),
         )
@@ -2863,13 +2857,11 @@ impl MpcManager {
         tob_channel: &mut impl OrderedBroadcastChannel<CertificateV1>,
         metrics: &Metrics,
     ) -> MpcResult<()> {
-        let mgr = Arc::clone(mpc_manager);
         let mut dealer_data = time_async(
             &metrics.mpc_dealer_crypto_duration_seconds,
             MPC_LABEL_NONCE_GENERATION,
-            spawn_blocking(move || {
+            Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
                 let mut rng = rand::thread_rng();
-                let mut mgr = mgr.write().unwrap();
                 mgr.prepare_avid_nonce_dealer_flow(batch_index, &mut rng)
             }),
         )
@@ -3455,15 +3447,10 @@ impl MpcManager {
             protocol_type: ProtocolTypeIndicator::NonceGeneration,
             epoch,
         };
-        let receiver = {
-            let mgr = Arc::clone(mpc_manager);
-            spawn_blocking(move || {
-                mgr.read()
-                    .unwrap()
-                    .create_avid_nonce_receiver(dealer, batch_index)
-            })
-            .await?
-        };
+        let receiver = Self::with_manager_blocking(mpc_manager, move |mgr| {
+            mgr.create_avid_nonce_receiver(dealer, batch_index)
+        })
+        .await?;
         let receiver = Arc::new(receiver);
         let verified_common = Arc::new(verified_common);
         let mut verified: Vec<batch_avss_avid::VerifiedComplaintResponse> = Vec::new();
@@ -6553,10 +6540,10 @@ fn consume_certified_nonce_outputs<T>(
     (pre_filter, dealers, outputs)
 }
 
-/// Time an async operation on `metric[label]`; the timer stops when `fut` completes.
-async fn time_async<F: Future>(metric: &HistogramVec, label: &str, fut: F) -> F::Output {
+/// Time an async operation on `metric[label]`, holding the timer until `f` completes.
+pub(crate) async fn time_async<F: Future>(metric: &HistogramVec, label: &str, f: F) -> F::Output {
     let _timer = metric.with_label_values(&[label]).start_timer();
-    fut.await
+    f.await
 }
 
 pub(crate) async fn spawn_blocking<F, T>(f: F) -> T

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -369,7 +369,7 @@ impl MpcManager {
     }
 
     /// Run `f` against a write-locked manager on a blocking thread.
-    fn with_manager_blocking_mut<T: Send + 'static>(
+    pub(crate) fn with_manager_blocking_mut<T: Send + 'static>(
         mpc_manager: &Arc<RwLock<Self>>,
         f: impl FnOnce(&mut Self) -> T + Send + 'static,
     ) -> Pin<Box<dyn Future<Output = T> + Send>> {
@@ -1513,19 +1513,18 @@ impl MpcManager {
         metrics: &Metrics,
     ) -> MpcResult<()> {
         // TODO(Optimization): Skip dealer phase if certificate is already on TOB
-        let _timer = metrics
-            .mpc_dealer_crypto_duration_seconds
-            .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-            .start_timer();
         let dealer_data = {
             let previous = previous.clone();
             let mut rng = StdRng::from_entropy();
-            Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
-                mgr.prepare_rotation_dealer_flow(&previous, &mut rng)
-            })
+            time_async(
+                &metrics.mpc_dealer_crypto_duration_seconds,
+                MPC_LABEL_KEY_ROTATION,
+                Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
+                    mgr.prepare_rotation_dealer_flow(&previous, &mut rng)
+                }),
+            )
             .await?
         };
-        drop(_timer);
         let mut aggregator = BlsSignatureAggregator::new_reduced(
             &dealer_data.committee,
             dealer_data.messages_hash.clone(),
@@ -1708,26 +1707,25 @@ impl MpcManager {
                 }
             }
             {
-                let _timer = metrics
-                    .mpc_message_process_duration_seconds
-                    .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                    .start_timer();
                 let previous = previous.clone();
                 let share_indices = dealer_share_indices.clone();
-                Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
-                    if share_indices.iter().any(|idx| {
-                        !mgr.dealer_outputs
-                            .contains_key(&DealerOutputsKey::Rotation(*idx))
-                            && !mgr
-                                .complaints_to_process
-                                .contains_key(&ComplaintsToProcessKey::Rotation(dealer, *idx))
-                    }) {
-                        mgr.process_certified_rotation_message(&dealer, &previous)?;
-                    }
-                    Ok::<_, MpcError>(())
-                })
+                time_async(
+                    &metrics.mpc_message_process_duration_seconds,
+                    MPC_LABEL_KEY_ROTATION,
+                    Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
+                        if share_indices.iter().any(|idx| {
+                            !mgr.dealer_outputs
+                                .contains_key(&DealerOutputsKey::Rotation(*idx))
+                                && !mgr
+                                    .complaints_to_process
+                                    .contains_key(&ComplaintsToProcessKey::Rotation(dealer, *idx))
+                        }) {
+                            mgr.process_certified_rotation_message(&dealer, &previous)?;
+                        }
+                        Ok::<_, MpcError>(())
+                    }),
+                )
                 .await?;
-                drop(_timer);
             }
             let (signers, epoch, rotation_msgs) = {
                 let mgr = mpc_manager.read().unwrap();
@@ -1793,18 +1791,17 @@ impl MpcManager {
             );
         }
         tracing::info!("run_key_rotation_as_party: threshold met, calling complete_key_rotation",);
-        let _timer = metrics
-            .mpc_completion_duration_seconds
-            .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-            .start_timer();
         let output = {
             let previous = previous.clone();
-            Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
-                mgr.complete_key_rotation(&previous, &certified_share_indices)
-            })
+            time_async(
+                &metrics.mpc_completion_duration_seconds,
+                MPC_LABEL_KEY_ROTATION,
+                Self::with_manager_blocking_mut(mpc_manager, move |mgr| {
+                    mgr.complete_key_rotation(&previous, &certified_share_indices)
+                }),
+            )
             .await?
         };
-        drop(_timer);
         Ok(output)
     }
 
@@ -5389,20 +5386,25 @@ impl MpcManager {
                 Ok(output) => output,
                 Err(e) => {
                     tracing::info!("Reconstruction failed ({e}), falling back to new-member path");
-                    let _fetch_timer = metrics
-                        .mpc_prepare_previous_fetch_public_output_duration_seconds
-                        .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                        .start_timer();
-                    Self::fetch_and_build_public_output(mpc_manager, p2p_channel, threshold_opt)
-                        .await?
+                    time_async(
+                        &metrics.mpc_prepare_previous_fetch_public_output_duration_seconds,
+                        MPC_LABEL_KEY_ROTATION,
+                        Self::fetch_and_build_public_output(
+                            mpc_manager,
+                            p2p_channel,
+                            threshold_opt,
+                        ),
+                    )
+                    .await?
                 }
             }
         } else {
-            let _fetch_timer = metrics
-                .mpc_prepare_previous_fetch_public_output_duration_seconds
-                .with_label_values(&[MPC_LABEL_KEY_ROTATION])
-                .start_timer();
-            Self::fetch_and_build_public_output(mpc_manager, p2p_channel, threshold_opt).await?
+            time_async(
+                &metrics.mpc_prepare_previous_fetch_public_output_duration_seconds,
+                MPC_LABEL_KEY_ROTATION,
+                Self::fetch_and_build_public_output(mpc_manager, p2p_channel, threshold_opt),
+            )
+            .await?
         };
         tracing::info!(
             "prepare_previous_output: is_member_of_previous_committee={is_member_of_previous_committee}, \

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -1400,6 +1400,8 @@ impl MpcManager {
                     .dealer_outputs
                     .remove(&DealerOutputsKey::Dkg(dealer));
             }
+            // Seed off-lock so the entropy read can't poison the manager lock.
+            let mut rng = StdRng::from_entropy();
             let has_complaint = time_async(
                 &metrics.mpc_message_process_duration_seconds,
                 MPC_LABEL_DKG,
@@ -1411,7 +1413,7 @@ impl MpcManager {
                             .complaints_to_process
                             .contains_key(&ComplaintsToProcessKey::Dkg(dealer))
                     {
-                        mgr.process_certified_dkg_message(dealer)?;
+                        mgr.process_certified_dkg_message(dealer, &mut rng)?;
                     }
                     Ok::<_, MpcError>(
                         mgr.complaints_to_process
@@ -1709,6 +1711,8 @@ impl MpcManager {
             {
                 let previous = previous.clone();
                 let share_indices = dealer_share_indices.clone();
+                // Seed off-lock so the entropy read can't poison the manager lock.
+                let mut rng = StdRng::from_entropy();
                 time_async(
                     &metrics.mpc_message_process_duration_seconds,
                     MPC_LABEL_KEY_ROTATION,
@@ -1720,7 +1724,7 @@ impl MpcManager {
                                     .complaints_to_process
                                     .contains_key(&ComplaintsToProcessKey::Rotation(dealer, *idx))
                         }) {
-                            mgr.process_certified_rotation_message(&dealer, &previous)?;
+                            mgr.process_certified_rotation_message(&dealer, &previous, &mut rng)?;
                         }
                         Ok::<_, MpcError>(())
                     }),
@@ -2204,7 +2208,7 @@ impl MpcManager {
             }
         };
         let dealer_session_id = self.current_session_id().dealer_session_id(&dealer);
-        let result = process_avss_message(
+        let result = verify_avss_message(
             &self.encryption_key,
             self.mpc_config.nodes.clone(),
             self.party_id,
@@ -2214,7 +2218,7 @@ impl MpcManager {
             None, // commitment: None for initial DKG
         )?;
         match result {
-            avss::ProcessedMessage::Valid(output) => {
+            Some(output) => {
                 self.dealer_outputs
                     .insert(DealerOutputsKey::Dkg(dealer), output);
                 let dkg_message = DealerMessagesHash {
@@ -2226,7 +2230,7 @@ impl MpcManager {
                         .sign(self.mpc_config.epoch, self.address, &dkg_message);
                 Ok(signature.signature().clone())
             }
-            avss::ProcessedMessage::Complaint(_) => Err(MpcError::InvalidMessage {
+            None => Err(MpcError::InvalidMessage {
                 sender: dealer,
                 reason: "Invalid shares".to_string(),
             }),
@@ -3752,7 +3756,11 @@ impl MpcManager {
         });
     }
 
-    fn process_certified_dkg_message(&mut self, dealer: Address) -> MpcResult<()> {
+    fn process_certified_dkg_message(
+        &mut self,
+        dealer: Address,
+        rng: &mut impl fastcrypto::traits::AllowedRng,
+    ) -> MpcResult<()> {
         let output_key = DealerOutputsKey::Dkg(dealer);
         let complaint_key = ComplaintsToProcessKey::Dkg(dealer);
         let message = self
@@ -3770,6 +3778,7 @@ impl MpcManager {
             None,
             output_key,
             complaint_key,
+            rng,
         )
     }
 
@@ -3831,6 +3840,7 @@ impl MpcManager {
         &mut self,
         dealer: &Address,
         previous_dkg_output: &MpcOutput,
+        rng: &mut impl fastcrypto::traits::AllowedRng,
     ) -> MpcResult<()> {
         let rotation_messages = self
             .current_rotation_messages
@@ -3857,6 +3867,7 @@ impl MpcManager {
                 commitment,
                 output_key,
                 complaint_key,
+                rng,
             )
             .map_err(|e| {
                 tracing::error!(
@@ -3880,6 +3891,7 @@ impl MpcManager {
         commitment: Option<G>,
         output_key: DealerOutputsKey,
         complaint_key: ComplaintsToProcessKey,
+        rng: &mut impl fastcrypto::traits::AllowedRng,
     ) -> MpcResult<()> {
         match process_avss_message(
             &self.encryption_key,
@@ -3892,6 +3904,7 @@ impl MpcManager {
             session_id,
             message,
             commitment,
+            rng,
         )? {
             avss::ProcessedMessage::Valid(output) => {
                 self.dealer_outputs.insert(output_key, output);
@@ -4696,7 +4709,7 @@ impl MpcManager {
             }
             let session_id = base_sid.rotation_session_id(&dealer, share_index);
             let commitment = previous_dkg_output.commitments.get(&share_index).copied();
-            match process_avss_message(
+            match verify_avss_message(
                 &self.encryption_key,
                 self.mpc_config.nodes.clone(),
                 self.party_id,
@@ -4705,10 +4718,10 @@ impl MpcManager {
                 message,
                 commitment,
             )? {
-                avss::ProcessedMessage::Valid(output) => {
+                Some(output) => {
                     outputs.push((DealerOutputsKey::Rotation(share_index), output));
                 }
-                avss::ProcessedMessage::Complaint(_) => {
+                None => {
                     return Err(MpcError::InvalidMessage {
                         sender: dealer,
                         reason: format!("Invalid rotation share for index {}", share_index),
@@ -4798,13 +4811,14 @@ impl MpcManager {
         &self,
         certificates: &[VerifiedCertificateV1],
         complaint_cache: &HashMap<DealerOutputsKey, avss::AvssOutput>,
+        rng: &mut impl fastcrypto::traits::AllowedRng,
     ) -> MpcResult<ReconstructionOutcome> {
         match certificates.first().map(VerifiedCertificateV1::inner) {
             Some(CertificateV1::Dkg(_)) | None => {
-                self.reconstruct_previous_dkg_output(certificates, complaint_cache)
+                self.reconstruct_previous_dkg_output(certificates, complaint_cache, rng)
             }
             Some(CertificateV1::Rotation(_)) => {
-                self.reconstruct_previous_rotation_output(certificates, complaint_cache)
+                self.reconstruct_previous_rotation_output(certificates, complaint_cache, rng)
             }
             Some(CertificateV1::NonceGeneration { .. }) => {
                 unreachable!(
@@ -4818,6 +4832,7 @@ impl MpcManager {
         &self,
         certificates: &[VerifiedCertificateV1],
         complaint_cache: &HashMap<DealerOutputsKey, avss::AvssOutput>,
+        rng: &mut impl fastcrypto::traits::AllowedRng,
     ) -> MpcResult<ReconstructionOutcome> {
         let committee = self.previous_committee.as_ref().ok_or_else(|| {
             MpcError::InvalidConfig("DKG reconstruction requires previous committee".into())
@@ -4848,7 +4863,7 @@ impl MpcManager {
             output_max_faulty,
             epoch: self.previous_epoch,
         };
-        self.reconstruct_dkg_output_locally(&context, certificates, complaint_cache)
+        self.reconstruct_dkg_output_locally(&context, certificates, complaint_cache, rng)
     }
 
     pub fn reconstruct_current_dkg_output(
@@ -4859,6 +4874,8 @@ impl MpcManager {
         if onchain_mpc_key.is_empty() {
             return MpcOutputRecoveryOutcome::NotApplicable;
         }
+        // Seed off-lock so the entropy read can't poison the manager lock.
+        let mut rng = StdRng::from_entropy();
         let candidate = {
             let mgr = mpc_manager.read().unwrap();
             let context = DkgReconstructionContext {
@@ -4874,6 +4891,7 @@ impl MpcManager {
                 &context,
                 certificates,
                 &HashMap::new(),
+                &mut rng,
             )) {
                 Ok(output) => output,
                 Err(outcome) => return outcome,
@@ -4902,6 +4920,8 @@ impl MpcManager {
         if onchain_mpc_key.is_empty() {
             return MpcOutputRecoveryOutcome::NotApplicable;
         }
+        // Seed off-lock so the entropy read can't poison the manager lock.
+        let mut rng = StdRng::from_entropy();
         let (current, previous) = {
             let mgr = mpc_manager.read().unwrap();
             let Some(input_threshold) = mgr.previous_reconfig_output_threshold else {
@@ -4921,13 +4941,16 @@ impl MpcManager {
                     &current_context,
                     current_certificates,
                     &HashMap::new(),
+                    &mut rng,
                 )) {
                     Ok(output) => output,
                     Err(outcome) => return outcome,
                 };
-            let previous = match Self::classify_reconstruction(
-                mgr.reconstruct_previous_output(previous_certificates, &HashMap::new()),
-            ) {
+            let previous = match Self::classify_reconstruction(mgr.reconstruct_previous_output(
+                previous_certificates,
+                &HashMap::new(),
+                &mut rng,
+            )) {
                 Ok(output) => output,
                 Err(outcome) => return outcome,
             };
@@ -4979,6 +5002,7 @@ impl MpcManager {
         context: &DkgReconstructionContext<'_>,
         certificates: &[VerifiedCertificateV1],
         complaint_cache: &HashMap<DealerOutputsKey, avss::AvssOutput>,
+        rng: &mut impl fastcrypto::traits::AllowedRng,
     ) -> MpcResult<ReconstructionOutcome> {
         let source_session_id = self.base_session_id_for_epoch(context.epoch, &ProtocolType::Dkg);
         let mut outputs: HashMap<PartyId, avss::AvssOutput> = HashMap::new();
@@ -5042,6 +5066,7 @@ impl MpcManager {
                 &session_id,
                 &message,
                 None,
+                rng,
             )? {
                 avss::ProcessedMessage::Valid(output) => {
                     outputs.insert(dealer_party_id, output);
@@ -5099,6 +5124,7 @@ impl MpcManager {
         &self,
         certificates: &[VerifiedCertificateV1],
         complaint_cache: &HashMap<DealerOutputsKey, avss::AvssOutput>,
+        rng: &mut impl fastcrypto::traits::AllowedRng,
     ) -> MpcResult<ReconstructionOutcome> {
         let nodes = self.previous_nodes.as_ref().ok_or_else(|| {
             MpcError::InvalidConfig("Rotation reconstruction requires previous nodes".into())
@@ -5138,7 +5164,7 @@ impl MpcManager {
             input_threshold,
             epoch: self.previous_epoch,
         };
-        self.reconstruct_rotation_output_locally(&context, certificates, complaint_cache)
+        self.reconstruct_rotation_output_locally(&context, certificates, complaint_cache, rng)
     }
 
     /// Makes no peer calls, but `complaint_cache` may hold outputs recovered from peers.
@@ -5147,6 +5173,7 @@ impl MpcManager {
         context: &RotationReconstructionContext<'_>,
         certificates: &[VerifiedCertificateV1],
         complaint_cache: &HashMap<DealerOutputsKey, avss::AvssOutput>,
+        rng: &mut impl fastcrypto::traits::AllowedRng,
     ) -> MpcResult<ReconstructionOutcome> {
         let source_session_id =
             self.base_session_id_for_epoch(context.epoch, &ProtocolType::KeyRotation);
@@ -5209,6 +5236,7 @@ impl MpcManager {
                     &session_id,
                     &message,
                     None,
+                    rng,
                 )? {
                     avss::ProcessedMessage::Valid(output) => {
                         local_outputs.insert(share_index, output);
@@ -5445,11 +5473,13 @@ impl MpcManager {
         loop {
             let certs = previous_certificates.to_vec();
             let cache_snapshot = complaint_cache.clone();
+            // Seed off-lock so the entropy read can't poison the manager lock.
+            let mut rng = StdRng::from_entropy();
             let outcome = time_async(
                 &metrics.mpc_prepare_previous_reconstruct_duration_seconds,
                 MPC_LABEL_KEY_ROTATION,
                 Self::with_manager_blocking(mpc_manager, move |mgr| {
-                    mgr.reconstruct_previous_output(&certs, &cache_snapshot)
+                    mgr.reconstruct_previous_output(&certs, &cache_snapshot, &mut rng)
                 }),
             )
             .await?;
@@ -6038,7 +6068,7 @@ impl MpcManager {
         }
         // Cross-epoch fallback: re-derive from message
         let (nodes, party_id, params) = self.config_for_epoch(epoch)?;
-        match process_avss_message(
+        verify_avss_message(
             self.encryption_key_for_epoch(epoch)?,
             nodes,
             party_id,
@@ -6046,12 +6076,12 @@ impl MpcManager {
             session_id,
             message,
             None,
-        )? {
-            avss::ProcessedMessage::Valid(output) => Ok(output),
-            avss::ProcessedMessage::Complaint(_) => Err(MpcError::NotFound(
+        )?
+        .ok_or_else(|| {
+            MpcError::NotFound(
                 "Peer is also a victim of this dealer — cannot help with complaint".into(),
-            )),
-        }
+            )
+        })
     }
 
     fn get_or_derive_rotation_output(
@@ -6069,7 +6099,7 @@ impl MpcManager {
             return Ok(output.clone());
         }
         let (nodes, party_id, params) = self.config_for_epoch(epoch)?;
-        match process_avss_message(
+        verify_avss_message(
             self.encryption_key_for_epoch(epoch)?,
             nodes,
             party_id,
@@ -6077,12 +6107,12 @@ impl MpcManager {
             session_id,
             message,
             None,
-        )? {
-            avss::ProcessedMessage::Valid(output) => Ok(output),
-            avss::ProcessedMessage::Complaint(_) => Err(MpcError::NotFound(
+        )?
+        .ok_or_else(|| {
+            MpcError::NotFound(
                 "Peer is also a victim of this dealer — cannot help with rotation complaint".into(),
-            )),
-        }
+            )
+        })
     }
 
     fn get_dealer_messages(
@@ -6352,7 +6382,10 @@ async fn hedged_retrieve<'a, P: P2PChannel + 'a>(
     }
 }
 
-fn process_avss_message(
+// Build a receiver and verify/decrypt this node's shares from a dealing.
+// Deterministic (no rng); logs the dealing context on error. Returns the
+// receiver too, so a caller that needs to complain can reuse it.
+fn verify_avss_shares(
     encryption_key: &PrivateKey<EncryptionGroupElement>,
     nodes: Nodes<EncryptionGroupElement>,
     party_id: u16,
@@ -6360,7 +6393,7 @@ fn process_avss_message(
     session_id: &SessionId,
     message: &avss::Message,
     commitment: Option<G>,
-) -> MpcResult<avss::ProcessedMessage> {
+) -> MpcResult<(avss::Receiver, Option<avss::AvssOutput>)> {
     let commitment_hex = commitment
         .as_ref()
         .map(|c| hex::encode(c.to_byte_array()))
@@ -6377,17 +6410,66 @@ fn process_avss_message(
         commitment,
         encryption_key.clone(),
     )?;
-    match receiver.process_message(message, &mut rand::thread_rng()) {
-        Ok(pm) => Ok(pm),
-        Err(e) => {
-            tracing::error!(
-                "process_avss_message failed: err={e}, \
-                 total_weight={total_weight}, num_nodes={num_nodes}, \
-                 commitment={commitment_hex}, session_id={session_id_hex}"
-            );
-            Err(MpcError::from(e))
-        }
-    }
+    let output = receiver.verify_message(message).map_err(|e| {
+        tracing::error!(
+            "verify_avss_shares failed: err={e}, \
+             total_weight={total_weight}, num_nodes={num_nodes}, \
+             commitment={commitment_hex}, session_id={session_id_hex}"
+        );
+        MpcError::from(e)
+    })?;
+    Ok((receiver, output))
+}
+
+// Verify-only: `Some` = valid share, `None` = invalid shares (complaint-eligible),
+// `Err` = malformed message. No rng — use `process_avss_message` when a complaint
+// must be produced.
+fn verify_avss_message(
+    encryption_key: &PrivateKey<EncryptionGroupElement>,
+    nodes: Nodes<EncryptionGroupElement>,
+    party_id: u16,
+    params: Parameters,
+    session_id: &SessionId,
+    message: &avss::Message,
+    commitment: Option<G>,
+) -> MpcResult<Option<avss::AvssOutput>> {
+    Ok(verify_avss_shares(
+        encryption_key,
+        nodes,
+        party_id,
+        params,
+        session_id,
+        message,
+        commitment,
+    )?
+    .1)
+}
+
+// Verify, and build a complaint (needs rng) if the shares are invalid.
+#[allow(clippy::too_many_arguments)]
+fn process_avss_message(
+    encryption_key: &PrivateKey<EncryptionGroupElement>,
+    nodes: Nodes<EncryptionGroupElement>,
+    party_id: u16,
+    params: Parameters,
+    session_id: &SessionId,
+    message: &avss::Message,
+    commitment: Option<G>,
+    rng: &mut impl fastcrypto::traits::AllowedRng,
+) -> MpcResult<avss::ProcessedMessage> {
+    let (receiver, output) = verify_avss_shares(
+        encryption_key,
+        nodes,
+        party_id,
+        params,
+        session_id,
+        message,
+        commitment,
+    )?;
+    Ok(match output {
+        Some(output) => avss::ProcessedMessage::Valid(output),
+        None => avss::ProcessedMessage::Complaint(receiver.create_complaint(message, rng)),
+    })
 }
 
 fn build_reduced_nodes(

--- a/crates/hashi/src/mpc/mpc_except_signing_tests.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing_tests.rs
@@ -2499,7 +2499,7 @@ async fn test_run_as_party_recovers_shares_via_complaint() {
         .cache_and_persist_dkg_message(party_manager.mpc_config.epoch, dealer_1_addr, &dealer_1_msg)
         .unwrap();
     party_manager
-        .process_certified_dkg_message(dealer_1_addr)
+        .process_certified_dkg_message(dealer_1_addr, &mut rand::thread_rng())
         .unwrap();
     // DKG: complaints keyed by dealer address
     assert!(
@@ -4383,7 +4383,7 @@ async fn test_recover_shares_via_complaint_succeeds_with_exact_threshold() {
         .cache_and_persist_dkg_message(party_manager.mpc_config.epoch, dealer_addr, inner_msg)
         .unwrap();
     party_manager
-        .process_certified_dkg_message(dealer_addr)
+        .process_certified_dkg_message(dealer_addr, &mut rand::thread_rng())
         .unwrap();
     // DKG: complaints keyed by dealer address
     assert!(
@@ -4459,7 +4459,7 @@ async fn test_recover_shares_via_complaint_skips_failed_signers() {
         .cache_and_persist_dkg_message(party_manager.mpc_config.epoch, dealer_addr, inner_msg)
         .unwrap();
     party_manager
-        .process_certified_dkg_message(dealer_addr)
+        .process_certified_dkg_message(dealer_addr, &mut rand::thread_rng())
         .unwrap();
     // DKG: complaints keyed by dealer address
     assert!(
@@ -4654,7 +4654,7 @@ async fn test_recover_shares_via_complaint_insufficient_signers() {
         .cache_and_persist_dkg_message(party_manager.mpc_config.epoch, dealer_addr, inner_msg)
         .unwrap();
     party_manager
-        .process_certified_dkg_message(dealer_addr)
+        .process_certified_dkg_message(dealer_addr, &mut rand::thread_rng())
         .unwrap();
     // DKG: complaints keyed by dealer address
     assert!(
@@ -4736,7 +4736,7 @@ async fn test_recover_shares_via_complaint_rejects_responders_not_in_config() {
         .cache_and_persist_dkg_message(party_manager.mpc_config.epoch, dealer_addr, inner_msg)
         .unwrap();
     party_manager
-        .process_certified_dkg_message(dealer_addr)
+        .process_certified_dkg_message(dealer_addr, &mut rand::thread_rng())
         .unwrap();
 
     // Pre-collect complaint responses from parties 3 and 4
@@ -4870,7 +4870,7 @@ async fn test_retrieve_dealer_message_success() {
     party_manager
         .write()
         .unwrap()
-        .process_certified_dkg_message(dealer_address)
+        .process_certified_dkg_message(dealer_address, &mut rand::thread_rng())
         .unwrap();
     assert!(
         party_manager
@@ -5814,7 +5814,7 @@ async fn test_retrieve_stores_invalid_message_for_later_complaint() {
     receiver_manager
         .write()
         .unwrap()
-        .process_certified_dkg_message(dealer_addr)
+        .process_certified_dkg_message(dealer_addr, &mut rand::thread_rng())
         .unwrap();
 
     let mgr = receiver_manager.read().unwrap();
@@ -7809,7 +7809,7 @@ async fn test_prepare_previous_output_refetches_diverged_dkg_message() {
             test_manager
                 .read()
                 .unwrap()
-                .reconstruct_previous_output(&previous_certs, &HashMap::new()),
+                .reconstruct_previous_output(&previous_certs, &HashMap::new(), &mut rand::thread_rng()),
             Err(MpcError::StoredMessageDiverged { dealer }) if dealer == diverged_dealer
         ),
         "reconstruction must reject the diverged copy by variant, before any repair",
@@ -8038,7 +8038,7 @@ async fn test_prepare_previous_output_refetches_diverged_rotation_message() {
             test_manager
                 .read()
                 .unwrap()
-                .reconstruct_previous_output(&rotation_certs, &HashMap::new()),
+                .reconstruct_previous_output(&rotation_certs, &HashMap::new(), &mut rand::thread_rng()),
             Err(MpcError::StoredMessageDiverged { dealer }) if dealer == diverged_dealer
         ),
         "reconstruction must reject the diverged copy by variant, before any repair",
@@ -8426,7 +8426,11 @@ fn test_process_certified_rotation_message_skips_processed_shares() {
 
     // Call process_certified_rotation_message
     receiver_manager
-        .process_certified_rotation_message(&rotation_dealer_addr, &dealer_dkg_output)
+        .process_certified_rotation_message(
+            &rotation_dealer_addr,
+            &dealer_dkg_output,
+            &mut rand::thread_rng(),
+        )
         .unwrap();
 
     // Verify share 1: output unchanged (skipped because already had output)
@@ -9253,6 +9257,7 @@ fn test_party_restart_uses_stored_rotation_messages() {
                     None,
                     output_key,
                     complaint_key,
+                    &mut rand::thread_rng(),
                 )
                 .unwrap();
         }
@@ -9422,7 +9427,11 @@ fn test_reconstruct_previous_dkg_output_with_shifted_party_ids() {
     // if previous committee parameters were not used for decryption.
     let reconstructed = unwrap_reconstruction_success(
         manager
-            .reconstruct_previous_dkg_output(&certificates, &HashMap::new())
+            .reconstruct_previous_dkg_output(
+                &certificates,
+                &HashMap::new(),
+                &mut rand::thread_rng(),
+            )
             .unwrap(),
     );
 
@@ -9489,7 +9498,7 @@ fn test_reconstruct_previous_dkg_output_stops_at_threshold() {
     target_manager.dealer_outputs.clear();
     for &i in &dealer_indices {
         target_manager
-            .process_certified_dkg_message(setup.address(i))
+            .process_certified_dkg_message(setup.address(i), &mut rand::thread_rng())
             .unwrap();
     }
     let key_all = target_manager
@@ -9590,7 +9599,11 @@ fn test_reconstruct_previous_dkg_output_stops_at_threshold() {
     // and produces key_threshold.
     let reconstructed = unwrap_reconstruction_success(
         manager
-            .reconstruct_previous_dkg_output(&certificates, &HashMap::new())
+            .reconstruct_previous_dkg_output(
+                &certificates,
+                &HashMap::new(),
+                &mut rand::thread_rng(),
+            )
             .unwrap(),
     );
 
@@ -9721,7 +9734,11 @@ fn test_reconstruct_previous_dkg_output_uses_previous_encryption_key() {
     .unwrap();
     let reconstructed = unwrap_reconstruction_success(
         manager_with_prev
-            .reconstruct_previous_dkg_output(&certificates, &HashMap::new())
+            .reconstruct_previous_dkg_output(
+                &certificates,
+                &HashMap::new(),
+                &mut rand::thread_rng(),
+            )
             .unwrap(),
     );
     assert_eq!(
@@ -9747,8 +9764,11 @@ fn test_reconstruct_previous_dkg_output_uses_previous_encryption_key() {
         &test_metrics(),
     )
     .unwrap();
-    let result =
-        manager_without_prev.reconstruct_previous_dkg_output(&certificates, &HashMap::new());
+    let result = manager_without_prev.reconstruct_previous_dkg_output(
+        &certificates,
+        &HashMap::new(),
+        &mut rand::thread_rng(),
+    );
     let Err(err) = result else {
         panic!("missing previous_encryption_key must error, got Ok");
     };
@@ -9908,7 +9928,12 @@ fn test_recover_current_dkg() {
         };
         assert!(
             matches!(
-                guard.reconstruct_dkg_output_locally(&context, &certificates, &HashMap::new()),
+                guard.reconstruct_dkg_output_locally(
+                    &context,
+                    &certificates,
+                    &HashMap::new(),
+                    &mut rand::thread_rng(),
+                ),
                 Err(MpcError::StoredMessageDiverged { .. })
             ),
             "the hash check, not a downstream AVSS failure, must reject the swapped message",
@@ -10280,7 +10305,11 @@ fn test_reconstruct_previous_rotation_output_with_shifted_party_ids() {
     // This would panic with index-out-of-bounds if previous committee parameters were not used for decryption.
     let reconstructed = unwrap_reconstruction_success(
         manager
-            .reconstruct_previous_rotation_output(&rotation_certificates, &HashMap::new())
+            .reconstruct_previous_rotation_output(
+                &rotation_certificates,
+                &HashMap::new(),
+                &mut rand::thread_rng(),
+            )
             .unwrap(),
     );
 

--- a/crates/hashi/src/mpc/rpc/service.rs
+++ b/crates/hashi/src/mpc/rpc/service.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::grpc::HttpService;
-use crate::mpc::spawn_blocking;
+use crate::mpc::MpcManager;
 use crate::mpc::types;
 use crate::mpc::types::MpcError;
 use crate::mpc::types::SigningError;
@@ -46,20 +46,20 @@ impl MpcService for HttpService {
             .mpc_rpc_handler_process_duration_seconds
             .with_label_values(&[label])
             .start_timer();
-        let response = spawn_blocking(move || -> Result<_, Status> {
-            let mut mgr = mpc_manager.write().unwrap();
-            validate_epoch(mgr.mpc_config.epoch, external_request.epoch)?;
-            mgr.handle_send_messages_request(sender, &internal_request)
-                .map_err(|e| {
-                    if matches!(&e, MpcError::NotReady(_)) {
-                        tracing::info!("send_messages from {sender:?}: {e}");
-                    } else {
-                        tracing::warn!("send_messages from {sender:?} failed: {e}");
-                    }
-                    mpc_error_to_status(e)
-                })
-        })
-        .await?;
+        let response =
+            MpcManager::with_manager_blocking_mut(&mpc_manager, move |mgr| -> Result<_, Status> {
+                validate_epoch(mgr.mpc_config.epoch, external_request.epoch)?;
+                mgr.handle_send_messages_request(sender, &internal_request)
+                    .map_err(|e| {
+                        if matches!(&e, MpcError::NotReady(_)) {
+                            tracing::info!("send_messages from {sender:?}: {e}");
+                        } else {
+                            tracing::warn!("send_messages from {sender:?} failed: {e}");
+                        }
+                        mpc_error_to_status(e)
+                    })
+            })
+            .await?;
         drop(_timer);
         Ok(tonic::Response::new(SendMessagesResponse::from(&response)))
     }
@@ -109,20 +109,20 @@ impl MpcService for HttpService {
         let internal_request = types::ComplainRequest::try_from(&external_request)
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
         let mpc_manager = self.mpc_manager()?;
-        let response = spawn_blocking(move || -> Result<_, Status> {
-            let mut mgr = mpc_manager.write().unwrap();
-            validate_epoch_current_or_previous(
-                mgr.mpc_config.epoch,
-                mgr.previous_epoch,
-                internal_request.epoch,
-            )?;
-            mgr.handle_complain_request(caller, &internal_request)
-                .map_err(|e| {
-                    tracing::warn!("complain failed: {e}");
-                    mpc_error_to_status(e)
-                })
-        })
-        .await?;
+        let response =
+            MpcManager::with_manager_blocking_mut(&mpc_manager, move |mgr| -> Result<_, Status> {
+                validate_epoch_current_or_previous(
+                    mgr.mpc_config.epoch,
+                    mgr.previous_epoch,
+                    internal_request.epoch,
+                )?;
+                mgr.handle_complain_request(caller, &internal_request)
+                    .map_err(|e| {
+                        tracing::warn!("complain failed: {e}");
+                        mpc_error_to_status(e)
+                    })
+            })
+            .await?;
         Ok(tonic::Response::new(ComplainResponse::from(&response)))
     }
 

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -34,7 +34,7 @@ use crate::mpc::MpcManager;
 use crate::mpc::MpcOutput;
 use crate::mpc::SigningManager;
 use crate::mpc::mpc_except_signing::VerifiedNonceCerts;
-use crate::mpc::mpc_except_signing::spawn_blocking;
+use crate::mpc::mpc_except_signing::time_async;
 use crate::mpc::rpc::RpcP2PChannel;
 use crate::mpc::types::CertificateV1;
 use crate::mpc::types::MpcOutputRecoveryOutcome;
@@ -503,19 +503,18 @@ impl MpcService {
         )
         .with_idle_timeout(NONCE_RECEIVE_IDLE_TIMEOUT);
         let metrics = &self.inner.metrics;
-        let _timer = metrics
-            .mpc_total_duration_seconds
-            .with_label_values(&[MPC_LABEL_NONCE_GENERATION])
-            .start_timer();
-        let nonce_result = MpcManager::run_nonce_generation(
-            &mpc_manager,
-            batch_index,
-            &p2p_channel,
-            &mut tob_channel,
-            metrics,
+        let nonce_result = time_async(
+            &metrics.mpc_total_duration_seconds,
+            MPC_LABEL_NONCE_GENERATION,
+            MpcManager::run_nonce_generation(
+                &mpc_manager,
+                batch_index,
+                &p2p_channel,
+                &mut tob_channel,
+                metrics,
+            ),
         )
         .await;
-        drop(_timer);
         let nonce_outputs =
             nonce_result.map_err(|e| anyhow::anyhow!("Nonce generation failed: {e}"))?;
         let (batch_size_per_weight, params) = {
@@ -1732,9 +1731,7 @@ pub(crate) async fn verify_fetched_certificates(
     certs: Vec<CertificateV1>,
     metrics: &Metrics,
 ) -> Vec<VerifiedCertificateV1> {
-    let mgr = Arc::clone(mpc_manager);
-    let (verified, rejected) = spawn_blocking(move || {
-        let mgr = mgr.read().unwrap();
+    let (verified, rejected) = MpcManager::with_manager_blocking(mpc_manager, move |mgr| {
         let mut verified = Vec::with_capacity(certs.len());
         let mut rejected: Vec<(&'static str, &'static str)> = Vec::new();
         for cert in certs {

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -519,13 +519,7 @@ impl MpcService {
             nonce_result.map_err(|e| anyhow::anyhow!("Nonce generation failed: {e}"))?;
         let (batch_size_per_weight, params) = {
             let mgr = mpc_manager.read().unwrap();
-            (
-                mgr.batch_size_per_weight,
-                Parameters {
-                    t: mgr.mpc_config.threshold,
-                    f: mgr.mpc_config.max_faulty,
-                },
-            )
+            (mgr.batch_size_per_weight, mgr.params())
         };
         let _timer = metrics
             .mpc_presig_conversion_duration_seconds
@@ -640,10 +634,7 @@ impl MpcService {
             let mgr = mpc_manager.read().unwrap();
             (
                 mgr.batch_size_per_weight,
-                Parameters {
-                    t: mgr.mpc_config.threshold,
-                    f: mgr.mpc_config.max_faulty,
-                },
+                mgr.params(),
                 mgr.mpc_config.nonce_generation_protocol,
                 mgr.required_nonce_weight(),
             )

--- a/crates/internal-tools/src/key_recovery.rs
+++ b/crates/internal-tools/src/key_recovery.rs
@@ -224,7 +224,11 @@ pub async fn run(args: Args, onchain_state: &OnchainState, chain_id: &str) -> an
         }
 
         let outcome = manager
-            .reconstruct_previous_output(&verified, &std::collections::HashMap::new())
+            .reconstruct_previous_output(
+                &verified,
+                &std::collections::HashMap::new(),
+                &mut rand::thread_rng(),
+            )
             .map_err(|e| anyhow!("reconstruction failed: {e}"))?;
 
         match outcome {

--- a/docker/hashi-guardian/enclave-Cargo.lock
+++ b/docker/hashi-guardian/enclave-Cargo.lock
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.11"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=179ba6ca65f567efb297d0f8d449d78cdef6745c#179ba6ca65f567efb297d0f8d449d78cdef6745c"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d9ae33b1f5abfc2c09974c7682175f281f6f528f#d9ae33b1f5abfc2c09974c7682175f281f6f528f"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2396,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.4"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=179ba6ca65f567efb297d0f8d449d78cdef6745c#179ba6ca65f567efb297d0f8d449d78cdef6745c"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d9ae33b1f5abfc2c09974c7682175f281f6f528f#d9ae33b1f5abfc2c09974c7682175f281f6f528f"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=179ba6ca65f567efb297d0f8d449d78cdef6745c#179ba6ca65f567efb297d0f8d449d78cdef6745c"
+source = "git+https://github.com/MystenLabs/fastcrypto.git?rev=d9ae33b1f5abfc2c09974c7682175f281f6f528f#d9ae33b1f5abfc2c09974c7682175f281f6f528f"
 dependencies = [
  "bcs",
  "digest 0.10.7",


### PR DESCRIPTION
Uses the fastcrypto `avss::Receiver` verify/complain split (MystenLabs/fastcrypto#1002) so the paths that only accept or reject a dealing never touch an rng.

- DKG/rotation acks, complaint responses, and cross-epoch re-derivation call a deterministic, rng-free `verify_message`.
- `process_avss_message` keeps an rng but verifies first and calls `create_complaint` only when the shares are invalid — so it stays on the two paths that actually broadcast a complaint (party phase, reconstruction), which seed a `StdRng` off-lock.
- The rpc handlers no longer seed an rng.

No entropy is read under the manager lock when dealers are honest, without threading an rng through the ack/complaint call graph.

Depends on MystenLabs/fastcrypto#1002; the fastcrypto rev is pinned to that PR and should be repointed to a `main` rev once it lands.