### PR TITLE
rust: leader GC job pruning dead TOB cert buckets

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -186,7 +186,8 @@ pub struct Hashi {
     pub versioning: Versioning,
     pub treasury: Treasury,
     pub proposals: Proposals,
-    /// TOB certificates by (epoch, batch_index) -> EpochCertsV1
+    /// TOB certificates by (epoch, batch_index, protocol_type). Values are
+    /// bare `EpochCertsV1` buckets or, for nonce certs, `StampedEpochCertsV1`.
     pub tob: Bag,
     /// Number of presignatures consumed in the current epoch.
     pub num_consumed_presigs: u64,

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -111,6 +111,11 @@ const MAINTENANCE_CF_NAME: &str = "maintenance";
 
 const MAINTENANCE_COMPACTION_KEY: &[u8] = b"last_compaction";
 
+/// Epochs of dealer/rotation material kept behind the committee-epoch cutoff
+/// (the previous committee's epoch is additionally exempt from pruning). Must
+/// stay strictly below the on-chain `KEY_GEN_CERT_RETENTION_EPOCHS` (8) in
+/// `cert_submission.move`: every epoch whose payloads may still exist in a
+/// policy-following DB must keep its cert bucket on-chain.
 const RETENTION_EXTRA_EPOCHS: u64 = 7;
 
 /// Outcome of compacting one keyspace, for logging and metrics.

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -4,6 +4,8 @@
 //! Garbage collection for expired on-chain data.
 
 use super::LeaderService;
+use crate::onchain::TobKey;
+use crate::onchain::TobPruneTarget;
 use crate::onchain::types::DepositRequest;
 use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
@@ -12,6 +14,7 @@ use crate::onchain::types::UtxoRecord;
 use crate::sui_tx_executor::ArchiveVictim;
 use crate::sui_tx_executor::SuiTxExecutor;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_sdk_types::Address;
@@ -36,6 +39,29 @@ const MAX_PROPOSAL_DELETIONS_PER_GC: usize = 500;
 // Cap the orphan scan so one cleanup task stays bounded; a larger backlog
 // drains over successive checkpoints. Mirrors the two caps above.
 const MAX_UTXO_CLEANUPS_PER_GC: usize = 500;
+
+// Cap how many TOB cert buckets one prune sweep destroys. Lower than the
+// caps above because each destroyed bucket is much heavier than one deleted
+// record: it drains a whole LinkedTable (~80 object deletions on a full
+// committee), so the per-transaction chunk in
+// `execute_destroy_tob_certs` is small and a sweep is several transactions.
+// A larger backlog drains over successive sweeps, oldest epochs first.
+const MAX_TOB_PRUNES_PER_GC: usize = 200;
+
+/// Mirror of the Move floors in `cert_submission.move`. The Move asserts are
+/// authoritative — drift here only produces aborting GC transactions, never
+/// an unsafe delete. Key-generation buckets are retained longer than the
+/// `tob::destroy_all` minimum because break-glass key recovery pairs them
+/// with the local DB's dealer/rotation messages (kept for the trailing 7
+/// epochs).
+const KEY_GEN_CERT_RETENTION_EPOCHS: u64 = 8;
+/// Nonce buckets are only ever read during their own epoch; +2 mirrors
+/// `tob::destroy_all`'s backstop.
+const NONCE_CERT_MIN_AGE_EPOCHS: u64 = 2;
+
+/// The destroy entries are v2-introduced; hold the prune job off until the
+/// active on-chain version carries them.
+const TOB_PRUNE_MIN_PACKAGE_VERSION: u64 = 2;
 
 /// Failure kind for the UTXO cleanup GC. `max_retries` is unbounded: this is
 /// a singleton maintenance task that must never permanently give up (a
@@ -87,6 +113,41 @@ impl crate::leader::retry::RetryPolicy for WithdrawalArchiveErrorKind {
     fn max_retries(self) -> u32 {
         u32::MAX
     }
+}
+
+/// Failure kind for the TOB cert prune GC. Same unbounded-retry rationale as
+/// [`UtxoCleanupErrorKind`]: singleton maintenance that must never
+/// permanently give up.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum TobPruneErrorKind {
+    Failed,
+}
+
+impl crate::leader::retry::RetryPolicy for TobPruneErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        5_000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        5 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
+    }
+}
+
+/// Result of one TOB prune sweep, consumed by the leader loop's reap arm.
+#[derive(Debug)]
+pub(super) struct TobPruneOutcome {
+    /// The hashi epoch captured when the sweep was spawned; advances the
+    /// once-per-epoch gate. Captured at spawn so an epoch flip mid-sweep
+    /// cannot mask the new epoch's work.
+    pub(super) swept_epoch: u64,
+    /// Whether the sweep selected fewer buckets than its cap — i.e. the
+    /// backlog is fully drained and the gate may close until the epoch
+    /// advances.
+    pub(super) drained: bool,
 }
 
 impl LeaderService {
@@ -545,6 +606,95 @@ impl LeaderService {
         );
         Ok(())
     }
+
+    /// If the hashi epoch has advanced since the last fully-drained sweep
+    /// and no task is in-flight, spawn a background task that lists the TOB
+    /// bag and destroys every dead cert bucket. Epoch-gated rather than
+    /// timestamp-gated because eligibility only changes at epoch boundaries
+    /// and candidate discovery is a live RPC bag listing, not a mirror read;
+    /// the gate is only advanced by a sweep that drained the backlog, so a
+    /// cap-limited sweep re-runs on the next leader checkpoint.
+    pub(super) fn check_prune_tob_certs(&mut self, checkpoint_timestamp_ms: u64) {
+        if self.tob_prune_task.is_some() {
+            debug!("TOB prune task already in-flight, skipping");
+            return;
+        }
+
+        // The destroy entries are v2-introduced. Gating on the ACTIVE version
+        // (not merely the latest published) also keeps the sweep off a chain
+        // whose semantics this binary does not implement.
+        let Some(active) = self.inner.onchain_state().active_package_version() else {
+            return;
+        };
+        if active < TOB_PRUNE_MIN_PACKAGE_VERSION {
+            return;
+        }
+
+        let current_epoch = self.inner.onchain_state().epoch();
+        if self.last_tob_prune_epoch == Some(current_epoch) {
+            return;
+        }
+
+        if self.tob_prune_retry.should_skip(checkpoint_timestamp_ms) {
+            debug!("TOB prune GC in backoff, skipping");
+            return;
+        }
+
+        let inner = self.inner.clone();
+        self.tob_prune_task = Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
+            Self::prune_tob_certs(inner, current_epoch).await
+        })));
+    }
+
+    /// List the TOB bag, select dead buckets, and destroy them on-chain.
+    ///
+    /// Freshness: the listing is a live RPC read; the committee epochs and
+    /// current epoch come from the mirror, which can only lag the chain. A
+    /// lagging epoch shrinks both floors and a missing recent committee only
+    /// disables key-generation selections, so staleness is strictly
+    /// conservative — and the Move floors re-check against the authoritative
+    /// on-chain epoch at execution regardless. Races with another pruner are
+    /// absorbed by the entries' missing-bucket idempotency.
+    async fn prune_tob_certs(
+        inner: Arc<crate::Hashi>,
+        swept_epoch: u64,
+    ) -> anyhow::Result<TobPruneOutcome> {
+        let keys = inner.onchain_state().list_tob_keys().await?;
+        let (committee_epochs, current_epoch) = {
+            let state = inner.onchain_state().state();
+            let committees = &state.hashi().committees;
+            (
+                committees.committees().keys().copied().collect(),
+                committees.epoch(),
+            )
+        };
+        let targets = find_tob_buckets_to_prune(&keys, &committee_epochs, current_epoch);
+        if targets.is_empty() {
+            debug!("No TOB cert buckets eligible for pruning");
+            return Ok(TobPruneOutcome {
+                swept_epoch,
+                drained: true,
+            });
+        }
+
+        // Whether more work may remain past the cap, decided before the
+        // destroy so a partially-failed batch also re-runs via the retry path.
+        let drained = targets.len() < MAX_TOB_PRUNES_PER_GC;
+        info!(
+            bucket_count = targets.len(),
+            drained, "Destroying dead TOB cert bucket(s)"
+        );
+        let mut executor = SuiTxExecutor::from_hashi(inner)?;
+        executor.execute_destroy_tob_certs(&targets).await?;
+        info!(
+            bucket_count = targets.len(),
+            "Successfully destroyed dead TOB cert buckets"
+        );
+        Ok(TobPruneOutcome {
+            swept_epoch,
+            drained,
+        })
+    }
 }
 
 fn deposit_request_expiration_timestamp_ms(request: &DepositRequest) -> u64 {
@@ -635,6 +785,94 @@ fn find_confirmed_withdrawals_pending_archive(
             request_ids: txn.request_ids.clone(),
         })
         .collect()
