### PR TITLE
Account for transaction weight during UTXO selection

### DIFF
--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -786,6 +786,7 @@ pub fn select_coins(
             net_amount: 0,
         });
     }
+    let total_requested = builder.total_requested();
 
     // ── Step 2: Input selection (largest-first) ────────────────────────────
     //
@@ -801,17 +802,17 @@ pub fn select_coins(
                 // Also ensure that if this UTXO were to be selected, the resulting unconfirmed
                 // chain depth would be less than the max relay limit
                 && u.status.mempool_chain_depth() < MAX_ANCESTOR_DEPTH
-                // Unspendable: its ancestors plus the input it would add
-                // already fill the package budget. Skipped rather than left
-                // to fail the selection, since largest-first would pick it
+                // Unspendable: its ancestors plus the lower-bound transaction
+                // weight containing this input exceed the package budget. Skipped rather
+                // than left to fail the selection, since largest-first would pick it
                 // on every retry and block withdrawals the others could fund.
-                && u.status.unconfirmed_ancestor_weight() + u.spend_path.input_weight()
-                    < params.max_ancestor_package_weight
+                && u.status.unconfirmed_ancestor_weight()
+                    + builder.weight_with_candidate(u, total_requested)
+                    <= params.max_ancestor_package_weight
         })
         .collect();
     pool.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| a.id.cmp(&b.id)));
 
-    let total_requested = builder.total_requested();
     let mut input_total = 0u64;
 
     for utxo in &pool {
@@ -969,6 +970,26 @@ impl<'a> TransactionBuilder<'a> {
     fn weight(&self) -> Weight {
         let input_count = self.inputs.len();
         let has_change = self.raw_change.is_none_or(|v| v > 0);
+        let input_weight = self
+            .inputs
+            .iter()
+            .map(|u| u.spend_path.input_weight())
+            .sum();
+
+        self.weight_for(input_count, input_weight, has_change)
+    }
+
+    /// Lower-bound transaction weight containing `candidate` and all selected outputs.
+    /// Includes change when the candidate alone overfunds the selected requests.
+    fn weight_with_candidate(&self, candidate: &UtxoCandidate, total_requested: u64) -> Weight {
+        self.weight_for(
+            1,
+            candidate.spend_path.input_weight(),
+            candidate.amount > total_requested,
+        )
+    }
+
+    fn weight_for(&self, input_count: usize, input_weight: Weight, has_change: bool) -> Weight {
         let output_count = self.outputs.len() + if has_change { 1 } else { 0 };
 
         // Non-witness fixed fields (scaled ×4):
@@ -980,13 +1001,6 @@ impl<'a> TransactionBuilder<'a> {
         let fixed = Weight::from_wu(32 + 2)
             + varint_weight(input_count as u64)
             + varint_weight(output_count as u64);
-
-        // Sum of all input weights (base + witness satisfaction).
-        let inputs: Weight = self
-            .inputs
-            .iter()
-            .map(|u| u.spend_path.input_weight())
-            .sum();
 
         // Sum of all withdrawal output weights.
         let outputs: Weight = self
@@ -1002,7 +1016,7 @@ impl<'a> TransactionBuilder<'a> {
             Weight::ZERO
         };
 
-        fixed + inputs + outputs + change
+        fixed + input_weight + outputs + change
     }
 
     /// The total value of all selected inputs.

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -1920,6 +1920,53 @@ fn test_infeasible_pending_candidate_is_skipped_not_fatal() {
     assert_conservation(&result);
 }
 
+/// Candidate eligibility must include the complete transaction, not only the
+/// candidate's input weight. This mirrors the package that blocked testnet.
+#[test]
+fn test_candidate_filter_includes_complete_transaction_weight() {
+    let stalled = pending_utxo_mixed(
+        1,
+        100_000_000,
+        &[
+            (0, 133_116, 10_000_000),
+            (0, 133_115, 10_000_000),
+            (0, 133_115, 10_000_000),
+        ],
+    );
+    let usable = confirmed_utxo(2, 5_000_000);
+    let requests = vec![make_request(1, 1_000_000, 0)];
+    let params = default_params();
+
+    let ancestor_weight = stalled.status.unconfirmed_ancestor_weight();
+    assert_eq!(ancestor_weight, Weight::from_wu(399_346));
+    assert!(
+        ancestor_weight + stalled.spend_path.input_weight() <= params.max_ancestor_package_weight,
+        "the old input-only eligibility check must admit this candidate"
+    );
+
+    let builder = TransactionBuilder {
+        fee_rate: default_fee_rate(),
+        params: &params,
+        inputs: Vec::new(),
+        outputs: vec![PendingOutput {
+            request: &requests[0],
+            net_amount: 0,
+        }],
+        raw_change: None,
+        final_change: None,
+    };
+    let candidate_weight = builder.weight_with_candidate(&stalled, 1_000_000);
+    assert_eq!(candidate_weight, Weight::from_wu(818));
+    assert!(ancestor_weight + candidate_weight > params.max_ancestor_package_weight);
+
+    let result = select_coins(&[stalled, usable], &requests, &params, default_fee_rate())
+        .expect("the confirmed UTXO should still fund the request");
+
+    assert_eq!(result.inputs.len(), 1);
+    assert_eq!(result.inputs[0].id, make_utxo_id(2));
+    assert_conservation(&result);
+}
+
 /// A shared parent must count once: one paying above target carries a
 /// surplus that, credited twice, cancels an underpayer's deficit.
 #[test]


### PR DESCRIPTION
This PR fixes the withdrawal blocker where Hashi repeatedly selected the same pending UTXO. Its ancestors fit under Bitcoin’s package-weight limit by themselves, but adding the withdrawal transaction pushed the package over the limit. Hashi only checked ancestor + input weight before selection, so every retry chose the same unusable UTXO and failed. The fix checks the full transaction weight upfront, skips that UTXO, and selects a usable alternative.
