### PR TITLE
[metrics] Export database size per keyspace and fjall's poisoned flag

### DIFF
--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -137,6 +137,21 @@ impl EpochGenerations {
         (epoch % 2) as usize
     }
 
+    /// The name this keyspace had before it was split, which generation 0 keeps.
+    fn name(&self) -> &'static str {
+        self.names[0]
+    }
+
+    /// Bytes fjall accounts to this keyspace across both generations.
+    fn disk_space(&self) -> u64 {
+        self.generations
+            .read()
+            .unwrap()
+            .iter()
+            .map(Keyspace::disk_space)
+            .sum()
+    }
+
     fn generation(&self, index: usize) -> Keyspace {
         self.generations.read().unwrap()[index].clone()
     }
@@ -310,6 +325,46 @@ impl Database {
 
     pub(crate) fn snapshot(&self) -> fjall::Snapshot {
         self.db.snapshot()
+    }
+
+    /// Bytes fjall accounts to each keyspace, with the epoch-scoped ones summed
+    /// across their generations.
+    pub fn keyspace_disk_space(&self) -> Vec<(&'static str, u64)> {
+        vec![
+            (ENCRYPTION_KEYS_CF_NAME, self.encryption_keys.disk_space()),
+            (SIGNING_KEYS_CF_NAME, self.signing_keys.disk_space()),
+            (
+                ENCRYPTION_EPOCH_INDEX_CF_NAME,
+                self.encryption_epoch_index.disk_space(),
+            ),
+            (
+                SIGNING_EPOCH_INDEX_CF_NAME,
+                self.signing_epoch_index.disk_space(),
+            ),
+            (DEALER_MESSAGES_CF_NAME, self.dealer_messages.disk_space()),
+            (
+                ROTATION_MESSAGES_CF_NAME,
+                self.rotation_messages.disk_space(),
+            ),
+            (self.nonce_messages.name(), self.nonce_messages.disk_space()),
+            (
+                self.avid_round_states.name(),
+                self.avid_round_states.disk_space(),
+            ),
+            (
+                self.avid_dealer_builders.name(),
+                self.avid_dealer_builders.disk_space(),
+            ),
+            (
+                self.avid_held_echoes.name(),
+                self.avid_held_echoes.disk_space(),
+            ),
+        ]
+    }
+
+    /// Bytes fjall accounts to the whole database, journals included.
+    pub fn total_disk_space(&self) -> Result<u64> {
+        self.db.disk_space()
     }
 
     /// Store an encryption private key, keyed by its public key, plus the
@@ -1973,6 +2028,41 @@ pub(crate) mod tests {
             }
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
+    }
+
+    /// The gauge has to name a keyspace an operator can act on, and has to fall
+    /// when that keyspace is retired.
+    #[test]
+    fn test_keyspace_disk_space_reports_the_epoch_scoped_keyspaces() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+
+        let nonce_msg = create_test_nonce_message();
+        for batch_index in 0..64 {
+            db.store_nonce_message(1, batch_index, &Address::new([1u8; 32]), &nonce_msg)
+                .unwrap();
+        }
+        for keyspace in db.nonce_messages.generations.read().unwrap().iter() {
+            keyspace.rotate_memtable_and_wait().unwrap();
+        }
+
+        let reported = |db: &Database| {
+            db.keyspace_disk_space()
+                .into_iter()
+                .find(|(name, _)| *name == "nonce_messages")
+                .expect("nonce_messages must be reported under its logical name")
+                .1
+        };
+        let occupied = reported(&db);
+        assert!(
+            occupied > 0,
+            "the written epoch should show up in the gauge"
+        );
+        assert!(db.total_disk_space().unwrap() >= occupied);
+
+        db.prune_messages_below(2, &PruningReferences::default())
+            .unwrap();
+        assert_eq!(reported(&db), 0, "retiring epoch 1 should drop the gauge");
     }
 
     /// Retirement puts a brand new keyspace behind the same name.

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -330,36 +330,29 @@ impl Database {
     /// Bytes fjall accounts to each keyspace, with the epoch-scoped ones summed
     /// across their generations.
     pub fn keyspace_disk_space(&self) -> Vec<(&'static str, u64)> {
-        vec![
-            (ENCRYPTION_KEYS_CF_NAME, self.encryption_keys.disk_space()),
-            (SIGNING_KEYS_CF_NAME, self.signing_keys.disk_space()),
-            (
-                ENCRYPTION_EPOCH_INDEX_CF_NAME,
-                self.encryption_epoch_index.disk_space(),
-            ),
-            (
-                SIGNING_EPOCH_INDEX_CF_NAME,
-                self.signing_epoch_index.disk_space(),
-            ),
-            (DEALER_MESSAGES_CF_NAME, self.dealer_messages.disk_space()),
-            (
-                ROTATION_MESSAGES_CF_NAME,
-                self.rotation_messages.disk_space(),
-            ),
-            (self.nonce_messages.name(), self.nonce_messages.disk_space()),
-            (
-                self.avid_round_states.name(),
-                self.avid_round_states.disk_space(),
-            ),
-            (
-                self.avid_dealer_builders.name(),
-                self.avid_dealer_builders.disk_space(),
-            ),
-            (
-                self.avid_held_echoes.name(),
-                self.avid_held_echoes.disk_space(),
-            ),
-        ]
+        let keyspaces = [
+            (ENCRYPTION_KEYS_CF_NAME, &self.encryption_keys),
+            (SIGNING_KEYS_CF_NAME, &self.signing_keys),
+            (ENCRYPTION_EPOCH_INDEX_CF_NAME, &self.encryption_epoch_index),
+            (SIGNING_EPOCH_INDEX_CF_NAME, &self.signing_epoch_index),
+            (DEALER_MESSAGES_CF_NAME, &self.dealer_messages),
+            (ROTATION_MESSAGES_CF_NAME, &self.rotation_messages),
+        ];
+        let epoch_scoped = [
+            &self.nonce_messages,
+            &self.avid_round_states,
+            &self.avid_dealer_builders,
+            &self.avid_held_echoes,
+        ];
+        keyspaces
+            .into_iter()
+            .map(|(name, keyspace)| (name, keyspace.disk_space()))
+            .chain(
+                epoch_scoped
+                    .into_iter()
+                    .map(|keyspace| (keyspace.name(), keyspace.disk_space())),
+            )
+            .collect()
     }
 
     /// Bytes fjall accounts to the whole database, journals included.

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -257,6 +257,22 @@ impl Database {
         ]
     }
 
