### PR TITLE
Fix end_reconfig signature in reconfiguration docs

### DIFF
--- a/design/docs/reconfiguration.mdx
+++ b/design/docs/reconfiguration.mdx
@@ -101,8 +101,7 @@ calling `hashi::reconfig::end_reconfig`:
 entry fun end_reconfig(
     self: &mut Hashi,
     mpc_public_key: vector<u8>,
-    signature: vector<u8>,
-    signers_bitmap: vector<u8>,
+    mpc_cert: CommitteeSignature,
     ctx: &TxContext,
 )
 ```


### PR DESCRIPTION
## Description
### What

Update the end_reconfig signature in `design/docs/reconfiguration.mdx` to match the implementation in [`packages/hashi/sources/core/reconfig.move`](https://github.com/MystenLabs/hashi/blob/main/packages/hashi/sources/core/reconfig.move#L81-L86).

### Why

The documentation previously listed `signature` and `signers_bitmap` as separate `vector<u8>` parameters, but the actual entry function accepts a single `mpc_cert: CommitteeSignature`.

The documentation now reflects the actual API.