### PR TITLE
docs: validator alert pack

### DIFF
--- a/docs/validator-alerts.md
+++ b/docs/validator-alerts.md
@@ -1,0 +1,66 @@
+# Validator alerting guide
+
+Recommended Prometheus alerts for hashi validator operators. A ready-to-use
+rules file lives at [`monitoring/validator-alerts.example.yml`](../monitoring/validator-alerts.example.yml).
+
+Two principles shape this list:
+
+1. **Node-local vs bridge-wide.** Some `hashi_*` metrics describe *your node*
+   (BTC view, mirror freshness, task liveness, gas); others mirror *shared
+   bridge state* (presig pool, queue sizes, pause flag). Alerting a node
+   operator on shared state produces alerts nobody at the node can act on.
+2. **Never alert on activity-gated values.** A gauge that only updates when
+   some activity happens cannot distinguish "quiet bridge" from "broken node".
+   Every alert below is driven by a value that updates unconditionally.
+
+## Per-node alerts
+
+| Alert | Expression | Why this threshold |
+| --- | --- | --- |
+| BTC view frozen | `changes(hashi_kyoto_best_height[90m]) == 0` | Signet produces ~1 block/10 min, so a healthy tip ticks ~6×/hour. 90 minutes of silence is a stuck BTC view, not a quiet chain. |
+| BTC not synced | `hashi_kyoto_synced == 0` for 15m | Brief resyncs are normal after restarts; sustained unsync is not. |
+| No BTC peers | `hashi_kyoto_connected_peers < 1` for 10m | No peers means no blocks, ahead of the tip going stale. |
+| Sui mirror stale | `time() - (hashi_latest_checkpoint_timestamp_ms / 1000) > 120` for 5m | The state watcher applies checkpoints continuously. Two minutes without an applied checkpoint means the watcher, mirror, or fullnode RPC is wedged — the node acts on stale bridge state while looking healthy elsewhere. |
+| Task wedged | `time() - hashi_task_last_iteration_timestamp_seconds > 600` | Each labeled task loop (`state_watcher`, `leader_loop`, `mpc_service`) iterates at least every 15s. A stale heartbeat catches a panicked or deadlocked task inside an otherwise-alive process. |
+| Reconfig not tracking | `changes(hashi_epoch[3h]) == 0` | Testnet reconfigures roughly every 40 minutes. If the committee epoch stops moving, either your node stopped following reconfig or the fleet itself stalled — check the operator channel before assuming local fault. |
+| Low gas | `hashi_sui_balance < 1e9` | Below 1 SUI the operator wallet is close to unable to submit. Refill. |
+| Binary behind chain | `hashi_package_version_unsupported == 1` | The chain moved to a package version this binary does not implement; autonomous writes are halted. Upgrade the binary immediately. |
+| Crash looping | `changes(process_start_time_seconds{job="<your-node>"}[1h]) > 3` | Uses the standard process exporter if you run one; any restart-count source works. |
+
+Dashboard-worthy but **not** alerts:
+
+- `hashi_package_version_active` / `hashi_package_version_supported_max` —
+  which version the node operates at, and the highest version the build
+  implements. During a rollout, `supported_max` is how the fleet's binary
+  upgrade progress is counted before the on-chain upgrade flips `active`.
+- `hashi_is_leader` — leadership rotates; useful context when reading other
+  metrics, meaningless to alert on.
+- `hashi_deposit_request_confirmations{status="not_found"}` — a sustained
+  nonzero value while peers confirm deposits normally suggests your bitcoind
+  or kyoto view is on the wrong network or corrupted.
+
+## What NOT to alert on
+
+- **`hashi_presig_pool_remaining == 0`.** This mirrors the *shared* presig
+  pool, not your node's health. Mysten monitors pool exhaustion fleet-side.
+  (Before the periodic sampler landed, this gauge also read 0 after any
+  restart until the next withdrawal — the archetypal activity-gated trap.)
+- **Failure ratios of `hashi_sui_tx_submissions_total{operation="confirm_deposit"}`.**
+  Deposit confirmation is a leader-submitted, aggressively-retried race with
+  several benign abort paths (already confirmed, reconfig window in progress,
+  approval from a previous committee awaiting re-approval). Per-node failure
+  ratios between 30% and 100% are all normal.
+- **Ratios of raw counters.** `a_total / b_total` spans the whole process
+  lifetime and drifts with history, not health. Always window both sides:
+  `increase(a_total[1h]) / increase(b_total[1h])`.
+
+## Scope reference
+
+| Metric | Scope |
+| --- | --- |
+| `hashi_kyoto_*` | node |
+| `hashi_latest_checkpoint_*`, `hashi_task_last_iteration_timestamp_seconds` | node |
+| `hashi_sui_balance`, `hashi_package_version_*`, `hashi_is_leader` | node |
+| `hashi_presig_pool_remaining`, `hashi_num_consumed_presigs` | bridge |
+| `hashi_deposit_queue_size`, `hashi_withdrawal_queue_*`, `hashi_utxo_pool_*` | bridge |
+| `hashi_paused`, `hashi_reconfig_in_progress`, `hashi_epoch`, `hashi_sui_epoch` | bridge (visible per node) |