+    /// Bytes of live tables per keyspace; journals and tables awaiting unlink
+    /// are not counted.
+    pub fn keyspace_disk_space(&self) -> [(&'static str, u64); 11] {
+        self.all_keyspaces()
+            .map(|(name, keyspace)| (name, keyspace.disk_space()))
+    }
+
+    /// fjall only reports poisoning by refusing a write; `persist` checks the
+    /// flag before touching the journal, so this is free once poisoned.
+    pub fn is_poisoned(&self) -> bool {
+        matches!(
+            self.db.persist(fjall::PersistMode::Buffer),
+            Err(fjall::Error::Poisoned)
+        )
+    }
+
     /// Rewrite every keyspace into a single run, dropping what
     /// `prune_messages_below` tombstoned. Pruning alone frees nothing: a
     /// tombstone is a few dozen bytes against a nonce message of hundreds of
@@ -2000,6 +2016,76 @@ pub(crate) mod tests {
             bytes_on_disk(&db.nonce_messages) < occupied / 10,
             "compaction must give back the {occupied} bytes pruning tombstoned",
         );
+    }
+
+    /// The gauge names the keyspace and falls once compaction has freed it.
+    #[test]
+    fn test_keyspace_disk_space_falls_after_compaction() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+
+        let nonce_msg = create_test_nonce_message();
+        for batch_index in 0..64 {
+            db.store_nonce_message(1, batch_index, &Address::new([1u8; 32]), &nonce_msg)
+                .unwrap();
+        }
+        db.nonce_messages.rotate_memtable_and_wait().unwrap();
+
+        let nonce_bytes = |db: &Database| {
+            db.keyspace_disk_space()
+                .into_iter()
+                .find(|(name, _)| *name == NONCE_MESSAGES_CF_NAME)
+                .expect("nonce_messages must be reported")
+                .1
+        };
+        assert!(nonce_bytes(&db) > 0, "epoch 1 should be on disk");
+
+        db.prune_messages_below(2, &PruningReferences::default())
+            .unwrap();
+        let compaction = db.major_compact();
+        assert!(compaction.unlink_error.is_none());
+        assert_eq!(
+            nonce_bytes(&db),
+            0,
+            "every row was pruned and compacted away"
+        );
+    }
+
+    /// Removing the tables directory makes the next flush fail, which poisons
+    /// the database from the worker thread.
+    #[test]
+    fn test_is_poisoned_after_a_failed_flush() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+        assert!(!db.is_poisoned());
+
+        let nonce_msg = create_test_nonce_message();
+        let dealer = Address::new([1u8; 32]);
+        for batch_index in 0..16 {
+            db.store_nonce_message(1, batch_index, &dealer, &nonce_msg)
+                .unwrap();
+        }
+        std::fs::remove_dir_all(db.nonce_messages.path().join("tables")).unwrap();
+        // `rotate_memtable_and_wait` would spin forever: a failed flush never
+        // clears the sealed memtable it waits on.
+        assert!(db.nonce_messages.rotate_memtable().unwrap());
+
+        // The flush worker sets the flag.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !db.is_poisoned() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the failed flush never poisoned the database"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(matches!(
+            db.store_nonce_message(1, 99, &dealer, &nonce_msg),
+            Err(fjall::Error::Poisoned)
+        ));
+
+        // Dropping the database blocks forever once a worker has crashed.
+        std::mem::forget(db);
     }
 
     #[test]

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -883,6 +883,7 @@ impl Hashi {
         let guardian_bootstrap_service = self.clone().start_guardian_bootstrap();
         let sui_balance_service = self.clone().start_sui_balance_metric();
         let sui_address_balance_sweeper_service = self.clone().start_sui_address_balance_sweeper();
+        let db_disk_usage_service = self.clone().start_db_disk_usage_metric();
 
         let service = Service::new()
             .merge(onchain_service)
@@ -893,7 +894,8 @@ impl Hashi {
             .merge(mpc_service)
             .merge(guardian_bootstrap_service)
             .merge(sui_balance_service)
-            .merge(sui_address_balance_sweeper_service);
+            .merge(sui_address_balance_sweeper_service)
+            .merge(db_disk_usage_service);
 
         Ok(service)
     }
@@ -1191,6 +1193,19 @@ impl Hashi {
                         tracing::warn!("Failed to sweep SUI coin objects into address balance: {e}")
                     }
                 }
