### PR TITLE
[db] Compact the database after reconfig so pruned rows free the disk

### DIFF
--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -122,6 +122,15 @@ pub struct CompactedKeyspace {
     pub error: Option<fjall::Error>,
 }
 
+/// Outcome of a whole-database major compaction.
+pub struct MajorCompaction {
+    pub keyspaces: Vec<CompactedKeyspace>,
+    /// Error from the final rotation that unlinks the retired tables. When
+    /// set, the compacted bytes stay on disk until a later rotation, so the
+    /// run as a whole failed even if every keyspace compacted cleanly.
+    pub unlink_error: Option<fjall::Error>,
+}
+
 /// Keyspaces included in snapshot backups. Add new backup/restore keyspaces here.
 #[derive(Clone, Copy)]
 enum BackupKeyspace {
@@ -250,7 +259,7 @@ impl Database {
     ///
     /// Blocking and slow, and it locks out background compaction for each
     /// keyspace while it runs — call it from a blocking thread.
-    pub fn major_compact(&self) -> Vec<CompactedKeyspace> {
+    pub fn major_compact(&self) -> MajorCompaction {
         let compacted: Vec<_> = self
             .all_keyspaces()
             .into_iter()
@@ -281,14 +290,15 @@ impl Database {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        if let Err(e) = self
+        let unlink_error = self
             .maintenance
             .insert(MAINTENANCE_COMPACTION_KEY, now.to_be_bytes())
             .and_then(|_| self.maintenance.rotate_memtable_and_wait().map(|_| ()))
-        {
-            tracing::warn!("unlinking compacted tables failed, retrying next epoch: {e}");
+            .err();
+        MajorCompaction {
+            keyspaces: compacted,
+            unlink_error,
         }
-        compacted
     }
 
     /// Store an encryption private key, keyed by its public key, plus the
@@ -1960,8 +1970,14 @@ pub(crate) mod tests {
             "pruning alone does not free the disk — this is the bug being fixed",
         );
 
-        let compacted = db.major_compact();
-        let nonce = compacted
+        let compaction = db.major_compact();
+        assert!(
+            compaction.unlink_error.is_none(),
+            "unlink rotation failed: {:?}",
+            compaction.unlink_error
+        );
+        let nonce = compaction
+            .keyspaces
             .iter()
             .find(|keyspace| keyspace.name == NONCE_MESSAGES_CF_NAME)
             .expect("nonce_messages must be compacted");

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -214,6 +214,7 @@ impl Database {
         self.db.snapshot()
     }
 
+    /// Every keyspace, for whole-database maintenance. Add new keyspaces here.
     fn all_keyspaces(&self) -> [(&'static str, &Keyspace); 10] {
         [
             (ENCRYPTION_KEYS_CF_NAME, &self.encryption_keys),
@@ -229,21 +230,16 @@ impl Database {
         ]
     }
 
-    /// Rewrite every keyspace into a single run, dropping the rows that
-    /// `prune_messages_below` tombstoned.
+    /// Rewrite every keyspace into a single run, dropping what
+    /// `prune_messages_below` tombstoned. Pruning alone frees nothing: a
+    /// tombstone is a few dozen bytes against a nonce message of hundreds of
+    /// kilobytes, so leveled compaction never rewrites the bottom level.
     ///
-    /// Pruning alone does not free the disk. A tombstone is a few dozen bytes
-    /// against a nonce message of hundreds of kilobytes, so leveled compaction
-    /// never accumulates enough write pressure to rewrite the bottom level and
-    /// the shadowed values stay on disk indefinitely.
-    ///
-    /// Blocking and potentially slow — run it off the reconfig path. Each
-    /// keyspace is compacted independently so one failure does not skip the
-    /// rest, and the caller gets a per-keyspace result to log and measure.
+    /// Blocking and slow, and it locks out background compaction for each
+    /// keyspace while it runs — keep it off the reconfig path.
     pub fn major_compact(&self) -> Vec<CompactedKeyspace> {
-        // A compaction only sees what is already in a table, so flush first —
-        // otherwise the prune's tombstones sit in the memtable and the values
-        // they shadow survive the merge.
+        // Compaction merges tables, not memtables, so the prune's tombstones
+        // have to reach a table first or the values they shadow survive it.
         for (name, keyspace) in self.all_keyspaces() {
             if let Err(e) = keyspace.rotate_memtable_and_wait() {
                 tracing::warn!("flushing {name} before compaction failed: {e}");
@@ -265,12 +261,10 @@ impl Database {
                 }
             })
             .collect();
-        // Compacting drops the merged-away tables from the current version but
-        // does not unlink them. fjall retires a version — and with it the table
-        // files — while rotating a memtable, and one rotation sweeps every
-        // keyspace. This is best effort: a rotation needs something to flush, so
-        // when every memtable is empty the files are unlinked by the next write
-        // that fills one, which under normal traffic is moments later.
+        // A compaction retires the tables it merged away but does not unlink
+        // them; fjall only does that while rotating a memtable, and one
+        // rotation sweeps every keyspace. Rotating needs something to flush, so
+        // on an idle keyspace the files go back on the next write instead.
         for (name, keyspace) in self.all_keyspaces() {
             if let Err(e) = keyspace.rotate_memtable() {
                 tracing::warn!("rotating {name} after compaction failed: {e}");

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -103,6 +103,15 @@ const SIGNING_EPOCH_INDEX_CF_NAME: &str = "signing_epoch_index";
 
 const RETENTION_EXTRA_EPOCHS: u64 = 7;
 
+/// Outcome of compacting one keyspace, for logging and metrics.
+pub struct CompactedKeyspace {
+    pub name: &'static str,
+    pub before: u64,
+    pub after: u64,
+    pub elapsed: std::time::Duration,
+    pub error: Option<fjall::Error>,
+}
+
 /// Keyspaces included in snapshot backups. Add new backup/restore keyspaces here.
 #[derive(Clone, Copy)]
 enum BackupKeyspace {
@@ -203,6 +212,71 @@ impl Database {
 
     pub(crate) fn snapshot(&self) -> fjall::Snapshot {
         self.db.snapshot()
+    }
+
+    fn all_keyspaces(&self) -> [(&'static str, &Keyspace); 10] {
+        [
+            (ENCRYPTION_KEYS_CF_NAME, &self.encryption_keys),
+            (SIGNING_KEYS_CF_NAME, &self.signing_keys),
+            (ENCRYPTION_EPOCH_INDEX_CF_NAME, &self.encryption_epoch_index),
+            (SIGNING_EPOCH_INDEX_CF_NAME, &self.signing_epoch_index),
+            (DEALER_MESSAGES_CF_NAME, &self.dealer_messages),
+            (ROTATION_MESSAGES_CF_NAME, &self.rotation_messages),
+            (NONCE_MESSAGES_CF_NAME, &self.nonce_messages),
+            (AVID_ROUND_STATES_CF_NAME, &self.avid_round_states),
+            (AVID_DEALER_BUILDERS_CF_NAME, &self.avid_dealer_builders),
+            (AVID_HELD_ECHOES_CF_NAME, &self.avid_held_echoes),
+        ]
+    }
+
+    /// Rewrite every keyspace into a single run, dropping the rows that
+    /// `prune_messages_below` tombstoned.
+    ///
+    /// Pruning alone does not free the disk. A tombstone is a few dozen bytes
+    /// against a nonce message of hundreds of kilobytes, so leveled compaction
+    /// never accumulates enough write pressure to rewrite the bottom level and
+    /// the shadowed values stay on disk indefinitely.
+    ///
+    /// Blocking and potentially slow — run it off the reconfig path. Each
+    /// keyspace is compacted independently so one failure does not skip the
+    /// rest, and the caller gets a per-keyspace result to log and measure.
+    pub fn major_compact(&self) -> Vec<CompactedKeyspace> {
+        // A compaction only sees what is already in a table, so flush first —
+        // otherwise the prune's tombstones sit in the memtable and the values
+        // they shadow survive the merge.
+        for (name, keyspace) in self.all_keyspaces() {
+            if let Err(e) = keyspace.rotate_memtable_and_wait() {
+                tracing::warn!("flushing {name} before compaction failed: {e}");
+            }
+        }
+        let compacted: Vec<_> = self
+            .all_keyspaces()
+            .into_iter()
+            .map(|(name, keyspace)| {
+                let before = keyspace.disk_space();
+                let started = std::time::Instant::now();
+                let error = keyspace.major_compact().err();
+                CompactedKeyspace {
+                    name,
+                    before,
+                    after: keyspace.disk_space(),
+                    elapsed: started.elapsed(),
+                    error,
+                }
+            })
+            .collect();
+        // Compacting drops the merged-away tables from the current version but
+        // does not unlink them. fjall retires a version — and with it the table
+        // files — while rotating a memtable, and one rotation sweeps every
+        // keyspace. This is best effort: a rotation needs something to flush, so
+        // when every memtable is empty the files are unlinked by the next write
+        // that fills one, which under normal traffic is moments later.
+        for (name, keyspace) in self.all_keyspaces() {
+            if let Err(e) = keyspace.rotate_memtable() {
+                tracing::warn!("rotating {name} after compaction failed: {e}");
+            }
+        }
+        compacted
     }
 
     /// Store an encryption private key, keyed by its public key, plus the
@@ -853,6 +927,8 @@ pub(crate) mod tests {
 
     use super::AvidRoundState;
     use super::Database;
+    use super::Keyspace;
+    use super::NONCE_MESSAGES_CF_NAME;
     use super::PruningReferences;
     use super::RETENTION_EXTRA_EPOCHS;
 
@@ -1826,6 +1902,76 @@ pub(crate) mod tests {
                 "signing key at epoch {epoch} should be kept"
             );
         }
+    }
+
+    /// Total size of the files backing a keyspace.
+    fn bytes_on_disk(keyspace: &Keyspace) -> u64 {
+        let Ok(entries) = std::fs::read_dir(keyspace.path().join("tables")) else {
+            return 0;
+        };
+        entries
+            .filter_map(|entry| entry.ok()?.metadata().ok())
+            .map(|metadata| metadata.len())
+            .sum()
+    }
+
+    /// Pruning tombstones the rows but leaves the bytes on disk — the tombstones
+    /// are far too small next to the values they shadow for leveled compaction
+    /// to rewrite the bottom level. Compacting is what actually frees the space.
+    #[test]
+    fn test_major_compaction_frees_what_pruning_only_tombstoned() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let db = Database::open(tmpdir.path()).unwrap();
+
+        let nonce_msg = create_test_nonce_message();
+        for batch_index in 0..256 {
+            for dealer in 0..16u8 {
+                db.store_nonce_message(1, batch_index, &Address::new([dealer; 32]), &nonce_msg)
+                    .unwrap();
+            }
+        }
+        db.nonce_messages.rotate_memtable_and_wait().unwrap();
+        let occupied = bytes_on_disk(&db.nonce_messages);
+        assert!(occupied > 0, "epoch 1 should be on disk before pruning");
+
+        db.prune_messages_below(2, &PruningReferences::default())
+            .unwrap();
+        assert!(
+            db.get_nonce_message(1, 0, &Address::new([0u8; 32]))
+                .unwrap()
+                .is_none(),
+            "pruning must delete the rows",
+        );
+        assert_eq!(
+            bytes_on_disk(&db.nonce_messages),
+            occupied,
+            "pruning alone does not free the disk — this is the bug being fixed",
+        );
+
+        let compacted = db.major_compact();
+        let nonce = compacted
+            .iter()
+            .find(|keyspace| keyspace.name == NONCE_MESSAGES_CF_NAME)
+            .expect("nonce_messages must be compacted");
+        assert!(
+            nonce.error.is_none(),
+            "compaction failed: {:?}",
+            nonce.error
+        );
+        assert_eq!(
+            nonce.after, 0,
+            "every row was pruned, so nothing should be live"
+        );
+
+        // Unlinking lands on the next rotation with something to flush, which
+        // ordinary write traffic supplies.
+        db.store_nonce_message(2, 0, &Address::new([0u8; 32]), &nonce_msg)
+            .unwrap();
+        db.nonce_messages.rotate_memtable_and_wait().unwrap();
+        assert!(
+            bytes_on_disk(&db.nonce_messages) < occupied / 10,
+            "compaction must give back the {occupied} bytes pruning tombstoned",
+        );
     }
 
     #[test]

--- a/crates/hashi/src/db.rs
+++ b/crates/hashi/src/db.rs
@@ -88,6 +88,13 @@ pub struct Database {
     // key: (big endian u64 epoch) + (big endian u32 batch_index) + (32-byte dealer address)
     // value: BCS-serialized HeldAvidEchoes
     avid_held_echoes: Keyspace,
+
+    // Column Family holding the single marker row `major_compact` writes so the
+    // rotation that unlinks retired tables always has something to flush.
+    //
+    // key: `MAINTENANCE_COMPACTION_KEY`
+    // value: big endian u64 unix seconds of the last major compaction
+    maintenance: Keyspace,
 }
 
 const ENCRYPTION_KEYS_CF_NAME: &str = "encryption_keys";
@@ -100,6 +107,9 @@ const AVID_DEALER_BUILDERS_CF_NAME: &str = "avid_dealer_builders";
 const AVID_HELD_ECHOES_CF_NAME: &str = "avid_held_echoes";
 const ENCRYPTION_EPOCH_INDEX_CF_NAME: &str = "encryption_epoch_index";
 const SIGNING_EPOCH_INDEX_CF_NAME: &str = "signing_epoch_index";
+const MAINTENANCE_CF_NAME: &str = "maintenance";
+
+const MAINTENANCE_COMPACTION_KEY: &[u8] = b"last_compaction";
 
 const RETENTION_EXTRA_EPOCHS: u64 = 7;
 
@@ -185,6 +195,7 @@ impl Database {
         )?;
         let signing_epoch_index =
             db.keyspace(SIGNING_EPOCH_INDEX_CF_NAME, KeyspaceCreateOptions::default)?;
+        let maintenance = db.keyspace(MAINTENANCE_CF_NAME, KeyspaceCreateOptions::default)?;
         reject_legacy_epoch_keyed_format(&encryption_keys, ENCRYPTION_KEYS_CF_NAME)?;
         reject_legacy_epoch_keyed_format(&signing_keys, SIGNING_KEYS_CF_NAME)?;
         Ok(Self {
@@ -199,6 +210,7 @@ impl Database {
             avid_round_states,
             avid_dealer_builders,
             avid_held_echoes,
+            maintenance,
         })
     }
 
@@ -215,7 +227,7 @@ impl Database {
     }
 
     /// Every keyspace, for whole-database maintenance. Add new keyspaces here.
-    fn all_keyspaces(&self) -> [(&'static str, &Keyspace); 10] {
+    fn all_keyspaces(&self) -> [(&'static str, &Keyspace); 11] {
         [
             (ENCRYPTION_KEYS_CF_NAME, &self.encryption_keys),
             (SIGNING_KEYS_CF_NAME, &self.signing_keys),
@@ -227,6 +239,7 @@ impl Database {
             (AVID_ROUND_STATES_CF_NAME, &self.avid_round_states),
             (AVID_DEALER_BUILDERS_CF_NAME, &self.avid_dealer_builders),
             (AVID_HELD_ECHOES_CF_NAME, &self.avid_held_echoes),
+            (MAINTENANCE_CF_NAME, &self.maintenance),
         ]
     }
 
@@ -236,22 +249,21 @@ impl Database {
     /// kilobytes, so leveled compaction never rewrites the bottom level.
     ///
     /// Blocking and slow, and it locks out background compaction for each
-    /// keyspace while it runs — keep it off the reconfig path.
+    /// keyspace while it runs — call it from a blocking thread.
     pub fn major_compact(&self) -> Vec<CompactedKeyspace> {
-        // Compaction merges tables, not memtables, so the prune's tombstones
-        // have to reach a table first or the values they shadow survive it.
-        for (name, keyspace) in self.all_keyspaces() {
-            if let Err(e) = keyspace.rotate_memtable_and_wait() {
-                tracing::warn!("flushing {name} before compaction failed: {e}");
-            }
-        }
         let compacted: Vec<_> = self
             .all_keyspaces()
             .into_iter()
             .map(|(name, keyspace)| {
                 let before = keyspace.disk_space();
                 let started = std::time::Instant::now();
-                let error = keyspace.major_compact().err();
+                // Compaction merges tables, not memtables, so the prune's
+                // tombstones have to reach a table first or the values they
+                // shadow survive the merge. A failed flush fails the keyspace.
+                let error = keyspace
+                    .rotate_memtable_and_wait()
+                    .and_then(|_| keyspace.major_compact())
+                    .err();
                 CompactedKeyspace {
                     name,
                     before,
@@ -261,14 +273,20 @@ impl Database {
                 }
             })
             .collect();
-        // A compaction retires the tables it merged away but does not unlink
-        // them; fjall only does that while rotating a memtable, and one
-        // rotation sweeps every keyspace. Rotating needs something to flush, so
-        // on an idle keyspace the files go back on the next write instead.
-        for (name, keyspace) in self.all_keyspaces() {
-            if let Err(e) = keyspace.rotate_memtable() {
-                tracing::warn!("rotating {name} after compaction failed: {e}");
-            }
+        // Compaction retires the tables it merged away, but only a memtable
+        // rotation unlinks them, and rotating an empty memtable is a no-op.
+        // Write a marker row so the rotation always has something to flush;
+        // one rotation sweeps every keyspace.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        if let Err(e) = self
+            .maintenance
+            .insert(MAINTENANCE_COMPACTION_KEY, now.to_be_bytes())
+            .and_then(|_| self.maintenance.rotate_memtable_and_wait().map(|_| ()))
+        {
+            tracing::warn!("unlinking compacted tables failed, retrying next epoch: {e}");
         }
         compacted
     }
@@ -1957,11 +1975,6 @@ pub(crate) mod tests {
             "every row was pruned, so nothing should be live"
         );
 
-        // Unlinking lands on the next rotation with something to flush, which
-        // ordinary write traffic supplies.
-        db.store_nonce_message(2, 0, &Address::new([0u8; 32]), &nonce_msg)
-            .unwrap();
-        db.nonce_messages.rotate_memtable_and_wait().unwrap();
         assert!(
             bytes_on_disk(&db.nonce_messages) < occupied / 10,
             "compaction must give back the {occupied} bytes pruning tombstoned",

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -941,7 +941,8 @@ impl Metrics {
             .unwrap(),
             db_major_compaction_failures_total: register_int_counter_vec_with_registry!(
                 "hashi_db_major_compaction_failures_total",
-                "Post-reconfig major compactions that failed, by keyspace",
+                "Post-reconfig major compactions that failed, by keyspace \
+                 (\"unlink\" is the final rotation that releases the disk)",
                 &["keyspace"],
                 registry,
             )
@@ -1235,6 +1236,12 @@ impl Metrics {
                 .with_label_values(labels)
                 .inc();
         }
+    }
+
+    pub fn record_major_compaction_unlink_failure(&self) {
+        self.db_major_compaction_failures_total
+            .with_label_values(&["unlink"])
+            .inc();
     }
 
     pub fn update_onchain_state(&self, state: &crate::onchain::OnchainState) {

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -171,7 +171,6 @@ pub struct Metrics {
     pub mpc_reconfig_total_duration_seconds: HistogramVec,
     pub mpc_end_reconfig_duration_seconds: HistogramVec,
     db_major_compaction_duration_seconds: HistogramVec,
-    db_keyspace_disk_bytes: IntGaugeVec,
     db_major_compaction_failures_total: IntCounterVec,
     pub mpc_prepare_signing_duration_seconds: HistogramVec,
     pub mpc_total_duration_seconds: HistogramVec,
@@ -940,13 +939,6 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
-            db_keyspace_disk_bytes: register_int_gauge_vec_with_registry!(
-                "hashi_db_keyspace_disk_bytes",
-                "bytes fjall accounts to each keyspace, sampled after compaction",
-                &["keyspace"],
-                registry,
-            )
-            .unwrap(),
             db_major_compaction_failures_total: register_int_counter_vec_with_registry!(
                 "hashi_db_major_compaction_failures_total",
                 "Post-reconfig major compactions that failed, by keyspace",
@@ -1238,9 +1230,6 @@ impl Metrics {
         self.db_major_compaction_duration_seconds
             .with_label_values(labels)
             .observe(keyspace.elapsed.as_secs_f64());
-        self.db_keyspace_disk_bytes
-            .with_label_values(labels)
-            .set(keyspace.after.min(i64::MAX as u64) as i64);
         if keyspace.error.is_some() {
             self.db_major_compaction_failures_total
                 .with_label_values(labels)

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -170,6 +170,9 @@ pub struct Metrics {
     // MPC profiling metrics
     pub mpc_reconfig_total_duration_seconds: HistogramVec,
     pub mpc_end_reconfig_duration_seconds: HistogramVec,
+    db_major_compaction_duration_seconds: HistogramVec,
+    db_keyspace_disk_bytes: IntGaugeVec,
+    db_major_compaction_failures_total: IntCounterVec,
     pub mpc_prepare_signing_duration_seconds: HistogramVec,
     pub mpc_total_duration_seconds: HistogramVec,
     pub mpc_dealer_crypto_duration_seconds: HistogramVec,
@@ -929,6 +932,28 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            db_major_compaction_duration_seconds: register_histogram_vec_with_registry!(
+                "hashi_db_major_compaction_duration_seconds",
+                "Duration of a post-reconfig major compaction, by keyspace",
+                &["keyspace"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            db_keyspace_disk_bytes: register_int_gauge_vec_with_registry!(
+                "hashi_db_keyspace_disk_bytes",
+                "bytes fjall accounts to each keyspace, sampled after compaction",
+                &["keyspace"],
+                registry,
+            )
+            .unwrap(),
+            db_major_compaction_failures_total: register_int_counter_vec_with_registry!(
+                "hashi_db_major_compaction_failures_total",
+                "Post-reconfig major compactions that failed, by keyspace",
+                &["keyspace"],
+                registry,
+            )
+            .unwrap(),
             mpc_prepare_signing_duration_seconds: register_histogram_vec_with_registry!(
                 "hashi_mpc_prepare_signing_duration_seconds",
                 "Duration of prepare_signing",
@@ -1206,6 +1231,21 @@ impl Metrics {
         self.task_last_iteration_timestamp_seconds
             .with_label_values(&[task])
             .set(now);
+    }
+
+    pub fn record_major_compaction(&self, keyspace: &crate::db::CompactedKeyspace) {
+        let labels = &[keyspace.name];
+        self.db_major_compaction_duration_seconds
+            .with_label_values(labels)
+            .observe(keyspace.elapsed.as_secs_f64());
+        self.db_keyspace_disk_bytes
+            .with_label_values(labels)
+            .set(keyspace.after.min(i64::MAX as u64) as i64);
+        if keyspace.error.is_some() {
+            self.db_major_compaction_failures_total
+                .with_label_values(labels)
+                .inc();
+        }
     }
 
     pub fn update_onchain_state(&self, state: &crate::onchain::OnchainState) {

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -106,7 +106,6 @@ pub struct MpcService {
     reconciling: Arc<tokio::sync::Mutex<()>>,
     backup_handle: crate::backup::BackupHandle,
     replacement_keys_target_epoch: Mutex<Option<u64>>,
-    compacting: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl MpcService {
@@ -121,7 +120,6 @@ impl MpcService {
             reconciling: Arc::new(tokio::sync::Mutex::new(())),
             backup_handle,
             replacement_keys_target_epoch: Mutex::new(None),
-            compacting: Arc::new(tokio::sync::Mutex::new(())),
         };
         let handle = MpcHandle { key_ready_rx };
         (service, handle)
@@ -1349,7 +1347,6 @@ impl MpcService {
                  will retry at next trigger"
             );
         }
-        self.backup_handle.backup_after_epoch_change(target_epoch);
         info!("end_reconfig complete for epoch {target_epoch}, running prepare_signing");
         let pruning_references = {
             let state = self.inner.onchain_state().state();
@@ -1380,7 +1377,11 @@ impl MpcService {
         {
             error!("Failed to prune old MPC messages below epoch {target_epoch}: {e}");
         }
-        self.spawn_major_compaction(target_epoch);
+        self.run_major_compaction(target_epoch).await;
+        // Only after compaction: the backup takes a database-wide snapshot,
+        // and a snapshot taken before the prune pins every value the
+        // compaction would otherwise drop.
+        self.backup_handle.backup_after_epoch_change(target_epoch);
         if !self.reconfig_target_live(target_epoch) {
             info!(
                 "handle_reconfig: epoch {target_epoch} no longer pending nor current; \
@@ -1418,35 +1419,33 @@ impl MpcService {
     /// Compact the database after an epoch change so the rows the prune just
     /// tombstoned are actually unlinked.
     ///
-    /// Detached on a blocking thread, and deliberately before `prepare_signing`
-    /// refills the presig pool: the keyspaces are at their emptiest right after
-    /// the prune, so the merge writes almost nothing. A run still going means
-    /// the last one outlasted an epoch, so skip rather than pile on.
-    fn spawn_major_compaction(&self, epoch: u64) {
-        let Ok(guard) = self.compacting.clone().try_lock_owned() else {
-            warn!("skipping post-reconfig compaction at epoch {epoch}: previous run still going");
-            return;
-        };
+    /// Awaited deliberately before `prepare_signing` refills the presig pool:
+    /// the keyspaces are at their emptiest right after the prune, so the merge
+    /// writes almost nothing.
+    async fn run_major_compaction(&self, epoch: u64) {
         let db = self.inner.db.clone();
-        let metrics = self.inner.metrics.clone();
-        tokio::task::spawn_blocking(move || {
-            let _guard = guard;
-            let started = std::time::Instant::now();
-            for keyspace in db.major_compact() {
-                metrics.record_major_compaction(&keyspace);
-                match &keyspace.error {
-                    Some(e) => error!("compacting {} failed: {e}", keyspace.name),
-                    None => info!(
-                        "compacted {} in {:?}: {} -> {} live bytes",
-                        keyspace.name, keyspace.elapsed, keyspace.before, keyspace.after,
-                    ),
-                }
+        let started = std::time::Instant::now();
+        let compacted = match tokio::task::spawn_blocking(move || db.major_compact()).await {
+            Ok(compacted) => compacted,
+            Err(e) => {
+                error!("post-reconfig compaction for epoch {epoch} panicked: {e}");
+                return;
             }
-            info!(
-                "post-reconfig compaction for epoch {epoch} finished in {:?}",
-                started.elapsed()
-            );
-        });
+        };
+        for keyspace in compacted {
+            self.inner.metrics.record_major_compaction(&keyspace);
+            match &keyspace.error {
+                Some(e) => error!("compacting {} failed: {e}", keyspace.name),
+                None => info!(
+                    "compacted {} in {:?}: {} -> {} live bytes",
+                    keyspace.name, keyspace.elapsed, keyspace.before, keyspace.after,
+                ),
+            }
+        }
+        info!(
+            "post-reconfig compaction for epoch {epoch} finished in {:?}",
+            started.elapsed()
+        );
     }
 
     fn setup_initial_dkg(&self, target_epoch: u64) -> anyhow::Result<()> {

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -5,6 +5,8 @@
 
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -106,6 +108,7 @@ pub struct MpcService {
     reconciling: Arc<tokio::sync::Mutex<()>>,
     backup_handle: crate::backup::BackupHandle,
     replacement_keys_target_epoch: Mutex<Option<u64>>,
+    compacting: Arc<AtomicBool>,
 }
 
 impl MpcService {
@@ -120,6 +123,7 @@ impl MpcService {
             reconciling: Arc::new(tokio::sync::Mutex::new(())),
             backup_handle,
             replacement_keys_target_epoch: Mutex::new(None),
+            compacting: Arc::new(AtomicBool::new(false)),
         };
         let handle = MpcHandle { key_ready_rx };
         (service, handle)
@@ -1378,6 +1382,7 @@ impl MpcService {
         {
             error!("Failed to prune old MPC messages below epoch {target_epoch}: {e}");
         }
+        self.spawn_major_compaction(target_epoch);
         if !self.reconfig_target_live(target_epoch) {
             info!(
                 "handle_reconfig: epoch {target_epoch} no longer pending nor current; \
@@ -1410,6 +1415,41 @@ impl MpcService {
         }
         drop(_prepare_signing_timer);
         drop(_reconfig_timer);
+    }
+
+    /// Compact the database after an epoch change, so that the rows the prune
+    /// just tombstoned are actually unlinked.
+    ///
+    /// Runs detached on a blocking thread: it is not on the reconfig path, and
+    /// fjall only takes its major-compaction lock, so reads and writes carry on
+    /// meanwhile. A run still in progress means the last one is slower than an
+    /// epoch, which is worth knowing about rather than piling onto.
+    fn spawn_major_compaction(&self, epoch: u64) {
+        if self.compacting.swap(true, Ordering::AcqRel) {
+            warn!("skipping post-reconfig compaction at epoch {epoch}: previous run still going");
+            return;
+        }
+        let db = self.inner.db.clone();
+        let metrics = self.inner.metrics.clone();
+        let compacting = self.compacting.clone();
+        tokio::task::spawn_blocking(move || {
+            let started = std::time::Instant::now();
+            for keyspace in db.major_compact() {
+                metrics.record_major_compaction(&keyspace);
+                match &keyspace.error {
+                    Some(e) => error!("compacting {} failed: {e}", keyspace.name),
+                    None => info!(
+                        "compacted {} in {:?}: {} -> {} bytes",
+                        keyspace.name, keyspace.elapsed, keyspace.before, keyspace.after,
+                    ),
+                }
+            }
+            info!(
+                "post-reconfig compaction for epoch {epoch} finished in {:?}",
+                started.elapsed()
+            );
+            compacting.store(false, Ordering::Release);
+        });
     }
 
     fn setup_initial_dkg(&self, target_epoch: u64) -> anyhow::Result<()> {

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -5,8 +5,6 @@
 
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -108,7 +106,7 @@ pub struct MpcService {
     reconciling: Arc<tokio::sync::Mutex<()>>,
     backup_handle: crate::backup::BackupHandle,
     replacement_keys_target_epoch: Mutex<Option<u64>>,
-    compacting: Arc<AtomicBool>,
+    compacting: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl MpcService {
@@ -123,7 +121,7 @@ impl MpcService {
             reconciling: Arc::new(tokio::sync::Mutex::new(())),
             backup_handle,
             replacement_keys_target_epoch: Mutex::new(None),
-            compacting: Arc::new(AtomicBool::new(false)),
+            compacting: Arc::new(tokio::sync::Mutex::new(())),
         };
         let handle = MpcHandle { key_ready_rx };
         (service, handle)
@@ -1417,29 +1415,29 @@ impl MpcService {
         drop(_reconfig_timer);
     }
 
-    /// Compact the database after an epoch change, so that the rows the prune
-    /// just tombstoned are actually unlinked.
+    /// Compact the database after an epoch change so the rows the prune just
+    /// tombstoned are actually unlinked.
     ///
-    /// Runs detached on a blocking thread: it is not on the reconfig path, and
-    /// fjall only takes its major-compaction lock, so reads and writes carry on
-    /// meanwhile. A run still in progress means the last one is slower than an
-    /// epoch, which is worth knowing about rather than piling onto.
+    /// Detached on a blocking thread, and deliberately before `prepare_signing`
+    /// refills the presig pool: the keyspaces are at their emptiest right after
+    /// the prune, so the merge writes almost nothing. A run still going means
+    /// the last one outlasted an epoch, so skip rather than pile on.
     fn spawn_major_compaction(&self, epoch: u64) {
-        if self.compacting.swap(true, Ordering::AcqRel) {
+        let Ok(guard) = self.compacting.clone().try_lock_owned() else {
             warn!("skipping post-reconfig compaction at epoch {epoch}: previous run still going");
             return;
-        }
+        };
         let db = self.inner.db.clone();
         let metrics = self.inner.metrics.clone();
-        let compacting = self.compacting.clone();
         tokio::task::spawn_blocking(move || {
+            let _guard = guard;
             let started = std::time::Instant::now();
             for keyspace in db.major_compact() {
                 metrics.record_major_compaction(&keyspace);
                 match &keyspace.error {
                     Some(e) => error!("compacting {} failed: {e}", keyspace.name),
                     None => info!(
-                        "compacted {} in {:?}: {} -> {} bytes",
+                        "compacted {} in {:?}: {} -> {} live bytes",
                         keyspace.name, keyspace.elapsed, keyspace.before, keyspace.after,
                     ),
                 }
@@ -1448,7 +1446,6 @@ impl MpcService {
                 "post-reconfig compaction for epoch {epoch} finished in {:?}",
                 started.elapsed()
             );
-            compacting.store(false, Ordering::Release);
         });
     }
 

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -1425,14 +1425,14 @@ impl MpcService {
     async fn run_major_compaction(&self, epoch: u64) {
         let db = self.inner.db.clone();
         let started = std::time::Instant::now();
-        let compacted = match tokio::task::spawn_blocking(move || db.major_compact()).await {
-            Ok(compacted) => compacted,
+        let compaction = match tokio::task::spawn_blocking(move || db.major_compact()).await {
+            Ok(compaction) => compaction,
             Err(e) => {
                 error!("post-reconfig compaction for epoch {epoch} panicked: {e}");
                 return;
             }
         };
-        for keyspace in compacted {
+        for keyspace in compaction.keyspaces {
             self.inner.metrics.record_major_compaction(&keyspace);
             match &keyspace.error {
                 Some(e) => error!("compacting {} failed: {e}", keyspace.name),
@@ -1442,10 +1442,22 @@ impl MpcService {
                 ),
             }
         }
-        info!(
-            "post-reconfig compaction for epoch {epoch} finished in {:?}",
-            started.elapsed()
-        );
+        // The unlink rotation is what actually releases the disk, so its
+        // failure fails the run even when every keyspace compacted cleanly.
+        match &compaction.unlink_error {
+            Some(e) => {
+                self.inner.metrics.record_major_compaction_unlink_failure();
+                error!(
+                    "post-reconfig compaction for epoch {epoch} failed after {:?}: \
+                     retired tables were not unlinked, the space is still held: {e}",
+                    started.elapsed()
+                );
+            }
+            None => info!(
+                "post-reconfig compaction for epoch {epoch} finished in {:?}",
+                started.elapsed()
+            ),
+        }
     }
 
     fn setup_initial_dkg(&self, target_epoch: u64) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

Pruning deletes the right rows but never frees the disk — a tombstone is a few dozen bytes next to a ~560KB nonce message, so leveled compaction never has reason to rewrite the bottom level. This runs a major compaction after each epoch change, off the reconfig path, which is the simpler alternative to #1006 that Luke and Brandon suggested.

## Changes

- Add `Database::major_compact`: per keyspace, flush then compact, reporting duration and size; a failed flush fails that keyspace instead of compacting blind.
- After compacting, write a marker row to a new `maintenance` keyspace and rotate it, so the retired table files are always unlinked before returning. If that rotation fails the run is reported failed — logged and counted under `hashi_db_major_compaction_failures_total{keyspace="unlink"}` — since nothing was actually released.
- Call it after the prune in `handle_reconfig`, awaited on a blocking thread, and enqueue the backup only after it finishes — the backup's database-wide snapshot would otherwise pin every value the compaction is meant to drop.
- Add `hashi_db_major_compaction_duration_seconds` and `hashi_db_major_compaction_failures_total`.

## Notes

Two ordering details that fjall's API doesn't hint at. Both showed up once the test measured real bytes in the keyspace directory instead of `disk_space()`, which only counts tables in the current version:

- **Flush before compacting.** A compaction merges tables, not memtables, so the prune's tombstones have to reach a table first — otherwise they aren't in the merge and the values they shadow survive it. Skipping the flush left 5.5MB of a 10.3MB keyspace behind instead of 3.7KB.
- **`major_compact` doesn't unlink anything.** It retires the tables it merged away, but fjall only unlinks them while rotating a memtable, and rotating an empty memtable is a no-op. The marker row in the `maintenance` keyspace gives the rotation something to flush, and one rotation sweeps every keyspace, so the disk is actually given back before `major_compact` returns.

Worth watching on one node before mainnet, which is what the duration metric is for. Major compaction takes fjall's per-keyspace major-compaction lock and background compactions take it shared, so a long run lets L0 pile up on that keyspace and can throttle writes. It also rewrites the whole keyspace and needs room for the output before the old tables go, so it is weakest exactly when the disk is nearly full. Running it right after the prune and before `prepare_signing` refills the presig pool keeps both windows small — nearly everything is tombstoned at that point, so the merge writes almost nothing.

## Test plan

`test_major_compaction_frees_what_pruning_only_tombstoned` writes 4096 nonce rows, prunes them, asserts the bytes are still on disk (the bug), then compacts and asserts they come back. It also pins the flush ordering — drop the flush and the assertion fails.

Full suite passes, clippy clean with `-D warnings`.

Canaried on devnet `hashi-server-2` and `-3` (partition roll, nodes 0-1 untouched as controls), across two live epoch boundaries. At the epoch-99 reconfig both nodes compacted all 11 keyspaces in ~310ms, awaited on the reconfig path, with the backup enqueued strictly after (visible in the logs 5ms behind the compaction summary):

- The node carrying 15h of accumulated garbage: `rotation_messages` 88.8MB → 21.3MB, `nonce_messages` 41.8MB → 0, and the DB volume dropped 125M → 41M **immediately** — the maintenance-keyspace rotation unlinked the retired tables with no follow-up write traffic.
- The node compacted the epoch before: a clean ~325ms no-op (21.3MB → 21.3MB), i.e. the steady-state cost of running this every epoch.

Both stayed ready throughout with zero restarts, `hashi_db_major_compaction_duration_seconds{keyspace}` populated, and no failure counters incremented.
