### PR TITLE
[db] Report not-ready when fjall has poisoned the database

### DIFF
--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -137,6 +137,21 @@ impl EpochGenerations {
         (epoch % 2) as usize
     }
 
+    /// The name this keyspace had before it was split, which generation 0 keeps.
+    fn name(&self) -> &'static str {
+        self.names[0]
+    }
+
+    /// Bytes fjall accounts to this keyspace across both generations.
+    fn disk_space(&self) -> u64 {
+        self.generations
+            .read()
+            .unwrap()
+            .iter()
+            .map(Keyspace::disk_space)
+            .sum()
+    }
+
     fn generation(&self, index: usize) -> Keyspace {
         self.generations.read().unwrap()[index].clone()
     }
@@ -310,6 +325,46 @@ impl Database {
 
     pub(crate) fn snapshot(&self) -> fjall::Snapshot {
         self.db.snapshot()
+    }
+
+    /// Bytes fjall accounts to each keyspace, with the epoch-scoped ones summed
+    /// across their generations.
+    pub fn keyspace_disk_space(&self) -> Vec<(&'static str, u64)> {
+        vec![
+            (ENCRYPTION_KEYS_CF_NAME, self.encryption_keys.disk_space()),
+            (SIGNING_KEYS_CF_NAME, self.signing_keys.disk_space()),
+            (
+                ENCRYPTION_EPOCH_INDEX_CF_NAME,
+                self.encryption_epoch_index.disk_space(),
+            ),
+            (
+                SIGNING_EPOCH_INDEX_CF_NAME,
+                self.signing_epoch_index.disk_space(),
+            ),
+            (DEALER_MESSAGES_CF_NAME, self.dealer_messages.disk_space()),
+            (
+                ROTATION_MESSAGES_CF_NAME,
+                self.rotation_messages.disk_space(),
+            ),
+            (self.nonce_messages.name(), self.nonce_messages.disk_space()),
+            (
+                self.avid_round_states.name(),
+                self.avid_round_states.disk_space(),
+            ),
+            (
+                self.avid_dealer_builders.name(),
+                self.avid_dealer_builders.disk_space(),
+            ),
+            (
+                self.avid_held_echoes.name(),
+                self.avid_held_echoes.disk_space(),
+            ),
+        ]
+    }
+
+    /// Bytes fjall accounts to the whole database, journals included.
+    pub fn total_disk_space(&self) -> Result<u64> {
+        self.db.disk_space()
     }
 
     /// Store an encryption private key, keyed by its public key, plus the
@@ -1973,6 +2028,41 @@ pub(crate) mod tests {
             }
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
+    }
+
+    /// The gauge has to name a keyspace an operator can act on, and has to fall
+    /// when that keyspace is retired.
+    #[test]
+    fn test_keyspace_disk_space_reports_the_epoch_scoped_keyspaces() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+
+        let nonce_msg = create_test_nonce_message();
+        for batch_index in 0..64 {
+            db.store_nonce_message(1, batch_index, &Address::new([1u8; 32]), &nonce_msg)
+                .unwrap();
+        }
+        for keyspace in db.nonce_messages.generations.read().unwrap().iter() {
+            keyspace.rotate_memtable_and_wait().unwrap();
+        }
+
+        let reported = |db: &Database| {
+            db.keyspace_disk_space()
+                .into_iter()
+                .find(|(name, _)| *name == "nonce_messages")
+                .expect("nonce_messages must be reported under its logical name")
+                .1
+        };
+        let occupied = reported(&db);
+        assert!(
+            occupied > 0,
+            "the written epoch should show up in the gauge"
+        );
+        assert!(db.total_disk_space().unwrap() >= occupied);
+
+        db.prune_messages_below(2, &PruningReferences::default())
+            .unwrap();
+        assert_eq!(reported(&db), 0, "retiring epoch 1 should drop the gauge");
     }
 
     /// Retirement puts a brand new keyspace behind the same name.

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -330,36 +330,29 @@ impl Database {
     /// Bytes fjall accounts to each keyspace, with the epoch-scoped ones summed
     /// across their generations.
     pub fn keyspace_disk_space(&self) -> Vec<(&'static str, u64)> {
-        vec![
-            (ENCRYPTION_KEYS_CF_NAME, self.encryption_keys.disk_space()),
-            (SIGNING_KEYS_CF_NAME, self.signing_keys.disk_space()),
-            (
-                ENCRYPTION_EPOCH_INDEX_CF_NAME,
-                self.encryption_epoch_index.disk_space(),
-            ),
-            (
-                SIGNING_EPOCH_INDEX_CF_NAME,
-                self.signing_epoch_index.disk_space(),
-            ),
-            (DEALER_MESSAGES_CF_NAME, self.dealer_messages.disk_space()),
-            (
-                ROTATION_MESSAGES_CF_NAME,
-                self.rotation_messages.disk_space(),
-            ),
-            (self.nonce_messages.name(), self.nonce_messages.disk_space()),
-            (
-                self.avid_round_states.name(),
-                self.avid_round_states.disk_space(),
-            ),
-            (
-                self.avid_dealer_builders.name(),
-                self.avid_dealer_builders.disk_space(),
-            ),
-            (
-                self.avid_held_echoes.name(),
-                self.avid_held_echoes.disk_space(),
-            ),
-        ]
+        let keyspaces = [
+            (ENCRYPTION_KEYS_CF_NAME, &self.encryption_keys),
+            (SIGNING_KEYS_CF_NAME, &self.signing_keys),
+            (ENCRYPTION_EPOCH_INDEX_CF_NAME, &self.encryption_epoch_index),
+            (SIGNING_EPOCH_INDEX_CF_NAME, &self.signing_epoch_index),
+            (DEALER_MESSAGES_CF_NAME, &self.dealer_messages),
+            (ROTATION_MESSAGES_CF_NAME, &self.rotation_messages),
+        ];
+        let epoch_scoped = [
+            &self.nonce_messages,
+            &self.avid_round_states,
+            &self.avid_dealer_builders,
+            &self.avid_held_echoes,
+        ];
+        keyspaces
+            .into_iter()
+            .map(|(name, keyspace)| (name, keyspace.disk_space()))
+            .chain(
+                epoch_scoped
+                    .into_iter()
+                    .map(|keyspace| (keyspace.name(), keyspace.disk_space())),
+            )
+            .collect()
     }
 
     /// Bytes fjall accounts to the whole database, journals included.

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -69,39 +69,171 @@ pub struct Database {
     //
     // key: (big endian u64 epoch) + (big endian u32 batch_index) + (32-byte validator address)
     // value: BCS-serialized batch_avss::Message
-    nonce_messages: Keyspace,
+    nonce_messages: EpochGenerations,
 
     // Column Family used to store per-round AVID receiver state for restart/resume.
     //
     // key: (big endian u64 epoch) + (big endian u32 batch_index) + (32-byte validator address)
     // value: BCS-serialized AvidRoundState
-    avid_round_states: Keyspace,
+    avid_round_states: EpochGenerations,
 
     // Column Family used to store this node's own AVID dealer builder per batch.
     //
     // key: (big endian u64 epoch) + (big endian u32 batch_index)
     // value: BCS-serialized AvssMessageBuilder
-    avid_dealer_builders: Keyspace,
+    avid_dealer_builders: EpochGenerations,
 
     // Column Family used to store this node's held AVID vote and outbound echoes per round.
     //
     // key: (big endian u64 epoch) + (big endian u32 batch_index) + (32-byte dealer address)
     // value: BCS-serialized HeldAvidEchoes
-    avid_held_echoes: Keyspace,
+    avid_held_echoes: EpochGenerations,
 }
 
 const ENCRYPTION_KEYS_CF_NAME: &str = "encryption_keys";
 const SIGNING_KEYS_CF_NAME: &str = "signing_keys";
 const DEALER_MESSAGES_CF_NAME: &str = "dealer_messages";
 const ROTATION_MESSAGES_CF_NAME: &str = "rotation_messages";
-const NONCE_MESSAGES_CF_NAME: &str = "nonce_messages";
-const AVID_ROUND_STATES_CF_NAME: &str = "avid_round_states";
-const AVID_DEALER_BUILDERS_CF_NAME: &str = "avid_dealer_builders";
-const AVID_HELD_ECHOES_CF_NAME: &str = "avid_held_echoes";
 const ENCRYPTION_EPOCH_INDEX_CF_NAME: &str = "encryption_epoch_index";
 const SIGNING_EPOCH_INDEX_CF_NAME: &str = "signing_epoch_index";
 
+// Generation names for the epoch-scoped keyspaces. Generation 0 keeps the
+// pre-split name so that rows written before this node rotated generations land
+// in a generation that `retire_epochs_below` eventually drops.
+const NONCE_MESSAGES_CF_NAMES: [&str; 2] = ["nonce_messages", "nonce_messages_g1"];
+const AVID_ROUND_STATES_CF_NAMES: [&str; 2] = ["avid_round_states", "avid_round_states_g1"];
+const AVID_DEALER_BUILDERS_CF_NAMES: [&str; 2] =
+    ["avid_dealer_builders", "avid_dealer_builders_g1"];
+const AVID_HELD_ECHOES_CF_NAMES: [&str; 2] = ["avid_held_echoes", "avid_held_echoes_g1"];
+
 const RETENTION_EXTRA_EPOCHS: u64 = 7;
+
+/// A keyspace whose rows are scoped to a single MPC epoch, split into two
+/// generations selected by the parity of that epoch.
+///
+/// Nonce and AVID rows are dead as soon as the next epoch is installed, and
+/// there are a lot of them: one nonce message is hundreds of kilobytes and every
+/// batch stores one per dealer. Deleting them row by row does not give the space
+/// back — a tombstone is a few dozen bytes against the value it shadows, so
+/// leveled compaction never accumulates enough write pressure to rewrite the
+/// bottom level, and the bytes stay on disk for as long as the node runs.
+///
+/// Splitting by parity makes retirement a whole-generation drop: the keyspace is
+/// deleted and recreated empty, which unlinks its files instead of leaving
+/// tombstones behind for a compaction that never comes.
+struct EpochGenerations {
+    names: [&'static str; 2],
+    // Swapped out wholesale by `retire_epochs_below`, so the handles cannot be
+    // borrowed for longer than a single operation.
+    generations: std::sync::RwLock<[Keyspace; 2]>,
+}
+
+impl EpochGenerations {
+    fn open(db: &fjall::Database, names: [&'static str; 2]) -> Result<Self> {
+        Ok(Self {
+            names,
+            generations: std::sync::RwLock::new([
+                db.keyspace(names[0], KeyspaceCreateOptions::default)?,
+                db.keyspace(names[1], KeyspaceCreateOptions::default)?,
+            ]),
+        })
+    }
+
+    fn index(epoch: u64) -> usize {
+        (epoch % 2) as usize
+    }
+
+    fn generation(&self, index: usize) -> Keyspace {
+        self.generations.read().unwrap()[index].clone()
+    }
+
+    /// The generation that owns `epoch`. Every write for `epoch` lands here.
+    fn owner(&self, epoch: u64) -> Keyspace {
+        self.generation(Self::index(epoch))
+    }
+
+    /// The generation that cannot own `epoch`.
+    fn other(&self, epoch: u64) -> Keyspace {
+        self.generation(Self::index(epoch) ^ 1)
+    }
+
+    /// Point-read a key belonging to `epoch`.
+    ///
+    /// Falls back to the other generation so that rows written before the
+    /// keyspace was split stay readable for whichever epoch is still live.
+    fn get(&self, epoch: u64, key: &[u8]) -> Result<Option<fjall::UserValue>> {
+        match self.owner(epoch).get(key)? {
+            Some(value) => Ok(Some(value)),
+            None => self.other(epoch).get(key),
+        }
+    }
+
+    fn insert(&self, epoch: u64, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+        self.owner(epoch).insert(key, value)
+    }
+
+    /// Delete a key from both generations, so that it stops resolving through
+    /// the pre-split fallback in [`Self::get`] as well.
+    fn remove(&self, key: Vec<u8>) -> Result<()> {
+        for generation in self.generations.read().unwrap().iter() {
+            generation.remove(key.clone())?;
+        }
+        Ok(())
+    }
+
+    /// List `(Address, T)` pairs under `prefix`, which must begin with `epoch`.
+    ///
+    /// Both generations are scanned for the same pre-split reason as [`Self::get`];
+    /// the owning generation wins where a key is present in both.
+    fn list_by_prefix<T: DeserializeOwned>(
+        &self,
+        epoch: u64,
+        prefix: &[u8],
+    ) -> Result<Vec<(Address, T)>> {
+        let mut rows: std::collections::BTreeMap<Address, T> =
+            list_messages_by_prefix(&self.other(epoch), prefix)?
+                .into_iter()
+                .collect();
+        rows.extend(list_messages_by_prefix(&self.owner(epoch), prefix)?);
+        Ok(rows.into_iter().collect())
+    }
+
+    /// Discard the rows for epochs below `cutoff_epoch`.
+    ///
+    /// Only the generation that cannot own `cutoff_epoch` is discarded. That is
+    /// sound because `cutoff_epoch` is the epoch being installed, and every
+    /// writer of these keyspaces stores under the node's own current MPC epoch,
+    /// which `handle_reconfig` sets to `cutoff_epoch` before any of this work
+    /// starts — so no row above `cutoff_epoch` exists yet and the newest row the
+    /// discarded generation can hold is `cutoff_epoch - 1`. Being unconditional,
+    /// this cannot race a peer persisting the new epoch's messages.
+    ///
+    /// Rows for `cutoff_epoch - 2` and older share the live generation's parity
+    /// and are discarded by the next epoch change instead, so these keyspaces
+    /// hold at most two epochs at a time.
+    ///
+    /// The generation is deleted and recreated rather than cleared: fjall only
+    /// unlinks a table file once a compaction marks it deleted, so clearing a
+    /// keyspace orphans its files until the next recovery, whereas dropping the
+    /// keyspace removes the directory as soon as the last handle goes away.
+    fn retire_epochs_below(&self, db: &fjall::Database, cutoff_epoch: u64) -> Result<()> {
+        // No epoch is below 0; without this the parity rule would discard the
+        // generation holding the odd epochs.
+        if cutoff_epoch == 0 {
+            return Ok(());
+        }
+        let index = Self::index(cutoff_epoch) ^ 1;
+        let mut generations = self.generations.write().unwrap();
+        // Unregisters the name and flags the keyspace for removal; the handle
+        // this clone was made from is what actually triggers it, below.
+        db.delete_keyspace(generations[index].clone())?;
+        // Dropping the last handle is what unlinks the directory. Concurrent
+        // readers holding a clone keep it alive until they are done, which fjall
+        // supports and which only defers the reclaim.
+        generations[index] = db.keyspace(self.names[index], KeyspaceCreateOptions::default)?;
+        Ok(())
+    }
+}
 
 /// Keyspaces included in snapshot backups. Add new backup/restore keyspaces here.
 #[derive(Clone, Copy)]
@@ -163,13 +295,10 @@ impl Database {
             db.keyspace(DEALER_MESSAGES_CF_NAME, KeyspaceCreateOptions::default)?;
         let rotation_messages =
             db.keyspace(ROTATION_MESSAGES_CF_NAME, KeyspaceCreateOptions::default)?;
-        let nonce_messages = db.keyspace(NONCE_MESSAGES_CF_NAME, KeyspaceCreateOptions::default)?;
-        let avid_round_states =
-            db.keyspace(AVID_ROUND_STATES_CF_NAME, KeyspaceCreateOptions::default)?;
-        let avid_dealer_builders =
-            db.keyspace(AVID_DEALER_BUILDERS_CF_NAME, KeyspaceCreateOptions::default)?;
-        let avid_held_echoes =
-            db.keyspace(AVID_HELD_ECHOES_CF_NAME, KeyspaceCreateOptions::default)?;
+        let nonce_messages = EpochGenerations::open(&db, NONCE_MESSAGES_CF_NAMES)?;
+        let avid_round_states = EpochGenerations::open(&db, AVID_ROUND_STATES_CF_NAMES)?;
+        let avid_dealer_builders = EpochGenerations::open(&db, AVID_DEALER_BUILDERS_CF_NAMES)?;
+        let avid_held_echoes = EpochGenerations::open(&db, AVID_HELD_ECHOES_CF_NAMES)?;
         let encryption_epoch_index = db.keyspace(
             ENCRYPTION_EPOCH_INDEX_CF_NAME,
             KeyspaceCreateOptions::default,
@@ -382,7 +511,7 @@ impl Database {
         ]
         .concat();
         let value = bcs::to_bytes(message).unwrap();
-        self.nonce_messages.insert(key, value)
+        self.nonce_messages.insert(epoch, key, value)
     }
 
     pub fn get_nonce_message(
@@ -397,7 +526,7 @@ impl Database {
             dealer.as_bytes(),
         ]
         .concat();
-        let bytes = match self.nonce_messages.get(key) {
+        let bytes = match self.nonce_messages.get(epoch, &key) {
             Ok(Some(bytes)) => bytes,
             Ok(None) => return Ok(None),
             Err(e) => return Err(e),
@@ -421,7 +550,7 @@ impl Database {
             batch_index.to_be_bytes().as_slice(),
         ]
         .concat();
-        list_messages_by_prefix(&self.nonce_messages, &prefix)
+        self.nonce_messages.list_by_prefix(epoch, &prefix)
     }
 
     pub fn delete_dealer_message(&self, epoch: u64, dealer: &Address) -> Result<()> {
@@ -463,7 +592,7 @@ impl Database {
         ]
         .concat();
         let value = bcs::to_bytes(state).unwrap();
-        self.avid_round_states.insert(key, value)
+        self.avid_round_states.insert(epoch, key, value)
     }
 
     pub fn get_avid_round_state(
@@ -478,7 +607,7 @@ impl Database {
             dealer.as_bytes(),
         ]
         .concat();
-        let bytes = match self.avid_round_states.get(key) {
+        let bytes = match self.avid_round_states.get(epoch, &key) {
             Ok(Some(bytes)) => bytes,
             Ok(None) => return Ok(None),
             Err(e) => return Err(e),
@@ -502,7 +631,7 @@ impl Database {
             batch_index.to_be_bytes().as_slice(),
         ]
         .concat();
-        list_messages_by_prefix(&self.avid_round_states, &prefix)
+        self.avid_round_states.list_by_prefix(epoch, &prefix)
     }
 
     pub fn store_avid_held_echoes(
@@ -519,7 +648,7 @@ impl Database {
         ]
         .concat();
         let value = bcs::to_bytes(held).unwrap();
-        self.avid_held_echoes.insert(key, value)
+        self.avid_held_echoes.insert(epoch, key, value)
     }
 
     pub fn get_avid_held_echoes(
@@ -534,7 +663,7 @@ impl Database {
             dealer.as_bytes(),
         ]
         .concat();
-        let bytes = match self.avid_held_echoes.get(key) {
+        let bytes = match self.avid_held_echoes.get(epoch, &key) {
             Ok(Some(bytes)) => bytes,
             Ok(None) => return Ok(None),
             Err(e) => return Err(e),
@@ -560,7 +689,7 @@ impl Database {
         ]
         .concat();
         let value = bcs::to_bytes(builder).unwrap();
-        self.avid_dealer_builders.insert(key, value)
+        self.avid_dealer_builders.insert(epoch, key, value)
     }
 
     pub fn get_avid_dealer_builder(
@@ -573,7 +702,7 @@ impl Database {
             batch_index.to_be_bytes().as_slice(),
         ]
         .concat();
-        let bytes = match self.avid_dealer_builders.get(key) {
+        let bytes = match self.avid_dealer_builders.get(epoch, &key) {
             Ok(Some(bytes)) => bytes,
             Ok(None) => return Ok(None),
             Err(e) => return Err(e),
@@ -619,10 +748,16 @@ impl Database {
             retention_cutoff,
             is_referenced_epoch,
         )?;
-        prune_keyspace(&self.nonce_messages, cutoff_epoch)?;
-        prune_keyspace(&self.avid_round_states, cutoff_epoch)?;
-        prune_keyspace(&self.avid_dealer_builders, cutoff_epoch)?;
-        prune_keyspace(&self.avid_held_echoes, cutoff_epoch)?;
+        // Epoch-scoped keyspaces are retired a generation at a time rather than
+        // a row at a time, so the space is actually returned to the filesystem.
+        self.nonce_messages
+            .retire_epochs_below(&self.db, cutoff_epoch)?;
+        self.avid_round_states
+            .retire_epochs_below(&self.db, cutoff_epoch)?;
+        self.avid_dealer_builders
+            .retire_epochs_below(&self.db, cutoff_epoch)?;
+        self.avid_held_echoes
+            .retire_epochs_below(&self.db, cutoff_epoch)?;
         Ok(())
     }
 }
@@ -696,23 +831,6 @@ fn list_messages_by_prefix<T: DeserializeOwned>(
         results.push((address, message));
     }
     Ok(results)
-}
-
-/// Delete entries from `keyspace` whose leading big-endian u64 epoch is `< cutoff_epoch`.
-fn prune_keyspace(keyspace: &Keyspace, cutoff_epoch: u64) -> Result<()> {
-    let keys_to_delete: Vec<_> = keyspace
-        .iter()
-        .filter_map(|guard| {
-            let key = guard.key().ok()?;
-            let epoch_bytes: [u8; 8] = key.as_ref().get(..8)?.try_into().ok()?;
-            let epoch = u64::from_be_bytes(epoch_bytes);
-            (epoch < cutoff_epoch).then(|| key.to_vec())
-        })
-        .collect();
-    for key in keys_to_delete {
-        keyspace.remove(key)?;
-    }
-    Ok(())
 }
 
 /// Delete entries from `keyspace` whose leading big-endian u64 epoch is
@@ -1609,30 +1727,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_delete_nonce_message() {
-        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
-        let db = Database::open(tmpdir.path()).unwrap();
-
-        let dealer1 = Address::new([1u8; 32]);
-        let dealer2 = Address::new([2u8; 32]);
-        let message = create_test_nonce_message();
-
-        db.store_nonce_message(1, 0, &dealer1, &message).unwrap();
-        db.store_nonce_message(1, 0, &dealer2, &message).unwrap();
-        assert_eq!(db.list_nonce_messages(1, 0).unwrap().len(), 2);
-
-        // Delete one
-        db.delete_nonce_message(1, 0, &dealer1).unwrap();
-        let remaining = db.list_nonce_messages(1, 0).unwrap();
-        assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].0, dealer2);
-
-        // Delete non-existent is a no-op
-        db.delete_nonce_message(1, 0, &dealer1).unwrap();
-        db.delete_nonce_message(1, 1, &dealer2).unwrap();
-    }
-
-    #[test]
     fn test_nonce_messages_overwrite() {
         let tmpdir = tempfile::Builder::new().tempdir().unwrap();
         let db = Database::open(tmpdir.path()).unwrap();
@@ -1728,10 +1822,14 @@ pub(crate) mod tests {
                 .unwrap();
             db.store_rotation_messages(epoch, &dealer, &rotation_msgs)
                 .unwrap();
-            db.store_nonce_message(epoch, 0, &dealer, &nonce_msg)
-                .unwrap();
-            db.store_avid_round_state(epoch, 0, &dealer, &avid_state)
-                .unwrap();
+            // Nonce and AVID rows are only ever written for the node's own
+            // current epoch, so nothing above the cutoff exists at prune time.
+            if epoch <= cutoff {
+                db.store_nonce_message(epoch, 0, &dealer, &nonce_msg)
+                    .unwrap();
+                db.store_avid_round_state(epoch, 0, &dealer, &avid_state)
+                    .unwrap();
+            }
             db.store_encryption_key(epoch, &EncryptionPrivateKey::new(&mut rand::thread_rng()))
                 .unwrap();
             db.store_signing_key(
@@ -1766,18 +1864,31 @@ pub(crate) mod tests {
                 "rotation messages at epoch {epoch} should be retained (>= cutoff - {RETENTION_EXTRA_EPOCHS})"
             );
         }
-        for epoch in 1..cutoff {
+        // Retiring epoch `cutoff` drops the generation that cannot hold it, i.e.
+        // every epoch below it of the opposite parity. The rest of the retired
+        // epochs share the live generation and go at the next epoch change.
+        for epoch in (1..cutoff).filter(|epoch| epoch % 2 != cutoff % 2) {
             assert!(
                 db.get_nonce_message(epoch, 0, &dealer).unwrap().is_none(),
-                "nonce message at epoch {epoch} should be pruned (flat cutoff)"
+                "nonce message at epoch {epoch} should be dropped with its generation"
             );
             assert!(
                 db.get_avid_round_state(epoch, 0, &dealer)
                     .unwrap()
                     .is_none(),
-                "avid round state at epoch {epoch} should be pruned (flat cutoff)"
+                "avid round state at epoch {epoch} should be dropped with its generation"
             );
         }
+        assert!(
+            db.get_nonce_message(cutoff, 0, &dealer).unwrap().is_some(),
+            "nonce message at the cutoff epoch is live and must survive"
+        );
+        assert!(
+            db.get_avid_round_state(cutoff, 0, &dealer)
+                .unwrap()
+                .is_some(),
+            "avid round state at the cutoff epoch is live and must survive"
+        );
         for epoch in 1..key_retain_floor {
             assert!(
                 db.get_encryption_key(epoch).unwrap().is_none(),
@@ -1808,16 +1919,6 @@ pub(crate) mod tests {
                 "rotation messages at epoch {epoch} should be kept"
             );
             assert!(
-                db.get_nonce_message(epoch, 0, &dealer).unwrap().is_some(),
-                "nonce message at epoch {epoch} should be kept"
-            );
-            assert!(
-                db.get_avid_round_state(epoch, 0, &dealer)
-                    .unwrap()
-                    .is_some(),
-                "avid round state at epoch {epoch} should be kept"
-            );
-            assert!(
                 db.get_encryption_key(epoch).unwrap().is_some(),
                 "encryption key at epoch {epoch} should be kept"
             );
@@ -1826,6 +1927,203 @@ pub(crate) mod tests {
                 "signing key at epoch {epoch} should be kept"
             );
         }
+    }
+
+    /// The bug this split exists to fix: point-deleting nonce rows left the
+    /// bytes on disk, because the tombstones were far too small next to the
+    /// values they shadowed to make leveled compaction rewrite the bottom level.
+    #[test]
+    fn test_retiring_an_epoch_returns_the_bytes_to_the_filesystem() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+
+        let nonce_msg = create_test_nonce_message();
+        for batch_index in 0..256 {
+            for dealer in 0..16u8 {
+                db.store_nonce_message(1, batch_index, &Address::new([dealer; 32]), &nonce_msg)
+                    .unwrap();
+            }
+        }
+        for keyspace in db.nonce_messages.generations.read().unwrap().iter() {
+            keyspace.rotate_memtable_and_wait().unwrap();
+        }
+        // Measure the files themselves: dereferencing the tables is not the
+        // property that matters, unlinking them is.
+        let occupied = bytes_on_disk(&db.nonce_messages);
+        assert!(occupied > 0, "epoch 1 should be on disk before retirement");
+
+        // Installing epoch 2 retires epoch 1.
+        db.prune_messages_below(2, &PruningReferences::default())
+            .unwrap();
+
+        let remaining = wait_for_bytes_on_disk_below(&db.nonce_messages, occupied / 10);
+        assert!(
+            remaining < occupied / 10,
+            "retiring epoch 1 must give back its {occupied} bytes, not just tombstone \
+             the rows; {remaining} bytes are still on disk",
+        );
+        assert!(
+            db.get_nonce_message(1, 0, &Address::new([0u8; 32]))
+                .unwrap()
+                .is_none(),
+        );
+    }
+
+    /// Total size of the files backing both generations.
+    fn bytes_on_disk(generations: &super::EpochGenerations) -> u64 {
+        generations
+            .generations
+            .read()
+            .unwrap()
+            .iter()
+            .map(|keyspace| {
+                let Ok(entries) = std::fs::read_dir(keyspace.path().join("tables")) else {
+                    return 0;
+                };
+                entries
+                    .filter_map(|entry| entry.ok()?.metadata().ok())
+                    .map(|metadata| metadata.len())
+                    .sum::<u64>()
+            })
+            .sum()
+    }
+
+    /// Tables are unlinked once the version that referenced them is dropped,
+    /// which a background worker does, so give it a moment to catch up.
+    fn wait_for_bytes_on_disk_below(generations: &super::EpochGenerations, target: u64) -> u64 {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let bytes = bytes_on_disk(generations);
+            if bytes < target || std::time::Instant::now() >= deadline {
+                return bytes;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    /// Retirement swaps in a brand new keyspace behind the same name, so the
+    /// database has to come back up on it.
+    #[test]
+    fn test_retired_generation_reopens() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let dealer = Address::new([1u8; 32]);
+        let message = create_test_nonce_message();
+        {
+            let db = Database::open(tmpdir.path()).unwrap();
+            db.store_nonce_message(1, 0, &dealer, &message).unwrap();
+            db.prune_messages_below(2, &PruningReferences::default())
+                .unwrap();
+            db.store_nonce_message(2, 0, &dealer, &message).unwrap();
+        }
+
+        let db = Database::open(tmpdir.path()).unwrap();
+        assert!(db.get_nonce_message(1, 0, &dealer).unwrap().is_none());
+        assert!(db.get_nonce_message(2, 0, &dealer).unwrap().is_some());
+
+        // And the fresh generation still retires normally afterwards.
+        db.prune_messages_below(3, &PruningReferences::default())
+            .unwrap();
+        assert!(db.get_nonce_message(2, 0, &dealer).unwrap().is_none());
+    }
+
+    /// Deleting a row must beat the pre-split fallback in `get`, otherwise the
+    /// e2e recovery tests would not actually be losing the message they delete.
+    #[test]
+    fn test_delete_nonce_message_clears_both_generations() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+
+        let dealer1 = Address::new([1u8; 32]);
+        let dealer2 = Address::new([2u8; 32]);
+        let message = create_test_nonce_message();
+
+        // Epoch 3 is owned by generation 1; put dealer1's row in generation 0
+        // the way a binary that predates the split would have.
+        db.nonce_messages.generations.read().unwrap()[0]
+            .insert(
+                [
+                    3u64.to_be_bytes().as_slice(),
+                    0u32.to_be_bytes().as_slice(),
+                    dealer1.as_bytes(),
+                ]
+                .concat(),
+                bcs::to_bytes(&message).unwrap(),
+            )
+            .unwrap();
+        db.store_nonce_message(3, 0, &dealer2, &message).unwrap();
+        assert_eq!(db.list_nonce_messages(3, 0).unwrap().len(), 2);
+
+        db.delete_nonce_message(3, 0, &dealer1).unwrap();
+        let remaining = db.list_nonce_messages(3, 0).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].0, dealer2);
+
+        // Deleting what is not there is a no-op.
+        db.delete_nonce_message(3, 0, &dealer1).unwrap();
+        db.delete_nonce_message(3, 1, &dealer2).unwrap();
+    }
+
+    /// A generation shares its parity with every other epoch, so a single epoch
+    /// change cannot drop everything. Two consecutive ones must.
+    #[test]
+    fn test_two_epoch_changes_retire_every_earlier_epoch() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+
+        let dealer = Address::new([1u8; 32]);
+        let nonce_msg = create_test_nonce_message();
+        for epoch in 1..=10 {
+            db.store_nonce_message(epoch, 0, &dealer, &nonce_msg)
+                .unwrap();
+        }
+
+        db.prune_messages_below(10, &PruningReferences::default())
+            .unwrap();
+        db.prune_messages_below(11, &PruningReferences::default())
+            .unwrap();
+
+        for epoch in 1..=10 {
+            assert!(
+                db.get_nonce_message(epoch, 0, &dealer).unwrap().is_none(),
+                "epoch {epoch} should be gone after two epoch changes"
+            );
+        }
+    }
+
+    /// Rows written before the keyspace was split live in whichever generation
+    /// carries the pre-split name, which is not always the one that owns their
+    /// epoch. They have to stay readable until an epoch change retires them.
+    #[test]
+    fn test_rows_in_the_non_owning_generation_are_still_readable() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+
+        // Epoch 3 is owned by generation 1; write it into generation 0 the way
+        // a binary that predates the split would have.
+        let dealer = Address::new([1u8; 32]);
+        let key = [
+            3u64.to_be_bytes().as_slice(),
+            0u32.to_be_bytes().as_slice(),
+            dealer.as_bytes(),
+        ]
+        .concat();
+        let nonce_msg = create_test_nonce_message();
+        db.nonce_messages.generations.read().unwrap()[0]
+            .insert(key, bcs::to_bytes(&nonce_msg).unwrap())
+            .unwrap();
+
+        assert!(db.get_nonce_message(3, 0, &dealer).unwrap().is_some());
+        assert_eq!(db.list_nonce_messages(3, 0).unwrap().len(), 1);
+
+        // Retiring epoch 4 drops generation 1; epoch 3 survives in generation 0.
+        db.prune_messages_below(4, &PruningReferences::default())
+            .unwrap();
+        assert!(db.get_nonce_message(3, 0, &dealer).unwrap().is_some());
+
+        // Retiring epoch 5 drops generation 0, taking the stale rows with it.
+        db.prune_messages_below(5, &PruningReferences::default())
+            .unwrap();
+        assert!(db.get_nonce_message(3, 0, &dealer).unwrap().is_none());
     }
 
     #[test]

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -28,11 +28,9 @@ use crate::mpc::types::RotationMessages;
 pub struct Database {
     db: fjall::Database,
 
-    // Latched when fjall poisons the database, which it does on a failed write
-    // — `ENOSPC` above all. Poisoning does not clear in-process: every later
-    // write fails the same way and only reopening recovers. Without this the
-    // node keeps answering RPCs and reporting ready while persisting nothing,
-    // which is how a full volume turned into a silently stalled key rotation.
+    // Latched when fjall poisons the database on a failed write, `ENOSPC`
+    // above all. Nothing recovers in-process, so the node has to stop
+    // reporting ready rather than serve on while persisting nothing.
     poisoned: std::sync::atomic::AtomicBool,
 
     // keyspaces
@@ -337,9 +335,7 @@ impl Database {
     }
 
     /// Pass a write result through, latching if it says fjall is poisoned.
-    ///
-    /// Reads never surface poisoning — fjall only checks the flag on the write
-    /// path — so this is both where it can be seen and where it matters.
+    /// Reads never surface it: fjall only checks the flag when writing.
     fn note_write<T>(&self, result: Result<T>) -> Result<T> {
         if matches!(result, Err(fjall::Error::Poisoned)) {
             self.poisoned
@@ -348,8 +344,8 @@ impl Database {
         result
     }
 
-    /// Whether fjall has poisoned this database. Never clears; only reopening
-    /// the database recovers, so the node needs to be restarted.
+    /// Whether fjall has poisoned this database. Never clears — only reopening
+    /// recovers, so the node has to be restarted.
     pub fn is_poisoned(&self) -> bool {
         self.poisoned.load(std::sync::atomic::Ordering::Relaxed)
     }
@@ -775,6 +771,10 @@ impl Database {
         cutoff_epoch: u64,
         pruning_references: &PruningReferences,
     ) -> Result<()> {
+        self.note_write(self.prune(cutoff_epoch, pruning_references))
+    }
+
+    fn prune(&self, cutoff_epoch: u64, pruning_references: &PruningReferences) -> Result<()> {
         let retention_cutoff = cutoff_epoch.saturating_sub(RETENTION_EXTRA_EPOCHS);
         // A key is retained if and only if its public key is referenced by a live committee or pending registration,
         // or it was created within the retention buffer.

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -98,8 +98,7 @@ const ENCRYPTION_EPOCH_INDEX_CF_NAME: &str = "encryption_epoch_index";
 const SIGNING_EPOCH_INDEX_CF_NAME: &str = "signing_epoch_index";
 
 // Generation names for the epoch-scoped keyspaces. Generation 0 keeps the
-// pre-split name so that rows written before this node rotated generations land
-// in a generation that `retire_epochs_below` eventually drops.
+// pre-split name, so rows written before the split are retired as usual.
 const NONCE_MESSAGES_CF_NAMES: [&str; 2] = ["nonce_messages", "nonce_messages_g1"];
 const AVID_ROUND_STATES_CF_NAMES: [&str; 2] = ["avid_round_states", "avid_round_states_g1"];
 const AVID_DEALER_BUILDERS_CF_NAMES: [&str; 2] =
@@ -108,28 +107,23 @@ const AVID_HELD_ECHOES_CF_NAMES: [&str; 2] = ["avid_held_echoes", "avid_held_ech
 
 const RETENTION_EXTRA_EPOCHS: u64 = 7;
 
+/// Number of generations an [`EpochGenerations`] keyspace is split across.
+const GENERATIONS: usize = 2;
+
 /// A keyspace whose rows are scoped to a single MPC epoch, split into two
-/// generations selected by the parity of that epoch.
+/// generations selected by epoch parity so that retiring an epoch can drop a
+/// whole generation.
 ///
-/// Nonce and AVID rows are dead as soon as the next epoch is installed, and
-/// there are a lot of them: one nonce message is hundreds of kilobytes and every
-/// batch stores one per dealer. Deleting them row by row does not give the space
-/// back — a tombstone is a few dozen bytes against the value it shadows, so
-/// leveled compaction never accumulates enough write pressure to rewrite the
-/// bottom level, and the bytes stay on disk for as long as the node runs.
-///
-/// Splitting by parity makes retirement a whole-generation drop: the keyspace is
-/// deleted and recreated empty, which unlinks its files instead of leaving
-/// tombstones behind for a compaction that never comes.
+/// Deleting these rows one by one never frees the disk: a tombstone is a few
+/// dozen bytes against a value of hundreds of kilobytes, so leveled compaction
+/// gets nowhere near enough write pressure to rewrite the bottom level.
 struct EpochGenerations {
-    names: [&'static str; 2],
-    // Swapped out wholesale by `retire_epochs_below`, so the handles cannot be
-    // borrowed for longer than a single operation.
-    generations: std::sync::RwLock<[Keyspace; 2]>,
+    names: [&'static str; GENERATIONS],
+    generations: std::sync::RwLock<[Keyspace; GENERATIONS]>,
 }
 
 impl EpochGenerations {
-    fn open(db: &fjall::Database, names: [&'static str; 2]) -> Result<Self> {
+    fn open(db: &fjall::Database, names: [&'static str; GENERATIONS]) -> Result<Self> {
         Ok(Self {
             names,
             generations: std::sync::RwLock::new([
@@ -147,20 +141,17 @@ impl EpochGenerations {
         self.generations.read().unwrap()[index].clone()
     }
 
-    /// The generation that owns `epoch`. Every write for `epoch` lands here.
+    /// The generation that owns `epoch`; every write for `epoch` lands here.
     fn owner(&self, epoch: u64) -> Keyspace {
         self.generation(Self::index(epoch))
     }
 
-    /// The generation that cannot own `epoch`.
+    /// The generation that cannot own `epoch`. Read as a fallback, so that rows
+    /// written before the split stay visible while their epoch is still live.
     fn other(&self, epoch: u64) -> Keyspace {
         self.generation(Self::index(epoch) ^ 1)
     }
 
-    /// Point-read a key belonging to `epoch`.
-    ///
-    /// Falls back to the other generation so that rows written before the
-    /// keyspace was split stay readable for whichever epoch is still live.
     fn get(&self, epoch: u64, key: &[u8]) -> Result<Option<fjall::UserValue>> {
         match self.owner(epoch).get(key)? {
             Some(value) => Ok(Some(value)),
@@ -172,19 +163,17 @@ impl EpochGenerations {
         self.owner(epoch).insert(key, value)
     }
 
-    /// Delete a key from both generations, so that it stops resolving through
-    /// the pre-split fallback in [`Self::get`] as well.
+    /// Delete a key from both generations, so it stops resolving through the
+    /// fallback in [`Self::other`] too.
     fn remove(&self, key: Vec<u8>) -> Result<()> {
-        for generation in self.generations.read().unwrap().iter() {
-            generation.remove(key.clone())?;
+        for index in 0..GENERATIONS {
+            self.generation(index).remove(key.clone())?;
         }
         Ok(())
     }
 
     /// List `(Address, T)` pairs under `prefix`, which must begin with `epoch`.
-    ///
-    /// Both generations are scanned for the same pre-split reason as [`Self::get`];
-    /// the owning generation wins where a key is present in both.
+    /// The owning generation wins where a key is in both.
     fn list_by_prefix<T: DeserializeOwned>(
         &self,
         epoch: u64,
@@ -198,38 +187,27 @@ impl EpochGenerations {
         Ok(rows.into_iter().collect())
     }
 
-    /// Discard the rows for epochs below `cutoff_epoch`.
+    /// Discard the rows for epochs below `cutoff_epoch`, which must be the epoch
+    /// being installed.
     ///
-    /// Only the generation that cannot own `cutoff_epoch` is discarded. That is
-    /// sound because `cutoff_epoch` is the epoch being installed, and every
-    /// writer of these keyspaces stores under the node's own current MPC epoch,
-    /// which `handle_reconfig` sets to `cutoff_epoch` before any of this work
-    /// starts — so no row above `cutoff_epoch` exists yet and the newest row the
-    /// discarded generation can hold is `cutoff_epoch - 1`. Being unconditional,
-    /// this cannot race a peer persisting the new epoch's messages.
+    /// Dropping the generation that cannot own `cutoff_epoch` needs no check:
+    /// every writer stores under the node's own current MPC epoch, which
+    /// `handle_reconfig` sets to `cutoff_epoch` before any of this runs, so the
+    /// newest row that generation can hold is `cutoff_epoch - 1`. Older rows
+    /// sharing the live generation's parity go at the next epoch change, leaving
+    /// at most two epochs on disk.
     ///
-    /// Rows for `cutoff_epoch - 2` and older share the live generation's parity
-    /// and are discarded by the next epoch change instead, so these keyspaces
-    /// hold at most two epochs at a time.
-    ///
-    /// The generation is deleted and recreated rather than cleared: fjall only
-    /// unlinks a table file once a compaction marks it deleted, so clearing a
-    /// keyspace orphans its files until the next recovery, whereas dropping the
-    /// keyspace removes the directory as soon as the last handle goes away.
+    /// Deleted and recreated rather than cleared, because fjall only unlinks a
+    /// table once a compaction marks it deleted — clearing would orphan the
+    /// files until the next recovery.
     fn retire_epochs_below(&self, db: &fjall::Database, cutoff_epoch: u64) -> Result<()> {
-        // No epoch is below 0; without this the parity rule would discard the
-        // generation holding the odd epochs.
         if cutoff_epoch == 0 {
             return Ok(());
         }
         let index = Self::index(cutoff_epoch) ^ 1;
         let mut generations = self.generations.write().unwrap();
-        // Unregisters the name and flags the keyspace for removal; the handle
-        // this clone was made from is what actually triggers it, below.
         db.delete_keyspace(generations[index].clone())?;
-        // Dropping the last handle is what unlinks the directory. Concurrent
-        // readers holding a clone keep it alive until they are done, which fjall
-        // supports and which only defers the reclaim.
+        // Overwriting the last handle is what unlinks the directory.
         generations[index] = db.keyspace(self.names[index], KeyspaceCreateOptions::default)?;
         Ok(())
     }
@@ -748,8 +726,7 @@ impl Database {
             retention_cutoff,
             is_referenced_epoch,
         )?;
-        // Epoch-scoped keyspaces are retired a generation at a time rather than
-        // a row at a time, so the space is actually returned to the filesystem.
+        // Retired a generation at a time so the space is actually freed.
         self.nonce_messages
             .retire_epochs_below(&self.db, cutoff_epoch)?;
         self.avid_round_states
@@ -1822,8 +1799,8 @@ pub(crate) mod tests {
                 .unwrap();
             db.store_rotation_messages(epoch, &dealer, &rotation_msgs)
                 .unwrap();
-            // Nonce and AVID rows are only ever written for the node's own
-            // current epoch, so nothing above the cutoff exists at prune time.
+            // These are only written for the node's own current epoch, so
+            // nothing above the cutoff exists at prune time.
             if epoch <= cutoff {
                 db.store_nonce_message(epoch, 0, &dealer, &nonce_msg)
                     .unwrap();
@@ -1864,9 +1841,8 @@ pub(crate) mod tests {
                 "rotation messages at epoch {epoch} should be retained (>= cutoff - {RETENTION_EXTRA_EPOCHS})"
             );
         }
-        // Retiring epoch `cutoff` drops the generation that cannot hold it, i.e.
-        // every epoch below it of the opposite parity. The rest of the retired
-        // epochs share the live generation and go at the next epoch change.
+        // Only the opposite parity goes now; the rest share the live
+        // generation and go at the next epoch change.
         for epoch in (1..cutoff).filter(|epoch| epoch % 2 != cutoff % 2) {
             assert!(
                 db.get_nonce_message(epoch, 0, &dealer).unwrap().is_none(),
@@ -1929,9 +1905,8 @@ pub(crate) mod tests {
         }
     }
 
-    /// The bug this split exists to fix: point-deleting nonce rows left the
-    /// bytes on disk, because the tombstones were far too small next to the
-    /// values they shadowed to make leveled compaction rewrite the bottom level.
+    /// The bug this split exists to fix: point-deleting the rows left the bytes
+    /// on disk.
     #[test]
     fn test_retiring_an_epoch_returns_the_bytes_to_the_filesystem() {
         let tmpdir = tempfile::Builder::new().tempdir().unwrap();
@@ -1947,8 +1922,8 @@ pub(crate) mod tests {
         for keyspace in db.nonce_messages.generations.read().unwrap().iter() {
             keyspace.rotate_memtable_and_wait().unwrap();
         }
-        // Measure the files themselves: dereferencing the tables is not the
-        // property that matters, unlinking them is.
+        // Measure the files, not fjall's accounting: unlinking is the property
+        // that matters, and dereferencing the tables is not enough.
         let occupied = bytes_on_disk(&db.nonce_messages);
         assert!(occupied > 0, "epoch 1 should be on disk before retirement");
 
@@ -1988,8 +1963,7 @@ pub(crate) mod tests {
             .sum()
     }
 
-    /// Tables are unlinked once the version that referenced them is dropped,
-    /// which a background worker does, so give it a moment to catch up.
+    /// A concurrent reader holding a handle defers the unlink, so allow for it.
     fn wait_for_bytes_on_disk_below(generations: &super::EpochGenerations, target: u64) -> u64 {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
@@ -2001,8 +1975,7 @@ pub(crate) mod tests {
         }
     }
 
-    /// Retirement swaps in a brand new keyspace behind the same name, so the
-    /// database has to come back up on it.
+    /// Retirement puts a brand new keyspace behind the same name.
     #[test]
     fn test_retired_generation_reopens() {
         let tmpdir = tempfile::Builder::new().tempdir().unwrap();
@@ -2026,8 +1999,28 @@ pub(crate) mod tests {
         assert!(db.get_nonce_message(2, 0, &dealer).unwrap().is_none());
     }
 
-    /// Deleting a row must beat the pre-split fallback in `get`, otherwise the
-    /// e2e recovery tests would not actually be losing the message they delete.
+    /// Write a nonce message the way a binary that predates the generation split
+    /// would have: straight into the generation carrying the pre-split name.
+    fn store_pre_split_nonce_message(
+        db: &Database,
+        epoch: u64,
+        batch_index: u32,
+        dealer: &Address,
+        message: &batch_avss::Message,
+    ) {
+        let key = [
+            epoch.to_be_bytes().as_slice(),
+            batch_index.to_be_bytes().as_slice(),
+            dealer.as_bytes(),
+        ]
+        .concat();
+        db.nonce_messages.generations.read().unwrap()[0]
+            .insert(key, bcs::to_bytes(message).unwrap())
+            .unwrap();
+    }
+
+    /// Deleting a row has to beat the pre-split fallback, or the e2e recovery
+    /// tests would not lose the message they delete.
     #[test]
     fn test_delete_nonce_message_clears_both_generations() {
         let tmpdir = tempfile::Builder::new().tempdir().unwrap();
@@ -2037,19 +2030,9 @@ pub(crate) mod tests {
         let dealer2 = Address::new([2u8; 32]);
         let message = create_test_nonce_message();
 
-        // Epoch 3 is owned by generation 1; put dealer1's row in generation 0
-        // the way a binary that predates the split would have.
-        db.nonce_messages.generations.read().unwrap()[0]
-            .insert(
-                [
-                    3u64.to_be_bytes().as_slice(),
-                    0u32.to_be_bytes().as_slice(),
-                    dealer1.as_bytes(),
-                ]
-                .concat(),
-                bcs::to_bytes(&message).unwrap(),
-            )
-            .unwrap();
+        // Epoch 3 is owned by generation 1, so dealer1's row lands in the
+        // generation that does not own it.
+        store_pre_split_nonce_message(&db, 3, 0, &dealer1, &message);
         db.store_nonce_message(3, 0, &dealer2, &message).unwrap();
         assert_eq!(db.list_nonce_messages(3, 0).unwrap().len(), 2);
 
@@ -2063,8 +2046,7 @@ pub(crate) mod tests {
         db.delete_nonce_message(3, 1, &dealer2).unwrap();
     }
 
-    /// A generation shares its parity with every other epoch, so a single epoch
-    /// change cannot drop everything. Two consecutive ones must.
+    /// One epoch change only drops one parity; two must drop everything.
     #[test]
     fn test_two_epoch_changes_retire_every_earlier_epoch() {
         let tmpdir = tempfile::Builder::new().tempdir().unwrap();
@@ -2090,27 +2072,16 @@ pub(crate) mod tests {
         }
     }
 
-    /// Rows written before the keyspace was split live in whichever generation
-    /// carries the pre-split name, which is not always the one that owns their
-    /// epoch. They have to stay readable until an epoch change retires them.
+    /// Pre-split rows sit in the generation carrying the pre-split name, which
+    /// is not always the one that owns their epoch.
     #[test]
     fn test_rows_in_the_non_owning_generation_are_still_readable() {
         let tmpdir = tempfile::Builder::new().tempdir().unwrap();
         let db = Database::open(tmpdir.path()).unwrap();
 
-        // Epoch 3 is owned by generation 1; write it into generation 0 the way
-        // a binary that predates the split would have.
+        // Epoch 3 is owned by generation 1.
         let dealer = Address::new([1u8; 32]);
-        let key = [
-            3u64.to_be_bytes().as_slice(),
-            0u32.to_be_bytes().as_slice(),
-            dealer.as_bytes(),
-        ]
-        .concat();
-        let nonce_msg = create_test_nonce_message();
-        db.nonce_messages.generations.read().unwrap()[0]
-            .insert(key, bcs::to_bytes(&nonce_msg).unwrap())
-            .unwrap();
+        store_pre_split_nonce_message(&db, 3, 0, &dealer, &create_test_nonce_message());
 
         assert!(db.get_nonce_message(3, 0, &dealer).unwrap().is_some());
         assert_eq!(db.list_nonce_messages(3, 0).unwrap().len(), 1);

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -27,6 +27,14 @@ use crate::mpc::types::RotationMessages;
 
 pub struct Database {
     db: fjall::Database,
+
+    // Latched when fjall poisons the database, which it does on a failed write
+    // — `ENOSPC` above all. Poisoning does not clear in-process: every later
+    // write fails the same way and only reopening recovers. Without this the
+    // node keeps answering RPCs and reporting ready while persisting nothing,
+    // which is how a full volume turned into a silently stalled key rotation.
+    poisoned: std::sync::atomic::AtomicBool,
+
     // keyspaces
 
     // Column Family used to store encryption private keys, keyed by their own public key.
@@ -302,6 +310,7 @@ impl Database {
         reject_legacy_epoch_keyed_format(&signing_keys, SIGNING_KEYS_CF_NAME)?;
         Ok(Self {
             db,
+            poisoned: std::sync::atomic::AtomicBool::new(false),
             encryption_keys,
             signing_keys,
             encryption_epoch_index,
@@ -325,6 +334,24 @@ impl Database {
 
     pub(crate) fn snapshot(&self) -> fjall::Snapshot {
         self.db.snapshot()
+    }
+
+    /// Pass a write result through, latching if it says fjall is poisoned.
+    ///
+    /// Reads never surface poisoning — fjall only checks the flag on the write
+    /// path — so this is both where it can be seen and where it matters.
+    fn note_write<T>(&self, result: Result<T>) -> Result<T> {
+        if matches!(result, Err(fjall::Error::Poisoned)) {
+            self.poisoned
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        result
+    }
+
+    /// Whether fjall has poisoned this database. Never clears; only reopening
+    /// the database recovers, so the node needs to be restarted.
+    pub fn is_poisoned(&self) -> bool {
+        self.poisoned.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Bytes fjall accounts to each keyspace, with the epoch-scoped ones summed
@@ -383,7 +410,7 @@ impl Database {
         let mut batch = self.db.batch();
         batch.insert(&self.encryption_keys, pubkey.clone(), value);
         batch.insert(&self.encryption_epoch_index, epoch_key, pubkey);
-        batch.commit()
+        self.note_write(batch.commit())
     }
 
     pub fn latest_encryption_key_epoch(&self) -> Result<Option<u64>> {
@@ -420,7 +447,7 @@ impl Database {
         let mut batch = self.db.batch();
         batch.insert(&self.signing_keys, pubkey.clone(), value);
         batch.insert(&self.signing_epoch_index, epoch_key, pubkey);
-        batch.commit()
+        self.note_write(batch.commit())
     }
 
     pub fn get_signing_key(&self, epoch: u64) -> Result<Option<Bls12381PrivateKey>> {
@@ -455,7 +482,7 @@ impl Database {
     ) -> Result<()> {
         let key = [epoch.to_be_bytes().as_slice(), dealer.as_bytes()].concat();
         let value = bcs::to_bytes(message).unwrap();
-        self.dealer_messages.insert(key, value)
+        self.note_write(self.dealer_messages.insert(key, value))
     }
 
     pub fn get_dealer_message(
@@ -493,7 +520,7 @@ impl Database {
     ) -> Result<()> {
         let key = [epoch.to_be_bytes().as_slice(), dealer.as_bytes()].concat();
         let value = bcs::to_bytes(messages).unwrap();
-        self.rotation_messages.insert(key, value)
+        self.note_write(self.rotation_messages.insert(key, value))
     }
 
     pub fn get_rotation_messages(
@@ -537,7 +564,7 @@ impl Database {
         ]
         .concat();
         let value = bcs::to_bytes(message).unwrap();
-        self.nonce_messages.insert(epoch, key, value)
+        self.note_write(self.nonce_messages.insert(epoch, key, value))
     }
 
     pub fn get_nonce_message(
@@ -581,12 +608,12 @@ impl Database {
 
     pub fn delete_dealer_message(&self, epoch: u64, dealer: &Address) -> Result<()> {
         let key = [epoch.to_be_bytes().as_slice(), dealer.as_bytes()].concat();
-        self.dealer_messages.remove(key)
+        self.note_write(self.dealer_messages.remove(key))
     }
 
     pub fn delete_rotation_messages(&self, epoch: u64, dealer: &Address) -> Result<()> {
         let key = [epoch.to_be_bytes().as_slice(), dealer.as_bytes()].concat();
-        self.rotation_messages.remove(key)
+        self.note_write(self.rotation_messages.remove(key))
     }
 
     pub fn delete_nonce_message(
@@ -601,7 +628,7 @@ impl Database {
             dealer.as_bytes(),
         ]
         .concat();
-        self.nonce_messages.remove(key)
+        self.note_write(self.nonce_messages.remove(key))
     }
 
     pub fn store_avid_round_state(
@@ -618,7 +645,7 @@ impl Database {
         ]
         .concat();
         let value = bcs::to_bytes(state).unwrap();
-        self.avid_round_states.insert(epoch, key, value)
+        self.note_write(self.avid_round_states.insert(epoch, key, value))
     }
 
     pub fn get_avid_round_state(
@@ -674,7 +701,7 @@ impl Database {
         ]
         .concat();
         let value = bcs::to_bytes(held).unwrap();
-        self.avid_held_echoes.insert(epoch, key, value)
+        self.note_write(self.avid_held_echoes.insert(epoch, key, value))
     }
 
     pub fn get_avid_held_echoes(
@@ -715,7 +742,7 @@ impl Database {
         ]
         .concat();
         let value = bcs::to_bytes(builder).unwrap();
-        self.avid_dealer_builders.insert(epoch, key, value)
+        self.note_write(self.avid_dealer_builders.insert(epoch, key, value))
     }
 
     pub fn get_avid_dealer_builder(
@@ -2021,6 +2048,28 @@ pub(crate) mod tests {
             }
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
+    }
+
+    #[test]
+    fn test_poisoning_latches_and_nothing_else_does() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+        assert!(!db.is_poisoned());
+
+        db.store_nonce_message(1, 0, &Address::new([1u8; 32]), &create_test_nonce_message())
+            .unwrap();
+        assert!(!db.is_poisoned(), "a healthy write must not latch");
+
+        let other = fjall::Error::Io(std::io::Error::other("some other failure"));
+        assert!(db.note_write::<()>(Err(other)).is_err());
+        assert!(!db.is_poisoned(), "an unrelated error must not latch");
+
+        assert!(db.note_write::<()>(Err(fjall::Error::Poisoned)).is_err());
+        assert!(db.is_poisoned());
+
+        // Poisoning is permanent for the process; a later success cannot clear it.
+        assert!(db.note_write(Ok(())).is_ok());
+        assert!(db.is_poisoned());
     }
 
     /// The gauge has to name a keyspace an operator can act on, and has to fall

--- a/crates/hashi/src/grpc/mod.rs
+++ b/crates/hashi/src/grpc/mod.rs
@@ -190,10 +190,8 @@ async fn health() -> impl axum::response::IntoResponse {
 }
 
 async fn ready(hashi: Arc<Hashi>) -> impl axum::response::IntoResponse {
-    // A poisoned database cannot be recovered without reopening it, so the node
-    // will never persist anything again. Report not-ready rather than keep
-    // serving: the process needs restarting, and on a full volume that also
-    // needs an operator. See `hashi_db_poisoned`.
+    // A poisoned database never persists again without a restart, so stop
+    // serving rather than look healthy. See `hashi_db_poisoned`.
     if hashi.db.is_poisoned() {
         return (
             axum::http::StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/hashi/src/grpc/mod.rs
+++ b/crates/hashi/src/grpc/mod.rs
@@ -190,6 +190,16 @@ async fn health() -> impl axum::response::IntoResponse {
 }
 
 async fn ready(hashi: Arc<Hashi>) -> impl axum::response::IntoResponse {
+    // A poisoned database cannot be recovered without reopening it, so the node
+    // will never persist anything again. Report not-ready rather than keep
+    // serving: the process needs restarting, and on a full volume that also
+    // needs an operator. See `hashi_db_poisoned`.
+    if hashi.db.is_poisoned() {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "database is poisoned and cannot persist writes — restart required",
+        );
+    }
     let onchain_state = hashi.onchain_state();
     // If the chain has moved past what this binary supports, report not-ready so
     // operators/orchestration surface it — the node has halted autonomous work

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -883,6 +883,7 @@ impl Hashi {
         let guardian_bootstrap_service = self.clone().start_guardian_bootstrap();
         let sui_balance_service = self.clone().start_sui_balance_metric();
         let sui_address_balance_sweeper_service = self.clone().start_sui_address_balance_sweeper();
+        let db_disk_usage_service = self.clone().start_db_disk_usage_metric();
 
         let service = Service::new()
             .merge(onchain_service)
@@ -893,7 +894,8 @@ impl Hashi {
             .merge(mpc_service)
             .merge(guardian_bootstrap_service)
             .merge(sui_balance_service)
-            .merge(sui_address_balance_sweeper_service);
+            .merge(sui_address_balance_sweeper_service)
+            .merge(db_disk_usage_service);
 
         Ok(service)
     }
@@ -1191,6 +1193,19 @@ impl Hashi {
                         tracing::warn!("Failed to sweep SUI coin objects into address balance: {e}")
                     }
                 }
+            }
+        })
+    }
+
+    fn start_db_disk_usage_metric(self: Arc<Self>) -> Service {
+        const SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+        Service::new().spawn_aborting(async move {
+            let mut interval = tokio::time::interval(SAMPLE_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                self.metrics.update_db_disk_usage(&self.db);
             }
         })
     }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -117,6 +117,8 @@ pub struct Metrics {
     pub never_retry_deposit_ids: IntGauge,
     pub withdrawals_finalized_total: IntCounter,
     pub presig_pool_remaining: IntGauge,
+    db_keyspace_disk_bytes: IntGaugeVec,
+    db_disk_bytes: IntGauge,
     pub sui_tx_submissions_total: IntCounterVec,
     pub sui_balance: IntGaugeVec,
     pub sui_address_balance_sweeps_total: IntCounter,
@@ -730,6 +732,19 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            db_keyspace_disk_bytes: register_int_gauge_vec_with_registry!(
+                "hashi_db_keyspace_disk_bytes",
+                "bytes fjall accounts to each database keyspace",
+                &["keyspace"],
+                registry,
+            )
+            .unwrap(),
+            db_disk_bytes: register_int_gauge_with_registry!(
+                "hashi_db_disk_bytes",
+                "bytes fjall accounts to the whole database, journals included",
+                registry,
+            )
+            .unwrap(),
             sui_tx_submissions_total: register_int_counter_vec_with_registry!(
                 "hashi_sui_tx_submissions_total",
                 "Total Sui transaction submissions by operation and outcome",
@@ -1198,6 +1213,18 @@ impl Metrics {
         self.task_last_iteration_timestamp_seconds
             .with_label_values(&[task])
             .set(now);
+    }
+
+    pub fn update_db_disk_usage(&self, db: &crate::db::Database) {
+        for (keyspace, bytes) in db.keyspace_disk_space() {
+            self.db_keyspace_disk_bytes
+                .with_label_values(&[keyspace])
+                .set(bytes.min(i64::MAX as u64) as i64);
+        }
+        match db.total_disk_space() {
+            Ok(bytes) => self.db_disk_bytes.set(bytes.min(i64::MAX as u64) as i64),
+            Err(e) => tracing::debug!("failed to read database disk usage: {e}"),
+        }
     }
 
     pub fn update_onchain_state(&self, state: &crate::onchain::OnchainState) {

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -119,6 +119,7 @@ pub struct Metrics {
     pub presig_pool_remaining: IntGauge,
     db_keyspace_disk_bytes: IntGaugeVec,
     db_disk_bytes: IntGauge,
+    db_poisoned: IntGauge,
     pub sui_tx_submissions_total: IntCounterVec,
     pub sui_balance: IntGaugeVec,
     pub sui_address_balance_sweeps_total: IntCounter,
@@ -745,6 +746,12 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            db_poisoned: register_int_gauge_with_registry!(
+                "hashi_db_poisoned",
+                "1 when fjall has poisoned the database and the node can no longer persist writes",
+                registry,
+            )
+            .unwrap(),
             sui_tx_submissions_total: register_int_counter_vec_with_registry!(
                 "hashi_sui_tx_submissions_total",
                 "Total Sui transaction submissions by operation and outcome",
@@ -1216,6 +1223,7 @@ impl Metrics {
     }
 
     pub fn update_db_disk_usage(&self, db: &crate::db::Database) {
+        self.db_poisoned.set(i64::from(db.is_poisoned()));
         for (keyspace, bytes) in db.keyspace_disk_space() {
             self.db_keyspace_disk_bytes
                 .with_label_values(&[keyspace])


### PR DESCRIPTION
Stacked on #1007.

## Summary

fjall poisons the database on a failed write and never recovers in-process — every later write returns `Poisoned` and only reopening clears it. The node carried on anyway, answering RPCs and passing its readiness probe while persisting nothing, which is how a full volume on testnet turned into a stalled key rotation with a fleet that still looked healthy.

## Changes

- Latch a flag on `Database` when a write comes back `Poisoned`, and expose `is_poisoned`.
- Fail `/ready` while latched, so the node stops taking traffic it cannot persist and a rollout will not proceed past it.
- Export `hashi_db_poisoned`.

## Notes

Only writes are checked, because fjall only consults the flag on the write path — a read cannot surface poisoning.

The flag never clears by design: the process has to be restarted, and if the cause was `ENOSPC` an operator has to resize first.

## Test plan

`test_poisoning_latches_and_nothing_else_does` — a healthy write and an unrelated IO error must not latch, `Poisoned` must, and a later success must not clear it.
