### PR TITLE
governance: committee-voted ignore/un-ignore of a member

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -1197,6 +1197,132 @@ mod tests {
         Ok(())
     }
 
+    /// A committee-voted ignore takes effect at the epoch boundary: the next
+    /// committee forms without the member, total weight re-sums, and the
+    /// smaller committee still confirms deposits and withdrawals end to end
+    /// (BLS certs, MPC reshare, and the guardian all follow the members
+    /// vector).
+    ///
+    /// Runs on the default snapshot-v1 + upgrade harness, so it also proves
+    /// the v2-only ignore_member surface is addressed at the upgraded
+    /// package id.
+    #[tokio::test]
+    async fn test_ignored_member_excluded_at_epoch_boundary() -> Result<()> {
+        init_test_logging();
+
+        let mut networks = setup_test_networks(TestNetworksBuilder::new().with_nodes(4)).await?;
+
+        let hashi_ids = networks.hashi_network.ids();
+
+        let (latest_package_id, members_before, weight_before, target, initial_epoch) = {
+            let nodes = networks.hashi_network.nodes();
+
+            // The v2-only ignore_member surface lives at the upgraded
+            // package id, not the snapshot-v1 publish id in `hashi_ids`.
+            let latest_package_id = nodes[0]
+                .hashi()
+                .onchain_state()
+                .package_id()
+                .ok_or_else(|| anyhow!("no package versions known"))?;
+
+            let committee = nodes[0]
+                .hashi()
+                .onchain_state()
+                .current_committee()
+                .ok_or_else(|| anyhow!("no current committee"))?;
+
+            let mut executors: Vec<SuiTxExecutor> = nodes
+                .iter()
+                .map(|node| {
+                    let hashi = node.hashi();
+                    SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())
+                })
+                .collect::<Result<_>>()?;
+            let target = executors
+                .last()
+                .ok_or_else(|| anyhow!("no executors"))?
+                .sender();
+            assert!(committee.index_of(&target).is_some());
+
+            let ignore_member_type_tag =
+                sui_sdk_types::TypeTag::Struct(Box::new(sui_sdk_types::StructTag::new(
+                    latest_package_id,
+                    sui_sdk_types::Identifier::from_static("ignore_member"),
+                    sui_sdk_types::Identifier::from_static("IgnoreMember"),
+                    vec![],
+                )));
+            crate::submit_proposal_through_quorum(
+                hashi_ids,
+                latest_package_id,
+                &mut executors,
+                hashi::cli::client::CreateProposalParams::IgnoreMember {
+                    target_validator_address: target,
+                    ignored: true,
+                    metadata: vec![],
+                },
+                ignore_member_type_tag,
+                "ignore_member",
+                "IgnoreMember",
+            )
+            .await?;
+
+            let initial_epoch = nodes[0]
+                .current_epoch()
+                .ok_or_else(|| anyhow!("no current Hashi epoch"))?;
+
+            (
+                latest_package_id,
+                committee.members().len(),
+                committee.total_weight(),
+                target,
+                initial_epoch,
+            )
+        };
+        info!(
+            ?target,
+            latest_package_id = %latest_package_id,
+            "ignore executed on-chain; closing the epoch"
+        );
+
+        networks.sui_network.force_close_epoch().await?;
+        let target_epoch = initial_epoch + 1;
+        let futs: Vec<_> = networks
+            .hashi_network()
+            .nodes()
+            .iter()
+            .map(|n| n.wait_for_epoch(target_epoch, Duration::from_secs(480)))
+            .collect();
+        for (i, r) in futures::future::join_all(futs)
+            .await
+            .into_iter()
+            .enumerate()
+        {
+            r.unwrap_or_else(|e| panic!("Node {i} failed to reach epoch {target_epoch}: {e}"));
+        }
+
+        // The new committee excludes the ignored member and total weight
+        // re-sums without them.
+        {
+            let nodes = networks.hashi_network.nodes();
+            let committee = nodes[0]
+                .hashi()
+                .onchain_state()
+                .current_committee()
+                .ok_or_else(|| anyhow!("no committee after epoch change"))?;
+            assert_eq!(committee.members().len(), members_before - 1);
+            assert!(committee.index_of(&target).is_none());
+            assert!(committee.total_weight() < weight_before);
+        }
+
+        // The smaller committee still drives the full deposit and
+        // withdrawal paths: BLS certs, MPC signing with the reshared key,
+        // and the guardian's committee-handoff-derived thresholds.
+        create_deposit_and_wait(&mut networks, 100_000).await?;
+        crate::test_helpers::create_withdrawal_and_wait(&mut networks, 30_000).await?;
+
+        Ok(())
+    }
+
     /// Waits for a `WithdrawalPickedForProcessing` that contains at least
     /// `min_requests` request IDs in a single batch, indicating that the new
     /// multi-request coin selection algorithm batched them together.

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -695,6 +695,27 @@ mod tests {
                 stamped_package,
             )
             .await?;
