### PR TITLE
guardian-init: scrape governance state only

### DIFF
--- a/crates/hashi-guardian-init/src/config.rs
+++ b/crates/hashi-guardian-init/src/config.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use bitcoin::Network;
 use hashi::config::HashiIds;
 use hashi::onchain::OnchainState;
+use hashi::onchain::ScrapeScope;
 use hashi_types::guardian::LimiterConfig;
 use hashi_types::guardian::UnresolvedS3Config;
 use serde::Deserialize;
@@ -102,9 +103,19 @@ impl<'de> Deserialize<'de> for HashiOnchainConfig {
 
 impl HashiOnchainConfig {
     pub async fn onchain_state(&self) -> anyhow::Result<OnchainState> {
-        let (state, _watcher) = OnchainState::new(&self.sui_rpc, self.hashi_ids, None, None, None)
-            .await
-            .with_context(|| format!("failed to connect to Sui RPC at {}", self.sui_rpc))?;
-        Ok(state)
+        // Every provisioning command reads only committee/governance data
+        // (verifying key, committee members), so skip the Bitcoin
+        // collections: a full scrape walks the entire withdrawal queue and
+        // UTXO pool — minutes of sequential paging on testnet — for state
+        // none of these commands touch. One-shot reader: the commands act
+        // on the snapshot, no watcher needed.
+        OnchainState::new_reader(
+            &self.sui_rpc,
+            self.hashi_ids,
+            None,
+            ScrapeScope::GovernanceOnly,
+        )
+        .await
+        .with_context(|| format!("failed to connect to Sui RPC at {}", self.sui_rpc))
     }
 }


### PR DESCRIPTION
The guardian provisioning commands (`key-provisioner provision`, `operator provision`/`activate`) read only the MPC verifying key and committee data, but `HashiOnchainConfig::onchain_state()` performed a `ScrapeScope::Full` scrape — walking the entire withdrawal queue and UTXO pool (~4.5k live entries, 2–4 minutes of sequential `ListDynamicFields` paging on testnet) for state none of the commands touch, and spawning a watcher whose handle was immediately dropped.

Switch to a one-shot `GovernanceOnly` reader, the same scope the equivalent governance CLI commands already use (`HashiClient::new`). Ceremony state reads drop from minutes to seconds.

Found while mapping withdrawal-state readers for the deferred-archival work; independent of that stack.