### PR TITLE
Add task heartbeats, supported-max version gauge, and steady presig pool sampling

### DIFF
--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -247,6 +247,9 @@ impl LeaderService {
                     };
 
                     let is_leader = self.is_current_leader(checkpoint_height);
+                    // Heartbeat before the non-leader `continue` so followers
+                    // report liveness too.
+                    self.inner.metrics.task_heartbeat("leader_loop");
                     self.inner.metrics.is_leader.set(i64::from(is_leader));
                     if is_leader {
                         was_leader = true;

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -100,6 +100,15 @@ pub struct Metrics {
     /// 1 when this binary supports no live on-chain package version (chain
     /// ahead of the binary); autonomous mutations are halted. 0 otherwise.
     package_version_unsupported: IntGauge,
+    /// Highest version in `SUPPORTED_PACKAGE_VERSIONS` — constant per build.
+    /// `package_version_active` reads the same for old and new binaries until
+    /// the chain upgrades, so only this gauge can count how much of the fleet
+    /// already runs a build that implements the next version.
+    package_version_supported_max: IntGauge,
+    /// Unix seconds of each long-running task loop's last iteration. A stale
+    /// entry means that task is wedged or dead inside a process whose other
+    /// metrics still look alive.
+    task_last_iteration_timestamp_seconds: IntGaugeVec,
 
     pub deposits_confirmed_total: IntCounter,
     pub deposits_rejected_utxo_spent: IntCounter,
@@ -664,6 +673,19 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            package_version_supported_max: register_int_gauge_with_registry!(
+                "hashi_package_version_supported_max",
+                "highest package version this build implements (fleet rollout census)",
+                registry,
+            )
+            .unwrap(),
+            task_last_iteration_timestamp_seconds: register_int_gauge_vec_with_registry!(
+                "hashi_task_last_iteration_timestamp_seconds",
+                "unix seconds of each task loop's last iteration; stale = task wedged",
+                &["task"],
+                registry,
+            )
+            .unwrap(),
             deposits_confirmed_total: register_int_counter_with_registry!(
                 "hashi_deposits_confirmed_total",
                 "Total number of deposits successfully confirmed on Sui",
@@ -1165,6 +1187,19 @@ impl Metrics {
             .inc_by(coin_objects as u64);
     }
 
+    /// Record a liveness heartbeat for a long-running task loop. Alert on
+    /// `time() - hashi_task_last_iteration_timestamp_seconds` staleness to
+    /// catch a single wedged task inside an otherwise-healthy process.
+    pub fn task_heartbeat(&self, task: &str) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        self.task_last_iteration_timestamp_seconds
+            .with_label_values(&[task])
+            .set(now);
+    }
+
     pub fn update_onchain_state(&self, state: &crate::onchain::OnchainState) {
         self.latest_checkpoint_height
             .set(state.latest_checkpoint_height() as i64);
@@ -1341,6 +1376,13 @@ impl Metrics {
             .set(support.active_version().map(|v| v as i64).unwrap_or(0));
         self.package_version_unsupported
             .set(i64::from(support.must_halt()));
+        self.package_version_supported_max.set(
+            crate::constants::SUPPORTED_PACKAGE_VERSIONS
+                .iter()
+                .copied()
+                .max()
+                .unwrap_or(0) as i64,
+        );
     }
 }
 

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -169,6 +169,17 @@ impl MpcService {
         let mut reconcile_tick = tokio::time::interval(RECONCILE_TICK);
         reconcile_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
+            self.inner.metrics.task_heartbeat("mpc_service");
+            // Re-sample the presig pool every iteration (at least each
+            // RECONCILE_TICK): the signing-time update in
+            // `forward_signing_results` alone leaves the gauge frozen — at 0
+            // after a restart — whenever no withdrawals are flowing.
+            if let Some(manager) = self.inner.current_signing_manager() {
+                self.inner
+                    .metrics
+                    .presig_pool_remaining
+                    .set(manager.presignatures_remaining() as i64);
+            }
             // Check for pending reconfig before blocking on `recv()`.
             if let Some(epoch) = self.get_pending_epoch_change() {
                 self.handle_reconfig(epoch).await;

--- a/crates/hashi/src/onchain/watcher.rs
+++ b/crates/hashi/src/onchain/watcher.rs
@@ -117,6 +117,7 @@ async fn clock_watcher(sui_rpc_url: String, state: OnchainState, metrics: Option
             });
 
             if let Some(metrics) = &metrics {
+                metrics.task_heartbeat("state_watcher");
                 metrics.update_onchain_state(&state);
             }
         }


### PR DESCRIPTION
Three node-health observability gaps, each motivated by a real incident or the upgrade-rollout plan:

- **`hashi_task_last_iteration_timestamp_seconds{task}`** — liveness heartbeat set at the top of each periodic task loop (`state_watcher`, `leader_loop`, `mpc_service`). A panicked or deadlocked task previously left a process that looked healthy on every other metric. Loops iterate at least every 15s (MPC reconcile tick) or every checkpoint, so staleness is unambiguous. The BTC monitor deliberately gets no heartbeat: its loop is event-driven, so a heartbeat there would be activity-gated — the kyoto metrics already cover that task.
- **`hashi_package_version_supported_max`** — constant per build, exported from `update_onchain_state`. `hashi_package_version_active` reads the same for old and new binaries until the chain upgrades, so this is the only signal that can count fleet binary rollout *before* an upgrade — the go/no-go census for executing the upgrade tx.
- **`presig_pool_remaining` re-sampled every MPC service iteration.** Previously set only inside withdrawal signing (`forward_signing_results`), so it sat frozen — at 0 after any restart — whenever no withdrawals flowed. This misfired an external operator's alert last week (Bitwise, Discord). Now it tracks the pool at least every 15s regardless of activity.

Stacked under it: a validator alert-pack doc that references these metrics.