### PR TITLE
withdraw: defer bag-to-bag moves to a batched archival GC

### DIFF
--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -282,38 +282,55 @@ entry fun confirm_withdrawal(
         EWithdrawalNotFullySigned,
     );
 
-    // Remove the in-flight withdrawal txn from the hot bag so we can do
-    // all the bookkeeping with a direct handle, then re-insert it into the
-    // confirmed bag at the end.
-    let mut txn = hashi.bitcoin_mut().withdrawal_queue_mut().remove_withdrawal_txn(withdrawal_id);
-    txn.mark_confirmed(clock);
-    txn.emit_withdrawal_confirmed();
+    // Copy the input/change data out of a short borrow; the txn itself stays
+    // in the hot bag. Its move to `confirmed_txns` — and the requests' status
+    // flip and move to `processed` — are deferred to
+    // `archive_confirmed_withdrawals`, keeping this transaction's runtime
+    // object count independent of the request count.
+    let (inputs, change_ids) = {
+        let txn = hashi.bitcoin().withdrawal_queue().borrow_withdrawal_txn(withdrawal_id);
+        (*txn.withdrawal_txn_inputs(), txn.change_utxo_ids())
+    };
 
-    // Update request statuses to Confirmed.
-    hashi
-        .bitcoin_mut()
-        .withdrawal_queue_mut()
-        .update_requests_confirmed(txn.withdrawal_txn_request_ids());
+    // Records the confirmation timestamp and emits WithdrawalConfirmed;
+    // aborts on a replayed confirmation cert.
+    hashi.bitcoin_mut().withdrawal_queue_mut().mark_txn_confirmed(withdrawal_id, clock);
 
     let epoch = hashi.committee_set().epoch();
 
     // Mark each input UTXO as spent and emit spent events. The actual record
     // removal from utxo_records is deferred to `cleanup_spent_utxos` so this
     // transaction stays well under Sui's 1000-object runtime cache limit.
-    txn.withdrawal_txn_inputs().do_ref!(|utxo| {
+    inputs.do_ref!(|utxo| {
         hashi.bitcoin_mut().utxo_pool_mut().mark_spent(utxo.id(), epoch);
     });
 
     // Promote the change UTXOs from unconfirmed to confirmed. If a change UTXO
     // was already locked by a subsequent withdrawal, only `produced_by` is
     // cleared.
-    let change_ids = txn.change_utxo_ids();
     change_ids.do!(|change_id| {
         hashi.bitcoin_mut().utxo_pool_mut().confirm_pending(change_id);
     });
+}
 
-    // Move the txn to the cold (historical) bag.
-    hashi.bitcoin_mut().withdrawal_queue_mut().insert_confirmed_txn(txn);
+/// Deferred archival for confirmed withdrawals: move each transaction from
+/// `withdrawal_txns` to `confirmed_txns` and its requests from `requests` to
+/// `processed` (setting status Confirmed). Idempotent per id, so callers may
+/// batch and retry freely.
+///
+/// Carries no committee cert: every write is derivable from already-certified
+/// state (`confirmed_timestamp_ms` is only ever set under a confirmation
+/// cert, the request list was bound by the commitment cert, and no funds
+/// move) — an adversarial caller can only archive earlier than the operator
+/// would, which is a semantic no-op.
+///
+/// Garbage collection: deliberately NOT gated on pause/reconfig — it moves
+/// no funds and must stay callable during an emergency pause.
+entry fun archive_confirmed_withdrawals(hashi: &mut Hashi, withdrawal_ids: vector<address>) {
+    hashi.versioning().assert_version_enabled();
+    withdrawal_ids.do!(|withdrawal_id| {
+        hashi.bitcoin_mut().withdrawal_queue_mut().archive_withdrawal_txn(withdrawal_id);
+    });
 }
 
 /// Reassign fresh presignatures to the still-unsigned inputs of a withdrawal

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -333,6 +333,40 @@ entry fun archive_confirmed_withdrawals(hashi: &mut Hashi, withdrawal_ids: vecto
     });
 }
 
+/// Chunked archival for a withdrawal whose request count exceeds one Sui
+/// transaction's runtime-object budget: archive the listed requests only,
+/// leaving the txn in the hot bag for `finish_archive_withdrawal_txns`.
+/// Every listed request is cross-checked against the withdrawal id, so a
+/// caller can only archive requests the confirmation cert already covers.
+///
+/// Garbage collection: deliberately NOT gated on pause/reconfig — it moves
+/// no funds and must stay callable during an emergency pause.
+entry fun archive_withdrawal_requests(
+    hashi: &mut Hashi,
+    withdrawal_id: address,
+    request_ids: vector<address>,
+) {
+    hashi.versioning().assert_version_enabled();
+    hashi
+        .bitcoin_mut()
+        .withdrawal_queue_mut()
+        .archive_withdrawal_requests(withdrawal_id, &request_ids);
+}
+
+/// Finish chunked archivals: move each listed txn to `confirmed_txns` once
+/// all of its requests are archived. Ids whose archival is incomplete (or
+/// already finished) are silently skipped, so batches survive races with
+/// in-flight chunk transactions.
+///
+/// Garbage collection: deliberately NOT gated on pause/reconfig — it moves
+/// no funds and must stay callable during an emergency pause.
+entry fun finish_archive_withdrawal_txns(hashi: &mut Hashi, withdrawal_ids: vector<address>) {
+    hashi.versioning().assert_version_enabled();
+    withdrawal_ids.do!(|withdrawal_id| {
+        hashi.bitcoin_mut().withdrawal_queue_mut().finish_archive_withdrawal_txn(withdrawal_id);
+    });
+}
+
 /// Reassign fresh presignatures to the still-unsigned inputs of a withdrawal
 /// whose signing batch is from a previous epoch. Only the pending tail is
 /// re-presigned; already-collected signatures are final and epoch-independent.

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -633,17 +633,77 @@ public(package) fun archive_withdrawal_txn(
         assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
         txn.request_ids
     };
