### PR TITLE
[Monitor] Address audit review nits

### DIFF
--- a/crates/hashi-monitor/audit.sample.yaml
+++ b/crates/hashi-monitor/audit.sample.yaml
@@ -1,11 +1,13 @@
 # Sample configuration for `hashi-monitor batch` and `hashi-monitor continuous`.
 
-# Liveness delay bounds (seconds)
+# All duration values are expressed in seconds.
+
+# Liveness delay bounds
 next_event_delays:
   - [E1HashiApproved, 300] # E1 (Hashi approval) -> E2 (Guardian signing)
   - [E2GuardianApproved, 300] # E2 (Guardian signing) -> E3 (BTC confirmed)
 
-# Clock skew tolerance: E_{i+1} can occur up to clock_skew seconds before E_i (default: 300s)
+# Clock skew tolerance: E_{i+1} can occur up to clock_skew before E_i (default: 300s)
 # clock_skew: 300
 
 # Sui withdrawal history searched before the guardian audit start (default: 1 hour)

--- a/crates/hashi-monitor/audit.testnet.yaml
+++ b/crates/hashi-monitor/audit.testnet.yaml
@@ -4,6 +4,8 @@
 # measurements. AWS credentials come from the default credential chain, and
 # the Signet JSON-RPC endpoint comes from HASHI_BITCOIN_RPC_URL.
 
+# All duration values are expressed in seconds.
+
 next_event_delays:
   # Active-testnet Guardian approvals normally arrive 13-15 minutes after E1.
   - [E1HashiApproved, 1200]

--- a/crates/hashi-monitor/src/audit/batch.rs
+++ b/crates/hashi-monitor/src/audit/batch.rs
@@ -226,7 +226,7 @@ impl BatchAuditor {
         tracing::info!(
             "batch progress watermarks:\n  verified_up_to_withdrawals={}\n  withdrawal_blockers={}\n  verified_up_to_deposits={}\n  next_start={}",
             utc_timestamp(progress.verified_up_to_withdrawals),
-            progress.withdrawal_blockers_summary(),
+            progress.withdrawal_blockers(),
             utc_timestamp(progress.verified_up_to_deposits),
             utc_timestamp(progress.restart_start),
         );

--- a/crates/hashi-monitor/src/audit/continuous.rs
+++ b/crates/hashi-monitor/src/audit/continuous.rs
@@ -117,7 +117,7 @@ impl ContinuousAuditor {
             utc_timestamp(self.inner.get_guardian_cursor()),
             utc_timestamp(self.inner.get_sui_cursor()),
             utc_timestamp(progress.verified_up_to_withdrawals),
-            progress.withdrawal_blockers_summary(),
+            progress.withdrawal_blockers(),
             utc_timestamp(progress.verified_up_to_deposits),
             utc_timestamp(progress.restart_start),
         );

--- a/crates/hashi-monitor/src/audit/mod.rs
+++ b/crates/hashi-monitor/src/audit/mod.rs
@@ -80,20 +80,29 @@ pub struct ProgressWatermarks {
     pub verified_up_to_withdrawals: UnixSeconds,
     pub verified_up_to_deposits: UnixSeconds,
     pub restart_start: UnixSeconds,
-    withdrawal_blockers: Vec<WithdrawalProgressBlocker>,
+    withdrawal_blockers: WithdrawalProgressBlockers,
 }
 
 impl ProgressWatermarks {
-    fn withdrawal_blockers_summary(&self) -> String {
-        if self.withdrawal_blockers.is_empty() {
-            return "none".to_string();
-        }
+    pub fn withdrawal_blockers(&self) -> &WithdrawalProgressBlockers {
+        &self.withdrawal_blockers
+    }
+}
 
-        self.withdrawal_blockers
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join("; ")
+#[derive(Clone, Debug)]
+pub struct WithdrawalProgressBlockers(Vec<WithdrawalProgressBlocker>);
+
+impl fmt::Display for WithdrawalProgressBlockers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Some((first, rest)) = self.0.split_first() else {
+            return f.write_str("none");
+        };
+
+        write!(f, "{first}")?;
+        for blocker in rest {
+            write!(f, "; {blocker}")?;
+        }
+        Ok(())
     }
 }
 
@@ -365,7 +374,7 @@ impl AuditorCore {
             verified_up_to_withdrawals,
             verified_up_to_deposits,
             restart_start: verified_up_to_withdrawals.min(verified_up_to_deposits),
-            withdrawal_blockers,
+            withdrawal_blockers: WithdrawalProgressBlockers(withdrawal_blockers),
         }
     }
 

--- a/crates/hashi-monitor/src/config.rs
+++ b/crates/hashi-monitor/src/config.rs
@@ -13,12 +13,14 @@ use serde::Deserialize;
 use crate::domain::WithdrawalEventType;
 
 /// Configuration shared by the batch and continuous monitor modes.
+///
+/// All duration values are expressed in seconds.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     /// Maximum allowed delay between consecutive events.
     pub next_event_delays: NextEventDelays,
 
-    /// E_{i+1} is allowed to occur up to clock_skew seconds before E_i (default: 300s).
+    /// E_{i+1} is allowed to occur up to `clock_skew` before E_i (default: 300s).
     #[serde(default = "default_clock_skew")]
     pub clock_skew: u64,
 
@@ -34,7 +36,7 @@ pub struct Config {
     pub btc: BtcConfig,
 }
 
-/// The maximum allowed delay between an event and its successor, in seconds.
+/// The maximum allowed delay between an event and its successor.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(try_from = "Vec<(WithdrawalEventType, u64)>")]
 pub struct NextEventDelays(Vec<(WithdrawalEventType, u64)>);


### PR DESCRIPTION
## Summary

- document the monitor-wide seconds convention in YAML and Rust configuration
- expose withdrawal progress blockers through a getter and format the collection via Display
- preserve the existing batch and continuous progress log output

Follow-up to #950.

## Testing

- make fmt
- cargo check