### PR TITLE
move: TOB cert bucket GC entries with per-protocol floors

### DIFF
--- a/design/docs/move-model-lifecycle.mdx
+++ b/design/docs/move-model-lifecycle.mdx
@@ -52,7 +52,7 @@ machine also gate on pause and (where ordering matters) on reconfiguration;
 garbage collection and operator registration deliberately do not.** Deposits,
 withdrawal approvals, signing, and confirmation all stop when governance
 pauses the system or while a committee handoff is pending. Cleanup entries
-(`cleanup_spent_utxos`, `destroy_all_certs`, `destroy_key_gen_certs`,
+(`cleanup_spent_utxos`, `destroy_key_gen_certs`,
 `destroy_nonce_certs`, `delete_expired_deposit`) and
 validator registration or key rotation stay callable, because an emergency
 pause must not block operators from maintaining nodes or the chain from

--- a/design/docs/move-model-lifecycle.mdx
+++ b/design/docs/move-model-lifecycle.mdx
@@ -52,7 +52,8 @@ machine also gate on pause and (where ordering matters) on reconfiguration;
 garbage collection and operator registration deliberately do not.** Deposits,
 withdrawal approvals, signing, and confirmation all stop when governance
 pauses the system or while a committee handoff is pending. Cleanup entries
-(`cleanup_spent_utxos`, `destroy_all_certs`, `delete_expired_deposit`) and
+(`cleanup_spent_utxos`, `destroy_all_certs`, `destroy_key_gen_certs`,
+`destroy_nonce_certs`, `delete_expired_deposit`) and
 validator registration or key rotation stay callable, because an emergency
 pause must not block operators from maintaining nodes or the chain from
 shedding dead state. One asymmetry is intentional: users can *request*

--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -5,6 +5,31 @@ module hashi::cert_submission;
 
 use hashi::{committee::CommitteeSignature, hashi::Hashi, tob::ProtocolType};
 
+// ~~~~~~~ Constants ~~~~~~~
+
+/// Key-generation cert buckets for the last N committee epochs are retained
+/// for break-glass key recovery: the `key_recovery` internal tool pairs a
+/// node's local DB — which keeps dealer/rotation messages for the trailing 7
+/// epochs — with the on-chain bucket of the epoch being reconstructed.
+/// Enforced on-chain because destruction is permissionless.
+const KEY_GEN_CERT_RETENTION_EPOCHS: u64 = 8;
+
+/// Nonce cert buckets are only ever read during their own epoch; +2 mirrors
+/// the `tob::destroy_all` backstop.
+const NONCE_CERT_MIN_AGE_EPOCHS: u64 = 2;
+
+// ~~~~~~~ Errors ~~~~~~~
+
+#[error]
+const ETooEarlyToDestroyNonceCerts: vector<u8> =
+    b"Nonce cert buckets may only be destroyed two epochs after their epoch";
+#[error]
+const ETooEarlyToDestroyKeyGenCerts: vector<u8> =
+    b"Key-generation cert buckets are retained for break-glass key recovery";
+#[error]
+const EKeyGenCertsStillNeeded: vector<u8> =
+    b"The previous committee's key-generation certs seed the next rotation";
+
 // ~~~~~~~ Entry Functions ~~~~~~~
 
 entry fun submit_dkg_cert(
@@ -71,7 +96,71 @@ entry fun destroy_all_certs(
     };
 }
 
+/// Destroy the key-generation (DKG or rotation) cert buckets of `epoch`.
+/// Garbage collection: permissionless and deliberately NOT gated on
+/// pause/reconfig — see `destroy_all_certs`.
+///
+/// A key-generation bucket stays live longer than its certs' epoch: the NEXT
+/// rotation reads the PREVIOUS committee's bucket to seed the handoff, and
+/// committee epochs can gap, so an age floor alone cannot identify the
+/// previous committee's bucket. Both floors are asserted unconditionally
+/// (premature calls abort even when the bucket is absent); an
+/// eligible-but-absent bucket is a no-op so batched GC transactions and
+/// permissionless racers cannot poison each other.
+entry fun destroy_key_gen_certs(hashi: &mut Hashi, epoch: u64) {
+    hashi.versioning().assert_version_enabled();
+    let current_epoch = hashi.committee_set().epoch();
+    assert!(current_epoch >= epoch + KEY_GEN_CERT_RETENTION_EPOCHS, ETooEarlyToDestroyKeyGenCerts);
+    assert!(hashi.committee_set().is_before_previous_committee(epoch), EKeyGenCertsStillNeeded);
+    // One entry covers both key-generation protocols: callers never need to
+    // know whether `epoch` was a genesis (DKG) or rotation epoch.
+    destroy_bucket_if_present(
+        hashi,
+        hashi::tob::tob_key(epoch, option::none(), hashi::tob::protocol_type_dkg()),
+        current_epoch,
+    );
+    destroy_bucket_if_present(
+        hashi,
+        hashi::tob::tob_key(epoch, option::none(), hashi::tob::protocol_type_key_rotation()),
+        current_epoch,
+    );
+}
+
+/// Destroy the nonce-generation cert bucket of `(epoch, batch_index)`.
+/// Garbage collection: permissionless and deliberately NOT gated on
+/// pause/reconfig — see `destroy_all_certs`. Nonce buckets are only ever
+/// read during their own epoch, so no committee-awareness is needed. The
+/// floor is asserted unconditionally; an eligible-but-absent bucket is a
+/// no-op (see `destroy_key_gen_certs`).
+entry fun destroy_nonce_certs(hashi: &mut Hashi, epoch: u64, batch_index: u32) {
+    hashi.versioning().assert_version_enabled();
+    let current_epoch = hashi.committee_set().epoch();
+    assert!(current_epoch >= epoch + NONCE_CERT_MIN_AGE_EPOCHS, ETooEarlyToDestroyNonceCerts);
+    destroy_bucket_if_present(
+        hashi,
+        hashi::tob::tob_key(
+            epoch,
+            option::some(batch_index),
+            hashi::tob::protocol_type_nonce_generation(),
+        ),
+        current_epoch,
+    );
+}
+
 // ~~~~~~~ Private Functions ~~~~~~~
+
+/// Remove and destroy the bucket at `key` if one is stored as an
+/// `EpochCertsV1`; otherwise do nothing. Probing by STORED type (not by the
+/// requested protocol) means a bucket written under a future value layout is
+/// left in place for the module version that understands it, instead of
+/// aborting the whole transaction or being destroyed as the wrong type.
+fun destroy_bucket_if_present(hashi: &mut Hashi, key: hashi::tob::TobKey, current_epoch: u64) {
+    let tob = hashi.tob_mut();
+    if (tob.contains_with_type<hashi::tob::TobKey, hashi::tob::EpochCertsV1>(key)) {
+        let epoch_certs: hashi::tob::EpochCertsV1 = tob.remove(key);
+        hashi::tob::destroy_all(epoch_certs, current_epoch);
+    }
+}
 
 fun submit_cert_internal(
     hashi: &mut Hashi,

--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -8,11 +8,17 @@ use hashi::{committee::CommitteeSignature, hashi::Hashi, tob::ProtocolType};
 // ~~~~~~~ Constants ~~~~~~~
 
 /// Key-generation cert buckets stay on-chain until their Sui epoch number is
-/// at least 8 below the current one. This matches the node DB's numeric
-/// retention window: dealer/rotation messages at `current - 7` and newer are
-/// retained for break-glass key recovery. This is an epoch-number distance,
-/// not a count of finalized committee generations (committee epochs can gap).
-/// Enforced on-chain because destruction is permissionless.
+/// at least 8 below the current one. This strictly exceeds the node DB's
+/// retention window (`RETENTION_EXTRA_EPOCHS = 7` in `db.rs`, anchored to the
+/// same committee-epoch counter): buckets hold only committee certificates
+/// over dealer-message hashes — the dealt payloads live exclusively in node
+/// DBs — so a bucket is only useful alongside DB material, and every epoch
+/// whose payloads may still exist under that window keeps its bucket. The
+/// previous committee's bucket is protected separately and at any age by
+/// `is_before_previous_committee`, mirroring the DB pruner's previous-epoch
+/// exemption. This is an epoch-number distance, not a count of finalized
+/// committee generations (committee epochs can gap). Enforced on-chain
+/// because destruction is permissionless.
 const KEY_GEN_CERT_RETENTION_EPOCHS: u64 = 8;
 
 /// Nonce cert buckets are only ever read during their own epoch; +2 mirrors
@@ -29,7 +35,7 @@ const ETooEarlyToDestroyKeyGenCerts: vector<u8> =
     b"Key-generation cert buckets are retained for break-glass key recovery";
 #[error]
 const EKeyGenCertsStillNeeded: vector<u8> =
-    b"Key-generation certs require a later finalized committee before pruning";
+    b"Key-generation cert buckets must be strictly older than the previous committee, whose bucket seeds the next rotation";
 #[error]
 const EUnsupportedCertBucketLayout: vector<u8> =
     b"TOB cert bucket has a layout this package version cannot prune";
@@ -78,12 +84,13 @@ entry fun submit_nonce_cert(
     submit_stamped_cert_internal(hashi, key, epoch, dealer, messages_hash, &cert, clock, ctx);
 }
 
-/// Deprecated compatibility entry. It cannot be removed while the deployed
-/// package uses the compatible-upgrade policy, so keep its ABI but route it
-/// through the protocol-specific floors below. `ProtocolType` has no public
-/// constructors and cannot currently be supplied as a PTB pure argument, but
-/// this routing prevents the legacy `+2` floor from becoming a key-generation
-/// bypass if that restriction ever changes.
+/// Deprecated entry, retained as defense in depth. Non-public `entry`
+/// functions are not linkage-checked, so the upgrade policy would permit
+/// deleting this; it is kept so any historical caller path routes through
+/// the protocol-specific floors below instead of the legacy `+2` rule.
+/// `ProtocolType` has no public constructors and cannot currently be
+/// supplied as a PTB pure argument, so this entry is unreachable today;
+/// the routing guards against that restriction ever loosening.
 entry fun destroy_all_certs(
     hashi: &mut Hashi,
     epoch: u64,

--- a/packages/hashi/sources/core/cert_submission.move
+++ b/packages/hashi/sources/core/cert_submission.move
@@ -7,10 +7,11 @@ use hashi::{committee::CommitteeSignature, hashi::Hashi, tob::ProtocolType};
 
 // ~~~~~~~ Constants ~~~~~~~
 
-/// Key-generation cert buckets for the last N committee epochs are retained
-/// for break-glass key recovery: the `key_recovery` internal tool pairs a
-/// node's local DB — which keeps dealer/rotation messages for the trailing 7
-/// epochs — with the on-chain bucket of the epoch being reconstructed.
+/// Key-generation cert buckets stay on-chain until their Sui epoch number is
+/// at least 8 below the current one. This matches the node DB's numeric
+/// retention window: dealer/rotation messages at `current - 7` and newer are
+/// retained for break-glass key recovery. This is an epoch-number distance,
+/// not a count of finalized committee generations (committee epochs can gap).
 /// Enforced on-chain because destruction is permissionless.
 const KEY_GEN_CERT_RETENTION_EPOCHS: u64 = 8;
 
@@ -28,7 +29,10 @@ const ETooEarlyToDestroyKeyGenCerts: vector<u8> =
     b"Key-generation cert buckets are retained for break-glass key recovery";
 #[error]
 const EKeyGenCertsStillNeeded: vector<u8> =
-    b"The previous committee's key-generation certs seed the next rotation";
+    b"Key-generation certs require a later finalized committee before pruning";
+#[error]
+const EUnsupportedCertBucketLayout: vector<u8> =
+    b"TOB cert bucket has a layout this package version cannot prune";
 
 // ~~~~~~~ Entry Functions ~~~~~~~
 
@@ -74,25 +78,22 @@ entry fun submit_nonce_cert(
     submit_stamped_cert_internal(hashi, key, epoch, dealer, messages_hash, &cert, clock, ctx);
 }
 
-/// Garbage collection: deliberately NOT gated on pause/reconfig — cert
-/// buckets old enough to destroy (see `tob::destroy_all`) carry no live
-/// state, and GC must stay callable during an emergency pause.
+/// Deprecated compatibility entry. It cannot be removed while the deployed
+/// package uses the compatible-upgrade policy, so keep its ABI but route it
+/// through the protocol-specific floors below. `ProtocolType` has no public
+/// constructors and cannot currently be supplied as a PTB pure argument, but
+/// this routing prevents the legacy `+2` floor from becoming a key-generation
+/// bypass if that restriction ever changes.
 entry fun destroy_all_certs(
     hashi: &mut Hashi,
     epoch: u64,
     batch_index: Option<u32>,
     protocol_type: ProtocolType,
 ) {
-    hashi.versioning().assert_version_enabled();
-    let is_nonce_generation = protocol_type.is_nonce_generation();
-    let key = hashi::tob::tob_key(epoch, batch_index, protocol_type);
-    let current_epoch = hashi.committee_set().epoch();
-    if (is_nonce_generation) {
-        let epoch_certs: hashi::tob::StampedEpochCertsV1 = hashi.tob_mut().remove(key);
-        hashi::tob::destroy_all_stamped(epoch_certs, current_epoch);
+    if (protocol_type.is_nonce_generation()) {
+        destroy_nonce_certs(hashi, epoch, batch_index.destroy_some());
     } else {
-        let epoch_certs: hashi::tob::EpochCertsV1 = hashi.tob_mut().remove(key);
-        hashi::tob::destroy_all(epoch_certs, current_epoch);
+        destroy_key_gen_certs(hashi, epoch);
     };
 }
 
@@ -114,12 +115,12 @@ entry fun destroy_key_gen_certs(hashi: &mut Hashi, epoch: u64) {
     assert!(hashi.committee_set().is_before_previous_committee(epoch), EKeyGenCertsStillNeeded);
     // One entry covers both key-generation protocols: callers never need to
     // know whether `epoch` was a genesis (DKG) or rotation epoch.
-    destroy_bucket_if_present(
+    destroy_bare_bucket_if_present(
         hashi,
         hashi::tob::tob_key(epoch, option::none(), hashi::tob::protocol_type_dkg()),
         current_epoch,
     );
-    destroy_bucket_if_present(
+    destroy_bare_bucket_if_present(
         hashi,
         hashi::tob::tob_key(epoch, option::none(), hashi::tob::protocol_type_key_rotation()),
         current_epoch,
@@ -136,7 +137,7 @@ entry fun destroy_nonce_certs(hashi: &mut Hashi, epoch: u64, batch_index: u32) {
     hashi.versioning().assert_version_enabled();
     let current_epoch = hashi.committee_set().epoch();
     assert!(current_epoch >= epoch + NONCE_CERT_MIN_AGE_EPOCHS, ETooEarlyToDestroyNonceCerts);
-    destroy_bucket_if_present(
+    destroy_nonce_bucket_if_present(
         hashi,
         hashi::tob::tob_key(
             epoch,
@@ -149,17 +150,48 @@ entry fun destroy_nonce_certs(hashi: &mut Hashi, epoch: u64, batch_index: u32) {
 
 // ~~~~~~~ Private Functions ~~~~~~~
 
-/// Remove and destroy the bucket at `key` if one is stored as an
-/// `EpochCertsV1`; otherwise do nothing. Probing by STORED type (not by the
-/// requested protocol) means a bucket written under a future value layout is
-/// left in place for the module version that understands it, instead of
-/// aborting the whole transaction or being destroyed as the wrong type.
-fun destroy_bucket_if_present(hashi: &mut Hashi, key: hashi::tob::TobKey, current_epoch: u64) {
+/// Remove a key-generation bucket only when it has the layout this version
+/// understands. An absent bucket is an idempotent no-op; a present bucket with
+/// an unknown layout aborts loudly so the off-chain sweep cannot report false
+/// success while state keeps accumulating.
+fun destroy_bare_bucket_if_present(hashi: &mut Hashi, key: hashi::tob::TobKey, current_epoch: u64) {
     let tob = hashi.tob_mut();
     if (tob.contains_with_type<hashi::tob::TobKey, hashi::tob::EpochCertsV1>(key)) {
         let epoch_certs: hashi::tob::EpochCertsV1 = tob.remove(key);
         hashi::tob::destroy_all(epoch_certs, current_epoch);
+    } else {
+        assert!(!tob.contains(key), EUnsupportedCertBucketLayout);
     }
+}
+
+/// Nonce buckets may use either the legacy bare layout or the stamped layout
+/// introduced in v2. As above, absence is idempotent and an unknown present
+/// layout aborts instead of being silently skipped.
+fun destroy_nonce_bucket_if_present(
+    hashi: &mut Hashi,
+    key: hashi::tob::TobKey,
+    current_epoch: u64,
+) {
+    let tob = hashi.tob_mut();
+    if (tob.contains_with_type<hashi::tob::TobKey, hashi::tob::EpochCertsV1>(key)) {
+        let epoch_certs: hashi::tob::EpochCertsV1 = tob.remove(key);
+        hashi::tob::destroy_all(epoch_certs, current_epoch);
+    } else if (tob.contains_with_type<hashi::tob::TobKey, hashi::tob::StampedEpochCertsV1>(key)) {
+        let epoch_certs: hashi::tob::StampedEpochCertsV1 = tob.remove(key);
+        hashi::tob::destroy_all_stamped(epoch_certs, current_epoch);
+    } else {
+        assert!(!tob.contains(key), EUnsupportedCertBucketLayout);
+    }
+}
+
+#[test_only]
+public fun destroy_all_certs_for_testing(
+    hashi: &mut Hashi,
+    epoch: u64,
+    batch_index: Option<u32>,
+    protocol_type: ProtocolType,
+) {
+    destroy_all_certs(hashi, epoch, batch_index, protocol_type)
 }
 
 fun submit_cert_internal(

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -497,6 +497,24 @@ public(package) fun has_committee(self: &CommitteeSet, epoch: u64): bool {
     self.committees.contains_with_type<u64, Committee>(epoch)
 }
 
+/// True iff at least one committee epoch lies strictly between `epoch` and
+/// the current epoch — i.e. `epoch` is strictly older than the previous
+/// committee's epoch. Committee epochs are Sui epochs and can gap (a reconfig
+/// may not run every Sui epoch), so this walks down from `current - 1` rather
+/// than assuming `current - 1` is the previous committee. The walk is bounded
+/// by the current↔previous committee gap in every case: it returns at the
+/// first committee found descending, and in the not-found case the range
+/// (epoch, current) contains no committee at all. A pending committee's epoch
+/// is `> current` and is never visited.
+public(package) fun is_before_previous_committee(self: &CommitteeSet, epoch: u64): bool {
+    let mut e = self.epoch;
+    while (e > epoch + 1) {
+        e = e - 1;
+        if (self.has_committee(e)) return true
+    };
+    false
+}
+
 public(package) fun pending_epoch_change(self: &CommitteeSet): Option<u64> {
     if (self.pending_epoch_change.is_some()) {
         option::some(self.pending_epoch_change.borrow().epoch)
@@ -841,6 +859,11 @@ public fun create_pre_genesis_for_testing(
 /// Drop a test CommitteeSet (Bag fields prevent plain drop).
 public fun destroy_for_testing(self: CommitteeSet) {
     std::unit_test::destroy(self)
+}
+
+#[test_only]
+public fun insert_committee_for_testing(self: &mut CommitteeSet, committee: Committee) {
+    self.insert_committee(committee)
 }
 
 #[test_only]

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -342,6 +342,24 @@ public(package) fun has_committee(self: &CommitteeSet, epoch: u64): bool {
     self.committees.contains_with_type<u64, Committee>(epoch)
 }
 
+/// True iff at least one committee epoch lies strictly between `epoch` and
+/// the current epoch — i.e. `epoch` is strictly older than the previous
+/// committee's epoch. Committee epochs are Sui epochs and can gap (a reconfig
+/// may not run every Sui epoch), so this walks down from `current - 1` rather
+/// than assuming `current - 1` is the previous committee. The walk is bounded
+/// by the current↔previous committee gap in every case: it returns at the
+/// first committee found descending, and in the not-found case the range
+/// (epoch, current) contains no committee at all. A pending committee's epoch
+/// is `> current` and is never visited.
+public(package) fun is_before_previous_committee(self: &CommitteeSet, epoch: u64): bool {
+    let mut e = self.epoch;
+    while (e > epoch + 1) {
+        e = e - 1;
+        if (self.has_committee(e)) return true
+    };
+    false
+}
+
 public(package) fun pending_epoch_change(self: &CommitteeSet): Option<u64> {
     if (self.pending_epoch_change.is_some()) {
         option::some(self.pending_epoch_change.borrow().epoch)
@@ -541,6 +559,11 @@ public fun set_pending_reconfig_for_testing(self: &mut CommitteeSet, committee: 
 #[test_only]
 public fun set_mpc_public_key_for_testing(self: &mut CommitteeSet, mpc_public_key: vector<u8>) {
     self.mpc_public_key = mpc_public_key;
+}
+
+#[test_only]
+public fun insert_committee_for_testing(self: &mut CommitteeSet, committee: Committee) {
+    self.insert_committee(committee)
 }
 
 #[test_only]

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -45,7 +45,8 @@ public struct Hashi has key {
     versioning: Versioning,
     treasury: Treasury,
     proposals: Proposals,
-    /// TOB certificates by (epoch, batch_index, protocol_type) -> EpochCertsV1
+    /// TOB certificates by (epoch, batch_index, protocol_type). Values are
+    /// bare `EpochCertsV1` buckets or, for nonce certs, `StampedEpochCertsV1`.
     tob: Bag,
     /// Number of presignatures consumed in the current epoch.
     /// Used by recovering nodes to derive `(batch_index, index_in_batch)`.

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -45,7 +45,7 @@ public struct Hashi has key {
     versioning: Versioning,
     treasury: Treasury,
     proposals: Proposals,
-    /// TOB certificates by (epoch, batch_index) -> EpochCertsV1
+    /// TOB certificates by (epoch, batch_index, protocol_type) -> EpochCertsV1
     tob: Bag,
     /// Number of presignatures consumed in the current epoch.
     /// Used by recovering nodes to derive `(batch_index, index_in_batch)`.

--- a/packages/hashi/tests/tob_pruning_tests.move
+++ b/packages/hashi/tests/tob_pruning_tests.move
@@ -60,6 +60,11 @@ fun add_bucket(hashi: &mut Hashi, key: hashi::tob::TobKey, ctx: &mut TxContext) 
     hashi.epoch_certs(key, ctx);
 }
 
+/// Create a stamped nonce bucket, bypassing the submit path's epoch check.
+fun add_stamped_bucket(hashi: &mut Hashi, key: hashi::tob::TobKey, ctx: &mut TxContext) {
+    hashi.epoch_certs_stamped(key, ctx);
+}
+
 // ~~~~~~~ Nonce Bucket Floors ~~~~~~~
 
 #[test]
@@ -124,6 +129,18 @@ fun nonce_previous_committee_epoch_prunable() {
     cert_submission::destroy_nonce_certs(&mut hashi, 2, 0);
 
     assert!(!hashi.tob_contains(nonce_key(2, 0)));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun stamped_nonce_bucket_is_destroyed() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_stamped_bucket(&mut hashi, nonce_key(8, 0), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
+
+    assert!(!hashi.tob_contains(nonce_key(8, 0)));
     std::unit_test::destroy(hashi);
 }
 
@@ -283,20 +300,37 @@ fun destroy_callable_while_paused_and_reconfiguring() {
     std::unit_test::destroy(hashi);
 }
 
-/// The destroy entries probe by STORED type: a bucket written under a
-/// different value layout (e.g. a future StampedEpochCertsV1) is left in
-/// place for the module version that understands it — no abort, no
-/// wrong-typed destruction.
 #[test]
-fun destroy_leaves_foreign_typed_bucket_in_place() {
+#[expected_failure(abort_code = cert_submission::EUnsupportedCertBucketLayout)]
+/// A present bucket with an unknown layout must fail loudly. Otherwise the
+/// off-chain sweep would log success while the bucket remained forever.
+fun destroy_rejects_unknown_bucket_layout() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
     let mut hashi = hashi_at_current_epoch(ctx);
     hashi.tob_mut().add(nonce_key(8, 0), 42u64);
 
     cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
 
-    assert!(hashi.tob_contains(nonce_key(8, 0)));
-    std::unit_test::destroy(hashi);
+    abort
+}
+
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyKeyGenCerts)]
+/// The legacy ABI is retained for upgrade compatibility, but it must not
+/// retain its old `+2` key-generation bypass.
+fun legacy_destroy_all_obeys_keygen_retention_floor() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, dkg_key(3), ctx);
+
+    cert_submission::destroy_all_certs_for_testing(
+        &mut hashi,
+        3,
+        option::none(),
+        hashi::tob::protocol_type_dkg(),
+    );
+
+    abort
 }
 
 // ~~~~~~~ Bucket Draining ~~~~~~~

--- a/packages/hashi/tests/tob_pruning_tests.move
+++ b/packages/hashi/tests/tob_pruning_tests.move
@@ -34,7 +34,7 @@ fun committee_at(epoch: u64): committee::Committee {
     committee::new_committee(
         epoch,
         vector[member],
-        hashi::mpc_config::new_for_testing(3334, 800, 3333, 0),
+        hashi::mpc_config::new_for_testing(3334, 800, 3333, 0, 0),
     )
 }
 
@@ -58,6 +58,11 @@ fun nonce_key(epoch: u64, batch_index: u32): hashi::tob::TobKey {
 /// current-or-pending epoch assert.
 fun add_bucket(hashi: &mut Hashi, key: hashi::tob::TobKey, ctx: &mut TxContext) {
     hashi.epoch_certs(key, ctx);
+}
+
+/// Create a stamped nonce bucket, bypassing the submit path's epoch check.
+fun add_stamped_bucket(hashi: &mut Hashi, key: hashi::tob::TobKey, ctx: &mut TxContext) {
+    hashi.epoch_certs_stamped(key, ctx);
 }
 
 // ~~~~~~~ Nonce Bucket Floors ~~~~~~~
@@ -124,6 +129,18 @@ fun nonce_previous_committee_epoch_prunable() {
     cert_submission::destroy_nonce_certs(&mut hashi, 2, 0);
 
     assert!(!hashi.tob_contains(nonce_key(2, 0)));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun stamped_nonce_bucket_is_destroyed() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_stamped_bucket(&mut hashi, nonce_key(8, 0), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
+
+    assert!(!hashi.tob_contains(nonce_key(8, 0)));
     std::unit_test::destroy(hashi);
 }
 
@@ -283,20 +300,37 @@ fun destroy_callable_while_paused_and_reconfiguring() {
     std::unit_test::destroy(hashi);
 }
 
-/// The destroy entries probe by STORED type: a bucket written under a
-/// different value layout (e.g. a future StampedEpochCertsV1) is left in
-/// place for the module version that understands it — no abort, no
-/// wrong-typed destruction.
 #[test]
-fun destroy_leaves_foreign_typed_bucket_in_place() {
+#[expected_failure(abort_code = cert_submission::EUnsupportedCertBucketLayout)]
+/// A present bucket with an unknown layout must fail loudly. Otherwise the
+/// off-chain sweep would log success while the bucket remained forever.
+fun destroy_rejects_unknown_bucket_layout() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
     let mut hashi = hashi_at_current_epoch(ctx);
     hashi.tob_mut().add(nonce_key(8, 0), 42u64);
 
     cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
 
-    assert!(hashi.tob_contains(nonce_key(8, 0)));
-    std::unit_test::destroy(hashi);
+    abort
+}
+
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyKeyGenCerts)]
+/// The legacy ABI is retained for upgrade compatibility, but it must not
+/// retain its old `+2` key-generation bypass.
+fun legacy_destroy_all_obeys_keygen_retention_floor() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, dkg_key(3), ctx);
+
+    cert_submission::destroy_all_certs_for_testing(
+        &mut hashi,
+        3,
+        option::none(),
+        hashi::tob::protocol_type_dkg(),
+    );
+
+    abort
 }
 
 // ~~~~~~~ Bucket Draining ~~~~~~~

--- a/packages/hashi/tests/tob_pruning_tests.move
+++ b/packages/hashi/tests/tob_pruning_tests.move
@@ -1,0 +1,288 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module hashi::tob_pruning_tests;
+
+use hashi::{cert_submission, committee, hashi::Hashi, test_utils};
+use sui::bls12381;
+
+const VOTER1: address = @0x1;
+const VOTER2: address = @0x2;
+const VOTER3: address = @0x3;
+
+const CURRENT_EPOCH: u64 = 10;
+
+// ~~~~~~~ Helpers ~~~~~~~
+
+/// Hashi whose current committee epoch is `CURRENT_EPOCH`.
+fun hashi_at_current_epoch(ctx: &mut TxContext): Hashi {
+    test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx)
+}
+
+/// Register a (minimal) committee at `epoch` so `has_committee(epoch)` holds.
+fun insert_committee_at(hashi: &mut Hashi, epoch: u64) {
+    hashi.committee_set_mut().insert_committee_for_testing(committee_at(epoch));
+}
+
+fun committee_at(epoch: u64): committee::Committee {
+    let sk = test_utils::bls_sk_for_testing();
+    let public_key = bls12381::g1_to_uncompressed_g1(
+        &bls12381::g1_from_bytes(&test_utils::bls_min_pk_from_sk(&sk)),
+    );
+    let member = committee::new_committee_member(VOTER1, public_key, sk, 1);
+    committee::new_committee(
+        epoch,
+        vector[member],
+        hashi::mpc_config::new_for_testing(800, 3333, 0, 0),
+    )
+}
+
+fun dkg_key(epoch: u64): hashi::tob::TobKey {
+    hashi::tob::tob_key(epoch, option::none(), hashi::tob::protocol_type_dkg())
+}
+
+fun rotation_key(epoch: u64): hashi::tob::TobKey {
+    hashi::tob::tob_key(epoch, option::none(), hashi::tob::protocol_type_key_rotation())
+}
+
+fun nonce_key(epoch: u64, batch_index: u32): hashi::tob::TobKey {
+    hashi::tob::tob_key(
+        epoch,
+        option::some(batch_index),
+        hashi::tob::protocol_type_nonce_generation(),
+    )
+}
+
+/// Create an (empty) bucket at `key`, bypassing the submit path's
+/// current-or-pending epoch assert.
+fun add_bucket(hashi: &mut Hashi, key: hashi::tob::TobKey, ctx: &mut TxContext) {
+    hashi.epoch_certs(key, ctx);
+}
+
+// ~~~~~~~ Nonce Bucket Floors ~~~~~~~
+
+#[test]
+fun nonce_destroyed_at_exact_floor() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, nonce_key(8, 0), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
+
+    assert!(!hashi.tob_contains(nonce_key(8, 0)));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyNonceCerts)]
+fun nonce_below_floor_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, nonce_key(9, 0), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 9, 0);
+
+    abort
+}
+
+#[test]
+fun nonce_missing_bucket_is_noop() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 5, 3);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun nonce_destroy_targets_single_batch() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, nonce_key(8, 0), ctx);
+    add_bucket(&mut hashi, nonce_key(8, 1), ctx);
+    add_bucket(&mut hashi, nonce_key(8, 2), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 2);
+
+    assert!(hashi.tob_contains(nonce_key(8, 0)));
+    assert!(hashi.tob_contains(nonce_key(8, 1)));
+    assert!(!hashi.tob_contains(nonce_key(8, 2)));
+    std::unit_test::destroy(hashi);
+}
+
+/// Nonce buckets are only ever read during their own epoch, so — unlike
+/// key-generation buckets — the previous committee's epoch is fair game.
+#[test]
+fun nonce_previous_committee_epoch_prunable() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 2);
+    add_bucket(&mut hashi, nonce_key(2, 0), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 2, 0);
+
+    assert!(!hashi.tob_contains(nonce_key(2, 0)));
+    std::unit_test::destroy(hashi);
+}
+
+// ~~~~~~~ Key-Generation Bucket Floors ~~~~~~~
+
+/// Committee epochs are Sui epochs and can gap: with committees {2, 10}, the
+/// bucket at 2 clears the retention floor (10 >= 2 + 8) but belongs to the
+/// PREVIOUS committee, whose certs seed the next rotation. This is exactly
+/// the case a bare age floor gets wrong.
+#[test]
+#[expected_failure(abort_code = cert_submission::EKeyGenCertsStillNeeded)]
+fun keygen_gap_previous_committee_protected() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 2);
+    add_bucket(&mut hashi, rotation_key(2), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 2);
+
+    abort
+}
+
+#[test]
+fun keygen_destroyed_when_strictly_older_than_previous_committee() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 0);
+    insert_committee_at(&mut hashi, 2);
+    add_bucket(&mut hashi, dkg_key(0), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 0);
+
+    assert!(!hashi.tob_contains(dkg_key(0)));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyKeyGenCerts)]
+fun keygen_retention_floor_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 3);
+    insert_committee_at(&mut hashi, 5);
+    add_bucket(&mut hashi, rotation_key(3), ctx);
+
+    // 10 < 3 + 8: within the break-glass retention window.
+    cert_submission::destroy_key_gen_certs(&mut hashi, 3);
+
+    abort
+}
+
+#[test]
+fun keygen_retention_exact_boundary() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 2);
+    insert_committee_at(&mut hashi, 5);
+    add_bucket(&mut hashi, rotation_key(2), ctx);
+
+    // 10 == 2 + 8, and the committee at 5 lies strictly between.
+    cert_submission::destroy_key_gen_certs(&mut hashi, 2);
+
+    assert!(!hashi.tob_contains(rotation_key(2)));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun keygen_removes_both_dkg_and_rotation_and_is_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 0);
+    insert_committee_at(&mut hashi, 2);
+    add_bucket(&mut hashi, dkg_key(0), ctx);
+    add_bucket(&mut hashi, rotation_key(0), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 0);
+    assert!(!hashi.tob_contains(dkg_key(0)));
+    assert!(!hashi.tob_contains(rotation_key(0)));
+
+    // Second call finds nothing and must not abort.
+    cert_submission::destroy_key_gen_certs(&mut hashi, 0);
+
+    std::unit_test::destroy(hashi);
+}
+
+/// A pending committee's epoch is above the current epoch, so it can never
+/// stand in for "a committee strictly between the bucket and now".
+#[test]
+#[expected_failure(abort_code = cert_submission::EKeyGenCertsStillNeeded)]
+fun keygen_pending_committee_not_a_guard_satisfier() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 2);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(committee_at(12));
+    add_bucket(&mut hashi, rotation_key(2), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 2);
+
+    abort
+}
+
+/// A bucket being written for a pending epoch (mid-reconfig) sits above the
+/// current epoch and is untouchable by the retention floor.
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyKeyGenCerts)]
+fun keygen_pending_epoch_bucket_protected() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(committee_at(12));
+    add_bucket(&mut hashi, rotation_key(12), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 12);
+
+    abort
+}
+
+// ~~~~~~~ Bucket Draining ~~~~~~~
+
+#[test]
+fun destroy_drains_populated_bucket() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+
+    let key = nonce_key(8, 0);
+    let sig = hashi::committee::new_committee_signature(8, vector[], vector[]);
+    let dealers = vector[VOTER1, VOTER2, VOTER3];
+    dealers.do!(|dealer| {
+        let epoch_certs = hashi.epoch_certs(key, ctx);
+        hashi::tob::submit_cert_with_signature(epoch_certs, 8, dealer, vector[1u8, 2, 3], &sig);
+    });
+    add_bucket(&mut hashi, nonce_key(8, 1), ctx);
+    assert!(hashi.epoch_certs_ref(key).num_certs() == 3);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
+
+    assert!(!hashi.tob_contains(key));
+    assert!(hashi.tob_contains(nonce_key(8, 1)));
+    std::unit_test::destroy(hashi);
+}
+
+// ~~~~~~~ Committee Walk ~~~~~~~
+
+#[test]
+fun is_before_previous_committee_walk() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 0);
+    insert_committee_at(&mut hashi, 2);
+
+    // Committees at {0, 2, 10}: epochs 0 and 1 have the committee at 2
+    // strictly between them and now; everything from 2 upward does not.
+    let committee_set = hashi.committee_set();
+    assert!(committee_set.is_before_previous_committee(0));
+    assert!(committee_set.is_before_previous_committee(1));
+    let mut e = 2;
+    while (e <= CURRENT_EPOCH) {
+        assert!(!committee_set.is_before_previous_committee(e));
+        e = e + 1;
+    };
+
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/tob_pruning_tests.move
+++ b/packages/hashi/tests/tob_pruning_tests.move
@@ -1,0 +1,288 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module hashi::tob_pruning_tests;
+
+use hashi::{cert_submission, committee, hashi::Hashi, test_utils};
+use sui::bls12381;
+
+const VOTER1: address = @0x1;
+const VOTER2: address = @0x2;
+const VOTER3: address = @0x3;
+
+const CURRENT_EPOCH: u64 = 10;
+
+// ~~~~~~~ Helpers ~~~~~~~
+
+/// Hashi whose current committee epoch is `CURRENT_EPOCH`.
+fun hashi_at_current_epoch(ctx: &mut TxContext): Hashi {
+    test_utils::create_hashi_with_committee(vector[VOTER1, VOTER2, VOTER3], ctx)
+}
+
+/// Register a (minimal) committee at `epoch` so `has_committee(epoch)` holds.
+fun insert_committee_at(hashi: &mut Hashi, epoch: u64) {
+    hashi.committee_set_mut().insert_committee_for_testing(committee_at(epoch));
+}
+
+fun committee_at(epoch: u64): committee::Committee {
+    let sk = test_utils::bls_sk_for_testing();
+    let public_key = bls12381::g1_to_uncompressed_g1(
+        &bls12381::g1_from_bytes(&test_utils::bls_min_pk_from_sk(&sk)),
+    );
+    let member = committee::new_committee_member(VOTER1, public_key, sk, 1);
+    committee::new_committee(
+        epoch,
+        vector[member],
+        hashi::mpc_config::new_for_testing(3334, 800, 3333, 0),
+    )
+}
+
+fun dkg_key(epoch: u64): hashi::tob::TobKey {
+    hashi::tob::tob_key(epoch, option::none(), hashi::tob::protocol_type_dkg())
+}
+
+fun rotation_key(epoch: u64): hashi::tob::TobKey {
+    hashi::tob::tob_key(epoch, option::none(), hashi::tob::protocol_type_key_rotation())
+}
+
+fun nonce_key(epoch: u64, batch_index: u32): hashi::tob::TobKey {
+    hashi::tob::tob_key(
+        epoch,
+        option::some(batch_index),
+        hashi::tob::protocol_type_nonce_generation(),
+    )
+}
+
+/// Create an (empty) bucket at `key`, bypassing the submit path's
+/// current-or-pending epoch assert.
+fun add_bucket(hashi: &mut Hashi, key: hashi::tob::TobKey, ctx: &mut TxContext) {
+    hashi.epoch_certs(key, ctx);
+}
+
+// ~~~~~~~ Nonce Bucket Floors ~~~~~~~
+
+#[test]
+fun nonce_destroyed_at_exact_floor() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, nonce_key(8, 0), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
+
+    assert!(!hashi.tob_contains(nonce_key(8, 0)));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyNonceCerts)]
+fun nonce_below_floor_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, nonce_key(9, 0), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 9, 0);
+
+    abort
+}
+
+#[test]
+fun nonce_missing_bucket_is_noop() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 5, 3);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun nonce_destroy_targets_single_batch() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, nonce_key(8, 0), ctx);
+    add_bucket(&mut hashi, nonce_key(8, 1), ctx);
+    add_bucket(&mut hashi, nonce_key(8, 2), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 2);
+
+    assert!(hashi.tob_contains(nonce_key(8, 0)));
+    assert!(hashi.tob_contains(nonce_key(8, 1)));
+    assert!(!hashi.tob_contains(nonce_key(8, 2)));
+    std::unit_test::destroy(hashi);
+}
+
+/// Nonce buckets are only ever read during their own epoch, so — unlike
+/// key-generation buckets — the previous committee's epoch is fair game.
+#[test]
+fun nonce_previous_committee_epoch_prunable() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 2);
+    add_bucket(&mut hashi, nonce_key(2, 0), ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 2, 0);
+
+    assert!(!hashi.tob_contains(nonce_key(2, 0)));
+    std::unit_test::destroy(hashi);
+}
+
+// ~~~~~~~ Key-Generation Bucket Floors ~~~~~~~
+
+/// Committee epochs are Sui epochs and can gap: with committees {2, 10}, the
+/// bucket at 2 clears the retention floor (10 >= 2 + 8) but belongs to the
+/// PREVIOUS committee, whose certs seed the next rotation. This is exactly
+/// the case a bare age floor gets wrong.
+#[test]
+#[expected_failure(abort_code = cert_submission::EKeyGenCertsStillNeeded)]
+fun keygen_gap_previous_committee_protected() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 2);
+    add_bucket(&mut hashi, rotation_key(2), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 2);
+
+    abort
+}
+
+#[test]
+fun keygen_destroyed_when_strictly_older_than_previous_committee() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 0);
+    insert_committee_at(&mut hashi, 2);
+    add_bucket(&mut hashi, dkg_key(0), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 0);
+
+    assert!(!hashi.tob_contains(dkg_key(0)));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyKeyGenCerts)]
+fun keygen_retention_floor_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 3);
+    insert_committee_at(&mut hashi, 5);
+    add_bucket(&mut hashi, rotation_key(3), ctx);
+
+    // 10 < 3 + 8: within the break-glass retention window.
+    cert_submission::destroy_key_gen_certs(&mut hashi, 3);
+
+    abort
+}
+
+#[test]
+fun keygen_retention_exact_boundary() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 2);
+    insert_committee_at(&mut hashi, 5);
+    add_bucket(&mut hashi, rotation_key(2), ctx);
+
+    // 10 == 2 + 8, and the committee at 5 lies strictly between.
+    cert_submission::destroy_key_gen_certs(&mut hashi, 2);
+
+    assert!(!hashi.tob_contains(rotation_key(2)));
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun keygen_removes_both_dkg_and_rotation_and_is_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 0);
+    insert_committee_at(&mut hashi, 2);
+    add_bucket(&mut hashi, dkg_key(0), ctx);
+    add_bucket(&mut hashi, rotation_key(0), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 0);
+    assert!(!hashi.tob_contains(dkg_key(0)));
+    assert!(!hashi.tob_contains(rotation_key(0)));
+
+    // Second call finds nothing and must not abort.
+    cert_submission::destroy_key_gen_certs(&mut hashi, 0);
+
+    std::unit_test::destroy(hashi);
+}
+
+/// A pending committee's epoch is above the current epoch, so it can never
+/// stand in for "a committee strictly between the bucket and now".
+#[test]
+#[expected_failure(abort_code = cert_submission::EKeyGenCertsStillNeeded)]
+fun keygen_pending_committee_not_a_guard_satisfier() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 2);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(committee_at(12));
+    add_bucket(&mut hashi, rotation_key(2), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 2);
+
+    abort
+}
+
+/// A bucket being written for a pending epoch (mid-reconfig) sits above the
+/// current epoch and is untouchable by the retention floor.
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyKeyGenCerts)]
+fun keygen_pending_epoch_bucket_protected() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(committee_at(12));
+    add_bucket(&mut hashi, rotation_key(12), ctx);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 12);
+
+    abort
+}
+
+// ~~~~~~~ Bucket Draining ~~~~~~~
+
+#[test]
+fun destroy_drains_populated_bucket() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+
+    let key = nonce_key(8, 0);
+    let sig = hashi::committee::new_committee_signature(8, vector[], vector[]);
+    let dealers = vector[VOTER1, VOTER2, VOTER3];
+    dealers.do!(|dealer| {
+        let epoch_certs = hashi.epoch_certs(key, ctx);
+        hashi::tob::submit_cert_with_signature(epoch_certs, 8, dealer, vector[1u8, 2, 3], &sig);
+    });
+    add_bucket(&mut hashi, nonce_key(8, 1), ctx);
+    assert!(hashi.epoch_certs_ref(key).num_certs() == 3);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
+
+    assert!(!hashi.tob_contains(key));
+    assert!(hashi.tob_contains(nonce_key(8, 1)));
+    std::unit_test::destroy(hashi);
+}
+
+// ~~~~~~~ Committee Walk ~~~~~~~
+
+#[test]
+fun is_before_previous_committee_walk() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 0);
+    insert_committee_at(&mut hashi, 2);
+
+    // Committees at {0, 2, 10}: epochs 0 and 1 have the committee at 2
+    // strictly between them and now; everything from 2 upward does not.
+    let committee_set = hashi.committee_set();
+    assert!(committee_set.is_before_previous_committee(0));
+    assert!(committee_set.is_before_previous_committee(1));
+    let mut e = 2;
+    while (e <= CURRENT_EPOCH) {
+        assert!(!committee_set.is_before_previous_committee(e));
+        e = e + 1;
+    };
+
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/tob_pruning_tests.move
+++ b/packages/hashi/tests/tob_pruning_tests.move
@@ -240,6 +240,65 @@ fun keygen_pending_epoch_bucket_protected() {
     abort
 }
 