-    request_ids.do!(|id| {
-        if (self.requests.contains(id)) {
-            let mut request: WithdrawalRequest = self.requests.remove(id);
-            assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
-            request.status = WithdrawalStatus::Confirmed;
-            self.processed.add(id, request);
-        } else {
-            let request: &mut WithdrawalRequest = self.processed.borrow_mut(id);
-            request.status = WithdrawalStatus::Confirmed;
-        }
+    request_ids.do!(|id| self.archive_request(withdrawal_id, id));
+    let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);
+    sui::event::emit(WithdrawalArchived {
+        withdrawal_txn_id: withdrawal_id,
+        request_ids,
     });
+    self.confirmed_txns.add(withdrawal_id, txn);
+}
+
+/// Archive one request of a confirmed withdrawal wherever it lives. The
+/// `withdrawal_txn_id` cross-check runs in BOTH branches: the chunked entry
+/// takes caller-supplied ids, and without the check in the fallback branch a
+/// caller could flip an unrelated archived request's status.
+fun archive_request(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+    request_id: address,
+) {
+    if (self.requests.contains(request_id)) {
+        let mut request: WithdrawalRequest = self.requests.remove(request_id);
+        assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
+        request.status = WithdrawalStatus::Confirmed;
+        self.processed.add(request_id, request);
+    } else {
+        let request: &mut WithdrawalRequest = self.processed.borrow_mut(request_id);
+        assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
+        request.status = WithdrawalStatus::Confirmed;
+    }
+}
+
+/// Chunked archival: archive only the listed requests of a confirmed
+/// withdrawal, leaving the txn in the hot bag. Lets a txn whose request
+/// count exceeds one Sui transaction's runtime-object budget archive across
+/// several transactions; `finish_archive_withdrawal_txn` moves the txn once
+/// every request is archived. No-ops if the txn is already fully archived
+/// (re-run or raced GC); idempotent per request via the `processed` branch.
+public(package) fun archive_withdrawal_requests(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+    request_ids: &vector<address>,
+) {
+    if (!self.withdrawal_txns.contains(withdrawal_id)) return;
+    {
+        let txn: &WithdrawalTransaction = self.withdrawal_txns.borrow(withdrawal_id);
+        assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
+    };
+    request_ids.do_ref!(|id| self.archive_request(withdrawal_id, *id));
+}
+
+/// Finish a chunked archival: move the txn to `confirmed_txns` once none of
+/// its requests remain in `requests`. Silently no-ops while any request is
+/// still unarchived (or if the txn is already archived), so batched GC calls
+/// survive races with in-flight chunk transactions; the caller re-arms and
+/// retries from mirror state. The completeness walk costs only a `contains`
+/// probe per request, so it stays cheap even at the largest batch sizes.
+public(package) fun finish_archive_withdrawal_txn(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+) {
+    if (!self.withdrawal_txns.contains(withdrawal_id)) return;
+    let request_ids = {
+        let txn: &WithdrawalTransaction = self.withdrawal_txns.borrow(withdrawal_id);
+        assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
+        txn.request_ids
+    };
+    let mut i = 0;
+    let n = request_ids.length();
+    while (i < n) {
+        if (self.requests.contains(request_ids[i])) return;
+        i = i + 1;
+    };
     let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);
     sui::event::emit(WithdrawalArchived {
         withdrawal_txn_id: withdrawal_id,

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -696,8 +696,9 @@ public(package) fun archive_withdrawal_requests(
 /// no-ops while any request is still unarchived (or if the txn is already
 /// archived), so batched GC calls survive races with in-flight chunk
 /// transactions; the caller re-arms and retries from mirror state. The walk
-/// costs a `contains` probe per request plus a status read for `processed`
-/// residents, so it stays cheap even at the largest batch sizes.
+/// costs two runtime objects per request (the `processed` field wrapper and
+/// the borrowed child), which fits Sui's object budget at the largest batch
+/// size — see the probe comment in the body.
 public(package) fun finish_archive_withdrawal_txn(
     self: &mut WithdrawalRequestQueue,
     withdrawal_id: address,
@@ -712,11 +713,15 @@ public(package) fun finish_archive_withdrawal_txn(
     let n = request_ids.length();
     while (i < n) {
         let id = request_ids[i];
-        if (self.requests.contains(id)) return;
-        if (self.processed.contains(id)) {
-            let request: &WithdrawalRequest = self.processed.borrow(id);
-            if (request.status != WithdrawalStatus::Confirmed) return;
-        };
+        // A committed request lives in exactly one bag and archival only
+        // ever adds to `processed`, so probing `processed` alone suffices: a
+        // request still in `requests` is simply not there yet. Skipping the
+        // `requests` probe keeps the walk at two runtime objects per request
+        // (field wrapper + child), inside Sui's object budget even at the
+        // largest batch size; a third probe per request would blow it.
+        if (!self.processed.contains(id)) return;
+        let request: &WithdrawalRequest = self.processed.borrow(id);
+        if (request.status != WithdrawalStatus::Confirmed) return;
         i = i + 1;
     };
     let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -44,6 +44,19 @@ const EWithdrawalAlreadyFinalized: vector<u8> = b"Withdrawal transaction is alre
 #[error]
 const EWithdrawalNotFullySigned: vector<u8> =
     b"Withdrawal transaction is missing one or more MPC signatures";
+#[error]
+const ECannotApproveCommittedRequest: vector<u8> =
+    b"Withdrawal request has already been committed to a transaction";
+#[error]
+const ERequestNotCancellable: vector<u8> =
+    b"Withdrawal request has already been committed and cannot be destroyed";
+#[error]
+const EWithdrawalNotConfirmed: vector<u8> = b"Withdrawal transaction has not been confirmed";
+#[error]
+const EWithdrawalAlreadyConfirmed: vector<u8> = b"Withdrawal transaction is already confirmed";
+#[error]
+const ERequestTxnMismatch: vector<u8> =
+    b"Withdrawal request is not linked to this withdrawal transaction";
 
 // ~~~~~~~ Structs ~~~~~~~
 
@@ -58,9 +71,13 @@ public enum WithdrawalStatus has copy, drop, store {
 /// Unified withdrawal request object. Tracks the full lifecycle of a withdrawal,
 /// from initial request through to confirmation or cancellation.
 ///
-/// Moves between bags on `WithdrawalRequestQueue`:
-/// - `requests` bag: active requests (Requested, Approved)
-/// - `processed` bag: completed requests (Processing, Signed, Confirmed)
+/// The `status` field is authoritative for lifecycle state. A request lives in
+/// the `requests` bag for its whole live lifecycle (Requested through
+/// Confirmed-awaiting-archival) and is moved to the `processed` archive only by
+/// the deferred `archive_withdrawal_txn` GC — keeping the per-request cost of
+/// commit/confirm to an in-place borrow instead of a bag move. Requests
+/// committed before the v2 upgrade were moved to `processed` at commit time
+/// and stay there; dual-location helpers cover both homes.
 ///
 /// The BTC balance starts full and is drained to zero at commit (burned) or cancel (returned).
 public struct WithdrawalRequest has key, store {
@@ -210,6 +227,15 @@ public struct WithdrawalCancelled has copy, drop {
     btc_amount: u64,
 }
 
+/// The deferred archival moved this confirmed withdrawal (and its requests)
+/// to the historical bags. Confirmation itself was announced by
+/// `WithdrawalConfirmed`; indexers tracking the request objects' terminal
+/// status flip should watch this event.
+public struct WithdrawalArchived has copy, drop {
+    withdrawal_txn_id: address,
+    request_ids: vector<address>,
+}
+
 // ~~~~~~~ Public Functions ~~~~~~~
 
 public fun output_utxo(amount: u64, bitcoin_address: vector<u8>): OutputUtxo {
@@ -274,6 +300,12 @@ public(package) fun approve_withdrawal(
     clock: &Clock,
 ) {
     let request: &mut WithdrawalRequest = self.requests.borrow_mut(request_id);
+    // A committed request stays in `requests` until archival, so an approval
+    // cert replayed after commit would otherwise reset Processing back to
+    // Approved — re-arming `commit_requests` on a request whose BTC is
+    // already drained. Before deferred archival this protection came from
+    // the request having left the bag.
+    assert!(request.status.is_active(), ECannotApproveCommittedRequest);
     request.status = WithdrawalStatus::Approved;
     request.approval_cert = option::some(cert);
     request.approved_timestamp_ms = option::some(clock.timestamp_ms());
@@ -307,9 +339,11 @@ public(package) fun extract_request_infos(
     })
 }
 
-/// Commit approved requests for a withdrawal transaction: drain BTC, update
-/// status, move from requests to processed. Returns the merged BTC balance
-/// for burning.
+/// Commit approved requests for a withdrawal transaction: drain BTC and
+/// update status in place. Returns the merged BTC balance for burning.
+/// The request stays in `requests` — the move to `processed` is deferred to
+/// `archive_withdrawal_txn` so this transaction pays two runtime objects per
+/// request instead of three.
 public(package) fun commit_requests(
     self: &mut WithdrawalRequestQueue,
     withdrawal_txn: &WithdrawalTransaction,
@@ -318,7 +352,7 @@ public(package) fun commit_requests(
     let mut total_btc = sui::balance::zero<BTC>();
 
     withdrawal_txn.request_ids.do_ref!(|id| {
-        let mut request: WithdrawalRequest = self.requests.remove(*id);
+        let request: &mut WithdrawalRequest = self.requests.borrow_mut(*id);
         assert!(request.status == WithdrawalStatus::Approved, ERequestNotApproved);
 
         // Drain the BTC balance and merge
@@ -327,7 +361,6 @@ public(package) fun commit_requests(
         // Update status and link to the withdrawal transaction
         request.status = WithdrawalStatus::Processing;
         request.withdrawal_txn_id = option::some(withdrawal_txn_id);
-        self.processed.add(*id, request);
     });
 
     total_btc
@@ -339,20 +372,23 @@ public(package) fun update_requests_signed(
     request_ids: &vector<address>,
 ) {
     request_ids.do_ref!(|id| {
-        let request: &mut WithdrawalRequest = self.processed.borrow_mut(*id);
+        let request = self.borrow_request_mut_any(*id);
         request.status = WithdrawalStatus::Signed;
     });
 }
 
-/// Update request statuses to Confirmed after withdrawal is finalized.
-public(package) fun update_requests_confirmed(
+/// Borrow a committed request wherever it lives: `requests` (in-place
+/// lifecycle) first, falling back to `processed` (requests committed before
+/// the deferred-archival upgrade, and archived requests).
+fun borrow_request_mut_any(
     self: &mut WithdrawalRequestQueue,
-    request_ids: &vector<address>,
-) {
-    request_ids.do_ref!(|id| {
-        let request: &mut WithdrawalRequest = self.processed.borrow_mut(*id);
-        request.status = WithdrawalStatus::Confirmed;
-    });
+    request_id: address,
+): &mut WithdrawalRequest {
+    if (self.requests.contains(request_id)) {
+        self.requests.borrow_mut(request_id)
+    } else {
+        self.processed.borrow_mut(request_id)
+    }
 }
 
 /// Cancel a withdrawal: drain BTC, clean up user index, destroy the request.
@@ -363,6 +399,11 @@ public(package) fun cancel_withdrawal(
     request_id: address,
 ): Balance<BTC> {
     let request: WithdrawalRequest = self.requests.remove(request_id);
+    // A committed request's id is still referenced by a live
+    // WithdrawalTransaction; destroying it would permanently abort that
+    // txn's archival. The entry-level `is_request_processing` gate refuses
+    // first — this backstops it.
+    assert!(request.status.is_active(), ERequestNotCancellable);
 
     let WithdrawalRequest {
         id,
@@ -389,13 +430,21 @@ public(package) fun borrow_request(
     self.requests.borrow(request_id)
 }
 
-/// Check if a request has already been committed to a WithdrawalTransaction
-/// (i.e. is in the processed bag as Processing/Signed/Confirmed).
+/// Check if a request has already been committed to a WithdrawalTransaction.
+/// Status-first: a committed request stays in `requests` (as
+/// Processing/Signed/Confirmed) until archival; the `processed` fallback
+/// covers requests committed before the deferred-archival upgrade and
+/// already-archived requests.
 public(package) fun is_request_processing(
     self: &WithdrawalRequestQueue,
     request_id: address,
 ): bool {
-    self.processed.contains(request_id)
+    if (self.requests.contains(request_id)) {
+        let request: &WithdrawalRequest = self.requests.borrow(request_id);
+        !request.status.is_active()
+    } else {
+        self.processed.contains(request_id)
+    }
 }
 
 // === Transaction Lifecycle ===
@@ -550,10 +599,57 @@ public(package) fun finalize_withdrawal_txn(
     emit_withdrawal_signed(txn);
 }
 
-/// Record the confirmation time on a withdrawal transaction. Called by
-/// `confirm_withdrawal` before the txn moves to the confirmed bag.
-public(package) fun mark_confirmed(self: &mut WithdrawalTransaction, clock: &Clock) {
-    self.confirmed_timestamp_ms = option::some(clock.timestamp_ms());
+/// Record confirmation in place: the txn stays in `withdrawal_txns` and the
+/// move to `confirmed_txns` is deferred to `archive_withdrawal_txn`. The
+/// already-confirmed guard is load-bearing replay protection: before deferred
+/// archival, a replayed confirmation cert aborted because the txn had left
+/// the hot bag; now the timestamp is the only barrier against double-emitting
+/// events and re-running the UTXO spend marking.
+public(package) fun mark_txn_confirmed(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+    clock: &Clock,
+) {
+    let txn: &mut WithdrawalTransaction = self.withdrawal_txns.borrow_mut(withdrawal_id);
+    assert!(txn.confirmed_timestamp_ms.is_none(), EWithdrawalAlreadyConfirmed);
+    txn.confirmed_timestamp_ms = option::some(clock.timestamp_ms());
+    txn.emit_withdrawal_confirmed();
+}
+
+/// Deferred archival for one confirmed withdrawal: move the txn to
+/// `confirmed_txns` and each of its requests to `processed` with status
+/// Confirmed. Idempotent — no-ops if the txn already archived (re-run or
+/// raced GC). Aborts if the txn exists but is not confirmed (caller error).
+///
+/// Requests committed before the deferred-archival upgrade already live in
+/// `processed`; for those only the status write applies.
+public(package) fun archive_withdrawal_txn(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+) {
+    if (!self.withdrawal_txns.contains(withdrawal_id)) return;
+    let request_ids = {
+        let txn: &WithdrawalTransaction = self.withdrawal_txns.borrow(withdrawal_id);
+        assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
+        txn.request_ids
+    };
+    request_ids.do!(|id| {
+        if (self.requests.contains(id)) {
+            let mut request: WithdrawalRequest = self.requests.remove(id);
+            assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
+            request.status = WithdrawalStatus::Confirmed;
+            self.processed.add(id, request);
+        } else {
+            let request: &mut WithdrawalRequest = self.processed.borrow_mut(id);
+            request.status = WithdrawalStatus::Confirmed;
+        }
+    });
+    let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);
+    sui::event::emit(WithdrawalArchived {
+        withdrawal_txn_id: withdrawal_id,
+        request_ids,
+    });
+    self.confirmed_txns.add(withdrawal_id, txn);
 }
 
 /// Reassign fresh presig indices to the still-pending inputs of a stale-epoch
@@ -702,6 +798,15 @@ public(package) fun is_approved(self: &WithdrawalStatus): bool {
     }
 }
 
+/// Status is Requested or Approved: the request has not been committed to a
+/// withdrawal transaction, so it can still be approved or cancelled.
+public(package) fun is_active(self: &WithdrawalStatus): bool {
+    match (self) {
+        WithdrawalStatus::Requested | WithdrawalStatus::Approved => true,
+        _ => false,
+    }
+}
+
 // === Event Emitters ===
 
 public(package) fun emit_withdrawal_requested(request: &WithdrawalRequest) {
@@ -772,6 +877,86 @@ fun txn_fully_signed(txn: &WithdrawalTransaction): bool {
 }
 
 // ~~~~~~~ Test Helpers ~~~~~~~
+
+#[test_only]
+public(package) fun request_in_requests(self: &WithdrawalRequestQueue, id: address): bool {
+    self.requests.contains(id)
+}
+
+#[test_only]
+public(package) fun request_in_processed(self: &WithdrawalRequestQueue, id: address): bool {
+    self.processed.contains(id)
+}
+
+#[test_only]
+public(package) fun has_withdrawal_txn(self: &WithdrawalRequestQueue, id: address): bool {
+    self.withdrawal_txns.contains(id)
+}
+
+#[test_only]
+public(package) fun has_confirmed_txn(self: &WithdrawalRequestQueue, id: address): bool {
+    self.confirmed_txns.contains(id)
+}
+
+/// Status of a request wherever it lives (requests first, processed fallback).
+#[test_only]
+public(package) fun request_status_any(
+    self: &WithdrawalRequestQueue,
+    id: address,
+): WithdrawalStatus {
+    if (self.requests.contains(id)) {
+        let request: &WithdrawalRequest = self.requests.borrow(id);
+        request.status
+    } else {
+        let request: &WithdrawalRequest = self.processed.borrow(id);
+        request.status
+    }
+}
+
+#[test_only]
+public(package) fun is_processing(self: &WithdrawalStatus): bool {
+    match (self) {
+        WithdrawalStatus::Processing => true,
+        _ => false,
+    }
+}
+
+#[test_only]
+public(package) fun is_signed(self: &WithdrawalStatus): bool {
+    match (self) {
+        WithdrawalStatus::Signed => true,
+        _ => false,
+    }
+}
+
+#[test_only]
+public(package) fun is_confirmed(self: &WithdrawalStatus): bool {
+    match (self) {
+        WithdrawalStatus::Confirmed => true,
+        _ => false,
+    }
+}
+
+/// Replicates the pre-deferred-archival commit (remove from `requests`, add
+/// to `processed`) so tests can simulate requests committed before the
+/// upgrade.
+#[test_only]
+public(package) fun commit_requests_v1_style_for_testing(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_txn: &WithdrawalTransaction,
+): Balance<BTC> {
+    let withdrawal_txn_id = withdrawal_txn.id.to_address();
+    let mut total_btc = sui::balance::zero<BTC>();
+    withdrawal_txn.request_ids.do_ref!(|id| {
+        let mut request: WithdrawalRequest = self.requests.remove(*id);
+        assert!(request.status == WithdrawalStatus::Approved, ERequestNotApproved);
+        total_btc.join(request.btc.withdraw_all());
+        request.status = WithdrawalStatus::Processing;
+        request.withdrawal_txn_id = option::some(withdrawal_txn_id);
+        self.processed.add(*id, request);
+    });
+    total_btc
+}
 
 #[test_only]
 public(package) fun new_withdrawal_txn_for_testing(

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -44,6 +44,19 @@ const EWithdrawalAlreadyFinalized: vector<u8> = b"Withdrawal transaction is alre
 #[error]
 const EWithdrawalNotFullySigned: vector<u8> =
     b"Withdrawal transaction is missing one or more MPC signatures";
+#[error]
+const ECannotApproveCommittedRequest: vector<u8> =
+    b"Withdrawal request has already been committed to a transaction";
+#[error]
+const ERequestNotCancellable: vector<u8> =
+    b"Withdrawal request has already been committed and cannot be destroyed";
+#[error]
+const EWithdrawalNotConfirmed: vector<u8> = b"Withdrawal transaction has not been confirmed";
+#[error]
+const EWithdrawalAlreadyConfirmed: vector<u8> = b"Withdrawal transaction is already confirmed";
+#[error]
+const ERequestTxnMismatch: vector<u8> =
+    b"Withdrawal request is not linked to this withdrawal transaction";
 
 // ~~~~~~~ Structs ~~~~~~~
 
@@ -58,9 +71,13 @@ public enum WithdrawalStatus has copy, drop, store {
 /// Unified withdrawal request object. Tracks the full lifecycle of a withdrawal,
 /// from initial request through to confirmation or cancellation.
 ///
-/// Moves between bags on `WithdrawalRequestQueue`:
-/// - `requests` bag: active requests (Requested, Approved)
-/// - `processed` bag: completed requests (Processing, Signed, Confirmed)
+/// The `status` field is authoritative for lifecycle state. A request lives in
+/// the `requests` bag for its whole live lifecycle (Requested through
+/// Confirmed-awaiting-archival) and is moved to the `processed` archive only by
+/// the deferred `archive_withdrawal_txn` GC — keeping the per-request cost of
+/// commit/confirm to an in-place borrow instead of a bag move. Requests
+/// committed before the v2 upgrade were moved to `processed` at commit time
+/// and stay there; dual-location helpers cover both homes.
 ///
 /// The BTC balance starts full and is drained to zero at commit (burned) or cancel (returned).
 public struct WithdrawalRequest has key, store {
@@ -210,6 +227,15 @@ public struct WithdrawalCancelled has copy, drop {
     btc_amount: u64,
 }
 
+/// The deferred archival moved this confirmed withdrawal (and its requests)
+/// to the historical bags. Confirmation itself was announced by
+/// `WithdrawalConfirmed`; indexers tracking the request objects' terminal
+/// status flip should watch this event.
+public struct WithdrawalArchived has copy, drop {
+    withdrawal_txn_id: address,
+    request_ids: vector<address>,
+}
+
 // ~~~~~~~ Public Functions ~~~~~~~
 
 public fun output_utxo(amount: u64, bitcoin_address: vector<u8>): OutputUtxo {
@@ -274,6 +300,12 @@ public(package) fun approve_withdrawal(
     clock: &Clock,
 ) {
     let request: &mut WithdrawalRequest = self.requests.borrow_mut(request_id);
+    // A committed request stays in `requests` until archival, so an approval
+    // cert replayed after commit would otherwise reset Processing back to
+    // Approved — re-arming `commit_requests` on a request whose BTC is
+    // already drained. Before deferred archival this protection came from
+    // the request having left the bag.
+    assert!(request.status.is_active(), ECannotApproveCommittedRequest);
     request.status = WithdrawalStatus::Approved;
     request.approval_cert = option::some(cert);
     request.approved_timestamp_ms = option::some(clock.timestamp_ms());
@@ -307,9 +339,11 @@ public(package) fun extract_request_infos(
     })
 }
 
-/// Commit approved requests for a withdrawal transaction: drain BTC, update
-/// status, move from requests to processed. Returns the merged BTC balance
-/// for burning.
+/// Commit approved requests for a withdrawal transaction: drain BTC and
+/// update status in place. Returns the merged BTC balance for burning.
+/// The request stays in `requests` — the move to `processed` is deferred to
+/// `archive_withdrawal_txn` so this transaction pays two runtime objects per
+/// request instead of three.
 public(package) fun commit_requests(
     self: &mut WithdrawalRequestQueue,
     withdrawal_txn: &WithdrawalTransaction,
@@ -318,7 +352,7 @@ public(package) fun commit_requests(
     let mut total_btc = sui::balance::zero<BTC>();
 
     withdrawal_txn.request_ids.do_ref!(|id| {
-        let mut request: WithdrawalRequest = self.requests.remove(*id);
+        let request: &mut WithdrawalRequest = self.requests.borrow_mut(*id);
         assert!(request.status == WithdrawalStatus::Approved, ERequestNotApproved);
 
         // Drain the BTC balance and merge
@@ -327,7 +361,6 @@ public(package) fun commit_requests(
         // Update status and link to the withdrawal transaction
         request.status = WithdrawalStatus::Processing;
         request.withdrawal_txn_id = option::some(withdrawal_txn_id);
-        self.processed.add(*id, request);
     });
 
     total_btc
@@ -339,20 +372,23 @@ public(package) fun update_requests_signed(
     request_ids: &vector<address>,
 ) {
     request_ids.do_ref!(|id| {
-        let request: &mut WithdrawalRequest = self.processed.borrow_mut(*id);
+        let request = self.borrow_request_mut_any(*id);
         request.status = WithdrawalStatus::Signed;
     });
 }
 
-/// Update request statuses to Confirmed after withdrawal is finalized.
-public(package) fun update_requests_confirmed(
+/// Borrow a committed request wherever it lives: `requests` (in-place
+/// lifecycle) first, falling back to `processed` (requests committed before
+/// the deferred-archival upgrade, and archived requests).
+fun borrow_request_mut_any(
     self: &mut WithdrawalRequestQueue,
-    request_ids: &vector<address>,
-) {
-    request_ids.do_ref!(|id| {
-        let request: &mut WithdrawalRequest = self.processed.borrow_mut(*id);
-        request.status = WithdrawalStatus::Confirmed;
-    });
+    request_id: address,
+): &mut WithdrawalRequest {
+    if (self.requests.contains(request_id)) {
+        self.requests.borrow_mut(request_id)
+    } else {
+        self.processed.borrow_mut(request_id)
+    }
 }
 
 /// Cancel a withdrawal: drain BTC, clean up user index, destroy the request.
@@ -363,6 +399,11 @@ public(package) fun cancel_withdrawal(
     request_id: address,
 ): Balance<BTC> {
     let request: WithdrawalRequest = self.requests.remove(request_id);
+    // A committed request's id is still referenced by a live
+    // WithdrawalTransaction; destroying it would permanently abort that
+    // txn's archival. The entry-level `is_request_processing` gate refuses
+    // first — this backstops it.
+    assert!(request.status.is_active(), ERequestNotCancellable);
 
     let WithdrawalRequest {
         id,
@@ -389,13 +430,21 @@ public(package) fun borrow_request(
     self.requests.borrow(request_id)
 }
 
-/// Check if a request has already been committed to a WithdrawalTransaction
-/// (i.e. is in the processed bag as Processing/Signed/Confirmed).
+/// Check if a request has already been committed to a WithdrawalTransaction.
+/// Status-first: a committed request stays in `requests` (as
+/// Processing/Signed/Confirmed) until archival; the `processed` fallback
+/// covers requests committed before the deferred-archival upgrade and
+/// already-archived requests.
 public(package) fun is_request_processing(
     self: &WithdrawalRequestQueue,
     request_id: address,
 ): bool {
-    self.processed.contains(request_id)
+    if (self.requests.contains(request_id)) {
+        let request: &WithdrawalRequest = self.requests.borrow(request_id);
+        !request.status.is_active()
+    } else {
+        self.processed.contains(request_id)
+    }
 }
 
 // === Transaction Lifecycle ===
@@ -553,10 +602,57 @@ public(package) fun finalize_withdrawal_txn(
     emit_withdrawal_signed(txn);
 }
 
-/// Record the confirmation time on a withdrawal transaction. Called by
-/// `confirm_withdrawal` before the txn moves to the confirmed bag.
-public(package) fun mark_confirmed(self: &mut WithdrawalTransaction, clock: &Clock) {
-    self.confirmed_timestamp_ms = option::some(clock.timestamp_ms());
+/// Record confirmation in place: the txn stays in `withdrawal_txns` and the
+/// move to `confirmed_txns` is deferred to `archive_withdrawal_txn`. The
+/// already-confirmed guard is load-bearing replay protection: before deferred
+/// archival, a replayed confirmation cert aborted because the txn had left
+/// the hot bag; now the timestamp is the only barrier against double-emitting
+/// events and re-running the UTXO spend marking.
+public(package) fun mark_txn_confirmed(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+    clock: &Clock,
+) {
+    let txn: &mut WithdrawalTransaction = self.withdrawal_txns.borrow_mut(withdrawal_id);
+    assert!(txn.confirmed_timestamp_ms.is_none(), EWithdrawalAlreadyConfirmed);
+    txn.confirmed_timestamp_ms = option::some(clock.timestamp_ms());
+    txn.emit_withdrawal_confirmed();
+}
+
+/// Deferred archival for one confirmed withdrawal: move the txn to
+/// `confirmed_txns` and each of its requests to `processed` with status
+/// Confirmed. Idempotent — no-ops if the txn already archived (re-run or
+/// raced GC). Aborts if the txn exists but is not confirmed (caller error).
+///
+/// Requests committed before the deferred-archival upgrade already live in
+/// `processed`; for those only the status write applies.
+public(package) fun archive_withdrawal_txn(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+) {
+    if (!self.withdrawal_txns.contains(withdrawal_id)) return;
+    let request_ids = {
+        let txn: &WithdrawalTransaction = self.withdrawal_txns.borrow(withdrawal_id);
+        assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
+        txn.request_ids
+    };
+    request_ids.do!(|id| {
+        if (self.requests.contains(id)) {
+            let mut request: WithdrawalRequest = self.requests.remove(id);
+            assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
+            request.status = WithdrawalStatus::Confirmed;
+            self.processed.add(id, request);
+        } else {
+            let request: &mut WithdrawalRequest = self.processed.borrow_mut(id);
+            request.status = WithdrawalStatus::Confirmed;
+        }
+    });
+    let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);
+    sui::event::emit(WithdrawalArchived {
+        withdrawal_txn_id: withdrawal_id,
+        request_ids,
+    });
+    self.confirmed_txns.add(withdrawal_id, txn);
 }
 
 /// Reassign fresh presig indices to the still-pending inputs of a stale-epoch
@@ -705,6 +801,15 @@ public(package) fun is_approved(self: &WithdrawalStatus): bool {
     }
 }
 
+/// Status is Requested or Approved: the request has not been committed to a
+/// withdrawal transaction, so it can still be approved or cancelled.
+public(package) fun is_active(self: &WithdrawalStatus): bool {
+    match (self) {
+        WithdrawalStatus::Requested | WithdrawalStatus::Approved => true,
+        _ => false,
+    }
+}
+
 // === Event Emitters ===
 
 public(package) fun emit_withdrawal_requested(request: &WithdrawalRequest) {
@@ -775,6 +880,86 @@ fun txn_fully_signed(txn: &WithdrawalTransaction): bool {
 }
 
 // ~~~~~~~ Test Helpers ~~~~~~~
+
+#[test_only]
+public(package) fun request_in_requests(self: &WithdrawalRequestQueue, id: address): bool {
+    self.requests.contains(id)
+}
+
+#[test_only]
+public(package) fun request_in_processed(self: &WithdrawalRequestQueue, id: address): bool {
+    self.processed.contains(id)
+}
+
+#[test_only]
+public(package) fun has_withdrawal_txn(self: &WithdrawalRequestQueue, id: address): bool {
+    self.withdrawal_txns.contains(id)
+}
+
+#[test_only]
+public(package) fun has_confirmed_txn(self: &WithdrawalRequestQueue, id: address): bool {
+    self.confirmed_txns.contains(id)
+}
+
+/// Status of a request wherever it lives (requests first, processed fallback).
+#[test_only]
+public(package) fun request_status_any(
+    self: &WithdrawalRequestQueue,
+    id: address,
+): WithdrawalStatus {
+    if (self.requests.contains(id)) {
+        let request: &WithdrawalRequest = self.requests.borrow(id);
+        request.status
+    } else {
+        let request: &WithdrawalRequest = self.processed.borrow(id);
+        request.status
+    }
+}
+
+#[test_only]
+public(package) fun is_processing(self: &WithdrawalStatus): bool {
+    match (self) {
+        WithdrawalStatus::Processing => true,
+        _ => false,
+    }
+}
+
+#[test_only]
+public(package) fun is_signed(self: &WithdrawalStatus): bool {
+    match (self) {
+        WithdrawalStatus::Signed => true,
+        _ => false,
+    }
+}
+
+#[test_only]
+public(package) fun is_confirmed(self: &WithdrawalStatus): bool {
+    match (self) {
+        WithdrawalStatus::Confirmed => true,
+        _ => false,
+    }
+}
+
+/// Replicates the pre-deferred-archival commit (remove from `requests`, add
+/// to `processed`) so tests can simulate requests committed before the
+/// upgrade.
+#[test_only]
+public(package) fun commit_requests_v1_style_for_testing(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_txn: &WithdrawalTransaction,
+): Balance<BTC> {
+    let withdrawal_txn_id = withdrawal_txn.id.to_address();
+    let mut total_btc = sui::balance::zero<BTC>();
+    withdrawal_txn.request_ids.do_ref!(|id| {
+        let mut request: WithdrawalRequest = self.requests.remove(*id);
+        assert!(request.status == WithdrawalStatus::Approved, ERequestNotApproved);
+        total_btc.join(request.btc.withdraw_all());
+        request.status = WithdrawalStatus::Processing;
+        request.withdrawal_txn_id = option::some(withdrawal_txn_id);
+        self.processed.add(*id, request);
+    });
+    total_btc
+}
 
 #[test_only]
 public(package) fun new_withdrawal_txn_for_testing(

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -636,17 +636,77 @@ public(package) fun archive_withdrawal_txn(
         assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
         txn.request_ids
     };
-    request_ids.do!(|id| {
-        if (self.requests.contains(id)) {
-            let mut request: WithdrawalRequest = self.requests.remove(id);
-            assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
-            request.status = WithdrawalStatus::Confirmed;
-            self.processed.add(id, request);
-        } else {
-            let request: &mut WithdrawalRequest = self.processed.borrow_mut(id);
-            request.status = WithdrawalStatus::Confirmed;
-        }
+    request_ids.do!(|id| self.archive_request(withdrawal_id, id));
+    let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);
+    sui::event::emit(WithdrawalArchived {
+        withdrawal_txn_id: withdrawal_id,
+        request_ids,
     });
+    self.confirmed_txns.add(withdrawal_id, txn);
+}
+
+/// Archive one request of a confirmed withdrawal wherever it lives. The
+/// `withdrawal_txn_id` cross-check runs in BOTH branches: the chunked entry
+/// takes caller-supplied ids, and without the check in the fallback branch a
+/// caller could flip an unrelated archived request's status.
+fun archive_request(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+    request_id: address,
+) {
+    if (self.requests.contains(request_id)) {
+        let mut request: WithdrawalRequest = self.requests.remove(request_id);
+        assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
+        request.status = WithdrawalStatus::Confirmed;
+        self.processed.add(request_id, request);
+    } else {
+        let request: &mut WithdrawalRequest = self.processed.borrow_mut(request_id);
+        assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
+        request.status = WithdrawalStatus::Confirmed;
+    }
+}
+
+/// Chunked archival: archive only the listed requests of a confirmed
+/// withdrawal, leaving the txn in the hot bag. Lets a txn whose request
+/// count exceeds one Sui transaction's runtime-object budget archive across
+/// several transactions; `finish_archive_withdrawal_txn` moves the txn once
+/// every request is archived. No-ops if the txn is already fully archived
+/// (re-run or raced GC); idempotent per request via the `processed` branch.
+public(package) fun archive_withdrawal_requests(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+    request_ids: &vector<address>,
+) {
+    if (!self.withdrawal_txns.contains(withdrawal_id)) return;
+    {
+        let txn: &WithdrawalTransaction = self.withdrawal_txns.borrow(withdrawal_id);
+        assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
+    };
+    request_ids.do_ref!(|id| self.archive_request(withdrawal_id, *id));
+}
+
+/// Finish a chunked archival: move the txn to `confirmed_txns` once none of
+/// its requests remain in `requests`. Silently no-ops while any request is
+/// still unarchived (or if the txn is already archived), so batched GC calls
+/// survive races with in-flight chunk transactions; the caller re-arms and
+/// retries from mirror state. The completeness walk costs only a `contains`
+/// probe per request, so it stays cheap even at the largest batch sizes.
+public(package) fun finish_archive_withdrawal_txn(
+    self: &mut WithdrawalRequestQueue,
+    withdrawal_id: address,
+) {
+    if (!self.withdrawal_txns.contains(withdrawal_id)) return;
+    let request_ids = {
+        let txn: &WithdrawalTransaction = self.withdrawal_txns.borrow(withdrawal_id);
+        assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
+        txn.request_ids
+    };
+    let mut i = 0;
+    let n = request_ids.length();
+    while (i < n) {
+        if (self.requests.contains(request_ids[i])) return;
+        i = i + 1;
+    };
     let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);
     sui::event::emit(WithdrawalArchived {
         withdrawal_txn_id: withdrawal_id,

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -685,12 +685,19 @@ public(package) fun archive_withdrawal_requests(
     request_ids.do_ref!(|id| self.archive_request(withdrawal_id, *id));
 }
 
-/// Finish a chunked archival: move the txn to `confirmed_txns` once none of
-/// its requests remain in `requests`. Silently no-ops while any request is
-/// still unarchived (or if the txn is already archived), so batched GC calls
-/// survive races with in-flight chunk transactions; the caller re-arms and
-/// retries from mirror state. The completeness walk costs only a `contains`
-/// probe per request, so it stays cheap even at the largest batch sizes.
+/// Finish a chunked archival: move the txn to `confirmed_txns` once every
+/// one of its requests has been archived — absent from the hot `requests`
+/// bag and, when resident in `processed`, flipped to `Confirmed`. Bag
+/// location alone is not completion: `processed` also holds requests
+/// committed before the v2 upgrade, still `Processing`/`Signed` until
+/// `archive_request` confirms them in place, so a location-only probe would
+/// let the permissionless finisher retire the txn immediately after
+/// confirmation and strand those requests with stale statuses. Silently
+/// no-ops while any request is still unarchived (or if the txn is already
+/// archived), so batched GC calls survive races with in-flight chunk
+/// transactions; the caller re-arms and retries from mirror state. The walk
+/// costs a `contains` probe per request plus a status read for `processed`
+/// residents, so it stays cheap even at the largest batch sizes.
 public(package) fun finish_archive_withdrawal_txn(
     self: &mut WithdrawalRequestQueue,
     withdrawal_id: address,
@@ -704,7 +711,12 @@ public(package) fun finish_archive_withdrawal_txn(
     let mut i = 0;
     let n = request_ids.length();
     while (i < n) {
-        if (self.requests.contains(request_ids[i])) return;
+        let id = request_ids[i];
+        if (self.requests.contains(id)) return;
+        if (self.processed.contains(id)) {
+            let request: &WithdrawalRequest = self.processed.borrow(id);
+            if (request.status != WithdrawalStatus::Confirmed) return;
+        };
         i = i + 1;
     };
     let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);

--- a/packages/hashi/tests/withdraw_tests.move
+++ b/packages/hashi/tests/withdraw_tests.move
@@ -269,3 +269,234 @@ fun test_cancel_processing_request() {
     clock.destroy_for_testing();
     std::unit_test::destroy(hashi);
 }
+
+// ======== Deferred archival (entry-level) tests ========
+
+fun dummy_queue_cert(): hashi::committee::CommitteeSignature {
+    hashi::committee::new_committee_signature(0, vector[], vector[])
+}
+
+/// Create, approve, commit (v2 in-place), fully sign and finalize a
+/// single-request withdrawal whose input UTXO is seeded in the pool.
+/// Returns (request_id, txn_id).
+fun setup_fully_signed_txn(
+    hashi: &mut hashi::hashi::Hashi,
+    clock: &clock::Clock,
+    ctx: &mut TxContext,
+): (address, address) {
+    let id = setup_withdrawal_request(hashi, clock, 10_000, ctx);
+    hashi.bitcoin_mut().withdrawal_queue_mut().approve_withdrawal(id, dummy_queue_cert(), clock);
+
+    let input_id = utxo::utxo_id(@0xBEEF, 0);
+    let input = utxo::utxo(input_id, 1_000_000, option::none());
+    hashi.bitcoin_mut().utxo_pool_mut().insert_active(input);
+
+    let txn = withdrawal_queue::new_withdrawal_txn_for_testing(
+        vector[id],
+        vector[input],
+        vector[withdrawal_queue::output_utxo(1, x"00")],
+        vector[],
+        @0xBEEF,
+        clock,
+        ctx,
+    );
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = hashi.bitcoin_mut().withdrawal_queue_mut().commit_requests(&txn);
+    btc.destroy_for_testing();
+    hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal_txn(txn);
+
+    let queue = hashi.bitcoin_mut().withdrawal_queue_mut();
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], clock);
+    queue.update_requests_signed(&vector[id]);
+    (id, txn_id)
+}
+
+fun confirm_via_entry(hashi: &mut hashi::hashi::Hashi, txn_id: address, clock: &clock::Clock) {
+    let epoch = 0u64;
+    let message = hashi::withdraw::new_withdrawal_confirmation_message(txn_id);
+    let message_bytes = build_cert_message(
+        epoch,
+        hashi::intent::withdrawal_confirmation(),
+        &message,
+    );
+    let cert = test_utils::sign_certificate(epoch, &message_bytes, 3);
+    hashi::withdraw::confirm_withdrawal(hashi, txn_id, cert, clock);
+}
+
+#[test]
+fun test_confirm_withdrawal_defers_archival() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (id, txn_id) = setup_fully_signed_txn(&mut hashi, &clock, ctx);
+    confirm_via_entry(&mut hashi, txn_id, &clock);
+
+    // Confirm recorded in place: txn stays in the hot bag, request keeps its
+    // Signed status in `requests`; both moves are deferred to archival.
+    let queue = hashi.bitcoin().withdrawal_queue();
+    assert!(queue.has_withdrawal_txn(txn_id));
+    assert!(!queue.has_confirmed_txn(txn_id));
+    assert!(queue.request_in_requests(id));
+    assert!(queue.request_status_any(id).is_signed());
+
+    // The archival GC completes both moves.
+    hashi::withdraw::archive_confirmed_withdrawals(&mut hashi, vector[txn_id]);
+    let queue = hashi.bitcoin().withdrawal_queue();
+    assert!(!queue.has_withdrawal_txn(txn_id));
+    assert!(queue.has_confirmed_txn(txn_id));
+    assert!(queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_confirmed());
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = hashi::withdrawal_queue::EWithdrawalAlreadyConfirmed)]
+fun test_confirm_withdrawal_replay_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (_id, txn_id) = setup_fully_signed_txn(&mut hashi, &clock, ctx);
+    confirm_via_entry(&mut hashi, txn_id, &clock);
+    // A replayed confirmation cert must abort instead of double-emitting
+    // events and re-running the UTXO spend marking.
+    confirm_via_entry(&mut hashi, txn_id, &clock);
+    abort 0
+}
+
+#[test]
+fun test_archive_entry_batch_mixed() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (_id1, txn_id1) = setup_fully_signed_txn(&mut hashi, &clock, ctx);
+    confirm_via_entry(&mut hashi, txn_id1, &clock);
+    // Archive the first ahead of the batch call: the batch must skip it.
+    hashi::withdraw::archive_confirmed_withdrawals(&mut hashi, vector[txn_id1]);
+
+    let id2 = setup_withdrawal_request(&mut hashi, &clock, 20_000, ctx);
+    hashi.bitcoin_mut().withdrawal_queue_mut().approve_withdrawal(id2, dummy_queue_cert(), &clock);
+    let input2_id = utxo::utxo_id(@0xF00D, 0);
+    let input2 = utxo::utxo(input2_id, 2_000_000, option::none());
+    hashi.bitcoin_mut().utxo_pool_mut().insert_active(input2);
+    let txn2 = withdrawal_queue::new_withdrawal_txn_for_testing(
+        vector[id2],
+        vector[input2],
+        vector[withdrawal_queue::output_utxo(1, x"00")],
+        vector[],
+        @0xF00D,
+        &clock,
+        ctx,
+    );
+    let txn_id2 = txn2.withdrawal_txn_id();
+    let btc2 = hashi.bitcoin_mut().withdrawal_queue_mut().commit_requests(&txn2);
+    btc2.destroy_for_testing();
+    hashi.bitcoin_mut().withdrawal_queue_mut().insert_withdrawal_txn(txn2);
+    {
+        let queue = hashi.bitcoin_mut().withdrawal_queue_mut();
+        queue.record_input_signatures(txn_id2, vector[0], vector[x"DEADBEEF"]);
+        queue.finalize_withdrawal_txn(txn_id2, vector[x"AAAAAAAA"], &clock);
+        queue.update_requests_signed(&vector[id2]);
+    };
+    confirm_via_entry(&mut hashi, txn_id2, &clock);
+
+    // Batch containing one already-archived and one fresh id succeeds.
+    hashi::withdraw::archive_confirmed_withdrawals(&mut hashi, vector[txn_id1, txn_id2]);
+    let queue = hashi.bitcoin().withdrawal_queue();
+    assert!(queue.has_confirmed_txn(txn_id1));
+    assert!(queue.has_confirmed_txn(txn_id2));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = hashi::withdraw::ECannotCancelProcessingWithdrawal)]
+fun test_cancel_pre_upgrade_processed_request() {
+    let epoch = 0u64;
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, epoch);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+
+    // Simulate a request committed before the deferred-archival upgrade: it
+    // sits in `processed`, so the cancellation gate must trip via the
+    // fallback bag check rather than the status-first path.
+    let id = setup_withdrawal_request(&mut hashi, &clock, 10_000, ctx);
+    hashi.bitcoin_mut().withdrawal_queue_mut().approve_withdrawal(id, dummy_queue_cert(), &clock);
+    let input = utxo::utxo(utxo::utxo_id(@0xBEEF, 0), 1_000_000, option::none());
+    let txn = withdrawal_queue::new_withdrawal_txn_for_testing(
+        vector[id],
+        vector[input],
+        vector[withdrawal_queue::output_utxo(1, x"00")],
+        vector[],
+        @0xBEEF,
+        &clock,
+        ctx,
+    );
+    let btc = hashi.bitcoin_mut().withdrawal_queue_mut().commit_requests_v1_style_for_testing(&txn);
+
+    let one_hour_ms = 1000 * 60 * 60;
+    clock.set_for_testing(one_hour_ms);
+    let refund = hashi::withdraw::cancel_withdrawal(&mut hashi, id, &clock, ctx);
+
+    // Cleanup — not reached.
+    refund.destroy_for_testing();
+    btc.destroy_for_testing();
+    std::unit_test::destroy(txn);
+    clock.destroy_for_testing();
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_archive_runs_while_paused() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (_id, txn_id) = setup_fully_signed_txn(&mut hashi, &clock, ctx);
+    confirm_via_entry(&mut hashi, txn_id, &clock);
+
+    // Pause the system (proposer + one more vote reaches 2/3), then verify
+    // archival (GC) still runs.
+    let proposal_id = test_utils::create_emergency_pause_proposal(
+        &mut hashi,
+        VOTER1,
+        true,
+        &clock,
+        ctx,
+    );
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    hashi::proposal::vote<hashi::emergency_pause::EmergencyPause>(
+        &mut hashi,
+        VOTER2,
+        proposal_id,
+        &clock,
+        ctx2,
+    );
+    let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
+    hashi::proposal::vote<hashi::emergency_pause::EmergencyPause>(
+        &mut hashi,
+        VOTER3,
+        proposal_id,
+        &clock,
+        ctx3,
+    );
+    hashi::emergency_pause::execute(&mut hashi, proposal_id, &clock);
+    assert!(hashi.config().paused());
+
+    hashi::withdraw::archive_confirmed_withdrawals(&mut hashi, vector[txn_id]);
+    assert!(hashi.bitcoin().withdrawal_queue().has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -1164,3 +1164,113 @@ fun test_queue_cancel_committed_request_aborts() {
     btc.destroy_for_testing();
     abort 0
 }
+
+// ======== Chunked archival tests ========
+
+/// Three-request txn: approved, committed (v2 in-place), fully signed,
+/// finalized, and confirmed. Returns (ids, txn_id).
+fun setup_confirmed_three_request_txn(
+    queue: &mut withdrawal_queue::WithdrawalRequestQueue,
+    clock: &clock::Clock,
+    ctx: &mut TxContext,
+): (vector<address>, address) {
+    let id1 = setup_request(queue, clock, 10_000, ctx);
+    let id2 = setup_request(queue, clock, 20_000, ctx);
+    let id3 = setup_request(queue, clock, 30_000, ctx);
+    queue.approve_withdrawal(id1, dummy_cert(), clock);
+    queue.approve_withdrawal(id2, dummy_cert(), clock);
+    queue.approve_withdrawal(id3, dummy_cert(), clock);
+    let txn = make_test_txn(vector[id1, id2, id3], @0xC0FFEE, clock, ctx);
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = queue.commit_requests(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], clock);
+    queue.update_requests_signed(&vector[id1, id2, id3]);
+    queue.mark_txn_confirmed(txn_id, clock);
+    (vector[id1, id2, id3], txn_id)
+}
+
+#[test]
+fun test_chunked_archive_partial_then_finish() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (ids, txn_id) = setup_confirmed_three_request_txn(&mut queue, &clock, ctx);
+
+    // Archive two of three: those move, the third stays, the txn stays hot.
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[0], ids[1]]);
+    assert!(queue.request_in_processed(ids[0]));
+    assert!(queue.request_status_any(ids[0]).is_confirmed());
+    assert!(queue.request_in_processed(ids[1]));
+    assert!(queue.request_in_requests(ids[2]));
+    assert!(queue.request_status_any(ids[2]).is_signed());
+    assert!(queue.has_withdrawal_txn(txn_id));
+
+    // Finish must no-op while a request remains unarchived.
+    queue.finish_archive_withdrawal_txn(txn_id);
+    assert!(queue.has_withdrawal_txn(txn_id));
+    assert!(!queue.has_confirmed_txn(txn_id));
+
+    // Archive the last request; finish now moves the txn.
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[2]]);
+    queue.finish_archive_withdrawal_txn(txn_id);
+    assert!(!queue.has_withdrawal_txn(txn_id));
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+fun test_chunked_archive_rerun_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (ids, txn_id) = setup_confirmed_three_request_txn(&mut queue, &clock, ctx);
+
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[0]]);
+    // Re-running the same chunk is a no-op status re-write, not an abort.
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[0]]);
+    assert!(queue.request_in_processed(ids[0]));
+    assert!(queue.request_status_any(ids[0]).is_confirmed());
+
+    // After the txn is fully archived, chunk calls no-op entirely.
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[1], ids[2]]);
+    queue.finish_archive_withdrawal_txn(txn_id);
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[0]]);
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+#[expected_failure(abort_code = withdrawal_queue::ERequestTxnMismatch)]
+fun test_chunked_archive_foreign_request_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (_ids, txn_id) = setup_confirmed_three_request_txn(&mut queue, &clock, ctx);
+    // A request belonging to a different withdrawal must be rejected in the
+    // requests branch (and the processed branch carries the same check).
+    let (foreign_id, _info) = approve_and_commit(&mut queue, &clock, 40_000, ctx);
+    queue.archive_withdrawal_requests(txn_id, &vector[foreign_id]);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = EWithdrawalNotConfirmed)]
+fun test_chunked_archive_unconfirmed_txn_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.archive_withdrawal_requests(txn_id, &vector[]);
+    abort 0
+}

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -16,6 +16,10 @@ use hashi::{
         EOutputAmountMismatch,
         EOutputAddressMismatch,
         EMinerFeeExceedsMax,
+        ECannotApproveCommittedRequest,
+        ERequestNotCancellable,
+        EWithdrawalNotConfirmed,
+        EWithdrawalAlreadyConfirmed,
     }
 };
 use sui::clock;
@@ -941,4 +945,215 @@ fun test_miner_fee_exceeds_max_aborts() {
     clock.destroy_for_testing();
     std::unit_test::destroy(queue);
     std::unit_test::destroy(config);
+}
+
+// ======== Deferred archival tests ========
+
+#[test]
+fun test_commit_leaves_request_in_requests_with_processing() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+
+    assert!(queue.request_in_requests(id));
+    assert!(!queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_processing());
+    // The bag-membership gate must still recognize the request as committed.
+    assert!(queue.is_request_processing(id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+#[expected_failure(abort_code = ECannotApproveCommittedRequest)]
+fun test_approve_committed_request_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+    // Replay of an approval cert against the committed request must not
+    // reset Processing back to Approved (it would re-arm commit on a
+    // drained request).
+    queue.approve_withdrawal(id, dummy_cert(), &clock);
+    abort 0
+}
+
+#[test]
+fun test_update_requests_signed_both_locations() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // v2-committed: request lives in `requests`.
+    let (v2_id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+    queue.update_requests_signed(&vector[v2_id]);
+    assert!(queue.request_in_requests(v2_id));
+    assert!(queue.request_status_any(v2_id).is_signed());
+
+    // v1-committed (pre-upgrade): request lives in `processed`.
+    let v1_id = setup_request(&mut queue, &clock, 60_000, ctx);
+    queue.approve_withdrawal(v1_id, dummy_cert(), &clock);
+    let txn = make_test_txn(vector[v1_id], @0xF00D, &clock, ctx);
+    let btc = queue.commit_requests_v1_style_for_testing(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.update_requests_signed(&vector[v1_id]);
+    assert!(queue.request_in_processed(v1_id));
+    assert!(queue.request_status_any(v1_id).is_signed());
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+fun test_archive_moves_request_and_txn() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.mark_txn_confirmed(txn_id, &clock);
+
+    // Confirmed but not yet archived: txn still in the hot bag.
+    assert!(queue.has_withdrawal_txn(txn_id));
+    assert!(!queue.has_confirmed_txn(txn_id));
+
+    queue.archive_withdrawal_txn(txn_id);
+
+    assert!(!queue.has_withdrawal_txn(txn_id));
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+fun test_archive_flips_request_to_confirmed_in_processed() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let id = setup_request(&mut queue, &clock, 50_000, ctx);
+    queue.approve_withdrawal(id, dummy_cert(), &clock);
+    let txn = make_test_txn(vector[id], @0xBEEF, &clock, ctx);
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = queue.commit_requests(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.update_requests_signed(&vector[id]);
+    queue.mark_txn_confirmed(txn_id, &clock);
+
+    queue.archive_withdrawal_txn(txn_id);
+
+    assert!(!queue.request_in_requests(id));
+    assert!(queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_confirmed());
+    assert!(queue.is_request_processing(id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+fun test_archive_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.mark_txn_confirmed(txn_id, &clock);
+
+    queue.archive_withdrawal_txn(txn_id);
+    // Re-run is a no-op, not an abort.
+    queue.archive_withdrawal_txn(txn_id);
+
+    assert!(!queue.has_withdrawal_txn(txn_id));
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+#[expected_failure(abort_code = EWithdrawalNotConfirmed)]
+fun test_archive_unconfirmed_txn_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.archive_withdrawal_txn(txn_id);
+    abort 0
+}
+
+#[test]
+fun test_archive_v1_leftover_stays_in_processed() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // Simulate a request committed before the upgrade: it already lives in
+    // `processed`, status Processing.
+    let id = setup_request(&mut queue, &clock, 50_000, ctx);
+    queue.approve_withdrawal(id, dummy_cert(), &clock);
+    let txn = make_test_txn(vector[id], @0xBEEF, &clock, ctx);
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = queue.commit_requests_v1_style_for_testing(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.update_requests_signed(&vector[id]);
+
+    // Confirmed under v2, archived by GC: the request gets its terminal
+    // status in place, no second move.
+    queue.mark_txn_confirmed(txn_id, &clock);
+    queue.archive_withdrawal_txn(txn_id);
+
+    assert!(queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_confirmed());
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+#[expected_failure(abort_code = EWithdrawalAlreadyConfirmed)]
+fun test_mark_txn_confirmed_twice_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.mark_txn_confirmed(txn_id, &clock);
+    queue.mark_txn_confirmed(txn_id, &clock);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = ERequestNotCancellable)]
+fun test_queue_cancel_committed_request_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+    // The entry-level is_request_processing gate refuses first in production;
+    // this defensive assert must also hold if the queue fn is reached.
+    let btc = queue.cancel_withdrawal(id);
+    btc.destroy_for_testing();
+    abort 0
 }

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -16,6 +16,10 @@ use hashi::{
         EOutputAmountMismatch,
         EOutputAddressMismatch,
         EMinerFeeExceedsMax,
+        ECannotApproveCommittedRequest,
+        ERequestNotCancellable,
+        EWithdrawalNotConfirmed,
+        EWithdrawalAlreadyConfirmed,
     }
 };
 use sui::clock;
@@ -948,4 +952,215 @@ fun test_miner_fee_exceeds_max_aborts() {
     clock.destroy_for_testing();
     std::unit_test::destroy(queue);
     std::unit_test::destroy(config);
+}
+
+// ======== Deferred archival tests ========
+
+#[test]
+fun test_commit_leaves_request_in_requests_with_processing() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+
+    assert!(queue.request_in_requests(id));
+    assert!(!queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_processing());
+    // The bag-membership gate must still recognize the request as committed.
+    assert!(queue.is_request_processing(id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+#[expected_failure(abort_code = ECannotApproveCommittedRequest)]
+fun test_approve_committed_request_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+    // Replay of an approval cert against the committed request must not
+    // reset Processing back to Approved (it would re-arm commit on a
+    // drained request).
+    queue.approve_withdrawal(id, dummy_cert(), &clock);
+    abort 0
+}
+
+#[test]
+fun test_update_requests_signed_both_locations() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // v2-committed: request lives in `requests`.
+    let (v2_id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+    queue.update_requests_signed(&vector[v2_id]);
+    assert!(queue.request_in_requests(v2_id));
+    assert!(queue.request_status_any(v2_id).is_signed());
+
+    // v1-committed (pre-upgrade): request lives in `processed`.
+    let v1_id = setup_request(&mut queue, &clock, 60_000, ctx);
+    queue.approve_withdrawal(v1_id, dummy_cert(), &clock);
+    let txn = make_test_txn(vector[v1_id], @0xF00D, &clock, ctx);
+    let btc = queue.commit_requests_v1_style_for_testing(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.update_requests_signed(&vector[v1_id]);
+    assert!(queue.request_in_processed(v1_id));
+    assert!(queue.request_status_any(v1_id).is_signed());
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+fun test_archive_moves_request_and_txn() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.mark_txn_confirmed(txn_id, &clock);
+
+    // Confirmed but not yet archived: txn still in the hot bag.
+    assert!(queue.has_withdrawal_txn(txn_id));
+    assert!(!queue.has_confirmed_txn(txn_id));
+
+    queue.archive_withdrawal_txn(txn_id);
+
+    assert!(!queue.has_withdrawal_txn(txn_id));
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+fun test_archive_flips_request_to_confirmed_in_processed() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let id = setup_request(&mut queue, &clock, 50_000, ctx);
+    queue.approve_withdrawal(id, dummy_cert(), &clock);
+    let txn = make_test_txn(vector[id], @0xBEEF, &clock, ctx);
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = queue.commit_requests(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.update_requests_signed(&vector[id]);
+    queue.mark_txn_confirmed(txn_id, &clock);
+
+    queue.archive_withdrawal_txn(txn_id);
+
+    assert!(!queue.request_in_requests(id));
+    assert!(queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_confirmed());
+    assert!(queue.is_request_processing(id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+fun test_archive_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.mark_txn_confirmed(txn_id, &clock);
+
+    queue.archive_withdrawal_txn(txn_id);
+    // Re-run is a no-op, not an abort.
+    queue.archive_withdrawal_txn(txn_id);
+
+    assert!(!queue.has_withdrawal_txn(txn_id));
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+#[expected_failure(abort_code = EWithdrawalNotConfirmed)]
+fun test_archive_unconfirmed_txn_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.archive_withdrawal_txn(txn_id);
+    abort 0
+}
+
+#[test]
+fun test_archive_v1_leftover_stays_in_processed() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // Simulate a request committed before the upgrade: it already lives in
+    // `processed`, status Processing.
+    let id = setup_request(&mut queue, &clock, 50_000, ctx);
+    queue.approve_withdrawal(id, dummy_cert(), &clock);
+    let txn = make_test_txn(vector[id], @0xBEEF, &clock, ctx);
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = queue.commit_requests_v1_style_for_testing(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.update_requests_signed(&vector[id]);
+
+    // Confirmed under v2, archived by GC: the request gets its terminal
+    // status in place, no second move.
+    queue.mark_txn_confirmed(txn_id, &clock);
+    queue.archive_withdrawal_txn(txn_id);
+
+    assert!(queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_confirmed());
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+#[expected_failure(abort_code = EWithdrawalAlreadyConfirmed)]
+fun test_mark_txn_confirmed_twice_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.mark_txn_confirmed(txn_id, &clock);
+    queue.mark_txn_confirmed(txn_id, &clock);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = ERequestNotCancellable)]
+fun test_queue_cancel_committed_request_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+    // The entry-level is_request_processing gate refuses first in production;
+    // this defensive assert must also hold if the queue fn is reached.
+    let btc = queue.cancel_withdrawal(id);
+    btc.destroy_for_testing();
+    abort 0
 }

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -1274,3 +1274,47 @@ fun test_chunked_archive_unconfirmed_txn_aborts() {
     queue.archive_withdrawal_requests(txn_id, &vector[]);
     abort 0
 }
+
+#[test]
+/// Regression: `processed` residency is not archival. A request committed
+/// before the v2 upgrade lives in `processed` while still `Signed`, so an
+/// adversarial early finish right after confirmation must no-op instead of
+/// retiring the txn and stranding the request with a stale status; archiving
+/// the request (Confirmed in place) then lets the finish complete.
+fun test_finish_archive_waits_for_v1_committed_requests() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    // v1-committed (pre-upgrade): request lives in `processed`.
+    let id = setup_request(&mut queue, &clock, 60_000, ctx);
+    queue.approve_withdrawal(id, dummy_cert(), &clock);
+    let txn = make_test_txn(vector[id], @0xF00D, &clock, ctx);
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = queue.commit_requests_v1_style_for_testing(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
+    queue.update_requests_signed(&vector[id]);
+    queue.mark_txn_confirmed(txn_id, &clock);
+    assert!(queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_signed());
+
+    // Adversarial early finish before any archive_request ran: must no-op.
+    queue.finish_archive_withdrawal_txn(txn_id);
+    assert!(queue.has_withdrawal_txn(txn_id));
+    assert!(!queue.has_confirmed_txn(txn_id));
+    assert!(queue.request_status_any(id).is_signed());
+
+    // Archive the request (Confirmed in place), then the finish completes.
+    queue.archive_withdrawal_requests(txn_id, &vector[id]);
+    queue.finish_archive_withdrawal_txn(txn_id);
+    assert!(!queue.has_withdrawal_txn(txn_id));
+    assert!(queue.has_confirmed_txn(txn_id));
+    assert!(queue.request_in_processed(id));
+    assert!(queue.request_status_any(id).is_confirmed());
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -1157,3 +1157,113 @@ fun test_queue_cancel_committed_request_aborts() {
     btc.destroy_for_testing();
     abort 0
 }
+
+// ======== Chunked archival tests ========
+
+/// Three-request txn: approved, committed (v2 in-place), fully signed,
+/// finalized, and confirmed. Returns (ids, txn_id).
+fun setup_confirmed_three_request_txn(
+    queue: &mut withdrawal_queue::WithdrawalRequestQueue,
+    clock: &clock::Clock,
+    ctx: &mut TxContext,
+): (vector<address>, address) {
+    let id1 = setup_request(queue, clock, 10_000, ctx);
+    let id2 = setup_request(queue, clock, 20_000, ctx);
+    let id3 = setup_request(queue, clock, 30_000, ctx);
+    queue.approve_withdrawal(id1, dummy_cert(), clock);
+    queue.approve_withdrawal(id2, dummy_cert(), clock);
+    queue.approve_withdrawal(id3, dummy_cert(), clock);
+    let txn = make_test_txn(vector[id1, id2, id3], @0xC0FFEE, clock, ctx);
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = queue.commit_requests(&txn);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+    queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
+    queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], clock);
+    queue.update_requests_signed(&vector[id1, id2, id3]);
+    queue.mark_txn_confirmed(txn_id, clock);
+    (vector[id1, id2, id3], txn_id)
+}
+
+#[test]
+fun test_chunked_archive_partial_then_finish() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (ids, txn_id) = setup_confirmed_three_request_txn(&mut queue, &clock, ctx);
+
+    // Archive two of three: those move, the third stays, the txn stays hot.
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[0], ids[1]]);
+    assert!(queue.request_in_processed(ids[0]));
+    assert!(queue.request_status_any(ids[0]).is_confirmed());
+    assert!(queue.request_in_processed(ids[1]));
+    assert!(queue.request_in_requests(ids[2]));
+    assert!(queue.request_status_any(ids[2]).is_signed());
+    assert!(queue.has_withdrawal_txn(txn_id));
+
+    // Finish must no-op while a request remains unarchived.
+    queue.finish_archive_withdrawal_txn(txn_id);
+    assert!(queue.has_withdrawal_txn(txn_id));
+    assert!(!queue.has_confirmed_txn(txn_id));
+
+    // Archive the last request; finish now moves the txn.
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[2]]);
+    queue.finish_archive_withdrawal_txn(txn_id);
+    assert!(!queue.has_withdrawal_txn(txn_id));
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+fun test_chunked_archive_rerun_idempotent() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (ids, txn_id) = setup_confirmed_three_request_txn(&mut queue, &clock, ctx);
+
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[0]]);
+    // Re-running the same chunk is a no-op status re-write, not an abort.
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[0]]);
+    assert!(queue.request_in_processed(ids[0]));
+    assert!(queue.request_status_any(ids[0]).is_confirmed());
+
+    // After the txn is fully archived, chunk calls no-op entirely.
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[1], ids[2]]);
+    queue.finish_archive_withdrawal_txn(txn_id);
+    queue.archive_withdrawal_requests(txn_id, &vector[ids[0]]);
+    assert!(queue.has_confirmed_txn(txn_id));
+
+    clock.destroy_for_testing();
+    std::unit_test::destroy(queue);
+}
+
+#[test]
+#[expected_failure(abort_code = withdrawal_queue::ERequestTxnMismatch)]
+fun test_chunked_archive_foreign_request_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let (_ids, txn_id) = setup_confirmed_three_request_txn(&mut queue, &clock, ctx);
+    // A request belonging to a different withdrawal must be rejected in the
+    // requests branch (and the processed branch carries the same check).
+    let (foreign_id, _info) = approve_and_commit(&mut queue, &clock, 40_000, ctx);
+    queue.archive_withdrawal_requests(txn_id, &vector[foreign_id]);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = EWithdrawalNotConfirmed)]
+fun test_chunked_archive_unconfirmed_txn_aborts() {
+    let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
+    let mut queue = setup_queue(ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let txn_id = setup_withdrawal_txn(&mut queue, &clock, 50_000, @0xBEEF, ctx);
+    queue.archive_withdrawal_requests(txn_id, &vector[]);
+    abort 0
+}


### PR DESCRIPTION
Move base of the withdrawal deferred-archival stack. Based on `main`; the Rust caller (batch-cap raise + leader GC job) lands stacked on top in #1023. v2-gated — every new archival entry asserts `assert_version_enabled()`, so the deferred flow only runs once the v2 upgrade is enabled.

## Problem

`commit_withdrawal_tx` and `confirm_withdrawal` are the withdrawal flow's two worst transactions by live object reads (Sui object-runtime cache loads):

- `commit_withdrawal_tx`: `12 + 3N + U` runtime objects, hitting the 922 engineered budget at the 298-request cap. The `3N` term is entirely the `requests → processed` ObjectBag move (old Field + child + new Field), one per request.
- `confirm_withdrawal`: `43 + 2N + I`, second worst.

## Change

Make the `status` field authoritative and write it in place; cert-free GC entries perform the deferred bag-to-bag moves in batches after final confirmation — the same pattern `mark_spent` / `cleanup_spent_utxos` already uses, and like them deliberately **not** pause/reconfig-gated (they move no funds and must stay callable during an emergency pause).

- `commit_requests` keeps the request in `requests` (drains BTC, sets Processing + txn link via `borrow_mut`) → commit drops to `12 + 2N + U`. #1023 turns that headroom into a 298 → 447 batch-cap raise.
- `confirm_withdrawal` records `confirmed_timestamp_ms` in place, emits `WithdrawalConfirmed`, and marks input UTXOs spent → `~42 + I`, decoupled from request count.

## Archival entries

All idempotent, all safe for permissionless callers — every write is derivable from already-certified monotone state, so an adversarial caller can at worst archive earlier than the operator would (a semantic no-op). A new `WithdrawalArchived` event announces the terminal status flip for indexers tracking the request objects.

- `archive_confirmed_withdrawals(ids)`: whole-txn atomic archival — the normal path for txns that fit one Sui transaction.
- `archive_withdrawal_requests(txn_id, request_ids)` + `finish_archive_withdrawal_txns(ids)`: chunked path for txns whose request cost exceeds one Sui transaction (needed once the cap rises past ~300). The `withdrawal_txn_id` cross-check runs in **both** location branches because the chunk entry takes caller-supplied ids; the finisher moves the txn only after a contains-only walk (one probe/request) confirms every request has left the hot bag, and silently skips incomplete/already-finished ids so batched calls survive races with in-flight chunk transactions.

## Explicit guards (previously implicit in bag membership)

Deferred archival keeps a committed request in `requests` instead of moving it out, so protections that used to come free from the request having left the bag are now explicit asserts (each unit-tested):

- `approve_withdrawal` refuses non-active requests — without this, an approval-cert replay would reset a committed request to Approved and re-arm a second commit against already-drained BTC.
- `mark_txn_confirmed` refuses replayed confirmation certs — the `confirmed_timestamp_ms`-already-set check is now the only barrier against double-emitting events and re-running the UTXO spend marking.
- `cancel_withdrawal` asserts the request is still active before destroying it — destroying a committed request (still referenced by a live `WithdrawalTransaction`) would permanently abort that txn's archival.

## Cross-version state

Requests committed pre-upgrade already live in `processed`. `update_requests_signed`, `is_request_processing`, and the archival walks are dual-location: they check `requests` first (status-first) and fall back to `processed`.

## Tests

19 new Move tests, full package suite green — in-place commit/confirm, confirmation-replay guard, dual-location `update_requests_signed`, archival idempotency + v1-leftover, chunked partial-then-finish, foreign-request rejection, unconfirmed-txn abort, GC-while-paused, and mixed batches. No changes to existing struct/enum layouts (only a new `WithdrawalArchived` event and new error constants).

Stacked: Rust caller in #1023.