+}
+
+/// Select the TOB cert buckets that are safe to destroy, mirroring the Move
+/// floors (which remain authoritative):
+///
+/// - Nonce buckets: `current_epoch >= epoch + 2`; only ever read during
+///   their own epoch.
+/// - Key-generation buckets: `current_epoch >= epoch + 8` (break-glass
+///   retention) AND a committee epoch strictly between the bucket's and now.
+///   Committee epochs are Sui epochs and can gap, and the previous
+///   committee's certs seed the next rotation, so an age floor alone cannot
+///   identify the previous committee's bucket. A pending committee's epoch
+///   sits above `current_epoch` and is excluded by the exclusive range
+///   bound.
+/// - Any other key shape is left alone: never destroy what we don't
+///   understand.
+///
+/// Output order: epochs ascending (oldest first); within an epoch the
+/// key-generation target first, then nonce batches DESCENDING by index, so
+/// truncation at [`MAX_TOB_PRUNES_PER_GC`] always leaves a partially-drained
+/// epoch's surviving batches as a contiguous `0..m` prefix (in-epoch presig
+/// recovery walks batches from 0 and stops at the first hole; dead epochs no
+/// longer need that, but the discipline costs nothing).
+///
+/// Pure-data core, extracted for unit testing like
+/// [`find_spent_utxos_pending_cleanup`].
+fn find_tob_buckets_to_prune(
+    keys: &[TobKey],
+    committee_epochs: &BTreeSet<u64>,
+    current_epoch: u64,
+) -> Vec<TobPruneTarget> {
+    use hashi_types::move_types::ProtocolType;
+
+    // Saturating arithmetic throughout: key epochs come from on-chain field
+    // names anyone can shape, and an overflow panic here would kill the
+    // leader's prune task.
+    let mut keygen_epochs: BTreeSet<u64> = BTreeSet::new();
+    let mut nonce_batches: BTreeMap<u64, BTreeSet<u32>> = BTreeMap::new();
+    for key in keys {
+        match (key.protocol_type, key.batch_index) {
+            (ProtocolType::Dkg | ProtocolType::KeyRotation, None) => {
+                // The bound check both encodes "strictly between" and keeps
+                // `range` from panicking on start > end for absurd epochs.
+                let lower = key.epoch.saturating_add(1);
+                let strictly_between = lower < current_epoch
+                    && committee_epochs
+                        .range(lower..current_epoch)
+                        .next()
+                        .is_some();
+                if current_epoch >= key.epoch.saturating_add(KEY_GEN_CERT_RETENTION_EPOCHS)
+                    && strictly_between
+                {
+                    keygen_epochs.insert(key.epoch);
+                }
+            }
+            (ProtocolType::NonceGeneration, Some(batch_index))
+                if current_epoch >= key.epoch.saturating_add(NONCE_CERT_MIN_AGE_EPOCHS) =>
+            {
+                nonce_batches
+                    .entry(key.epoch)
+                    .or_default()
+                    .insert(batch_index);
+            }
+            _ => {}
+        }
+    }
+
+    let epochs: BTreeSet<u64> = keygen_epochs
+        .iter()
+        .chain(nonce_batches.keys())
+        .copied()
+        .collect();
+    let mut targets = Vec::new();
+    for epoch in epochs {
+        if keygen_epochs.contains(&epoch) {
+            targets.push(TobPruneTarget::KeyGen { epoch });
+        }
+        if let Some(batches) = nonce_batches.get(&epoch) {
+            targets.extend(
+                batches
+                    .iter()
+                    .rev()
+                    .map(|&batch_index| TobPruneTarget::NonceBatch { epoch, batch_index }),
+            );
+        }
+    }
+    targets.truncate(MAX_TOB_PRUNES_PER_GC);
+    targets
 }
 
 #[cfg(test)]
@@ -831,5 +1069,214 @@ mod tests {
             withdrawal_txn(1, false),
             withdrawal_txn(2, true),
         ]));
