### PR TITLE
[Guardian] Serialize and fence S3 log writes

### DIFF
--- a/crates/hashi-guardian-init/src/operator_activate.rs
+++ b/crates/hashi-guardian-init/src/operator_activate.rs
@@ -7,8 +7,8 @@
 use anyhow::Context;
 use anyhow::ensure;
 use hashi_guardian::HEARTBEAT_INTERVAL;
-use hashi_guardian::MAX_S3_WRITE_FAILURE_INTERVAL;
 use hashi_guardian::OTHER_SESSION_QUIET_PERIOD;
+use hashi_guardian::S3_WRITE_ATTEMPT_TIMEOUT;
 use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::ActivationState;
 use hashi_types::guardian::GuardianError;
@@ -31,13 +31,12 @@ use tracing::warn;
 use crate::config::Config;
 use crate::guardian_info::verified_live_guardian_info;
 
-// The live-session freshness threshold is intentionally shorter than the
-// writer's normal upper bound: one heartbeat interval plus the S3 write-failure
-// interval (six minutes). A not-live session may therefore still recover, and
-// ten minutes leaves an explicit operational buffer for that recovery.
+// The retry window is long enough for the next scheduled heartbeat to start a
+// complete S3 attempt: one heartbeat interval plus five minutes. A not-live
+// session may therefore still recover before the ten-minute window expires.
 const CURRENT_SESSION_HEARTBEAT_RETRY_WINDOW: Duration = Duration::from_mins(10);
 const _: () = assert!(
-    HEARTBEAT_INTERVAL.as_secs() + MAX_S3_WRITE_FAILURE_INTERVAL.as_secs()
+    HEARTBEAT_INTERVAL.as_secs() + S3_WRITE_ATTEMPT_TIMEOUT.as_secs()
         < CURRENT_SESSION_HEARTBEAT_RETRY_WINDOW.as_secs()
 );
 

--- a/crates/hashi-guardian/Cargo.toml
+++ b/crates/hashi-guardian/Cargo.toml
@@ -31,6 +31,7 @@ aws-smithy-mocks = { version = "0.1", optional = true }
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.12.0", features = ["test-util"] }
 aws-smithy-mocks = "0.1"
+tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 # Stubs out the AWS Nitro NSM attestation call so the guardian can run

--- a/crates/hashi-guardian/README.md
+++ b/crates/hashi-guardian/README.md
@@ -15,6 +15,54 @@ V2 for callers. In particular, V1 KP-share logs carry one fingerprint and
 ciphertext per share, while V2 carries a fingerprint-to-ciphertext map per
 share so one KP can rotate between multiple accepted certificates.
 
+## Heartbeat write fencing
+
+Every Guardian S3 log write is serialized. After the first successful
+withdraw-mode heartbeat, the writer allows another attempt only when its full
+timeout fits before the latest successful heartbeat plus the reader's quiet
+period minus the clock-skew budget. Successful non-heartbeat writes do not
+extend that deadline.
+
+The writer captures a monotonic timestamp immediately before constructing the
+signed heartbeat record and renews its local deadline only after S3 confirms
+the write. Readers independently apply the same quiet period to the heartbeat's
+signed wall-clock timestamp. The fencing argument makes these assumptions:
+
+- **Assumption 1: clock skew does not make the activating reader's quiet-period
+  boundary occur before the writer's fence.**
+  - **What it is:** The clocks need not be identical. The safety requirement is
+    that the reader must not declare the prior session quiet while the writer is
+    still allowed to make a write. The writer places its fence
+    `ACTIVATING_READER_CLOCK_SKEW_BUDGET` before the reader's quiet-period
+    boundary. Reader-ahead skew and any post-deadline S3 durability delay share
+    that margin; their combined duration must not exhaust it.
+  - **Where we make it:** `LogWriter::write` captures the monotonic renewal time
+    immediately before `LogRecord::new` captures the signed wall-clock time, and
+    `LatestHeartbeatTime` subtracts the skew budget from the writer's fence.
+    Heartbeat readers derive inactivity from the signed timestamp and the full
+    quiet period.
+- **Assumption 2: monotonic time advances across platform suspension.**
+  - **What it is:** A paused enclave cannot resume with its local write deadline
+    still artificially in the future.
+  - **Where we make it:** `LatestHeartbeatTime` and all writer deadlines use
+    `tokio::time::Instant`; the fencing proof requires this clock to advance
+    while the platform is suspended.
+- **Assumption 3: suspension does not resume execution within one future poll.**
+  - **What it is:** Execution does not pause between a deadline check and
+    network transmission, or between the final time check and result
+    propagation.
+  - **Where we make it:** `complete_before_attempt_deadline` checks the timer
+    before polling the S3 future and checks time again after that future
+    completes, but cannot inspect execution inside one poll.
+- **Assumption 4: S3 does not make a timed-out request durable arbitrarily
+  later.**
+  - **What it is:** Cancelling a request future cannot retract a PUT already
+    accepted by S3. If that PUT becomes durable after its local deadline, the
+    delay plus any reader-ahead clock skew remains within
+    `ACTIVATING_READER_CLOCK_SKEW_BUDGET`.
+  - **Where we make it:** `complete_before_attempt_deadline` drops the S3 future
+    when its timer wins.
+
 ## S3 log key format
 
 Canonical key layout:

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -29,6 +29,8 @@ use std::time::Duration;
 use tokio::sync::OwnedMutexGuard;
 use tracing::info;
 
+use crate::log_writer::LogWriteCoordinator;
+use crate::log_writer::LogWriteKind;
 use crate::s3_client::GuardianS3Client;
 use crate::s3_reader::GuardianReader;
 use hashi_types::committee::Committee as HashiCommittee;
@@ -44,6 +46,8 @@ pub struct Enclave {
     /// Serializes lifecycle and control-plane transitions so concurrent
     /// operations cannot race a check-then-set.
     control_lock: tokio::sync::Mutex<()>,
+    /// Serializes S3 log writes and fences them against heartbeat expiry.
+    log_write_coordinator: LogWriteCoordinator,
 }
 
 /// Configuration set during initialization (immutable after set)
@@ -322,6 +326,7 @@ impl Enclave {
             },
             temporary_init_state: RwLock::new(None),
             control_lock: tokio::sync::Mutex::new(()),
+            log_write_coordinator: LogWriteCoordinator::new(),
         }
     }
 
@@ -415,6 +420,9 @@ impl Enclave {
             });
         }
         self.assert_state_installed_for(next);
+        if next == WithdrawStage::OperatorInitialized.into() {
+            self.log_write_coordinator.arm_heartbeat_fencing();
+        }
         *lifecycle = next;
         Ok(())
     }
@@ -558,18 +566,35 @@ impl Enclave {
         SessionID::from_signing_pubkey(&self.signing_pubkey())
     }
 
