### PR TITLE
leader: archive confirmed withdrawals through a batched, version-gated GC

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -37,6 +37,7 @@ mod tests {
     use crate::test_helpers::txid_to_address;
     use crate::test_helpers::wait_for_deposit_confirmation;
     use crate::test_helpers::wait_for_spent_utxo_cleanup;
+    use crate::test_helpers::wait_for_withdrawal_archival;
 
     const MAX_TX_SIZE_BYTES: usize = 131_072;
     const MAX_SERIALIZED_TX_EFFECTS_SIZE_BYTES: usize = 524_288;
@@ -576,6 +577,12 @@ mod tests {
         // must now clean them from its mirror, and the eventless cleanup
         // deletions must reach every node's mirror via the object stream.
         wait_for_spent_utxo_cleanup(&networks, Duration::from_secs(60)).await?;
+
+        // The confirm left the withdrawal txn (and its requests) in the hot
+        // bags; the leader's deferred-archival GC must move them to the
+        // archive bags on-chain, observable as the ids draining from every
+        // node's mirror. This pins the deferred-archival GC end-to-end.
+        wait_for_withdrawal_archival(&networks, Duration::from_secs(60)).await?;
 
         let guardian_state = networks
             .guardian_harness
@@ -1423,6 +1430,13 @@ mod tests {
         drop(miner);
 
         info!("Batch withdrawal confirmed on Sui");
+
+        // The confirm left the batched txn (and both requests) in the hot
+        // bags; the leader's deferred-archival GC must drain them from every
+        // node's mirror. This pins the deferred-archival GC end-to-end for
+        // the batched (multi-request) shape.
+        wait_for_withdrawal_archival(&networks, Duration::from_secs(60)).await?;
+
         info!("=== Batch Withdrawal Test Passed ===");
         Ok(())
     }

--- a/crates/e2e-tests/src/test_helpers.rs
+++ b/crates/e2e-tests/src/test_helpers.rs
@@ -17,6 +17,7 @@ use hashi::sui_tx_executor::SuiTxExecutor;
 use hashi_types::bitcoin::BitcoinAddress;
 use hashi_types::move_types::DepositConfirmed;
 use hashi_types::move_types::WithdrawalConfirmed;
+use hashi_types::move_types::WithdrawalStatus;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -393,6 +394,71 @@ pub async fn wait_for_spent_utxo_cleanup(networks: &TestNetworks, timeout: Durat
             return Err(anyhow!(
                 "Timeout after {timeout:?} waiting for the spent-UTXO cleanup: node {index}'s \
                  mirror still shows {pending} spent record(s) and {tombstones} tombstone(s)"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Wait until every node's object mirror shows the deferred withdrawal
+/// archival completed: no withdrawal transaction with
+/// `confirmed_timestamp_ms` set is still sitting in the hot
+/// `withdrawal_txns` bag, and no request in a post-commit status
+/// (Processing/Signed/Confirmed) is lingering in the hot `requests` bag.
+///
+/// Under the v2 package `confirm_withdrawal` leaves the transaction (and
+/// its requests) in the hot bags; the leader's deferred-archival GC
+/// (`archive_confirmed_withdrawals`, armed by the confirm) later moves
+/// them to `confirmed_txns`/`processed`. The mirror does not track those
+/// archive bags, so "archived" is observable exactly as the ids draining
+/// from every node's hot-bag mirror.
+pub async fn wait_for_withdrawal_archival(
+    networks: &TestNetworks,
+    timeout: Duration,
+) -> Result<()> {
+    info!("Waiting for the withdrawal archival to reach every node's mirror...");
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let laggard =
+            networks
+                .hashi_network
+                .nodes()
+                .iter()
+                .enumerate()
+                .find_map(|(index, node)| {
+                    let state = node.hashi().onchain_state();
+                    let confirmed_txns = state
+                        .withdrawal_txns()
+                        .iter()
+                        .filter(|txn| txn.is_confirmed())
+                        .count();
+                    let terminal_requests = state
+                        .withdrawal_requests()
+                        .iter()
+                        .filter(|request| {
+                            matches!(
+                                request.status,
+                                WithdrawalStatus::Processing
+                                    | WithdrawalStatus::Signed
+                                    | WithdrawalStatus::Confirmed
+                            )
+                        })
+                        .count();
+                    (confirmed_txns > 0 || terminal_requests > 0).then_some((
+                        index,
+                        confirmed_txns,
+                        terminal_requests,
+                    ))
+                });
+        let Some((index, confirmed_txns, terminal_requests)) = laggard else {
+            info!("Every node's mirror shows the confirmed withdrawals archived");
+            return Ok(());
+        };
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "Timeout after {timeout:?} waiting for the withdrawal archival: node {index}'s \
+                 mirror still shows {confirmed_txns} confirmed txn(s) in the hot bag and \
+                 {terminal_requests} post-commit request(s)"
             ));
         }
         tokio::time::sleep(Duration::from_millis(500)).await;

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -9,11 +9,15 @@
 //! - Package ID routing updates correctly in OnchainState
 
 use anyhow::Result;
+use anyhow::anyhow;
 use e2e_tests::TestNetworksBuilder;
 use e2e_tests::snapshot;
+use e2e_tests::test_helpers::BackgroundMiner;
 use e2e_tests::test_helpers::create_deposit_and_wait;
+use e2e_tests::test_helpers::extract_witness_program;
 use e2e_tests::test_helpers::get_hbtc_balance;
 use e2e_tests::test_helpers::init_test_logging;
+use e2e_tests::test_helpers::subscribe_withdrawal_confirmations;
 use e2e_tests::upgrade_flow;
 use hashi::sui_tx_executor::SuiTxExecutor;
 use std::time::Duration;
@@ -324,5 +328,176 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
     info!("v2 canary module call succeeded");
 
     info!("=== SNAPSHOT UPGRADE TEST PASSED ===");
+    Ok(())
+}
+
+/// A withdrawal committed and fully signed under the deployed **v1 bytecode**
+/// must complete after the governance upgrade to the current source:
+/// confirmation runs through the v2 `confirm_withdrawal` (which defers
+/// archival), and the leader's archival GC — armed by the confirm and
+/// version-gated on active >= 2 — then drains it.
+///
+/// This is the mid-flight rollout window the deferred-archival change has to
+/// survive: v1's commit moved the requests into the unmirrored `processed`
+/// bag, so the upgraded package confirms and archives a transaction whose
+/// requests never sat in the v2 hot-bag layout. The final assertion is that
+/// nothing wedges — signing/confirm completes and both hot-bag mirrors drain
+/// to empty on every node.
+///
+/// Parking the withdrawal fully-signed-but-unconfirmed needs no
+/// block-withholding machinery: commit and signing are driven purely by Sui
+/// checkpoints, while confirmation additionally requires the signed Bitcoin
+/// transaction to be mined — so simply not mining regtest blocks holds the
+/// flow at fully-signed under v1 (the same seam the signature-chunking tests
+/// use to observe `WithdrawalSigned` before starting their miner).
+#[tokio::test]
+async fn test_withdrawal_committed_under_v1_completes_after_upgrade() -> Result<()> {
+    init_test_logging();
+
+    // v1 = the checked-in deployed bytecode snapshot; no auto-upgrade — this
+    // test drives the upgrade itself, mid-withdrawal.
+    let mut networks = TestNetworksBuilder::new()
+        .with_nodes(4)
+        .with_v1_from_snapshot(snapshot::default_snapshot_dir()?)
+        .without_upgrade()
+        .build()
+        .await?;
+
+    let hashi_ids = networks.hashi_network.ids();
+    info!("snapshot-published v1 package ID: {}", hashi_ids.package_id);
+
+    // Committee/DKG must complete before anything can be signed (and before
+    // the upgrade proposal can pass at its 100% quorum).
+    networks.hashi_network.nodes()[0]
+        .wait_for_mpc_key(Duration::from_secs(120))
+        .await?;
+
+    // ── Deposit under v1 ────────────────────────────────────────────────
+    let deposit_sats = 100_000u64;
+    let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_sats).await?;
+
+    // ── Withdrawal: commit + full signing under v1, confirmation withheld ──
+    let node0 = networks.hashi_network.nodes()[0].hashi().clone();
+    let user_key = networks.sui_network.user_keys.first().unwrap().clone();
+    let withdrawal_sats = 30_000u64;
+    let btc_destination = networks.bitcoin_node.get_new_address()?;
+    let destination_bytes = extract_witness_program(&btc_destination)?;
+
+    let mut executor = SuiTxExecutor::from_config(&node0.config, node0.onchain_state())?
+        .with_signer(user_key.into());
+    let withdrawal_request_id = executor
+        .execute_create_withdrawal_request(withdrawal_sats, destination_bytes)
+        .await?;
+    info!("withdrawal request created under v1: {withdrawal_request_id}");
+
+    // With no regtest blocks being mined the flow parks at
+    // fully-signed-but-unconfirmed: presig generation, MPC signing, and the
+    // guardian finalize all complete (Sui-driven), the signed Bitcoin tx is
+    // broadcast, but the leader cannot observe it mined and so cannot
+    // confirm.
+    let deadline = std::time::Instant::now() + Duration::from_secs(180);
+    loop {
+        if node0
+            .onchain_state()
+            .withdrawal_txns()
+            .iter()
+            .any(|txn| txn.is_fully_signed() && !txn.is_confirmed())
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for the withdrawal to fully sign under the v1 bytecode"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    // Still a single-version chain: commit + signing really ran under v1.
+    assert_eq!(
+        node0
+            .onchain_state()
+            .state()
+            .package_versions()
+            .versions()
+            .len(),
+        1,
+        "the withdrawal must be committed and fully signed before any upgrade"
+    );
+    info!("withdrawal fully signed under v1 (unconfirmed; no regtest blocks mined)");
+
+    // ── Governance upgrade to the current source, mid-withdrawal ────────
+    let new_package_id = upgrade_flow::execute_full_upgrade(&mut networks).await?;
+    assert_ne!(
+        new_package_id, hashi_ids.package_id,
+        "upgrade should mint a new package id"
+    );
+    upgrade_flow::wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30))
+        .await?;
+    info!("upgraded mid-withdrawal: new package {new_package_id}");
+
+    // ── Complete the flow under v2: confirm, then archival GC ───────────
+    //
+    // Subscribe before the miner starts: the parked withdrawal cannot
+    // confirm until its Bitcoin tx is mined, so the subscription provably
+    // precedes the event.
+    let confirmations =
+        subscribe_withdrawal_confirmations(&mut networks.sui_network.client).await?;
+    let miner = BackgroundMiner::start(&networks.bitcoin_node);
+    let confirmed = confirmations
+        .wait_for(withdrawal_request_id, Duration::from_secs(300))
+        .await?;
+    drop(miner);
+    info!(
+        "v1-committed withdrawal confirmed via the v2 package: txid={}",
+        confirmed.txid
+    );
+
+    // The hBTC actually burned — the withdrawal completed, not merely landed.
+    assert_eq!(
+        get_hbtc_balance(
+            &mut networks.sui_network.client,
+            hashi_ids.package_id,
+            hbtc_recipient,
+        )
+        .await?,
+        deposit_sats - withdrawal_sats,
+        "withdrawal committed under v1 should burn hBTC once confirmed under v2"
+    );
+
+    // The v2 confirm left the txn in the hot bag with
+    // `confirmed_timestamp_ms` set; the archival GC must now move it to
+    // `confirmed_txns`. The v1-committed requests lived in the unmirrored
+    // `processed` bag since commit time, and the archive bags are unmirrored
+    // too — so completion is observable exactly as both hot-bag mirrors
+    // draining to empty on every node, and nothing may wedge on the
+    // cross-version state.
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        let laggard =
+            networks
+                .hashi_network
+                .nodes()
+                .iter()
+                .enumerate()
+                .find_map(|(index, node)| {
+                    let state = node.hashi().onchain_state();
+                    let txns = state.withdrawal_txns().len();
+                    let requests = state.withdrawal_requests().len();
+                    (txns > 0 || requests > 0).then_some((index, txns, requests))
+                });
+        let Some((index, txns, requests)) = laggard else {
+            break;
+        };
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "node {index}'s mirror still shows {txns} withdrawal txn(s) and {requests} \
+                 request(s) after the post-upgrade archival window"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    info!("withdrawal_txns and withdrawal_requests empty on every node");
+
+    info!("=== V1-COMMITTED WITHDRAWAL COMPLETES AFTER UPGRADE TEST PASSED ===");
     Ok(())
 }

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -579,6 +579,17 @@ impl WithdrawalStatus {
     pub fn is_requested(&self) -> bool {
         matches!(self, Self::Requested)
     }
+
+    /// Lowercase status name, for metric labels and CLI rendering.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Requested => "requested",
+            Self::Approved => "approved",
+            Self::Processing => "processing",
+            Self::Signed => "signed",
+            Self::Confirmed => "confirmed",
+        }
+    }
 }
 
 /// Rust version of the Move hashi::withdrawal_queue::WithdrawalRequest type.