+
+            tokio::time::timeout(Duration::from_secs(30), async {
+                loop {
+                    let v1_disabled = networks.hashi_network.nodes().iter().all(|node| {
+                        !node
+                            .hashi()
+                            .onchain_state()
+                            .state()
+                            .hashi()
+                            .config
+                            .enabled_versions
+                            .contains(&1)
+                    });
+                    if v1_disabled {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+            })
+            .await
+            .map_err(|_| anyhow!("timed out waiting for every node to observe v1 disabled"))?;
         }
         {
             let hashi = networks.hashi_network.nodes()[0].hashi();

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -1244,6 +1244,11 @@ mod tests {
                 .sender();
             assert!(committee.index_of(&target).is_some());
 
+            info!(
+                v1 = %hashi_ids.package_id,
+                latest = %latest_package_id,
+                "package ids in play"
+            );
             let ignore_member_type_tag =
                 sui_sdk_types::TypeTag::Struct(Box::new(sui_sdk_types::StructTag::new(
                     latest_package_id,
@@ -1251,8 +1256,14 @@ mod tests {
                     sui_sdk_types::Identifier::from_static("IgnoreMember"),
                     vec![],
                 )));
+            let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+                &mut networks.sui_network.client.clone(),
+                hashi_ids.hashi_object_id,
+            )
+            .await?;
             crate::submit_proposal_through_quorum(
                 hashi_ids,
+                hashi_isv,
                 latest_package_id,
                 &mut executors,
                 hashi::cli::client::CreateProposalParams::IgnoreMember {
@@ -1760,8 +1771,14 @@ mod tests {
             .unwrap_or(hashi_ids.package_id);
 
         let validator_address = executor.sender();
+        let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+            &mut networks.sui_network.client.clone(),
+            hashi_ids.hashi_object_id,
+        )
+        .await?;
         let builder = build_create_proposal_transaction(
             hashi_ids,
+            hashi_isv,
             execute_package_id,
             validator_address,
             CreateProposalParams::UpdateConfig {
@@ -1865,11 +1882,17 @@ mod tests {
             .onchain_state()
             .package_id()
             .unwrap_or(hashi_ids.package_id);
+        let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+            &mut networks.sui_network.client.clone(),
+            hashi_ids.hashi_object_id,
+        )
+        .await?;
         let mut proposal_ids = Vec::new();
         let mut last_checkpoint = 0u64;
         for i in 0..3u64 {
             let builder = build_create_proposal_transaction(
                 hashi_ids,
+                hashi_isv,
                 execute_package_id,
                 creator,
                 CreateProposalParams::UpdateConfig {

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -682,8 +682,19 @@ mod tests {
                     )
                 })
                 .collect::<Result<_>>()?;
-            crate::upgrade_flow::disable_version(&mut executors, hashi_ids, 1, stamped_package)
-                .await?;
+            let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+                &mut networks.sui_network.client.clone(),
+                hashi_ids.hashi_object_id,
+            )
+            .await?;
+            crate::upgrade_flow::disable_version(
+                &mut executors,
+                hashi_ids,
+                hashi_isv,
+                1,
+                stamped_package,
+            )
+            .await?;
         }
         {
             let hashi = networks.hashi_network.nodes()[0].hashi();

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -1187,6 +1187,132 @@ mod tests {
         Ok(())
     }
 
+    /// A committee-voted ignore takes effect at the epoch boundary: the next
+    /// committee forms without the member, total weight re-sums, and the
+    /// smaller committee still confirms deposits and withdrawals end to end
+    /// (BLS certs, MPC reshare, and the guardian all follow the members
+    /// vector).
+    ///
+    /// Runs on the default snapshot-v1 + upgrade harness, so it also proves
+    /// the v2-only ignore_member surface is addressed at the upgraded
+    /// package id.
+    #[tokio::test]
+    async fn test_ignored_member_excluded_at_epoch_boundary() -> Result<()> {
+        init_test_logging();
+
+        let mut networks = setup_test_networks(TestNetworksBuilder::new().with_nodes(4)).await?;
+
+        let hashi_ids = networks.hashi_network.ids();
+
+        let (latest_package_id, members_before, weight_before, target, initial_epoch) = {
+            let nodes = networks.hashi_network.nodes();
+
+            // The v2-only ignore_member surface lives at the upgraded
+            // package id, not the snapshot-v1 publish id in `hashi_ids`.
+            let latest_package_id = nodes[0]
+                .hashi()
+                .onchain_state()
+                .package_id()
+                .ok_or_else(|| anyhow!("no package versions known"))?;
+
+            let committee = nodes[0]
+                .hashi()
+                .onchain_state()
+                .current_committee()
+                .ok_or_else(|| anyhow!("no current committee"))?;
+
+            let mut executors: Vec<SuiTxExecutor> = nodes
+                .iter()
+                .map(|node| {
+                    let hashi = node.hashi();
+                    SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())
+                })
+                .collect::<Result<_>>()?;
+            let target = executors
+                .last()
+                .ok_or_else(|| anyhow!("no executors"))?
+                .sender();
+            assert!(committee.index_of(&target).is_some());
+
+            let ignore_member_type_tag =
+                sui_sdk_types::TypeTag::Struct(Box::new(sui_sdk_types::StructTag::new(
+                    latest_package_id,
+                    sui_sdk_types::Identifier::from_static("ignore_member"),
+                    sui_sdk_types::Identifier::from_static("IgnoreMember"),
+                    vec![],
+                )));
+            crate::submit_proposal_through_quorum(
+                hashi_ids,
+                latest_package_id,
+                &mut executors,
+                hashi::cli::client::CreateProposalParams::IgnoreMember {
+                    target_validator_address: target,
+                    ignored: true,
+                    metadata: vec![],
+                },
+                ignore_member_type_tag,
+                "ignore_member",
+                "IgnoreMember",
+            )
+            .await?;
+
+            let initial_epoch = nodes[0]
+                .current_epoch()
+                .ok_or_else(|| anyhow!("no current Hashi epoch"))?;
+
+            (
+                latest_package_id,
+                committee.members().len(),
+                committee.total_weight(),
+                target,
+                initial_epoch,
+            )
+        };
+        info!(
+            ?target,
+            latest_package_id = %latest_package_id,
+            "ignore executed on-chain; closing the epoch"
+        );
+
+        networks.sui_network.force_close_epoch().await?;
+        let target_epoch = initial_epoch + 1;
+        let futs: Vec<_> = networks
+            .hashi_network()
+            .nodes()
+            .iter()
+            .map(|n| n.wait_for_epoch(target_epoch, Duration::from_secs(480)))
+            .collect();
+        for (i, r) in futures::future::join_all(futs)
+            .await
+            .into_iter()
+            .enumerate()
+        {
+            r.unwrap_or_else(|e| panic!("Node {i} failed to reach epoch {target_epoch}: {e}"));
+        }
+
+        // The new committee excludes the ignored member and total weight
+        // re-sums without them.
+        {
+            let nodes = networks.hashi_network.nodes();
+            let committee = nodes[0]
+                .hashi()
+                .onchain_state()
+                .current_committee()
+                .ok_or_else(|| anyhow!("no committee after epoch change"))?;
+            assert_eq!(committee.members().len(), members_before - 1);
+            assert!(committee.index_of(&target).is_none());
+            assert!(committee.total_weight() < weight_before);
+        }
+
+        // The smaller committee still drives the full deposit and
+        // withdrawal paths: BLS certs, MPC signing with the reshared key,
+        // and the guardian's committee-handoff-derived thresholds.
+        create_deposit_and_wait(&mut networks, 100_000).await?;
+        crate::test_helpers::create_withdrawal_and_wait(&mut networks, 30_000).await?;
+
+        Ok(())
+    }
+
     /// Waits for a `WithdrawalPickedForProcessing` that contains at least
     /// `min_requests` request IDs in a single batch, indicating that the new
     /// multi-request coin selection algorithm batched them together.

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -1234,6 +1234,11 @@ mod tests {
                 .sender();
             assert!(committee.index_of(&target).is_some());
 
+            info!(
+                v1 = %hashi_ids.package_id,
+                latest = %latest_package_id,
+                "package ids in play"
+            );
             let ignore_member_type_tag =
                 sui_sdk_types::TypeTag::Struct(Box::new(sui_sdk_types::StructTag::new(
                     latest_package_id,
@@ -1241,8 +1246,14 @@ mod tests {
                     sui_sdk_types::Identifier::from_static("IgnoreMember"),
                     vec![],
                 )));
+            let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+                &mut networks.sui_network.client.clone(),
+                hashi_ids.hashi_object_id,
+            )
+            .await?;
             crate::submit_proposal_through_quorum(
                 hashi_ids,
+                hashi_isv,
                 latest_package_id,
                 &mut executors,
                 hashi::cli::client::CreateProposalParams::IgnoreMember {
@@ -1735,8 +1746,14 @@ mod tests {
         use hashi::cli::client::build_create_proposal_transaction;
 
         let validator_address = executor.sender();
+        let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+            &mut networks.sui_network.client.clone(),
+            hashi_ids.hashi_object_id,
+        )
+        .await?;
         let builder = build_create_proposal_transaction(
             hashi_ids,
+            hashi_isv,
             hashi_ids.package_id,
             validator_address,
             CreateProposalParams::UpdateConfig {
@@ -1833,11 +1850,17 @@ mod tests {
         let hashi_ids = networks.hashi_network.ids();
         let mut executor = SuiTxExecutor::from_config(&healthy.config, healthy.onchain_state())?;
         let creator = executor.sender();
+        let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+            &mut networks.sui_network.client.clone(),
+            hashi_ids.hashi_object_id,
+        )
+        .await?;
         let mut proposal_ids = Vec::new();
         let mut last_checkpoint = 0u64;
         for i in 0..3u64 {
             let builder = build_create_proposal_transaction(
                 hashi_ids,
+                hashi_isv,
                 hashi_ids.package_id,
                 creator,
                 CreateProposalParams::UpdateConfig {

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -708,8 +708,9 @@ pub(crate) async fn apply_onchain_config_overrides(
     Ok(())
 }
 
-/// `execute_package_id` must be the chain's latest package: calling the
+/// `execute_package_id` must be the chain's active package: calling the
 /// original id after an upgrade executes the old bytecode.
+#[allow(clippy::too_many_arguments)]
 async fn submit_proposal_through_quorum(
     hashi_ids: hashi::config::HashiIds,
     hashi_initial_shared_version: u64,

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -675,6 +675,11 @@ pub(crate) async fn apply_onchain_config_overrides(
         .onchain_state()
         .package_id()
         .unwrap_or(hashi_ids.package_id);
+    let hashi_initial_shared_version = hashi::cli::client::fetch_initial_shared_version(
+        &mut networks.sui_network.client.clone(),
+        hashi_ids.hashi_object_id,
+    )
+    .await?;
 
     // Build one executor per node, reused across all overrides.
     let mut executors: Vec<SuiTxExecutor> = nodes
@@ -705,6 +710,7 @@ pub(crate) async fn apply_onchain_config_overrides(
         );
         exec_checkpoint = submit_proposal_through_quorum(
             hashi_ids,
+            hashi_initial_shared_version,
             execute_package_id,
             &mut executors,
             CreateProposalParams::UpdateMpcConfig {
@@ -726,6 +732,7 @@ pub(crate) async fn apply_onchain_config_overrides(
         tracing::info!("applying on-chain config override: {key} = {value:?}");
         exec_checkpoint = submit_proposal_through_quorum(
             hashi_ids,
+            hashi_initial_shared_version,
             execute_package_id,
             &mut executors,
             CreateProposalParams::UpdateConfig {
@@ -770,6 +777,7 @@ pub(crate) async fn apply_onchain_config_overrides(
 /// original id after an upgrade executes the old bytecode.
 async fn submit_proposal_through_quorum(
     hashi_ids: hashi::config::HashiIds,
+    hashi_initial_shared_version: u64,
     execute_package_id: sui_sdk_types::Address,
     executors: &mut [hashi::sui_tx_executor::SuiTxExecutor],
     create_params: hashi::cli::client::CreateProposalParams,
@@ -783,8 +791,13 @@ async fn submit_proposal_through_quorum(
     use hashi::cli::upgrade::extract_proposal_id_from_response;
 
     let creator = executors[0].sender();
-    let create_tx =
-        build_create_proposal_transaction(hashi_ids, execute_package_id, creator, create_params);
+    let create_tx = build_create_proposal_transaction(
+        hashi_ids,
+        hashi_initial_shared_version,
+        execute_package_id,
+        creator,
+        create_params,
+    );
     let response = executors[0].execute(create_tx).await?;
     anyhow::ensure!(
         response.transaction().effects().status().success(),
@@ -796,6 +809,7 @@ async fn submit_proposal_through_quorum(
         let voter = executor.sender();
         let vote_tx = build_vote_transaction(
             hashi_ids,
+            hashi_initial_shared_version,
             execute_package_id,
             voter,
             proposal_id,
@@ -809,6 +823,7 @@ async fn submit_proposal_through_quorum(
     }
     let execute_tx = build_execute_proposal_transaction(
         hashi_ids,
+        hashi_initial_shared_version,
         proposal_id,
         execute_package_id,
         module_name,

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -608,6 +608,11 @@ pub(crate) async fn apply_onchain_config_overrides(
         .onchain_state()
         .package_id()
         .unwrap_or(hashi_ids.package_id);
+    let hashi_initial_shared_version = hashi::cli::client::fetch_initial_shared_version(
+        &mut networks.sui_network.client.clone(),
+        hashi_ids.hashi_object_id,
+    )
+    .await?;
 
     // Build one executor per node, reused across all overrides.
     let mut executors: Vec<SuiTxExecutor> = nodes
@@ -639,6 +644,7 @@ pub(crate) async fn apply_onchain_config_overrides(
         );
         exec_checkpoint = submit_proposal_through_quorum(
             hashi_ids,
+            hashi_initial_shared_version,
             execute_package_id,
             &mut executors,
             CreateProposalParams::UpdateMpcConfig {
@@ -661,6 +667,7 @@ pub(crate) async fn apply_onchain_config_overrides(
         tracing::info!("applying on-chain config override: {key} = {value:?}");
         exec_checkpoint = submit_proposal_through_quorum(
             hashi_ids,
+            hashi_initial_shared_version,
             execute_package_id,
             &mut executors,
             CreateProposalParams::UpdateConfig {
@@ -705,6 +712,7 @@ pub(crate) async fn apply_onchain_config_overrides(
 /// original id after an upgrade executes the old bytecode.
 async fn submit_proposal_through_quorum(
     hashi_ids: hashi::config::HashiIds,
+    hashi_initial_shared_version: u64,
     execute_package_id: sui_sdk_types::Address,
     executors: &mut [hashi::sui_tx_executor::SuiTxExecutor],
     create_params: hashi::cli::client::CreateProposalParams,
@@ -718,8 +726,13 @@ async fn submit_proposal_through_quorum(
     use hashi::cli::upgrade::extract_proposal_id_from_response;
 
     let creator = executors[0].sender();
-    let create_tx =
-        build_create_proposal_transaction(hashi_ids, execute_package_id, creator, create_params);
+    let create_tx = build_create_proposal_transaction(
+        hashi_ids,
+        hashi_initial_shared_version,
+        execute_package_id,
+        creator,
+        create_params,
+    );
     let response = executors[0].execute(create_tx).await?;
     anyhow::ensure!(
         response.transaction().effects().status().success(),
@@ -731,6 +744,7 @@ async fn submit_proposal_through_quorum(
         let voter = executor.sender();
         let vote_tx = build_vote_transaction(
             hashi_ids,
+            hashi_initial_shared_version,
             execute_package_id,
             voter,
             proposal_id,
@@ -744,6 +758,7 @@ async fn submit_proposal_through_quorum(
     }
     let execute_tx = build_execute_proposal_transaction(
         hashi_ids,
+        hashi_initial_shared_version,
         proposal_id,
         execute_package_id,
         module_name,

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -773,8 +773,9 @@ pub(crate) async fn apply_onchain_config_overrides(
     Ok(())
 }
 
-/// `execute_package_id` must be the chain's latest package: calling the
+/// `execute_package_id` must be the chain's active package: calling the
 /// original id after an upgrade executes the old bytecode.
+#[allow(clippy::too_many_arguments)]
 async fn submit_proposal_through_quorum(
     hashi_ids: hashi::config::HashiIds,
     hashi_initial_shared_version: u64,

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -507,7 +507,19 @@ impl TestNetworksBuilder {
                         )
                     })
                     .collect::<Result<_>>()?;
-                upgrade_flow::disable_version(&mut executors, hashi_ids, 1, new_package_id).await?;
+                let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+                    &mut test_networks.sui_network.client.clone(),
+                    hashi_ids.hashi_object_id,
+                )
+                .await?;
+                upgrade_flow::disable_version(
+                    &mut executors,
+                    hashi_ids,
+                    hashi_isv,
+                    1,
+                    new_package_id,
+                )
+                .await?;
                 upgrade_flow::wait_for_version_disabled(
                     &test_networks,
                     1,

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -332,6 +332,11 @@ async fn execute_full_upgrade_with_proposal(
         .collect();
     anyhow::ensure!(!nodes.is_empty(), "no running nodes to drive the upgrade");
     let hashi_ids = networks.hashi_network.ids();
+    let hashi_initial_shared_version = hashi::cli::client::fetch_initial_shared_version(
+        &mut networks.sui_network.client.clone(),
+        hashi_ids.hashi_object_id,
+    )
+    .await?;
 
     let mut executors: Vec<SuiTxExecutor> = nodes
         .iter()
@@ -401,8 +406,13 @@ async fn execute_full_upgrade_with_proposal(
             )
         }
     };
-    let create_tx =
-        build_create_proposal_transaction(hashi_ids, current_package_id, creator, proposal_params);
+    let create_tx = build_create_proposal_transaction(
+        hashi_ids,
+        hashi_initial_shared_version,
+        current_package_id,
+        creator,
+        proposal_params,
+    );
     let response = executors[0].execute(create_tx).await?;
     anyhow::ensure!(
         response.transaction().effects().status().success(),
@@ -424,6 +434,7 @@ async fn execute_full_upgrade_with_proposal(
         let voter = executor.sender();
         let vote_tx = build_vote_transaction(
             hashi_ids,
+            hashi_initial_shared_version,
             current_package_id,
             voter,
             proposal_id,
@@ -519,12 +530,14 @@ pub async fn wait_for_version_disabled(
 pub async fn disable_version(
     executors: &mut [SuiTxExecutor],
     hashi_ids: HashiIds,
+    hashi_initial_shared_version: u64,
     version: u64,
     execute_package_id: Address,
 ) -> Result<()> {
     let creator = executors[0].sender();
     let create_tx = build_create_proposal_transaction(
         hashi_ids,
+        hashi_initial_shared_version,
         execute_package_id,
         creator,
         CreateProposalParams::DisableVersion {
@@ -551,6 +564,7 @@ pub async fn disable_version(
         let voter = executor.sender();
         let vote_tx = build_vote_transaction(
             hashi_ids,
+            hashi_initial_shared_version,
             execute_package_id,
             voter,
             proposal_id,
@@ -565,6 +579,7 @@ pub async fn disable_version(
 
     let execute_tx = build_execute_proposal_transaction(
         hashi_ids,
+        hashi_initial_shared_version,
         proposal_id,
         execute_package_id,
         "disable_version",

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -305,6 +305,11 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
         .collect();
     anyhow::ensure!(!nodes.is_empty(), "no running nodes to drive the upgrade");
     let hashi_ids = networks.hashi_network.ids();
+    let hashi_initial_shared_version = hashi::cli::client::fetch_initial_shared_version(
+        &mut networks.sui_network.client.clone(),
+        hashi_ids.hashi_object_id,
+    )
+    .await?;
 
     let mut executors: Vec<SuiTxExecutor> = nodes
         .iter()
@@ -346,6 +351,7 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
     let creator = executors[0].sender();
     let create_tx = build_create_proposal_transaction(
         hashi_ids,
+        hashi_initial_shared_version,
         hashi_ids.package_id,
         creator,
         CreateProposalParams::Upgrade {
@@ -374,7 +380,8 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
         let voter = executor.sender();
         let vote_tx = build_vote_transaction(
             hashi_ids,
-            hashi_ids.package_id,
+            hashi_initial_shared_version,
+            current_package_id,
             voter,
             proposal_id,
             upgrade_type_tag.clone(),
@@ -411,12 +418,14 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
 pub async fn disable_version(
     executors: &mut [SuiTxExecutor],
     hashi_ids: HashiIds,
+    hashi_initial_shared_version: u64,
     version: u64,
     execute_package_id: Address,
 ) -> Result<()> {
     let creator = executors[0].sender();
     let create_tx = build_create_proposal_transaction(
         hashi_ids,
+        hashi_initial_shared_version,
         execute_package_id,
         creator,
         CreateProposalParams::DisableVersion {
@@ -443,6 +452,7 @@ pub async fn disable_version(
         let voter = executor.sender();
         let vote_tx = build_vote_transaction(
             hashi_ids,
+            hashi_initial_shared_version,
             execute_package_id,
             voter,
             proposal_id,
@@ -457,6 +467,7 @@ pub async fn disable_version(
 
     let execute_tx = build_execute_proposal_transaction(
         hashi_ids,
+        hashi_initial_shared_version,
         proposal_id,
         execute_package_id,
         "disable_version",

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -142,7 +142,12 @@ async fn test_upgrade_via_proposal() -> Result<()> {
         .map(|node| SuiTxExecutor::from_config(&node.hashi().config, node.hashi().onchain_state()))
         .collect::<Result<_>>()?;
 
-    upgrade_flow::disable_version(&mut executors, hashi_ids, 1, new_package_id).await?;
+    let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+        &mut networks.sui_network.client.clone(),
+        hashi_ids.hashi_object_id,
+    )
+    .await?;
+    upgrade_flow::disable_version(&mut executors, hashi_ids, hashi_isv, 1, new_package_id).await?;
     info!("version 1 disabled");
 
     let mut builder = TransactionBuilder::new();

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -537,7 +537,12 @@ async fn test_withdrawal_committed_under_v1_completes_after_upgrade() -> Result<
         .iter()
         .map(|node| SuiTxExecutor::from_config(&node.hashi().config, node.hashi().onchain_state()))
         .collect::<Result<_>>()?;
-    upgrade_flow::disable_version(&mut executors, hashi_ids, 1, new_package_id).await?;
+    let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+        &mut networks.sui_network.client.clone(),
+        hashi_ids.hashi_object_id,
+    )
+    .await?;
+    upgrade_flow::disable_version(&mut executors, hashi_ids, hashi_isv, 1, new_package_id).await?;
     upgrade_flow::wait_for_version_disabled(&networks, 1, Duration::from_secs(30)).await?;
     assert_eq!(
         node0.onchain_state().withdrawal_effective_version(),
@@ -724,7 +729,13 @@ async fn test_v1_entries_abort_against_v2_committed_request() -> Result<()> {
         .iter()
         .map(|node| SuiTxExecutor::from_config(&node.hashi().config, node.hashi().onchain_state()))
         .collect::<Result<_>>()?;
-    upgrade_flow::disable_version(&mut executors, hashi_ids, 1, active_package_id).await?;
+    let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+        &mut networks.sui_network.client.clone(),
+        hashi_ids.hashi_object_id,
+    )
+    .await?;
+    upgrade_flow::disable_version(&mut executors, hashi_ids, hashi_isv, 1, active_package_id)
+        .await?;
 
     // Every watcher must converge on v1-disabled; the proposal execution is
     // checkpointed, so the fullnode state the direct v1 calls run against

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -229,7 +229,12 @@ async fn test_upgrade_via_proposal() -> Result<()> {
         .map(|node| SuiTxExecutor::from_config(&node.hashi().config, node.hashi().onchain_state()))
         .collect::<Result<_>>()?;
 
-    upgrade_flow::disable_version(&mut executors, hashi_ids, 1, new_package_id).await?;
+    let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+        &mut networks.sui_network.client.clone(),
+        hashi_ids.hashi_object_id,
+    )
+    .await?;
+    upgrade_flow::disable_version(&mut executors, hashi_ids, hashi_isv, 1, new_package_id).await?;
     info!("version 1 disabled");
 
     let mut builder = TransactionBuilder::new();

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -283,7 +283,9 @@ pub struct MemberInfo {
     /// beginning of the next epoch.
     pub next_epoch_encryption_public_key: Vec<u8>,
 
-    /// Open-ended per-member extension slot. Empty today.
+    /// Open-ended per-member extension slot. Carries the governance flags
+    /// ([`MEMBER_IGNORED_KEY`]) as typed values while `MemberInfo`'s layout
+    /// is frozen on the deployed network.
     pub extra_fields: Config,
 }
 
@@ -422,6 +424,20 @@ impl Config {
             .find(|(k, _)| k == key)
             .and_then(|(_, v)| match v {
                 ConfigValue::U64(n) => Some(*n),
+                _ => None,
+            })
+            .unwrap_or(default)
+    }
+
+    /// Read a `bool` value by key, falling back to `default` if the key is
+    /// absent or not a `Bool` (matches the Move accessors' default-on-absent
+    /// behavior).
+    pub fn get_bool(&self, key: &str, default: bool) -> bool {
+        self.0
+            .iter()
+            .find(|(k, _)| k == key)
+            .and_then(|(_, v)| match v {
+                ConfigValue::Bool(b) => Some(*b),
                 _ => None,
             })
             .unwrap_or(default)
@@ -924,6 +940,24 @@ pub struct AbortReconfig {
 pub struct UpdateGuardian {
     pub url: String,
 }
+
+/// Rust version of the Move hashi::ignore_member::IgnoreMember type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct IgnoreMember {
+    pub validator_address: Address,
+    pub ignored: bool,
+}
+
+impl MoveType for IgnoreMember {
+    /// Introduced by the v2 upgrade; the defining address is v2's forever.
+    const PACKAGE_VERSION: u64 = 2;
+    const MODULE: &'static str = "ignore_member";
+    const NAME: &'static str = "IgnoreMember";
+}
+
+/// `MemberInfo.extra_fields` key holding the governance "ignored" flag.
+/// Mirrors `MEMBER_IGNORED_KEY` in `committee_set.move`.
+pub const MEMBER_IGNORED_KEY: &str = "ignored";
 
 /// Rust version of the Move sui::vec_map::VecMap type.
 #[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
@@ -1798,6 +1832,21 @@ mod tests {
     use super::*;
 
     use sui_sdk_types::Identifier;
+
+    #[test]
+    fn config_get_bool_reads_present_absent_and_wrong_variant() {
+        let config = Config::from_entries(vec![
+            ("ignored".to_string(), ConfigValue::Bool(true)),
+            ("cleared".to_string(), ConfigValue::Bool(false)),
+            ("numeric".to_string(), ConfigValue::U64(1)),
+        ]);
+        assert!(config.get_bool("ignored", false));
+        assert!(!config.get_bool("cleared", true));
+        // Absent key and wrong variant both fall back to the default.
+        assert!(!config.get_bool("missing", false));
+        assert!(config.get_bool("missing", true));
+        assert!(!config.get_bool("numeric", false));
+    }
 
     fn tag(address: Address, module: &str, name: &str, type_params: Vec<TypeTag>) -> StructTag {
         StructTag::new(

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -283,7 +283,9 @@ pub struct MemberInfo {
     /// beginning of the next epoch.
     pub next_epoch_encryption_public_key: Vec<u8>,
 
-    /// Open-ended per-member extension slot. Empty today.
+    /// Open-ended per-member extension slot. Carries the governance flags
+    /// ([`MEMBER_IGNORED_KEY`]) as typed values while `MemberInfo`'s layout
+    /// is frozen on the deployed network.
     pub extra_fields: Config,
 }
 
@@ -424,6 +426,20 @@ impl Config {
             .find(|(k, _)| k == key)
             .and_then(|(_, v)| match v {
                 ConfigValue::U64(n) => Some(*n),
+                _ => None,
+            })
+            .unwrap_or(default)
+    }
+
+    /// Read a `bool` value by key, falling back to `default` if the key is
+    /// absent or not a `Bool` (matches the Move accessors' default-on-absent
+    /// behavior).
+    pub fn get_bool(&self, key: &str, default: bool) -> bool {
+        self.0
+            .iter()
+            .find(|(k, _)| k == key)
+            .and_then(|(_, v)| match v {
+                ConfigValue::Bool(b) => Some(*b),
                 _ => None,
             })
             .unwrap_or(default)
@@ -901,6 +917,24 @@ pub struct AbortReconfig {
 pub struct UpdateGuardian {
     pub url: String,
 }
+
+/// Rust version of the Move hashi::ignore_member::IgnoreMember type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct IgnoreMember {
+    pub validator_address: Address,
+    pub ignored: bool,
+}
+
+impl MoveType for IgnoreMember {
+    /// Introduced by the v2 upgrade; the defining address is v2's forever.
+    const PACKAGE_VERSION: u64 = 2;
+    const MODULE: &'static str = "ignore_member";
+    const NAME: &'static str = "IgnoreMember";
+}
+
+/// `MemberInfo.extra_fields` key holding the governance "ignored" flag.
+/// Mirrors `MEMBER_IGNORED_KEY` in `committee_set.move`.
+pub const MEMBER_IGNORED_KEY: &str = "ignored";
 
 /// Rust version of the Move sui::vec_map::VecMap type.
 #[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
@@ -1774,6 +1808,21 @@ mod tests {
     use super::*;
 
     use sui_sdk_types::Identifier;
+
+    #[test]
+    fn config_get_bool_reads_present_absent_and_wrong_variant() {
+        let config = Config::from_entries(vec![
+            ("ignored".to_string(), ConfigValue::Bool(true)),
+            ("cleared".to_string(), ConfigValue::Bool(false)),
+            ("numeric".to_string(), ConfigValue::U64(1)),
+        ]);
+        assert!(config.get_bool("ignored", false));
+        assert!(!config.get_bool("cleared", true));
+        // Absent key and wrong variant both fall back to the default.
+        assert!(!config.get_bool("missing", false));
+        assert!(config.get_bool("missing", true));
+        assert!(!config.get_bool("numeric", false));
+    }
 
     fn tag(address: Address, module: &str, name: &str, type_params: Vec<TypeTag>) -> StructTag {
         StructTag::new(

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -69,6 +69,12 @@ pub enum CreateProposalParams {
         pause: bool,
         metadata: Vec<(String, String)>,
     },
+    IgnoreMember {
+        target_validator_address: Address,
+        /// `true` proposes ignoring the member; `false` proposes re-admitting.
+        ignored: bool,
+        metadata: Vec<(String, String)>,
+    },
 }
 
 /// Live on-chain proposal detail fields not cached by `OnchainState`.
@@ -372,6 +378,11 @@ impl HashiClient {
                             bcs::from_bytes(value_bytes).context("deserialize UpdateGuardian")?;
                         (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
                     }
+                    ProposalType::IgnoreMember => {
+                        let p: move_types::Proposal<move_types::IgnoreMember> =
+                            bcs::from_bytes(value_bytes).context("deserialize IgnoreMember")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
                     ProposalType::Unknown(s) => {
                         anyhow::bail!("Cannot fetch details for unknown proposal type: {s}")
                     }
@@ -500,6 +511,16 @@ impl HashiClient {
         Ok(builder)
     }
 
+    /// The full deployed version -> package id history.
+    pub fn package_versions(&self) -> hashi_types::move_types::PackageVersions {
+        self.onchain_state.state().package_versions().clone()
+    }
+
+    /// The scraped on-chain state backing this client.
+    pub fn onchain_state(&self) -> &OnchainState {
+        &self.onchain_state
+    }
+
     /// Build a proposal creation transaction.
     pub fn build_create_proposal_transaction(
         &self,
@@ -542,6 +563,7 @@ impl HashiClient {
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::AbortReconfig => "abort_reconfig",
             ProposalType::UpdateGuardian => "update_guardian",
+            ProposalType::IgnoreMember => "ignore_member",
             ProposalType::Upgrade => {
                 anyhow::bail!(
                     "Upgrade proposals require the full upgrade flow (execute + publish + finalize)"
@@ -581,6 +603,10 @@ impl HashiClient {
 /// Build a `TransactionBuilder` for creating a proposal, given `HashiIds` and params.
 ///
 /// This is a standalone function so it can be reused outside `HashiClient` (e.g. in tests).
+///
+/// `call_package` is the active package id. Proposal modules introduced by an
+/// upgrade (such as `ignore_member`) only exist at an upgraded address, and
+/// all governance calls use one package generation consistently.
 pub fn build_create_proposal_transaction(
     hashi_ids: HashiIds,
     call_package: Address,
@@ -774,6 +800,31 @@ pub fn build_create_proposal_transaction(
                 ],
             );
         }
+        CreateProposalParams::IgnoreMember {
+            target_validator_address,
+            ignored,
+            metadata,
+        } => {
+            let target_arg = builder.pure(&target_validator_address);
+            let ignored_arg = builder.pure(&ignored);
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    // The ignore_member module exists only from v2 on.
+                    call_package,
+                    Identifier::from_static("ignore_member"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    target_arg,
+                    ignored_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
+            );
+        }
     }
 
     builder
@@ -940,21 +991,39 @@ pub fn build_vote_transaction(
 
 /// Get the TypeTag for a proposal type (from on-chain type)
 ///
-/// Returns an error if the proposal type is `Unknown`.
+/// A Move type's tag carries its DEFINING package's address forever, so
+/// v1-era proposal types are addressed at `original_package_id` while types
+/// introduced by an upgrade resolve their defining version through
+/// `packages`.
+///
+/// Returns an error if the proposal type is `Unknown`, or defined by a
+/// package version not deployed on this chain.
 pub fn get_proposal_type_arg(
-    package_id: Address,
+    packages: &hashi_types::move_types::PackageVersions,
+    original_package_id: Address,
     proposal_type: &crate::onchain::types::ProposalType,
 ) -> Result<TypeTag> {
     use crate::onchain::types::ProposalType;
+    use hashi_types::move_types::MoveType as _;
 
-    let (module, name) = match proposal_type {
-        ProposalType::Upgrade => ("upgrade", "Upgrade"),
-        ProposalType::UpdateConfig => ("update_config", "UpdateConfig"),
-        ProposalType::EnableVersion => ("enable_version", "EnableVersion"),
-        ProposalType::DisableVersion => ("disable_version", "DisableVersion"),
-        ProposalType::EmergencyPause => ("emergency_pause", "EmergencyPause"),
-        ProposalType::AbortReconfig => ("abort_reconfig", "AbortReconfig"),
-        ProposalType::UpdateGuardian => ("update_guardian", "UpdateGuardian"),
+    let (package_id, module, name) = match proposal_type {
+        ProposalType::Upgrade => (original_package_id, "upgrade", "Upgrade"),
+        ProposalType::UpdateConfig => (original_package_id, "update_config", "UpdateConfig"),
+        ProposalType::EnableVersion => (original_package_id, "enable_version", "EnableVersion"),
+        ProposalType::DisableVersion => (original_package_id, "disable_version", "DisableVersion"),
+        ProposalType::EmergencyPause => (original_package_id, "emergency_pause", "EmergencyPause"),
+        ProposalType::AbortReconfig => (original_package_id, "abort_reconfig", "AbortReconfig"),
+        ProposalType::UpdateGuardian => (original_package_id, "update_guardian", "UpdateGuardian"),
+        ProposalType::IgnoreMember => (
+            packages
+                .get(hashi_types::move_types::IgnoreMember::PACKAGE_VERSION)
+                .context(
+                    "ignore_member is introduced by package v2, which is not deployed on this \
+                     chain yet",
+                )?,
+            hashi_types::move_types::IgnoreMember::MODULE,
+            hashi_types::move_types::IgnoreMember::NAME,
+        ),
         ProposalType::Unknown(s) => {
             anyhow::bail!(
                 "Cannot vote on unknown proposal type '{}'. \

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -73,6 +73,12 @@ pub enum CreateProposalParams {
         pause: bool,
         metadata: Vec<(String, String)>,
     },
+    IgnoreMember {
+        target_validator_address: Address,
+        /// `true` proposes ignoring the member; `false` proposes re-admitting.
+        ignored: bool,
+        metadata: Vec<(String, String)>,
+    },
 }
 
 /// Live on-chain proposal detail fields not cached by `OnchainState`.
@@ -389,6 +395,11 @@ impl HashiClient {
                             bcs::from_bytes(value_bytes).context("deserialize UpdateGuardian")?;
                         (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
                     }
+                    ProposalType::IgnoreMember => {
+                        let p: move_types::Proposal<move_types::IgnoreMember> =
+                            bcs::from_bytes(value_bytes).context("deserialize IgnoreMember")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
                     ProposalType::Unknown(s) => {
                         anyhow::bail!("Cannot fetch details for unknown proposal type: {s}")
                     }
@@ -517,6 +528,16 @@ impl HashiClient {
         Ok(builder)
     }
 
+    /// The full deployed version -> package id history.
+    pub fn package_versions(&self) -> hashi_types::move_types::PackageVersions {
+        self.onchain_state.state().package_versions().clone()
+    }
+
+    /// The scraped on-chain state backing this client.
+    pub fn onchain_state(&self) -> &OnchainState {
+        &self.onchain_state
+    }
+
     /// Build a proposal creation transaction.
     pub fn build_create_proposal_transaction(
         &self,
@@ -559,6 +580,7 @@ impl HashiClient {
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::AbortReconfig => "abort_reconfig",
             ProposalType::UpdateGuardian => "update_guardian",
+            ProposalType::IgnoreMember => "ignore_member",
             ProposalType::Upgrade | ProposalType::UpgradeV2 => {
                 anyhow::bail!(
                     "Upgrade proposals require the full upgrade flow (execute + publish + finalize)"
@@ -621,6 +643,10 @@ impl HashiClient {
 /// Build a `TransactionBuilder` for creating a proposal, given `HashiIds` and params.
 ///
 /// This is a standalone function so it can be reused outside `HashiClient` (e.g. in tests).
+///
+/// `call_package` is the active package id. Proposal modules introduced by an
+/// upgrade (such as `ignore_member`) only exist at an upgraded address, and
+/// all governance calls use one package generation consistently.
 pub fn build_create_proposal_transaction(
     hashi_ids: HashiIds,
     call_package: Address,
@@ -836,6 +862,31 @@ pub fn build_create_proposal_transaction(
                 ],
             );
         }
+        CreateProposalParams::IgnoreMember {
+            target_validator_address,
+            ignored,
+            metadata,
+        } => {
+            let target_arg = builder.pure(&target_validator_address);
+            let ignored_arg = builder.pure(&ignored);
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    // The ignore_member module exists only from v2 on.
+                    call_package,
+                    Identifier::from_static("ignore_member"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    target_arg,
+                    ignored_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
+            );
+        }
     }
 
     builder
@@ -1002,6 +1053,11 @@ pub fn build_vote_transaction(
 
 /// Get the TypeTag for a proposal type (from on-chain type)
 ///
+/// `package_id` must be the type's DEFINING package (a Move type's tag
+/// carries that address forever) — resolve it via
+/// [`HashiClient::proposal_type_arg`], which routes each proposal type to
+/// the package version that introduced it.
+///
 /// Returns an error if the proposal type is `Unknown`.
 pub fn get_proposal_type_arg(
     package_id: Address,
@@ -1018,6 +1074,7 @@ pub fn get_proposal_type_arg(
         ProposalType::EmergencyPause => ("emergency_pause", "EmergencyPause"),
         ProposalType::AbortReconfig => ("abort_reconfig", "AbortReconfig"),
         ProposalType::UpdateGuardian => ("update_guardian", "UpdateGuardian"),
+        ProposalType::IgnoreMember => ("ignore_member", "IgnoreMember"),
         ProposalType::Unknown(s) => {
             anyhow::bail!(
                 "Cannot vote on unknown proposal type '{}'. \

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -106,6 +106,11 @@ pub struct HashiClient {
     onchain_state: OnchainState,
     /// Hashi package and object IDs
     hashi_ids: HashiIds,
+    /// The Hashi shared object's initial shared version, fetched once at
+    /// construction. Immutable for the object's lifetime, and needed to
+    /// build fully-resolved shared inputs (see
+    /// [`build_create_proposal_transaction`]).
+    hashi_initial_shared_version: u64,
     /// Optional executor for signing and submitting transactions
     executor: Option<SuiTxExecutor>,
 }
@@ -165,6 +170,10 @@ impl HashiClient {
         .await
         .context("Failed to initialize on-chain state")?;
 
+        let hashi_initial_shared_version =
+            fetch_initial_shared_version(&mut onchain_state.client(), hashi_ids.hashi_object_id)
+                .await?;
+
         // Try to create executor if keypair is available
         let executor = match config.load_keypair()? {
             Some(signer) => {
@@ -184,6 +193,7 @@ impl HashiClient {
         Ok(Self {
             onchain_state,
             hashi_ids,
+            hashi_initial_shared_version,
             executor,
         })
     }
@@ -471,6 +481,7 @@ impl HashiClient {
         let validator_address = self.resolve_validator_address()?;
         Ok(build_vote_transaction(
             self.hashi_ids,
+            self.hashi_initial_shared_version,
             self.call_package(),
             validator_address,
             proposal_id,
@@ -490,14 +501,17 @@ impl HashiClient {
 
         let mut builder = TransactionBuilder::new();
 
+        // Fully-resolved shared input: see build_vote_transaction.
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
+                .with_version(self.hashi_initial_shared_version)
                 .as_shared()
                 .with_mutable(true),
         );
         let validator_address_arg = builder.pure(&validator_address);
         let proposal_id_arg = builder.pure(&proposal_id);
 
+        // Active package for the same linkage reason as build_vote_transaction.
         builder.move_call(
             Function::new(
                 self.call_package(),
@@ -529,6 +543,7 @@ impl HashiClient {
         let validator_address = self.resolve_validator_address()?;
         Ok(build_create_proposal_transaction(
             self.hashi_ids,
+            self.hashi_initial_shared_version,
             self.call_package(),
             validator_address,
             params,
@@ -575,14 +590,17 @@ impl HashiClient {
         };
 
         let mut builder = TransactionBuilder::new();
+        // Fully-resolved shared inputs: see build_create_proposal_transaction.
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
+                .with_version(self.hashi_initial_shared_version)
                 .as_shared()
                 .with_mutable(true),
         );
         let proposal_id_arg = builder.pure(&proposal_id);
         let clock_arg = builder.object(
             ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+                .with_version(1)
                 .as_shared()
                 .with_mutable(false),
         );
@@ -609,19 +627,27 @@ impl HashiClient {
 /// all governance calls use one package generation consistently.
 pub fn build_create_proposal_transaction(
     hashi_ids: HashiIds,
+    hashi_initial_shared_version: u64,
     call_package: Address,
     validator_address: Address,
     params: CreateProposalParams,
 ) -> TransactionBuilder {
     let mut builder = TransactionBuilder::new();
 
+    // Shared inputs are fully resolved (initial shared version + mutability)
+    // so the fullnode's simulate-time resolver never has to inspect the
+    // called function's signature: that inspection fails with
+    // INVALID_LINKAGE on sui >= 1.76 fullnodes for modules introduced by a
+    // package upgrade (e.g. ignore_member).
     let hashi_arg = builder.object(
         ObjectInput::new(hashi_ids.hashi_object_id)
+            .with_version(hashi_initial_shared_version)
             .as_shared()
             .with_mutable(true),
     );
     let clock_arg = builder.object(
         ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .with_version(1)
             .as_shared()
             .with_mutable(false),
     );
@@ -957,14 +983,20 @@ fn build_metadata(
 /// committee member.
 pub fn build_vote_transaction(
     hashi_ids: HashiIds,
+    hashi_initial_shared_version: u64,
     call_package: Address,
     validator_address: Address,
     proposal_id: Address,
     type_arg: TypeTag,
 ) -> TransactionBuilder {
     let mut builder = TransactionBuilder::new();
+    // Fully-resolved shared inputs: the type arg may name an
+    // upgrade-introduced type, and the fullnode's simulate-time resolver
+    // fails with INVALID_LINKAGE on those when it has to inspect the call
+    // to infer input mutability (sui >= 1.76).
     let hashi_arg = builder.object(
         ObjectInput::new(hashi_ids.hashi_object_id)
+            .with_version(hashi_initial_shared_version)
             .as_shared()
             .with_mutable(true),
     );
@@ -972,10 +1004,16 @@ pub fn build_vote_transaction(
     let proposal_id_arg = builder.pure(&proposal_id);
     let clock_arg = builder.object(
         ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .with_version(1)
             .as_shared()
             .with_mutable(false),
     );
 
+    // Call through the active package: a transaction's linkage cannot call
+    // the original package while a type argument references an
+    // upgrade-introduced type (exact-v1 vs at-least-v2 conflict). Every
+    // module rides along in an upgrade, and v1-era type args unify fine
+    // under a v2 call, so latest is always safe.
     builder.move_call(
         Function::new(
             call_package,

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -110,6 +110,11 @@ pub struct HashiClient {
     onchain_state: OnchainState,
     /// Hashi package and object IDs
     hashi_ids: HashiIds,
+    /// The Hashi shared object's initial shared version, fetched once at
+    /// construction. Immutable for the object's lifetime, and needed to
+    /// build fully-resolved shared inputs (see
+    /// [`build_create_proposal_transaction`]).
+    hashi_initial_shared_version: u64,
     /// Optional executor for signing and submitting transactions
     executor: Option<SuiTxExecutor>,
     /// The RPC endpoint this client talks to (used for explorer deep-links)
@@ -171,6 +176,10 @@ impl HashiClient {
         .await
         .context("Failed to initialize on-chain state")?;
 
+        let hashi_initial_shared_version =
+            fetch_initial_shared_version(&mut onchain_state.client(), hashi_ids.hashi_object_id)
+                .await?;
+
         // Try to create executor if keypair is available
         let executor = match config.load_keypair()? {
             Some(signer) => {
@@ -190,6 +199,7 @@ impl HashiClient {
         Ok(Self {
             onchain_state,
             hashi_ids,
+            hashi_initial_shared_version,
             executor,
             sui_rpc_url: config.sui_rpc_url.clone(),
         })
@@ -488,6 +498,7 @@ impl HashiClient {
         let validator_address = self.resolve_validator_address()?;
         Ok(build_vote_transaction(
             self.hashi_ids,
+            self.hashi_initial_shared_version,
             self.call_package(),
             validator_address,
             proposal_id,
@@ -507,14 +518,17 @@ impl HashiClient {
 
         let mut builder = TransactionBuilder::new();
 
+        // Fully-resolved shared input: see build_vote_transaction.
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
+                .with_version(self.hashi_initial_shared_version)
                 .as_shared()
                 .with_mutable(true),
         );
         let validator_address_arg = builder.pure(&validator_address);
         let proposal_id_arg = builder.pure(&proposal_id);
 
+        // Active package for the same linkage reason as build_vote_transaction.
         builder.move_call(
             Function::new(
                 self.call_package(),
@@ -546,6 +560,7 @@ impl HashiClient {
         let validator_address = self.resolve_validator_address()?;
         Ok(build_create_proposal_transaction(
             self.hashi_ids,
+            self.hashi_initial_shared_version,
             self.call_package(),
             validator_address,
             params,
@@ -592,14 +607,17 @@ impl HashiClient {
         };
 
         let mut builder = TransactionBuilder::new();
+        // Fully-resolved shared inputs: see build_create_proposal_transaction.
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
+                .with_version(self.hashi_initial_shared_version)
                 .as_shared()
                 .with_mutable(true),
         );
         let proposal_id_arg = builder.pure(&proposal_id);
         let clock_arg = builder.object(
             ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+                .with_version(1)
                 .as_shared()
                 .with_mutable(false),
         );
@@ -649,19 +667,27 @@ impl HashiClient {
 /// all governance calls use one package generation consistently.
 pub fn build_create_proposal_transaction(
     hashi_ids: HashiIds,
+    hashi_initial_shared_version: u64,
     call_package: Address,
     validator_address: Address,
     params: CreateProposalParams,
 ) -> TransactionBuilder {
     let mut builder = TransactionBuilder::new();
 
+    // Shared inputs are fully resolved (initial shared version + mutability)
+    // so the fullnode's simulate-time resolver never has to inspect the
+    // called function's signature: that inspection fails with
+    // INVALID_LINKAGE on sui >= 1.76 fullnodes for modules introduced by a
+    // package upgrade (e.g. ignore_member).
     let hashi_arg = builder.object(
         ObjectInput::new(hashi_ids.hashi_object_id)
+            .with_version(hashi_initial_shared_version)
             .as_shared()
             .with_mutable(true),
     );
     let clock_arg = builder.object(
         ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .with_version(1)
             .as_shared()
             .with_mutable(false),
     );
@@ -1019,14 +1045,20 @@ fn build_metadata(
 /// committee member.
 pub fn build_vote_transaction(
     hashi_ids: HashiIds,
+    hashi_initial_shared_version: u64,
     call_package: Address,
     validator_address: Address,
     proposal_id: Address,
     type_arg: TypeTag,
 ) -> TransactionBuilder {
     let mut builder = TransactionBuilder::new();
+    // Fully-resolved shared inputs: the type arg may name an
+    // upgrade-introduced type, and the fullnode's simulate-time resolver
+    // fails with INVALID_LINKAGE on those when it has to inspect the call
+    // to infer input mutability (sui >= 1.76).
     let hashi_arg = builder.object(
         ObjectInput::new(hashi_ids.hashi_object_id)
+            .with_version(hashi_initial_shared_version)
             .as_shared()
             .with_mutable(true),
     );
@@ -1034,10 +1066,16 @@ pub fn build_vote_transaction(
     let proposal_id_arg = builder.pure(&proposal_id);
     let clock_arg = builder.object(
         ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .with_version(1)
             .as_shared()
             .with_mutable(false),
     );
 
+    // Call through the active package: a transaction's linkage cannot call
+    // the original package while a type argument references an
+    // upgrade-introduced type (exact-v1 vs at-least-v2 conflict). Every
+    // module rides along in an upgrade, and v1-era type args unify fine
+    // under a v2 call, so latest is always safe.
     builder.move_call(
         Function::new(
             call_package,

--- a/crates/hashi/src/cli/commands/committee.rs
+++ b/crates/hashi/src/cli/commands/committee.rs
@@ -53,6 +53,8 @@ pub async fn list_members(config: &CliConfig, epoch: Option<u64>) -> Result<()> 
         validator: String,
         #[tabled(rename = "Operator Address")]
         operator: String,
+        #[tabled(rename = "Ignored")]
+        ignored: String,
     }
 
     let rows: Vec<MemberRow> = members
@@ -60,6 +62,13 @@ pub async fn list_members(config: &CliConfig, epoch: Option<u64>) -> Result<()> 
         .map(|m| MemberRow {
             validator: display::format_address(&m.validator_address),
             operator: display::format_address(&m.operator_address),
+            // Registry view: shows the governance flag as soon as it is set,
+            // before the epoch-boundary effect on the committee.
+            ignored: if m.ignored {
+                "yes".to_string()
+            } else {
+                String::new()
+            },
         })
         .collect();
 
@@ -104,6 +113,12 @@ pub async fn view_member(config: &CliConfig, address: &str) -> Result<()> {
             );
             if let Some(uri) = &m.endpoint_url {
                 println!("  {} {}", "Endpoint:".bold(), uri);
+            }
+            if m.ignored {
+                println!(
+                    "  {} yes (excluded from the next committee formation)",
+                    "Ignored:".bold()
+                );
             }
             println!("{}", "━".repeat(60).dimmed());
         }

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -773,6 +773,73 @@ pub async fn create_emergency_pause_proposal(
     Ok(())
 }
 
+/// Create a proposal to ignore (or re-admit) a registered committee member.
+pub async fn create_ignore_member_proposal(
+    config: &CliConfig,
+    validator: &str,
+    unignore: bool,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let target: Address = validator
+        .parse()
+        .with_context(|| format!("invalid validator address: {validator}"))?;
+    let action = if unignore { "Un-ignore" } else { "Ignore" };
+    let title = format!("Creating {action} Member Proposal:");
+    print_detail(&format!("\n{}", title.bold()));
+    print_detail(&format!("  Target: {}", target));
+    print_metadata(&metadata);
+
+    let client = HashiClient::new(config).await?;
+
+    // The flag is only read at the next committee formation. Tell the
+    // operator when the change will actually bite.
+    match client.onchain_state().pending_epoch_change() {
+        Some(pending) => print_detail(&format!(
+            "  Effect: a reconfiguration to epoch {pending} is already in flight — the change \
+             takes effect one epoch later, at the formation after it completes",
+        )),
+        None => print_detail(
+            "  Effect: at the next committee formation (start of the next reconfiguration)",
+        ),
+    }
+
+    if !unignore {
+        // Warn when the target carries so much weight that excluding it
+        // approaches the BFT bound (see ignore_member.move's module doc).
+        if let Some(committee) = client.onchain_state().current_committee() {
+            let weight = committee.weight_of(&target).unwrap_or(0);
+            let total = committee.total_weight();
+            if total > 0 && weight * 10_000 / total > 2_500 {
+                print_detail(&format!(
+                    "  WARNING: target holds {weight} of {total} committee weight (> 25%). \
+                     Exclusion only works while non-participating weight stays at or below \
+                     1/3 of the committee — beyond that, governance and reconfiguration are \
+                     both blocked."
+                ));
+            }
+        }
+    }
+
+    prompt_continue(
+        &format!("create this {} member proposal", action.to_lowercase()),
+        tx_opts,
+    )
+    .await?;
+
+    let mut client = client;
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::IgnoreMember {
+        target_validator_address: target,
+        ignored: !unignore,
+        metadata,
+    })?;
+
+    print_info("Transaction: ignore_member::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
 // ============ Helper Functions ============
 
 fn print_proposal_detailed(

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -216,7 +216,11 @@ pub async fn vote(
     print_info("Building vote transaction...");
 
     // Infer the type tag from the on-chain proposal type
-    let type_arg = get_proposal_type_arg(client.hashi_ids().package_id, &proposal.proposal_type)?;
+    let type_arg = get_proposal_type_arg(
+        &client.package_versions(),
+        client.hashi_ids().package_id,
+        &proposal.proposal_type,
+    )?;
     let tx = client.build_vote_transaction(proposal_addr, type_arg)?;
 
     print_info(&format!(
@@ -320,7 +324,11 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
     print_info("Building remove_vote transaction...");
 
     // Infer the type tag from the on-chain proposal type
-    let type_arg = get_proposal_type_arg(client.hashi_ids().package_id, &proposal.proposal_type)?;
+    let type_arg = get_proposal_type_arg(
+        &client.package_versions(),
+        client.hashi_ids().package_id,
+        &proposal.proposal_type,
+    )?;
     let tx = client.build_remove_vote_transaction(proposal_addr, type_arg)?;
 
     print_info(&format!(
@@ -698,6 +706,73 @@ pub async fn create_emergency_pause_proposal(
     })?;
 
     print_info("Transaction: emergency_pause::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
+/// Create a proposal to ignore (or re-admit) a registered committee member.
+pub async fn create_ignore_member_proposal(
+    config: &CliConfig,
+    validator: &str,
+    unignore: bool,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let target: Address = validator
+        .parse()
+        .with_context(|| format!("invalid validator address: {validator}"))?;
+    let action = if unignore { "Un-ignore" } else { "Ignore" };
+    let title = format!("Creating {action} Member Proposal:");
+    print_detail(&format!("\n{}", title.bold()));
+    print_detail(&format!("  Target: {}", target));
+    print_metadata(&metadata);
+
+    let client = HashiClient::new(config).await?;
+
+    // The flag is only read at the next committee formation. Tell the
+    // operator when the change will actually bite.
+    match client.onchain_state().pending_epoch_change() {
+        Some(pending) => print_detail(&format!(
+            "  Effect: a reconfiguration to epoch {pending} is already in flight — the change \
+             takes effect one epoch later, at the formation after it completes",
+        )),
+        None => print_detail(
+            "  Effect: at the next committee formation (start of the next reconfiguration)",
+        ),
+    }
+
+    if !unignore {
+        // Warn when the target carries so much weight that excluding it
+        // approaches the BFT bound (see ignore_member.move's module doc).
+        if let Some(committee) = client.onchain_state().current_committee() {
+            let weight = committee.weight_of(&target).unwrap_or(0);
+            let total = committee.total_weight();
+            if total > 0 && weight * 10_000 / total > 2_500 {
+                print_detail(&format!(
+                    "  WARNING: target holds {weight} of {total} committee weight (> 25%). \
+                     Exclusion only works while non-participating weight stays at or below \
+                     1/3 of the committee — beyond that, governance and reconfiguration are \
+                     both blocked."
+                ));
+            }
+        }
+    }
+
+    prompt_continue(
+        &format!("create this {} member proposal", action.to_lowercase()),
+        tx_opts,
+    )
+    .await?;
+
+    let mut client = client;
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::IgnoreMember {
+        target_validator_address: target,
+        ignored: !unignore,
+        metadata,
+    })?;
+
+    print_info("Transaction: ignore_member::propose");
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
     print_created_proposal_id(response.as_ref());
     Ok(())

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -288,6 +288,27 @@ pub enum CreateProposalCommands {
         #[clap(flatten)]
         metadata: MetadataArgs,
     },
+
+    /// Propose ignoring a registered member (or re-admitting with
+    /// `--unignore`).
+    ///
+    /// An ignored member is treated as no longer part of the committee. The
+    /// flag takes effect at the next committee FORMATION: the current
+    /// committee is unchanged, and if a reconfiguration is already in
+    /// flight the change lands one epoch later. The member stays registered
+    /// and keeps proposal/vote authorization throughout.
+    IgnoreMember {
+        /// The target member's Sui validator address.
+        #[clap(long)]
+        validator: String,
+
+        /// Propose re-admitting the member instead of ignoring them.
+        #[clap(long)]
+        unignore: bool,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
 }
 
 /// Shared metadata arguments for proposal creation
@@ -979,6 +1000,20 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                     commands::proposal::create_emergency_pause_proposal(
                         &config,
                         unpause,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::IgnoreMember {
+                    validator,
+                    unignore,
+                    metadata,
+                } => {
+                    commands::proposal::create_ignore_member_proposal(
+                        &config,
+                        &validator,
+                        unignore,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -327,6 +327,27 @@ pub enum CreateProposalCommands {
         #[clap(flatten)]
         metadata: MetadataArgs,
     },
+
+    /// Propose ignoring a registered member (or re-admitting with
+    /// `--unignore`).
+    ///
+    /// An ignored member is treated as no longer part of the committee. The
+    /// flag takes effect at the next committee FORMATION: the current
+    /// committee is unchanged, and if a reconfiguration is already in
+    /// flight the change lands one epoch later. The member stays registered
+    /// and keeps proposal/vote authorization throughout.
+    IgnoreMember {
+        /// The target member's Sui validator address.
+        #[clap(long)]
+        validator: String,
+
+        /// Propose re-admitting the member instead of ignoring them.
+        #[clap(long)]
+        unignore: bool,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
 }
 
 /// Shared metadata arguments for proposal creation
@@ -1088,6 +1109,20 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                     commands::proposal::create_emergency_pause_proposal(
                         &config,
                         unpause,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::IgnoreMember {
+                    validator,
+                    unignore,
+                    metadata,
+                } => {
+                    commands::proposal::create_ignore_member_proposal(
+                        &config,
+                        &validator,
+                        unignore,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/types.rs
+++ b/crates/hashi/src/cli/types.rs
@@ -57,6 +57,7 @@ pub mod display {
             ProposalType::EmergencyPause => "EmergencyPause".to_string(),
             ProposalType::AbortReconfig => "AbortReconfig".to_string(),
             ProposalType::UpdateGuardian => "UpdateGuardian".to_string(),
+            ProposalType::IgnoreMember => "IgnoreMember".to_string(),
             ProposalType::Unknown(s) => format!("Unknown({})", s),
         }
     }

--- a/crates/hashi/src/cli/types.rs
+++ b/crates/hashi/src/cli/types.rs
@@ -56,6 +56,7 @@ pub mod display {
             ProposalType::EmergencyPause => "EmergencyPause".to_string(),
             ProposalType::AbortReconfig => "AbortReconfig".to_string(),
             ProposalType::UpdateGuardian => "UpdateGuardian".to_string(),
+            ProposalType::IgnoreMember => "IgnoreMember".to_string(),
             ProposalType::Unknown(s) => format!("Unknown({})", s),
         }
     }

--- a/crates/hashi/src/cli/upgrade.rs
+++ b/crates/hashi/src/cli/upgrade.rs
@@ -225,6 +225,7 @@ pub fn build_upgrade_execution_transaction(
 /// `hashi_ids.package_id`.
 pub fn build_execute_proposal_transaction(
     hashi_ids: HashiIds,
+    hashi_initial_shared_version: u64,
     proposal_id: Address,
     execute_package_id: Address,
     proposal_module: &str,
@@ -233,14 +234,21 @@ pub fn build_execute_proposal_transaction(
         .map_err(|e| anyhow!("invalid proposal module {proposal_module:?}: {e}"))?;
 
     let mut builder = TransactionBuilder::new();
+    // Shared inputs are fully resolved (initial shared version + mutability)
+    // so the fullnode's simulate-time resolver never has to inspect the
+    // called function's signature: that inspection fails with
+    // INVALID_LINKAGE on sui >= 1.76 fullnodes for modules introduced by a
+    // package upgrade (e.g. ignore_member).
     let hashi_arg = builder.object(
         ObjectInput::new(hashi_ids.hashi_object_id)
+            .with_version(hashi_initial_shared_version)
             .as_shared()
             .with_mutable(true),
     );
     let proposal_id_arg = builder.pure(&proposal_id);
     let clock_arg = builder.object(
         ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .with_version(1)
             .as_shared()
             .with_mutable(false),
     );

--- a/crates/hashi/src/cli/upgrade.rs
+++ b/crates/hashi/src/cli/upgrade.rs
@@ -289,6 +289,7 @@ pub fn build_upgrade_v2_execution_transaction(
 /// `hashi_ids.package_id`.
 pub fn build_execute_proposal_transaction(
     hashi_ids: HashiIds,
+    hashi_initial_shared_version: u64,
     proposal_id: Address,
     execute_package_id: Address,
     proposal_module: &str,
@@ -297,14 +298,21 @@ pub fn build_execute_proposal_transaction(
         .map_err(|e| anyhow!("invalid proposal module {proposal_module:?}: {e}"))?;
 
     let mut builder = TransactionBuilder::new();
+    // Shared inputs are fully resolved (initial shared version + mutability)
+    // so the fullnode's simulate-time resolver never has to inspect the
+    // called function's signature: that inspection fails with
+    // INVALID_LINKAGE on sui >= 1.76 fullnodes for modules introduced by a
+    // package upgrade (e.g. ignore_member).
     let hashi_arg = builder.object(
         ObjectInput::new(hashi_ids.hashi_object_id)
+            .with_version(hashi_initial_shared_version)
             .as_shared()
             .with_mutable(true),
     );
     let proposal_id_arg = builder.pure(&proposal_id);
     let clock_arg = builder.object(
         ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .with_version(1)
             .as_shared()
             .with_mutable(false),
     );

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -6,7 +6,6 @@
 use super::LeaderService;
 use crate::onchain::types::DepositRequest;
 use crate::onchain::types::Proposal;
-use crate::onchain::types::ProposalType;
 use crate::onchain::types::UtxoId;
 use crate::onchain::types::UtxoRecord;
 use crate::sui_tx_executor::SuiTxExecutor;
@@ -272,8 +271,6 @@ impl LeaderService {
         expired_proposals: Vec<Proposal>,
     ) -> anyhow::Result<()> {
         use sui_sdk_types::Identifier;
-        use sui_sdk_types::StructTag;
-        use sui_sdk_types::TypeTag;
         use sui_transaction_builder::Function;
         use sui_transaction_builder::ObjectInput;
         use sui_transaction_builder::TransactionBuilder;
@@ -297,58 +294,21 @@ impl LeaderService {
         );
 
         // Add a move call for each expired proposal
+        let packages = inner.onchain_state().state().package_versions().clone();
         for proposal in &expired_proposals {
             let proposal_id_arg = builder.pure(&proposal.id);
 
-            // Get the type argument for the proposal
-            let type_arg = match &proposal.proposal_type {
-                ProposalType::UpdateConfig => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
-                    Identifier::from_static("update_config"),
-                    Identifier::from_static("UpdateConfig"),
-                    vec![],
-                ))),
-                ProposalType::EnableVersion => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
-                    Identifier::from_static("enable_version"),
-                    Identifier::from_static("EnableVersion"),
-                    vec![],
-                ))),
-                ProposalType::DisableVersion => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
-                    Identifier::from_static("disable_version"),
-                    Identifier::from_static("DisableVersion"),
-                    vec![],
-                ))),
-                ProposalType::Upgrade => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
-                    Identifier::from_static("upgrade"),
-                    Identifier::from_static("Upgrade"),
-                    vec![],
-                ))),
-                ProposalType::EmergencyPause => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
-                    Identifier::from_static("emergency_pause"),
-                    Identifier::from_static("EmergencyPause"),
-                    vec![],
-                ))),
-                ProposalType::AbortReconfig => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
-                    Identifier::from_static("abort_reconfig"),
-                    Identifier::from_static("AbortReconfig"),
-                    vec![],
-                ))),
-                ProposalType::UpdateGuardian => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
-                    Identifier::from_static("update_guardian"),
-                    Identifier::from_static("UpdateGuardian"),
-                    vec![],
-                ))),
-                ProposalType::Unknown(type_name) => {
-                    error!(
-                        "Cannot delete proposal {:?} with unknown type: {}",
-                        proposal.id, type_name
-                    );
+            // Get the type argument for the proposal. This resolves each
+            // type's DEFINING package address (v1-era types at the original
+            // id, upgrade-introduced types at their defining version's id).
+            let type_arg = match crate::cli::client::get_proposal_type_arg(
+                &packages,
+                hashi_ids.package_id,
+                &proposal.proposal_type,
+            ) {
+                Ok(type_arg) => type_arg,
+                Err(error) => {
+                    error!("Cannot delete proposal {:?}: {error:#}", proposal.id);
                     continue;
                 }
             };

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -277,11 +277,21 @@ impl LeaderService {
 
         let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
         let hashi_ids = inner.config.hashi_ids();
+        let hashi_initial_shared_version = crate::cli::client::fetch_initial_shared_version(
+            &mut inner.onchain_state().client(),
+            hashi_ids.hashi_object_id,
+        )
+        .await?;
 
         let mut builder = TransactionBuilder::new();
 
+        // Fully-resolved shared inputs: expired proposals may carry
+        // upgrade-introduced type args (e.g. IgnoreMember), which the
+        // fullnode's simulate-time resolver cannot inspect on sui >= 1.76
+        // unless every shared input is pre-resolved.
         let hashi_arg = builder.object(
             ObjectInput::new(hashi_ids.hashi_object_id)
+                .with_version(hashi_initial_shared_version)
                 .as_shared()
                 .with_mutable(true),
         );
@@ -289,6 +299,7 @@ impl LeaderService {
         // Clock object (0x6) - immutable shared object
         let clock_arg = builder.object(
             ObjectInput::new(Address::from_static("0x6"))
+                .with_version(1)
                 .as_shared()
                 .with_mutable(false),
         );
@@ -313,6 +324,9 @@ impl LeaderService {
                 }
             };
 
+            // Active package: the type arg may name an upgrade-introduced
+            // type, and calling the original package alongside it is a
+            // linkage conflict (see build_vote_transaction).
             builder.move_call(
                 Function::new(
                     executor.active_call_package_id(),

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -407,12 +407,21 @@ impl LeaderService {
 
         let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
         let hashi_ids = inner.config.hashi_ids();
-        let package_versions = inner.onchain_state().state().package_versions().clone();
+        let hashi_initial_shared_version = crate::cli::client::fetch_initial_shared_version(
+            &mut inner.onchain_state().client(),
+            hashi_ids.hashi_object_id,
+        )
+        .await?;
 
         let mut builder = TransactionBuilder::new();
 
+        // Fully-resolved shared inputs: expired proposals may carry
+        // upgrade-introduced type args (e.g. IgnoreMember), which the
+        // fullnode's simulate-time resolver cannot inspect on sui >= 1.76
+        // unless every shared input is pre-resolved.
         let hashi_arg = builder.object(
             ObjectInput::new(hashi_ids.hashi_object_id)
+                .with_version(hashi_initial_shared_version)
                 .as_shared()
                 .with_mutable(true),
         );
@@ -420,6 +429,7 @@ impl LeaderService {
         // Clock object (0x6) - immutable shared object
         let clock_arg = builder.object(
             ObjectInput::new(Address::from_static("0x6"))
+                .with_version(1)
                 .as_shared()
                 .with_mutable(false),
         );
@@ -511,6 +521,9 @@ impl LeaderService {
                 }
             };
 
+            // Active package: the type arg may name an upgrade-introduced
+            // type, and calling the original package alongside it is a
+            // linkage conflict (see build_vote_transaction).
             builder.move_call(
                 Function::new(
                     executor.active_call_package_id(),

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -425,6 +425,7 @@ impl LeaderService {
         );
 
         // Add a move call for each expired proposal
+        let package_versions = inner.onchain_state().state().package_versions().clone();
         for proposal in &expired_proposals {
             let proposal_id_arg = builder.pure(&proposal.id);
 
@@ -493,6 +494,12 @@ impl LeaderService {
                     type_package_id,
                     Identifier::from_static("update_guardian"),
                     Identifier::from_static("UpdateGuardian"),
+                    vec![],
+                ))),
+                ProposalType::IgnoreMember => TypeTag::Struct(Box::new(StructTag::new(
+                    type_package_id,
+                    Identifier::from_static("ignore_member"),
+                    Identifier::from_static("IgnoreMember"),
                     vec![],
                 ))),
                 ProposalType::Unknown(type_name) => {

--- a/crates/hashi/src/mpc/mpc_except_signing_tests.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing_tests.rs
@@ -140,6 +140,7 @@ impl TestSetup {
                     endpoint_url: None,
                     tls_public_key: None,
                     next_epoch_encryption_public_key,
+                    ignored: false,
                 };
                 (addr, member_info)
             })
@@ -225,6 +226,7 @@ impl TestSetup {
                     endpoint_url: None,
                     tls_public_key: None,
                     next_epoch_encryption_public_key,
+                    ignored: false,
                 };
                 (addr, member_info)
             })
@@ -1077,6 +1079,7 @@ fn test_mpc_manager_new_fails_if_no_committee_for_epoch() {
                 next_epoch_encryption_public_key: Some(PublicKey::from_private_key(
                     &encryption_keys[i],
                 )),
+                ignored: false,
             };
             (addr, member_info)
         })
@@ -1170,6 +1173,7 @@ fn test_mpc_manager_new_finds_input_committee_across_gap() {
                 next_epoch_encryption_public_key: Some(PublicKey::from_private_key(
                     &encryption_keys[i],
                 )),
+                ignored: false,
             };
             (addr, info)
         })
@@ -1255,6 +1259,7 @@ fn test_epoch_lookups_reject_neither_current_nor_previous() {
                 next_epoch_encryption_public_key: Some(PublicKey::from_private_key(
                     &encryption_keys[i],
                 )),
+                ignored: false,
             };
             (addr, info)
         })
@@ -1360,6 +1365,7 @@ fn test_mpc_manager_new_uses_explicit_epoch_not_committee_set_recompute() {
                 next_epoch_encryption_public_key: Some(PublicKey::from_private_key(
                     &encryption_keys[i],
                 )),
+                ignored: false,
             };
             (addr, info)
         })

--- a/crates/hashi/src/mpc/mpc_except_signing_tests.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing_tests.rs
@@ -141,6 +141,7 @@ impl TestSetup {
                     endpoint_url: None,
                     tls_public_key: None,
                     next_epoch_encryption_public_key,
+                    ignored: false,
                 };
                 (addr, member_info)
             })
@@ -228,6 +229,7 @@ impl TestSetup {
                     endpoint_url: None,
                     tls_public_key: None,
                     next_epoch_encryption_public_key,
+                    ignored: false,
                 };
                 (addr, member_info)
             })
@@ -1082,6 +1084,7 @@ fn test_mpc_manager_new_fails_if_no_committee_for_epoch() {
                 next_epoch_encryption_public_key: Some(PublicKey::from_private_key(
                     &encryption_keys[i],
                 )),
+                ignored: false,
             };
             (addr, member_info)
         })
@@ -1175,6 +1178,7 @@ fn test_mpc_manager_new_finds_input_committee_across_gap() {
                 next_epoch_encryption_public_key: Some(PublicKey::from_private_key(
                     &encryption_keys[i],
                 )),
+                ignored: false,
             };
             (addr, info)
         })
@@ -1261,6 +1265,7 @@ fn test_epoch_lookups_reject_neither_current_nor_previous() {
                 next_epoch_encryption_public_key: Some(PublicKey::from_private_key(
                     &encryption_keys[i],
                 )),
+                ignored: false,
             };
             (addr, info)
         })
@@ -1367,6 +1372,7 @@ fn test_mpc_manager_new_uses_explicit_epoch_not_committee_set_recompute() {
                 next_epoch_encryption_public_key: Some(PublicKey::from_private_key(
                     &encryption_keys[i],
                 )),
+                ignored: false,
             };
             (addr, info)
         })

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -713,6 +713,12 @@ impl OnchainState {
         self.state().hashi.committees.current_committee().cloned()
     }
 
+    /// The next epoch a reconfiguration is currently transitioning to, if
+    /// one is in flight.
+    pub fn pending_epoch_change(&self) -> Option<u64> {
+        self.state().hashi.committees.pending_epoch_change()
+    }
+
     pub fn current_committee_members(&self) -> Option<Vec<CommitteeMember>> {
         self.state()
             .hashi()
@@ -1630,7 +1636,7 @@ fn convert_move_member_info(info: move_types::MemberInfo) -> types::MemberInfo {
         endpoint_url,
         tls_public_key,
         next_epoch_encryption_public_key,
-        extra_fields: _,
+        extra_fields,
     } = info;
     types::MemberInfo {
         validator_address,
@@ -1642,6 +1648,7 @@ fn convert_move_member_info(info: move_types::MemberInfo) -> types::MemberInfo {
             next_epoch_encryption_public_key.as_slice(),
         )
         .map(Into::into),
+        ignored: extra_fields.get_bool(move_types::MEMBER_IGNORED_KEY, false),
     }
 }
 
@@ -2162,6 +2169,7 @@ fn decode_proposal(type_tag: &TypeTag, contents: &[u8]) -> Option<types::Proposa
         types::ProposalType::EmergencyPause => parse::<move_types::EmergencyPause>(contents),
         types::ProposalType::AbortReconfig => parse::<move_types::AbortReconfig>(contents),
         types::ProposalType::UpdateGuardian => parse::<move_types::UpdateGuardian>(contents),
+        types::ProposalType::IgnoreMember => parse::<move_types::IgnoreMember>(contents),
         types::ProposalType::Unknown(_) => None,
     }?;
     Some(types::Proposal {
@@ -2198,6 +2206,7 @@ pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
         ("emergency_pause", "EmergencyPause") => types::ProposalType::EmergencyPause,
         ("abort_reconfig", "AbortReconfig") => types::ProposalType::AbortReconfig,
         ("update_guardian", "UpdateGuardian") => types::ProposalType::UpdateGuardian,
+        ("ignore_member", "IgnoreMember") => types::ProposalType::IgnoreMember,
         _ => types::ProposalType::Unknown(format!("{}::{}", inner_tag.module(), inner_tag.name())),
     }
 }
@@ -2285,6 +2294,63 @@ mod tests {
     use crate::mpc::EncryptionGroupElement;
 
     use super::*;
+
+    #[test]
+    fn test_convert_move_member_info_reads_ignored_flag() {
+        let mut rng = rand::thread_rng();
+        let validator_address =
+            Address::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let signing_keypair = fastcrypto::bls12381::min_pk::BLS12381KeyPair::generate(&mut rng);
+        let uncompressed_pubkey =
+            blst::min_pk::PublicKey::uncompress(signing_keypair.public().as_bytes())
+                .unwrap()
+                .serialize()
+                .to_vec();
+
+        let member = |extra_fields: move_types::Config| move_types::MemberInfo {
+            validator_address,
+            operator_address: validator_address,
+            next_epoch_public_key: uncompressed_pubkey.clone(),
+            endpoint_url: String::new(),
+            tls_public_key: vec![],
+            next_epoch_encryption_public_key: vec![],
+            extra_fields,
+        };
+
+        // Absent key (the state of every member registered before the flag
+        // existed) means not ignored.
+        let converted = convert_move_member_info(member(move_types::Config::from_entries(vec![])));
+        assert!(!converted.ignored);
+
+        let converted = convert_move_member_info(member(move_types::Config::from_entries(vec![(
+            move_types::MEMBER_IGNORED_KEY.to_string(),
+            move_types::ConfigValue::Bool(true),
+        )])));
+        assert!(converted.ignored);
+    }
+
+    #[test]
+    fn test_parse_proposal_type_ignore_member() {
+        use sui_sdk_types::Identifier;
+        use sui_sdk_types::StructTag;
+
+        let package =
+            Address::from_hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+                .unwrap();
+        let inner = TypeTag::Struct(Box::new(StructTag::new(
+            package,
+            Identifier::new("ignore_member").unwrap(),
+            Identifier::new("IgnoreMember").unwrap(),
+            vec![],
+        )));
+        let tag = TypeTag::Struct(Box::new(StructTag::new(
+            package,
+            Identifier::new("proposal").unwrap(),
+            Identifier::new("Proposal").unwrap(),
+            vec![inner],
+        )));
+        assert_eq!(parse_proposal_type(&tag), types::ProposalType::IgnoreMember);
+    }
 
     #[test]
     fn test_convert_move_committee_member() {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -679,6 +679,12 @@ impl OnchainState {
         self.state().hashi.committees.current_committee().cloned()
     }
 
+    /// The next epoch a reconfiguration is currently transitioning to, if
+    /// one is in flight.
+    pub fn pending_epoch_change(&self) -> Option<u64> {
+        self.state().hashi.committees.pending_epoch_change()
+    }
+
     pub fn current_committee_members(&self) -> Option<Vec<CommitteeMember>> {
         self.state()
             .hashi()
@@ -1600,7 +1606,7 @@ fn convert_move_member_info(info: move_types::MemberInfo) -> types::MemberInfo {
         endpoint_url,
         tls_public_key,
         next_epoch_encryption_public_key,
-        extra_fields: _,
+        extra_fields,
     } = info;
     types::MemberInfo {
         validator_address,
@@ -1612,6 +1618,7 @@ fn convert_move_member_info(info: move_types::MemberInfo) -> types::MemberInfo {
             next_epoch_encryption_public_key.as_slice(),
         )
         .map(Into::into),
+        ignored: extra_fields.get_bool(move_types::MEMBER_IGNORED_KEY, false),
     }
 }
 
@@ -2131,6 +2138,7 @@ fn decode_proposal(type_tag: &TypeTag, contents: &[u8]) -> Option<types::Proposa
         types::ProposalType::EmergencyPause => parse::<move_types::EmergencyPause>(contents),
         types::ProposalType::AbortReconfig => parse::<move_types::AbortReconfig>(contents),
         types::ProposalType::UpdateGuardian => parse::<move_types::UpdateGuardian>(contents),
+        types::ProposalType::IgnoreMember => parse::<move_types::IgnoreMember>(contents),
         types::ProposalType::Unknown(_) => None,
     }?;
     Some(types::Proposal {
@@ -2166,6 +2174,7 @@ pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
         ("emergency_pause", "EmergencyPause") => types::ProposalType::EmergencyPause,
         ("abort_reconfig", "AbortReconfig") => types::ProposalType::AbortReconfig,
         ("update_guardian", "UpdateGuardian") => types::ProposalType::UpdateGuardian,
+        ("ignore_member", "IgnoreMember") => types::ProposalType::IgnoreMember,
         _ => types::ProposalType::Unknown(format!("{}::{}", inner_tag.module(), inner_tag.name())),
     }
 }
@@ -2179,6 +2188,63 @@ mod tests {
     use crate::mpc::EncryptionGroupElement;
 
     use super::*;
+
+    #[test]
+    fn test_convert_move_member_info_reads_ignored_flag() {
+        let mut rng = rand::thread_rng();
+        let validator_address =
+            Address::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap();
+        let signing_keypair = fastcrypto::bls12381::min_pk::BLS12381KeyPair::generate(&mut rng);
+        let uncompressed_pubkey =
+            blst::min_pk::PublicKey::uncompress(signing_keypair.public().as_bytes())
+                .unwrap()
+                .serialize()
+                .to_vec();
+
+        let member = |extra_fields: move_types::Config| move_types::MemberInfo {
+            validator_address,
+            operator_address: validator_address,
+            next_epoch_public_key: uncompressed_pubkey.clone(),
+            endpoint_url: String::new(),
+            tls_public_key: vec![],
+            next_epoch_encryption_public_key: vec![],
+            extra_fields,
+        };
+
+        // Absent key (the state of every member registered before the flag
+        // existed) means not ignored.
+        let converted = convert_move_member_info(member(move_types::Config::from_entries(vec![])));
+        assert!(!converted.ignored);
+
+        let converted = convert_move_member_info(member(move_types::Config::from_entries(vec![(
+            move_types::MEMBER_IGNORED_KEY.to_string(),
+            move_types::ConfigValue::Bool(true),
+        )])));
+        assert!(converted.ignored);
+    }
+
+    #[test]
+    fn test_parse_proposal_type_ignore_member() {
+        use sui_sdk_types::Identifier;
+        use sui_sdk_types::StructTag;
+
+        let package =
+            Address::from_hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+                .unwrap();
+        let inner = TypeTag::Struct(Box::new(StructTag::new(
+            package,
+            Identifier::new("ignore_member").unwrap(),
+            Identifier::new("IgnoreMember").unwrap(),
+            vec![],
+        )));
+        let tag = TypeTag::Struct(Box::new(StructTag::new(
+            package,
+            Identifier::new("proposal").unwrap(),
+            Identifier::new("Proposal").unwrap(),
+            vec![inner],
+        )));
+        assert_eq!(parse_proposal_type(&tag), types::ProposalType::IgnoreMember);
+    }
 
     #[test]
     fn test_convert_move_committee_member() {

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -467,6 +467,11 @@ pub struct MemberInfo {
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
     pub next_epoch_encryption_public_key: Option<EncryptionPublicKey>,
+
+    /// Governance "ignored" flag from `extra_fields`: when set, the next
+    /// committee formation skips this member. The current epoch's committee
+    /// is unaffected.
+    pub ignored: bool,
 }
 
 impl fmt::Debug for MemberInfo {
@@ -497,6 +502,7 @@ impl fmt::Debug for MemberInfo {
                     .as_ref()
                     .map(|b| Base64("EncryptionPublicKey", b.as_slice())),
             )
+            .field("ignored", &self.ignored)
             .finish()
     }
 }
@@ -574,6 +580,7 @@ pub enum ProposalType {
     EmergencyPause,
     AbortReconfig,
     UpdateGuardian,
+    IgnoreMember,
     Unknown(String),
 }
 
@@ -587,6 +594,7 @@ impl ProposalType {
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::AbortReconfig => "abort_reconfig",
             ProposalType::UpdateGuardian => "update_guardian",
+            ProposalType::IgnoreMember => "ignore_member",
             ProposalType::Unknown(_) => "unknown",
         }
     }
@@ -600,6 +608,7 @@ impl ProposalType {
             "emergency_pause",
             "abort_reconfig",
             "update_guardian",
+            "ignore_member",
             "unknown",
         ]
     }

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -467,6 +467,11 @@ pub struct MemberInfo {
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
     pub next_epoch_encryption_public_key: Option<EncryptionPublicKey>,
+
+    /// Governance "ignored" flag from `extra_fields`: when set, the next
+    /// committee formation skips this member. The current epoch's committee
+    /// is unaffected.
+    pub ignored: bool,
 }
 
 impl fmt::Debug for MemberInfo {
@@ -497,6 +502,7 @@ impl fmt::Debug for MemberInfo {
                     .as_ref()
                     .map(|b| Base64("EncryptionPublicKey", b.as_slice())),
             )
+            .field("ignored", &self.ignored)
             .finish()
     }
 }
@@ -575,6 +581,7 @@ pub enum ProposalType {
     EmergencyPause,
     AbortReconfig,
     UpdateGuardian,
+    IgnoreMember,
     Unknown(String),
 }
 
@@ -587,6 +594,7 @@ impl ProposalType {
     pub fn package_version(&self) -> Option<u64> {
         match self {
             ProposalType::UpgradeV2 => Some(2),
+            ProposalType::IgnoreMember => Some(2),
             ProposalType::Unknown(_) => None,
             _ => Some(1),
         }
@@ -602,6 +610,7 @@ impl ProposalType {
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::AbortReconfig => "abort_reconfig",
             ProposalType::UpdateGuardian => "update_guardian",
+            ProposalType::IgnoreMember => "ignore_member",
             ProposalType::Unknown(_) => "unknown",
         }
     }
@@ -616,6 +625,7 @@ impl ProposalType {
             "emergency_pause",
             "abort_reconfig",
             "update_guardian",
+            "ignore_member",
             "unknown",
         ]
     }

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -438,6 +438,10 @@ fun remove_committee(self: &mut CommitteeSet, epoch: u64): Committee {
     self.committees.remove(epoch)
 }
 
+/// Thin wrapper extracting the epoch and voting powers from the system
+/// object. Split from `new_committee_from_voting_powers` because unit tests
+/// cannot construct a `SuiSystemState`: the pure inner function is what lets
+/// formation (including the ignore filtering) be unit-tested at all.
 fun new_committee_from_validator_set(
     self: &CommitteeSet,
     sui_system: &sui_system::sui_system::SuiSystemState,

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -27,9 +27,13 @@ use sui::{
 /// before this key existed need no migration.
 ///
 /// The flag lives in `extra_fields` only because `MemberInfo`'s layout is
-/// frozen on the deployed network; when testnet is wiped before mainnet,
-/// promote it to a real `ignored: bool` field on `MemberInfo` and delete
-/// this key.
+/// frozen on the deployed network.
+///
+/// TODO(pre-mainnet-wipe): when testnet is wiped and the Move versions are
+/// squashed before mainnet, promote this to a root-level `ignored: bool`
+/// field on `MemberInfo` and delete this key (and its Rust mirror
+/// `MEMBER_IGNORED_KEY` / the `extra_fields` decode in
+/// `convert_move_member_info`).
 const MEMBER_IGNORED_KEY: vector<u8> = b"ignored";
 
 // ~~~~~~~ Errors ~~~~~~~
@@ -519,11 +523,7 @@ fun is_authorized(self: &MemberInfo, ctx: &TxContext): bool {
 /// Whether governance has flagged this member as ignored. An absent key
 /// means not ignored.
 fun is_ignored(self: &MemberInfo): bool {
-    self
-        .extra_fields
-        .try_get(MEMBER_IGNORED_KEY)
-        .map!(|value| value.as_bool())
-        .destroy_or!(false)
+    self.extra_fields.try_get(MEMBER_IGNORED_KEY).map!(|value| value.as_bool()).destroy_or!(false)
 }
 
 fun assert_authorized(self: &MemberInfo, ctx: &TxContext) {

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -11,7 +11,7 @@
 #[allow(unused_function, unused_field)]
 module hashi::committee_set;
 
-use hashi::{committee::{Self, Committee}, config::{Self, Config}};
+use hashi::{committee::{Self, Committee}, config::{Self, Config}, config_value};
 use std::string::String;
 use sui::{
     bag::Bag,
@@ -19,6 +19,23 @@ use sui::{
     bls12381::{UncompressedG1, bls12381_min_pk_verify, g1_from_bytes, g1_to_uncompressed_g1},
     group_ops::Element
 };
+
+// ~~~~~~~ Constants ~~~~~~~
+
+/// `MemberInfo.extra_fields` key holding the governance "ignored" flag as a
+/// `Bool` value. An absent key means not ignored, so members registered
+/// before this key existed need no migration.
+///
+/// The flag lives in `extra_fields` only because `MemberInfo`'s layout is
+/// frozen on the deployed network; when testnet is wiped before mainnet,
+/// promote it to a real `ignored: bool` field on `MemberInfo` and delete
+/// this key.
+const MEMBER_IGNORED_KEY: vector<u8> = b"ignored";
+
+// ~~~~~~~ Errors ~~~~~~~
+
+#[error(code = 0)]
+const EMemberNotRegistered: vector<u8> = b"No member is registered under this validator address";
 
 // ~~~~~~~ Structs ~~~~~~~
 
@@ -89,9 +106,13 @@ public struct MemberInfo has store {
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
     next_epoch_encryption_public_key: vector<u8>,
-    /// Open-ended per-member extension slot. Empty today; lets future
-    /// upgrades attach new member data (e.g. per-protocol keys) without a
-    /// MemberInfoV2 migration.
+    /// Open-ended per-member extension slot; lets future upgrades attach new
+    /// member data (e.g. per-protocol keys) without a MemberInfoV2 migration.
+    ///
+    /// Carries the governance flags (`MEMBER_IGNORED_KEY`) as typed values
+    /// because MemberInfo's layout is frozen on the deployed network. When
+    /// testnet is wiped before mainnet, promote them to real `bool` fields
+    /// on MemberInfo and delete the keys.
     extra_fields: Config,
 }
 
@@ -230,6 +251,35 @@ public(package) fun set_operator_address(
     let member = self.member_mut(validator_address);
     member.assert_authorized(ctx);
     member.operator_address = operator_address;
+}
+
+/// Set or clear the governance "ignored" flag on a registered member.
+///
+/// Unlike the operator-gated `set_*` functions above, this deliberately has
+/// no `assert_authorized`: it is a governance write reachable only through
+/// the quorum-gated `ignore_member::execute` — `public(package)` visibility
+/// is the gate.
+///
+/// The flag is only read at committee formation (`start_reconfig`), so it
+/// takes effect at the next formation; the current epoch's committee is
+/// never altered.
+public(package) fun set_member_ignored(
+    self: &mut CommitteeSet,
+    validator_address: address,
+    ignored: bool,
+) {
+    assert!(self.has_member(validator_address), EMemberNotRegistered);
+    self
+        .member_mut(validator_address)
+        .extra_fields
+        .upsert(MEMBER_IGNORED_KEY, config_value::new_bool(ignored));
+}
+
+/// Whether the registered member is currently flagged as ignored by
+/// governance. Aborts if no member is registered under this address.
+public(package) fun is_member_ignored(self: &CommitteeSet, validator_address: address): bool {
+    assert!(self.has_member(validator_address), EMemberNotRegistered);
+    self.member(validator_address).is_ignored()
 }
 
 public(package) fun start_reconfig(
@@ -390,8 +440,25 @@ fun new_committee_from_validator_set(
     config: Config,
     ctx: &TxContext,
 ): Committee {
-    let epoch = ctx.epoch();
-    let mut validator_set = sui_system.active_validator_voting_powers();
+    self.new_committee_from_voting_powers(
+        ctx.epoch(),
+        sui_system.active_validator_voting_powers(),
+        config,
+    )
+}
+
+/// Build a committee for `epoch` from a validator -> voting-power map,
+/// keeping only validators that are registered members with usable keys and
+/// that governance has not flagged as ignored.
+///
+/// The iteration order of `validator_set` determines member order, which is
+/// load-bearing: it is the BLS signers-bitmap index and the MPC party id.
+fun new_committee_from_voting_powers(
+    self: &CommitteeSet,
+    epoch: u64,
+    mut validator_set: sui::vec_map::VecMap<address, u64>,
+    config: Config,
+): Committee {
     let g1_identity = g1_to_uncompressed_g1(&sui::bls12381::g1_identity());
 
     let mut committee_members = vector[];
@@ -405,6 +472,13 @@ fun new_committee_from_validator_set(
         };
 
         let member = self.member(validator_address);
+
+        // If governance has flagged the member as ignored, skip them: they
+        // are treated as not part of the committee, and total weight re-sums
+        // without them.
+        if (member.is_ignored()) {
+            continue
+        };
 
         // If the member has not registered a valid bls public key, skip them
         if (sui::group_ops::equal(&member.next_epoch_public_key, &g1_identity)) {
@@ -440,6 +514,16 @@ fun new_committee_from_validator_set(
 fun is_authorized(self: &MemberInfo, ctx: &TxContext): bool {
     let sender = ctx.sender();
     sender == self.validator_address || sender == self.operator_address
+}
+
+/// Whether governance has flagged this member as ignored. An absent key
+/// means not ignored.
+fun is_ignored(self: &MemberInfo): bool {
+    self
+        .extra_fields
+        .try_get(MEMBER_IGNORED_KEY)
+        .map!(|value| value.as_bool())
+        .destroy_or!(false)
 }
 
 fun assert_authorized(self: &MemberInfo, ctx: &TxContext) {
@@ -541,6 +625,19 @@ public fun set_pending_reconfig_for_testing(self: &mut CommitteeSet, committee: 
 #[test_only]
 public fun set_mpc_public_key_for_testing(self: &mut CommitteeSet, mpc_public_key: vector<u8>) {
     self.mpc_public_key = mpc_public_key;
+}
+
+#[test_only]
+/// Exercise committee formation (including the registration/key/ignored skip
+/// branches) without a SuiSystemState by supplying the voting-power map
+/// directly.
+public fun new_committee_from_voting_powers_for_testing(
+    self: &CommitteeSet,
+    epoch: u64,
+    validator_set: sui::vec_map::VecMap<address, u64>,
+    config: Config,
+): Committee {
+    self.new_committee_from_voting_powers(epoch, validator_set, config)
 }
 
 #[test_only]

--- a/packages/hashi/sources/core/proposal/types/ignore_member.move
+++ b/packages/hashi/sources/core/proposal/types/ignore_member.move
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Governance proposal for ignoring (or re-admitting) a registered committee
+/// member. An ignored member is treated as no longer part of the committee:
+/// the next committee formation skips them, so their voting weight drops out
+/// of total stake and every downstream threshold (certificates, proposal
+/// quorums, MPC parameters) re-derives without them.
+///
+/// Semantics and limits:
+/// - The flag takes effect at the next committee FORMATION (`start_reconfig`).
+///   If a reconfiguration is already in flight when the proposal executes,
+///   that is one epoch later — the pending committee is immutable once formed.
+///   The current epoch's committee is never altered: bitmap indices, MPC
+///   party ids, and leader rotation all stay intact until the boundary.
+/// - The proposal targets the validator ADDRESS; it applies to whatever
+///   registration holds that address at execute time, including a
+///   re-registration after a deregistration cycle.
+/// - Exclusion is only reachable while governance itself is live: this
+///   proposal needs 6667 bps of the full current denominator, and the epoch
+///   transition enacting it needs the outgoing committee's handoff
+///   certificate at the same threshold (whose denominator still includes the
+///   ignored member). Non-participating weight must therefore stay at or
+///   below 3333 bps of the current committee — the standard BFT bound —
+///   for the mechanism to help; beyond it the system is already stuck.
+/// - Ignoring does not touch the registry: the member stays registered,
+///   keeps proposal/vote authorization, and can be re-admitted by executing
+///   the same proposal type with `ignored: false`. If every registered
+///   member were ignored, committee formation would abort and the current
+///   committee would simply continue — recoverable by un-ignoring.
+module hashi::ignore_member;
+
+use hashi::{hashi::Hashi, proposal};
+use std::string::String;
+use sui::{clock::Clock, vec_map::VecMap};
+
+// ~~~~~~~ Constants ~~~~~~~
+
+const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Errors ~~~~~~~
+
+#[error(code = 0)]
+const EMemberNotRegistered: vector<u8> = b"Target validator is not a registered member";
+#[error(code = 1)]
+const EAlreadyInRequestedState: vector<u8> = b"Member is already in the requested ignored state";
+
+// ~~~~~~~ Structs ~~~~~~~
+
+public struct IgnoreMember has copy, drop, store {
+    validator_address: address,
+    ignored: bool,
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
+
+public fun propose(
+    hashi: &mut Hashi,
+    validator_address: address,
+    target_validator_address: address,
+    ignored: bool,
+    metadata: VecMap<String, String>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    hashi.versioning().assert_version_enabled();
+    // Fast feedback for the proposer; state can still drift before execute.
+    assert!(hashi.committee_set().has_member(target_validator_address), EMemberNotRegistered);
+    assert!(
+        hashi.committee_set().is_member_ignored(target_validator_address) != ignored,
+        EAlreadyInRequestedState,
+    );
+    proposal::create(
+        hashi,
+        validator_address,
+        IgnoreMember { validator_address: target_validator_address, ignored },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
+}
+
+public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
+    hashi.versioning().assert_version_enabled();
+    let IgnoreMember { validator_address, ignored } = proposal::execute(hashi, proposal_id, clock);
+    // Registered-ness is re-asserted inside the setter (state may have
+    // drifted since propose). The no-op condition is deliberately not
+    // re-asserted: racing proposals degrade to an idempotent write, never a
+    // wrong state, and any outcome is revocable by the opposite proposal.
+    hashi.committee_set_mut().set_member_ignored(validator_address, ignored);
+}

--- a/packages/hashi/tests/ignore_member_tests.move
+++ b/packages/hashi/tests/ignore_member_tests.move
@@ -5,13 +5,7 @@
 #[allow(implicit_const_copy)]
 module hashi::ignore_member_tests;
 
-use hashi::{
-    committee,
-    ignore_member::{Self, IgnoreMember},
-    mpc_config,
-    proposal,
-    test_utils
-};
+use hashi::{committee, ignore_member::{Self, IgnoreMember}, mpc_config, proposal, test_utils};
 use sui::{clock, vec_map};
 
 // ======== Test Addresses ========

--- a/packages/hashi/tests/ignore_member_tests.move
+++ b/packages/hashi/tests/ignore_member_tests.move
@@ -1,0 +1,306 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+#[allow(implicit_const_copy)]
+module hashi::ignore_member_tests;
+
+use hashi::{
+    committee,
+    ignore_member::{Self, IgnoreMember},
+    mpc_config,
+    proposal,
+    test_utils
+};
+use sui::{clock, vec_map};
+
+// ======== Test Addresses ========
+const VOTER1: address = @0x1;
+const VOTER2: address = @0x2;
+const VOTER3: address = @0x3;
+const NON_MEMBER: address = @0x999;
+
+// ======== Helpers ========
+
+/// Propose ignoring (or un-ignoring) `target` as VOTER1, vote with VOTER2 and
+/// VOTER3 to reach quorum, and execute. `nonce` must be unique per call
+/// within a test so each proposal object gets a distinct ID.
+fun ignore_through_quorum(
+    hashi: &mut hashi::hashi::Hashi,
+    target: address,
+    ignored: bool,
+    clock: &clock::Clock,
+    nonce: u64,
+) {
+    let ctx1 = &mut tx_context::new_from_hint(VOTER1, nonce, 0, 0, 0);
+    let proposal_id = test_utils::create_ignore_member_proposal(
+        hashi,
+        VOTER1,
+        target,
+        ignored,
+        clock,
+        ctx1,
+    );
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    proposal::vote<IgnoreMember>(hashi, VOTER2, proposal_id, clock, ctx2);
+    let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
+    proposal::vote<IgnoreMember>(hashi, VOTER3, proposal_id, clock, ctx3);
+    ignore_member::execute(hashi, proposal_id, clock);
+}
+
+/// The voting-power map for the standard three test voters, in reverse order
+/// so that VecMap::pop yields VOTER1 first (matching registration order).
+fun voting_powers(w1: u64, w2: u64, w3: u64): sui::vec_map::VecMap<address, u64> {
+    let mut powers = vec_map::empty();
+    powers.insert(VOTER3, w3);
+    powers.insert(VOTER2, w2);
+    powers.insert(VOTER1, w1);
+    powers
+}
+
+// ======== Proposal Lifecycle ========
+
+#[test]
+/// A quorum-approved ignore proposal sets the flag; the current epoch's
+/// committee is unchanged.
+fun test_execute_ignore_sets_flag() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    ignore_through_quorum(&mut hashi, VOTER3, true, &clock, 1);
+
+    assert!(hashi.committee_set().is_member_ignored(VOTER3));
+    // The current committee snapshot is untouched: VOTER3 still in it with
+    // full weight.
+    let current = hashi.committee_set().current_committee();
+    assert!(current.has_member(&VOTER3));
+    assert!(current.total_weight() == 3);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// Un-ignore through the same proposal type restores the member for future
+/// formations.
+fun test_execute_unignore_clears_flag() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    ignore_through_quorum(&mut hashi, VOTER3, true, &clock, 1);
+    assert!(hashi.committee_set().is_member_ignored(VOTER3));
+
+    ignore_through_quorum(&mut hashi, VOTER3, false, &clock, 2);
+    assert!(!hashi.committee_set().is_member_ignored(VOTER3));
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = ignore_member::EMemberNotRegistered)]
+/// Proposing to ignore an address with no registered member aborts.
+fun test_propose_unregistered_target_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let _id = test_utils::create_ignore_member_proposal(
+        &mut hashi,
+        VOTER1,
+        NON_MEMBER,
+        true,
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = ignore_member::EAlreadyInRequestedState)]
+/// Proposing a no-op (member already in the requested state) aborts at
+/// propose time.
+fun test_propose_noop_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let _id = test_utils::create_ignore_member_proposal(
+        &mut hashi,
+        VOTER1,
+        VOTER3,
+        false,
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// Two racing proposals for the same member: executing the second (now a
+/// no-op) is harmless and idempotent — drift degrades to a repeated write,
+/// never an abort.
+fun test_execute_after_drift_is_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // Both proposals created while VOTER3 is not ignored.
+    let ctx1 = &mut test_utils::new_tx_context(VOTER1, 0);
+    let first = test_utils::create_ignore_member_proposal(
+        &mut hashi,
+        VOTER1,
+        VOTER3,
+        true,
+        &clock,
+        ctx1,
+    );
+    let ctx1b = &mut tx_context::new_from_hint(VOTER1, 1, 0, 0, 0);
+    let second = test_utils::create_ignore_member_proposal(
+        &mut hashi,
+        VOTER1,
+        VOTER3,
+        true,
+        &clock,
+        ctx1b,
+    );
+
+    // Reach quorum on both.
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    proposal::vote<IgnoreMember>(&mut hashi, VOTER2, first, &clock, ctx2);
+    let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
+    proposal::vote<IgnoreMember>(&mut hashi, VOTER3, first, &clock, ctx3);
+    let ctx2b = &mut test_utils::new_tx_context(VOTER2, 0);
+    proposal::vote<IgnoreMember>(&mut hashi, VOTER2, second, &clock, ctx2b);
+    let ctx3b = &mut test_utils::new_tx_context(VOTER3, 0);
+    proposal::vote<IgnoreMember>(&mut hashi, VOTER3, second, &clock, ctx3b);
+
+    ignore_member::execute(&mut hashi, first, &clock);
+    assert!(hashi.committee_set().is_member_ignored(VOTER3));
+    // Second execute re-applies the same flag without aborting.
+    ignore_member::execute(&mut hashi, second, &clock);
+    assert!(hashi.committee_set().is_member_ignored(VOTER3));
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+// ======== Committee Formation ========
+
+#[test]
+/// Formation skips an ignored member and total weight re-sums without them.
+fun test_formation_skips_ignored_member() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_weighted_committee(
+        voters,
+        vector[1, 2, 3],
+        ctx,
+    );
+    let clock = clock::create_for_testing(ctx);
+
+    ignore_through_quorum(&mut hashi, VOTER2, true, &clock, 1);
+
+    let next = hashi
+        .committee_set()
+        .new_committee_from_voting_powers_for_testing(
+            1,
+            voting_powers(1, 2, 3),
+            mpc_config::new_for_testing(3334, 800, 3333, 0),
+        );
+    assert!(next.n_members() == 2);
+    assert!(!next.has_member(&VOTER2));
+    assert!(next.has_member(&VOTER1));
+    assert!(next.has_member(&VOTER3));
+    assert!(next.total_weight() == 4);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// After un-ignoring, the next formation includes the member again.
+fun test_formation_includes_unignored_member() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    ignore_through_quorum(&mut hashi, VOTER2, true, &clock, 1);
+    ignore_through_quorum(&mut hashi, VOTER2, false, &clock, 2);
+
+    let next = hashi
+        .committee_set()
+        .new_committee_from_voting_powers_for_testing(
+            1,
+            voting_powers(1, 1, 1),
+            mpc_config::new_for_testing(3334, 800, 3333, 0),
+        );
+    assert!(next.n_members() == 3);
+    assert!(next.has_member(&VOTER2));
+    assert!(next.total_weight() == 3);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// A flag flip executed while a pending committee exists does not alter that
+/// pending committee — it only affects the NEXT formation ("takes effect at
+/// the next committee formation" semantics).
+fun test_ignore_mid_reconfig_affects_next_formation_only() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // A pending committee (epoch 1) is already formed, including VOTER3.
+    let sk = test_utils::bls_sk_for_testing();
+    let public_key = sui::bls12381::g1_to_uncompressed_g1(
+        &sui::bls12381::g1_from_bytes(&test_utils::bls_min_pk_from_sk(&sk)),
+    );
+    let members = vector[
+        committee::new_committee_member(VOTER1, public_key, sk, 1),
+        committee::new_committee_member(VOTER2, public_key, sk, 1),
+        committee::new_committee_member(VOTER3, public_key, sk, 1),
+    ];
+    let pending = committee::new_committee(
+        1,
+        members,
+        mpc_config::new_for_testing(3334, 800, 3333, 0),
+    );
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(pending);
+
+    // Ignore VOTER3 while the reconfig is in flight.
+    ignore_through_quorum(&mut hashi, VOTER3, true, &clock, 1);
+
+    // The pending committee is immutable: VOTER3 is still in it.
+    let pending_ref = hashi.committee_set().get_committee(1);
+    assert!(pending_ref.has_member(&VOTER3));
+    assert!(pending_ref.total_weight() == 3);
+
+    // The next formation (epoch 2) skips them.
+    let next = hashi
+        .committee_set()
+        .new_committee_from_voting_powers_for_testing(
+            2,
+            voting_powers(1, 1, 1),
+            mpc_config::new_for_testing(3334, 800, 3333, 0),
+        );
+    assert!(!next.has_member(&VOTER3));
+    assert!(next.total_weight() == 2);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/ignore_member_tests.move
+++ b/packages/hashi/tests/ignore_member_tests.move
@@ -211,7 +211,7 @@ fun test_formation_skips_ignored_member() {
         .new_committee_from_voting_powers_for_testing(
             1,
             voting_powers(1, 2, 3),
-            mpc_config::new_for_testing(3334, 800, 3333, 0),
+            mpc_config::new_for_testing(3334, 800, 3333, 0, 0),
         );
     assert!(next.n_members() == 2);
     assert!(!next.has_member(&VOTER2));
@@ -239,7 +239,7 @@ fun test_formation_includes_unignored_member() {
         .new_committee_from_voting_powers_for_testing(
             1,
             voting_powers(1, 1, 1),
-            mpc_config::new_for_testing(3334, 800, 3333, 0),
+            mpc_config::new_for_testing(3334, 800, 3333, 0, 0),
         );
     assert!(next.n_members() == 3);
     assert!(next.has_member(&VOTER2));
@@ -272,7 +272,7 @@ fun test_ignore_mid_reconfig_affects_next_formation_only() {
     let pending = committee::new_committee(
         1,
         members,
-        mpc_config::new_for_testing(3334, 800, 3333, 0),
+        mpc_config::new_for_testing(3334, 800, 3333, 0, 0),
     );
     hashi.committee_set_mut().set_pending_reconfig_for_testing(pending);
 
@@ -290,7 +290,7 @@ fun test_ignore_mid_reconfig_affects_next_formation_only() {
         .new_committee_from_voting_powers_for_testing(
             2,
             voting_powers(1, 1, 1),
-            mpc_config::new_for_testing(3334, 800, 3333, 0),
+            mpc_config::new_for_testing(3334, 800, 3333, 0, 0),
         );
     assert!(!next.has_member(&VOTER3));
     assert!(next.total_weight() == 2);

--- a/packages/hashi/tests/ignore_member_tests.move
+++ b/packages/hashi/tests/ignore_member_tests.move
@@ -211,7 +211,7 @@ fun test_formation_skips_ignored_member() {
         .new_committee_from_voting_powers_for_testing(
             1,
             voting_powers(1, 2, 3),
-            mpc_config::new_for_testing(3334, 800, 3333, 0),
+            mpc_config::new_for_testing(800, 3333, 0, 0),
         );
     assert!(next.n_members() == 2);
     assert!(!next.has_member(&VOTER2));
@@ -239,7 +239,7 @@ fun test_formation_includes_unignored_member() {
         .new_committee_from_voting_powers_for_testing(
             1,
             voting_powers(1, 1, 1),
-            mpc_config::new_for_testing(3334, 800, 3333, 0),
+            mpc_config::new_for_testing(800, 3333, 0, 0),
         );
     assert!(next.n_members() == 3);
     assert!(next.has_member(&VOTER2));
@@ -272,7 +272,7 @@ fun test_ignore_mid_reconfig_affects_next_formation_only() {
     let pending = committee::new_committee(
         1,
         members,
-        mpc_config::new_for_testing(3334, 800, 3333, 0),
+        mpc_config::new_for_testing(800, 3333, 0, 0),
     );
     hashi.committee_set_mut().set_pending_reconfig_for_testing(pending);
 
@@ -290,7 +290,7 @@ fun test_ignore_mid_reconfig_affects_next_formation_only() {
         .new_committee_from_voting_powers_for_testing(
             2,
             voting_powers(1, 1, 1),
-            mpc_config::new_for_testing(3334, 800, 3333, 0),
+            mpc_config::new_for_testing(800, 3333, 0, 0),
         );
     assert!(!next.has_member(&VOTER3));
     assert!(next.total_weight() == 2);

--- a/packages/hashi/tests/test_utils.move
+++ b/packages/hashi/tests/test_utils.move
@@ -14,6 +14,7 @@ use hashi::{
     emergency_pause,
     enable_version,
     hashi::Hashi,
+    ignore_member,
     update_config
 };
 use sui::{bag, bls12381, clock::Clock, vec_map};
@@ -265,6 +266,26 @@ public fun create_emergency_pause_proposal(
 ): ID {
     let metadata = vec_map::empty();
     emergency_pause::propose(hashi, validator_address, pause, metadata, clock, ctx)
+}
+
+/// Creates an ignore-member (or un-ignore) proposal and returns its ID
+public fun create_ignore_member_proposal(
+    hashi: &mut Hashi,
+    validator_address: address,
+    target_validator_address: address,
+    ignored: bool,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    ignore_member::propose(
+        hashi,
+        validator_address,
+        target_validator_address,
+        ignored,
+        vec_map::empty(),
+        clock,
+        ctx,
+    )
 }
 
 /// Creates an abort reconfig proposal and returns its ID


### PR DESCRIPTION
The committee can now vote to **ignore** a registered member — treating them as no longer part of the committee — and reverse it with the same proposal type. Motivated by testnet validators that lag on upgrades and stall quorums while still counting toward every denominator.

Based on `main`, which already carries the shared version-framework base (#1026): `SUPPORTED_PACKAGE_VERSIONS = [1, 2]`, `SuiTxExecutor::active_call_package_id` + active-version `start_reconfig` routing, `fetch_initial_shared_version`, and `HashiClient::latest_package_id`. This PR is the base of the governance stack; **#993** (voluntary resignation) stacks on top.

## Semantics
- **Storage**: a `Bool` under key `"ignored"` in `MemberInfo.extra_fields` (the config-typed extension slot), written only by the new quorum-gated (6667 bps) `ignore_member` proposal type. `MemberInfo`'s layout stays frozen; a doc note marks the flag for promotion to a real field at the pre-mainnet testnet wipe.
- **Effect at the next committee formation, nothing mid-epoch**: the sole mechanism is a skip branch in `new_committee_from_validator_set`. Total weight re-sums, so certificates, proposal quorums, MPC t/f, leader rotation, and the guardian's handoff-derived thresholds all re-derive with **zero special-casing** — the member is simply absent from the members vector. The current epoch's bitmap indices / MPC party ids are never disturbed. If a reconfiguration is already in flight, the change lands one formation later.
- **Bounds documented in the module doc**: exclusion (and the reconfig enacting it, whose handoff cert still counts the ignored member in its denominator) requires non-participating weight ≤ 3333 bps — the standard BFT bound. The registry is untouched: an ignored member keeps proposal/vote authorization, and an all-ignored registry degrades to "reconfig aborts, current committee continues" — recoverable by un-ignoring.

## Rust wiring
Full proposal-kind checklist for `IgnoreMember`: `MoveType` mirror at defining version 2, decode/parse arms, `extra_fields` `Bool` decode + `get_bool`, expired-proposal GC, and CLI `proposal create ignore-member --validator <addr> [--unignore]` with effect-timing guidance and a >25%-weight warning, plus committee views showing the flag.

## Linkage handling for the v2 proposal type
Driving a v2-introduced proposal type on current fullnodes needs the linkage-safe transaction construction whose primitives live in `main` (#1026). This PR **applies** them to the governance path:
- Proposal create/execute/vote/remove-vote and the proposal GC build **fully-resolved shared inputs** (initial shared version + explicit mutability) via `fetch_initial_shared_version`, so sui ≥ 1.76 fullnodes never `INVALID_LINKAGE` on the upgrade-introduced `ignore_member` module.
- Calls that carry an upgrade-introduced type argument (`vote` / `remove_vote` / `delete_expired`) route through the **latest** package (`latest_package_id`); `get_proposal_type_arg` now resolves each type's **defining** address via `PackageVersions`, replacing the GC's hand-rolled `TypeTag` map.

## Tests
- Move: new tests in `ignore_member_tests.move` — proposal lifecycle, formation skip via a test-only voting-powers entry point, un-ignore restore, no-op/unregistered aborts, drift idempotence, and the mid-reconfig "next formation" semantics.
- Rust units: extra-fields decode, `get_bool`, proposal-type parse; Move-compat gate stays green (all Move changes are compatible additions).
- e2e `test_ignored_member_excluded_at_epoch_boundary`: snapshot-v1 publish → upgrade → DKG → governance ignore at the v2 address → epoch change → asserts the 3-member committee with re-summed weight → **deposit and withdrawal confirm with the smaller committee** (proving certs, reshare, and guardian all follow).