+    }
+
+    // ~~~~~~~ find_tob_buckets_to_prune ~~~~~~~
+
+    use hashi_types::move_types::ProtocolType;
+
+    fn nonce_key(epoch: u64, batch_index: u32) -> TobKey {
+        TobKey {
+            epoch,
+            batch_index: Some(batch_index),
+            protocol_type: ProtocolType::NonceGeneration,
+        }
+    }
+
+    fn keygen_key(epoch: u64, protocol_type: ProtocolType) -> TobKey {
+        TobKey {
+            epoch,
+            batch_index: None,
+            protocol_type,
+        }
+    }
+
+    fn epochs(list: &[u64]) -> BTreeSet<u64> {
+        list.iter().copied().collect()
+    }
+
+    #[test]
+    fn nonce_floor_is_exactly_two_epochs() {
+        let keys = [nonce_key(8, 0), nonce_key(9, 0)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[2, 10]), 10);
+        assert_eq!(
+            targets,
+            vec![TobPruneTarget::NonceBatch {
+                epoch: 8,
+                batch_index: 0
+            }]
+        );
+    }
+
+    #[test]
+    fn keygen_within_retention_kept() {
+        // current-7 clears the committee guard (committee at 5 strictly
+        // between) but sits inside the break-glass retention window.
+        let keys = [keygen_key(3, ProtocolType::KeyRotation)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[3, 5, 10]), 10);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn keygen_requires_committee_strictly_between() {
+        // Gap scenario: committees {2, 10} — the bucket at 2 belongs to the
+        // PREVIOUS committee even though it clears the age floor, so it must
+        // be kept. With a committee at 0 below it, the bucket at 0 goes.
+        let keys = [keygen_key(2, ProtocolType::KeyRotation)];
+        assert!(find_tob_buckets_to_prune(&keys, &epochs(&[2, 10]), 10).is_empty());
+
+        let keys = [
+            keygen_key(0, ProtocolType::Dkg),
+            keygen_key(2, ProtocolType::KeyRotation),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert_eq!(targets, vec![TobPruneTarget::KeyGen { epoch: 0 }]);
+    }
+
+    #[test]
+    fn keygen_selected_at_exact_retention_boundary() {
+        // current == epoch + KEY_GEN_CERT_RETENTION_EPOCHS is the first
+        // eligible epoch; one below is not.
+        let keys = [keygen_key(2, ProtocolType::KeyRotation)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[2, 5, 10]), 10);
+        assert_eq!(targets, vec![TobPruneTarget::KeyGen { epoch: 2 }]);
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[2, 5, 9]), 9);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn keygen_committee_at_exactly_epoch_plus_one_satisfies_guard() {
+        // Pins the inclusive lower bound of the strictly-between range: a
+        // committee at bucket_epoch + 1 is enough.
+        let keys = [keygen_key(2, ProtocolType::KeyRotation)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[3, 10]), 10);
+        assert_eq!(targets, vec![TobPruneTarget::KeyGen { epoch: 2 }]);
+    }
+
+    #[test]
+    fn keygen_pending_committee_does_not_satisfy_guard() {
+        // A pending committee (epoch 12 > current 10) is in the committee
+        // set but must not stand in for "strictly between".
+        let keys = [keygen_key(2, ProtocolType::KeyRotation)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[2, 10, 12]), 10);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn current_and_pending_epoch_buckets_never_selected() {
+        let keys = [
+            nonce_key(10, 0),
+            nonce_key(12, 0),
+            keygen_key(10, ProtocolType::KeyRotation),
+            keygen_key(12, ProtocolType::KeyRotation),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10, 12]), 10);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn ordering_oldest_epoch_first_nonce_batches_descending() {
+        let keys = [
+            nonce_key(3, 0),
+            nonce_key(3, 1),
+            nonce_key(0, 2),
+            nonce_key(0, 0),
+            nonce_key(0, 1),
+            keygen_key(0, ProtocolType::Dkg),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert_eq!(
+            targets,
+            vec![
+                TobPruneTarget::KeyGen { epoch: 0 },
+                TobPruneTarget::NonceBatch {
+                    epoch: 0,
+                    batch_index: 2
+                },
+                TobPruneTarget::NonceBatch {
+                    epoch: 0,
+                    batch_index: 1
+                },
+                TobPruneTarget::NonceBatch {
+                    epoch: 0,
+                    batch_index: 0
+                },
+                TobPruneTarget::NonceBatch {
+                    epoch: 3,
+                    batch_index: 1
+                },
+                TobPruneTarget::NonceBatch {
+                    epoch: 3,
+                    batch_index: 0
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn cap_truncation_leaves_contiguous_prefix() {
+        // One epoch with more batches than the cap: the selected batches are
+        // the HIGHEST indices, so the survivors are exactly 0..m.
+        let keys: Vec<TobKey> = (0..MAX_TOB_PRUNES_PER_GC as u32 + 7)
+            .map(|i| nonce_key(1, i))
+            .collect();
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[1, 10]), 10);
+        assert_eq!(targets.len(), MAX_TOB_PRUNES_PER_GC);
+        let selected: BTreeSet<u32> = targets
+            .iter()
+            .map(|t| match t {
+                TobPruneTarget::NonceBatch { batch_index, .. } => *batch_index,
+                other => panic!("unexpected target {other:?}"),
+            })
+            .collect();
+        let expected: BTreeSet<u32> = (7..MAX_TOB_PRUNES_PER_GC as u32 + 7).collect();
+        assert_eq!(selected, expected);
+    }
+
+    #[test]
+    fn dkg_and_rotation_same_epoch_dedupe_to_one_keygen_target() {
+        let keys = [
+            keygen_key(0, ProtocolType::Dkg),
+            keygen_key(0, ProtocolType::KeyRotation),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert_eq!(targets, vec![TobPruneTarget::KeyGen { epoch: 0 }]);
+    }
+
+    #[test]
+    fn malformed_key_shapes_skipped() {
+        // Nonce without a batch index, keygen with one: shapes the writers
+        // never produce. Never destroy what we don't understand.
+        let keys = [
+            TobKey {
+                epoch: 0,
+                batch_index: None,
+                protocol_type: ProtocolType::NonceGeneration,
+            },
+            TobKey {
+                epoch: 0,
+                batch_index: Some(1),
+                protocol_type: ProtocolType::Dkg,
+            },
+            TobKey {
+                epoch: 0,
+                batch_index: Some(1),
+                protocol_type: ProtocolType::KeyRotation,
+            },
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn absurd_epochs_do_not_panic() {
+        // Field names are attacker-shapeable; saturating arithmetic must
+        // hold at the extremes.
+        let keys = [
+            nonce_key(u64::MAX, 0),
+            keygen_key(u64::MAX, ProtocolType::Dkg),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert!(targets.is_empty());
     }
 }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -4,6 +4,8 @@
 //! Garbage collection for expired on-chain data.
 
 use super::LeaderService;
+use crate::onchain::TobKey;
+use crate::onchain::TobPruneTarget;
 use crate::onchain::types::DepositRequest;
 use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
@@ -11,6 +13,7 @@ use crate::onchain::types::UtxoId;
 use crate::onchain::types::UtxoRecord;
 use crate::sui_tx_executor::SuiTxExecutor;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_sdk_types::Address;
@@ -36,6 +39,29 @@ const MAX_PROPOSAL_DELETIONS_PER_GC: usize = 500;
 // drains over successive checkpoints. Mirrors the two caps above.
 const MAX_UTXO_CLEANUPS_PER_GC: usize = 500;
 
+// Cap how many TOB cert buckets one prune sweep destroys. Lower than the
+// caps above because each destroyed bucket is much heavier than one deleted
+// record: it drains a whole LinkedTable (~80 object deletions on a full
+// committee), so the per-transaction chunk in
+// `execute_destroy_tob_certs` is small and a sweep is several transactions.
+// A larger backlog drains over successive sweeps, oldest epochs first.
+const MAX_TOB_PRUNES_PER_GC: usize = 200;
+
+/// Mirror of the Move floors in `cert_submission.move`. The Move asserts are
+/// authoritative — drift here only produces aborting GC transactions, never
+/// an unsafe delete. Key-generation buckets are retained longer than the
+/// `tob::destroy_all` minimum because break-glass key recovery pairs them
+/// with the local DB's dealer/rotation messages (kept for the trailing 7
+/// epochs).
+const KEY_GEN_CERT_RETENTION_EPOCHS: u64 = 8;
+/// Nonce buckets are only ever read during their own epoch; +2 mirrors
+/// `tob::destroy_all`'s backstop.
+const NONCE_CERT_MIN_AGE_EPOCHS: u64 = 2;
+
+/// The destroy entries are v2-introduced; hold the prune job off until the
+/// active on-chain version carries them.
+const TOB_PRUNE_MIN_PACKAGE_VERSION: u64 = 2;
+
 /// Failure kind for the UTXO cleanup GC. `max_retries` is unbounded: this is
 /// a singleton maintenance task that must never permanently give up (a
 /// drained gas wallet can heal by top-up), so it backs off to `max_delay_ms`
@@ -57,6 +83,41 @@ impl crate::leader::retry::RetryPolicy for UtxoCleanupErrorKind {
     fn max_retries(self) -> u32 {
         u32::MAX
     }
+}
+
+/// Failure kind for the TOB cert prune GC. Same unbounded-retry rationale as
+/// [`UtxoCleanupErrorKind`]: singleton maintenance that must never
+/// permanently give up.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum TobPruneErrorKind {
+    Failed,
+}
+
+impl crate::leader::retry::RetryPolicy for TobPruneErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        5_000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        5 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
+    }
+}
+
+/// Result of one TOB prune sweep, consumed by the leader loop's reap arm.
+#[derive(Debug)]
+pub(super) struct TobPruneOutcome {
+    /// The hashi epoch captured when the sweep was spawned; advances the
+    /// once-per-epoch gate. Captured at spawn so an epoch flip mid-sweep
+    /// cannot mask the new epoch's work.
+    pub(super) swept_epoch: u64,
+    /// Whether the sweep selected fewer buckets than its cap — i.e. the
+    /// backlog is fully drained and the gate may close until the epoch
+    /// advances.
+    pub(super) drained: bool,
 }
 
 impl LeaderService {
@@ -374,6 +435,95 @@ impl LeaderService {
         );
         Ok(())
     }
+
+    /// If the hashi epoch has advanced since the last fully-drained sweep
+    /// and no task is in-flight, spawn a background task that lists the TOB
+    /// bag and destroys every dead cert bucket. Epoch-gated rather than
+    /// timestamp-gated because eligibility only changes at epoch boundaries
+    /// and candidate discovery is a live RPC bag listing, not a mirror read;
+    /// the gate is only advanced by a sweep that drained the backlog, so a
+    /// cap-limited sweep re-runs on the next leader checkpoint.
+    pub(super) fn check_prune_tob_certs(&mut self, checkpoint_timestamp_ms: u64) {
+        if self.tob_prune_task.is_some() {
+            debug!("TOB prune task already in-flight, skipping");
+            return;
+        }
+
+        // The destroy entries are v2-introduced. Gating on the ACTIVE version
+        // (not merely the latest published) also keeps the sweep off a chain
+        // whose semantics this binary does not implement.
+        let Some(active) = self.inner.onchain_state().active_package_version() else {
+            return;
+        };
+        if active < TOB_PRUNE_MIN_PACKAGE_VERSION {
+            return;
+        }
+
+        let current_epoch = self.inner.onchain_state().epoch();
+        if self.last_tob_prune_epoch == Some(current_epoch) {
+            return;
+        }
+
+        if self.tob_prune_retry.should_skip(checkpoint_timestamp_ms) {
+            debug!("TOB prune GC in backoff, skipping");
+            return;
+        }
+
+        let inner = self.inner.clone();
+        self.tob_prune_task = Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
+            Self::prune_tob_certs(inner, current_epoch).await
+        })));
+    }
+
+    /// List the TOB bag, select dead buckets, and destroy them on-chain.
+    ///
+    /// Freshness: the listing is a live RPC read; the committee epochs and
+    /// current epoch come from the mirror, which can only lag the chain. A
+    /// lagging epoch shrinks both floors and a missing recent committee only
+    /// disables key-generation selections, so staleness is strictly
+    /// conservative — and the Move floors re-check against the authoritative
+    /// on-chain epoch at execution regardless. Races with another pruner are
+    /// absorbed by the entries' missing-bucket idempotency.
+    async fn prune_tob_certs(
+        inner: Arc<crate::Hashi>,
+        swept_epoch: u64,
+    ) -> anyhow::Result<TobPruneOutcome> {
+        let keys = inner.onchain_state().list_tob_keys().await?;
+        let (committee_epochs, current_epoch) = {
+            let state = inner.onchain_state().state();
+            let committees = &state.hashi().committees;
+            (
+                committees.committees().keys().copied().collect(),
+                committees.epoch(),
+            )
+        };
+        let targets = find_tob_buckets_to_prune(&keys, &committee_epochs, current_epoch);
+        if targets.is_empty() {
+            debug!("No TOB cert buckets eligible for pruning");
+            return Ok(TobPruneOutcome {
+                swept_epoch,
+                drained: true,
+            });
+        }
+
+        // Whether more work may remain past the cap, decided before the
+        // destroy so a partially-failed batch also re-runs via the retry path.
+        let drained = targets.len() < MAX_TOB_PRUNES_PER_GC;
+        info!(
+            bucket_count = targets.len(),
+            drained, "Destroying dead TOB cert bucket(s)"
+        );
+        let mut executor = SuiTxExecutor::from_hashi(inner)?;
+        executor.execute_destroy_tob_certs(&targets).await?;
+        info!(
+            bucket_count = targets.len(),
+            "Successfully destroyed dead TOB cert buckets"
+        );
+        Ok(TobPruneOutcome {
+            swept_epoch,
+            drained,
+        })
+    }
 }
 
 /// Return UTXO IDs whose `spent_epoch` is set — these are spent UTXOs