@@ -724,6 +735,11 @@ impl WithdrawalTransaction {
     /// Whether the 2-of-2 witness is fully assembled and the txn is broadcast-ready.
     pub fn is_fully_signed(&self) -> bool {
         self.signing.is_complete() && self.guardian_signatures.is_some()
+    }
+
+    /// Whether the Bitcoin transaction has been confirmed on-chain.
+    pub fn is_confirmed(&self) -> bool {
+        self.confirmed_timestamp_ms.is_some()
     }
 
     /// Dense per-input MPC signatures, available only once fully signed (the

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -18,6 +18,7 @@ use crate::cli::config::CliConfig;
 use crate::cli::print_info;
 use crate::cli::print_success;
 use crate::cli::types::display;
+use crate::onchain::types::WithdrawalStatus;
 use crate::onchain::types::WithdrawalTransaction;
 
 pub async fn run(action: WithdrawCommands, config: &CliConfig, tx_opts: &TxOptions) -> Result<()> {
@@ -238,7 +239,10 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
     println!("\n{}", "Withdrawal Status".bold());
     println!("{}", "━".repeat(60).dimmed());
 
-    // Check pending request queue first
+    // Check the mirrored request map first. With deferred archival a request
+    // stays here for its whole live lifecycle — Requested/Approved, then
+    // Processing/Signed once committed into a withdrawal txn, then Confirmed
+    // until the archival GC moves it to the processed archive.
     if let Some(wr) = withdrawal_requests.iter().find(|w| w.id == req_addr) {
         println!(
             "  {} {}",
@@ -261,99 +265,85 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
             "Requested:".bold(),
             display::format_timestamp(wr.created_timestamp_ms)
         );
-        println!();
 
-        let status_label = if wr.status.is_approved() {
-            "Approved".green()
-        } else {
-            "Requested".yellow()
-        };
+        match wr.status {
+            WithdrawalStatus::Requested | WithdrawalStatus::Approved => {
+                println!();
+                let status_label = if wr.status.is_approved() {
+                    "Approved".green()
+                } else {
+                    "Requested".yellow()
+                };
 
-        let step = if wr.status.is_approved() { 2 } else { 1 };
-        println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
-        println!(
-            "    {} Requested",
-            if step >= 1 {
-                "[done]".green()
-            } else {
-                "[    ]".dimmed()
+                let step = if wr.status.is_approved() { 2 } else { 1 };
+                println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
+                println!(
+                    "    {} Requested",
+                    if step >= 1 {
+                        "[done]".green()
+                    } else {
+                        "[    ]".dimmed()
+                    }
+                );
+                println!(
+                    "    {} Approved",
+                    if step >= 2 {
+                        "[done]".green()
+                    } else {
+                        "[    ]".dimmed()
+                    }
+                );
+                println!("    {} Committed", "[    ]".dimmed());
+                println!("    {} Signed", "[    ]".dimmed());
+                println!("    {} Broadcast", "[    ]".dimmed());
+                println!("    {} Confirmed", "[    ]".dimmed());
             }
-        );
-        println!(
-            "    {} Approved",
-            if step >= 2 {
-                "[done]".green()
-            } else {
-                "[    ]".dimmed()
+            // Committed into a withdrawal txn (BTC drained): render the txn's
+            // signing progress, looked up by the request's withdrawal_txn_id.
+            WithdrawalStatus::Processing | WithdrawalStatus::Signed => {
+                let txn = wr
+                    .withdrawal_txn_id
+                    .and_then(|id| withdrawal_txns.iter().find(|p| p.id == id));
+                if let Some(pw) = txn {
+                    print_txn_progress(config, pw);
+                } else {
+                    println!();
+                    print_info(&format!(
+                        "Request status is {} but its withdrawal transaction was not \
+                         found in the pending queues.",
+                        wr.status.as_str()
+                    ));
+                }
             }
-        );
-        println!("    {} Committed", "[    ]".dimmed());
-        println!("    {} Signed", "[    ]".dimmed());
-        println!("    {} Broadcast", "[    ]".dimmed());
-        println!("    {} Confirmed", "[    ]".dimmed());
+            // Terminal state: the withdrawal is complete; the request only
+            // lingers on-chain until the archival GC sweeps it.
+            WithdrawalStatus::Confirmed => {
+                println!();
+                println!(
+                    "  {} {} (6/6)",
+                    "Progress:".bold(),
+                    "Confirmed (archival pending)".green()
+                );
+                println!("    {} Requested", "[done]".green());
+                println!("    {} Approved", "[done]".green());
+                println!("    {} Committed", "[done]".green());
+                println!("    {} Signed", "[done]".green());
+                println!("    {} Broadcast", "[done]".green());
+                println!("    {} Confirmed", "[done]".green());
+            }
+        }
     }
     // Check committed/signed withdrawal transactions
     else if let Some(pw) = withdrawal_txns
         .iter()
         .find(|p| p.request_ids.contains(&req_addr))
     {
-        let txid: bitcoin::Txid = pw.txid.into();
-        let is_signed = pw.is_fully_signed();
-        let signed_inputs = pw.signing.signed_count();
-        let num_inputs = pw.signing.num_inputs();
-        let step = if is_signed { 4 } else { 3 };
-        // Distinguish the multi-checkpoint signing window: an in-progress txn
-        // shows "Signing (X/N)" rather than a flat "Committed".
-        let status_label = if is_signed {
-            "Signed".green()
-        } else if signed_inputs > 0 {
-            format!("Signing ({signed_inputs}/{num_inputs})").cyan()
-        } else {
-            "Committed".cyan()
-        };
-
         println!(
             "  {} {}",
             "Request ID:".bold(),
             display::format_address_full(&req_addr)
         );
-        println!("  {} {}", "BTC txid:".bold(), txid);
-        println!();
-        println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
-        println!("    {} Requested", "[done]".green());
-        println!("    {} Approved", "[done]".green());
-        println!("    {} Committed          txid: {}", "[done]".green(), txid);
-        println!(
-            "    {} Signed",
-            if is_signed {
-                "[done]".green()
-            } else {
-                "[    ]".dimmed()
-            }
-        );
-        println!("    {} Broadcast", "[    ]".dimmed());
-        println!("    {} Confirmed", "[    ]".dimmed());
-
-        // BTC context
-        if let Ok(Some(btc_rpc)) = config.btc_rpc_client() {
-            println!();
-            println!("  {}", "BTC Context:".bold());
-            match btc_rpc.get_raw_transaction_verbose(txid) {
-                Ok(info) => {
-                    let confirmations = info.confirmations.unwrap_or(0) as u32;
-                    let tx_status = if confirmations > 0 {
-                        "Confirmed".to_string()
-                    } else {
-                        "In Mempool".to_string()
-                    };
-                    println!("    {} {}", "TX Status:".bold(), tx_status);
-                    println!("    {} {}/6", "Confirmations:".bold(), confirmations);
-                }
-                Err(_) => {
-                    println!("    {}", "(transaction not found on BTC node)".dimmed());
-                }
-            }
-        }
+        print_txn_progress(config, pw);
     } else {
         print_info(
             "Withdrawal request not found in pending queues (may be confirmed or cancelled).",
@@ -364,13 +354,104 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Render the committed-phase progress checklist (steps 3-6) and Bitcoin-side
+/// context for a withdrawal transaction. Shared by the request-map lookup
+/// (Processing/Signed requests point at their txn via `withdrawal_txn_id`)
+/// and the txn-map fallback lookup.
+fn print_txn_progress(config: &CliConfig, pw: &WithdrawalTransaction) {
+    let txid: bitcoin::Txid = pw.txid.into();
+    let is_confirmed = pw.is_confirmed();
+    let is_signed = pw.is_fully_signed();
+    let signed_inputs = pw.signing.signed_count();
+    let num_inputs = pw.signing.num_inputs();
+    let step = if is_confirmed {
+        6
+    } else if is_signed {
+        4
+    } else {
+        3
+    };
+    // Distinguish the multi-checkpoint signing window: an in-progress txn
+    // shows "Signing (X/N)" rather than a flat "Committed". A confirmed txn
+    // lingers in the pending map until the archival GC sweeps it, so it must
+    // render as complete rather than broadcast-ready.
+    let status_label = if is_confirmed {
+        "Confirmed (archival pending)".green()
+    } else if is_signed {
+        "Signed".green()
+    } else if signed_inputs > 0 {
+        format!("Signing ({signed_inputs}/{num_inputs})").cyan()
+    } else {
+        "Committed".cyan()
+    };
+
+    println!("  {} {}", "BTC txid:".bold(), txid);
+    println!();
+    println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
+    println!("    {} Requested", "[done]".green());
+    println!("    {} Approved", "[done]".green());
+    println!("    {} Committed          txid: {}", "[done]".green(), txid);
+    println!(
+        "    {} Signed",
+        if is_signed {
+            "[done]".green()
+        } else {
+            "[    ]".dimmed()
+        }
+    );
+    println!(
+        "    {} Broadcast",
+        if is_confirmed {
+            "[done]".green()
+        } else {
+            "[    ]".dimmed()
+        }
+    );
+    println!(
+        "    {} Confirmed",
+        if is_confirmed {
+            "[done]".green()
+        } else {
+            "[    ]".dimmed()
+        }
+    );
+
+    // BTC context
+    if let Ok(Some(btc_rpc)) = config.btc_rpc_client() {
+        println!();
+        println!("  {}", "BTC Context:".bold());
+        match btc_rpc.get_raw_transaction_verbose(txid) {
+            Ok(info) => {
+                let confirmations = info.confirmations.unwrap_or(0) as u32;
+                let tx_status = if confirmations > 0 {
+                    "Confirmed".to_string()
+                } else {
+                    "In Mempool".to_string()
+                };
+                println!("    {} {}", "TX Status:".bold(), tx_status);
+                println!("    {} {}/6", "Confirmations:".bold(), confirmations);
+            }
+            Err(_) => {
+                println!("    {}", "(transaction not found on BTC node)".dimmed());
+            }
+        }
+    }
+}
+
 async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
     let client = HashiClient::new_with_bitcoin_state(config).await?;
 
     let requests = client.fetch_withdrawal_requests()?;
     let pending = client.fetch_withdrawal_txns()?;
-    let signed_count = pending.iter().filter(|pw| pw.is_fully_signed()).count();
-    let committed_count = pending.len() - signed_count;
+    // Confirmed txns linger in the pending map until the archival GC sweeps
+    // them; classify them first so they are never counted as actionable
+    // "signed" (they are also fully signed).
+    let confirmed_count = pending.iter().filter(|pw| pw.is_confirmed()).count();
+    let signed_count = pending
+        .iter()
+        .filter(|pw| !pw.is_confirmed() && pw.is_fully_signed())
+        .count();
+    let committed_count = pending.len() - confirmed_count - signed_count;
 
     match output_format {
         OutputFormat::Json => {
@@ -380,7 +461,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                     serde_json::json!({
                         "request_id": wr.id.to_string(),
                         "amount_sats": wr.btc_amount,
-                        "status": if wr.status.is_approved() { "approved" } else { "requested" },
+                        "status": wr.status.as_str(),
                         "caller": wr.sender.to_string(),
                         "requested_ms": wr.created_timestamp_ms,
                     })
@@ -397,6 +478,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                     "queued_count": requests.len(),
                     "committed_count": committed_count,
                     "signed_count": signed_count,
+                    "confirmed_count": confirmed_count,
                 }))?
             );
         }
@@ -418,16 +500,11 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                         "Requested".bold()
                     );
                     for wr in &requests {
-                        let status = if wr.status.is_approved() {
-                            "Approved"
-                        } else {
-                            "Requested"
-                        };
                         println!(
                             "  {:<20} {:<14} {:<10} {:<20} {}",
                             display::format_address_full(&wr.id),
                             wr.btc_amount,
-                            status,
+                            wr.status.as_str(),
                             display::format_address_full(&wr.sender),
                             display::format_timestamp(wr.created_timestamp_ms)
                         );
@@ -441,7 +518,9 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                     println!("  {}", "Pending Broadcast:".bold().underline());
                     for pw in &pending {
                         let txid: bitcoin::Txid = pw.txid.into();
-                        let status = if pw.is_fully_signed() {
+                        let status = if pw.is_confirmed() {
+                            "Confirmed (archival pending)"
+                        } else if pw.is_fully_signed() {
                             "Signed"
                         } else {
                             "Committed"
@@ -456,10 +535,11 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                 }
 
                 println!(
-                    "\n  {} queued, {} committed, {} signed",
+                    "\n  {} queued, {} committed, {} signed, {} confirmed awaiting archival",
                     requests.len(),
                     committed_count,
-                    signed_count
+                    signed_count,
+                    confirmed_count
                 );
             }
 
@@ -476,9 +556,19 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
 /// of the `WithdrawalTransaction` and is unrelated to the Bitcoin txid.
 fn withdrawal_txn_row(pw: &WithdrawalTransaction) -> serde_json::Value {
     let txid: bitcoin::Txid = pw.txid.into();
+    // A confirmed txn is also fully signed, so check confirmation first: it
+    // lingers only until the archival GC sweeps it and must not be reported
+    // as an actionable "signed" txn.
+    let status = if pw.is_confirmed() {
+        "confirmed"
+    } else if pw.is_fully_signed() {
+        "signed"
+    } else {
+        "committed"
+    };
     serde_json::json!({
         "txid": txid.to_string(),
-        "status": if pw.is_fully_signed() { "signed" } else { "committed" },
+        "status": status,
         "request_count": pw.request_ids.len(),
     })
 }
@@ -537,5 +627,15 @@ mod tests {
     fn withdrawal_txn_row_reports_committed_until_fully_signed() {
         let row = withdrawal_txn_row(&withdrawal_txn(false));
         assert_eq!(row["status"], "committed");
+    }
+
+    /// A confirmed txn lingering until the archival GC must classify as
+    /// "confirmed", not fall through to "signed" (it is also fully signed).
+    #[test]
+    fn withdrawal_txn_row_reports_confirmed_over_signed() {
+        let mut txn = withdrawal_txn(true);
+        txn.confirmed_timestamp_ms = Some(2);
+        let row = withdrawal_txn_row(&txn);
+        assert_eq!(row["status"], "confirmed");
     }
 }

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -160,8 +160,10 @@ pub struct Config {
     /// transaction. The batch commits immediately once this many requests are
     /// ready, without waiting for `withdrawal_batching_delay_ms` to elapse.
     ///
-    /// Defaults to 298 (the algorithm's hard upper bound, set by the Sui
-    /// commit transaction's runtime-object budget). Note that large batches
+    /// Defaults to 447 (the algorithm's hard upper bound, set by the Sui
+    /// commit transaction's runtime-object budget under the deferred-archival
+    /// package; a chain still executing v1 bytecode is additionally capped
+    /// at 298 at batch-build time). Note that large batches
     /// automatically shrink the input side: coin selection reserves the
     /// commit object budget for requests first, so a full batch spends only
     /// a handful of funding inputs and performs no consolidation.
@@ -619,7 +621,10 @@ mod tests {
     #[test]
     fn test_withdrawal_max_batch_size_defaults_to_absolute_cap() {
         let config = Config::default();
-        assert_eq!(config.withdrawal_max_batch_size(), 298);
+        // The config clamp is the v2 cap; the leader additionally applies
+        // the version-aware cap at batch-build time, so a v1-active chain
+        // still gets the legacy 298.
+        assert_eq!(config.withdrawal_max_batch_size(), 447);
     }
 
     #[test]
@@ -655,7 +660,7 @@ mod tests {
             withdrawal_max_batch_size: Some(1_000),
             ..Config::default()
         };
-        assert_eq!(config.withdrawal_max_batch_size(), 298);
+        assert_eq!(config.withdrawal_max_batch_size(), 447);
     }
 
     #[test]

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -59,6 +59,35 @@ impl crate::leader::retry::RetryPolicy for UtxoCleanupErrorKind {
     }
 }
 
+// Cap the archival scan so one GC task stays bounded; a larger backlog
+// drains over successive checkpoints, oldest confirmations first.
+const MAX_WITHDRAWAL_ARCHIVES_PER_GC: usize = 500;
+
+// `archive_confirmed_withdrawals` first exists in the v2 package, and
+// pre-upgrade there is nothing to archive (v1 confirm archives inline).
+const WITHDRAWAL_ARCHIVE_MIN_PACKAGE_VERSION: u64 = 2;
+
+/// Failure kind for the withdrawal archival GC. Unbounded retries for the
+/// same reason as [`UtxoCleanupErrorKind`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum WithdrawalArchiveErrorKind {
+    Failed,
+}
+
+impl crate::leader::retry::RetryPolicy for WithdrawalArchiveErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        5_000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        5 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
+    }
+}
+
 impl LeaderService {
     /// Check for and delete expired deposit requests.
     /// Deposit requests are sorted by timestamp and deleted if they are older than
@@ -267,6 +296,101 @@ impl LeaderService {
         Ok(utxo_ids.len())
     }
 
+    /// Kick the deferred-archival GC for confirmed withdrawals. Shape and
+    /// arming protocol mirror [`Self::check_cleanup_spent_utxos`]; the extra
+    /// version gate exists because the archival entry only exists in v2
+    /// bytecode (and gating on the ACTIVE version also keeps the task off a
+    /// chain whose semantics this binary does not implement).
+    pub(super) fn check_archive_confirmed_withdrawals(&mut self, checkpoint_timestamp_ms: u64) {
+        if self.withdrawal_archive_gc_task.is_some() {
+            debug!("Withdrawal archival GC task already in-flight, skipping");
+            return;
+        }
+
+        let Some(active) = self.inner.onchain_state().active_package_version() else {
+            return;
+        };
+        if active < WITHDRAWAL_ARCHIVE_MIN_PACKAGE_VERSION {
+            return;
+        }
+
+        if !self.withdrawal_archive_scan_needed {
+            return;
+        }
+
+        if self
+            .withdrawal_archive_retry
+            .should_skip(checkpoint_timestamp_ms)
+        {
+            debug!("Withdrawal archival GC in backoff, skipping");
+            return;
+        }
+
+        self.withdrawal_archive_scan_needed = false;
+        let inner = self.inner.clone();
+        let scan_target = self.withdrawal_archive_scan_target;
+        self.withdrawal_archive_gc_task =
+            Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
+                Self::archive_confirmed_withdrawals(inner, scan_target).await
+            })));
+    }
+
+    /// Scan the mirror for confirmed-but-unarchived withdrawal txns and
+    /// archive them (moving each txn to `confirmed_txns` and its requests to
+    /// `processed` on-chain). Returns how many were archived so the caller
+    /// can re-arm past the per-GC cap. Freshness protocol identical to
+    /// [`Self::cleanup_spent_utxos`].
+    async fn archive_confirmed_withdrawals(
+        inner: Arc<crate::Hashi>,
+        scan_target: u64,
+    ) -> anyhow::Result<usize> {
+        const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
+        if tokio::time::timeout(
+            VISIBILITY_TIMEOUT,
+            inner.onchain_state().wait_until_checkpoint(scan_target),
+        )
+        .await
+        .is_err()
+        {
+            anyhow::bail!(
+                "mirror did not reach the archival scan target checkpoint {scan_target} within \
+                 {VISIBILITY_TIMEOUT:?}"
+            );
+        }
+        let withdrawal_txns = inner.onchain_state().withdrawal_txns();
+        let victims = find_confirmed_withdrawals_pending_archive(&withdrawal_txns);
+        if victims.is_empty() {
+            return Ok(0);
+        }
+
+        info!(
+            txn_count = victims.len(),
+            "Archiving confirmed withdrawal(s) pending archival",
+        );
+        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        let landed_at = executor
+            .execute_archive_confirmed_withdrawals(&victims)
+            .await?;
+        if tokio::time::timeout(
+            VISIBILITY_TIMEOUT,
+            inner.onchain_state().wait_until_checkpoint(landed_at),
+        )
+        .await
+        .is_err()
+        {
+            warn!(
+                landed_at,
+                "Timeout waiting for the mirror to reach the archival checkpoint; \
+                 the next scan may resubmit already-archived txns"
+            );
+        }
+        info!(
+            txn_count = victims.len(),
+            "Successfully archived confirmed withdrawals",
+        );
+        Ok(victims.len())
+    }
+
     async fn delete_expired_proposals(
         inner: Arc<crate::Hashi>,
         expired_proposals: Vec<Proposal>,
@@ -389,6 +513,24 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
         .filter(|(_, record)| record.spent_epoch.is_some())
         .map(|(id, _)| *id)
         .take(MAX_UTXO_CLEANUPS_PER_GC)
+        .collect()
+}
+
+/// Confirmed-but-unarchived withdrawal txns, oldest confirmation first so a
+/// capped backlog drains FIFO. Each victim carries its request count so the
+/// executor can pack GC transactions against the runtime-object budget.
+fn find_confirmed_withdrawals_pending_archive(
+    withdrawal_txns: &[crate::onchain::types::WithdrawalTransaction],
+) -> Vec<(Address, usize)> {
+    let mut confirmed: Vec<_> = withdrawal_txns
+        .iter()
+        .filter(|txn| txn.is_confirmed())
+        .collect();
+    confirmed.sort_by_key(|txn| txn.confirmed_timestamp_ms);
+    confirmed
+        .into_iter()
+        .take(MAX_WITHDRAWAL_ARCHIVES_PER_GC)
+        .map(|txn| (txn.id, txn.request_ids.len()))
         .collect()
 }
 

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -9,6 +9,7 @@ use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
 use crate::onchain::types::UtxoId;
 use crate::onchain::types::UtxoRecord;