-    async fn write_log(&self, message: LogMessage) -> GuardianResult<()> {
+    async fn write_log(&self, message: LogMessage, kind: LogWriteKind) -> GuardianResult<()> {
         let log = LogRecord::new(self.s3_session_id(), message, &self.config.signing_keys);
+        let logger = self.config.s3_logger()?;
 
-        self.config.s3_logger()?.write_log_record(log).await
+        self.log_write_coordinator
+            .write(kind, |fencing_deadline| async move {
+                match fencing_deadline {
+                    Some(deadline) => logger.write_log_record_before(log, deadline).await,
+                    None => logger.write_log_record(log).await,
+                }
+            })
+            .await
     }
 
-    async fn write_log_or_abort(&self, message: LogMessage) -> GuardianResult<()> {
+    async fn write_log_or_abort(
+        &self,
+        message: LogMessage,
+        kind: LogWriteKind,
+    ) -> GuardianResult<()> {
         let log = LogRecord::new(self.s3_session_id(), message, &self.config.signing_keys);
+        let logger = self.config.s3_logger()?;
 
-        self.config
-            .s3_logger()?
-            .write_log_record_or_abort(log)
+        self.log_write_coordinator
+            .write(kind, |fencing_deadline| async move {
+                match fencing_deadline {
+                    Some(deadline) => logger.write_log_record_or_abort_before(log, deadline).await,
+                    None => logger.write_log_record_or_abort(log).await,
+                }
+            })
             .await
     }
 
@@ -577,30 +602,35 @@ impl Enclave {
     /// S3 write/access issues. The incomplete enclave cannot serve and will restart,
     /// so S3 being ahead after a lost acknowledgement is acceptable.
     pub async fn log_init(&self, msg: InitLogMessage) -> GuardianResult<()> {
-        self.write_log(LogMessage::Init(Box::new(msg))).await
+        self.write_log(LogMessage::Init(Box::new(msg)), LogWriteKind::Other)
+            .await
     }
 
     pub async fn log_withdraw(&self, msg: WithdrawalLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Withdrawal(Box::new(msg)))
+        self.write_log_or_abort(LogMessage::Withdrawal(Box::new(msg)), LogWriteKind::Other)
             .await
     }
 
     pub async fn log_committee_update(&self, msg: CommitteeUpdateLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::CommitteeUpdate(Box::new(msg)))
-            .await
+        self.write_log_or_abort(
+            LogMessage::CommitteeUpdate(Box::new(msg)),
+            LogWriteKind::Other,
+        )
+        .await
     }
 
     pub async fn log_genesis(&self, msg: GenesisLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Genesis(Box::new(msg)))
+        self.write_log_or_abort(LogMessage::Genesis(Box::new(msg)), LogWriteKind::Other)
             .await
     }
 
     pub async fn log_heartbeat(&self, msg: HeartbeatLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Heartbeat(msg)).await
+        self.write_log_or_abort(LogMessage::Heartbeat(msg), LogWriteKind::Heartbeat)
+            .await
     }
 
     pub async fn log_ceremony(&self, state: CeremonyLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Ceremony(Box::new(state)))
+        self.write_log_or_abort(LogMessage::Ceremony(Box::new(state)), LogWriteKind::Other)
             .await
     }
 
@@ -613,9 +643,14 @@ impl Enclave {
         cert_seq: u64,
         encrypted_shares: KPEncryptedSharesRoster,
     ) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::KpShareState(Box::new(
-            KpShareStateLogMessage::new(sharing_seq, cert_seq, encrypted_shares),
-        )))
+        self.write_log_or_abort(
+            LogMessage::KpShareState(Box::new(KpShareStateLogMessage::new(
+                sharing_seq,
+                cert_seq,
+                encrypted_shares,
+            ))),
+            LogWriteKind::Other,
+        )
         .await
     }
 

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 use tokio::sync::OwnedMutexGuard;
 use tracing::info;
 
+use crate::log_writer::LogWriter;
 use crate::s3_client::GuardianS3Client;
 use crate::s3_reader::GuardianReader;
 use hashi_types::committee::Committee as HashiCommittee;
@@ -48,6 +49,8 @@ pub struct Enclave {
     control_lock: tokio::sync::Mutex<()>,
     /// Ceremony state retained until every KP confirms successful share recovery.
     pending_ceremony: OnceLock<PendingCeremony>,
+    /// Serializes and fences every S3 log write from this enclave session.
+    log_writer: LogWriter,
 }
 
 /// Configuration set during initialization (immutable after set)
@@ -395,6 +398,7 @@ impl Enclave {
             temporary_init_state: RwLock::new(None),
             pending_ceremony: OnceLock::new(),
             control_lock: tokio::sync::Mutex::new(()),
+            log_writer: LogWriter::new(),
         }
     }
 
@@ -636,49 +640,41 @@ impl Enclave {
     }
 
     async fn write_log(&self, message: LogMessage) -> GuardianResult<()> {
-        let log = LogRecord::new(self.s3_session_id(), message, &self.config.signing_keys);
-
-        self.config.s3_logger()?.write_log_record(log).await
+        let s3 = self.config.s3_logger()?;
+        self.log_writer
+            .write(s3, self.s3_session_id(), message, &self.config.signing_keys)
+            .await;
+        Ok(())
     }
 
-    async fn write_log_or_abort(&self, message: LogMessage) -> GuardianResult<()> {
-        let log = LogRecord::new(self.s3_session_id(), message, &self.config.signing_keys);
-
-        self.config
-            .s3_logger()?
-            .write_log_record_or_abort(log)
-            .await
-    }
-
-    /// Only init skips grace-period retries, providing quick fail-stop for basic
-    /// S3 write/access issues. The incomplete enclave cannot serve and will restart,
-    /// so S3 being ahead after a lost acknowledgement is acceptable.
     pub async fn log_init(&self, msg: InitLogMessage) -> GuardianResult<()> {
         self.write_log(LogMessage::Init(Box::new(msg))).await
     }
 
     pub async fn log_withdraw(&self, msg: WithdrawalLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Withdrawal(Box::new(msg)))
-            .await
+        self.write_log(LogMessage::Withdrawal(Box::new(msg))).await
     }
 
     pub async fn log_committee_update(&self, msg: CommitteeUpdateLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::CommitteeUpdate(Box::new(msg)))
+        self.write_log(LogMessage::CommitteeUpdate(Box::new(msg)))
             .await
     }
 
     pub async fn log_genesis(&self, msg: GenesisLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Genesis(Box::new(msg)))
-            .await
+        self.write_log(LogMessage::Genesis(Box::new(msg))).await
     }
 
     pub async fn log_heartbeat(&self, msg: HeartbeatLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Heartbeat(msg)).await
+        assert_eq!(
+            self.mode(),
+            EnclaveMode::Withdraw,
+            "heartbeats are only supported in withdraw mode"
+        );
+        self.write_log(LogMessage::Heartbeat(msg)).await
     }
 
     pub async fn log_ceremony(&self, state: CeremonyLogMessage) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::Ceremony(Box::new(state)))