--- a/monitoring/validator-alerts.example.yml
+++ b/monitoring/validator-alerts.example.yml
@@ -1,0 +1,95 @@
+# Example Prometheus alerting rules for a hashi validator node.
+# See docs/validator-alerts.md for the rationale behind each rule and for
+# the list of metrics you should NOT alert on.
+#
+# Drop this into your Prometheus rule_files and adjust thresholds/labels to
+# your paging setup. Expressions assume your node's hashi metrics are
+# scraped into the local Prometheus without extra relabeling.
+
+groups:
+  - name: hashi-validator-node-health
+    rules:
+      - alert: HashiBtcViewFrozen
+        expr: changes(hashi_kyoto_best_height[90m]) == 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "BTC view frozen"
+          description: >-
+            hashi_kyoto_best_height has not changed in 90 minutes. Signet
+            ticks roughly every 10 minutes, so the node's Bitcoin view is
+            stuck (kyoto wedged, no peers, or bitcoind issue).
+
+      - alert: HashiBtcNotSynced
+        expr: hashi_kyoto_synced == 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "BTC view not synced for 15m"
+          description: >-
+            Brief resyncs after a restart are normal; sustained unsync is
+            not. Check hashi_kyoto_sync_percent and peer count.
+
+      - alert: HashiNoBtcPeers
+        expr: hashi_kyoto_connected_peers < 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "no BTC peers connected"
+          description: "Without peers the BTC tip will go stale next."
+
+      - alert: HashiSuiMirrorStale
+        expr: time() - (hashi_latest_checkpoint_timestamp_ms / 1000) > 120
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Sui state mirror stale"
+          description: >-
+            No Sui checkpoint has been applied to the node's bridge-state
+            mirror for over 2 minutes. The watcher, mirror, or fullnode RPC
+            is wedged; the node is acting on stale state even if other
+            metrics look healthy.
+
+      - alert: HashiTaskWedged
+        expr: time() - hashi_task_last_iteration_timestamp_seconds > 600
+        labels:
+          severity: critical
+        annotations:
+          summary: "task loop {{ $labels.task }} wedged"
+          description: >-
+            The {{ $labels.task }} loop has not iterated in 10 minutes; all
+            heartbeat-labeled loops iterate at least every 15 seconds. A
+            task inside the process has panicked or deadlocked.
+
+      - alert: HashiReconfigNotTracking
+        expr: changes(hashi_epoch[3h]) == 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "committee epoch not advancing"
+          description: >-
+            Testnet reconfigures roughly every 40 minutes. Check the
+            operator channel first: if the fleet is reconfiguring and your
+            epoch is not moving, your node is stuck.
+
+      - alert: HashiLowGas
+        expr: hashi_sui_balance < 1e9
+        labels:
+          severity: warning
+        annotations:
+          summary: "operator wallet below 1 SUI"
+          description: "Refill the operator gas wallet."
+
+      - alert: HashiBinaryBehindChain
+        expr: hashi_package_version_unsupported == 1
+        labels:
+          severity: critical
+        annotations:
+          summary: "binary does not support the live package version"
+          description: >-
+            The chain has moved past every package version this build
+            implements; autonomous writes are halted. Upgrade the node
+            binary immediately.


### PR DESCRIPTION
Stacked on #995 (references the heartbeat and supported-max metrics it adds).

A blessed per-node alert set for external validator operators: `docs/validator-alerts.md` with rationale and thresholds, plus a ready-to-use `monitoring/validator-alerts.example.yml` Prometheus rules file.

Motivated by the recent operator support threads: Bitwise alerted on `hashi_presig_pool_remaining == 0` (bridge-shared, activity-gated — misfired after their restart) and diagnosed a "95% failure rate" from a cumulative-counter ratio on `confirm_deposit` (leader-raced, benign aborts, fleet ratios span 30–100%). The doc encodes both as explicit anti-patterns, and documents the node-local vs bridge-wide scope of every operator-facing metric so the next alert gets built on the right signal.