+use crate::sui_tx_executor::ArchiveVictim;
 use crate::sui_tx_executor::SuiTxExecutor;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -517,11 +518,12 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
 }
 
 /// Confirmed-but-unarchived withdrawal txns, oldest confirmation first so a
-/// capped backlog drains FIFO. Each victim carries its request count so the
-/// executor can pack GC transactions against the runtime-object budget.
+/// capped backlog drains FIFO. Each victim carries its request ids so the
+/// executor can pack GC transactions against the runtime-object budget and
+/// chunk oversized txns through the split archival entries.
 fn find_confirmed_withdrawals_pending_archive(
     withdrawal_txns: &[crate::onchain::types::WithdrawalTransaction],
-) -> Vec<(Address, usize)> {
+) -> Vec<ArchiveVictim> {
     let mut confirmed: Vec<_> = withdrawal_txns
         .iter()
         .filter(|txn| txn.is_confirmed())
@@ -530,7 +532,10 @@ fn find_confirmed_withdrawals_pending_archive(
     confirmed
         .into_iter()
         .take(MAX_WITHDRAWAL_ARCHIVES_PER_GC)
-        .map(|txn| (txn.id, txn.request_ids.len()))
+        .map(|txn| ArchiveVictim {
+            txn_id: txn.id,
+            request_ids: txn.request_ids.clone(),
+        })
         .collect()
 }
 

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -128,6 +128,15 @@ pub(crate) struct LeaderService {
     // confirm. Zero at boot: the bootstrap mirror is fresh by construction.
     utxo_cleanup_scan_target: u64,
 
+    // Singleton task that archives confirmed withdrawals (moving them and
+    // their requests to the cold bags on-chain); resolves to how many txns
+    // it archived. Same arming/retry/freshness shape as the UTXO cleanup;
+    // only spawned once the active package version has the archival entry.
+    withdrawal_archive_gc_task: Option<AbortOnDropHandle<anyhow::Result<usize>>>,
+    withdrawal_archive_retry: GlobalRetryTracker<garbage_collection::WithdrawalArchiveErrorKind>,
+    withdrawal_archive_scan_needed: bool,
+    withdrawal_archive_scan_target: u64,
+
     // Singleton task that reconciles the guardian committee with the on-chain committee.
     guardian_committee_reconcile_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     // Last hashi epoch we triggered a guardian-committee reconcile for, so
@@ -167,6 +176,12 @@ impl LeaderService {
             utxo_cleanup_retry: GlobalRetryTracker::new(),
             utxo_cleanup_scan_needed: true,
             utxo_cleanup_scan_target: 0,
+            withdrawal_archive_gc_task: None,
+            withdrawal_archive_retry: GlobalRetryTracker::new(),
+            // Armed at boot for crash-between-confirm-and-archive recovery;
+            // a no-op pre-upgrade (the version gate skips the spawn).
+            withdrawal_archive_scan_needed: true,
+            withdrawal_archive_scan_target: 0,
             guardian_committee_reconcile_task: None,
             last_guardian_reconcile_epoch: None,
         }
@@ -268,6 +283,7 @@ impl LeaderService {
                     self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
                     self.check_delete_proposals(checkpoint_timestamp_ms);
                     self.check_cleanup_spent_utxos(checkpoint_timestamp_ms);
+                    self.check_archive_confirmed_withdrawals(checkpoint_timestamp_ms);
                     self.process_stale_unapproved_deposits_if_new_epoch();
                     self.process_approved_deposit_requests();
                 }
@@ -348,6 +364,25 @@ impl LeaderService {
                         }
                     }
                     Self::log_task_result("utxo_cleanup_gc", result);
+                }
+                Some(result) = OptionFuture::from(self.withdrawal_archive_gc_task.as_mut()) => {
+                    self.withdrawal_archive_gc_task = None;
+                    // Same re-arm policy as the UTXO cleanup arm above.
+                    match &result {
+                        Ok(Ok(0)) => self.withdrawal_archive_retry.clear(),
+                        Ok(Ok(_)) => {
+                            self.withdrawal_archive_retry.clear();
+                            self.withdrawal_archive_scan_needed = true;
+                        }
+                        _ => {
+                            self.withdrawal_archive_retry.record_failure(
+                                garbage_collection::WithdrawalArchiveErrorKind::Failed,
+                                checkpoint_rx.borrow().timestamp_ms,
+                            );
+                            self.withdrawal_archive_scan_needed = true;
+                        }
+                    }
+                    Self::log_task_result("withdrawal_archive_gc", result);
                 }
                 Some(result) = OptionFuture::from(self.guardian_committee_reconcile_task.as_mut()) => {
                     self.guardian_committee_reconcile_task = None;

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -384,10 +384,18 @@ impl LeaderService {
             let err_msg = format!("{e}");
             error!("approve_request PTB failed: {err_msg}");
 
-            // Try to identify which request caused the failure by checking
-            // which ones no longer exist in the queue (canceled).
+            // Try to identify which request caused the failure by dropping
+            // every request that is no longer approvable: cancelled requests
+            // vanish from the queue, and with deferred archival a request
+            // that some earlier PTB already approved or committed lingers
+            // with an advanced status (re-approving it would abort the PTB).
             let before_len = certified.len();
-            certified.retain(|(id, _)| inner.onchain_state().withdrawal_request(id).is_some());
+            certified.retain(|(id, _)| {
+                inner
+                    .onchain_state()
+                    .withdrawal_request(id)
+                    .is_some_and(|r| is_still_approvable(&r))
+            });
 
             if certified.len() == before_len {
                 error!("Could not identify failed request, aborting retry");
@@ -819,6 +827,52 @@ impl WithdrawalTxCommitment {
                 })
                 .collect(),
             txid: self.txid.as_bytes().to_vec().into(),
+        }
+    }
+}
+
+/// A request is worth retrying in an approval PTB only while its status is
+/// still Requested. Cancelled requests vanish from the queue entirely; under
+/// deferred archival, approved/committed/terminal requests linger in the
+/// queue with an advanced status, and re-approving any of them aborts the
+/// whole PTB on-chain.
+fn is_still_approvable(request: &hashi_types::move_types::WithdrawalRequest) -> bool {
+    request.status.is_requested()
+}
+
+#[cfg(test)]
+mod approvable_tests {
+    use super::*;
+    use hashi_types::move_types::WithdrawalStatus;
+
+    fn request_with_status(status: WithdrawalStatus) -> hashi_types::move_types::WithdrawalRequest {
+        hashi_types::move_types::WithdrawalRequest {
+            id: sui_sdk_types::Address::new([1; 32]),
+            sender: sui_sdk_types::Address::new([2; 32]),
+            btc_amount: 1,
+            bitcoin_address: vec![0; 20],
+            created_timestamp_ms: 0,
+            status,
+            approval_cert: None,
+            approved_timestamp_ms: None,
+            withdrawal_txn_id: None,
+            sui_tx_digest: sui_sdk_types::Digest::new([0; 32]),
+            btc: 1,
+        }
+    }
+
+    #[test]
+    fn only_requested_is_approvable() {
+        assert!(is_still_approvable(&request_with_status(
+            WithdrawalStatus::Requested
+        )));
+        for status in [
+            WithdrawalStatus::Approved,
+            WithdrawalStatus::Processing,
+            WithdrawalStatus::Signed,
+            WithdrawalStatus::Confirmed,
+        ] {
+            assert!(!is_still_approvable(&request_with_status(status)));
         }
     }
 }