@@ -390,6 +540,94 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
         .map(|(id, _)| *id)
         .take(MAX_UTXO_CLEANUPS_PER_GC)
         .collect()
+}
+
+/// Select the TOB cert buckets that are safe to destroy, mirroring the Move
+/// floors (which remain authoritative):
+///
+/// - Nonce buckets: `current_epoch >= epoch + 2`; only ever read during
+///   their own epoch.
+/// - Key-generation buckets: `current_epoch >= epoch + 8` (break-glass
+///   retention) AND a committee epoch strictly between the bucket's and now.
+///   Committee epochs are Sui epochs and can gap, and the previous
+///   committee's certs seed the next rotation, so an age floor alone cannot
+///   identify the previous committee's bucket. A pending committee's epoch
+///   sits above `current_epoch` and is excluded by the exclusive range
+///   bound.
+/// - Any other key shape is left alone: never destroy what we don't
+///   understand.
+///
+/// Output order: epochs ascending (oldest first); within an epoch the
+/// key-generation target first, then nonce batches DESCENDING by index, so
+/// truncation at [`MAX_TOB_PRUNES_PER_GC`] always leaves a partially-drained
+/// epoch's surviving batches as a contiguous `0..m` prefix (in-epoch presig
+/// recovery walks batches from 0 and stops at the first hole; dead epochs no
+/// longer need that, but the discipline costs nothing).
+///
+/// Pure-data core, extracted for unit testing like
+/// [`find_spent_utxos_pending_cleanup`].
+fn find_tob_buckets_to_prune(
+    keys: &[TobKey],
+    committee_epochs: &BTreeSet<u64>,
+    current_epoch: u64,
+) -> Vec<TobPruneTarget> {
+    use hashi_types::move_types::ProtocolType;
+
+    // Saturating arithmetic throughout: key epochs come from on-chain field
+    // names anyone can shape, and an overflow panic here would kill the
+    // leader's prune task.
+    let mut keygen_epochs: BTreeSet<u64> = BTreeSet::new();
+    let mut nonce_batches: BTreeMap<u64, BTreeSet<u32>> = BTreeMap::new();
+    for key in keys {
+        match (key.protocol_type, key.batch_index) {
+            (ProtocolType::Dkg | ProtocolType::KeyRotation, None) => {
+                // The bound check both encodes "strictly between" and keeps
+                // `range` from panicking on start > end for absurd epochs.
+                let lower = key.epoch.saturating_add(1);
+                let strictly_between = lower < current_epoch
+                    && committee_epochs
+                        .range(lower..current_epoch)
+                        .next()
+                        .is_some();
+                if current_epoch >= key.epoch.saturating_add(KEY_GEN_CERT_RETENTION_EPOCHS)
+                    && strictly_between
+                {
+                    keygen_epochs.insert(key.epoch);
+                }
+            }
+            (ProtocolType::NonceGeneration, Some(batch_index))
+                if current_epoch >= key.epoch.saturating_add(NONCE_CERT_MIN_AGE_EPOCHS) =>
+            {
+                nonce_batches
+                    .entry(key.epoch)
+                    .or_default()
+                    .insert(batch_index);
+            }
+            _ => {}
+        }
+    }
+
+    let epochs: BTreeSet<u64> = keygen_epochs
+        .iter()
+        .chain(nonce_batches.keys())
+        .copied()
+        .collect();
+    let mut targets = Vec::new();
+    for epoch in epochs {
+        if keygen_epochs.contains(&epoch) {
+            targets.push(TobPruneTarget::KeyGen { epoch });
+        }
+        if let Some(batches) = nonce_batches.get(&epoch) {
+            targets.extend(
+                batches
+                    .iter()
+                    .rev()
+                    .map(|&batch_index| TobPruneTarget::NonceBatch { epoch, batch_index }),
+            );
+        }
+    }
+    targets.truncate(MAX_TOB_PRUNES_PER_GC);
+    targets
 }
 
 #[cfg(test)]