+/// The floors assert before the presence probe: a premature call must abort
+/// even when the bucket does not exist, so a too-early call can never
+/// silently "succeed".
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyNonceCerts)]
+fun nonce_below_floor_aborts_even_when_bucket_absent() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 9, 0);
+
+    abort
+}
+
+#[test]
+#[expected_failure(abort_code = cert_submission::ETooEarlyToDestroyKeyGenCerts)]
+fun keygen_below_floor_aborts_even_when_bucket_absent() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    insert_committee_at(&mut hashi, 5);
+
+    cert_submission::destroy_key_gen_certs(&mut hashi, 4);
+
+    abort
+}
+
+/// GC entries are deliberately not gated on pause or reconfig (see
+/// design/docs/move-model-lifecycle.mdx): dead state must stay sheddable
+/// during an emergency pause and mid-handoff.
+#[test]
+fun destroy_callable_while_paused_and_reconfiguring() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    add_bucket(&mut hashi, nonce_key(8, 0), ctx);
+    hashi.config_mut().set_paused(true);
+    hashi.committee_set_mut().set_pending_reconfig_for_testing(committee_at(12));
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
+
+    assert!(!hashi.tob_contains(nonce_key(8, 0)));
+    std::unit_test::destroy(hashi);
+}
+
+/// The destroy entries probe by STORED type: a bucket written under a
+/// different value layout (e.g. a future StampedEpochCertsV1) is left in
+/// place for the module version that understands it — no abort, no
+/// wrong-typed destruction.
+#[test]
+fun destroy_leaves_foreign_typed_bucket_in_place() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, CURRENT_EPOCH);
+    let mut hashi = hashi_at_current_epoch(ctx);
+    hashi.tob_mut().add(nonce_key(8, 0), 42u64);
+
+    cert_submission::destroy_nonce_certs(&mut hashi, 8, 0);
+
+    assert!(hashi.tob_contains(nonce_key(8, 0)));
+    std::unit_test::destroy(hashi);
+}
+
 // ~~~~~~~ Bucket Draining ~~~~~~~
 
 #[test]