-            .await
+        self.write_log(LogMessage::Ceremony(Box::new(state))).await
     }
 
     /// Persist the current encrypted KP share state to `kp-shares/` for recovery.
@@ -690,7 +686,7 @@ impl Enclave {
         cert_seq: u64,
         encrypted_shares: KPEncryptedSharesRoster,
     ) -> GuardianResult<()> {
-        self.write_log_or_abort(LogMessage::KpShareState(Box::new(
+        self.write_log(LogMessage::KpShareState(Box::new(
             KpShareStateLogMessage::new(sharing_seq, cert_seq, encrypted_shares),
         )))
         .await

--- a/crates/hashi-guardian/src/lib.rs
+++ b/crates/hashi-guardian/src/lib.rs
@@ -5,22 +5,25 @@ use std::time::Duration;
 
 /// Interval between successful heartbeat writes.
 pub const HEARTBEAT_INTERVAL: Duration = Duration::from_mins(1);
-/// Maximum write failure interval before the enclave aborts.
-pub const MAX_S3_WRITE_FAILURE_INTERVAL: Duration = Duration::from_mins(5);
+/// Absolute timeout for one Guardian S3 log write attempt.
+pub const S3_WRITE_ATTEMPT_TIMEOUT: Duration = Duration::from_mins(5);
 /// The live session's latest heartbeat must be at most 3 minutes old.
 pub const LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE: Duration = Duration::from_mins(3);
 /// Silence required before another session is considered inactive.
 pub const OTHER_SESSION_QUIET_PERIOD: Duration = Duration::from_mins(10);
+/// Reader-ahead wall-clock skew reserved by the writer's earlier fence.
+pub const ACTIVATING_READER_CLOCK_SKEW_BUDGET: Duration = Duration::from_mins(1);
 
-// An enclave that cannot write its next heartbeat must abort before another
-// session is allowed to treat it as quiet. This fencing argument assumes the
-// old enclave either keeps executing until that abort or is permanently
-// terminated. Nitro Enclaves currently have no suspend/resume lifecycle (and
-// stopping the parent terminates its enclaves); a future platform that can
-// resume preserved enclave memory would need an explicit activation-generation
-// fence before serving withdrawals.
+// Withdraw-mode log writes are serialized. After the first durable heartbeat,
+// every attempt must fit strictly before the last successful heartbeat plus
+// the reader's quiet period, minus the clock-skew budget. At cooperative poll
+// boundaries, the timer-first deadline checks time before polling S3 and
+// rejects results observed after the boundary. See the README for the fencing
+// assumptions.
 const _: () = assert!(
-    HEARTBEAT_INTERVAL.as_secs() + MAX_S3_WRITE_FAILURE_INTERVAL.as_secs()
+    HEARTBEAT_INTERVAL.as_secs()
+        + S3_WRITE_ATTEMPT_TIMEOUT.as_secs()
+        + ACTIVATING_READER_CLOCK_SKEW_BUDGET.as_secs()
         < OTHER_SESSION_QUIET_PERIOD.as_secs()
 );
 
@@ -28,6 +31,7 @@ pub mod attestation;
 pub mod ceremony_mode;
 pub mod enclave;
 pub mod info;
+mod log_writer;
 pub mod operator_init;
 pub mod rpc;
 pub mod s3_client; // used by the monitor

--- a/crates/hashi-guardian/src/lib.rs
+++ b/crates/hashi-guardian/src/lib.rs
@@ -19,6 +19,11 @@ pub const OTHER_SESSION_QUIET_PERIOD: Duration = Duration::from_mins(10);
 // stopping the parent terminates its enclaves); a future platform that can
 // resume preserved enclave memory would need an explicit activation-generation
 // fence before serving withdrawals.
+//
+// After withdraw-mode operator initialization, all Guardian log writes are
+// serialized. Each write checks that its complete failure interval ends before
+// the quiet-period boundary, and a heartbeat refreshes that boundary only after
+// its durable write succeeds.
 const _: () = assert!(
     HEARTBEAT_INTERVAL.as_secs() + MAX_S3_WRITE_FAILURE_INTERVAL.as_secs()
         < OTHER_SESSION_QUIET_PERIOD.as_secs()
@@ -28,6 +33,7 @@ pub mod attestation;
 pub mod ceremony_mode;
 pub mod enclave;
 pub mod info;
+mod log_writer;
 pub mod operator_init;
 pub mod rpc;
 pub mod s3_client; // used by the monitor

--- a/crates/hashi-guardian/src/log_writer.rs
+++ b/crates/hashi-guardian/src/log_writer.rs
@@ -1,0 +1,247 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::MAX_S3_WRITE_FAILURE_INTERVAL;
+use crate::OTHER_SESSION_QUIET_PERIOD;
+use hashi_types::guardian::GuardianResult;
+use std::future::Future;
+use std::sync::Mutex;
+use tokio::time::Instant;
+
+/// Serializes Guardian log writes and fences them against heartbeat expiry.
+pub(crate) struct LogWriteCoordinator {
+    write_lock: tokio::sync::Mutex<()>,
+    heartbeat_health: Mutex<HeartbeatHealth>,
+}
+
+#[derive(Clone, Copy)]
+enum HeartbeatHealth {
+    Disabled,
+    Armed { last_successful_heartbeat: Instant },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LogWriteKind {
+    Heartbeat,
+    Other,
+}
+
+impl LogWriteCoordinator {
+    pub(crate) fn new() -> Self {
+        Self {
+            write_lock: tokio::sync::Mutex::new(()),
+            heartbeat_health: Mutex::new(HeartbeatHealth::Disabled),
+        }
+    }
+
+    /// Begin heartbeat fencing after withdraw-mode operator initialization.
+    ///
+    /// The successful operator-init log provides the initial grace period. The
+    /// heartbeat writer runs immediately thereafter and replaces this timestamp
+    /// with the first successful heartbeat timestamp.
+    pub(crate) fn arm_heartbeat_fencing(&self) {
+        let mut health = self
+            .heartbeat_health
+            .lock()
+            .expect("heartbeat-health lock poisoned");
+        assert!(
+            matches!(*health, HeartbeatHealth::Disabled),
+            "heartbeat fencing already armed"
+        );
+        *health = HeartbeatHealth::Armed {
+            last_successful_heartbeat: Instant::now(),
+        };
+    }
+
+    /// Run one S3 log write while holding the enclave-wide write permit.
+    ///
+    /// When heartbeat fencing is armed, the callback receives the absolute
+    /// deadline by which the write must finish. The pre-write check ensures that
+    /// the complete S3 retry interval ends before another session may regard this
+    /// one as quiet. A heartbeat advances the local lease only after its durable
+    /// write.
+    pub(crate) async fn write<Write, WriteFuture>(
+        &self,
+        kind: LogWriteKind,
+        write: Write,
+    ) -> GuardianResult<()>
+    where
+        Write: FnOnce(Option<Instant>) -> WriteFuture,
+        WriteFuture: Future<Output = GuardianResult<()>>,
+    {
+        let _write_guard = self.write_lock.lock().await;
+        let write_deadline = self.write_deadline_before_write();
+
+        let result = write(write_deadline).await;
+        if result.is_ok() {
+            if let Some(deadline) = write_deadline {
+                assert!(
+                    Instant::now() < deadline,
+                    "S3 log write completed after the heartbeat fencing deadline"
+                );
+            }
+            if kind == LogWriteKind::Heartbeat {
+                self.record_successful_heartbeat();
+            }
+        }
+        result
+    }
+
+    fn write_deadline_before_write(&self) -> Option<Instant> {
+        let HeartbeatHealth::Armed {
+            last_successful_heartbeat,
+        } = *self
+            .heartbeat_health
+            .lock()
+            .expect("heartbeat-health lock poisoned")
+        else {
+            return None;
+        };
+
+        let fencing_deadline = last_successful_heartbeat
+            .checked_add(OTHER_SESSION_QUIET_PERIOD)
+            .expect("heartbeat fencing deadline overflow");
+        let now = Instant::now();
+        let write_deadline = now
+            .checked_add(MAX_S3_WRITE_FAILURE_INTERVAL)
+            .expect("S3 write deadline overflow");
+        assert!(
+            write_deadline < fencing_deadline,
+            "last successful Guardian heartbeat is too old to safely start an S3 log write"
+        );
+        Some(write_deadline)
+    }
+
+    fn record_successful_heartbeat(&self) {
+        let mut health = self
+            .heartbeat_health
+            .lock()
+            .expect("heartbeat-health lock poisoned");
+        let HeartbeatHealth::Armed { .. } = *health else {
+            panic!("heartbeat succeeded before heartbeat fencing was armed");
+        };
+        *health = HeartbeatHealth::Armed {
+            last_successful_heartbeat: Instant::now(),
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    #[tokio::test]
+    async fn serializes_log_writes() {
+        let coordinator = Arc::new(LogWriteCoordinator::new());
+        let first_entered = Arc::new(Notify::new());
+        let release_first = Arc::new(Notify::new());
+        let second_entered = Arc::new(AtomicBool::new(false));
+
+        let first = {
+            let coordinator = coordinator.clone();
+            let first_entered = first_entered.clone();
+            let release_first = release_first.clone();
+            tokio::spawn(async move {
+                coordinator
+                    .write(LogWriteKind::Other, |_| async move {
+                        first_entered.notify_one();
+                        release_first.notified().await;
+                        Ok(())
+                    })
+                    .await
+            })
+        };
+        first_entered.notified().await;
+
+        let second = {
+            let coordinator = coordinator.clone();
+            let second_entered = second_entered.clone();
+            tokio::spawn(async move {
+                coordinator
+                    .write(LogWriteKind::Other, |_| async move {
+                        second_entered.store(true, Ordering::SeqCst);
+                        Ok(())
+                    })
+                    .await
+            })
+        };
+
+        tokio::task::yield_now().await;
+        assert!(!second_entered.load(Ordering::SeqCst));
+        release_first.notify_one();
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+        assert!(second_entered.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_heartbeat_panics_before_starting_write() {
+        let coordinator = Arc::new(LogWriteCoordinator::new());
+        coordinator.arm_heartbeat_fencing();
+        tokio::time::advance(OTHER_SESSION_QUIET_PERIOD - MAX_S3_WRITE_FAILURE_INTERVAL).await;
+
+        let write_started = Arc::new(AtomicBool::new(false));
+        let task = {
+            let coordinator = coordinator.clone();
+            let write_started = write_started.clone();
+            tokio::spawn(async move {
+                coordinator
+                    .write(LogWriteKind::Other, |_| async move {
+                        write_started.store(true, Ordering::SeqCst);
+                        Ok(())
+                    })
+                    .await
+            })
+        };
+
+        assert!(task.await.unwrap_err().is_panic());
+        assert!(!write_started.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn successful_heartbeat_refreshes_fencing_deadline() {
+        let coordinator = LogWriteCoordinator::new();
+        coordinator.arm_heartbeat_fencing();
+        let nearly_stale =
+            OTHER_SESSION_QUIET_PERIOD - MAX_S3_WRITE_FAILURE_INTERVAL - Duration::from_secs(1);
+        tokio::time::advance(nearly_stale).await;
+
+        coordinator
+            .write(LogWriteKind::Heartbeat, |deadline| async move {
+                assert!(deadline.is_some());
+                Ok(())
+            })
+            .await
+            .unwrap();
+        tokio::time::advance(nearly_stale).await;
+
+        coordinator
+            .write(LogWriteKind::Other, |deadline| async move {
+                assert!(deadline.is_some());
+                Ok(())
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn write_completing_at_its_deadline_panics() {
+        let coordinator = Arc::new(LogWriteCoordinator::new());
+        coordinator.arm_heartbeat_fencing();
+        let task = tokio::spawn(async move {
+            coordinator
+                .write(LogWriteKind::Other, |_| async move {
+                    tokio::time::advance(MAX_S3_WRITE_FAILURE_INTERVAL).await;
+                    Ok(())
+                })
+                .await
+        });
+
+        assert!(task.await.unwrap_err().is_panic());
+    }
+}

--- a/crates/hashi-guardian/src/log_writer.rs
+++ b/crates/hashi-guardian/src/log_writer.rs
@@ -1,0 +1,420 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::s3_client::GuardianS3Client;
+use crate::ACTIVATING_READER_CLOCK_SKEW_BUDGET;
+use crate::OTHER_SESSION_QUIET_PERIOD;
+use crate::S3_WRITE_ATTEMPT_TIMEOUT;
+use hashi_types::guardian::GuardianError;
+use hashi_types::guardian::GuardianError::S3Error;
+use hashi_types::guardian::GuardianSignKeyPair;
+use hashi_types::guardian::LogMessage;
+use hashi_types::guardian::LogRecord;
+use hashi_types::guardian::LogType;
+use hashi_types::guardian::SessionID;
+use std::future::Future;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+use tracing::warn;
+
+const MAX_S3_WRITE_ATTEMPTS: usize = 5;
+const S3_WRITE_RETRY_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Serializes every Guardian log write and owns the session-heartbeat fence.
+pub(crate) struct LogWriter {
+    state: Mutex<LatestHeartbeatTime>,
+}
+
+struct LatestHeartbeatTime(Option<Instant>);
+
+enum DeadlineExceeded<T> {
+    PerAttemptTimerElapsed,
+    CompletionObservedLate(T),
+}
+
+impl LatestHeartbeatTime {
+    fn new() -> Self {
+        Self(None)
+    }
+
+    /// The local monotonic deadline before which the next S3 write must finish.
+    /// The skew budget makes this deadline earlier than the reader's quiet
+    /// period boundary for the heartbeat's signed wall-clock timestamp.
+    fn next_write_deadline(&self) -> Option<Instant> {
+        self.0.map(|heartbeat| {
+            heartbeat
+                .checked_add(OTHER_SESSION_QUIET_PERIOD)
+                .and_then(|deadline| deadline.checked_sub(ACTIVATING_READER_CLOCK_SKEW_BUDGET))
+                .expect("Guardian heartbeat deadline overflow")
+        })
+    }
+
+    fn renew(&mut self, heartbeat: Instant) {
+        self.0 = Some(heartbeat);
+    }
+}
+
+impl LogWriter {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(LatestHeartbeatTime::new()),
+        }
+    }
+
+    /// Construct and persist one serialized log record; see the README for fencing assumptions.
+    pub(crate) async fn write(
+        &self,
+        s3: &GuardianS3Client,
+        session_id: SessionID,
+        message: LogMessage,
+        signing_key: &GuardianSignKeyPair,
+    ) {
+        let mut state = self.state.lock().await;
+        let write_started_at = Instant::now();
+        let record = LogRecord::new(session_id, message, signing_key);
+        let deadline = state.next_write_deadline();
+
+        write_with_retries(s3, &record, deadline).await;
+        if record.log_type() == LogType::Heartbeat {
+            state.renew(write_started_at);
+        }
+    }
+}
+
+async fn write_with_retries(
+    s3: &GuardianS3Client,
+    record: &LogRecord,
+    absolute_deadline: Option<Instant>,
+) {
+    let key = record.object_key();
+    let mut last_error = None;
+
+    for attempt in 1..=MAX_S3_WRITE_ATTEMPTS {
+        let attempt_deadline = Instant::now()
+            .checked_add(S3_WRITE_ATTEMPT_TIMEOUT)
+            .expect("S3 write deadline overflow");
+        if absolute_deadline.is_some_and(|deadline| attempt_deadline >= deadline) {
+            panic_write_failure(
+                key,
+                "cannot complete another S3 attempt before the heartbeat fence",
+                last_error,
+            );
+        }
+
+        match complete_before_attempt_deadline(attempt_deadline, s3.write_log_record_once(record))
+            .await
+        {
+            Ok(Ok(())) => return,
+            Ok(Err(error)) => last_error = Some(error),
+            Err(DeadlineExceeded::PerAttemptTimerElapsed) => {
+                last_error = Some(S3Error(format!(
+                    "S3 log {key} reached its attempt deadline before completion was accepted"
+                )));
+            }
+            Err(DeadlineExceeded::CompletionObservedLate(Ok(()))) => {
+                last_error = Some(S3Error(format!(
+                    "S3 log {key} was confirmed after its attempt deadline"
+                )));
+            }
+            Err(DeadlineExceeded::CompletionObservedLate(Err(error))) => {
+                last_error = Some(S3Error(format!(
+                    "S3 log {key} failed after its attempt deadline: {error}"
+                )));
+            }
+        }
+
+        if attempt < MAX_S3_WRITE_ATTEMPTS {
+            warn!(
+                %key,
+                attempt,
+                max_attempts = MAX_S3_WRITE_ATTEMPTS,
+                error = ?last_error,
+                "S3 log write attempt failed; retrying"
+            );
+            tokio::time::sleep(S3_WRITE_RETRY_INTERVAL).await;
+        }
+    }
+
+    panic_write_failure(
+        key,
+        "failed after the maximum number of S3 attempts",
+        last_error,
+    )
+}
+
+fn panic_write_failure(key: &str, reason: &str, error: Option<GuardianError>) -> ! {
+    if let Some(error) = error {
+        panic!("S3 log {key} {reason}: {error}");
+    }
+    panic!("S3 log {key} {reason}");
+}
+
+/// Complete one S3 attempt before its deadline; see the README for fencing assumptions.
+async fn complete_before_attempt_deadline<F>(
+    deadline: Instant,
+    future: F,
+) -> Result<F::Output, DeadlineExceeded<F::Output>>
+where
+    F: Future,
+{
+    tokio::select! {
+        // biased ensures that the deadline check is polled first
+        biased;
+        // Deadline check
+        _ = tokio::time::sleep_until(deadline) => {
+            Err(DeadlineExceeded::PerAttemptTimerElapsed)
+        },
+        // S3 write check
+        result = future => {
+            if Instant::now() < deadline {
+                Ok(result)
+            } else {
+                Err(DeadlineExceeded::CompletionObservedLate(result))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_s3::operation::put_object::PutObjectOutput;
+    use aws_sdk_s3::Client;
+    use aws_smithy_mocks::mock;
+    use aws_smithy_mocks::mock_client;
+    use aws_smithy_mocks::RuleMode;
+    use hashi_types::guardian::GuardianInfo;
+    use hashi_types::guardian::HeartbeatLogMessage;
+    use hashi_types::guardian::InitLogMessage;
+    use hashi_types::guardian::NitroAttestation;
+    use hashi_types::guardian::ResolvedS3Config;
+    use std::future::pending;
+    use std::future::ready;
+    use std::sync::Arc;
+
+    fn signing_key() -> GuardianSignKeyPair {
+        GuardianSignKeyPair::from([7u8; 32])
+    }
+
+    fn session_id(signing_key: &GuardianSignKeyPair) -> SessionID {
+        SessionID::from_signing_pubkey(&signing_key.verification_key())
+    }
+
+    fn mock_s3(client: Client) -> GuardianS3Client {
+        GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client)
+    }
+
+    fn heartbeat(seq: u64) -> LogMessage {
+        LogMessage::Heartbeat(HeartbeatLogMessage::new(seq))
+    }
+
+    fn first_init(signing_key: &GuardianSignKeyPair) -> LogMessage {
+        LogMessage::Init(Box::new(InitLogMessage::OIAttestationUnsigned {
+            attestation: NitroAttestation::new(vec![]),
+            signing_public_key: signing_key.verification_key(),
+        }))
+    }
+
+    fn signed_init() -> LogMessage {
+        LogMessage::Init(Box::new(InitLogMessage::OIGuardianInfo(Box::new(
+            GuardianInfo::mock_for_testing(),
+        ))))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_four_failures_then_succeeds() {
+        let put_flaky = mock!(Client::put_object)
+            .match_requests(|req| {
+                req.key()
+                    .is_some_and(|key| key.ends_with("01-oi-attestation-unsigned.json"))
+            })
+            .sequence()
+            .http_status(500, None)
+            .times(4)
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&put_flaky]);
+        let s3 = mock_s3(client);
+        let writer = LogWriter::new();
+        let signing_key = signing_key();
+
+        writer
+            .write(
+                &s3,
+                session_id(&signing_key),
+                first_init(&signing_key),
+                &signing_key,
+            )
+            .await;
+
+        assert_eq!(put_flaky.num_calls(), 5);
+    }
+
+    #[tokio::test]
+    async fn write_waits_for_serialization_lock_before_put() {
+        let put_ok = mock!(Client::put_object).then_output(|| PutObjectOutput::builder().build());
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_ok]);
+        let s3 = Arc::new(mock_s3(client));
+        let writer = Arc::new(LogWriter::new());
+        let signing_key = Arc::new(signing_key());
+        let state_guard = writer.state.lock().await;
+
+        let task = {
+            let writer = writer.clone();
+            let s3 = s3.clone();
+            let signing_key = signing_key.clone();
+            tokio::spawn(async move {
+                writer
+                    .write(
+                        &s3,
+                        session_id(&signing_key),
+                        first_init(&signing_key),
+                        &signing_key,
+                    )
+                    .await
+            })
+        };
+        tokio::task::yield_now().await;
+
+        assert_eq!(put_ok.num_calls(), 0);
+        drop(state_guard);
+        task.await.unwrap();
+        assert_eq!(put_ok.num_calls(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn write_panics_after_five_failures() {
+        let put_fail = mock!(Client::put_object)
+            .sequence()
+            .http_status(500, None)
+            .times(5)
+            .build();
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_fail]);
+        let s3 = Arc::new(mock_s3(client));
+        let writer = Arc::new(LogWriter::new());
+        let signing_key = Arc::new(signing_key());
+
+        let task = tokio::spawn(async move {
+            writer
+                .write(
+                    &s3,
+                    session_id(&signing_key),
+                    first_init(&signing_key),
+                    &signing_key,
+                )
+                .await
+        });
+
+        assert!(task.await.unwrap_err().is_panic());
+        assert_eq!(put_fail.num_calls(), 5);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn no_attempt_starts_when_its_full_budget_reaches_the_fence() {
+        let put_ok = mock!(Client::put_object).then_output(|| PutObjectOutput::builder().build());
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_ok]);
+        let s3 = Arc::new(mock_s3(client));
+        let writer = Arc::new(LogWriter::new());
+        let signing_key = Arc::new(signing_key());
+
+        writer
+            .write(&s3, session_id(&signing_key), heartbeat(1), &signing_key)
+            .await;
+        tokio::time::advance(
+            OTHER_SESSION_QUIET_PERIOD
+                - ACTIVATING_READER_CLOCK_SKEW_BUDGET
+                - S3_WRITE_ATTEMPT_TIMEOUT,
+        )
+        .await;
+
+        let task = {
+            let writer = writer.clone();
+            let s3 = s3.clone();
+            let signing_key = signing_key.clone();
+            tokio::spawn(async move {
+                writer
+                    .write(&s3, session_id(&signing_key), signed_init(), &signing_key)
+                    .await
+            })
+        };
+
+        assert!(task.await.unwrap_err().is_panic());
+        assert_eq!(put_ok.num_calls(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn non_heartbeat_write_does_not_renew_the_heartbeat_fence() {
+        let put_ok = mock!(Client::put_object).then_output(|| PutObjectOutput::builder().build());
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_ok]);
+        let s3 = Arc::new(mock_s3(client));
+        let writer = Arc::new(LogWriter::new());
+        let signing_key = Arc::new(signing_key());
+
+        writer
+            .write(&s3, session_id(&signing_key), heartbeat(1), &signing_key)
+            .await;
+        tokio::time::advance(Duration::from_mins(3)).await;
+        writer
+            .write(&s3, session_id(&signing_key), signed_init(), &signing_key)
+            .await;
+        tokio::time::advance(Duration::from_mins(1)).await;
+
+        let task = tokio::spawn(async move {
+            writer
+                .write(&s3, session_id(&signing_key), heartbeat(2), &signing_key)
+                .await
+        });
+
+        assert!(task.await.unwrap_err().is_panic());
+        assert_eq!(put_ok.num_calls(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn successful_heartbeat_renews_the_heartbeat_fence() {
+        let put_ok = mock!(Client::put_object).then_output(|| PutObjectOutput::builder().build());
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_ok]);
+        let s3 = mock_s3(client);
+        let writer = LogWriter::new();
+        let signing_key = signing_key();
+
+        writer
+            .write(&s3, session_id(&signing_key), heartbeat(1), &signing_key)
+            .await;
+        tokio::time::advance(Duration::from_mins(3)).await;
+        writer
+            .write(&s3, session_id(&signing_key), heartbeat(2), &signing_key)
+            .await;
+        tokio::time::advance(Duration::from_mins(3)).await;
+        writer
+            .write(&s3, session_id(&signing_key), signed_init(), &signing_key)
+            .await;
+
+        assert_eq!(put_ok.num_calls(), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deadline_wins_when_write_is_also_ready() {
+        let deadline = Instant::now();
+
+        let result = complete_before_attempt_deadline(deadline, ready(())).await;
+
+        assert!(matches!(
+            result,
+            Err(DeadlineExceeded::PerAttemptTimerElapsed)
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pending_write_loses_when_attempt_deadline_elapses() {
+        let deadline = Instant::now() + S3_WRITE_ATTEMPT_TIMEOUT;
+
+        let result = complete_before_attempt_deadline(deadline, pending::<()>()).await;
+
+        assert!(matches!(
+            result,
+            Err(DeadlineExceeded::PerAttemptTimerElapsed)
+        ));
+        assert_eq!(Instant::now(), deadline);
+    }
+}

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -17,6 +17,7 @@ use std::collections::BTreeSet;
 use std::sync::Once;
 use std::time::Duration;
 use std::time::SystemTime;
+use tokio::time::Instant;
 
 use aws_sdk_s3::config::retry::RetryConfig;
 use aws_sdk_s3::primitives::ByteStream;
@@ -176,6 +177,19 @@ impl GuardianS3Client {
         self.write_at_key(&key, &log, object_lock_duration).await
     }
 
+    /// Attempt one immutable log write before an absolute fencing deadline.
+    pub(crate) async fn write_log_record_before(
+        &self,
+        log: LogRecord,
+        deadline: Instant,
+    ) -> GuardianResult<()> {
+        let key = log.object_key().to_string();
+        match tokio::time::timeout_at(deadline, self.write_log_record(log)).await {
+            Ok(result) => result,
+            Err(_) => panic!("S3 log {key} was not written before its fencing deadline"),
+        }
+    }
+
     /// Retry an immutable log write through the grace period, then abort.
     /// State-changing RPCs call this from their root-owned task.
     pub async fn write_log_record_or_abort(&self, log: LogRecord) -> GuardianResult<()> {
@@ -187,10 +201,33 @@ impl GuardianS3Client {
         .await
     }
 
+    /// Retry an immutable log write until an absolute heartbeat-fencing deadline.
+    pub(crate) async fn write_log_record_or_abort_before(
+        &self,
+        log: LogRecord,
+        deadline: Instant,
+    ) -> GuardianResult<()> {
+        self.write_log_record_or_abort_until(log, deadline, S3_WRITE_RETRY_INTERVAL)
+            .await
+    }
+
     async fn write_log_record_or_abort_inner(
         &self,
         log: LogRecord,
         max_failure_interval: Duration,
+        retry_interval: Duration,
+    ) -> GuardianResult<()> {
+        let deadline = Instant::now()
+            .checked_add(max_failure_interval)
+            .expect("S3 write deadline overflow");
+        self.write_log_record_or_abort_until(log, deadline, retry_interval)
+            .await
+    }
+
+    async fn write_log_record_or_abort_until(
+        &self,
+        log: LogRecord,
+        deadline: Instant,
         retry_interval: Duration,
     ) -> GuardianResult<()> {
         let object_lock_duration = self.object_lock_duration(&log);
@@ -207,12 +244,9 @@ impl GuardianS3Client {
             }
         };
 
-        match tokio::time::timeout(max_failure_interval, write_until_success).await {
+        match tokio::time::timeout_at(deadline, write_until_success).await {
             Ok(result) => result,
-            Err(_) => panic!(
-                "S3 log {} was not written within {:?}",
-                key, max_failure_interval
-            ),
+            Err(_) => panic!("S3 log {key} was not written before its deadline"),
         }
     }
 
@@ -918,7 +952,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "was not written within")]
+    #[should_panic(expected = "was not written before its deadline")]
     async fn test_log_writer_panics_after_failure_interval() {
         let put_fail = mock!(Client::put_object)
             .match_requests(|req| req.bucket() == Some("bucket"))

--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::MAX_S3_WRITE_FAILURE_INTERVAL;
 use anyhow::Context;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_credential_types::provider::SharedCredentialsProvider;
@@ -32,10 +31,9 @@ use serde::Serialize;
 use tracing::info;
 use tracing::warn;
 
-/// Maximum attempts the AWS SDK makes before returning one write failure.
+/// Maximum attempts the AWS SDK makes for reads and control-plane operations.
+/// Log PUTs override this because the Guardian log writer owns their retries.
 const MAX_RETRY_ATTEMPTS: u32 = 5;
-/// Delay between application-level retries of an immutable S3 log write.
-const S3_WRITE_RETRY_INTERVAL: Duration = Duration::from_secs(10);
 // TODO(testnet-wipe): Remove this escape hatch after the planned testnet wipe.
 /// Temporary testnet escape hatch for logs whose legacy seven-day locks expired.
 const SKIP_S3_OBJECT_LOCK_CHECK_ENV: &str = "HASHI_SKIP_S3_OBJECT_LOCK_CHECK";
@@ -169,51 +167,12 @@ impl GuardianS3Client {
     // S3 Write
     // ========================================================================
 
-    /// Attempt one immutable log write, relying on the AWS SDK retry policy.
-    pub async fn write_log_record(&self, log: LogRecord) -> GuardianResult<()> {
-        let key = log.object_key().to_string();
-        let object_lock_duration = self.object_lock_duration(&log);
-        self.write_at_key(&key, &log, object_lock_duration).await
-    }
-
-    /// Retry an immutable log write through the grace period, then abort.
-    /// State-changing RPCs call this from their root-owned task.
-    pub async fn write_log_record_or_abort(&self, log: LogRecord) -> GuardianResult<()> {
-        self.write_log_record_or_abort_inner(
-            log,
-            MAX_S3_WRITE_FAILURE_INTERVAL,
-            S3_WRITE_RETRY_INTERVAL,
-        )
-        .await
-    }
-
-    async fn write_log_record_or_abort_inner(
-        &self,
-        log: LogRecord,
-        max_failure_interval: Duration,
-        retry_interval: Duration,
-    ) -> GuardianResult<()> {
-        let object_lock_duration = self.object_lock_duration(&log);
+    /// Attempt one immutable log PUT. The Guardian log writer owns retries and
+    /// deadlines, so SDK retries are disabled for this operation.
+    pub(crate) async fn write_log_record_once(&self, log: &LogRecord) -> GuardianResult<()> {
         let key = log.object_key();
-        let write_until_success = async {
-            loop {
-                match self.write_at_key(key, &log, object_lock_duration).await {
-                    Ok(()) => return Ok(()),
-                    Err(error) => {
-                        warn!(%key, ?error, "S3 log write failed; retrying");
-                        tokio::time::sleep(retry_interval).await;
-                    }
-                }
-            }
-        };
-
-        match tokio::time::timeout(max_failure_interval, write_until_success).await {
-            Ok(result) => result,
-            Err(_) => panic!(
-                "S3 log {} was not written within {:?}",
-                key, max_failure_interval
-            ),
-        }
+        let object_lock_duration = self.object_lock_duration(log);
+        self.write_at_key_once(key, log, object_lock_duration).await
     }
 
     fn object_lock_duration(&self, log: &LogRecord) -> Duration {
@@ -223,7 +182,7 @@ impl GuardianS3Client {
     /// Write a value to S3 at an explicit key.
     ///
     /// This is intended for ordered log streams where the caller determines the key.
-    async fn write_at_key<T: Serialize>(
+    async fn write_at_key_once<T: Serialize>(
         &self,
         key: &str,
         value: &T,
@@ -252,6 +211,10 @@ impl GuardianS3Client {
             .object_lock_retain_until_date(DateTime::from(expiry_time))
             .if_none_match("*")
             .body(ByteStream::from(body.clone()))
+            .customize()
+            .config_override(
+                aws_sdk_s3::config::Builder::new().retry_config(RetryConfig::disabled()),
+            )
             .send()
             .await;
         if let Err(e) = result {
@@ -786,7 +749,7 @@ mod tests {
         let logger = mk_logger_with_client(client);
         let object_lock_duration = Duration::from_mins(5);
         logger
-            .write_at_key(
+            .write_at_key_once(
                 "init/session/01-oi-attestation-unsigned.json",
                 &TestPayload { a: 1 },
                 object_lock_duration,
@@ -823,7 +786,7 @@ mod tests {
         );
         let logger = mk_logger_with_client(client);
         logger
-            .write_at_key("key", &TestPayload { a: 1 }, Duration::from_mins(5))
+            .write_at_key_once("key", &TestPayload { a: 1 }, Duration::from_mins(5))
             .await
             .unwrap();
 
@@ -855,7 +818,7 @@ mod tests {
         );
         let logger = mk_logger_with_client(client);
         logger
-            .write_at_key("key", &TestPayload { a: 1 }, Duration::from_mins(5))
+            .write_at_key_once("key", &TestPayload { a: 1 }, Duration::from_mins(5))
             .await
             .unwrap();
     }
@@ -884,74 +847,13 @@ mod tests {
         );
         let logger = mk_logger_with_client(client);
         logger
-            .write_at_key("key", &TestPayload { a: 1 }, Duration::from_mins(5))
+            .write_at_key_once("key", &TestPayload { a: 1 }, Duration::from_mins(5))
             .await
             .unwrap();
     }
 
     #[tokio::test]
-    async fn test_log_writer_retries_beyond_sdk_attempts() {
-        let put_flaky = mock!(Client::put_object)
-            .match_requests(|req| req.bucket() == Some("bucket"))
-            .sequence()
-            .http_status(500, None)
-            .times(5)
-            .output(|| PutObjectOutput::builder().build())
-            .build();
-        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&put_flaky], |b| b
-            .retry_config(RetryConfig::standard().with_max_attempts(1)));
-        let logger = mk_logger_with_client(client);
-        let signing_key = GuardianSignKeyPair::new(rand::thread_rng());
-        let log = LogRecord::new(
-            "session".into(),
-            LogMessage::Heartbeat(HeartbeatLogMessage::new(7)),
-            &signing_key,
-        );
-
-        // The generous deadline avoids CI timing sensitivity without slowing success;
-        // zero delay keeps the application-level retry sequence immediate.
-        logger
-            .write_log_record_or_abort_inner(log, Duration::from_secs(10), Duration::ZERO)
-            .await
-            .unwrap();
-        assert_eq!(put_flaky.num_calls(), 6);
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "was not written within")]
-    async fn test_log_writer_panics_after_failure_interval() {
-        let put_fail = mock!(Client::put_object)
-            .match_requests(|req| req.bucket() == Some("bucket"))
-            .sequence()
-            .http_status(500, None)
-            .times(100)
-            .build();
-        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_fail], |builder| {
-            builder.retry_config(RetryConfig::standard().with_max_attempts(1))
-        });
-        let logger = mk_logger_with_client(client);
-        let signing_key = GuardianSignKeyPair::new(rand::thread_rng());
-        let log = LogRecord::new(
-            "session".into(),
-            LogMessage::Heartbeat(HeartbeatLogMessage::new(7)),
-            &signing_key,
-        );
-
-        // The first PUT runs immediately, then retries every 5ms until the 50ms
-        // deadline panics (roughly 10 attempts; scheduling makes the count inexact).
-        logger
-            .write_log_record_or_abort_inner(
-                log,
-                Duration::from_millis(50),
-                Duration::from_millis(5),
-            )
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_write_retries_on_transient_failures() {
-        // Two transient failures followed by success.
+    async fn log_put_disables_sdk_retries() {
         let put_flaky = mock!(Client::put_object)
             .match_requests(|req| req.bucket() == Some("bucket"))
             .sequence()
@@ -960,21 +862,23 @@ mod tests {
             .output(|| PutObjectOutput::builder().build())
             .build();
 
-        // Override retry attempts on the test client so the operation has enough attempts
-        // to reach the success response.
+        // The client would retry three times, but log PUTs override that policy
+        // so the serialized writer is the only retry controller.
         let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&put_flaky], |b| b
             .retry_config(RetryConfig::standard().with_max_attempts(3)));
         let logger = mk_logger_with_client(client);
         let object_lock_duration = Duration::from_mins(5);
-        logger
-            .write_at_key(
+        let error = logger
+            .write_at_key_once(
                 "init/session/01-oi-attestation-unsigned.json",
                 &TestPayload { a: 1 },
                 object_lock_duration,
             )
             .await
-            .unwrap();
-        assert_eq!(put_flaky.num_calls(), 3);
+            .expect_err("one PUT failure must be returned to the log writer");
+
+        assert!(matches!(error, S3Error(_)));
+        assert_eq!(put_flaky.num_calls(), 1);
     }
 
     #[test]

--- a/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/heartbeat.rs
@@ -33,8 +33,8 @@ impl HeartbeatWriter {
     ///
     /// - If operator init is not complete, this is a no-op.
     ///
-    /// The shared S3 writer retries failures and aborts the process if its grace
-    /// period expires.
+    /// The shared S3 writer retries failures and aborts the process on a
+    /// terminal retry or heartbeat-fence failure.
     pub async fn tick(&mut self) -> GuardianResult<()> {
         if self.enclave.lifecycle() == WithdrawStage::Uninitialized.into() {
             return Ok(());
@@ -94,5 +94,14 @@ mod tests {
             panic!("expected V2 heartbeat record");
         };
         assert_eq!(message.seq, 0);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "heartbeats are only supported in withdraw mode")]
+    async fn ceremony_mode_rejects_heartbeats() {
+        Enclave::create_with_random_keys_for_mode(EnclaveMode::Ceremony)
+            .log_heartbeat(HeartbeatLogMessage::new(0))
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- serialize every Guardian S3 log write through one enclave-wide writer
- use one explicit retry layer: up to five attempts, a fresh five-minute timeout per attempt, and a ten-second retry interval
- disable AWS SDK retries for log PUTs while retaining the configured SDK retry policy for reads and control-plane operations
- renew the withdraw-session write deadline only after a successful heartbeat write
- require every subsequent S3 attempt to have its complete timeout available before the heartbeat-derived absolute deadline
- apply the same retry and fail-stop policy to initialization, ceremony, heartbeat, and serving-operation logs

Successful withdrawals, committee updates, and other non-heartbeat records do not extend the deadline. Serving operations require activation, and activation requires a recent durable heartbeat, so an activated withdraw enclave has a heartbeat-derived write fence.

## Behavior

Before this change, initialization logs relied on SDK retries, while other log writes used an application-level five-minute retry window around SDK-retried operations.

After this change, every log type uses the serialized writer. Each log PUT gets one SDK attempt, the writer retries timely failures up to five times, and any terminal write failure aborts the enclave. Once a heartbeat has succeeded, no new PUT starts unless its full five-minute attempt budget fits before the absolute deadline derived from that heartbeat.

Conditional PUTs remain idempotent: if an acknowledgement is lost and a retry receives `412 Precondition Failed`, the writer accepts the existing object only after verifying exact contents and a compliance lock.

## Fencing assumptions

The writer uses monotonic time and captures the renewal instant immediately before constructing the signed heartbeat record. The cooperative deadline check assumes that:

- monotonic time advances across platform suspension
- suspension does not resume execution within a future poll between a deadline check and network transmission or result propagation
- S3 does not make a timed-out request durable arbitrarily later
- the activating reader clock is not ahead of the writer when applying the same quiet-period boundary

## Verification

- `cargo fmt -- --config imports_granularity=Item --config format_code_in_doc_comments=true`
- `cargo check`
- `cargo test -p hashi-guardian log_writer::tests` — 9 passed
- `cargo test -p hashi-guardian` — 96 passed
- `cargo test -p hashi-guardian-init` — 8 passed