@@ -485,5 +723,214 @@ mod tests {
 
         let result = find_spent_utxos_pending_cleanup(&utxo_records);
         assert_eq!(result.len(), MAX_UTXO_CLEANUPS_PER_GC);
+    }
+
+    // ~~~~~~~ find_tob_buckets_to_prune ~~~~~~~
+
+    use hashi_types::move_types::ProtocolType;
+
+    fn nonce_key(epoch: u64, batch_index: u32) -> TobKey {
+        TobKey {
+            epoch,
+            batch_index: Some(batch_index),
+            protocol_type: ProtocolType::NonceGeneration,
+        }
+    }
+
+    fn keygen_key(epoch: u64, protocol_type: ProtocolType) -> TobKey {
+        TobKey {
+            epoch,
+            batch_index: None,
+            protocol_type,
+        }
+    }
+
+    fn epochs(list: &[u64]) -> BTreeSet<u64> {
+        list.iter().copied().collect()
+    }
+
+    #[test]
+    fn nonce_floor_is_exactly_two_epochs() {
+        let keys = [nonce_key(8, 0), nonce_key(9, 0)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[2, 10]), 10);
+        assert_eq!(
+            targets,
+            vec![TobPruneTarget::NonceBatch {
+                epoch: 8,
+                batch_index: 0
+            }]
+        );
+    }
+
+    #[test]
+    fn keygen_within_retention_kept() {
+        // current-7 clears the committee guard (committee at 5 strictly
+        // between) but sits inside the break-glass retention window.
+        let keys = [keygen_key(3, ProtocolType::KeyRotation)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[3, 5, 10]), 10);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn keygen_requires_committee_strictly_between() {
+        // Gap scenario: committees {2, 10} — the bucket at 2 belongs to the
+        // PREVIOUS committee even though it clears the age floor, so it must
+        // be kept. With a committee at 0 below it, the bucket at 0 goes.
+        let keys = [keygen_key(2, ProtocolType::KeyRotation)];
+        assert!(find_tob_buckets_to_prune(&keys, &epochs(&[2, 10]), 10).is_empty());
+
+        let keys = [
+            keygen_key(0, ProtocolType::Dkg),
+            keygen_key(2, ProtocolType::KeyRotation),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert_eq!(targets, vec![TobPruneTarget::KeyGen { epoch: 0 }]);
+    }
+
+    #[test]
+    fn keygen_selected_at_exact_retention_boundary() {
+        // current == epoch + KEY_GEN_CERT_RETENTION_EPOCHS is the first
+        // eligible epoch; one below is not.
+        let keys = [keygen_key(2, ProtocolType::KeyRotation)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[2, 5, 10]), 10);
+        assert_eq!(targets, vec![TobPruneTarget::KeyGen { epoch: 2 }]);
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[2, 5, 9]), 9);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn keygen_committee_at_exactly_epoch_plus_one_satisfies_guard() {
+        // Pins the inclusive lower bound of the strictly-between range: a
+        // committee at bucket_epoch + 1 is enough.
+        let keys = [keygen_key(2, ProtocolType::KeyRotation)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[3, 10]), 10);
+        assert_eq!(targets, vec![TobPruneTarget::KeyGen { epoch: 2 }]);
+    }
+
+    #[test]
+    fn keygen_pending_committee_does_not_satisfy_guard() {
+        // A pending committee (epoch 12 > current 10) is in the committee
+        // set but must not stand in for "strictly between".
+        let keys = [keygen_key(2, ProtocolType::KeyRotation)];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[2, 10, 12]), 10);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn current_and_pending_epoch_buckets_never_selected() {
+        let keys = [
+            nonce_key(10, 0),
+            nonce_key(12, 0),
+            keygen_key(10, ProtocolType::KeyRotation),
+            keygen_key(12, ProtocolType::KeyRotation),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10, 12]), 10);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn ordering_oldest_epoch_first_nonce_batches_descending() {
+        let keys = [
+            nonce_key(3, 0),
+            nonce_key(3, 1),
+            nonce_key(0, 2),
+            nonce_key(0, 0),
+            nonce_key(0, 1),
+            keygen_key(0, ProtocolType::Dkg),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert_eq!(
+            targets,
+            vec![
+                TobPruneTarget::KeyGen { epoch: 0 },
+                TobPruneTarget::NonceBatch {
+                    epoch: 0,
+                    batch_index: 2
+                },
+                TobPruneTarget::NonceBatch {
+                    epoch: 0,
+                    batch_index: 1
+                },
+                TobPruneTarget::NonceBatch {
+                    epoch: 0,
+                    batch_index: 0
+                },
+                TobPruneTarget::NonceBatch {
+                    epoch: 3,
+                    batch_index: 1
+                },
+                TobPruneTarget::NonceBatch {
+                    epoch: 3,
+                    batch_index: 0
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn cap_truncation_leaves_contiguous_prefix() {
+        // One epoch with more batches than the cap: the selected batches are
+        // the HIGHEST indices, so the survivors are exactly 0..m.
+        let keys: Vec<TobKey> = (0..MAX_TOB_PRUNES_PER_GC as u32 + 7)
+            .map(|i| nonce_key(1, i))
+            .collect();
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[1, 10]), 10);
+        assert_eq!(targets.len(), MAX_TOB_PRUNES_PER_GC);
+        let selected: BTreeSet<u32> = targets
+            .iter()
+            .map(|t| match t {
+                TobPruneTarget::NonceBatch { batch_index, .. } => *batch_index,
+                other => panic!("unexpected target {other:?}"),
+            })
+            .collect();
+        let expected: BTreeSet<u32> = (7..MAX_TOB_PRUNES_PER_GC as u32 + 7).collect();
+        assert_eq!(selected, expected);
+    }
+
+    #[test]
+    fn dkg_and_rotation_same_epoch_dedupe_to_one_keygen_target() {
+        let keys = [
+            keygen_key(0, ProtocolType::Dkg),
+            keygen_key(0, ProtocolType::KeyRotation),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert_eq!(targets, vec![TobPruneTarget::KeyGen { epoch: 0 }]);
+    }
+
+    #[test]
+    fn malformed_key_shapes_skipped() {
+        // Nonce without a batch index, keygen with one: shapes the writers
+        // never produce. Never destroy what we don't understand.
+        let keys = [
+            TobKey {
+                epoch: 0,
+                batch_index: None,
+                protocol_type: ProtocolType::NonceGeneration,
+            },
+            TobKey {
+                epoch: 0,
+                batch_index: Some(1),
+                protocol_type: ProtocolType::Dkg,
+            },
+            TobKey {
+                epoch: 0,
+                batch_index: Some(1),
+                protocol_type: ProtocolType::KeyRotation,
+            },
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert!(targets.is_empty());
+    }
+
+    #[test]
+    fn absurd_epochs_do_not_panic() {
+        // Field names are attacker-shapeable; saturating arithmetic must
+        // hold at the extremes.
+        let keys = [
+            nonce_key(u64::MAX, 0),
+            keygen_key(u64::MAX, ProtocolType::Dkg),
+        ];
+        let targets = find_tob_buckets_to_prune(&keys, &epochs(&[0, 2, 10]), 10);
+        assert!(targets.is_empty());
     }
 }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -818,9 +818,10 @@ fn find_tob_buckets_to_prune(
 ) -> Vec<TobPruneTarget> {
     use hashi_types::move_types::ProtocolType;
 
-    // Saturating arithmetic throughout: key epochs come from on-chain field
-    // names anyone can shape, and an overflow panic here would kill the
-    // leader's prune task.
+    // Saturating arithmetic throughout: bag writes are committee-gated
+    // (submit entries assert membership and current/pending epoch), but the
+    // pruner treats field-name epochs as untrusted data anyway; an overflow
+    // panic here would kill the leader's prune task.
     let mut keygen_epochs: BTreeSet<u64> = BTreeSet::new();
     let mut nonce_batches: BTreeMap<u64, BTreeSet<u32>> = BTreeMap::new();
     for key in keys {

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -128,6 +128,15 @@ pub(crate) struct LeaderService {
     // confirm. Zero at boot: the bootstrap mirror is fresh by construction.
     utxo_cleanup_scan_target: u64,
 
+    // Singleton task that destroys dead TOB cert buckets on-chain; resolves
+    // to the sweep's outcome (epoch swept, whether the backlog drained).
+    tob_prune_task: Option<AbortOnDropHandle<anyhow::Result<garbage_collection::TobPruneOutcome>>>,
+    tob_prune_retry: GlobalRetryTracker<garbage_collection::TobPruneErrorKind>,
+    // Last hashi epoch whose TOB prune sweep fully drained the backlog.
+    // `None` triggers a sweep on the first leader tick (boot backlog); a
+    // cap-limited or failed sweep leaves it unset so the next tick re-runs.
+    last_tob_prune_epoch: Option<u64>,
+
     // Singleton task that reconciles the guardian committee with the on-chain committee.
     guardian_committee_reconcile_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     // Last hashi epoch we triggered a guardian-committee reconcile for, so
@@ -167,6 +176,9 @@ impl LeaderService {
             utxo_cleanup_retry: GlobalRetryTracker::new(),
             utxo_cleanup_scan_needed: true,
             utxo_cleanup_scan_target: 0,
+            tob_prune_task: None,
+            tob_prune_retry: GlobalRetryTracker::new(),
+            last_tob_prune_epoch: None,
             guardian_committee_reconcile_task: None,
             last_guardian_reconcile_epoch: None,
         }
@@ -271,6 +283,7 @@ impl LeaderService {
                     self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
                     self.check_delete_proposals(checkpoint_timestamp_ms);
                     self.check_cleanup_spent_utxos(checkpoint_timestamp_ms);
+                    self.check_prune_tob_certs(checkpoint_timestamp_ms);
                     self.process_stale_unapproved_deposits_if_new_epoch();
                     self.process_approved_deposit_requests();
                 }
@@ -351,6 +364,24 @@ impl LeaderService {
                         }
                     }
                     Self::log_task_result("utxo_cleanup_gc", result);
+                }
+                Some(result) = OptionFuture::from(self.tob_prune_task.as_mut()) => {
+                    self.tob_prune_task = None;
+                    match &result {
+                        Ok(Ok(outcome)) => {
+                            self.tob_prune_retry.clear();
+                            // Only a fully-drained sweep closes the epoch
+                            // gate; a cap-limited one re-runs next tick.
+                            if outcome.drained {
+                                self.last_tob_prune_epoch = Some(outcome.swept_epoch);
+                            }
+                        }
+                        _ => self.tob_prune_retry.record_failure(
+                            garbage_collection::TobPruneErrorKind::Failed,
+                            checkpoint_rx.borrow().timestamp_ms,
+                        ),
+                    }
+                    Self::log_task_result("tob_prune", result);
                 }
                 Some(result) = OptionFuture::from(self.guardian_committee_reconcile_task.as_mut()) => {
                     self.guardian_committee_reconcile_task = None;

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -139,6 +139,14 @@ pub(crate) struct LeaderService {
     withdrawal_archive_retry: GlobalRetryTracker<garbage_collection::WithdrawalArchiveErrorKind>,
     withdrawal_archive_scan_needed: bool,
     withdrawal_archive_scan_target: u64,
+    // Singleton task that destroys dead TOB cert buckets on-chain; resolves
+    // to the sweep's outcome (epoch swept, whether the backlog drained).
+    tob_prune_task: Option<AbortOnDropHandle<anyhow::Result<garbage_collection::TobPruneOutcome>>>,
+    tob_prune_retry: GlobalRetryTracker<garbage_collection::TobPruneErrorKind>,
+    // Last hashi epoch whose TOB prune sweep fully drained the backlog.
+    // `None` triggers a sweep on the first leader tick (boot backlog); a
+    // cap-limited or failed sweep leaves it unset so the next tick re-runs.
+    last_tob_prune_epoch: Option<u64>,
 
     // Singleton task that reconciles the guardian committee with the on-chain committee.
     guardian_committee_reconcile_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
@@ -190,6 +198,9 @@ impl LeaderService {
             // a no-op pre-upgrade (the version gate skips the spawn).
             withdrawal_archive_scan_needed: true,
             withdrawal_archive_scan_target: 0,
+            tob_prune_task: None,
+            tob_prune_retry: GlobalRetryTracker::new(),
+            last_tob_prune_epoch: None,
             guardian_committee_reconcile_task: None,
             last_guardian_reconcile_epoch: None,
             last_withdrawal_semantics: None,
@@ -300,6 +311,7 @@ impl LeaderService {
                     self.check_delete_proposals(checkpoint_timestamp_ms);
                     self.check_cleanup_spent_utxos(checkpoint_timestamp_ms);
                     self.check_archive_confirmed_withdrawals(checkpoint_timestamp_ms);
+                    self.check_prune_tob_certs(checkpoint_timestamp_ms);
                     self.process_stale_unapproved_deposits_if_new_epoch();
                     self.process_approved_deposit_requests();
                 }
@@ -399,6 +411,24 @@ impl LeaderService {
                         }
                     }
                     Self::log_task_result("withdrawal_archive_gc", result);
+                }
+                Some(result) = OptionFuture::from(self.tob_prune_task.as_mut()) => {
+                    self.tob_prune_task = None;
+                    match &result {
+                        Ok(Ok(outcome)) => {
+                            self.tob_prune_retry.clear();
+                            // Only a fully-drained sweep closes the epoch
+                            // gate; a cap-limited one re-runs next tick.
+                            if outcome.drained {
+                                self.last_tob_prune_epoch = Some(outcome.swept_epoch);
+                            }
+                        }
+                        _ => self.tob_prune_retry.record_failure(
+                            garbage_collection::TobPruneErrorKind::Failed,
+                            checkpoint_rx.borrow().timestamp_ms,
+                        ),
+                    }
+                    Self::log_task_result("tob_prune", result);
                 }
                 Some(result) = OptionFuture::from(self.guardian_committee_reconcile_task.as_mut()) => {
                     self.guardian_committee_reconcile_task = None;

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -162,11 +162,23 @@ pub struct State {
     withdrawal_signed_at_ms: BTreeMap<Address, u64>,
 }
 
-#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
-struct TobKey {
-    epoch: u64,
-    batch_index: Option<u32>,
-    protocol_type: move_types::ProtocolType,
+/// Rust mirror of the Move `hashi::tob::TobKey` dynamic-field name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
+pub struct TobKey {
+    pub epoch: u64,
+    pub batch_index: Option<u32>,
+    pub protocol_type: move_types::ProtocolType,
+}
+
+/// One TOB bucket the leader's GC has selected for on-chain destruction.
+/// `KeyGen` covers both the Dkg and KeyRotation buckets of an epoch — the
+/// Move entry (`cert_submission::destroy_key_gen_certs`) probes both keys, so
+/// the caller never needs to know whether the epoch was genesis or a
+/// rotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TobPruneTarget {
+    KeyGen { epoch: u64 },
+    NonceBatch { epoch: u64, batch_index: u32 },
 }
 
 impl OnchainState {
@@ -974,6 +986,44 @@ impl OnchainState {
             }
         }
         Ok(None)
+    }
+
+    /// List every TOB bucket key in the on-chain bag, for the leader's GC.
+    ///
+    /// Decodes dynamic-field NAMES only — the `TobKey` layout is frozen — so
+    /// bucket VALUE layouts this binary cannot decode never fail the sweep.
+    /// Whether a bucket's stored type is supported for removal is decided
+    /// on-chain by the destroy entry. A name that fails to decode as a
+    /// `TobKey` is skipped with a warning rather than failing the listing.
+    pub async fn list_tob_keys(&self) -> Result<Vec<TobKey>> {
+        let tob_id = self.tob_id();
+        let mut stream = self
+            .0
+            .client
+            .clone()
+            .list_dynamic_fields(
+                ListDynamicFieldsRequest::default()
+                    .with_parent(tob_id)
+                    .with_page_size(SCRAPE_PAGE_SIZE)
+                    // field_id rides along solely for the skip-warning
+                    // below: a masked-out field would log an empty default.
+                    .with_read_mask(FieldMask::from_paths([
+                        DynamicField::path_builder().field_id(),
+                        DynamicField::path_builder().name().finish(),
+                    ])),
+            )
+            .pipe(Box::pin);
+        let mut keys = Vec::new();
+        while let Some(field) = stream.try_next().await? {
+            match bcs::from_bytes::<TobKey>(field.name().value()) {
+                Ok(key) => keys.push(key),
+                Err(e) => tracing::warn!(
+                    field_id = %field.field_id(),
+                    "Skipping TOB bag entry whose name does not decode as a TobKey: {e}"
+                ),
+            }
+        }
+        Ok(keys)
     }
 
     async fn collect_table_nodes<V: serde::de::DeserializeOwned>(

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -162,11 +162,23 @@ pub struct State {
     withdrawal_signed_at_ms: BTreeMap<Address, u64>,
 }
 
-#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
-struct TobKey {
-    epoch: u64,
-    batch_index: Option<u32>,
-    protocol_type: move_types::ProtocolType,
+/// Rust mirror of the Move `hashi::tob::TobKey` dynamic-field name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde_derive::Serialize, serde_derive::Deserialize)]
+pub struct TobKey {
+    pub epoch: u64,
+    pub batch_index: Option<u32>,
+    pub protocol_type: move_types::ProtocolType,
+}
+
+/// One TOB bucket the leader's GC has selected for on-chain destruction.
+/// `KeyGen` covers both the Dkg and KeyRotation buckets of an epoch — the
+/// Move entry (`cert_submission::destroy_key_gen_certs`) probes both keys, so
+/// the caller never needs to know whether the epoch was genesis or a
+/// rotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TobPruneTarget {
+    KeyGen { epoch: u64 },
+    NonceBatch { epoch: u64, batch_index: u32 },
 }
 
 impl OnchainState {
@@ -938,6 +950,44 @@ impl OnchainState {
             }
         }
         Ok(None)
+    }
+
+    /// List every TOB bucket key in the on-chain bag, for the leader's GC.
+    ///
+    /// Decodes dynamic-field NAMES only — the `TobKey` layout is frozen — so
+    /// bucket VALUE layouts this binary cannot decode never fail the sweep.
+    /// Whether a bucket's stored type is supported for removal is decided
+    /// on-chain by the destroy entry. A name that fails to decode as a
+    /// `TobKey` is skipped with a warning rather than failing the listing.
+    pub async fn list_tob_keys(&self) -> Result<Vec<TobKey>> {
+        let tob_id = self.tob_id();
+        let mut stream = self
+            .0
+            .client
+            .clone()
+            .list_dynamic_fields(
+                ListDynamicFieldsRequest::default()
+                    .with_parent(tob_id)
+                    .with_page_size(SCRAPE_PAGE_SIZE)
+                    // field_id rides along solely for the skip-warning
+                    // below: a masked-out field would log an empty default.
+                    .with_read_mask(FieldMask::from_paths([
+                        DynamicField::path_builder().field_id(),
+                        DynamicField::path_builder().name().finish(),
+                    ])),
+            )
+            .pipe(Box::pin);
+        let mut keys = Vec::new();
+        while let Some(field) = stream.try_next().await? {
+            match bcs::from_bytes::<TobKey>(field.name().value()) {
+                Ok(key) => keys.push(key),
+                Err(e) => tracing::warn!(
+                    field_id = %field.field_id(),
+                    "Skipping TOB bag entry whose name does not decode as a TobKey: {e}"
+                ),
+            }
+        }
+        Ok(keys)
     }
 
     async fn collect_table_nodes<V: serde::de::DeserializeOwned>(

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1835,6 +1835,121 @@ impl SuiTxExecutor {
         }
         Ok(max_checkpoint)
     }
+
+    /// Destroy dead TOB cert buckets via the v2 GC entries
+    /// (`cert_submission::destroy_key_gen_certs` / `destroy_nonce_certs`).
+    ///
+    /// One move call per bucket — scalar pure args only, so the builder's
+    /// pure-input dedup is harmless. The binding per-transaction limit is
+    /// Sui's 2048 deleted-object-ids cap: destroying a bucket deletes its bag
+    /// `Field`, its `LinkedTable`, and one node per dealer (committee-sized,
+    /// ~80 ids today), and a `KeyGen` target may destroy TWO buckets. Bucket
+    /// sizes are unknowable here (candidate discovery decodes field names
+    /// only) and grow with committee size, so instead of a sizing model the
+    /// chunking is adaptive: start at `TOB_DESTROYS_PER_TX` calls per
+    /// transaction and HALVE any failing chunk down to singletons.
+    /// Transient RPC failures take the split path too — harmless, they just
+    /// retry at a smaller size — and only a singleton failure propagates, so
+    /// an over-limit chunk can never permanently wedge the sweep behind an
+    /// unbounded identical retry.
+    ///
+    /// The entries are v2-introduced, so the calls route to the ACTIVE
+    /// package (they do not exist in the original package) and the Hashi
+    /// shared input is pre-resolved: sui >= 1.76 fullnodes fail simulation
+    /// with INVALID_LINKAGE when inferring an unresolved shared input's
+    /// mutability requires inspecting an upgraded package's module (see
+    /// `delete_expired_proposals`).
+    pub async fn execute_destroy_tob_certs(
+        &mut self,
+        targets: &[crate::onchain::TobPruneTarget],
+    ) -> anyhow::Result<()> {
+        let call_package_id = self.active_call_package_id();
+        let hashi_initial_shared_version = crate::cli::client::fetch_initial_shared_version(
+            &mut self.client,
+            self.hashi_ids.hashi_object_id,
+        )
+        .await?;
+
+        let mut queue: std::collections::VecDeque<&[crate::onchain::TobPruneTarget]> =
+            targets.chunks(Self::TOB_DESTROYS_PER_TX).collect();
+        while let Some(chunk) = queue.pop_front() {
+            match self
+                .destroy_tob_chunk(chunk, call_package_id, hashi_initial_shared_version)
+                .await
+            {
+                Ok(()) => {}
+                Err(e) if chunk.len() > 1 => {
+                    let mid = chunk.len() / 2;
+                    tracing::warn!(
+                        chunk_len = chunk.len(),
+                        "destroy TOB certs chunk failed; splitting and retrying: {e:#}"
+                    );
+                    queue.push_front(&chunk[mid..]);
+                    queue.push_front(&chunk[..mid]);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Initial destroy-calls-per-transaction for [`Self::execute_destroy_tob_certs`].
+    /// 10 full ~80-id buckets is ~800 deleted ids against the 2048 cap;
+    /// larger committees are absorbed by the adaptive halving.
+    const TOB_DESTROYS_PER_TX: usize = 10;
+
+    /// One destroy transaction for `chunk`; see [`Self::execute_destroy_tob_certs`].
+    async fn destroy_tob_chunk(
+        &mut self,
+        chunk: &[crate::onchain::TobPruneTarget],
+        call_package_id: Address,
+        hashi_initial_shared_version: u64,
+    ) -> anyhow::Result<()> {
+        use crate::onchain::TobPruneTarget;
+
+        let mut builder = TransactionBuilder::new();
+        let hashi_arg = builder.object(
+            ObjectInput::new(self.hashi_ids.hashi_object_id)
+                .with_version(hashi_initial_shared_version)
+                .as_shared()
+                .with_mutable(true),
+        );
+        for target in chunk {
+            match target {
+                TobPruneTarget::KeyGen { epoch } => {
+                    let epoch_arg = builder.pure(epoch);
+                    builder.move_call(
+                        Function::new(
+                            call_package_id,
+                            Identifier::from_static("cert_submission"),
+                            Identifier::from_static("destroy_key_gen_certs"),
+                        ),
+                        vec![hashi_arg, epoch_arg],
+                    );
+                }
+                TobPruneTarget::NonceBatch { epoch, batch_index } => {
+                    let epoch_arg = builder.pure(epoch);
+                    let batch_index_arg = builder.pure(batch_index);
+                    builder.move_call(
+                        Function::new(
+                            call_package_id,
+                            Identifier::from_static("cert_submission"),
+                            Identifier::from_static("destroy_nonce_certs"),
+                        ),
+                        vec![hashi_arg, epoch_arg, batch_index_arg],
+                    );
+                }
+            }
+        }
+        let response = self.execute(builder).await?;
+        if !response.transaction().effects().status().success() {
+            anyhow::bail!(
+                "destroy TOB certs transaction failed: {:?}",
+                response.transaction().effects().status()
+            );
+        }
+        Ok(())
+    }
 }
 
 // TODO: the builders below take the call target, but `cli/commands/{deposit,

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1937,6 +1937,121 @@ impl SuiTxExecutor {
         }
         Ok(max_checkpoint)
     }
+
+    /// Destroy dead TOB cert buckets via the v2 GC entries
+    /// (`cert_submission::destroy_key_gen_certs` / `destroy_nonce_certs`).
+    ///
+    /// One move call per bucket — scalar pure args only, so the builder's
+    /// pure-input dedup is harmless. The binding per-transaction limit is
+    /// Sui's 2048 deleted-object-ids cap: destroying a bucket deletes its bag
+    /// `Field`, its `LinkedTable`, and one node per dealer (committee-sized,
+    /// ~80 ids today), and a `KeyGen` target may destroy TWO buckets. Bucket
+    /// sizes are unknowable here (candidate discovery decodes field names
+    /// only) and grow with committee size, so instead of a sizing model the
+    /// chunking is adaptive: start at `TOB_DESTROYS_PER_TX` calls per
+    /// transaction and HALVE any failing chunk down to singletons.
+    /// Transient RPC failures take the split path too — harmless, they just
+    /// retry at a smaller size — and only a singleton failure propagates, so
+    /// an over-limit chunk can never permanently wedge the sweep behind an
+    /// unbounded identical retry.
+    ///
+    /// The entries are v2-introduced, so the calls route to the ACTIVE
+    /// package (they do not exist in the original package) and the Hashi
+    /// shared input is pre-resolved: sui >= 1.76 fullnodes fail simulation
+    /// with INVALID_LINKAGE when inferring an unresolved shared input's
+    /// mutability requires inspecting an upgraded package's module (see
+    /// `delete_expired_proposals`).
+    pub async fn execute_destroy_tob_certs(
+        &mut self,
+        targets: &[crate::onchain::TobPruneTarget],
+    ) -> anyhow::Result<()> {
+        let call_package_id = self.active_call_package_id();
+        let hashi_initial_shared_version = crate::cli::client::fetch_initial_shared_version(
+            &mut self.client,
+            self.hashi_ids.hashi_object_id,
+        )
+        .await?;
+
+        let mut queue: std::collections::VecDeque<&[crate::onchain::TobPruneTarget]> =
+            targets.chunks(Self::TOB_DESTROYS_PER_TX).collect();
+        while let Some(chunk) = queue.pop_front() {
+            match self
+                .destroy_tob_chunk(chunk, call_package_id, hashi_initial_shared_version)
+                .await
+            {
+                Ok(()) => {}
+                Err(e) if chunk.len() > 1 => {
+                    let mid = chunk.len() / 2;
+                    tracing::warn!(
+                        chunk_len = chunk.len(),
+                        "destroy TOB certs chunk failed; splitting and retrying: {e:#}"
+                    );
+                    queue.push_front(&chunk[mid..]);
+                    queue.push_front(&chunk[..mid]);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Initial destroy-calls-per-transaction for [`Self::execute_destroy_tob_certs`].
+    /// 10 full ~80-id buckets is ~800 deleted ids against the 2048 cap;
+    /// larger committees are absorbed by the adaptive halving.
+    const TOB_DESTROYS_PER_TX: usize = 10;
+
+    /// One destroy transaction for `chunk`; see [`Self::execute_destroy_tob_certs`].
+    async fn destroy_tob_chunk(
+        &mut self,
+        chunk: &[crate::onchain::TobPruneTarget],
+        call_package_id: Address,
+        hashi_initial_shared_version: u64,
+    ) -> anyhow::Result<()> {
+        use crate::onchain::TobPruneTarget;
+
+        let mut builder = TransactionBuilder::new();
+        let hashi_arg = builder.object(
+            ObjectInput::new(self.hashi_ids.hashi_object_id)
+                .with_version(hashi_initial_shared_version)
+                .as_shared()
+                .with_mutable(true),
+        );
+        for target in chunk {
+            match target {
+                TobPruneTarget::KeyGen { epoch } => {
+                    let epoch_arg = builder.pure(epoch);
+                    builder.move_call(
+                        Function::new(
+                            call_package_id,
+                            Identifier::from_static("cert_submission"),
+                            Identifier::from_static("destroy_key_gen_certs"),
+                        ),
+                        vec![hashi_arg, epoch_arg],
+                    );
+                }
+                TobPruneTarget::NonceBatch { epoch, batch_index } => {
+                    let epoch_arg = builder.pure(epoch);
+                    let batch_index_arg = builder.pure(batch_index);
+                    builder.move_call(
+                        Function::new(
+                            call_package_id,
+                            Identifier::from_static("cert_submission"),
+                            Identifier::from_static("destroy_nonce_certs"),
+                        ),
+                        vec![hashi_arg, epoch_arg, batch_index_arg],
+                    );
+                }
+            }
+        }
+        let response = self.execute(builder).await?;
+        if !response.transaction().effects().status().success() {
+            anyhow::bail!(
+                "destroy TOB certs transaction failed: {:?}",
+                response.transaction().effects().status()
+            );
+        }
+        Ok(())
+    }
 }
 
 /// A confirmed withdrawal txn awaiting archival, with its request ids so the

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -349,6 +349,28 @@ impl TransactionExecutionError {
     }
 }
 
+/// The SDK build error behind `e`, if `e` is a [`TxFailure::NotSubmitted`]
+/// raised by [`finalize`] wrapping one.
+fn builder_error(e: &anyhow::Error) -> Option<&sui_transaction_builder::Error> {
+    match e.downcast_ref::<TxFailure>()? {
+        TxFailure::NotSubmitted(inner) => inner.downcast_ref(),
+        TxFailure::Submit(_) => None,
+    }
+}
+
+/// Whether `e` is a failure of transaction *execution* (a failed simulation
+/// inside the SDK build, or a failed on-chain status) rather than of building
+/// or submitting the transaction. [`SuiTxExecutor::execute_destroy_tob_certs`]
+/// splits a failing chunk only on these: only execution can reject a chunk
+/// for its size, so a build or transport failure is propagated as is.
+fn is_execution_failure(e: &anyhow::Error) -> bool {
+    e.downcast_ref::<TransactionExecutionError>().is_some()
+        || matches!(
+            builder_error(e),
+            Some(sui_transaction_builder::Error::SimulationFailure(_))
+        )
+}
+
 /// Set the sender and gas overrides on `builder`, then finish it according to
 /// `mode`: serialize it unsigned, dry-run it, or sign and submit it.
 ///
@@ -1949,11 +1971,15 @@ impl SuiTxExecutor {
     /// sizes are unknowable here (candidate discovery decodes field names
     /// only) and grow with committee size, so instead of a sizing model the
     /// chunking is adaptive: start at `TOB_DESTROYS_PER_TX` calls per
-    /// transaction and HALVE any failing chunk down to singletons.
-    /// Transient RPC failures take the split path too — harmless, they just
-    /// retry at a smaller size — and only a singleton failure propagates, so
-    /// an over-limit chunk can never permanently wedge the sweep behind an
-    /// unbounded identical retry.
+    /// transaction and HALVE any chunk that fails to EXECUTE down to
+    /// singletons. Every chunk is simulated by the SDK build before it is
+    /// submitted, so an over-limit chunk always fails there (typed, nothing
+    /// submitted, no gas burned); a failed on-chain status is treated the
+    /// same way. Build and transport failures are not size signals, so they
+    /// propagate immediately to the caller's retry backoff instead of
+    /// spending halving attempts on a doomed RPC. Only a singleton execution
+    /// failure propagates, so an over-limit chunk can never permanently
+    /// wedge the sweep behind an unbounded identical retry.
     ///
     /// The entries are v2-introduced, so the calls route to the ACTIVE
     /// package (they do not exist in the original package) and the Hashi
@@ -1980,11 +2006,11 @@ impl SuiTxExecutor {
                 .await
             {
                 Ok(()) => {}
-                Err(e) if chunk.len() > 1 => {
+                Err(e) if chunk.len() > 1 && is_execution_failure(&e) => {
                     let mid = chunk.len() / 2;
                     tracing::warn!(
                         chunk_len = chunk.len(),
-                        "destroy TOB certs chunk failed; splitting and retrying: {e:#}"
+                        "destroy TOB certs chunk failed to execute; splitting and retrying: {e:#}"
                     );
                     queue.push_front(&chunk[mid..]);
                     queue.push_front(&chunk[..mid]);
@@ -2044,11 +2070,13 @@ impl SuiTxExecutor {
             }
         }
         let response = self.execute(builder).await?;
-        if !response.transaction().effects().status().success() {
-            anyhow::bail!(
-                "destroy TOB certs transaction failed: {:?}",
-                response.transaction().effects().status()
-            );
+        let status = response.transaction().effects().status();
+        if !status.success() {
+            return Err(TransactionExecutionError {
+                function: "destroy_tob_certs",
+                status: status.clone(),
+            }
+            .into());
         }
         Ok(())
     }
@@ -2828,6 +2856,46 @@ pub async fn sweep_to_address_balance(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn destroy_tob_splits_only_on_execution_failures() {
+        // A failed on-chain status is an execution failure.
+        let on_chain: anyhow::Error = TransactionExecutionError {
+            function: "destroy_tob_certs",
+            status: ExecutionStatus::default(),
+        }
+        .into();
+        assert!(is_execution_failure(&on_chain));
+
+        // The simulate RPC failing (as opposed to the simulated execution
+        // failing) is a build failure, not a size signal. Wrapped exactly as
+        // `finalize` wraps SDK build errors, and the intermediate downcast is
+        // asserted separately: `SimulationFailure` cannot be constructed
+        // outside the SDK, so this is what proves the classifier can reach
+        // the SDK error at all (a silently failing downcast would mean
+        // "never split", wedging the sweep on a genuinely over-limit chunk).
+        let simulate_rpc: anyhow::Error = TxFailure::NotSubmitted(
+            sui_transaction_builder::Error::Input(
+                "error simulating transaction: connection refused".to_owned(),
+            )
+            .into(),
+        )
+        .into();
+        assert!(matches!(
+            builder_error(&simulate_rpc),
+            Some(sui_transaction_builder::Error::Input(_))
+        ));
+        assert!(!is_execution_failure(&simulate_rpc));
+
+        // Neither is a post-submit transport failure or an untyped error
+        // from before the build (e.g. the shared-version fetch).
+        let submit: anyhow::Error =
+            TxFailure::Submit(Box::new(ExecuteAndWaitError::MissingTransaction)).into();
+        assert!(!is_execution_failure(&submit));
+        assert!(!is_execution_failure(&anyhow::anyhow!(
+            "shared version fetch failed"
+        )));
+    }
 
     #[test]
     fn chunk_empty_input() {


### PR DESCRIPTION
Stacked on #1001 (base: `main` → #1001 → this), whose Move entries this drives. Closes the loop on #1001: the on-chain destroy entries existed but nothing called them.

The upgrade-safe transaction plumbing this job depends on — `SuiTxExecutor::active_call_package_id`, `cli::client::fetch_initial_shared_version`, and `SUPPORTED_PACKAGE_VERSIONS = [1, 2]` — now lives in `main` (extracted to #1026, merged), so it is no longer part of this PR; this PR only consumes it.

## Change

A fourth singleton GC job in the leader's per-checkpoint loop, alongside deposits / proposals / UTXO cleanup:

- **`OnchainState::list_tob_keys`** — pages the TOB bag decoding dynamic-field **names only**, so bucket value layouts this binary cannot decode (e.g. a future `StampedEpochCertsV1`) never fail the sweep; undecodable names are skipped with a warning (with `field_id` in the read mask so the warning is actionable). Type safety of the actual removal lives in the Move entries' stored-type probe.
- **`find_tob_buckets_to_prune`** — pure selection predicate mirroring the Move floors (which stay authoritative; drift here only produces aborting transactions, never unsafe deletes). Nonce at `current ≥ epoch+2`; keygen at `current ≥ epoch+8` AND a committee epoch strictly between bucket and now (gap-safe, pending-committee-safe). Unknown key shapes are never selected; saturating arithmetic throughout since field names are attacker-shapeable. Epochs drain oldest-first, nonce batches descending by index so cap truncation always leaves a contiguous `0..m` prefix.
- **Scheduling** — epoch-gated: the gate only closes on a sweep that fully drained (selected under the 200-target cap), so backlogs re-sweep every checkpoint until empty; gated on `active_package_version() >= 2` (the entries are v2-introduced — on a v1-active chain the job stays dormant by construction); unbounded retry with backoff like the UTXO job. Mirror staleness is strictly conservative: a lagging epoch shrinks both floors, a missing committee only disables keygen selection.
- **`execute_destroy_tob_certs`** — one move call per bucket (scalar pures only), routed to the active package with a pre-resolved Hashi shared input (the INVALID_LINKAGE class documented on `delete_expired_proposals`: sui ≥ 1.76 fullnodes fail simulation when inferring an unresolved shared input's mutability requires inspecting an upgraded package's module). Chunking is **adaptive**: 10 calls per transaction, halving any failing chunk down to singletons. Bucket sizes are committee-sized and unknowable from a name-only listing, and destroying one deletes ~dealers+2 object ids against Sui's 2048 deleted-ids-per-tx cap — a fixed chunk would deterministically wedge the sweep behind an unbounded identical retry once committees pass ~100 members (found in adversarial review; mainnet-realistic).

## Tests

- 12 predicate unit tests: floors (exact boundaries both sides), the gap scenario, pending committees, ordering, contiguous-prefix truncation, Dkg+KeyRotation dedup, malformed shapes, absurd-epoch non-panic.
- e2e (extends the resignation flow, which already crosses two epoch boundaries): asserts a below-floor destroy is rejected at `initial+1`, then that the leader **actually prunes** the initial epoch's nonce buckets on-chain after the second boundary while the key-generation bucket survives the retention floor. Verified locally (88s).
- Full `hashi` suite 643/643 (gpg-gated test excluded), clippy clean, `version_policy_tests` untouched.