### PR DESCRIPTION
## Problem

`Hashi.tob` grows without bound: per committee epoch it gains one key-generation bucket plus one nonce bucket per presig batch, each a Bag field + LinkedTable + ~78 dealer nodes. Nothing has ever removed them — `destroy_all_certs` has been uncallable since #757 demoted the `ProtocolType` constructors to `public(package)` (a Move enum cannot be a PTB pure argument), and no off-chain caller ever existed. The bag is also paged in full on every node bootstrap (`scrape_tob_entries`), so growth is a startup cost too.

## Change

Two new primitive-argument, permissionless GC entries mirroring the `submit_*` split, gated (per the GC convention) only on the version check:

- **`destroy_nonce_certs(epoch, batch_index)`** — floor `current >= epoch + 2`. Nonce buckets are only ever read during their own epoch (presigs are strictly single-epoch; local nonce state is flat-pruned at the boundary), so +2 has a full epoch of margin.
- **`destroy_key_gen_certs(epoch)`** — probes both the Dkg and KeyRotation keys, so callers never need to know whether an epoch was genesis or a rotation. Two floors, both required:
  - `current >= epoch + 8`: node DBs retain dealer/rotation messages for the trailing 7 epochs specifically so break-glass key recovery (`internal-tools/key_recovery`) can pair them with the on-chain bucket. Destruction is permissionless, so this window must be enforced on-chain — driver policy alone cannot protect it.
  - `committee_set::is_before_previous_committee(epoch)`: committee epochs are Sui epochs (`ctx.epoch()`) and can gap, so the previous committee can sit at `current − k`, k ≥ 2. Its key-generation bucket seeds the next rotation (`fetch_key_generation_certificates(previous_epoch)` hard-errors if absent), so a bare age floor would let anyone brick the next reconfig. The guard requires a committee epoch strictly between the bucket and now; the walk is bounded by the current↔previous gap.