+            }
+        })
+    }
+
+    fn start_db_disk_usage_metric(self: Arc<Self>) -> Service {
+        const SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+        Service::new().spawn_aborting(async move {
+            let mut interval = tokio::time::interval(SAMPLE_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                self.metrics.update_db_disk_usage(&self.db);
             }
         })
     }

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -946,6 +946,7 @@ impl Hashi {
         let guardian_bootstrap_service = self.clone().start_guardian_bootstrap();
         let sui_balance_service = self.clone().start_sui_balance_metric();
         let sui_address_balance_sweeper_service = self.clone().start_sui_address_balance_sweeper();
+        let db_metrics_service = self.clone().start_db_metrics();
 
         let service = Service::new()
             .merge(onchain_service)
@@ -957,7 +958,8 @@ impl Hashi {
             .merge(mpc_service)
             .merge(guardian_bootstrap_service)
             .merge(sui_balance_service)
-            .merge(sui_address_balance_sweeper_service);
+            .merge(sui_address_balance_sweeper_service)
+            .merge(db_metrics_service);
 
         Ok(service)
     }
@@ -1323,6 +1325,19 @@ impl Hashi {
                     }
                     Err(e) => tracing::debug!("failed to fetch operator SUI balance: {e}"),
                 }
+            }
+        })
+    }
+
+    fn start_db_metrics(self: Arc<Self>) -> Service {
+        const SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+        Service::new().spawn_aborting(async move {
+            let mut interval = tokio::time::interval(SAMPLE_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                self.metrics.update_db(&self.db);
             }
         })
     }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -117,6 +117,8 @@ pub struct Metrics {
     pub never_retry_deposit_ids: IntGauge,
     pub withdrawals_finalized_total: IntCounter,
     pub presig_pool_remaining: IntGauge,
+    db_keyspace_disk_bytes: IntGaugeVec,
+    db_disk_bytes: IntGauge,
     pub sui_tx_submissions_total: IntCounterVec,
     pub sui_balance: IntGaugeVec,
     pub sui_address_balance_sweeps_total: IntCounter,
@@ -730,6 +732,19 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            db_keyspace_disk_bytes: register_int_gauge_vec_with_registry!(
+                "hashi_db_keyspace_disk_bytes",
+                "bytes fjall accounts to each database keyspace",
+                &["keyspace"],
+                registry,
+            )
+            .unwrap(),
+            db_disk_bytes: register_int_gauge_with_registry!(
+                "hashi_db_disk_bytes",
+                "bytes fjall accounts to the whole database, journals included",
+                registry,
+            )
+            .unwrap(),
             sui_tx_submissions_total: register_int_counter_vec_with_registry!(
                 "hashi_sui_tx_submissions_total",
                 "Total Sui transaction submissions by operation and outcome",
@@ -1198,6 +1213,18 @@ impl Metrics {
         self.task_last_iteration_timestamp_seconds
             .with_label_values(&[task])
             .set(now);
+    }
+
+    pub fn update_db_disk_usage(&self, db: &crate::db::Database) {
+        for (keyspace, bytes) in db.keyspace_disk_space() {
+            self.db_keyspace_disk_bytes
+                .with_label_values(&[keyspace])
+                .set(bytes.min(i64::MAX as u64) as i64);
+        }
+        match db.total_disk_space() {
+            Ok(bytes) => self.db_disk_bytes.set(bytes.min(i64::MAX as u64) as i64),
+            Err(e) => tracing::debug!("failed to read database disk usage: {e}"),
+        }
     }
 
     pub fn update_onchain_state(&self, state: &crate::onchain::OnchainState) {

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -205,6 +205,8 @@ pub struct Metrics {
     pub mpc_end_reconfig_duration_seconds: HistogramVec,
     db_major_compaction_duration_seconds: HistogramVec,
     db_major_compaction_failures_total: IntCounterVec,
+    db_keyspace_disk_bytes: IntGaugeVec,
+    db_poisoned: IntGauge,
     pub mpc_prepare_signing_duration_seconds: HistogramVec,
     pub mpc_total_duration_seconds: HistogramVec,
     pub mpc_dealer_crypto_duration_seconds: HistogramVec,
@@ -1169,6 +1171,19 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            db_keyspace_disk_bytes: register_int_gauge_vec_with_registry!(
+                "hashi_db_keyspace_disk_bytes",
+                "Bytes of live tables in each database keyspace",
+                &["keyspace"],
+                registry,
+            )
+            .unwrap(),
+            db_poisoned: register_int_gauge_with_registry!(
+                "hashi_db_poisoned",
+                "1 once fjall has refused a write for good; only a restart recovers",
+                registry,
+            )
+            .unwrap(),
             mpc_prepare_signing_duration_seconds: register_histogram_vec_with_registry!(
                 "hashi_mpc_prepare_signing_duration_seconds",
                 "Duration of prepare_signing",
@@ -1464,6 +1479,15 @@ impl Metrics {
         self.db_major_compaction_failures_total
             .with_label_values(&["unlink"])
             .inc();
+    }
+
+    pub fn update_db(&self, db: &crate::db::Database) {
+        for (keyspace, bytes) in db.keyspace_disk_space() {
+            self.db_keyspace_disk_bytes
+                .with_label_values(&[keyspace])
+                .set(i64::try_from(bytes).unwrap_or(i64::MAX));
+        }
+        self.db_poisoned.set(i64::from(db.is_poisoned()));
     }
 
     pub fn set_utxo_pool_ages(&self, average_age_blocks: i64, oldest_age_blocks: i64) {

--- a/docs/validator-alerts.md
+++ b/docs/validator-alerts.md
@@ -25,6 +25,7 @@ Two principles shape this list:
 | Reconfig not tracking | `changes(hashi_epoch[3h]) == 0` | Testnet reconfigures roughly every 40 minutes. If the committee epoch stops moving, either your node stopped following reconfig or the fleet itself stalled — check the operator channel before assuming local fault. |
 | Low gas | `hashi_sui_balance < 1e9` | Below 1 SUI the operator wallet is close to unable to submit. Refill. |
 | Binary behind chain | `hashi_package_version_unsupported == 1` | The chain moved to a package version this binary does not implement; autonomous writes are halted. Upgrade the binary immediately. |
+| Database poisoned | `hashi_db_poisoned == 1` | fjall refuses every write after a failed flush or fsync (usually a full disk) until the process restarts, while reads and signing carry on looking healthy. Free the disk, then restart. |
 | Crash looping | `changes(process_start_time_seconds{job="<your-node>"}[1h]) > 3` | Uses the standard process exporter if you run one; any restart-count source works. |
 
 Dashboard-worthy but **not** alerts:
@@ -35,6 +36,9 @@ Dashboard-worthy but **not** alerts:
   upgrade progress is counted before the on-chain upgrade flips `active`.
 - `hashi_is_leader` — leadership rotates; useful context when reading other
   metrics, meaningless to alert on.
+- `hashi_db_keyspace_disk_bytes` — live table bytes per keyspace. Each one
+  should fall at every epoch boundary; one that climbs across epochs is
+  leaking. Alert on the volume itself, not on this.
 - `hashi_deposit_outpoint_confirmations{status="not_found"}` — expected for
   unbroadcast transactions. It is suspicious only when your node reports it
   while peers report confirmations for the same deposits.
@@ -62,6 +66,7 @@ Dashboard-worthy but **not** alerts:
 | `hashi_deposit_outpoint_confirmations` | node |
 | `hashi_latest_checkpoint_*`, `hashi_task_last_iteration_timestamp_seconds` | node |
 | `hashi_sui_balance`, `hashi_package_version_*`, `hashi_is_leader` | node |
+| `hashi_db_*` | node |
 | `hashi_presig_pool_remaining`, `hashi_num_consumed_presigs` | bridge |
 | `hashi_deposit_queue_size`, `hashi_withdrawal_queue_*`, `hashi_utxo_pool_*` | bridge |
 | `hashi_paused`, `hashi_reconfig_in_progress`, `hashi_epoch`, `hashi_sui_epoch` | bridge (visible per node) |

--- a/monitoring/validator-alerts.example.yml
+++ b/monitoring/validator-alerts.example.yml
@@ -93,3 +93,15 @@ groups:
             The chain has moved past every package version this build
             implements; autonomous writes are halted. Upgrade the node
             binary immediately.
+
+      - alert: HashiDbPoisoned
+        expr: hashi_db_poisoned == 1
+        labels:
+          severity: critical
+        annotations:
+          summary: "database poisoned; restart required"
+          description: >-
+            fjall refused a write after a failed flush or fsync (usually a
+            full disk) and will refuse every write until the process
+            restarts; reads and signing carry on looking healthy. Free the
+            disk, then restart the node.


### PR DESCRIPTION
## Summary

Nothing reported how big the database was or which keyspace was growing, which is how `nonce_messages` filled every testnet volume before anyone noticed. And once fjall hits a failed flush (usually a full disk) it silently refuses every write until the process restarts, while reads and signing carry on and the node looks healthy. This adds a gauge for each, sampled once a minute, and an alert for the second.

## Changes

- `hashi_db_keyspace_disk_bytes{keyspace}`: live table bytes per keyspace from `Keyspace::disk_space`, which is in-memory accounting. Each keyspace should fall at every epoch boundary once the post-reconfig compaction runs.
- `hashi_db_poisoned`: fjall has no accessor for its poison flag, so `Database::is_poisoned` probes with `persist(PersistMode::Buffer)`, which checks the flag before touching the journal. This also catches poisoning from background flush and compaction failures, which a write-side latch would miss.
- `Hashi::start_db_metrics` samples both every 60s through `Metrics::update_db`.
- `HashiDbPoisoned` rule in `docs/validator-alerts.md` and `monitoring/validator-alerts.example.yml`; the keyspace gauge is listed as dashboard-only.
- Tests: the gauge reads 0 after prune + compaction, and the poison test poisons a real fjall database by deleting the keyspace's `tables` directory and rotating the memtable. It polls for the flag and then leaks the handle, because the blocking rotate spins forever after a failed flush and dropping the database hangs after a worker crash.