--- a/crates/hashi/src/leader/withdrawal_transactions.rs
+++ b/crates/hashi/src/leader/withdrawal_transactions.rs
@@ -1085,7 +1085,10 @@ impl LeaderService {
     pub(super) fn process_signed_withdrawal_txns(&mut self) {
         debug!("Entering process_signed_withdrawal_txns");
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
-        withdrawal_txns.retain(|p| p.is_fully_signed());
+        // A confirmed txn lingers in the hot bag until the archival GC moves
+        // it; it is fully signed, so without the second clause it would be
+        // re-picked for broadcast/confirm every checkpoint forever.
+        withdrawal_txns.retain(|p| p.is_fully_signed() && !p.is_confirmed());
         withdrawal_txns.sort_by_key(|p| p.created_timestamp_ms);
 
         let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
@@ -1153,7 +1156,7 @@ impl LeaderService {
     /// Drains the BTC-block-triggered withdrawal check queue into its separate bounded task pool.
     fn process_pending_btc_block_withdrawal_checks(&mut self) {
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
-        withdrawal_txns.retain(|p| p.is_fully_signed());
+        withdrawal_txns.retain(|p| p.is_fully_signed() && !p.is_confirmed());
         withdrawal_txns.sort_by_key(|p| p.created_timestamp_ms);
 
         let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
@@ -1258,6 +1261,12 @@ impl LeaderService {
                 // until the next confirm.
                 self.utxo_cleanup_scan_needed = true;
                 self.utxo_cleanup_scan_target = self.utxo_cleanup_scan_target.max(checkpoint);
+                // Same protocol for the deferred archival: the confirm left
+                // the txn (and its requests) in the hot containers with only
+                // the confirmed timestamp distinguishing them.
+                self.withdrawal_archive_scan_needed = true;
+                self.withdrawal_archive_scan_target =
+                    self.withdrawal_archive_scan_target.max(checkpoint);
             }
             Ok(WithdrawalBroadcastOutcome::WaitForNextBitcoinBlock) => {
                 self.withdrawal_broadcast_retry_tracker

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1185,22 +1185,62 @@ impl Metrics {
         self.paused.set(if hashi.config.paused() { 1 } else { 0 });
         self.deposit_queue_size
             .set(hashi.bitcoin().deposit_queue.requests().len() as i64);
-        let (requested, approved) = hashi
-            .bitcoin()
-            .withdrawal_queue
-            .requests()
-            .values()
-            .partition::<Vec<_>, _>(|r| r.status.is_requested());
-        // Three on-chain withdrawal-txn states, distinguished for operator
-        // visibility now that signing spans a multi-checkpoint window:
-        //   signed  = fully signed (2-of-2 witness assembled), broadcast-ready
-        //   signing = some inputs MPC-signed but not yet finalized (in progress)
-        //   pending = committed on-chain but no inputs signed yet
+        // Four mirrored withdrawal-request states. With deferred archival a
+        // request stays in the mirrored `requests` map after commitment (BTC
+        // drained) until the archival GC moves it out, so the post-approval
+        // states must be split from the actionable queue:
+        //   requested                 = awaiting committee approval
+        //   approved                  = approved, awaiting commitment into a txn
+        //   committed                 = committed into a withdrawal txn
+        //                               (Processing or Signed)
+        //   confirmed_pending_archive = confirmed on Bitcoin, awaiting the
+        //                               archival GC
+        {
+            use crate::onchain::types::WithdrawalStatus;
+            let mut requested = Vec::new();
+            let mut approved = Vec::new();
+            let mut committed = Vec::new();
+            let mut confirmed_pending_archive = Vec::new();
+            for r in hashi.bitcoin().withdrawal_queue.requests().values() {
+                match r.status {
+                    WithdrawalStatus::Requested => requested.push(r),
+                    WithdrawalStatus::Approved => approved.push(r),
+                    WithdrawalStatus::Processing | WithdrawalStatus::Signed => committed.push(r),
+                    WithdrawalStatus::Confirmed => confirmed_pending_archive.push(r),
+                }
+            }
+            for (label, class) in [
+                ("requested", &requested),
+                ("approved", &approved),
+                ("committed", &committed),
+                ("confirmed_pending_archive", &confirmed_pending_archive),
+            ] {
+                self.withdrawal_queue_size
+                    .with_label_values(&[label])
+                    .set(class.len() as i64);
+                self.withdrawal_queue_value
+                    .with_label_values(&[label, "BTC"])
+                    .set(class.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
+            }
+        }
+        // Four on-chain withdrawal-txn states, distinguished for operator
+        // visibility now that signing spans a multi-checkpoint window and
+        // archival is deferred to a batched GC:
+        //   confirmed = Bitcoin-confirmed, lingering in `withdrawal_txns`
+        //               until the archival GC moves it out. This count is the
+        //               archival-backlog signal: a persistently growing value
+        //               means the archival GC is stalled.
+        //   signed    = fully signed (2-of-2 witness assembled), broadcast-ready
+        //   signing   = some inputs MPC-signed but not yet finalized (in progress)
+        //   pending   = committed on-chain but no inputs signed yet
+        let mut confirmed = Vec::new();
         let mut signed = Vec::new();
         let mut signing = Vec::new();
         let mut pending = Vec::new();
         for w in hashi.bitcoin().withdrawal_queue.withdrawal_txns().values() {
-            if w.is_fully_signed() {
+            if w.is_confirmed() {
+                confirmed.push(w);
+            } else if w.is_fully_signed() {
                 signed.push(w);
             } else if w.signing.signed_count() > 0 {
                 signing.push(w);
@@ -1208,54 +1248,25 @@ impl Metrics {
                 pending.push(w);
             }
         }
-        self.withdrawal_queue_size
-            .with_label_values(&["requested"])
-            .set(requested.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["requested", "BTC"])
-            .set(requested.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
-        self.withdrawal_queue_size
-            .with_label_values(&["approved"])
-            .set(approved.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["approved", "BTC"])
-            .set(approved.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
-        self.withdrawal_queue_size
-            .with_label_values(&["pending"])
-            .set(pending.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["pending", "BTC"])
-            .set(
-                pending
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
-        self.withdrawal_queue_size
-            .with_label_values(&["signing"])
-            .set(signing.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["signing", "BTC"])
-            .set(
-                signing
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
-        self.withdrawal_queue_size
-            .with_label_values(&["signed"])
-            .set(signed.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["signed", "BTC"])
-            .set(
-                signed
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
+        for (label, class) in [
+            ("confirmed", &confirmed),
+            ("signed", &signed),
+            ("signing", &signing),
+            ("pending", &pending),
+        ] {
+            self.withdrawal_queue_size
+                .with_label_values(&[label])
+                .set(class.len() as i64);
+            self.withdrawal_queue_value
+                .with_label_values(&[label, "BTC"])
+                .set(
+                    class
+                        .iter()
+                        .flat_map(|w| &w.withdrawal_outputs)
+                        .map(|o| o.amount)
+                        .sum::<u64>() as i64,
+                );
+        }
         // Track three views of utxo_records:
         // - available:         all selectable UTXOs (spent_by = None), whether
         //                      confirmed or not; this is the coin-selection pool

--- a/crates/hashi/src/onchain/apply.rs
+++ b/crates/hashi/src/onchain/apply.rs
@@ -216,6 +216,13 @@ pub(super) enum Effect {
     /// transaction (2-of-2 witness complete). Drives the local limiter
     /// and the pick-to-sign metric.
     WithdrawalTxnFullySigned(Box<types::WithdrawalTransaction>),
+    /// A withdrawal transaction's `confirmed_timestamp_ms` went from
+    /// `None` to `Some` in this transaction: the v2 in-place confirm,
+    /// which leaves the txn in the in-flight bag until a later archival
+    /// GC moves it out. Drives the sign-to-confirm and total duration
+    /// metrics in the deferred-archival world (under v1 bytecode the
+    /// confirm moves the txn instead, so this never fires there).
+    WithdrawalTxnConfirmed(Box<types::WithdrawalTransaction>),
     /// A withdrawal transaction left the in-flight bag (confirmed and
     /// moved to the historical record, or deleted).
     WithdrawalTxnRemoved(Box<types::WithdrawalTransaction>),
@@ -624,13 +631,16 @@ fn apply_write(
             decode::<move_types::WithdrawalTransaction>(contents, &id).map(|txn| {
                 let txn_id = txn.id;
                 let withdrawal_queue = &mut hashi.bitcoin_mut().withdrawal_queue;
-                let was_fully_signed = withdrawal_queue
-                    .withdrawal_txns
-                    .get(&txn_id)
-                    .is_some_and(|t| t.is_fully_signed());
+                let old = withdrawal_queue.withdrawal_txns.get(&txn_id);
+                let was_fully_signed = old.is_some_and(|t| t.is_fully_signed());
+                let was_confirmed = old.is_some_and(|t| t.confirmed_timestamp_ms.is_some());
                 if !was_fully_signed && txn.is_fully_signed() {
                     out.effects
                         .push(Effect::WithdrawalTxnFullySigned(Box::new(txn.clone())));
+                }
+                if !was_confirmed && txn.is_confirmed() {
+                    out.effects
+                        .push(Effect::WithdrawalTxnConfirmed(Box::new(txn.clone())));
                 }
                 withdrawal_queue.withdrawal_txns.insert(txn_id, txn);
                 TrackedKind::WithdrawalTxn(txn_id)
@@ -1403,8 +1413,10 @@ mod tests {
         ))]));
         assert!(out.effects.is_empty());
 
-        // Confirmed: the value moves to the confirmed_txns bag (new
-        // wrapper, old wrapper deleted).
+        // Confirmed the v1 way: the value moves to the confirmed_txns
+        // bag (new wrapper, old wrapper deleted) with no prior in-place
+        // confirm, so the removal carries `confirmed_timestamp_ms:
+        // None` — the mirror observes the durations at this point.
         let wrapper2 = addr(0x53);
         let out = fixture.apply(&tx(vec![
             written(wrapper_object(wrapper2, value_id, 3, confirmed_txns_id())),
@@ -1412,7 +1424,61 @@ mod tests {
             TxChange::Deleted { id: wrapper1 },
         ]));
         assert!(
-            matches!(out.effects.as_slice(), [Effect::WithdrawalTxnRemoved(txn)] if txn.id == value_id)
+            matches!(out.effects.as_slice(), [Effect::WithdrawalTxnRemoved(txn)]
+                if txn.id == value_id && txn.confirmed_timestamp_ms.is_none())
+        );
+        assert!(
+            fixture
+                .hashi
+                .bitcoin()
+                .withdrawal_queue
+                .withdrawal_txns
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn withdrawal_txn_in_place_confirm_then_deferred_archival() {
+        let mut fixture = Fixture::new();
+        let wrapper1 = addr(0x51);
+        let value_id = addr(0x52);
+
+        let signed = withdrawal_txn(value_id, true);
+        fixture.apply(&tx(vec![
+            written(wrapper_object(wrapper1, value_id, 1, withdrawal_txns_id())),
+            written(withdrawal_txn_object(&signed, 1, wrapper1)),
+        ]));
+
+        // v2 in-place confirm: a value-only mutation flips
+        // `confirmed_timestamp_ms` None -> Some exactly once.
+        let mut confirmed = signed.clone();
+        confirmed.confirmed_timestamp_ms = Some(8);
+        let out = fixture.apply(&tx(vec![written(withdrawal_txn_object(
+            &confirmed, 2, wrapper1,
+        ))]));
+        assert!(
+            matches!(out.effects.as_slice(), [Effect::WithdrawalTxnConfirmed(txn)]
+                if txn.id == value_id && txn.confirmed_timestamp_ms == Some(8))
+        );
+
+        // Replay of the same frame (Some -> Some): no duplicate effect.
+        let out = fixture.apply(&tx(vec![written(withdrawal_txn_object(
+            &confirmed, 2, wrapper1,
+        ))]));
+        assert!(out.effects.is_empty());
+
+        // The later archival GC moves the value to the confirmed_txns
+        // bag; the removal carries the mirror copy's Some timestamp —
+        // the key the mirror's duration-dedup skip relies on.
+        let wrapper2 = addr(0x53);
+        let out = fixture.apply(&tx(vec![
+            written(wrapper_object(wrapper2, value_id, 3, confirmed_txns_id())),
+            written(withdrawal_txn_object(&confirmed, 3, wrapper2)),
+            TxChange::Deleted { id: wrapper1 },
+        ]));
+        assert!(
+            matches!(out.effects.as_slice(), [Effect::WithdrawalTxnRemoved(txn)]
+                if txn.id == value_id && txn.confirmed_timestamp_ms == Some(8))
         );
         assert!(
             fixture

--- a/crates/hashi/src/onchain/mirror.rs
+++ b/crates/hashi/src/onchain/mirror.rs
@@ -461,6 +461,9 @@ fn handle_effects(state: &OnchainState, timestamp_ms: u64, effects: Vec<apply::E
             apply::Effect::WithdrawalTxnFullySigned(txn) => {
                 withdrawal_txn_fully_signed(state, timestamp_ms, &txn);
             }
+            apply::Effect::WithdrawalTxnConfirmed(txn) => {
+                withdrawal_txn_confirmed(state, timestamp_ms, &txn);
+            }
             apply::Effect::WithdrawalTxnRemoved(txn) => {
                 withdrawal_txn_removed(state, timestamp_ms, &txn);
             }
@@ -540,9 +543,41 @@ fn withdrawal_txn_fully_signed(
     }
 }
 
-/// A withdrawal transaction left the in-flight bag (confirmed and
-/// moved to the historical record, or deleted): observe the
-/// sign-to-confirm and total durations.
+/// A withdrawal transaction was confirmed in place (the v2 deferred
+/// archival: `confirmed_timestamp_ms` set while the txn stays in the
+/// in-flight bag): observe the sign-to-confirm and total durations. The
+/// later archival move skips them (`withdrawal_txn_removed`).
+fn withdrawal_txn_confirmed(
+    state: &OnchainState,
+    timestamp_ms: u64,
+    txn: &types::WithdrawalTransaction,
+) {
+    tracing::info!(withdrawal_txn_id = %txn.id, "Withdrawal confirmed on-chain");
+    let signed_at = state.state_mut().withdrawal_signed_at_ms.remove(&txn.id);
+    let Some(metrics) = state.metrics() else {
+        return;
+    };
+    if let Some(signed_at) = signed_at {
+        let sign_to_confirm = timestamp_ms.saturating_sub(signed_at);
+        metrics
+            .withdrawal_duration_seconds
+            .with_label_values(&["sign_to_confirm"])
+            .observe(Duration::from_millis(sign_to_confirm).as_secs_f64());
+    }
+    let total = timestamp_ms.saturating_sub(txn.created_timestamp_ms);
+    metrics
+        .withdrawal_duration_seconds
+        .with_label_values(&["total"])
+        .observe(Duration::from_millis(total).as_secs_f64());
+}
+
+/// A withdrawal transaction left the in-flight bag. Under v1 bytecode
+/// the confirm itself archives it, so the sign-to-confirm and total
+/// durations are observed here. Under v2 the confirm wrote
+/// `confirmed_timestamp_ms` in place and the durations were already
+/// observed then (`withdrawal_txn_confirmed`); observing again at the
+/// archival move would fold GC latency into the histograms, so an
+/// already-confirmed txn only clears its bookkeeping.
 fn withdrawal_txn_removed(
     state: &OnchainState,
     timestamp_ms: u64,
@@ -550,6 +585,9 @@ fn withdrawal_txn_removed(
 ) {
     tracing::info!(withdrawal_txn_id = %txn.id, "Withdrawal transaction left the in-flight bag");
     let signed_at = state.state_mut().withdrawal_signed_at_ms.remove(&txn.id);
+    if txn.confirmed_timestamp_ms.is_some() {
+        return;
+    }
     let Some(metrics) = state.metrics() else {
         return;
     };

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1780,6 +1780,143 @@ impl SuiTxExecutor {
         }
         Ok(max_checkpoint)
     }
+
+    /// Package id of the version this binary operates at. Entry functions
+    /// introduced by an upgrade only exist in the upgraded bytecode, so
+    /// calling them through the original package id fails; targets for such
+    /// calls must resolve through the active version.
+    fn active_version_package(&self) -> anyhow::Result<Address> {
+        let onchain_state = self
+            .onchain_state
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("executor has no onchain state to resolve versions"))?;
+        let state = onchain_state.state();
+        let version = state
+            .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
+            .active_version()
+            .ok_or_else(|| anyhow::anyhow!("no active package version resolved"))?;
+        state
+            .package_versions()
+            .get(version)
+            .ok_or_else(|| anyhow::anyhow!("active version {version} has no published package"))
+    }
+
+    /// Submit `withdraw::archive_confirmed_withdrawals` for the given
+    /// confirmed txns, greedily packed so every transaction stays inside the
+    /// runtime-object budget (a whole txn's requests archive together, so
+    /// packing is by per-victim cost, not count). `victims` pairs each txn id
+    /// with its request count. Returns the max landed checkpoint.
+    ///
+    /// The entry only exists in the v2 package; the caller gates on the
+    /// active version, and the target resolves through it.
+    pub async fn execute_archive_confirmed_withdrawals(
+        &mut self,
+        victims: &[(Address, usize)],
+    ) -> anyhow::Result<u64> {
+        let package_id = self.active_version_package()?;
+        let mut max_checkpoint = 0;
+        for chunk in chunk_archive_victims(victims) {
+            let mut builder = TransactionBuilder::new();
+            let hashi_arg = builder.object(
+                ObjectInput::new(self.hashi_ids.hashi_object_id)
+                    .as_shared()
+                    .with_mutable(true),
+            );
+            let ids_arg = builder.pure(&chunk);
+            builder.move_call(
+                Function::new(
+                    package_id,
+                    Identifier::from_static("withdraw"),
+                    Identifier::from_static("archive_confirmed_withdrawals"),
+                ),
+                vec![hashi_arg, ids_arg],
+            );
+
+            let response = self.execute(builder).await?;
+            if !response.transaction().effects().status().success() {
+                anyhow::bail!(
+                    "archive_confirmed_withdrawals failed: {:?}",
+                    response.transaction().effects().status()
+                );
+            }
+            let checkpoint = response.transaction().checkpoint_opt().ok_or_else(|| {
+                anyhow::anyhow!("archive_confirmed_withdrawals response missing checkpoint")
+            })?;
+            max_checkpoint = max_checkpoint.max(checkpoint);
+        }
+        Ok(max_checkpoint)
+    }
+}
+
+/// Greedy-pack archival victims into per-transaction chunks under the
+/// runtime-object budget. A single victim always fits alone (the
+/// `withdrawals.rs` compile-time assert guarantees a max-size txn does).
+fn chunk_archive_victims(victims: &[(Address, usize)]) -> Vec<Vec<Address>> {
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS;
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET;
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST;
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN;
+
+    let budget =
+        WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET - WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS;
+    let mut chunks = Vec::new();
+    let mut current = Vec::new();
+    let mut used = 0usize;
+    for (id, request_count) in victims {
+        let cost = WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+            + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST * request_count;
+        if !current.is_empty() && used + cost > budget {
+            chunks.push(std::mem::take(&mut current));
+            used = 0;
+        }
+        current.push(*id);
+        used += cost;
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod archive_chunking_tests {
+    use super::*;
+
+    fn addr(byte: u8) -> Address {
+        Address::new([byte; 32])
+    }
+
+    #[test]
+    fn empty_input_yields_no_chunks() {
+        assert!(chunk_archive_victims(&[]).is_empty());
+    }
+
+    #[test]
+    fn one_max_size_txn_fits_alone() {
+        use crate::utxo_pool::CoinSelectionParams;
+        let chunks =
+            chunk_archive_victims(&[(addr(1), CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)]);
+        assert_eq!(chunks, vec![vec![addr(1)]]);
+    }
+
+    #[test]
+    fn small_victims_pack_together() {
+        let victims: Vec<_> = (0..10u8).map(|i| (addr(i), 1usize)).collect();
+        let chunks = chunk_archive_victims(&victims);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), 10);
+    }
+
+    #[test]
+    fn budget_boundary_splits() {
+        // Each 100-request victim costs 3 + 300 = 303; the 910-object budget
+        // fits three (909) and the fourth spills into a second chunk.
+        let victims: Vec<_> = (0..4u8).map(|i| (addr(i), 100usize)).collect();
+        let chunks = chunk_archive_victims(&victims);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), 3);
+        assert_eq!(chunks[1].len(), 1);
+    }
 }
 
 /// Build the PTB for a single deposit request. Pure (no signer / no network),

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1801,57 +1801,106 @@ impl SuiTxExecutor {
             .ok_or_else(|| anyhow::anyhow!("active version {version} has no published package"))
     }
 
-    /// Submit `withdraw::archive_confirmed_withdrawals` for the given
-    /// confirmed txns, greedily packed so every transaction stays inside the
-    /// runtime-object budget (a whole txn's requests archive together, so
-    /// packing is by per-victim cost, not count). `victims` pairs each txn id
-    /// with its request count. Returns the max landed checkpoint.
+    /// Archive the given confirmed withdrawal txns, packed into a plan of
+    /// GC transactions that each stay inside the runtime-object budget.
+    /// Victims that fit a single transaction go through the atomic
+    /// `archive_confirmed_withdrawals` entry; oversized ones (request cost
+    /// beyond one transaction) archive through `archive_withdrawal_requests`
+    /// chunks followed by `finish_archive_withdrawal_txns`. Returns the max
+    /// landed checkpoint.
     ///
-    /// The entry only exists in the v2 package; the caller gates on the
+    /// The entries only exist in the v2 package; the caller gates on the
     /// active version, and the target resolves through it.
-    pub async fn execute_archive_confirmed_withdrawals(
+    pub(crate) async fn execute_archive_confirmed_withdrawals(
         &mut self,
-        victims: &[(Address, usize)],
+        victims: &[ArchiveVictim],
     ) -> anyhow::Result<u64> {
         let package_id = self.active_version_package()?;
         let mut max_checkpoint = 0;
-        for chunk in chunk_archive_victims(victims) {
+        for call in plan_archive_calls(victims) {
             let mut builder = TransactionBuilder::new();
             let hashi_arg = builder.object(
                 ObjectInput::new(self.hashi_ids.hashi_object_id)
                     .as_shared()
                     .with_mutable(true),
             );
-            let ids_arg = builder.pure(&chunk);
+            let (function, args) = match &call {
+                ArchiveCall::Atomic(txn_ids) => {
+                    let ids_arg = builder.pure(txn_ids);
+                    ("archive_confirmed_withdrawals", vec![hashi_arg, ids_arg])
+                }
+                ArchiveCall::Requests {
+                    txn_id,
+                    request_ids,
+                } => {
+                    let txn_arg = builder.pure(txn_id);
+                    let ids_arg = builder.pure(request_ids);
+                    (
+                        "archive_withdrawal_requests",
+                        vec![hashi_arg, txn_arg, ids_arg],
+                    )
+                }
+                ArchiveCall::Finish(txn_ids) => {
+                    let ids_arg = builder.pure(txn_ids);
+                    ("finish_archive_withdrawal_txns", vec![hashi_arg, ids_arg])
+                }
+            };
             builder.move_call(
                 Function::new(
                     package_id,
                     Identifier::from_static("withdraw"),
-                    Identifier::from_static("archive_confirmed_withdrawals"),
+                    Identifier::new(function)?,
                 ),
-                vec![hashi_arg, ids_arg],
+                args,
             );
 
             let response = self.execute(builder).await?;
             if !response.transaction().effects().status().success() {
                 anyhow::bail!(
-                    "archive_confirmed_withdrawals failed: {:?}",
+                    "{function} failed: {:?}",
                     response.transaction().effects().status()
                 );
             }
-            let checkpoint = response.transaction().checkpoint_opt().ok_or_else(|| {
-                anyhow::anyhow!("archive_confirmed_withdrawals response missing checkpoint")
-            })?;
+            let checkpoint = response
+                .transaction()
+                .checkpoint_opt()
+                .ok_or_else(|| anyhow::anyhow!("{function} response missing checkpoint"))?;
             max_checkpoint = max_checkpoint.max(checkpoint);
         }
         Ok(max_checkpoint)
     }
 }
 
-/// Greedy-pack archival victims into per-transaction chunks under the
-/// runtime-object budget. A single victim always fits alone (the
-/// `withdrawals.rs` compile-time assert guarantees a max-size txn does).
-fn chunk_archive_victims(victims: &[(Address, usize)]) -> Vec<Vec<Address>> {
+/// A confirmed withdrawal txn awaiting archival, with its request ids so the
+/// planner can price and, when oversized, chunk it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ArchiveVictim {
+    pub txn_id: Address,
+    pub request_ids: Vec<Address>,
+}
+
+/// One GC transaction of an archival plan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ArchiveCall {
+    /// Whole txns archived atomically, several per transaction.
+    Atomic(Vec<Address>),
+    /// One request chunk of an oversized txn.
+    Requests {
+        txn_id: Address,
+        request_ids: Vec<Address>,
+    },
+    /// Move fully-chunk-archived txns to the cold bag. Emitted after every
+    /// chunk of the txns it finishes, so in-order execution completes them.
+    Finish(Vec<Address>),
+}
+
+/// Pack archival victims into per-transaction calls under the runtime-object
+/// budget. Victims whose whole cost fits one transaction greedy-pack into
+/// atomic calls; oversized ones split into request chunks plus a batched
+/// finish (the `withdrawals.rs` compile-time asserts guarantee every chunk
+/// makes progress and a max-size finish walk fits one transaction).
+fn plan_archive_calls(victims: &[ArchiveVictim]) -> Vec<ArchiveCall> {
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST;
     use crate::withdrawals::WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS;
     use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET;
     use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST;
@@ -1859,63 +1908,139 @@ fn chunk_archive_victims(victims: &[(Address, usize)]) -> Vec<Vec<Address>> {
 
     let budget =
         WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET - WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS;
-    let mut chunks = Vec::new();
-    let mut current = Vec::new();
-    let mut used = 0usize;
-    for (id, request_count) in victims {
+    let requests_per_chunk = (budget - WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN)
+        / WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST;
+
+    let mut calls = Vec::new();
+    let mut atomic: Vec<Address> = Vec::new();
+    let mut atomic_used = 0usize;
+    let mut finish: Vec<Address> = Vec::new();
+    let mut finish_used = 0usize;
+    for victim in victims {
         let cost = WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
-            + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST * request_count;
-        if !current.is_empty() && used + cost > budget {
-            chunks.push(std::mem::take(&mut current));
-            used = 0;
+            + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST * victim.request_ids.len();
+        if cost <= budget {
+            if atomic_used + cost > budget {
+                calls.push(ArchiveCall::Atomic(std::mem::take(&mut atomic)));
+                atomic_used = 0;
+            }
+            atomic.push(victim.txn_id);
+            atomic_used += cost;
+        } else {
+            for chunk in victim.request_ids.chunks(requests_per_chunk) {
+                calls.push(ArchiveCall::Requests {
+                    txn_id: victim.txn_id,
+                    request_ids: chunk.to_vec(),
+                });
+            }
+            let finish_cost = WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+                + WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST * victim.request_ids.len();
+            if finish_used + finish_cost > budget {
+                calls.push(ArchiveCall::Finish(std::mem::take(&mut finish)));
+                finish_used = 0;
+            }
+            finish.push(victim.txn_id);
+            finish_used += finish_cost;
         }
-        current.push(*id);
-        used += cost;
     }
-    if !current.is_empty() {
-        chunks.push(current);
+    if !atomic.is_empty() {
+        calls.push(ArchiveCall::Atomic(atomic));
     }
-    chunks
+    if !finish.is_empty() {
+        calls.push(ArchiveCall::Finish(finish));
+    }
+    calls
 }
 
 #[cfg(test)]
-mod archive_chunking_tests {
+mod archive_planning_tests {
     use super::*;
+    use crate::utxo_pool::CoinSelectionParams;
 
     fn addr(byte: u8) -> Address {
         Address::new([byte; 32])
     }
 
-    #[test]
-    fn empty_input_yields_no_chunks() {
-        assert!(chunk_archive_victims(&[]).is_empty());
+    fn victim(byte: u8, request_count: usize) -> ArchiveVictim {
+        // Planning depends only on counts; the ids themselves are opaque.
+        ArchiveVictim {
+            txn_id: addr(byte),
+            request_ids: (0..request_count).map(|i| addr(i as u8)).collect(),
+        }
     }
 
     #[test]
-    fn one_max_size_txn_fits_alone() {
-        use crate::utxo_pool::CoinSelectionParams;
-        let chunks =
-            chunk_archive_victims(&[(addr(1), CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)]);
-        assert_eq!(chunks, vec![vec![addr(1)]]);
+    fn empty_input_yields_no_calls() {
+        assert!(plan_archive_calls(&[]).is_empty());
     }
 
     #[test]
-    fn small_victims_pack_together() {
-        let victims: Vec<_> = (0..10u8).map(|i| (addr(i), 1usize)).collect();
-        let chunks = chunk_archive_victims(&victims);
-        assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0].len(), 10);
+    fn small_victims_pack_into_one_atomic_call() {
+        let victims: Vec<_> = (0..10u8).map(|i| victim(i, 1)).collect();
+        let calls = plan_archive_calls(&victims);
+        assert_eq!(calls.len(), 1);
+        assert!(matches!(&calls[0], ArchiveCall::Atomic(ids) if ids.len() == 10));
     }
 
     #[test]
-    fn budget_boundary_splits() {
+    fn atomic_budget_boundary_splits() {
         // Each 100-request victim costs 3 + 300 = 303; the 910-object budget
-        // fits three (909) and the fourth spills into a second chunk.
-        let victims: Vec<_> = (0..4u8).map(|i| (addr(i), 100usize)).collect();
-        let chunks = chunk_archive_victims(&victims);
-        assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0].len(), 3);
-        assert_eq!(chunks[1].len(), 1);
+        // fits three (909) and the fourth spills into a second call.
+        let victims: Vec<_> = (0..4u8).map(|i| victim(i, 100)).collect();
+        let calls = plan_archive_calls(&victims);
+        assert_eq!(calls.len(), 2);
+        assert!(matches!(&calls[0], ArchiveCall::Atomic(ids) if ids.len() == 3));
+        assert!(matches!(&calls[1], ArchiveCall::Atomic(ids) if ids.len() == 1));
+    }
+
+    #[test]
+    fn max_size_txn_chunks_then_finishes() {
+        // A 447-request txn costs 3 + 1341, beyond one transaction: it must
+        // split into request chunks (302 per chunk at 3/request under the
+        // 910 budget) followed by one finish.
+        let victims = [victim(1, CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)];
+        let calls = plan_archive_calls(&victims);
+        assert_eq!(calls.len(), 3);
+        let (mut chunked, mut finished) = (0usize, Vec::new());
+        for call in &calls {
+            match call {
+                ArchiveCall::Requests {
+                    txn_id,
+                    request_ids,
+                } => {
+                    assert_eq!(*txn_id, addr(1));
+                    chunked += request_ids.len();
+                }
+                ArchiveCall::Finish(ids) => finished = ids.clone(),
+                ArchiveCall::Atomic(_) => panic!("oversized victim must not go atomic"),
+            }
+        }
+        assert_eq!(chunked, CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS);
+        assert_eq!(finished, vec![addr(1)]);
+        // The finish must come after every chunk of the txn it completes.
+        assert!(matches!(calls.last(), Some(ArchiveCall::Finish(_))));
+    }
+
+    #[test]
+    fn mixed_sizes_route_by_cost() {
+        let victims = [
+            victim(1, 5),
+            victim(2, CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS),
+            victim(3, 5),
+        ];
+        let calls = plan_archive_calls(&victims);
+        let atomics: Vec<_> = calls
+            .iter()
+            .filter(|c| matches!(c, ArchiveCall::Atomic(_)))
+            .collect();
+        assert_eq!(atomics.len(), 1);
+        assert!(matches!(atomics[0], ArchiveCall::Atomic(ids) if ids.len() == 2));
+        assert!(
+            calls
+                .iter()
+                .any(|c| matches!(c, ArchiveCall::Requests { .. }))
+        );
+        assert!(matches!(calls.last(), Some(ArchiveCall::Finish(ids)) if ids == &vec![addr(2)]));
     }
 }
 

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -356,15 +356,16 @@ impl CoinSelectionParams {
     pub const DEFAULT_MAX_INPUTS: usize = 400;
 
     /// Maximum number of withdrawal requests per batch, derived from the
-    /// Sui commit transaction's runtime-object budget: at 3 runtime objects
-    /// per request, `(922 budget - 12 fixed - 16 reserved funding inputs) /
-    /// 3 = 298`. The reserve keeps room for the largest-first funding
+    /// Sui commit transaction's runtime-object budget: at the v2 (in-place
+    /// commit) cost of 2 runtime objects per request, `(922 budget - 12
+    /// fixed - 16 reserved funding inputs) / 2 = 447`. The reserve keeps
+    /// room for the largest-first funding
     /// inputs when a batch is at this cap (a compile-time assertion in
     /// `withdrawals.rs` ties this value to those constants); the descending
     /// retry loop in `build_withdrawal_tx_commitment` shrinks the batch if
     /// even the reserve is not enough.
     ///
-    /// Bitcoin-side limits do not bind here: a 298-output batch with 16
+    /// Bitcoin-side limits do not bind here: a 447-output batch with 16
     /// taproot script-path inputs is ~58 kWU, well under the 400 kWU
     /// standardness cap, and leaves ample room under the 101 kvB mempool
     /// cluster budget for a direct child.
@@ -376,7 +377,13 @@ impl CoinSelectionParams {
     /// commit budget in `safe_withdrawal_flow_max_inputs` automatically
     /// squeezes the input side down toward the funding reserve (optimizing
     /// withdrawal throughput).
-    pub const MAX_WITHDRAWAL_REQUESTS: usize = 298;
+    /// The v2 (deferred-archival) cap: with commit writing request status in
+    /// place, each request costs 2 runtime objects instead of the 3 the
+    /// v1 bag move paid, and the archival GC chunks oversized txns, so the
+    /// commit budget alone binds. Chains still operating at package v1 are
+    /// capped at [`crate::withdrawals::LEGACY_MAX_WITHDRAWAL_REQUESTS`] via
+    /// `max_withdrawal_requests`.
+    pub const MAX_WITHDRAWAL_REQUESTS: usize = 447;
 
     /// Default minimum fee rate floor (3 sat/vB), deliberately above
     /// Bitcoin Core's 1 sat/vB relay minimum.

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -155,6 +155,29 @@ const WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS: usize = 43;
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
 
+/// Runtime-object cost model for the deferred `archive_confirmed_withdrawals`
+/// GC (v2 package): ~3 objects per archived txn (hot-bag `Field` + child
+/// borrow, new cold-bag `Field`; the remove reuses the cache) and ~3 per
+/// request (the `requests` removal `Field` + child + the new `processed`
+/// `Field`; the pre-upgrade-leftover fallback path costs the same bound).
+/// Conservative upper bounds pending sui-replay measurement; the executor's
+/// greedy packer sizes each GC transaction from these.
+pub(crate) const WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS: usize = 12;
+pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN: usize = 3;
+pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET: usize = WITHDRAWAL_RUNTIME_OBJECT_BUDGET;
+
+// A whole txn's requests archive together (the entry has no partial-archival
+// mode), so the largest committable batch must fit one GC transaction.
+const _: () = assert!(
+    WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS
+        + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+        + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST
+            * CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        <= WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET,
+    "a max-size withdrawal txn must archive in a single GC transaction"
+);
+
 /// How many inputs fit in [`WITHDRAWAL_RUNTIME_OBJECT_BUDGET`] after the
 /// fixed overhead and the per-request cost of `request_count` requests.
 fn runtime_object_input_budget(

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -107,16 +107,43 @@ pub(crate) fn withdrawal_limiter_consumption_amount(txn: &WithdrawalTransaction)
 /// Target 922 to leave 7.8% headroom below the hard cap.
 const WITHDRAWAL_RUNTIME_OBJECT_BUDGET: usize = 922;
 
-/// Runtime-object cost model for `commit_withdrawal_tx`. Empirical
-/// measurements put commit transactions at roughly
-/// `3 * requests + 1 * selected_utxos + fixed_overhead` runtime objects:
-/// each request is removed from the `requests` ObjectBag and re-added to
-/// `processed` (the `Field` wrapper, the child request object, and the new
+/// Runtime-object cost model for the v2 (deferred-archival)
+/// `commit_withdrawal_tx`: each request is mutated in place in the
+/// `requests` ObjectBag (the `Field` wrapper plus the child request object,
+/// 2 per request — the v1 bag move paid a third for the new `processed`
 /// `Field`), and each input borrows and locks its `utxo_records` entry (one
-/// `Field` per input).
+/// `Field` per input). The v1 empirical baseline was `3 * requests +
+/// 1 * selected_utxos + fixed_overhead`; the 2/request coefficient follows
+/// from removing the `Field` creation and should be confirmed by sui-replay
+/// before the upgrade ships.
 const WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS: usize = 12;
-const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
 const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
+
+/// The pre-deferred-archival batch cap, still enforced while the chain
+/// operates at package v1: v1 bytecode's commit pays 3 runtime objects per
+/// request, and pre-v2 validators have this bound compiled in. See
+/// [`max_withdrawal_requests`].
+pub(crate) const LEGACY_MAX_WITHDRAWAL_REQUESTS: usize = 298;
+
+/// The package version at which the deferred-archival flow (in-place
+/// commit, chunked archival GC) is live; the canonical constant for both
+/// the archival GC gate and the batch-cap switch.
+pub(crate) const DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION: u64 = 2;
+
+/// The request cap for the active package version. The larger v2 cap is
+/// only safe once the chain executes v2 bytecode (in-place commit) AND the
+/// fleet runs binaries that accept it — the same rollout discipline the
+/// upgrade train already requires: binaries first, then the upgrade tx.
+/// Gating on the resolved active version makes the flip atomic with the
+/// upgrade checkpoint on every node.
+pub(crate) fn max_withdrawal_requests(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+    } else {
+        LEGACY_MAX_WITHDRAWAL_REQUESTS
+    }
+}
 
 /// Funding-input reserve at the request-count cap. With largest-first
 /// selection a batch is normally funded by a handful of inputs; 16 leaves
@@ -152,8 +179,27 @@ const _: () = assert!(
 /// checked alongside it so a future change to either cost cannot silently
 /// regress the other.
 const WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS: usize = 43;
-const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
+/// v2 confirm defers every request-status write to the archival GC, so its
+/// object cost no longer scales with the request count.
+const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 0;
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
+
+/// v1 bytecode coefficients, still applied while the chain operates at
+/// package v1: commit moved each request between bags (3 objects) and
+/// confirm borrowed each request to set its status (2 objects).
+const LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+const LEGACY_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
+
+// Pin the legacy cap to the v1 commit derivation the same way the current
+// cap is pinned below: refuse to compile if either drifts from its model.
+const _: () = assert!(
+    LEGACY_MAX_WITHDRAWAL_REQUESTS
+        == (WITHDRAWAL_RUNTIME_OBJECT_BUDGET
+            - WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS
+            - WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS * WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT)
+            / LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST,
+    "LEGACY_MAX_WITHDRAWAL_REQUESTS must equal the v1 commit object-budget derivation"
+);
 
 /// Runtime-object cost model for the deferred `archive_confirmed_withdrawals`
 /// GC (v2 package): ~3 objects per archived txn (hot-bag `Field` + child
@@ -167,15 +213,28 @@ pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET: usize = WITHDRAWAL_RUNTIME_OBJECT_BUDGET;
 
-// A whole txn's requests archive together (the entry has no partial-archival
-// mode), so the largest committable batch must fit one GC transaction.
+/// Cost of `finish_archive_withdrawal_txn`'s completeness walk: one
+/// `contains` probe per request, on top of the txn borrow.
+pub(crate) const WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST: usize = 1;
+
+// A txn whose requests exceed one GC transaction archives through the
+// chunked entries (`archive_withdrawal_requests` + finish); the packer only
+// needs each chunk to make progress and the finisher's probe walk to fit a
+// single transaction at the largest committable batch.
 const _: () = assert!(
     WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS
         + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
         + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST
+        <= WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET,
+    "an archival chunk must fit at least one request per GC transaction"
+);
+const _: () = assert!(
+    WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS
+        + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+        + WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST
             * CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
         <= WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET,
-    "a max-size withdrawal txn must archive in a single GC transaction"
+    "a max-size txn's archival finish walk must fit a single GC transaction"
 );
 
 /// How many inputs fit in [`WITHDRAWAL_RUNTIME_OBJECT_BUDGET`] after the
@@ -193,19 +252,48 @@ fn runtime_object_input_budget(
     input_objects / objects_per_input
 }
 
-fn safe_withdrawal_commit_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+/// Per-request commit cost for the version the chain executes: v1 bytecode
+/// moves each request between bags (3 objects), v2 mutates in place (2).
+fn commit_objects_per_request(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST
+    } else {
+        LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST
+    }
+}
+
+/// Per-request confirm cost for the version the chain executes: v1 bytecode
+/// borrows every request to set its status (2 objects), v2 defers the
+/// status writes to the archival GC (0).
+fn confirm_objects_per_request(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST
+    } else {
+        LEGACY_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST
+    }
+}
+
+fn safe_withdrawal_commit_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     configured_max_inputs.min(runtime_object_input_budget(
         WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS,
-        WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST,
+        commit_objects_per_request(active_package_version),
         WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT,
         request_count,
     ))
 }
 
-fn safe_withdrawal_confirm_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+fn safe_withdrawal_confirm_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     configured_max_inputs.min(runtime_object_input_budget(
         WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS,
-        WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST,
+        confirm_objects_per_request(active_package_version),
         WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT,
         request_count,
     ))
@@ -213,8 +301,13 @@ fn safe_withdrawal_confirm_max_inputs(request_count: usize, configured_max_input
 
 /// The input cap for the whole withdrawal flow at a given request count:
 /// the configured cap, the per-request consolidation budget, and the
-/// runtime-object budgets of both the commit and confirm transactions.
-fn safe_withdrawal_flow_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+/// runtime-object budgets of both the commit and confirm transactions —
+/// each priced for the bytecode the active package version executes.
+fn safe_withdrawal_flow_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     let request_input_budget =
         request_count.saturating_mul(CoinSelectionParams::DEFAULT_INPUT_BUDGET);
     configured_max_inputs
@@ -222,10 +315,12 @@ fn safe_withdrawal_flow_max_inputs(request_count: usize, configured_max_inputs: 
         .min(safe_withdrawal_commit_max_inputs(
             request_count,
             configured_max_inputs,
+            active_package_version,
         ))
         .min(safe_withdrawal_confirm_max_inputs(
             request_count,
             configured_max_inputs,
+            active_package_version,
         ))
 }
 
@@ -258,9 +353,13 @@ const _: () = assert!(
 /// Otherwise pool health is the scarce resource: cap the batch at
 /// [`CONSOLIDATION_MODE_MAX_REQUESTS`] so the full per-request
 /// consolidation budget stays available (consolidation mode).
-fn withdrawal_batch_request_cap(pending_requests: usize, available_utxos: usize) -> usize {
+fn withdrawal_batch_request_cap(
+    pending_requests: usize,
+    available_utxos: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     if pending_requests > available_utxos {
-        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        max_withdrawal_requests(active_package_version)
     } else {
         CONSOLIDATION_MODE_MAX_REQUESTS
     }
@@ -299,15 +398,19 @@ fn validate_commitment_shape(
     request_count: usize,
     input_count: usize,
     outputs: &[OutputUtxo],
+    active_package_version: Option<u64>,
 ) -> anyhow::Result<()> {
+    let max_requests = max_withdrawal_requests(active_package_version);
     anyhow::ensure!(
-        request_count <= CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
-        "Commitment has {request_count} requests, exceeding the batch cap of {}",
-        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
+        request_count <= max_requests,
+        "Commitment has {request_count} requests, exceeding the batch cap of {max_requests}",
     );
 
-    let max_inputs =
-        safe_withdrawal_flow_max_inputs(request_count, CoinSelectionParams::DEFAULT_MAX_INPUTS);
+    let max_inputs = safe_withdrawal_flow_max_inputs(
+        request_count,
+        CoinSelectionParams::DEFAULT_MAX_INPUTS,
+        active_package_version,
+    );
     anyhow::ensure!(
         input_count <= max_inputs,
         "Commitment has {input_count} inputs for {request_count} requests, \
@@ -472,6 +575,7 @@ impl Hashi {
             approval.request_ids.len(),
             approval.selected_utxos.len(),
             &approval.outputs,
+            self.onchain_state().active_package_version(),
         )?;
 
         // 1. Verify each request_id exists and is approved
@@ -1366,8 +1470,13 @@ impl Hashi {
 
         // Drain versus consolidate: size the batch cap by comparing the
         // queue depth to the available pool. `candidates` counts every
-        // unlocked UTXO — the same set coin selection draws from.
-        let batch_request_cap = withdrawal_batch_request_cap(requests.len(), candidates.len());
+        // unlocked UTXO — the same set coin selection draws from. The cap
+        // (and the input models below) follow the active package version,
+        // so the leader proposes only shapes the executing bytecode can
+        // afford and every validator generation will certify.
+        let active_package_version = self.onchain_state().active_package_version();
+        let batch_request_cap =
+            withdrawal_batch_request_cap(requests.len(), candidates.len(), active_package_version);
         let configured_max_requests = self
             .config
             .withdrawal_max_batch_size()
@@ -1395,7 +1504,11 @@ impl Hashi {
         let mut last_selection_error = None;
         let mut result = None;
         for request_count in (1..=configured_max_requests).rev() {
-            let max_inputs = safe_withdrawal_flow_max_inputs(request_count, configured_max_inputs);
+            let max_inputs = safe_withdrawal_flow_max_inputs(
+                request_count,
+                configured_max_inputs,
+                active_package_version,
+            );
             if max_inputs == 0 {
                 continue;
             }
@@ -2179,18 +2292,32 @@ mod tests {
         }
     }
 
+    /// Active-version shorthand for the model tests: the deferred-archival
+    /// package and the legacy chain.
+    const V2: Option<u64> = Some(DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION);
+    const V1: Option<u64> = Some(1);
+
     #[test]
     fn batch_cap_drains_when_queue_outnumbers_pool() {
         assert_eq!(
-            withdrawal_batch_request_cap(5_000, 1_000),
+            withdrawal_batch_request_cap(5_000, 1_000, V2),
             CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        );
+        assert_eq!(
+            withdrawal_batch_request_cap(5_000, 1_000, V1),
+            LEGACY_MAX_WITHDRAWAL_REQUESTS
+        );
+        assert_eq!(
+            withdrawal_batch_request_cap(5_000, 1_000, None),
+            LEGACY_MAX_WITHDRAWAL_REQUESTS,
+            "an unresolved active version must fall back to the legacy cap",
         );
     }
 
     #[test]
     fn batch_cap_consolidates_when_pool_outnumbers_queue() {
         assert_eq!(
-            withdrawal_batch_request_cap(10, 1_000),
+            withdrawal_batch_request_cap(10, 1_000, V2),
             CONSOLIDATION_MODE_MAX_REQUESTS
         );
     }
@@ -2198,7 +2325,7 @@ mod tests {
     #[test]
     fn batch_cap_prefers_consolidation_at_parity() {
         assert_eq!(
-            withdrawal_batch_request_cap(500, 500),
+            withdrawal_batch_request_cap(500, 500, V2),
             CONSOLIDATION_MODE_MAX_REQUESTS
         );
     }
@@ -2304,21 +2431,34 @@ mod tests {
 
     #[test]
     fn withdrawal_flow_budget_at_absolute_cap() {
-        assert_eq!(CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS, 298);
+        assert_eq!(CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS, 447);
         assert_eq!(CoinSelectionParams::DEFAULT_MAX_INPUTS, 400);
+        // Both caps leave exactly the funding-input reserve under their own
+        // commit coefficients: 922 - 12 - 2*447 = 922 - 12 - 3*298 = 16.
         assert_eq!(
             safe_withdrawal_commit_max_inputs(
                 CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
                 CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V2,
             ),
             WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
-            "at the request cap, the commit object budget leaves exactly \
+            "at the v2 request cap, the commit object budget leaves exactly \
              the funding-input reserve",
+        );
+        assert_eq!(
+            safe_withdrawal_commit_max_inputs(
+                LEGACY_MAX_WITHDRAWAL_REQUESTS,
+                CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V1,
+            ),
+            WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
+            "at the legacy request cap under v1 coefficients, likewise",
         );
         assert_eq!(
             safe_withdrawal_flow_max_inputs(
                 CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
                 CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V2,
             ),
             WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
             "a full drain-mode batch spends the object budget on requests, \
@@ -2333,7 +2473,7 @@ mod tests {
     #[test]
     fn withdrawal_flow_budget_at_legacy_batch_size() {
         assert_eq!(
-            safe_withdrawal_flow_max_inputs(40, CoinSelectionParams::DEFAULT_MAX_INPUTS),
+            safe_withdrawal_flow_max_inputs(40, CoinSelectionParams::DEFAULT_MAX_INPUTS, V2),
             400,
             "40 requests × 10 inputs/request still fills the configured input cap",
         );
@@ -2342,7 +2482,7 @@ mod tests {
     #[test]
     fn withdrawal_flow_budget_scales_inputs_with_request_count() {
         assert_eq!(
-            safe_withdrawal_flow_max_inputs(10, CoinSelectionParams::DEFAULT_MAX_INPUTS),
+            safe_withdrawal_flow_max_inputs(10, CoinSelectionParams::DEFAULT_MAX_INPUTS, V2),
             10 * CoinSelectionParams::DEFAULT_INPUT_BUDGET,
             "at low request counts, the per-request input budget is binding",
         );
@@ -2362,16 +2502,21 @@ mod tests {
     #[test]
     fn commitment_shape_accepts_production_envelopes() {
         // (requests, inputs): the consolidation-heavy legacy shape, the
-        // drain-mode shape at the request cap, and a minimal batch.
-        for (requests, inputs) in [(40, 400), (298, 16), (1, 10)] {
-            validate_commitment_shape(requests, inputs, &p2tr_outputs(requests + 1))
+        // drain-mode shapes at both request caps, and a minimal batch.
+        for (requests, inputs) in [(40, 400), (298, 16), (447, 16), (1, 10)] {
+            validate_commitment_shape(requests, inputs, &p2tr_outputs(requests + 1), V2)
                 .unwrap_or_else(|e| panic!("{requests} requests / {inputs} inputs rejected: {e}"));
         }
+        // A v1-active chain keeps the legacy envelope and refuses the larger one.
+        validate_commitment_shape(298, 16, &p2tr_outputs(299), V1)
+            .expect("legacy cap batch must validate on a v1-active chain");
+        let err = validate_commitment_shape(299, 16, &p2tr_outputs(300), V1).unwrap_err();
+        assert!(err.to_string().contains("exceeding the batch cap"), "{err}");
     }
 
     #[test]
     fn commitment_shape_rejects_request_count_above_cap() {
-        let err = validate_commitment_shape(299, 1, &p2tr_outputs(299)).unwrap_err();
+        let err = validate_commitment_shape(448, 1, &p2tr_outputs(448), V2).unwrap_err();
         assert!(err.to_string().contains("exceeding the batch cap"), "{err}");
     }
 
@@ -2379,9 +2524,9 @@ mod tests {
     fn commitment_shape_rejects_inputs_above_flow_cap() {
         // One over the per-request consolidation budget, the configured
         // input cap, and the commit object budget's funding reserve.
-        for (requests, inputs) in [(1, 11), (40, 401), (298, 17)] {
-            let err =
-                validate_commitment_shape(requests, inputs, &p2tr_outputs(requests)).unwrap_err();
+        for (requests, inputs) in [(1, 11), (40, 401), (447, 17)] {
+            let err = validate_commitment_shape(requests, inputs, &p2tr_outputs(requests), V2)
+                .unwrap_err();
             assert!(
                 err.to_string().contains("exceeding the flow cap"),
                 "{requests} requests / {inputs} inputs: {err}"
@@ -2394,22 +2539,28 @@ mod tests {
         // Request and input counts inside their caps, but enough change
         // outputs to push the transaction past the 400 kWU standardness
         // limit (~2,300 P2TR outputs).
-        let err = validate_commitment_shape(298, 16, &p2tr_outputs(3_000)).unwrap_err();
+        let err = validate_commitment_shape(447, 16, &p2tr_outputs(3_000), V2).unwrap_err();
         assert!(err.to_string().contains("standardness limit"), "{err}");
     }
 
     #[test]
     fn commitment_shape_accepts_change_outputs_at_cap() {
-        validate_commitment_shape(40, 400, &p2tr_outputs(40 + WITHDRAWAL_MAX_CHANGE_OUTPUTS))
-            .expect("a commitment at the change-output cap must validate");
+        validate_commitment_shape(
+            40,
+            400,
+            &p2tr_outputs(40 + WITHDRAWAL_MAX_CHANGE_OUTPUTS),
+            V2,
+        )
+        .expect("a commitment at the change-output cap must validate");
     }
 
     #[test]
     fn commitment_shape_rejects_change_outputs_above_cap() {
         let err = validate_commitment_shape(
-            298,
+            447,
             16,
-            &p2tr_outputs(298 + WITHDRAWAL_MAX_CHANGE_OUTPUTS + 1),
+            &p2tr_outputs(447 + WITHDRAWAL_MAX_CHANGE_OUTPUTS + 1),
+            V2,
         )
         .unwrap_err();
         assert!(err.to_string().contains("change outputs"), "{err}");
@@ -2437,16 +2588,22 @@ mod tests {
     /// safety net.
     #[test]
     fn withdrawal_confirm_budget_never_binds() {
-        for request_count in 1..=1000 {
-            let configured = CoinSelectionParams::DEFAULT_MAX_INPUTS;
-            let without_confirm = configured
-                .min(request_count * CoinSelectionParams::DEFAULT_INPUT_BUDGET)
-                .min(safe_withdrawal_commit_max_inputs(request_count, configured));
-            assert_eq!(
-                safe_withdrawal_flow_max_inputs(request_count, configured),
-                without_confirm,
-                "confirm budget unexpectedly binds at {request_count} requests",
-            );
+        for active in [V1, V2] {
+            for request_count in 1..=1000 {
+                let configured = CoinSelectionParams::DEFAULT_MAX_INPUTS;
+                let without_confirm = configured
+                    .min(request_count * CoinSelectionParams::DEFAULT_INPUT_BUDGET)
+                    .min(safe_withdrawal_commit_max_inputs(
+                        request_count,
+                        configured,
+                        active,
+                    ));
+                assert_eq!(
+                    safe_withdrawal_flow_max_inputs(request_count, configured, active),
+                    without_confirm,
+                    "confirm budget unexpectedly binds at {request_count} requests ({active:?})",
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Stacked on #1003 (Move base). Rust side of the deferred withdrawal archival, **including the capacity claim: the batch cap rises 298 → 447 behind the active-version gate.**

**Version gating** (two switches, both keyed on the resolved active version so the flip is atomic with the upgrade checkpoint):
1. The archival GC spawn (`active >= 2` — the entries don't exist in v1 bytecode, and pre-flip there's nothing to archive since v1 confirm archives inline).
2. The batch cap and runtime-object cost models: `max_withdrawal_requests(active)` returns 447 once v2 bytecode executes (in-place commit = 2 objects/request, confirm = 0/request) and the legacy 298 with v1 coefficients (3 and 2) otherwise. The leader sizes batches and validators check commitment shapes with the same function, so mixed generations always agree on what's certifiable — a pre-upgrade chain keeps today's envelope exactly. Compile-time asserts pin both cap derivations: `(922−12−16)/2 = 447` and `(922−12−16)/3 = 298`.

Everything else is unconditional tolerance of both package generations:
- **Mirror**: status-derived `Effect::WithdrawalTxnConfirmed` drives the duration histograms at confirm time; the retire path dedups so v1 inline archival keeps its accounting and GC latency stays out of the histograms.
- **Leader**: broadcast/confirm selection excludes confirmed txns; the approve-retry probe drops requests that are no longer status-Requested; `ConfirmedOnSui` arms the archival scan.
- **GC**: `cleanup_spent_utxos` template (singleton, infinite-backoff retry, checkpoint-freshness waits, boot-armed). Victims carry request ids; the executor **plans per victim**: txns fitting one transaction greedy-pack through the atomic entry, oversized ones (possible once the 447 cap is in effect) split into `archive_withdrawal_requests` chunks + a batched finish, each call priced against the 922 budget.
- **Metrics/CLI**: txn-level `confirmed` class = archival-backlog alert signal; CLI renders confirmed-awaiting-archival accurately.

**Verified**: 630/630 hashi unit tests (incl. archival planning, both-version cost models, version-aware shape checks); `test_bitcoin_withdrawal_e2e_flow` green in 75s (v2 path end-to-end incl. archival GC); `test_withdrawal_committed_under_v1_completes_after_upgrade` green in 66s (fully-signed withdrawal parked under v1 bytecode, governance upgrade, v2 confirm + archival over cross-version state).

Follow-up before the upgrade ships: sui-replay measurement of the real commit/archive coefficients (2/request commit and 3/request archive are principled but unmeasured; the caps only get *more* headroom if they're lower).