Both entries no-op on an eligible-but-absent bucket (batched GC transactions and permissionless racers cannot poison each other) but assert the floors unconditionally, so a premature call can never silently succeed. Removal probes by **stored type** (`contains_with_type<TobKey, EpochCertsV1>`), leaving any future bucket layout in place for the version that understands it — the extension point the stamped-cert work (#953) needs, avoiding the bare-bucket-stranding hazard found in its review.

`tob::destroy_all`'s `+2` assert stays as defense-in-depth; the dead `destroy_all_certs` entry is left untouched.

## Tests

18 new tests in `tob_pruning_tests.move`: floor boundaries (exact and one-below, with and without the bucket present), the gap scenario (committees {2,10} — retention passes, committee guard aborts), pending-reconfig cases (pending committee neither satisfies the guard nor is destroyable), both-buckets destruction + idempotency, foreign-typed bucket left in place, callability while paused and mid-reconfig, populated-bucket drain, and direct walk checks.

The entries ride v2 (`PACKAGE_VERSION = 2`) and gate on `versioning().assert_version_enabled()`; this PR adds **no** version-framework plumbing (that lives in #1026, now merged into main) and bumps nothing — `version_policy_tests` and `move_upgrade_compat` pass unchanged.

## Stacking

Based on `main` (the version-framework enablement + shared linkage helpers were extracted to #1026 and merged). This is the base of the TOB pruning stack; the Rust driver that feeds these entries through the leader GC loop is #1002, stacked directly on this PR.