### PR TITLE
leader: archive confirmed withdrawals through a batched, version-gated GC

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -234,13 +234,25 @@ mod tests {
         }
     }
 
-    fn assert_deposit_request_unapproved(networks: &TestNetworks, request_id: Address) {
-        let onchain_state = networks.hashi_network.nodes()[0].hashi().onchain_state();
-        let deposit_request = onchain_state
-            .deposit_requests()
-            .into_iter()
-            .find(|request| request.id == request_id)
-            .unwrap_or_else(|| panic!("deposit request {request_id} not found"));
+    async fn assert_deposit_request_unapproved(networks: &TestNetworks, request_id: Address) {
+        // The mirror observes the create transaction a checkpoint later, so
+        // wait for visibility before asserting the property itself.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let deposit_request = loop {
+            let found = networks.hashi_network.nodes()[0]
+                .hashi()
+                .onchain_state()
+                .deposit_requests()
+                .into_iter()
+                .find(|request| request.id == request_id);
+            if let Some(request) = found {
+                break request;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("deposit request {request_id} never appeared in the mirror");
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        };
         assert!(
             deposit_request.approval_cert.is_none(),
             "brand-new deposit should not be approved by epoch-change stale-cert processing"
@@ -433,7 +445,7 @@ mod tests {
                 Some(hbtc_recipient),
             )
             .await?;
-        assert_deposit_request_unapproved(&networks, unapproved_request_id);
+        assert_deposit_request_unapproved(&networks, unapproved_request_id).await;
 
         let initial_epoch = networks.hashi_network.nodes()[0]
             .current_epoch()
@@ -460,7 +472,7 @@ mod tests {
             Duration::from_secs(180),
         )
         .await?;
-        assert_deposit_request_unapproved(&networks, unapproved_request_id);
+        assert_deposit_request_unapproved(&networks, unapproved_request_id).await;
 
         let hbtc_balance = get_hbtc_balance(
             &mut networks.sui_network.client,

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -1613,10 +1613,18 @@ mod tests {
         use hashi::cli::client::CreateProposalParams;
         use hashi::cli::client::build_create_proposal_transaction;
 
+        // Calls route through the chain's LATEST package: the default boot
+        // upgrades to the current source and disables v1, so a call built
+        // against the original id aborts at `versioning::assert_version_enabled`.
+        let execute_package_id = hashi
+            .onchain_state()
+            .package_id()
+            .unwrap_or(hashi_ids.package_id);
+
         let validator_address = executor.sender();
         let builder = build_create_proposal_transaction(
             hashi_ids,
-            hashi_ids.package_id,
+            execute_package_id,
             validator_address,
             CreateProposalParams::UpdateConfig {
                 key: "bitcoin_deposit_minimum".to_string(),
@@ -1712,12 +1720,19 @@ mod tests {
         let hashi_ids = networks.hashi_network.ids();
         let mut executor = SuiTxExecutor::from_config(&healthy.config, healthy.onchain_state())?;
         let creator = executor.sender();
+        // Calls route through the chain's LATEST package: the default boot
+        // disables v1, so the original id would abort at
+        // `versioning::assert_version_enabled`.
+        let execute_package_id = healthy
+            .onchain_state()
+            .package_id()
+            .unwrap_or(hashi_ids.package_id);
         let mut proposal_ids = Vec::new();
         let mut last_checkpoint = 0u64;
         for i in 0..3u64 {
             let builder = build_create_proposal_transaction(
                 hashi_ids,
-                hashi_ids.package_id,
+                execute_package_id,
                 creator,
                 CreateProposalParams::UpdateConfig {
                     // Never voted on or executed, so the values are inert.

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -512,6 +512,16 @@ mod tests {
         );
 
         let hashi = networks.hashi_network.nodes()[0].hashi().clone();
+
+        // The archival assertion below is v2 behavior; a dormant flow (v1
+        // still enabled) would run v1 semantics and time it out. Pin that
+        // the default boot's DisableVersion(1) actually opened the gate.
+        assert_eq!(
+            hashi.onchain_state().withdrawal_effective_version(),
+            Some(2),
+            "the withdrawal dormancy gate must be open under the default boot"
+        );
+
         let user_key = networks.sui_network.user_keys.first().unwrap();
         let withdrawal_amount_sats = 30_000u64;
         let btc_destination = networks.bitcoin_node.get_new_address()?;
@@ -670,28 +680,9 @@ mod tests {
         )
         .await?;
         rotate_into_avid(&mut networks).await?;
-        {
-            let hashi_ids = networks.hashi_network.ids();
-            let stamped_package = networks.hashi_network.nodes()[0]
-                .hashi()
-                .onchain_state()
-                .active_package()
-                .expect("an active package after upgrade")
-                .0;
-            let mut executors: Vec<hashi::sui_tx_executor::SuiTxExecutor> = networks
-                .hashi_network
-                .nodes()
-                .iter()
-                .map(|node| {
-                    hashi::sui_tx_executor::SuiTxExecutor::from_config(
-                        &node.hashi().config,
-                        node.hashi().onchain_state(),
-                    )
-                })
-                .collect::<Result<_>>()?;
-            crate::upgrade_flow::disable_version(&mut executors, hashi_ids, 1, stamped_package)
-                .await?;
-        }
+        // No in-test DisableVersion(1): the default builder boot already
+        // disables v1 (a second disable would abort on-chain). The
+        // assertion below still pins the layout precondition.
         {
             let hashi = networks.hashi_network.nodes()[0].hashi();
             let mpc_manager = hashi.mpc_manager().expect("mpc manager after rotation");
@@ -2653,6 +2644,17 @@ mod tests {
         rotate_into_avid(&mut networks).await?;
 
         let hashi = networks.hashi_network.nodes()[0].hashi().clone();
+
+        // The drain-mode cap this test fills is the v2 cap; a dormant flow
+        // (v1 still enabled) would trim the batch to 298 and never fire at
+        // the configured capacity. Pin that the default boot's
+        // DisableVersion(1) actually opened the gate.
+        assert_eq!(
+            hashi.onchain_state().withdrawal_effective_version(),
+            Some(2),
+            "the withdrawal dormancy gate must be open under the default boot"
+        );
+
         let user_key = networks.sui_network.user_keys.first().unwrap().clone();
         let hbtc_recipient = user_key.public_key().derive_address();
 

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -37,6 +37,7 @@ mod tests {
     use crate::test_helpers::txid_to_address;
     use crate::test_helpers::wait_for_deposit_confirmation;
     use crate::test_helpers::wait_for_spent_utxo_cleanup;
+    use crate::test_helpers::wait_for_withdrawal_archival;
 
     const MAX_TX_SIZE_BYTES: usize = 131_072;
     const MAX_SERIALIZED_TX_EFFECTS_SIZE_BYTES: usize = 524_288;
@@ -576,6 +577,12 @@ mod tests {
         // must now clean them from its mirror, and the eventless cleanup
         // deletions must reach every node's mirror via the object stream.
         wait_for_spent_utxo_cleanup(&networks, Duration::from_secs(60)).await?;
+
+        // The confirm left the withdrawal txn (and its requests) in the hot
+        // bags; the leader's deferred-archival GC must move them to the
+        // archive bags on-chain, observable as the ids draining from every
+        // node's mirror. This pins the deferred-archival GC end-to-end.
+        wait_for_withdrawal_archival(&networks, Duration::from_secs(60)).await?;
 
         let guardian_state = networks
             .guardian_harness
@@ -1496,6 +1503,13 @@ mod tests {
         drop(miner);
 
         info!("Batch withdrawal confirmed on Sui");
+
+        // The confirm left the batched txn (and both requests) in the hot
+        // bags; the leader's deferred-archival GC must drain them from every
+        // node's mirror. This pins the deferred-archival GC end-to-end for
+        // the batched (multi-request) shape.
+        wait_for_withdrawal_archival(&networks, Duration::from_secs(60)).await?;
+
         info!("=== Batch Withdrawal Test Passed ===");
         Ok(())
     }

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -324,6 +324,16 @@ impl HashiNetwork {
     }
 
     pub async fn register_and_start_pending_node(&mut self, client: sui_rpc::Client) -> Result<()> {
+        // The registration call must route through the package that is enabled
+        // NOW (the default boot upgrades and disables v1 — the original id
+        // aborts at `versioning::assert_version_enabled`). The pending node has
+        // no Hashi instance to read the chain through, so borrow a running
+        // node's onchain state for the executor's version routing.
+        let onchain_state = self
+            .nodes
+            .iter()
+            .find(|n| n.is_running())
+            .map(|n| n.hashi().onchain_state().clone());
         let node = self
             .nodes
             .iter_mut()
@@ -343,7 +353,7 @@ impl HashiNetwork {
             [127, 0, 0, 1],
             hashi::config::get_available_port(),
         )));
-        register_onchain(client, &node.config).await?;
+        register_onchain(client, &node.config, onchain_state.as_ref()).await?;
         node.start().await?;
         Ok(())
     }
@@ -672,17 +682,35 @@ impl Default for HashiNetworkBuilder {
     }
 }
 
-async fn register_onchain(client: sui_rpc::Client, config: &HashiConfig) -> Result<()> {
+/// `onchain_state` supplies the executor's version routing so the register
+/// call executes the package that is enabled at submission time. Without it
+/// the executor falls back to the ORIGINAL package id, which aborts once the
+/// post-upgrade boot has disabled v1.
+async fn register_onchain(
+    client: sui_rpc::Client,
+    config: &HashiConfig,
+    onchain_state: Option<&hashi::onchain::OnchainState>,
+) -> Result<()> {
     let signer = config.operator_private_key()?;
     let hashi_ids = config.hashi_ids();
     let mut executor = hashi::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids);
+    if let Some(onchain_state) = onchain_state {
+        executor = executor.with_onchain_state(onchain_state);
+    }
     executor
         .execute_register_or_update_validator(config, None, None, None)
         .await
         .map(|_| ())
 }
 
-pub async fn update_tls_public_key(client: sui_rpc::Client, config: &HashiConfig) -> Result<()> {
+/// `call_package_id` is the package the Move call routes through — the
+/// chain's LATEST package (resolve it from a node's onchain state after the
+/// boot-time upgrade); the original id aborts once v1 is disabled.
+pub async fn update_tls_public_key(
+    client: sui_rpc::Client,
+    config: &HashiConfig,
+    call_package_id: Address,
+) -> Result<()> {
     let hashi_ids = config.hashi_ids();
     let private_key = config.operator_private_key()?;
     let validator_address = config.validator_address()?;
@@ -702,7 +730,7 @@ pub async fn update_tls_public_key(client: sui_rpc::Client, config: &HashiConfig
 
     builder.move_call(
         Function::new(
-            hashi_ids.package_id,
+            call_package_id,
             Identifier::from_static("validator"),
             Identifier::from_static("update_tls_public_key"),
         ),

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -148,6 +148,12 @@ pub struct TestNetworksBuilder {
     /// a real network is in. Opt out via [`Self::without_upgrade`] when v1-only
     /// is the point (snapshot signing) or the test drives its own upgrade.
     upgrade_to_current_source: bool,
+    /// When true, the auto-upgrade boot leaves v1 in the enabled set (the raw
+    /// legacy-upgrade outcome) instead of running DisableVersion(1). With v1
+    /// enabled the node-side withdrawal flow is dormant at v1 semantics, so
+    /// this is only for tests that deliberately exercise the both-enabled
+    /// bootstrap window. See [`Self::keep_v1_enabled`].
+    keep_v1_enabled: bool,
 }
 
 impl TestNetworksBuilder {
@@ -170,6 +176,7 @@ impl TestNetworksBuilder {
             external_guardian: None,
             v1_snapshot_dir: None,
             upgrade_to_current_source: true,
+            keep_v1_enabled: false,
         }
     }
 
@@ -178,6 +185,17 @@ impl TestNetworksBuilder {
     /// For tests where v1-only is the point, or that drive their own upgrade.
     pub fn without_upgrade(mut self) -> Self {
         self.upgrade_to_current_source = false;
+        self
+    }
+
+    /// Leave v1 in the enabled set after the default auto-upgrade boot,
+    /// skipping the DisableVersion(1) step. The node-side withdrawal flow
+    /// stays dormant at v1 semantics while v1 is enabled (see
+    /// `hashi::withdrawals::withdrawal_effective_version`), so only tests
+    /// that deliberately exercise the both-enabled bootstrap window (or that
+    /// drive DisableVersion(1) themselves) should opt in.
+    pub fn keep_v1_enabled(mut self) -> Self {
+        self.keep_v1_enabled = true;
         self
     }
 
@@ -464,6 +482,60 @@ impl TestNetworksBuilder {
             )
             .await?;
             tracing::info!("chain upgraded; the network runs the post-upgrade state");
+
+            // The legacy v1 -> v2 upgrade leaves BOTH versions enabled, and
+            // the node-side withdrawal flow stays dormant at v1 semantics
+            // while v1 is enabled (see
+            // `hashi::withdrawals::withdrawal_effective_version`). Close the
+            // bootstrap window through governance so the default boot hands
+            // tests a chain whose v2 withdrawal semantics are actually live;
+            // a withdrawal e2e running against the both-enabled window would
+            // silently exercise v1 and pass vacuously. Tests that need the
+            // window opt out via `keep_v1_enabled`.
+            if !self.keep_v1_enabled {
+                let hashi_ids = test_networks.hashi_network.ids();
+                let mut executors: Vec<hashi::sui_tx_executor::SuiTxExecutor> = test_networks
+                    .hashi_network
+                    .nodes()
+                    .iter()
+                    .filter(|node| node.is_running())
+                    .map(|node| {
+                        let hashi = node.hashi();
+                        hashi::sui_tx_executor::SuiTxExecutor::from_config(
+                            &hashi.config,
+                            hashi.onchain_state(),
+                        )
+                    })
+                    .collect::<Result<_>>()?;
+                upgrade_flow::disable_version(&mut executors, hashi_ids, 1, new_package_id).await?;
+                upgrade_flow::wait_for_version_disabled(
+                    &test_networks,
+                    1,
+                    std::time::Duration::from_secs(30),
+                )
+                .await?;
+                for (i, node) in test_networks
+                    .hashi_network
+                    .nodes()
+                    .iter()
+                    .filter(|node| node.is_running())
+                    .enumerate()
+                {
+                    let onchain = node.hashi().onchain_state();
+                    anyhow::ensure!(
+                        onchain.active_package_version() == Some(2),
+                        "node {i}: active version 2 must resolve after DisableVersion(1)"
+                    );
+                    anyhow::ensure!(
+                        onchain.withdrawal_effective_version() == Some(2),
+                        "node {i}: the withdrawal dormancy gate must be open (effective v2) \
+                         after DisableVersion(1)"
+                    );
+                }
+                tracing::info!(
+                    "version 1 disabled; the withdrawal flow runs v2 semantics on every node"
+                );
+            }
 
             // `update_config` cannot insert, and `init_defaults` runs only at the
             // original publish, so a key this upgrade adds keeps its default.

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -1627,7 +1627,15 @@ mod tests {
                 .unwrap()
                 .to_string(),
         );
-        super::hashi_network::update_tls_public_key(client, &updated_config)
+        // Route the call through the chain's LATEST package (the default boot
+        // upgrades and disables v1; the original id aborts at
+        // `versioning::assert_version_enabled`).
+        let call_package_id = test_networks.hashi_network().nodes()[0]
+            .hashi()
+            .onchain_state()
+            .package_id()
+            .unwrap_or(ids.package_id);
+        super::hashi_network::update_tls_public_key(client, &updated_config, call_package_id)
             .await
             .unwrap();
 

--- a/crates/e2e-tests/src/main.rs
+++ b/crates/e2e-tests/src/main.rs
@@ -931,7 +931,11 @@ async fn cmd_deposit(amount: u64, recipient: Option<&str>, data_dir: &Path) -> R
     let txid_address = sui_sdk_types::Address::new(txid.to_byte_array());
 
     let client = sui_rpc::Client::new(&state.sui_rpc_url)?;
-    let mut executor = hashi::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids);
+    // Attach the onchain state so the deposit call routes through the package
+    // version that is enabled NOW (a bare executor calls the ORIGINAL package,
+    // which aborts on a chain that has upgraded and disabled v1).
+    let mut executor = hashi::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids)
+        .with_onchain_state(&onchain_state);
 
     let request_id = executor
         .execute_create_deposit_request(txid_address, vout, amount, Some(recipient_addr))

--- a/crates/e2e-tests/src/test_helpers.rs
+++ b/crates/e2e-tests/src/test_helpers.rs
@@ -17,6 +17,7 @@ use hashi::sui_tx_executor::SuiTxExecutor;
 use hashi_types::bitcoin::BitcoinAddress;
 use hashi_types::move_types::DepositConfirmed;
 use hashi_types::move_types::WithdrawalConfirmed;
+use hashi_types::move_types::WithdrawalStatus;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -393,6 +394,71 @@ pub async fn wait_for_spent_utxo_cleanup(networks: &TestNetworks, timeout: Durat
             return Err(anyhow!(
                 "Timeout after {timeout:?} waiting for the spent-UTXO cleanup: node {index}'s \
                  mirror still shows {pending} spent record(s) and {tombstones} tombstone(s)"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Wait until every node's object mirror shows the deferred withdrawal
+/// archival completed: no withdrawal transaction with
+/// `confirmed_timestamp_ms` set is still sitting in the hot
+/// `withdrawal_txns` bag, and no request in a post-commit status
+/// (Processing/Signed/Confirmed) is lingering in the hot `requests` bag.
+///
+/// Under the v2 package `confirm_withdrawal` leaves the transaction (and
+/// its requests) in the hot bags; the leader's deferred-archival GC
+/// (`archive_confirmed_withdrawals`, armed by the confirm) later moves
+/// them to `confirmed_txns`/`processed`. The mirror does not track those
+/// archive bags, so "archived" is observable exactly as the ids draining
+/// from every node's hot-bag mirror.
+pub async fn wait_for_withdrawal_archival(
+    networks: &TestNetworks,
+    timeout: Duration,
+) -> Result<()> {
+    info!("Waiting for the withdrawal archival to reach every node's mirror...");
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let laggard =
+            networks
+                .hashi_network
+                .nodes()
+                .iter()
+                .enumerate()
+                .find_map(|(index, node)| {
+                    let state = node.hashi().onchain_state();
+                    let confirmed_txns = state
+                        .withdrawal_txns()
+                        .iter()
+                        .filter(|txn| txn.is_confirmed())
+                        .count();
+                    let terminal_requests = state
+                        .withdrawal_requests()
+                        .iter()
+                        .filter(|request| {
+                            matches!(
+                                request.status,
+                                WithdrawalStatus::Processing
+                                    | WithdrawalStatus::Signed
+                                    | WithdrawalStatus::Confirmed
+                            )
+                        })
+                        .count();
+                    (confirmed_txns > 0 || terminal_requests > 0).then_some((
+                        index,
+                        confirmed_txns,
+                        terminal_requests,
+                    ))
+                });
+        let Some((index, confirmed_txns, terminal_requests)) = laggard else {
+            info!("Every node's mirror shows the confirmed withdrawals archived");
+            return Ok(());
+        };
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "Timeout after {timeout:?} waiting for the withdrawal archival: node {index}'s \
+                 mirror still shows {confirmed_txns} confirmed txn(s) in the hot bag and \
+                 {terminal_requests} post-commit request(s)"
             ));
         }
         tokio::time::sleep(Duration::from_millis(500)).await;

--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -465,6 +465,52 @@ async fn execute_full_upgrade_with_proposal(
     Ok(new_package_id)
 }
 
+/// Poll until every running node's mirror shows `version` out of the
+/// enabled set (the DisableVersion execution reaching each watcher).
+/// Prints per-node diagnostics before failing on timeout.
+pub async fn wait_for_version_disabled(
+    networks: &TestNetworks,
+    version: u64,
+    max_wait: std::time::Duration,
+) -> Result<()> {
+    let wait_start = std::time::Instant::now();
+    loop {
+        let all_disabled = networks
+            .hashi_network
+            .nodes()
+            .iter()
+            .filter(|node| node.is_running())
+            .all(|node| {
+                let state = node.hashi().onchain_state().state();
+                !state.hashi().config.enabled_versions.contains(&version)
+            });
+        if all_disabled {
+            return Ok(());
+        }
+        if wait_start.elapsed() > max_wait {
+            for (i, node) in networks
+                .hashi_network
+                .nodes()
+                .iter()
+                .filter(|node| node.is_running())
+                .enumerate()
+            {
+                let enabled = node
+                    .hashi()
+                    .onchain_state()
+                    .state()
+                    .hashi()
+                    .config
+                    .enabled_versions
+                    .clone();
+                tracing::info!("node {i}: enabled_versions={enabled:?}");
+            }
+            anyhow::bail!("timeout: not all nodes' mirrors show version {version} disabled");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
 /// Propose + vote + execute a DisableVersion governance action.
 ///
 /// `execute_package_id` is the package whose `disable_version::execute` is called.

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -14,6 +14,7 @@ use e2e_tests::TestNetworksBuilder;
 use e2e_tests::snapshot;
 use e2e_tests::test_helpers::BackgroundMiner;
 use e2e_tests::test_helpers::create_deposit_and_wait;
+use e2e_tests::test_helpers::extract_witness_program;
 use e2e_tests::test_helpers::get_hbtc_balance;
 use e2e_tests::test_helpers::init_test_logging;
 use e2e_tests::test_helpers::subscribe_withdrawal_confirmations;

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -9,11 +9,14 @@
 //! - Package ID routing updates correctly in OnchainState
 
 use anyhow::Result;
+use anyhow::anyhow;
 use e2e_tests::TestNetworksBuilder;
 use e2e_tests::snapshot;
+use e2e_tests::test_helpers::BackgroundMiner;
 use e2e_tests::test_helpers::create_deposit_and_wait;
 use e2e_tests::test_helpers::get_hbtc_balance;
 use e2e_tests::test_helpers::init_test_logging;
+use e2e_tests::test_helpers::subscribe_withdrawal_confirmations;
 use e2e_tests::upgrade_flow;
 use hashi::sui_tx_executor::SuiTxExecutor;
 use std::time::Duration;
@@ -324,5 +327,176 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
     info!("v2 canary module call succeeded");
 
     info!("=== SNAPSHOT UPGRADE TEST PASSED ===");
+    Ok(())
+}
+
+/// A withdrawal committed and fully signed under the deployed **v1 bytecode**
+/// must complete after the governance upgrade to the current source:
+/// confirmation runs through the v2 `confirm_withdrawal` (which defers
+/// archival), and the leader's archival GC — armed by the confirm and
+/// version-gated on active >= 2 — then drains it.
+///
+/// This is the mid-flight rollout window the deferred-archival change has to
+/// survive: v1's commit moved the requests into the unmirrored `processed`
+/// bag, so the upgraded package confirms and archives a transaction whose
+/// requests never sat in the v2 hot-bag layout. The final assertion is that
+/// nothing wedges — signing/confirm completes and both hot-bag mirrors drain
+/// to empty on every node.
+///
+/// Parking the withdrawal fully-signed-but-unconfirmed needs no
+/// block-withholding machinery: commit and signing are driven purely by Sui
+/// checkpoints, while confirmation additionally requires the signed Bitcoin
+/// transaction to be mined — so simply not mining regtest blocks holds the
+/// flow at fully-signed under v1 (the same seam the signature-chunking tests
+/// use to observe `WithdrawalSigned` before starting their miner).
+#[tokio::test]
+async fn test_withdrawal_committed_under_v1_completes_after_upgrade() -> Result<()> {
+    init_test_logging();
+
+    // v1 = the checked-in deployed bytecode snapshot; no auto-upgrade — this
+    // test drives the upgrade itself, mid-withdrawal.
+    let mut networks = TestNetworksBuilder::new()
+        .with_nodes(4)
+        .with_v1_from_snapshot(snapshot::default_snapshot_dir()?)
+        .without_upgrade()
+        .build()
+        .await?;
+
+    let hashi_ids = networks.hashi_network.ids();
+    info!("snapshot-published v1 package ID: {}", hashi_ids.package_id);
+
+    // Committee/DKG must complete before anything can be signed (and before
+    // the upgrade proposal can pass at its 100% quorum).
+    networks.hashi_network.nodes()[0]
+        .wait_for_mpc_key(Duration::from_secs(120))
+        .await?;
+
+    // ── Deposit under v1 ────────────────────────────────────────────────
+    let deposit_sats = 100_000u64;
+    let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_sats).await?;
+
+    // ── Withdrawal: commit + full signing under v1, confirmation withheld ──
+    let node0 = networks.hashi_network.nodes()[0].hashi().clone();
+    let user_key = networks.sui_network.user_keys.first().unwrap().clone();
+    let withdrawal_sats = 30_000u64;
+    let btc_destination = networks.bitcoin_node.get_new_address()?;
+    let destination_bytes = extract_witness_program(&btc_destination)?;
+
+    let mut executor = SuiTxExecutor::from_config(&node0.config, node0.onchain_state())?
+        .with_signer(user_key.into());
+    let withdrawal_request_id = executor
+        .execute_create_withdrawal_request(withdrawal_sats, destination_bytes)
+        .await?;
+    info!("withdrawal request created under v1: {withdrawal_request_id}");
+
+    // With no regtest blocks being mined the flow parks at
+    // fully-signed-but-unconfirmed: presig generation, MPC signing, and the
+    // guardian finalize all complete (Sui-driven), the signed Bitcoin tx is
+    // broadcast, but the leader cannot observe it mined and so cannot
+    // confirm.
+    let deadline = std::time::Instant::now() + Duration::from_secs(180);
+    loop {
+        if node0
+            .onchain_state()
+            .withdrawal_txns()
+            .iter()
+            .any(|txn| txn.is_fully_signed() && !txn.is_confirmed())
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for the withdrawal to fully sign under the v1 bytecode"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    // Still a single-version chain: commit + signing really ran under v1.
+    assert_eq!(
+        node0
+            .onchain_state()
+            .state()
+            .package_versions()
+            .versions()
+            .len(),
+        1,
+        "the withdrawal must be committed and fully signed before any upgrade"
+    );
+    info!("withdrawal fully signed under v1 (unconfirmed; no regtest blocks mined)");
+
+    // ── Governance upgrade to the current source, mid-withdrawal ────────
+    let new_package_id = upgrade_flow::execute_full_upgrade(&mut networks).await?;
+    assert_ne!(
+        new_package_id, hashi_ids.package_id,
+        "upgrade should mint a new package id"
+    );
+    upgrade_flow::wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30))
+        .await?;
+    info!("upgraded mid-withdrawal: new package {new_package_id}");
+
+    // ── Complete the flow under v2: confirm, then archival GC ───────────
+    //
+    // Subscribe before the miner starts: the parked withdrawal cannot
+    // confirm until its Bitcoin tx is mined, so the subscription provably
+    // precedes the event.
+    let confirmations =
+        subscribe_withdrawal_confirmations(&mut networks.sui_network.client).await?;
+    let miner = BackgroundMiner::start(&networks.bitcoin_node);
+    let confirmed = confirmations
+        .wait_for(withdrawal_request_id, Duration::from_secs(300))
+        .await?;
+    drop(miner);
+    info!(
+        "v1-committed withdrawal confirmed via the v2 package: txid={}",
+        confirmed.txid
+    );
+
+    // The hBTC actually burned — the withdrawal completed, not merely landed.
+    assert_eq!(
+        get_hbtc_balance(
+            &mut networks.sui_network.client,
+            hashi_ids.package_id,
+            hbtc_recipient,
+        )
+        .await?,
+        deposit_sats - withdrawal_sats,
+        "withdrawal committed under v1 should burn hBTC once confirmed under v2"
+    );
+
+    // The v2 confirm left the txn in the hot bag with
+    // `confirmed_timestamp_ms` set; the archival GC must now move it to
+    // `confirmed_txns`. The v1-committed requests lived in the unmirrored
+    // `processed` bag since commit time, and the archive bags are unmirrored
+    // too — so completion is observable exactly as both hot-bag mirrors
+    // draining to empty on every node, and nothing may wedge on the
+    // cross-version state.
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        let laggard =
+            networks
+                .hashi_network
+                .nodes()
+                .iter()
+                .enumerate()
+                .find_map(|(index, node)| {
+                    let state = node.hashi().onchain_state();
+                    let txns = state.withdrawal_txns().len();
+                    let requests = state.withdrawal_requests().len();
+                    (txns > 0 || requests > 0).then_some((index, txns, requests))
+                });
+        let Some((index, txns, requests)) = laggard else {
+            break;
+        };
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "node {index}'s mirror still shows {txns} withdrawal txn(s) and {requests} \
+                 request(s) after the post-upgrade archival window"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    info!("withdrawal_txns and withdrawal_requests empty on every node");
+
+    info!("=== V1-COMMITTED WITHDRAWAL COMPLETES AFTER UPGRADE TEST PASSED ===");
     Ok(())
 }

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -20,14 +20,21 @@ use e2e_tests::test_helpers::init_test_logging;
 use e2e_tests::test_helpers::subscribe_withdrawal_confirmations;
 use e2e_tests::upgrade_flow;
 use hashi::sui_tx_executor::SuiTxExecutor;
+use hashi_types::move_types::WithdrawalStatus;
 use std::collections::BTreeSet;
 use std::time::Duration;
 use sui_sdk_types::Address;
 use sui_sdk_types::Identifier;
+use sui_sdk_types::StructTag;
+use sui_sdk_types::TypeTag;
 use sui_transaction_builder::Function;
 use sui_transaction_builder::ObjectInput;
 use sui_transaction_builder::TransactionBuilder;
 use tracing::info;
+
+/// The Sui framework package (`0x2`), for consuming the `Balance<BTC>` a
+/// direct `cancel_withdrawal` call would return via `coin::from_balance`.
+const SUI_FRAMEWORK_ADDRESS: Address = Address::from_static("0x2");
 
 /// Upgrade v2 binds the committee-approved exclusivity policy to publication.
 ///
@@ -561,5 +568,340 @@ async fn test_withdrawal_committed_under_v1_completes_after_upgrade() -> Result<
     info!("withdrawal_txns and withdrawal_requests empty on every node");
 
     info!("=== V1-COMMITTED WITHDRAWAL COMPLETES AFTER UPGRADE TEST PASSED ===");
+    Ok(())
+}
+
+/// Assert that a direct v1 entry call failed at the v1 version gate — the
+/// `EVersionDisabled` abort raised by `versioning::assert_version_enabled`,
+/// located in the v1 package — and not merely that it failed. The gate is the
+/// first statement of both v1 entries, so the abort provably fires before any
+/// argument-semantic check could.
+fn assert_version_gate_abort<T>(result: Result<T>, v1_package_id: Address, what: &str) {
+    let err = match result {
+        Ok(_) => panic!("{what} against a v2-committed request must abort at the version gate"),
+        Err(err) => err,
+    };
+    let err_msg = err.to_string();
+    info!("{what} rejected: {err_msg}");
+    assert!(
+        err_msg.contains("EVersionDisabled") || err_msg.contains("assert_version_enabled"),
+        "{what}: expected the EVersionDisabled abort from versioning::assert_version_enabled, \
+         got: {err_msg}"
+    );
+    let v1_hex = v1_package_id.to_string();
+    let v1_hex = v1_hex.trim_start_matches("0x");
+    assert!(
+        err_msg.contains(v1_hex),
+        "{what}: the abort must locate in the v1 package {v1_package_id}, got: {err_msg}"
+    );
+}
+
+/// Direct v1 entries against a v2-committed request must abort at the gate.
+///
+/// The deferred-archival commit (v2) flips the request to `Processing` *in
+/// place*: it stays in the hot `requests` bag with its balance drained. The
+/// deployed v1 bytecode predates that layout — its `cancel_withdrawal` guard
+/// (`is_request_processing`, per the bytecode snapshot) only consults the
+/// `processed` bag v1 itself moved requests into at commit time. Aimed at a
+/// v2-committed request the v1 guard passes, and with v1 still enabled the
+/// entry would destroy the request and mint a refund out of a balance the
+/// in-flight WithdrawalTransaction already drained; v1's `approve_request`
+/// (replaying a cert) would similarly reset the committed request to
+/// `Approved` for a second commit. `DisableVersion(1)` is what closes this
+/// hazard: both entries assert the version gate as their first statement.
+///
+/// This test pins that closure by calling the deployed v1 bytecode directly
+/// at its package id, against a live v2-committed withdrawal:
+/// - v1 `withdraw::cancel_withdrawal` (as the requester, return consumed via
+///   `coin::from_balance` at BTC's defining v1 address) aborts EVersionDisabled
+/// - v1 `withdraw::approve_request` (garbage cert; the gate precedes cert
+///   verification) aborts EVersionDisabled
+/// - the request is untouched afterwards, and the normal v2 flow then
+///   confirms and archives it on every node.
+#[tokio::test]
+async fn test_v1_entries_abort_against_v2_committed_request() -> Result<()> {
+    init_test_logging();
+
+    // Standard boot: the deployed-v1 snapshot auto-upgraded to the current
+    // source. Both versions stay enabled — disabling v1 is this test's move.
+    let mut networks = TestNetworksBuilder::new().with_nodes(4).build().await?;
+    let hashi_ids = networks.hashi_network.ids();
+
+    networks.hashi_network.nodes()[0]
+        .wait_for_mpc_key(Duration::from_secs(120))
+        .await?;
+
+    let node0 = networks.hashi_network.nodes()[0].hashi().clone();
+    let (v1_package_id, active_package_id) = {
+        let state = node0.onchain_state().state();
+        let versions = state.package_versions();
+        assert_eq!(
+            versions.latest_version(),
+            Some(2),
+            "default boot lands the chain at package v2"
+        );
+        assert!(
+            state.hashi().config.enabled_versions.contains(&1),
+            "the boot upgrade must leave v1 enabled; disabling it is this test's move"
+        );
+        (
+            versions.get(1).expect("v1 must be in the version map"),
+            versions.latest_id().expect("v2 must be in the version map"),
+        )
+    };
+    assert_eq!(
+        v1_package_id, hashi_ids.package_id,
+        "v1 is the original package"
+    );
+    assert_ne!(v1_package_id, active_package_id);
+
+    // ── Deposit, then drive a withdrawal to committed-under-v2 ──────────
+    let deposit_sats = 100_000u64;
+    let withdrawal_sats = 30_000u64;
+    let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_sats).await?;
+
+    let user_key = networks.sui_network.user_keys.first().unwrap().clone();
+    let btc_destination = networks.bitcoin_node.get_new_address()?;
+    let destination_bytes = extract_witness_program(&btc_destination)?;
+    let mut user_executor = SuiTxExecutor::from_config(&node0.config, node0.onchain_state())?
+        .with_signer(user_key.into());
+    let requester = user_executor.sender();
+    let withdrawal_request_id = user_executor
+        .execute_create_withdrawal_request(withdrawal_sats, destination_bytes)
+        .await?;
+    info!("withdrawal request created: {withdrawal_request_id}");
+
+    // Committed under v2 = the in-place status flip to Processing with the
+    // balance drained, still in the hot `requests` bag — which is exactly
+    // what the mirror covers (a v1-style commit would instead have moved the
+    // request into the unmirrored `processed` bag).
+    let deadline = std::time::Instant::now() + Duration::from_secs(180);
+    let committed = loop {
+        if let Some(request) = node0
+            .onchain_state()
+            .withdrawal_request(&withdrawal_request_id)
+            && request.status == WithdrawalStatus::Processing
+        {
+            break request;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for the withdrawal to commit under v2"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    };
+    assert_eq!(
+        committed.btc, 0,
+        "the v2 commit must drain the request's balance in place"
+    );
+    assert!(
+        committed.withdrawal_txn_id.is_some(),
+        "a committed request must reference its withdrawal transaction"
+    );
+    info!("withdrawal committed under v2 (Processing, balance drained, still in `requests`)");
+
+    // ── DisableVersion(1) via governance ────────────────────────────────
+    let mut executors: Vec<SuiTxExecutor> = networks
+        .hashi_network
+        .nodes()
+        .iter()
+        .map(|node| SuiTxExecutor::from_config(&node.hashi().config, node.hashi().onchain_state()))
+        .collect::<Result<_>>()?;
+    upgrade_flow::disable_version(&mut executors, hashi_ids, 1, active_package_id).await?;
+
+    // Every watcher must converge on v1-disabled; the proposal execution is
+    // checkpointed, so the fullnode state the direct v1 calls run against
+    // already has it.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let converged = networks.hashi_network.nodes().iter().all(|node| {
+            let state = node.hashi().onchain_state().state();
+            !state.hashi().config.enabled_versions.contains(&1)
+        });
+        if converged {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for the watchers to reflect DisableVersion(1)"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    info!("version 1 disabled");
+
+    // ── Direct v1 `withdraw::cancel_withdrawal` on the committed id ─────
+    //
+    // Deployed v1 signature (from the bytecode snapshot):
+    //   public fun cancel_withdrawal(&mut Hashi, address, &Clock, &mut TxContext): Balance<BTC>
+    // A `public fun` return must be consumed, so the PTB wraps it through
+    // `coin::from_balance` and transfers the coin to the sender — with BTC
+    // addressed at its DEFINING package, v1 (type identity survives
+    // upgrades). The version gate aborts in command 0, before any of that.
+    let mut builder = TransactionBuilder::new();
+    let hashi_arg = builder.object(
+        ObjectInput::new(hashi_ids.hashi_object_id)
+            .as_shared()
+            .with_mutable(true),
+    );
+    let request_id_arg = builder.pure(&withdrawal_request_id);
+    let clock_arg = builder.object(
+        ObjectInput::new(hashi::sui_tx_executor::SUI_CLOCK_OBJECT_ID)
+            .as_shared()
+            .with_mutable(false),
+    );
+    let refund = builder.move_call(
+        Function::new(
+            v1_package_id,
+            Identifier::from_static("withdraw"),
+            Identifier::from_static("cancel_withdrawal"),
+        ),
+        vec![hashi_arg, request_id_arg, clock_arg],
+    );
+    let btc_type = TypeTag::Struct(Box::new(StructTag::new(
+        v1_package_id,
+        Identifier::from_static("btc"),
+        Identifier::from_static("BTC"),
+        vec![],
+    )));
+    let refund_coin = builder.move_call(
+        Function::new(
+            SUI_FRAMEWORK_ADDRESS,
+            Identifier::from_static("coin"),
+            Identifier::from_static("from_balance"),
+        )
+        .with_type_args(vec![btc_type]),
+        vec![refund],
+    );
+    let recipient_arg = builder.pure(&requester);
+    builder.transfer_objects(vec![refund_coin], recipient_arg);
+
+    let cancel_result = user_executor.execute(builder).await;
+    assert_version_gate_abort(cancel_result, v1_package_id, "v1 cancel_withdrawal");
+
+    // ── Direct v1 `withdraw::approve_request` with a garbage cert ───────
+    //
+    // Deployed v1 signature:
+    //   entry fun approve_request(&mut Hashi, address, CommitteeSignature, &Clock)
+    // The gate is asserted before certificate verification, and v1's
+    // `committee::new_committee_signature` is a bare struct pack (verified in
+    // the disassembly), so dummy contents construct fine and the abort can
+    // only come from the gate.
+    let mut builder = TransactionBuilder::new();
+    let hashi_arg = builder.object(
+        ObjectInput::new(hashi_ids.hashi_object_id)
+            .as_shared()
+            .with_mutable(true),
+    );
+    let request_id_arg = builder.pure(&withdrawal_request_id);
+    let epoch_arg = builder.pure(&0u64);
+    let signature_arg = builder.pure(&vec![0u8; 96]);
+    let bitmap_arg = builder.pure(&vec![0xffu8]);
+    let cert_arg = builder.move_call(
+        Function::new(
+            v1_package_id,
+            Identifier::from_static("committee"),
+            Identifier::from_static("new_committee_signature"),
+        ),
+        vec![epoch_arg, signature_arg, bitmap_arg],
+    );
+    let clock_arg = builder.object(
+        ObjectInput::new(hashi::sui_tx_executor::SUI_CLOCK_OBJECT_ID)
+            .as_shared()
+            .with_mutable(false),
+    );
+    builder.move_call(
+        Function::new(
+            v1_package_id,
+            Identifier::from_static("withdraw"),
+            Identifier::from_static("approve_request"),
+        ),
+        vec![hashi_arg, request_id_arg, cert_arg, clock_arg],
+    );
+
+    let approve_result = user_executor.execute(builder).await;
+    assert_version_gate_abort(approve_result, v1_package_id, "v1 approve_request");
+
+    // ── The aborted v1 calls changed nothing ────────────────────────────
+    //
+    // Signing continues in the background, so the status may legitimately
+    // have advanced Processing -> Signed; what the v1 entries would have
+    // left behind — a vanished, refunded request (cancel) or a reset to
+    // Approved (approve) — must not have happened.
+    let after = node0
+        .onchain_state()
+        .withdrawal_request(&withdrawal_request_id)
+        .expect("the v2-committed request must still sit in the `requests` bag");
+    assert_eq!(
+        after.btc, 0,
+        "the drained balance must not have been refunded"
+    );
+    assert!(
+        matches!(
+            after.status,
+            WithdrawalStatus::Processing | WithdrawalStatus::Signed
+        ),
+        "the request must still be committed, got {:?}",
+        after.status
+    );
+    info!(
+        "request intact after the aborted v1 calls (status {:?})",
+        after.status
+    );
+
+    // ── And the normal v2 flow finishes on top of it ────────────────────
+    //
+    // Subscribe before the miner starts so the confirmation event cannot be
+    // missed, then let confirm + the archival GC drain both hot-bag mirrors
+    // on every node — proving the v1 attempts left nothing to wedge on.
+    let confirmations =
+        subscribe_withdrawal_confirmations(&mut networks.sui_network.client).await?;
+    let miner = BackgroundMiner::start(&networks.bitcoin_node);
+    let confirmed = confirmations
+        .wait_for(withdrawal_request_id, Duration::from_secs(300))
+        .await?;
+    drop(miner);
+    info!("withdrawal confirmed under v2: txid={}", confirmed.txid);
+
+    assert_eq!(
+        get_hbtc_balance(
+            &mut networks.sui_network.client,
+            hashi_ids.package_id,
+            hbtc_recipient,
+        )
+        .await?,
+        deposit_sats - withdrawal_sats,
+        "the confirmed withdrawal should burn exactly the withdrawn hBTC"
+    );
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        let laggard =
+            networks
+                .hashi_network
+                .nodes()
+                .iter()
+                .enumerate()
+                .find_map(|(index, node)| {
+                    let state = node.hashi().onchain_state();
+                    let txns = state.withdrawal_txns().len();
+                    let requests = state.withdrawal_requests().len();
+                    (txns > 0 || requests > 0).then_some((index, txns, requests))
+                });
+        let Some((index, txns, requests)) = laggard else {
+            break;
+        };
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "node {index}'s mirror still shows {txns} withdrawal txn(s) and {requests} \
+                 request(s) after the archival window"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    info!("withdrawal_txns and withdrawal_requests empty on every node");
+
+    info!("=== V1 ENTRIES ABORT AGAINST V2-COMMITTED REQUEST TEST PASSED ===");
     Ok(())
 }

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -9,11 +9,14 @@
 //! - Package ID routing updates correctly in OnchainState
 
 use anyhow::Result;
+use anyhow::anyhow;
 use e2e_tests::TestNetworksBuilder;
 use e2e_tests::snapshot;
+use e2e_tests::test_helpers::BackgroundMiner;
 use e2e_tests::test_helpers::create_deposit_and_wait;
 use e2e_tests::test_helpers::get_hbtc_balance;
 use e2e_tests::test_helpers::init_test_logging;
+use e2e_tests::test_helpers::subscribe_withdrawal_confirmations;
 use e2e_tests::upgrade_flow;
 use hashi::sui_tx_executor::SuiTxExecutor;
 use std::collections::BTreeSet;
@@ -386,5 +389,176 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
     info!("v2 canary module call succeeded");
 
     info!("=== SNAPSHOT UPGRADE TEST PASSED ===");
+    Ok(())
+}
+
+/// A withdrawal committed and fully signed under the deployed **v1 bytecode**
+/// must complete after the governance upgrade to the current source:
+/// confirmation runs through the v2 `confirm_withdrawal` (which defers
+/// archival), and the leader's archival GC — armed by the confirm and
+/// version-gated on active >= 2 — then drains it.
+///
+/// This is the mid-flight rollout window the deferred-archival change has to
+/// survive: v1's commit moved the requests into the unmirrored `processed`
+/// bag, so the upgraded package confirms and archives a transaction whose
+/// requests never sat in the v2 hot-bag layout. The final assertion is that
+/// nothing wedges — signing/confirm completes and both hot-bag mirrors drain
+/// to empty on every node.
+///
+/// Parking the withdrawal fully-signed-but-unconfirmed needs no
+/// block-withholding machinery: commit and signing are driven purely by Sui
+/// checkpoints, while confirmation additionally requires the signed Bitcoin
+/// transaction to be mined — so simply not mining regtest blocks holds the
+/// flow at fully-signed under v1 (the same seam the signature-chunking tests
+/// use to observe `WithdrawalSigned` before starting their miner).
+#[tokio::test]
+async fn test_withdrawal_committed_under_v1_completes_after_upgrade() -> Result<()> {
+    init_test_logging();
+
+    // v1 = the checked-in deployed bytecode snapshot; no auto-upgrade — this
+    // test drives the upgrade itself, mid-withdrawal.
+    let mut networks = TestNetworksBuilder::new()
+        .with_nodes(4)
+        .with_v1_from_snapshot(snapshot::default_snapshot_dir()?)
+        .without_upgrade()
+        .build()
+        .await?;
+
+    let hashi_ids = networks.hashi_network.ids();
+    info!("snapshot-published v1 package ID: {}", hashi_ids.package_id);
+
+    // Committee/DKG must complete before anything can be signed (and before
+    // the upgrade proposal can pass at its 100% quorum).
+    networks.hashi_network.nodes()[0]
+        .wait_for_mpc_key(Duration::from_secs(120))
+        .await?;
+
+    // ── Deposit under v1 ────────────────────────────────────────────────
+    let deposit_sats = 100_000u64;
+    let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_sats).await?;
+
+    // ── Withdrawal: commit + full signing under v1, confirmation withheld ──
+    let node0 = networks.hashi_network.nodes()[0].hashi().clone();
+    let user_key = networks.sui_network.user_keys.first().unwrap().clone();
+    let withdrawal_sats = 30_000u64;
+    let btc_destination = networks.bitcoin_node.get_new_address()?;
+    let destination_bytes = extract_witness_program(&btc_destination)?;
+
+    let mut executor = SuiTxExecutor::from_config(&node0.config, node0.onchain_state())?
+        .with_signer(user_key.into());
+    let withdrawal_request_id = executor
+        .execute_create_withdrawal_request(withdrawal_sats, destination_bytes)
+        .await?;
+    info!("withdrawal request created under v1: {withdrawal_request_id}");
+
+    // With no regtest blocks being mined the flow parks at
+    // fully-signed-but-unconfirmed: presig generation, MPC signing, and the
+    // guardian finalize all complete (Sui-driven), the signed Bitcoin tx is
+    // broadcast, but the leader cannot observe it mined and so cannot
+    // confirm.
+    let deadline = std::time::Instant::now() + Duration::from_secs(180);
+    loop {
+        if node0
+            .onchain_state()
+            .withdrawal_txns()
+            .iter()
+            .any(|txn| txn.is_fully_signed() && !txn.is_confirmed())
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for the withdrawal to fully sign under the v1 bytecode"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    // Still a single-version chain: commit + signing really ran under v1.
+    assert_eq!(
+        node0
+            .onchain_state()
+            .state()
+            .package_versions()
+            .versions()
+            .len(),
+        1,
+        "the withdrawal must be committed and fully signed before any upgrade"
+    );
+    info!("withdrawal fully signed under v1 (unconfirmed; no regtest blocks mined)");
+
+    // ── Governance upgrade to the current source, mid-withdrawal ────────
+    let new_package_id = upgrade_flow::execute_full_upgrade(&mut networks).await?;
+    assert_ne!(
+        new_package_id, hashi_ids.package_id,
+        "upgrade should mint a new package id"
+    );
+    upgrade_flow::wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30))
+        .await?;
+    info!("upgraded mid-withdrawal: new package {new_package_id}");
+
+    // ── Complete the flow under v2: confirm, then archival GC ───────────
+    //
+    // Subscribe before the miner starts: the parked withdrawal cannot
+    // confirm until its Bitcoin tx is mined, so the subscription provably
+    // precedes the event.
+    let confirmations =
+        subscribe_withdrawal_confirmations(&mut networks.sui_network.client).await?;
+    let miner = BackgroundMiner::start(&networks.bitcoin_node);
+    let confirmed = confirmations
+        .wait_for(withdrawal_request_id, Duration::from_secs(300))
+        .await?;
+    drop(miner);
+    info!(
+        "v1-committed withdrawal confirmed via the v2 package: txid={}",
+        confirmed.txid
+    );
+
+    // The hBTC actually burned — the withdrawal completed, not merely landed.
+    assert_eq!(
+        get_hbtc_balance(
+            &mut networks.sui_network.client,
+            hashi_ids.package_id,
+            hbtc_recipient,
+        )
+        .await?,
+        deposit_sats - withdrawal_sats,
+        "withdrawal committed under v1 should burn hBTC once confirmed under v2"
+    );
+
+    // The v2 confirm left the txn in the hot bag with
+    // `confirmed_timestamp_ms` set; the archival GC must now move it to
+    // `confirmed_txns`. The v1-committed requests lived in the unmirrored
+    // `processed` bag since commit time, and the archive bags are unmirrored
+    // too — so completion is observable exactly as both hot-bag mirrors
+    // draining to empty on every node, and nothing may wedge on the
+    // cross-version state.
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        let laggard =
+            networks
+                .hashi_network
+                .nodes()
+                .iter()
+                .enumerate()
+                .find_map(|(index, node)| {
+                    let state = node.hashi().onchain_state();
+                    let txns = state.withdrawal_txns().len();
+                    let requests = state.withdrawal_requests().len();
+                    (txns > 0 || requests > 0).then_some((index, txns, requests))
+                });
+        let Some((index, txns, requests)) = laggard else {
+            break;
+        };
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "node {index}'s mirror still shows {txns} withdrawal txn(s) and {requests} \
+                 request(s) after the post-upgrade archival window"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    info!("withdrawal_txns and withdrawal_requests empty on every node");
+
+    info!("=== V1-COMMITTED WITHDRAWAL COMPLETES AFTER UPGRADE TEST PASSED ===");
     Ok(())
 }

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -38,14 +38,20 @@ const SUI_FRAMEWORK_ADDRESS: Address = Address::from_static("0x2");
 
 /// Upgrade v2 binds the committee-approved exclusivity policy to publication.
 ///
-/// The default builder first performs the unavoidable legacy v1 → v2 upgrade.
-/// This test then publishes v3 through `upgrade_v2` with `exclusive = true`
-/// and verifies that the same transaction leaves only v3 enabled. Because the
-/// test binary supports v1 and v2, it must halt autonomous writes afterward.
+/// The builder first performs the unavoidable legacy v1 → v2 upgrade, with
+/// `keep_v1_enabled` so BOTH versions stay enabled (the raw legacy-upgrade
+/// outcome). This test then publishes v3 through `upgrade_v2` with
+/// `exclusive = true` and verifies that the same transaction leaves only v3
+/// enabled, retiring {1, 2} atomically. Because the test binary supports v1
+/// and v2, it must halt autonomous writes afterward.
 #[tokio::test]
 async fn test_upgrade_v2_exclusive_via_proposal() -> Result<()> {
     init_test_logging();
-    let mut networks = TestNetworksBuilder::new().with_nodes(4).build().await?;
+    let mut networks = TestNetworksBuilder::new()
+        .with_nodes(4)
+        .keep_v1_enabled()
+        .build()
+        .await?;
 
     networks.hashi_network.nodes()[0]
         .wait_for_mpc_key(Duration::from_secs(120))
@@ -106,10 +112,18 @@ async fn test_upgrade_v2_exclusive_via_proposal() -> Result<()> {
 /// 1. Watcher picks up new package — PackageUpgraded updates OnchainState
 /// 2. Validators confirm deposits post-upgrade — leader routes calls correctly
 /// 3. Package ID routing — OnchainState.package_id() returns the new package
+///
+/// `keep_v1_enabled`: this test drives DisableVersion(1) itself after its
+/// own vN -> vN+1 upgrade (a second disable would abort on-chain), and the
+/// v1-rejection assertion needs v1 to still be enabled until that move.
 #[tokio::test]
 async fn test_upgrade_via_proposal() -> Result<()> {
     init_test_logging();
-    let mut networks = TestNetworksBuilder::new().with_nodes(4).build().await?;
+    let mut networks = TestNetworksBuilder::new()
+        .with_nodes(4)
+        .keep_v1_enabled()
+        .build()
+        .await?;
 
     let hashi_ids = networks.hashi_network.ids();
     info!("original package ID: {}", hashi_ids.package_id);
@@ -401,10 +415,12 @@ async fn snapshot_v1_upgrades_to_current_source() -> Result<()> {
 }
 
 /// A withdrawal committed and fully signed under the deployed **v1 bytecode**
-/// must complete after the governance upgrade to the current source:
-/// confirmation runs through the v2 `confirm_withdrawal` (which defers
-/// archival), and the leader's archival GC — armed by the confirm and
-/// version-gated on active >= 2 — then drains it.
+/// must complete after the governance upgrade to the current source AND the
+/// DisableVersion(1) that closes the bootstrap window: with v1 still enabled
+/// the withdrawal flow stays dormant at v1 semantics, so the disable is what
+/// activates v2. Confirmation then runs through the v2 `confirm_withdrawal`
+/// (which defers archival), and the leader's archival GC (armed by the
+/// confirm, gated on the withdrawal-effective version >= 2) then drains it.
 ///
 /// This is the mid-flight rollout window the deferred-archival change has to
 /// survive: v1's commit moved the requests into the unmirrored `processed`
@@ -503,6 +519,27 @@ async fn test_withdrawal_committed_under_v1_completes_after_upgrade() -> Result<
     upgrade_flow::wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30))
         .await?;
     info!("upgraded mid-withdrawal: new package {new_package_id}");
+
+    // ── DisableVersion(1): open the withdrawal dormancy gate ────────────
+    //
+    // The legacy upgrade leaves both versions enabled, and with v1 enabled
+    // the flow stays dormant at v1 semantics: confirm would route the v1
+    // bytecode (which archives inline) and the archival GC would never
+    // arm, so the v2 path this test exists to exercise would go untested.
+    let mut executors: Vec<SuiTxExecutor> = networks
+        .hashi_network
+        .nodes()
+        .iter()
+        .map(|node| SuiTxExecutor::from_config(&node.hashi().config, node.hashi().onchain_state()))
+        .collect::<Result<_>>()?;
+    upgrade_flow::disable_version(&mut executors, hashi_ids, 1, new_package_id).await?;
+    upgrade_flow::wait_for_version_disabled(&networks, 1, Duration::from_secs(30)).await?;
+    assert_eq!(
+        node0.onchain_state().withdrawal_effective_version(),
+        Some(2),
+        "the withdrawal dormancy gate must be open before the v2 completion is asserted"
+    );
+    info!("version 1 disabled mid-withdrawal; v2 withdrawal semantics active");
 
     // ── Complete the flow under v2: confirm, then archival GC ───────────
     //
@@ -618,13 +655,25 @@ fn assert_version_gate_abort<T>(result: Result<T>, v1_package_id: Address, what:
 ///   verification) aborts EVersionDisabled
 /// - the request is untouched afterwards, and the normal v2 flow then
 ///   confirms and archives it on every node.
+///
+/// Ordering note: DisableVersion(1) runs BEFORE the withdrawal is created.
+/// The node-side flow is dormant at v1 semantics while v1 is enabled, so a
+/// commit inside the both-enabled window would be a v1 bag-move commit and
+/// the "v2-committed request" premise would be false. The direct-v1-call
+/// assertions only need v1 disabled at call time, which this order
+/// preserves.
 #[tokio::test]
 async fn test_v1_entries_abort_against_v2_committed_request() -> Result<()> {
     init_test_logging();
 
-    // Standard boot: the deployed-v1 snapshot auto-upgraded to the current
-    // source. Both versions stay enabled — disabling v1 is this test's move.
-    let mut networks = TestNetworksBuilder::new().with_nodes(4).build().await?;
+    // Boot with `keep_v1_enabled`: the deployed-v1 snapshot auto-upgraded to
+    // the current source with both versions left enabled; running
+    // DisableVersion(1) is this test's move.
+    let mut networks = TestNetworksBuilder::new()
+        .with_nodes(4)
+        .keep_v1_enabled()
+        .build()
+        .await?;
     let hashi_ids = networks.hashi_network.ids();
 
     networks.hashi_network.nodes()[0]
@@ -642,7 +691,7 @@ async fn test_v1_entries_abort_against_v2_committed_request() -> Result<()> {
         );
         assert!(
             state.hashi().config.enabled_versions.contains(&1),
-            "the boot upgrade must leave v1 enabled; disabling it is this test's move"
+            "the keep_v1_enabled boot must leave v1 enabled; disabling it is this test's move"
         );
         (
             versions.get(1).expect("v1 must be in the version map"),
@@ -655,11 +704,35 @@ async fn test_v1_entries_abort_against_v2_committed_request() -> Result<()> {
     );
     assert_ne!(v1_package_id, active_package_id);
 
-    // ── Deposit, then drive a withdrawal to committed-under-v2 ──────────
+    // ── Deposit under the both-enabled window ───────────────────────────
     let deposit_sats = 100_000u64;
     let withdrawal_sats = 30_000u64;
     let hbtc_recipient = create_deposit_and_wait(&mut networks, deposit_sats).await?;
 
+    // ── DisableVersion(1) via governance, BEFORE any withdrawal ─────────
+    //
+    // With v1 enabled the withdrawal flow is dormant at v1 semantics; the
+    // disable is what makes the upcoming commit a v2 in-place commit.
+    let mut executors: Vec<SuiTxExecutor> = networks
+        .hashi_network
+        .nodes()
+        .iter()
+        .map(|node| SuiTxExecutor::from_config(&node.hashi().config, node.hashi().onchain_state()))
+        .collect::<Result<_>>()?;
+    upgrade_flow::disable_version(&mut executors, hashi_ids, 1, active_package_id).await?;
+
+    // Every watcher must converge on v1-disabled; the proposal execution is
+    // checkpointed, so the fullnode state the direct v1 calls run against
+    // already has it.
+    upgrade_flow::wait_for_version_disabled(&networks, 1, Duration::from_secs(30)).await?;
+    assert_eq!(
+        node0.onchain_state().withdrawal_effective_version(),
+        Some(2),
+        "the withdrawal dormancy gate must be open before the v2 commit is driven"
+    );
+    info!("version 1 disabled; v2 withdrawal semantics active");
+
+    // ── Drive a withdrawal to committed-under-v2 ────────────────────────
     let user_key = networks.sui_network.user_keys.first().unwrap().clone();
     let btc_destination = networks.bitcoin_node.get_new_address()?;
     let destination_bytes = extract_witness_program(&btc_destination)?;
@@ -700,36 +773,6 @@ async fn test_v1_entries_abort_against_v2_committed_request() -> Result<()> {
         "a committed request must reference its withdrawal transaction"
     );
     info!("withdrawal committed under v2 (Processing, balance drained, still in `requests`)");
-
-    // ── DisableVersion(1) via governance ────────────────────────────────
-    let mut executors: Vec<SuiTxExecutor> = networks
-        .hashi_network
-        .nodes()
-        .iter()
-        .map(|node| SuiTxExecutor::from_config(&node.hashi().config, node.hashi().onchain_state()))
-        .collect::<Result<_>>()?;
-    upgrade_flow::disable_version(&mut executors, hashi_ids, 1, active_package_id).await?;
-
-    // Every watcher must converge on v1-disabled; the proposal execution is
-    // checkpointed, so the fullnode state the direct v1 calls run against
-    // already has it.
-    let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    loop {
-        let converged = networks.hashi_network.nodes().iter().all(|node| {
-            let state = node.hashi().onchain_state().state();
-            !state.hashi().config.enabled_versions.contains(&1)
-        });
-        if converged {
-            break;
-        }
-        if std::time::Instant::now() >= deadline {
-            return Err(anyhow!(
-                "timed out waiting for the watchers to reflect DisableVersion(1)"
-            ));
-        }
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
-    info!("version 1 disabled");
 
     // ── Direct v1 `withdraw::cancel_withdrawal` on the committed id ─────
     //

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -587,6 +587,17 @@ impl WithdrawalStatus {
     pub fn is_requested(&self) -> bool {
         matches!(self, Self::Requested)
     }
+
+    /// Lowercase status name, for metric labels and CLI rendering.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Requested => "requested",
+            Self::Approved => "approved",
+            Self::Processing => "processing",
+            Self::Signed => "signed",
+            Self::Confirmed => "confirmed",
+        }
+    }
 }
 
 /// Rust version of the Move hashi::withdrawal_queue::WithdrawalRequest type.
@@ -732,6 +743,11 @@ impl WithdrawalTransaction {
     /// Whether the 2-of-2 witness is fully assembled and the txn is broadcast-ready.
     pub fn is_fully_signed(&self) -> bool {
         self.signing.is_complete() && self.guardian_signatures.is_some()
+    }
+
+    /// Whether the Bitcoin transaction has been confirmed on-chain.
+    pub fn is_confirmed(&self) -> bool {
+        self.confirmed_timestamp_ms.is_some()
     }
 
     /// Dense per-input MPC signatures, available only once fully signed (the

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -594,6 +594,17 @@ impl WithdrawalStatus {
     pub fn is_requested(&self) -> bool {
         matches!(self, Self::Requested)
     }
+
+    /// Lowercase status name, for metric labels and CLI rendering.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Requested => "requested",
+            Self::Approved => "approved",
+            Self::Processing => "processing",
+            Self::Signed => "signed",
+            Self::Confirmed => "confirmed",
+        }
+    }
 }
 
 /// Rust version of the Move hashi::withdrawal_queue::WithdrawalRequest type.
@@ -739,6 +750,11 @@ impl WithdrawalTransaction {
     /// Whether the 2-of-2 witness is fully assembled and the txn is broadcast-ready.
     pub fn is_fully_signed(&self) -> bool {
         self.signing.is_complete() && self.guardian_signatures.is_some()
+    }
+
+    /// Whether the Bitcoin transaction has been confirmed on-chain.
+    pub fn is_confirmed(&self) -> bool {
+        self.confirmed_timestamp_ms.is_some()
     }
 
     /// Dense per-input MPC signatures, available only once fully signed (the

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -588,6 +588,13 @@ impl WithdrawalStatus {
         matches!(self, Self::Requested)
     }
 
+    /// Returns true while the request still awaits action in the queue
+    /// (`Requested` or `Approved`); false once committed into a withdrawal
+    /// txn. Mirrors Move's `WithdrawalStatus::is_active`.
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Requested | Self::Approved)
+    }
+
     /// Lowercase status name, for metric labels and CLI rendering.
     pub fn as_str(&self) -> &'static str {
         match self {

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -188,9 +188,14 @@ async fn request(
     let parsed_txid: bitcoin::Txid = txid.parse().context("Invalid txid")?;
     let txid_address = sui_sdk_types::Address::new(parsed_txid.to_byte_array());
 
+    // `deposit` gates on `assert_version_enabled`, so the call must target
+    // the active version's package: a v1-targeted creation aborts once v1
+    // is disabled.
+    let (_onchain, call_package) = super::resolve_active_call_package(config, hashi_ids).await?;
+
     let builder = crate::sui_tx_executor::build_create_deposit_request(
         hashi_ids,
-        hashi_ids.package_id,
+        call_package,
         txid_address,
         vout,
         amount,
@@ -340,8 +345,13 @@ async fn request_all(
     // 3 dynamic-field ops per deposit × 1000 object-runtime cap = 333/PTB.
     const CHUNK_SIZE: usize = 333;
 
+    // The attached reader state makes the executor route its calls through
+    // the active version's package (a v1-targeted creation aborts once v1
+    // is disabled).
+    let (onchain, _call_package) = super::resolve_active_call_package(config, hashi_ids).await?;
     let sui_client = crate::sui_rpc_client::new_sui_rpc_client(&config.sui_rpc_url)?;
-    let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(sui_client, signer, hashi_ids);
+    let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(sui_client, signer, hashi_ids)
+        .with_onchain_state(&onchain);
 
     let txid_address =
         sui_sdk_types::Address::new(bitcoin::hashes::Hash::to_byte_array(parsed_txid));

--- a/crates/hashi/src/cli/commands/mod.rs
+++ b/crates/hashi/src/cli/commands/mod.rs
@@ -14,10 +14,10 @@ pub mod withdraw;
 use anyhow::Context;
 
 /// Resolve, from a one-shot governance read, the package id CLI-built Hashi
-/// transactions must call: the active version's package. Resolution failure
-/// is a hard error with no fallback to the original package id, because v1
-/// bytecode's guards do not match v2 on-chain state (a v1-targeted cancel
-/// can destroy a request a live withdrawal txn still references) and every
+/// transactions must call: the active version's package. Correctly NOT
+/// dormancy-gated: withdrawal entry calls go through
+/// [`resolve_withdrawal_call_package`] instead. Resolution failure is a hard
+/// error with no fallback to the original package id, because every
 /// v1-targeted entry aborts once v1 is disabled. Returns the reader state
 /// alongside the id so batch paths can attach it to a
 /// [`crate::sui_tx_executor::SuiTxExecutor`] for self-routing.
@@ -37,5 +37,33 @@ pub(crate) async fn resolve_active_call_package(
         "no supported active on-chain package version resolved; refusing to fall back to the \
          original package",
     )?;
+    Ok((state, package))
+}
+
+/// [`resolve_active_call_package`] for withdrawal entry calls, which route
+/// through the withdrawal-effective version (the active version, held at v1
+/// while the bootstrap window keeps v1 enabled; see
+/// [`crate::withdrawals::withdrawal_effective_version`]) so CLI-built
+/// withdrawals run the same bytecode generation the committee's flow is
+/// committing under. Same no-fallback rule.
+pub(crate) async fn resolve_withdrawal_call_package(
+    config: &super::config::CliConfig,
+    hashi_ids: crate::config::HashiIds,
+) -> anyhow::Result<(crate::onchain::OnchainState, sui_sdk_types::Address)> {
+    let state = crate::onchain::OnchainState::new_reader(
+        &config.sui_rpc_url,
+        hashi_ids,
+        None,
+        crate::onchain::ScrapeScope::GovernanceOnly,
+    )
+    .await
+    .context("failed to read on-chain governance state to resolve the withdrawal package")?;
+    let package = state
+        .withdrawal_package()
+        .map(|(id, _version)| id)
+        .context(
+            "no withdrawal-effective on-chain package version resolved; refusing to fall back to \
+         the original package",
+        )?;
     Ok((state, package))
 }

--- a/crates/hashi/src/cli/commands/mod.rs
+++ b/crates/hashi/src/cli/commands/mod.rs
@@ -10,3 +10,32 @@ pub mod config;
 pub mod deposit;
 pub mod proposal;
 pub mod withdraw;
+
+use anyhow::Context;
+
+/// Resolve, from a one-shot governance read, the package id CLI-built Hashi
+/// transactions must call: the active version's package. Resolution failure
+/// is a hard error with no fallback to the original package id, because v1
+/// bytecode's guards do not match v2 on-chain state (a v1-targeted cancel
+/// can destroy a request a live withdrawal txn still references) and every
+/// v1-targeted entry aborts once v1 is disabled. Returns the reader state
+/// alongside the id so batch paths can attach it to a
+/// [`crate::sui_tx_executor::SuiTxExecutor`] for self-routing.
+pub(crate) async fn resolve_active_call_package(
+    config: &super::config::CliConfig,
+    hashi_ids: crate::config::HashiIds,
+) -> anyhow::Result<(crate::onchain::OnchainState, sui_sdk_types::Address)> {
+    let state = crate::onchain::OnchainState::new_reader(
+        &config.sui_rpc_url,
+        hashi_ids,
+        None,
+        crate::onchain::ScrapeScope::GovernanceOnly,
+    )
+    .await
+    .context("failed to read on-chain governance state to resolve the active package")?;
+    let package = state.active_package().map(|(id, _version)| id).context(
+        "no supported active on-chain package version resolved; refusing to fall back to the \
+         original package",
+    )?;
+    Ok((state, package))
+}

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -18,6 +18,7 @@ use crate::cli::config::CliConfig;
 use crate::cli::print_info;
 use crate::cli::print_success;
 use crate::cli::types::display;
+use crate::onchain::types::WithdrawalRequest;
 use crate::onchain::types::WithdrawalStatus;
 use crate::onchain::types::WithdrawalTransaction;
 
@@ -87,6 +88,12 @@ async fn request(
         .context("Withdrawal address does not match the configured Bitcoin network")?;
     let destination_bytes = witness_program_from_address(&btc_addr)?;
 
+    // `request_withdrawal` gates on `assert_version_enabled`, so the call
+    // must target the active version's package: a v1-targeted creation
+    // aborts once v1 is disabled. The resolved state also routes the batch
+    // executor below.
+    let (onchain, call_package) = super::resolve_active_call_package(config, hashi_ids).await?;
+
     let mut client = crate::sui_rpc_client::new_sui_rpc_client(&config.sui_rpc_url)?;
 
     // A single request supports all tx modes (execute / dry-run /
@@ -97,7 +104,7 @@ async fn request(
 
         let builder = crate::sui_tx_executor::build_create_withdrawal_request(
             hashi_ids,
-            hashi_ids.package_id,
+            call_package,
             amount,
             destination_bytes,
         );
@@ -136,9 +143,12 @@ async fn request(
          and --dry-run apply to a single withdrawal request"
     );
 
-    // Execute mode guarantees a signer (rejected above otherwise).
+    // Execute mode guarantees a signer (rejected above otherwise). The
+    // attached reader state makes the executor route its calls through the
+    // active version's package.
     let signer = signer.expect("execute mode requires a signer");
-    let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids);
+    let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids)
+        .with_onchain_state(&onchain);
 
     // ~3 PTB commands per request (split + call) vs the 1024 command cap.
     const CHUNK_SIZE: usize = 250;
@@ -202,23 +212,11 @@ async fn cancel(config: &CliConfig, tx_opts: &TxOptions, request_id: &str) -> Re
 
     // Resolve the active version's package so the cancel runs the bytecode
     // generation whose committed-request gate matches the chain's state
-    // (v1's bag-membership gate misses v2 in-place-committed requests).
-    let call_package = crate::onchain::OnchainState::new_reader(
-        &config.sui_rpc_url,
-        hashi_ids,
-        None,
-        crate::onchain::ScrapeScope::GovernanceOnly,
-    )
-    .await
-    .ok()
-    .and_then(|state| {
-        let guard = state.state();
-        let version = guard
-            .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
-            .active_version()?;
-        guard.package_versions().get(version)
-    })
-    .unwrap_or(hashi_ids.package_id);
+    // (v1's bag-membership gate misses v2 in-place-committed requests). A
+    // resolution failure must abort the command, not fall back: a v1-routed
+    // cancel aimed at a v2-committed request would destroy a request its
+    // live withdrawal txn still references.
+    let (_onchain, call_package) = super::resolve_active_call_package(config, hashi_ids).await?;
     let builder =
         crate::sui_tx_executor::build_cancel_withdrawal(hashi_ids, call_package, &req_addr, sender);
 
@@ -464,6 +462,11 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
 
     let requests = client.fetch_withdrawal_requests()?;
     let pending = client.fetch_withdrawal_txns()?;
+    // The v2 flow commits requests in place, so the mirrored map holds both
+    // the actionable queue and requests already committed into a withdrawal
+    // txn (those linger until the archival GC sweeps them and are counted
+    // through their txn's request_count).
+    let (queued, committed_in_place) = partition_queued(&requests);
     // Confirmed txns linger in the pending map until the archival GC sweeps
     // them; classify them first so they are never counted as actionable
     // "signed" (they are also fully signed).
@@ -476,7 +479,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
 
     match output_format {
         OutputFormat::Json => {
-            let queued: Vec<_> = requests
+            let queued_rows: Vec<_> = queued
                 .iter()
                 .map(|wr| {
                     serde_json::json!({
@@ -494,9 +497,10 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
             println!(
                 "{}",
                 serde_json::to_string_pretty(&serde_json::json!({
-                    "queued": queued,
+                    "queued": queued_rows,
                     "withdrawal_txns": withdrawal_txns,
-                    "queued_count": requests.len(),
+                    "queued_count": queued.len(),
+                    "committed_in_place_count": committed_in_place.len(),
                     "committed_count": committed_count,
                     "signed_count": signed_count,
                     "confirmed_count": confirmed_count,
@@ -510,7 +514,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
             if requests.is_empty() && pending.is_empty() {
                 print_info("No withdrawal requests found.");
             } else {
-                if !requests.is_empty() {
+                if !queued.is_empty() {
                     println!("  {}", "Queued:".bold().underline());
                     println!(
                         "  {:<20} {:<14} {:<10} {:<20} {}",
@@ -520,7 +524,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                         "Caller".bold(),
                         "Requested".bold()
                     );
-                    for wr in &requests {
+                    for wr in &queued {
                         println!(
                             "  {:<20} {:<14} {:<10} {:<20} {}",
                             display::format_address_full(&wr.id),
@@ -533,7 +537,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                 }
 
                 if !pending.is_empty() {
-                    if !requests.is_empty() {
+                    if !queued.is_empty() {
                         println!();
                     }
                     println!("  {}", "Pending Broadcast:".bold().underline());
@@ -556,8 +560,10 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                 }
 
                 println!(
-                    "\n  {} queued, {} committed, {} signed, {} confirmed awaiting archival",
-                    requests.len(),
+                    "\n  {} queued, {} committed in place; txns: {} committed, {} signed, \
+                     {} confirmed awaiting archival",
+                    queued.len(),
+                    committed_in_place.len(),
                     committed_count,
                     signed_count,
                     confirmed_count
@@ -569,6 +575,17 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Split the mirrored request map into the actionable queue
+/// (Requested/Approved) and the requests the v2 flow committed in place
+/// (Processing/Signed, plus the defensively handled Confirmed). The latter
+/// must not report as queued backlog: their BTC is already drained into a
+/// withdrawal txn, which the txn view counts.
+fn partition_queued(
+    requests: &[WithdrawalRequest],
+) -> (Vec<&WithdrawalRequest>, Vec<&WithdrawalRequest>) {
+    requests.iter().partition(|wr| wr.status.is_active())
 }
 
 /// The JSON row for one in-flight withdrawal transaction.
@@ -658,5 +675,51 @@ mod tests {
         txn.confirmed_timestamp_ms = Some(2);
         let row = withdrawal_txn_row(&txn);
         assert_eq!(row["status"], "confirmed");
+    }
+
+    fn request_with_status(status: WithdrawalStatus) -> WithdrawalRequest {
+        WithdrawalRequest {
+            id: sui_sdk_types::Address::new([1; 32]),
+            sender: sui_sdk_types::Address::new([2; 32]),
+            btc_amount: 1,
+            bitcoin_address: vec![0; 20],
+            created_timestamp_ms: 0,
+            status,
+            approval_cert: None,
+            approved_timestamp_ms: None,
+            withdrawal_txn_id: None,
+            sui_tx_digest: sui_sdk_types::Digest::new([0; 32]),
+            btc: 1,
+        }
+    }
+
+    /// Requests the v2 flow committed in place linger in the mirrored map
+    /// until the archival GC sweeps them; the queued view must exclude them
+    /// (they are already counted through their withdrawal txn).
+    #[test]
+    fn queued_view_excludes_committed_in_place_requests() {
+        let requests: Vec<_> = [
+            WithdrawalStatus::Requested,
+            WithdrawalStatus::Approved,
+            WithdrawalStatus::Processing,
+            WithdrawalStatus::Signed,
+            WithdrawalStatus::Confirmed,
+        ]
+        .into_iter()
+        .map(request_with_status)
+        .collect();
+
+        let (queued, committed_in_place) = partition_queued(&requests);
+        let statuses = |group: &[&WithdrawalRequest]| {
+            group
+                .iter()
+                .map(|wr| wr.status.as_str())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(statuses(&queued), ["requested", "approved"]);
+        assert_eq!(
+            statuses(&committed_in_place),
+            ["processing", "signed", "confirmed"]
+        );
     }
 }

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -89,10 +89,11 @@ async fn request(
     let destination_bytes = witness_program_from_address(&btc_addr)?;
 
     // `request_withdrawal` gates on `assert_version_enabled`, so the call
-    // must target the active version's package: a v1-targeted creation
-    // aborts once v1 is disabled. The resolved state also routes the batch
-    // executor below.
-    let (onchain, call_package) = super::resolve_active_call_package(config, hashi_ids).await?;
+    // must target the withdrawal-effective version's package: v1 while the
+    // bootstrap window keeps v1 enabled (matching the flow's dormancy), the
+    // active version after, where a v1-targeted creation would abort. The
+    // resolved state also routes the batch executor below.
+    let (onchain, call_package) = super::resolve_withdrawal_call_package(config, hashi_ids).await?;
 
     let mut client = crate::sui_rpc_client::new_sui_rpc_client(&config.sui_rpc_url)?;
 
@@ -144,8 +145,8 @@ async fn request(
     );
 
     // Execute mode guarantees a signer (rejected above otherwise). The
-    // attached reader state makes the executor route its calls through the
-    // active version's package.
+    // attached reader state makes the executor route its withdrawal calls
+    // through the withdrawal-effective version's package.
     let signer = signer.expect("execute mode requires a signer");
     let mut executor = crate::sui_tx_executor::SuiTxExecutor::new(client, signer, hashi_ids)
         .with_onchain_state(&onchain);
@@ -210,13 +211,16 @@ async fn cancel(config: &CliConfig, tx_opts: &TxOptions, request_id: &str) -> Re
             "No sender available: pass --sender (the refund recipient) or configure a keypair",
         )?;
 
-    // Resolve the active version's package so the cancel runs the bytecode
-    // generation whose committed-request gate matches the chain's state
-    // (v1's bag-membership gate misses v2 in-place-committed requests). A
-    // resolution failure must abort the command, not fall back: a v1-routed
-    // cancel aimed at a v2-committed request would destroy a request its
-    // live withdrawal txn still references.
-    let (_onchain, call_package) = super::resolve_active_call_package(config, hashi_ids).await?;
+    // Resolve the withdrawal-effective version's package so the cancel runs
+    // the bytecode generation whose committed-request gate matches the shape
+    // the flow is committing (v1's bag-membership gate misses v2
+    // in-place-committed requests, and vice versa; dormancy keeps the flow
+    // at v1 shapes exactly while v1 is still enabled). A resolution failure
+    // must abort the command, not fall back: a v1-routed cancel aimed at a
+    // v2-committed request would destroy a request its live withdrawal txn
+    // still references.
+    let (_onchain, call_package) =
+        super::resolve_withdrawal_call_package(config, hashi_ids).await?;
     let builder =
         crate::sui_tx_executor::build_cancel_withdrawal(hashi_ids, call_package, &req_addr, sender);
 

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -200,12 +200,27 @@ async fn cancel(config: &CliConfig, tx_opts: &TxOptions, request_id: &str) -> Re
             "No sender available: pass --sender (the refund recipient) or configure a keypair",
         )?;
 
-    let builder = crate::sui_tx_executor::build_cancel_withdrawal(
+    // Resolve the active version's package so the cancel runs the bytecode
+    // generation whose committed-request gate matches the chain's state
+    // (v1's bag-membership gate misses v2 in-place-committed requests).
+    let call_package = crate::onchain::OnchainState::new_reader(
+        &config.sui_rpc_url,
         hashi_ids,
-        hashi_ids.package_id,
-        &req_addr,
-        sender,
-    );
+        None,
+        crate::onchain::ScrapeScope::GovernanceOnly,
+    )
+    .await
+    .ok()
+    .and_then(|state| {
+        let guard = state.state();
+        let version = guard
+            .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
+            .active_version()?;
+        guard.package_versions().get(version)
+    })
+    .unwrap_or(hashi_ids.package_id);
+    let builder =
+        crate::sui_tx_executor::build_cancel_withdrawal(hashi_ids, call_package, &req_addr, sender);
 
     match tx_opts.mode() {
         TxMode::SerializeUnsigned => print_info("Building unsigned withdrawal cancellation..."),

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -544,7 +544,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                     if !queued.is_empty() {
                         println!();
                     }
-                    println!("  {}", "Pending Broadcast:".bold().underline());
+                    println!("  {}", "Withdrawal Transactions:".bold().underline());
                     for pw in &pending {
                         let txid: bitcoin::Txid = pw.txid.into();
                         let status = if pw.is_confirmed() {

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -18,6 +18,7 @@ use crate::cli::config::CliConfig;
 use crate::cli::print_info;
 use crate::cli::print_success;
 use crate::cli::types::display;
+use crate::onchain::types::WithdrawalStatus;
 use crate::onchain::types::WithdrawalTransaction;
 
 pub async fn run(action: WithdrawCommands, config: &CliConfig, tx_opts: &TxOptions) -> Result<()> {
@@ -244,7 +245,10 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
     println!("\n{}", "Withdrawal Status".bold());
     println!("{}", "━".repeat(60).dimmed());
 
-    // Check pending request queue first
+    // Check the mirrored request map first. With deferred archival a request
+    // stays here for its whole live lifecycle — Requested/Approved, then
+    // Processing/Signed once committed into a withdrawal txn, then Confirmed
+    // until the archival GC moves it to the processed archive.
     if let Some(wr) = withdrawal_requests.iter().find(|w| w.id == req_addr) {
         println!(
             "  {} {}",
@@ -267,99 +271,85 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
             "Requested:".bold(),
             display::format_timestamp(wr.created_timestamp_ms)
         );
-        println!();
 
-        let status_label = if wr.status.is_approved() {
-            "Approved".green()
-        } else {
-            "Requested".yellow()
-        };
+        match wr.status {
+            WithdrawalStatus::Requested | WithdrawalStatus::Approved => {
+                println!();
+                let status_label = if wr.status.is_approved() {
+                    "Approved".green()
+                } else {
+                    "Requested".yellow()
+                };
 
-        let step = if wr.status.is_approved() { 2 } else { 1 };
-        println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
-        println!(
-            "    {} Requested",
-            if step >= 1 {
-                "[done]".green()
-            } else {
-                "[    ]".dimmed()
+                let step = if wr.status.is_approved() { 2 } else { 1 };
+                println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
+                println!(
+                    "    {} Requested",
+                    if step >= 1 {
+                        "[done]".green()
+                    } else {
+                        "[    ]".dimmed()
+                    }
+                );
+                println!(
+                    "    {} Approved",
+                    if step >= 2 {
+                        "[done]".green()
+                    } else {
+                        "[    ]".dimmed()
+                    }
+                );
+                println!("    {} Committed", "[    ]".dimmed());
+                println!("    {} Signed", "[    ]".dimmed());
+                println!("    {} Broadcast", "[    ]".dimmed());
+                println!("    {} Confirmed", "[    ]".dimmed());
             }
-        );
-        println!(
-            "    {} Approved",
-            if step >= 2 {
-                "[done]".green()
-            } else {
-                "[    ]".dimmed()
+            // Committed into a withdrawal txn (BTC drained): render the txn's
+            // signing progress, looked up by the request's withdrawal_txn_id.
+            WithdrawalStatus::Processing | WithdrawalStatus::Signed => {
+                let txn = wr
+                    .withdrawal_txn_id
+                    .and_then(|id| withdrawal_txns.iter().find(|p| p.id == id));
+                if let Some(pw) = txn {
+                    print_txn_progress(config, pw);
+                } else {
+                    println!();
+                    print_info(&format!(
+                        "Request status is {} but its withdrawal transaction was not \
+                         found in the pending queues.",
+                        wr.status.as_str()
+                    ));
+                }
             }
-        );
-        println!("    {} Committed", "[    ]".dimmed());
-        println!("    {} Signed", "[    ]".dimmed());
-        println!("    {} Broadcast", "[    ]".dimmed());
-        println!("    {} Confirmed", "[    ]".dimmed());
+            // Terminal state: the withdrawal is complete; the request only
+            // lingers on-chain until the archival GC sweeps it.
+            WithdrawalStatus::Confirmed => {
+                println!();
+                println!(
+                    "  {} {} (6/6)",
+                    "Progress:".bold(),
+                    "Confirmed (archival pending)".green()
+                );
+                println!("    {} Requested", "[done]".green());
+                println!("    {} Approved", "[done]".green());
+                println!("    {} Committed", "[done]".green());
+                println!("    {} Signed", "[done]".green());
+                println!("    {} Broadcast", "[done]".green());
+                println!("    {} Confirmed", "[done]".green());
+            }
+        }
     }
     // Check committed/signed withdrawal transactions
     else if let Some(pw) = withdrawal_txns
         .iter()
         .find(|p| p.request_ids.contains(&req_addr))
     {
-        let txid: bitcoin::Txid = pw.txid.into();
-        let is_signed = pw.is_fully_signed();
-        let signed_inputs = pw.signing.signed_count();
-        let num_inputs = pw.signing.num_inputs();
-        let step = if is_signed { 4 } else { 3 };
-        // Distinguish the multi-checkpoint signing window: an in-progress txn
-        // shows "Signing (X/N)" rather than a flat "Committed".
-        let status_label = if is_signed {
-            "Signed".green()
-        } else if signed_inputs > 0 {
-            format!("Signing ({signed_inputs}/{num_inputs})").cyan()
-        } else {
-            "Committed".cyan()
-        };
-
         println!(
             "  {} {}",
             "Request ID:".bold(),
             display::format_address_full(&req_addr)
         );
-        println!("  {} {}", "BTC txid:".bold(), txid);
-        println!();
-        println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
-        println!("    {} Requested", "[done]".green());
-        println!("    {} Approved", "[done]".green());
-        println!("    {} Committed          txid: {}", "[done]".green(), txid);
-        println!(
-            "    {} Signed",
-            if is_signed {
-                "[done]".green()
-            } else {
-                "[    ]".dimmed()
-            }
-        );
-        println!("    {} Broadcast", "[    ]".dimmed());
-        println!("    {} Confirmed", "[    ]".dimmed());
-
-        // BTC context
-        if let Ok(Some(btc_rpc)) = config.btc_rpc_client() {
-            println!();
-            println!("  {}", "BTC Context:".bold());
-            match btc_rpc.get_raw_transaction_verbose(txid) {
-                Ok(info) => {
-                    let confirmations = info.confirmations.unwrap_or(0) as u32;
-                    let tx_status = if confirmations > 0 {
-                        "Confirmed".to_string()
-                    } else {
-                        "In Mempool".to_string()
-                    };
-                    println!("    {} {}", "TX Status:".bold(), tx_status);
-                    println!("    {} {}/6", "Confirmations:".bold(), confirmations);
-                }
-                Err(_) => {
-                    println!("    {}", "(transaction not found on BTC node)".dimmed());
-                }
-            }
-        }
+        print_txn_progress(config, pw);
     } else {
         print_info(
             "Withdrawal request not found in pending queues (may be confirmed or cancelled).",
@@ -370,13 +360,104 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Render the committed-phase progress checklist (steps 3-6) and Bitcoin-side
+/// context for a withdrawal transaction. Shared by the request-map lookup
+/// (Processing/Signed requests point at their txn via `withdrawal_txn_id`)
+/// and the txn-map fallback lookup.
+fn print_txn_progress(config: &CliConfig, pw: &WithdrawalTransaction) {
+    let txid: bitcoin::Txid = pw.txid.into();
+    let is_confirmed = pw.is_confirmed();
+    let is_signed = pw.is_fully_signed();
+    let signed_inputs = pw.signing.signed_count();
+    let num_inputs = pw.signing.num_inputs();
+    let step = if is_confirmed {
+        6
+    } else if is_signed {
+        4
+    } else {
+        3
+    };
+    // Distinguish the multi-checkpoint signing window: an in-progress txn
+    // shows "Signing (X/N)" rather than a flat "Committed". A confirmed txn
+    // lingers in the pending map until the archival GC sweeps it, so it must
+    // render as complete rather than broadcast-ready.
+    let status_label = if is_confirmed {
+        "Confirmed (archival pending)".green()
+    } else if is_signed {
+        "Signed".green()
+    } else if signed_inputs > 0 {
+        format!("Signing ({signed_inputs}/{num_inputs})").cyan()
+    } else {
+        "Committed".cyan()
+    };
+
+    println!("  {} {}", "BTC txid:".bold(), txid);
+    println!();
+    println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
+    println!("    {} Requested", "[done]".green());
+    println!("    {} Approved", "[done]".green());
+    println!("    {} Committed          txid: {}", "[done]".green(), txid);
+    println!(
+        "    {} Signed",
+        if is_signed {
+            "[done]".green()
+        } else {
+            "[    ]".dimmed()
+        }
+    );
+    println!(
+        "    {} Broadcast",
+        if is_confirmed {
+            "[done]".green()
+        } else {
+            "[    ]".dimmed()
+        }
+    );
+    println!(
+        "    {} Confirmed",
+        if is_confirmed {
+            "[done]".green()
+        } else {
+            "[    ]".dimmed()
+        }
+    );
+
+    // BTC context
+    if let Ok(Some(btc_rpc)) = config.btc_rpc_client() {
+        println!();
+        println!("  {}", "BTC Context:".bold());
+        match btc_rpc.get_raw_transaction_verbose(txid) {
+            Ok(info) => {
+                let confirmations = info.confirmations.unwrap_or(0) as u32;
+                let tx_status = if confirmations > 0 {
+                    "Confirmed".to_string()
+                } else {
+                    "In Mempool".to_string()
+                };
+                println!("    {} {}", "TX Status:".bold(), tx_status);
+                println!("    {} {}/6", "Confirmations:".bold(), confirmations);
+            }
+            Err(_) => {
+                println!("    {}", "(transaction not found on BTC node)".dimmed());
+            }
+        }
+    }
+}
+
 async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
     let client = HashiClient::new_with_bitcoin_state(config).await?;
 
     let requests = client.fetch_withdrawal_requests()?;
     let pending = client.fetch_withdrawal_txns()?;
-    let signed_count = pending.iter().filter(|pw| pw.is_fully_signed()).count();
-    let committed_count = pending.len() - signed_count;
+    // Confirmed txns linger in the pending map until the archival GC sweeps
+    // them; classify them first so they are never counted as actionable
+    // "signed" (they are also fully signed).
+    let confirmed_count = pending.iter().filter(|pw| pw.is_confirmed()).count();
+    let signed_count = pending
+        .iter()
+        .filter(|pw| !pw.is_confirmed() && pw.is_fully_signed())
+        .count();
+    let committed_count = pending.len() - confirmed_count - signed_count;
 
     match output_format {
         OutputFormat::Json => {
@@ -386,7 +467,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                     serde_json::json!({
                         "request_id": wr.id.to_string(),
                         "amount_sats": wr.btc_amount,
-                        "status": if wr.status.is_approved() { "approved" } else { "requested" },
+                        "status": wr.status.as_str(),
                         "caller": wr.sender.to_string(),
                         "requested_ms": wr.created_timestamp_ms,
                     })
@@ -403,6 +484,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                     "queued_count": requests.len(),
                     "committed_count": committed_count,
                     "signed_count": signed_count,
+                    "confirmed_count": confirmed_count,
                 }))?
             );
         }
@@ -424,16 +506,11 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                         "Requested".bold()
                     );
                     for wr in &requests {
-                        let status = if wr.status.is_approved() {
-                            "Approved"
-                        } else {
-                            "Requested"
-                        };
                         println!(
                             "  {:<20} {:<14} {:<10} {:<20} {}",
                             display::format_address_full(&wr.id),
                             wr.btc_amount,
-                            status,
+                            wr.status.as_str(),
                             display::format_address_full(&wr.sender),
                             display::format_timestamp(wr.created_timestamp_ms)
                         );
@@ -447,7 +524,9 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                     println!("  {}", "Pending Broadcast:".bold().underline());
                     for pw in &pending {
                         let txid: bitcoin::Txid = pw.txid.into();
-                        let status = if pw.is_fully_signed() {
+                        let status = if pw.is_confirmed() {
+                            "Confirmed (archival pending)"
+                        } else if pw.is_fully_signed() {
                             "Signed"
                         } else {
                             "Committed"
@@ -462,10 +541,11 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                 }
 
                 println!(
-                    "\n  {} queued, {} committed, {} signed",
+                    "\n  {} queued, {} committed, {} signed, {} confirmed awaiting archival",
                     requests.len(),
                     committed_count,
-                    signed_count
+                    signed_count,
+                    confirmed_count
                 );
             }
 
@@ -482,9 +562,19 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
 /// of the `WithdrawalTransaction` and is unrelated to the Bitcoin txid.
 fn withdrawal_txn_row(pw: &WithdrawalTransaction) -> serde_json::Value {
     let txid: bitcoin::Txid = pw.txid.into();
+    // A confirmed txn is also fully signed, so check confirmation first: it
+    // lingers only until the archival GC sweeps it and must not be reported
+    // as an actionable "signed" txn.
+    let status = if pw.is_confirmed() {
+        "confirmed"
+    } else if pw.is_fully_signed() {
+        "signed"
+    } else {
+        "committed"
+    };
     serde_json::json!({
         "txid": txid.to_string(),
-        "status": if pw.is_fully_signed() { "signed" } else { "committed" },
+        "status": status,
         "request_count": pw.request_ids.len(),
     })
 }
@@ -543,5 +633,15 @@ mod tests {
     fn withdrawal_txn_row_reports_committed_until_fully_signed() {
         let row = withdrawal_txn_row(&withdrawal_txn(false));
         assert_eq!(row["status"], "committed");
+    }
+
+    /// A confirmed txn lingering until the archival GC must classify as
+    /// "confirmed", not fall through to "signed" (it is also fully signed).
+    #[test]
+    fn withdrawal_txn_row_reports_confirmed_over_signed() {
+        let mut txn = withdrawal_txn(true);
+        txn.confirmed_timestamp_ms = Some(2);
+        let row = withdrawal_txn_row(&txn);
+        assert_eq!(row["status"], "confirmed");
     }
 }

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -152,8 +152,10 @@ pub struct Config {
     /// transaction. The batch commits immediately once this many requests are
     /// ready, without waiting for `withdrawal_batching_delay_ms` to elapse.
     ///
-    /// Defaults to 298 (the algorithm's hard upper bound, set by the Sui
-    /// commit transaction's runtime-object budget). Note that large batches
+    /// Defaults to 447 (the algorithm's hard upper bound, set by the Sui
+    /// commit transaction's runtime-object budget under the deferred-archival
+    /// package; a chain still executing v1 bytecode is additionally capped
+    /// at 298 at batch-build time). Note that large batches
     /// automatically shrink the input side: coin selection reserves the
     /// commit object budget for requests first, so a full batch spends only
     /// a handful of funding inputs and performs no consolidation.
@@ -646,7 +648,10 @@ mod tests {
     #[test]
     fn test_withdrawal_max_batch_size_defaults_to_absolute_cap() {
         let config = Config::new_for_testing();
-        assert_eq!(config.withdrawal_max_batch_size(), 298);
+        // The config clamp is the v2 cap; the leader additionally applies
+        // the version-aware cap at batch-build time, so a v1-active chain
+        // still gets the legacy 298.
+        assert_eq!(config.withdrawal_max_batch_size(), 447);
     }
 
     #[test]
@@ -674,7 +679,7 @@ mod tests {
     fn test_withdrawal_max_batch_size_clamps_to_absolute_cap() {
         let mut config = Config::new_for_testing();
         config.withdrawal_max_batch_size = Some(1_000);
-        assert_eq!(config.withdrawal_max_batch_size(), 298);
+        assert_eq!(config.withdrawal_max_batch_size(), 447);
     }
 
     #[test]

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -185,7 +185,8 @@ impl LeaderService {
     /// task that scans the object mirror for spent-but-uncleaned UTXO
     /// records and cleans them. The scan is armed at boot
     /// (crash-between-confirm-and-cleanup recovery), whenever a withdrawal
-    /// confirms on Sui, and after a task that did work or failed.
+    /// confirms on Sui, after a task that did work or failed, and by the
+    /// disarmed-state mirror probe below.
     pub(super) fn check_cleanup_spent_utxos(&mut self, checkpoint_timestamp_ms: u64) {
         if self.utxo_cleanup_gc_task.is_some() {
             debug!("UTXO cleanup GC task already in-flight, skipping");
@@ -193,7 +194,17 @@ impl LeaderService {
         }
 
         if !self.utxo_cleanup_scan_needed {
-            return;
+            // The arming flag is local, and a confirm can land without this
+            // node's broadcast result path observing it (another leader
+            // submitted it, the task timeout truncated the result, or it
+            // was submitted out-of-band); the retained-txn filter then
+            // blocks any retry from re-emitting ConfirmedOnSui. The spent
+            // records are still visible in every mirror, so probe for them
+            // rather than trust the flag alone.
+            if !has_spent_utxos_pending_cleanup(&self.inner.onchain_state().utxo_records()) {
+                return;
+            }
+            self.utxo_cleanup_scan_needed = true;
         }
 
         if self.utxo_cleanup_retry.should_skip(checkpoint_timestamp_ms) {
@@ -295,7 +306,17 @@ impl LeaderService {
         }
 
         if !self.withdrawal_archive_scan_needed {
-            return;
+            // Mirror probe matching the cleanup arm in
+            // `check_cleanup_spent_utxos`: a confirm whose ConfirmedOnSui
+            // result never reached this node still leaves its txn visible
+            // as confirmed in the mirror, and no retry can re-emit the
+            // result once the mirror shows the confirm.
+            if !has_confirmed_withdrawals_pending_archive(
+                &self.inner.onchain_state().withdrawal_txns(),
+            ) {
+                return;
+            }
+            self.withdrawal_archive_scan_needed = true;
         }
 
         if self
@@ -553,6 +574,25 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
         .collect()
 }
 
+/// Disarmed-state probe for the cleanup scan's arming gate: whether the
+/// mirror holds any spent-but-uncleaned UTXO record. The arming flag is
+/// local to one node, so records left by a confirm this node's result path
+/// never observed would otherwise strand until an unrelated confirm re-arms
+/// whichever node is leader.
+fn has_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>) -> bool {
+    utxo_records
+        .values()
+        .any(|record| record.spent_epoch.is_some())
+}
+
+/// Disarmed-state probe for the archival scan's arming gate, the
+/// withdrawal-archive twin of [`has_spent_utxos_pending_cleanup`].
+fn has_confirmed_withdrawals_pending_archive(
+    withdrawal_txns: &[crate::onchain::types::WithdrawalTransaction],
+) -> bool {
+    withdrawal_txns.iter().any(|txn| txn.is_confirmed())
+}
+
 /// Confirmed-but-unarchived withdrawal txns, oldest confirmation first so a
 /// capped backlog drains FIFO. Each victim carries its request ids so the
 /// executor can pack GC transactions against the runtime-object budget and
@@ -579,8 +619,10 @@ fn find_confirmed_withdrawals_pending_archive(
 mod tests {
     use super::*;
     use crate::onchain::types::Utxo;
+    use crate::onchain::types::WithdrawalTransaction;
     use hashi_types::bitcoin_txid::BitcoinTxid;
     use hashi_types::move_types::CommitteeSignature;
+    use hashi_types::move_types::SigningBatch;
     use sui_sdk_types::Digest;
 
     /// Helper: build a `UtxoId` from a distinguishing byte and vout.
@@ -718,5 +760,54 @@ mod tests {
 
         let result = find_spent_utxos_pending_cleanup(&utxo_records);
         assert_eq!(result.len(), MAX_UTXO_CLEANUPS_PER_GC);
+    }
+
+    /// Helper: build a `WithdrawalTransaction` that is confirmed or not.
+    fn withdrawal_txn(byte: u8, confirmed: bool) -> WithdrawalTransaction {
+        WithdrawalTransaction {
+            id: Address::new([byte; 32]),
+            txid: BitcoinTxid::new([byte; 32]),
+            request_ids: vec![],
+            inputs: vec![],
+            withdrawal_outputs: vec![],
+            change_outputs: vec![],
+            created_timestamp_ms: 0,
+            signed_timestamp_ms: None,
+            confirmed_timestamp_ms: confirmed.then_some(1),
+            randomness: vec![],
+            signing: SigningBatch {
+                signatures: vec![],
+                epoch: 0,
+            },
+            guardian_signatures: None,
+        }
+    }
+
+    /// The disarmed-state probe must arm only when a spent record actually
+    /// exists in the mirror; anything else would re-arm every leader tick.
+    #[test]
+    fn cleanup_probe_requires_a_spent_record() {
+        assert!(!has_spent_utxos_pending_cleanup(&BTreeMap::new()));
+        assert!(!has_spent_utxos_pending_cleanup(&BTreeMap::from([(
+            utxo_id(1, 0),
+            record(None)
+        )])));
+        assert!(has_spent_utxos_pending_cleanup(&BTreeMap::from([
+            (utxo_id(1, 0), record(None)),
+            (utxo_id(2, 0), record(Some(3))),
+        ])));
+    }
+
+    /// The archival twin: arm only on a confirmed-but-unarchived txn.
+    #[test]
+    fn archive_probe_requires_a_confirmed_txn() {
+        assert!(!has_confirmed_withdrawals_pending_archive(&[]));
+        assert!(!has_confirmed_withdrawals_pending_archive(&[
+            withdrawal_txn(1, false)
+        ]));
+        assert!(has_confirmed_withdrawals_pending_archive(&[
+            withdrawal_txn(1, false),
+            withdrawal_txn(2, true),
+        ]));
     }
 }

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -59,6 +59,35 @@ impl crate::leader::retry::RetryPolicy for UtxoCleanupErrorKind {
     }
 }
 
+// Cap the archival scan so one GC task stays bounded; a larger backlog
+// drains over successive checkpoints, oldest confirmations first.
+const MAX_WITHDRAWAL_ARCHIVES_PER_GC: usize = 500;
+
+// `archive_confirmed_withdrawals` first exists in the v2 package, and
+// pre-upgrade there is nothing to archive (v1 confirm archives inline).
+const WITHDRAWAL_ARCHIVE_MIN_PACKAGE_VERSION: u64 = 2;
+
+/// Failure kind for the withdrawal archival GC. Unbounded retries for the
+/// same reason as [`UtxoCleanupErrorKind`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum WithdrawalArchiveErrorKind {
+    Failed,
+}
+
+impl crate::leader::retry::RetryPolicy for WithdrawalArchiveErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        5_000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        5 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
+    }
+}
+
 impl LeaderService {
     /// Check for and delete expired deposit requests.
     /// Deposit requests are sorted by timestamp and deleted if they are older than
@@ -267,6 +296,101 @@ impl LeaderService {
         Ok(utxo_ids.len())
     }
 
+    /// Kick the deferred-archival GC for confirmed withdrawals. Shape and
+    /// arming protocol mirror [`Self::check_cleanup_spent_utxos`]; the extra
+    /// version gate exists because the archival entry only exists in v2
+    /// bytecode (and gating on the ACTIVE version also keeps the task off a
+    /// chain whose semantics this binary does not implement).
+    pub(super) fn check_archive_confirmed_withdrawals(&mut self, checkpoint_timestamp_ms: u64) {
+        if self.withdrawal_archive_gc_task.is_some() {
+            debug!("Withdrawal archival GC task already in-flight, skipping");
+            return;
+        }
+
+        let Some(active) = self.inner.onchain_state().active_package_version() else {
+            return;
+        };
+        if active < WITHDRAWAL_ARCHIVE_MIN_PACKAGE_VERSION {
+            return;
+        }
+
+        if !self.withdrawal_archive_scan_needed {
+            return;
+        }
+
+        if self
+            .withdrawal_archive_retry
+            .should_skip(checkpoint_timestamp_ms)
+        {
+            debug!("Withdrawal archival GC in backoff, skipping");
+            return;
+        }
+
+        self.withdrawal_archive_scan_needed = false;
+        let inner = self.inner.clone();
+        let scan_target = self.withdrawal_archive_scan_target;
+        self.withdrawal_archive_gc_task =
+            Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
+                Self::archive_confirmed_withdrawals(inner, scan_target).await
+            })));
+    }
+
+    /// Scan the mirror for confirmed-but-unarchived withdrawal txns and
+    /// archive them (moving each txn to `confirmed_txns` and its requests to
+    /// `processed` on-chain). Returns how many were archived so the caller
+    /// can re-arm past the per-GC cap. Freshness protocol identical to
+    /// [`Self::cleanup_spent_utxos`].
+    async fn archive_confirmed_withdrawals(
+        inner: Arc<crate::Hashi>,
+        scan_target: u64,
+    ) -> anyhow::Result<usize> {
+        const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
+        if tokio::time::timeout(
+            VISIBILITY_TIMEOUT,
+            inner.onchain_state().wait_until_checkpoint(scan_target),
+        )
+        .await
+        .is_err()
+        {
+            anyhow::bail!(
+                "mirror did not reach the archival scan target checkpoint {scan_target} within \
+                 {VISIBILITY_TIMEOUT:?}"
+            );
+        }
+        let withdrawal_txns = inner.onchain_state().withdrawal_txns();
+        let victims = find_confirmed_withdrawals_pending_archive(&withdrawal_txns);
+        if victims.is_empty() {
+            return Ok(0);
+        }
+
+        info!(
+            txn_count = victims.len(),
+            "Archiving confirmed withdrawal(s) pending archival",
+        );
+        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        let landed_at = executor
+            .execute_archive_confirmed_withdrawals(&victims)
+            .await?;
+        if tokio::time::timeout(
+            VISIBILITY_TIMEOUT,
+            inner.onchain_state().wait_until_checkpoint(landed_at),
+        )
+        .await
+        .is_err()
+        {
+            warn!(
+                landed_at,
+                "Timeout waiting for the mirror to reach the archival checkpoint; \
+                 the next scan may resubmit already-archived txns"
+            );
+        }
+        info!(
+            txn_count = victims.len(),
+            "Successfully archived confirmed withdrawals",
+        );
+        Ok(victims.len())
+    }
+
     async fn delete_expired_proposals(
         inner: Arc<crate::Hashi>,
         expired_proposals: Vec<Proposal>,
@@ -389,6 +513,24 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
         .filter(|(_, record)| record.spent_epoch.is_some())
         .map(|(id, _)| *id)
         .take(MAX_UTXO_CLEANUPS_PER_GC)
+        .collect()
+}
+
+/// Confirmed-but-unarchived withdrawal txns, oldest confirmation first so a
+/// capped backlog drains FIFO. Each victim carries its request count so the
+/// executor can pack GC transactions against the runtime-object budget.
+fn find_confirmed_withdrawals_pending_archive(
+    withdrawal_txns: &[crate::onchain::types::WithdrawalTransaction],
+) -> Vec<(Address, usize)> {
+    let mut confirmed: Vec<_> = withdrawal_txns
+        .iter()
+        .filter(|txn| txn.is_confirmed())
+        .collect();
+    confirmed.sort_by_key(|txn| txn.confirmed_timestamp_ms);
+    confirmed
+        .into_iter()
+        .take(MAX_WITHDRAWAL_ARCHIVES_PER_GC)
+        .map(|txn| (txn.id, txn.request_ids.len()))
         .collect()
 }
 

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -290,18 +290,20 @@ impl LeaderService {
     /// Kick the deferred-archival GC for confirmed withdrawals. Shape and
     /// arming protocol mirror [`Self::check_cleanup_spent_utxos`]; the extra
     /// version gate exists because the archival entry only exists in v2
-    /// bytecode (and gating on the ACTIVE version also keeps the task off a
-    /// chain whose semantics this binary does not implement).
+    /// bytecode. It gates on the withdrawal-EFFECTIVE version (the active
+    /// version, held at v1 while the bootstrap window keeps v1 enabled): a
+    /// dormant flow confirms through v1 bytecode, which archives inline and
+    /// leaves nothing for this GC.
     pub(super) fn check_archive_confirmed_withdrawals(&mut self, checkpoint_timestamp_ms: u64) {
         if self.withdrawal_archive_gc_task.is_some() {
             debug!("Withdrawal archival GC task already in-flight, skipping");
             return;
         }
 
-        let Some(active) = self.inner.onchain_state().active_package_version() else {
+        let Some(effective) = self.inner.onchain_state().withdrawal_effective_version() else {
             return;
         };
-        if active < WITHDRAWAL_ARCHIVE_MIN_PACKAGE_VERSION {
+        if effective < WITHDRAWAL_ARCHIVE_MIN_PACKAGE_VERSION {
             return;
         }
 

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -9,6 +9,7 @@ use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
 use crate::onchain::types::UtxoId;
 use crate::onchain::types::UtxoRecord;
+use crate::sui_tx_executor::ArchiveVictim;
 use crate::sui_tx_executor::SuiTxExecutor;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -553,11 +554,12 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
 }
 
 /// Confirmed-but-unarchived withdrawal txns, oldest confirmation first so a
-/// capped backlog drains FIFO. Each victim carries its request count so the
-/// executor can pack GC transactions against the runtime-object budget.
+/// capped backlog drains FIFO. Each victim carries its request ids so the
+/// executor can pack GC transactions against the runtime-object budget and
+/// chunk oversized txns through the split archival entries.
 fn find_confirmed_withdrawals_pending_archive(
     withdrawal_txns: &[crate::onchain::types::WithdrawalTransaction],
-) -> Vec<(Address, usize)> {
+) -> Vec<ArchiveVictim> {
     let mut confirmed: Vec<_> = withdrawal_txns
         .iter()
         .filter(|txn| txn.is_confirmed())
@@ -566,7 +568,10 @@ fn find_confirmed_withdrawals_pending_archive(
     confirmed
         .into_iter()
         .take(MAX_WITHDRAWAL_ARCHIVES_PER_GC)
-        .map(|txn| (txn.id, txn.request_ids.len()))
+        .map(|txn| ArchiveVictim {
+            txn_id: txn.id,
+            request_ids: txn.request_ids.clone(),
+        })
         .collect()
 }
 

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -59,6 +59,35 @@ impl crate::leader::retry::RetryPolicy for UtxoCleanupErrorKind {
     }
 }
 
+// Cap the archival scan so one GC task stays bounded; a larger backlog
+// drains over successive checkpoints, oldest confirmations first.
+const MAX_WITHDRAWAL_ARCHIVES_PER_GC: usize = 500;
+
+// `archive_confirmed_withdrawals` first exists in the v2 package, and
+// pre-upgrade there is nothing to archive (v1 confirm archives inline).
+const WITHDRAWAL_ARCHIVE_MIN_PACKAGE_VERSION: u64 = 2;
+
+/// Failure kind for the withdrawal archival GC. Unbounded retries for the
+/// same reason as [`UtxoCleanupErrorKind`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum WithdrawalArchiveErrorKind {
+    Failed,
+}
+
+impl crate::leader::retry::RetryPolicy for WithdrawalArchiveErrorKind {
+    fn retry_base_delay_ms(self) -> u64 {
+        5_000
+    }
+
+    fn max_delay_ms(self) -> u64 {
+        5 * 60 * 1000
+    }
+
+    fn max_retries(self) -> u32 {
+        u32::MAX
+    }
+}
+
 impl LeaderService {
     /// Check for and delete expired deposit requests.
     /// Unapproved requests expire based on creation time; approved requests expire based on
@@ -246,6 +275,101 @@ impl LeaderService {
         Ok(utxo_ids.len())
     }
 
+    /// Kick the deferred-archival GC for confirmed withdrawals. Shape and
+    /// arming protocol mirror [`Self::check_cleanup_spent_utxos`]; the extra
+    /// version gate exists because the archival entry only exists in v2
+    /// bytecode (and gating on the ACTIVE version also keeps the task off a
+    /// chain whose semantics this binary does not implement).
+    pub(super) fn check_archive_confirmed_withdrawals(&mut self, checkpoint_timestamp_ms: u64) {
+        if self.withdrawal_archive_gc_task.is_some() {
+            debug!("Withdrawal archival GC task already in-flight, skipping");
+            return;
+        }
+
+        let Some(active) = self.inner.onchain_state().active_package_version() else {
+            return;
+        };
+        if active < WITHDRAWAL_ARCHIVE_MIN_PACKAGE_VERSION {
+            return;
+        }
+
+        if !self.withdrawal_archive_scan_needed {
+            return;
+        }
+
+        if self
+            .withdrawal_archive_retry
+            .should_skip(checkpoint_timestamp_ms)
+        {
+            debug!("Withdrawal archival GC in backoff, skipping");
+            return;
+        }
+
+        self.withdrawal_archive_scan_needed = false;
+        let inner = self.inner.clone();
+        let scan_target = self.withdrawal_archive_scan_target;
+        self.withdrawal_archive_gc_task =
+            Some(AbortOnDropHandle::new(tokio::task::spawn(async move {
+                Self::archive_confirmed_withdrawals(inner, scan_target).await
+            })));
+    }
+
+    /// Scan the mirror for confirmed-but-unarchived withdrawal txns and
+    /// archive them (moving each txn to `confirmed_txns` and its requests to
+    /// `processed` on-chain). Returns how many were archived so the caller
+    /// can re-arm past the per-GC cap. Freshness protocol identical to
+    /// [`Self::cleanup_spent_utxos`].
+    async fn archive_confirmed_withdrawals(
+        inner: Arc<crate::Hashi>,
+        scan_target: u64,
+    ) -> anyhow::Result<usize> {
+        const VISIBILITY_TIMEOUT: Duration = Duration::from_secs(30);
+        if tokio::time::timeout(
+            VISIBILITY_TIMEOUT,
+            inner.onchain_state().wait_until_checkpoint(scan_target),
+        )
+        .await
+        .is_err()
+        {
+            anyhow::bail!(
+                "mirror did not reach the archival scan target checkpoint {scan_target} within \
+                 {VISIBILITY_TIMEOUT:?}"
+            );
+        }
+        let withdrawal_txns = inner.onchain_state().withdrawal_txns();
+        let victims = find_confirmed_withdrawals_pending_archive(&withdrawal_txns);
+        if victims.is_empty() {
+            return Ok(0);
+        }
+
+        info!(
+            txn_count = victims.len(),
+            "Archiving confirmed withdrawal(s) pending archival",
+        );
+        let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
+        let landed_at = executor
+            .execute_archive_confirmed_withdrawals(&victims)
+            .await?;
+        if tokio::time::timeout(
+            VISIBILITY_TIMEOUT,
+            inner.onchain_state().wait_until_checkpoint(landed_at),
+        )
+        .await
+        .is_err()
+        {
+            warn!(
+                landed_at,
+                "Timeout waiting for the mirror to reach the archival checkpoint; \
+                 the next scan may resubmit already-archived txns"
+            );
+        }
+        info!(
+            txn_count = victims.len(),
+            "Successfully archived confirmed withdrawals",
+        );
+        Ok(victims.len())
+    }
+
     async fn delete_expired_proposals(
         inner: Arc<crate::Hashi>,
         expired_proposals: Vec<Proposal>,
@@ -425,6 +549,24 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
         .filter(|(_, record)| record.spent_epoch.is_some())
         .map(|(id, _)| *id)
         .take(MAX_UTXO_CLEANUPS_PER_GC)
+        .collect()
+}
+
+/// Confirmed-but-unarchived withdrawal txns, oldest confirmation first so a
+/// capped backlog drains FIFO. Each victim carries its request count so the
+/// executor can pack GC transactions against the runtime-object budget.
+fn find_confirmed_withdrawals_pending_archive(
+    withdrawal_txns: &[crate::onchain::types::WithdrawalTransaction],
+) -> Vec<(Address, usize)> {
+    let mut confirmed: Vec<_> = withdrawal_txns
+        .iter()
+        .filter(|txn| txn.is_confirmed())
+        .collect();
+    confirmed.sort_by_key(|txn| txn.confirmed_timestamp_ms);
+    confirmed
+        .into_iter()
+        .take(MAX_WITHDRAWAL_ARCHIVES_PER_GC)
+        .map(|txn| (txn.id, txn.request_ids.len()))
         .collect()
 }
 

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -9,6 +9,7 @@ use crate::onchain::types::Proposal;
 use crate::onchain::types::ProposalType;
 use crate::onchain::types::UtxoId;
 use crate::onchain::types::UtxoRecord;
+use crate::sui_tx_executor::ArchiveVictim;
 use crate::sui_tx_executor::SuiTxExecutor;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -517,11 +518,12 @@ fn find_spent_utxos_pending_cleanup(utxo_records: &BTreeMap<UtxoId, UtxoRecord>)
 }
 
 /// Confirmed-but-unarchived withdrawal txns, oldest confirmation first so a
-/// capped backlog drains FIFO. Each victim carries its request count so the
-/// executor can pack GC transactions against the runtime-object budget.
+/// capped backlog drains FIFO. Each victim carries its request ids so the
+/// executor can pack GC transactions against the runtime-object budget and
+/// chunk oversized txns through the split archival entries.
 fn find_confirmed_withdrawals_pending_archive(
     withdrawal_txns: &[crate::onchain::types::WithdrawalTransaction],
-) -> Vec<(Address, usize)> {
+) -> Vec<ArchiveVictim> {
     let mut confirmed: Vec<_> = withdrawal_txns
         .iter()
         .filter(|txn| txn.is_confirmed())
@@ -530,7 +532,10 @@ fn find_confirmed_withdrawals_pending_archive(
     confirmed
         .into_iter()
         .take(MAX_WITHDRAWAL_ARCHIVES_PER_GC)
-        .map(|txn| (txn.id, txn.request_ids.len()))
+        .map(|txn| ArchiveVictim {
+            txn_id: txn.id,
+            request_ids: txn.request_ids.clone(),
+        })
         .collect()
 }
 

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -128,6 +128,15 @@ pub(crate) struct LeaderService {
     // confirm. Zero at boot: the bootstrap mirror is fresh by construction.
     utxo_cleanup_scan_target: u64,
 
+    // Singleton task that archives confirmed withdrawals (moving them and
+    // their requests to the cold bags on-chain); resolves to how many txns
+    // it archived. Same arming/retry/freshness shape as the UTXO cleanup;
+    // only spawned once the active package version has the archival entry.
+    withdrawal_archive_gc_task: Option<AbortOnDropHandle<anyhow::Result<usize>>>,
+    withdrawal_archive_retry: GlobalRetryTracker<garbage_collection::WithdrawalArchiveErrorKind>,
+    withdrawal_archive_scan_needed: bool,
+    withdrawal_archive_scan_target: u64,
+
     // Singleton task that reconciles the guardian committee with the on-chain committee.
     guardian_committee_reconcile_task: Option<AbortOnDropHandle<anyhow::Result<()>>>,
     // Last hashi epoch we triggered a guardian-committee reconcile for, so
@@ -167,6 +176,12 @@ impl LeaderService {
             utxo_cleanup_retry: GlobalRetryTracker::new(),
             utxo_cleanup_scan_needed: true,
             utxo_cleanup_scan_target: 0,
+            withdrawal_archive_gc_task: None,
+            withdrawal_archive_retry: GlobalRetryTracker::new(),
+            // Armed at boot for crash-between-confirm-and-archive recovery;
+            // a no-op pre-upgrade (the version gate skips the spawn).
+            withdrawal_archive_scan_needed: true,
+            withdrawal_archive_scan_target: 0,
             guardian_committee_reconcile_task: None,
             last_guardian_reconcile_epoch: None,
         }
@@ -271,6 +286,7 @@ impl LeaderService {
                     self.check_delete_expired_deposit_requests(checkpoint_timestamp_ms);
                     self.check_delete_proposals(checkpoint_timestamp_ms);
                     self.check_cleanup_spent_utxos(checkpoint_timestamp_ms);
+                    self.check_archive_confirmed_withdrawals(checkpoint_timestamp_ms);
                     self.process_stale_unapproved_deposits_if_new_epoch();
                     self.process_approved_deposit_requests();
                 }
@@ -351,6 +367,25 @@ impl LeaderService {
                         }
                     }
                     Self::log_task_result("utxo_cleanup_gc", result);
+                }
+                Some(result) = OptionFuture::from(self.withdrawal_archive_gc_task.as_mut()) => {
+                    self.withdrawal_archive_gc_task = None;
+                    // Same re-arm policy as the UTXO cleanup arm above.
+                    match &result {
+                        Ok(Ok(0)) => self.withdrawal_archive_retry.clear(),
+                        Ok(Ok(_)) => {
+                            self.withdrawal_archive_retry.clear();
+                            self.withdrawal_archive_scan_needed = true;
+                        }
+                        _ => {
+                            self.withdrawal_archive_retry.record_failure(
+                                garbage_collection::WithdrawalArchiveErrorKind::Failed,
+                                checkpoint_rx.borrow().timestamp_ms,
+                            );
+                            self.withdrawal_archive_scan_needed = true;
+                        }
+                    }
+                    Self::log_task_result("withdrawal_archive_gc", result);
                 }
                 Some(result) = OptionFuture::from(self.guardian_committee_reconcile_task.as_mut()) => {
                     self.guardian_committee_reconcile_task = None;

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -119,7 +119,10 @@ pub(crate) struct LeaderService {
     utxo_cleanup_gc_task: Option<AbortOnDropHandle<anyhow::Result<usize>>>,
     utxo_cleanup_retry: GlobalRetryTracker<garbage_collection::UtxoCleanupErrorKind>,
     // Arms the cleanup scan: set at boot (crash recovery), when a withdrawal
-    // confirms on Sui, and after a cleanup task that did work or failed.
+    // confirms on Sui, and after a cleanup task that did work or failed. The
+    // check-side mirror probe also arms it while disarmed, since a confirm
+    // submitted by another leader (or one whose local result was lost)
+    // leaves victims visible in the mirror without ever setting the flag.
     utxo_cleanup_scan_needed: bool,
     // Checkpoint the scan's mirror read must cover before deciding: the
     // highest checkpoint a confirm tx landed in (monotonic). A scan from a

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -146,6 +146,11 @@ pub(crate) struct LeaderService {
     // we only kick a new task when the chain advances (not every checkpoint).
     // `None` triggers an initial reconcile on the first leader tick.
     last_guardian_reconcile_epoch: Option<u64>,
+
+    // Last observed (effective, active) withdrawal package version pair, so
+    // the semantics-selection log fires only on change. `None` logs the
+    // initial selection on the first tick.
+    last_withdrawal_semantics: Option<(Option<u64>, Option<u64>)>,
 }
 
 impl LeaderService {
@@ -187,6 +192,7 @@ impl LeaderService {
             withdrawal_archive_scan_target: 0,
             guardian_committee_reconcile_task: None,
             last_guardian_reconcile_epoch: None,
+            last_withdrawal_semantics: None,
         }
     }
 
@@ -265,6 +271,10 @@ impl LeaderService {
                     };
 
                     let is_leader = self.is_current_leader(checkpoint_height);
+                    // Before the non-leader `continue`, like the heartbeat:
+                    // every node reports its withdrawal semantics selection,
+                    // not just the current leader.
+                    self.observe_withdrawal_semantics();
                     // Heartbeat before the non-leader `continue` so followers
                     // report liveness too.
                     self.inner.metrics.task_heartbeat("leader_loop");

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -34,6 +34,26 @@ use tracing::warn;
 const WITHDRAWAL_APPROVAL_PTB_BATCH_SIZE: usize = 200;
 
 impl LeaderService {
+    /// Info-log the withdrawal flow's semantics selection whenever it
+    /// changes (once at boot, then on DisableVersion(1) or an upgrade), so
+    /// operators can see the v1-dormancy gate engage and release. An
+    /// effective version below the active one means dormancy is holding
+    /// the flow at v1 semantics through the bootstrap both-enabled window.
+    pub(super) fn observe_withdrawal_semantics(&mut self) {
+        let effective = self.inner.onchain_state().withdrawal_effective_version();
+        let active = self.inner.onchain_state().active_package_version();
+        if self.last_withdrawal_semantics == Some((effective, active)) {
+            return;
+        }
+        self.last_withdrawal_semantics = Some((effective, active));
+        info!(
+            effective_package_version = ?effective,
+            active_package_version = ?active,
+            dormant = effective < active,
+            "Withdrawal flow semantics selected",
+        );
+    }
+
     // ========================================================================
     // Step 1: Approve unapproved withdrawal requests
     // ========================================================================
@@ -555,7 +575,7 @@ impl LeaderService {
 
         let max_batch = withdrawal_fire_threshold(
             self.inner.config.withdrawal_max_batch_size(),
-            self.inner.onchain_state().active_package_version(),
+            self.inner.onchain_state().withdrawal_effective_version(),
         );
         let delay_ms = self.inner.config.withdrawal_batching_delay_ms();
 
@@ -844,13 +864,13 @@ fn is_still_approvable(request: &hashi_types::move_types::WithdrawalRequest) -> 
 }
 
 /// The batch size at which the scheduler stops holding for more demand.
-/// Capped by the active version's executable request cap: commitment
-/// construction trims the batch to it, so a threshold above the cap can
-/// never be met at that version and only pays the full batching delay
-/// before committing the capped batch anyway.
-fn withdrawal_fire_threshold(config_max: usize, active_package_version: Option<u64>) -> usize {
+/// Capped by the withdrawal-effective version's executable request cap:
+/// commitment construction trims the batch to it, so a threshold above
+/// the cap can never be met at that version and only pays the full
+/// batching delay before committing the capped batch anyway.
+fn withdrawal_fire_threshold(config_max: usize, effective_package_version: Option<u64>) -> usize {
     config_max.min(crate::withdrawals::max_withdrawal_requests(
-        active_package_version,
+        effective_package_version,
     ))
 }
 
@@ -909,5 +929,20 @@ mod fire_threshold_tests {
         // A configured maximum below the cap passes through at any version.
         assert_eq!(withdrawal_fire_threshold(2, None), 2);
         assert_eq!(withdrawal_fire_threshold(2, Some(2)), 2);
+    }
+
+    /// Both-enabled means v1 semantics at this seam too: the threshold is
+    /// fed the withdrawal-effective version, which dormancy holds at 1
+    /// while v1 stays in the enabled set even though the active version
+    /// is 2.
+    #[test]
+    fn fire_threshold_stays_legacy_while_v1_is_enabled() {
+        let both_enabled = [1u64, 2].into_iter().collect();
+        let effective = crate::withdrawals::withdrawal_effective_version(2, &both_enabled);
+        assert_eq!(withdrawal_fire_threshold(447, Some(effective)), 298);
+
+        let v1_disabled = [2u64].into_iter().collect();
+        let effective = crate::withdrawals::withdrawal_effective_version(2, &v1_disabled);
+        assert_eq!(withdrawal_fire_threshold(447, Some(effective)), 447);
     }
 }

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -553,7 +553,10 @@ impl LeaderService {
             (approved, false)
         };
 
-        let max_batch = self.inner.config.withdrawal_max_batch_size();
+        let max_batch = withdrawal_fire_threshold(
+            self.inner.config.withdrawal_max_batch_size(),
+            self.inner.onchain_state().active_package_version(),
+        );
         let delay_ms = self.inner.config.withdrawal_batching_delay_ms();
 
         let batch_is_full = batch.len() >= max_batch;
@@ -840,6 +843,17 @@ fn is_still_approvable(request: &hashi_types::move_types::WithdrawalRequest) -> 
     request.status.is_requested()
 }
 
+/// The batch size at which the scheduler stops holding for more demand.
+/// Capped by the active version's executable request cap: commitment
+/// construction trims the batch to it, so a threshold above the cap can
+/// never be met at that version and only pays the full batching delay
+/// before committing the capped batch anyway.
+fn withdrawal_fire_threshold(config_max: usize, active_package_version: Option<u64>) -> usize {
+    config_max.min(crate::withdrawals::max_withdrawal_requests(
+        active_package_version,
+    ))
+}
+
 #[cfg(test)]
 mod approvable_tests {
     use super::*;
@@ -874,5 +888,26 @@ mod approvable_tests {
         ] {
             assert!(!is_still_approvable(&request_with_status(status)));
         }
+    }
+}
+
+#[cfg(test)]
+mod fire_threshold_tests {
+    use super::*;
+
+    /// The scheduler's fire threshold must track the version-resolved
+    /// executable cap that commitment construction enforces (298 at v1 or
+    /// unresolved, 447 at v2): a threshold the builder trims below can
+    /// never fire and only pays the full batching delay. A literal
+    /// 298-request e2e is impractical (each request needs a funded
+    /// deposit), so pin the threshold seam the builder shares instead.
+    #[test]
+    fn fire_threshold_tracks_the_version_resolved_cap() {
+        assert_eq!(withdrawal_fire_threshold(447, None), 298);
+        assert_eq!(withdrawal_fire_threshold(447, Some(1)), 298);
+        assert_eq!(withdrawal_fire_threshold(447, Some(2)), 447);
+        // A configured maximum below the cap passes through at any version.
+        assert_eq!(withdrawal_fire_threshold(2, None), 2);
+        assert_eq!(withdrawal_fire_threshold(2, Some(2)), 2);
     }
 }

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -385,10 +385,18 @@ impl LeaderService {
             let err_msg = format!("{e}");
             error!("approve_request PTB failed: {err_msg}");
 
-            // Try to identify which request caused the failure by checking
-            // which ones no longer exist in the queue (canceled).
+            // Try to identify which request caused the failure by dropping
+            // every request that is no longer approvable: cancelled requests
+            // vanish from the queue, and with deferred archival a request
+            // that some earlier PTB already approved or committed lingers
+            // with an advanced status (re-approving it would abort the PTB).
             let before_len = certified.len();
-            certified.retain(|(id, _)| inner.onchain_state().withdrawal_request(id).is_some());
+            certified.retain(|(id, _)| {
+                inner
+                    .onchain_state()
+                    .withdrawal_request(id)
+                    .is_some_and(|r| is_still_approvable(&r))
+            });
 
             if certified.len() == before_len {
                 error!("Could not identify failed request, aborting retry");
@@ -819,6 +827,52 @@ impl WithdrawalTxCommitment {
                 })
                 .collect(),
             txid: self.txid.as_bytes().to_vec().into(),
+        }
+    }
+}
+
+/// A request is worth retrying in an approval PTB only while its status is
+/// still Requested. Cancelled requests vanish from the queue entirely; under
+/// deferred archival, approved/committed/terminal requests linger in the
+/// queue with an advanced status, and re-approving any of them aborts the
+/// whole PTB on-chain.
+fn is_still_approvable(request: &hashi_types::move_types::WithdrawalRequest) -> bool {
+    request.status.is_requested()
+}
+
+#[cfg(test)]
+mod approvable_tests {
+    use super::*;
+    use hashi_types::move_types::WithdrawalStatus;
+
+    fn request_with_status(status: WithdrawalStatus) -> hashi_types::move_types::WithdrawalRequest {
+        hashi_types::move_types::WithdrawalRequest {
+            id: sui_sdk_types::Address::new([1; 32]),
+            sender: sui_sdk_types::Address::new([2; 32]),
+            btc_amount: 1,
+            bitcoin_address: vec![0; 20],
+            created_timestamp_ms: 0,
+            status,
+            approval_cert: None,
+            approved_timestamp_ms: None,
+            withdrawal_txn_id: None,
+            sui_tx_digest: sui_sdk_types::Digest::new([0; 32]),
+            btc: 1,
+        }
+    }
+
+    #[test]
+    fn only_requested_is_approvable() {
+        assert!(is_still_approvable(&request_with_status(
+            WithdrawalStatus::Requested
+        )));
+        for status in [
+            WithdrawalStatus::Approved,
+            WithdrawalStatus::Processing,
+            WithdrawalStatus::Signed,
+            WithdrawalStatus::Confirmed,
+        ] {
+            assert!(!is_still_approvable(&request_with_status(status)));
         }
     }
 }

--- a/crates/hashi/src/leader/withdrawal_transactions.rs
+++ b/crates/hashi/src/leader/withdrawal_transactions.rs
@@ -1085,7 +1085,10 @@ impl LeaderService {
     pub(super) fn process_signed_withdrawal_txns(&mut self) {
         debug!("Entering process_signed_withdrawal_txns");
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
-        withdrawal_txns.retain(|p| p.is_fully_signed());
+        // A confirmed txn lingers in the hot bag until the archival GC moves
+        // it; it is fully signed, so without the second clause it would be
+        // re-picked for broadcast/confirm every checkpoint forever.
+        withdrawal_txns.retain(|p| p.is_fully_signed() && !p.is_confirmed());
         withdrawal_txns.sort_by_key(|p| p.created_timestamp_ms);
 
         let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
@@ -1153,7 +1156,7 @@ impl LeaderService {
     /// Drains the BTC-block-triggered withdrawal check queue into its separate bounded task pool.
     fn process_pending_btc_block_withdrawal_checks(&mut self) {
         let mut withdrawal_txns = self.inner.onchain_state().withdrawal_txns();
-        withdrawal_txns.retain(|p| p.is_fully_signed());
+        withdrawal_txns.retain(|p| p.is_fully_signed() && !p.is_confirmed());
         withdrawal_txns.sort_by_key(|p| p.created_timestamp_ms);
 
         let pending_ids: Vec<Address> = withdrawal_txns.iter().map(|p| p.id).collect();
@@ -1258,6 +1261,12 @@ impl LeaderService {
                 // until the next confirm.
                 self.utxo_cleanup_scan_needed = true;
                 self.utxo_cleanup_scan_target = self.utxo_cleanup_scan_target.max(checkpoint);
+                // Same protocol for the deferred archival: the confirm left
+                // the txn (and its requests) in the hot containers with only
+                // the confirmed timestamp distinguishing them.
+                self.withdrawal_archive_scan_needed = true;
+                self.withdrawal_archive_scan_target =
+                    self.withdrawal_archive_scan_target.max(checkpoint);
             }
             Ok(WithdrawalBroadcastOutcome::WaitForNextBitcoinBlock) => {
                 self.withdrawal_broadcast_retry_tracker

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1374,22 +1374,62 @@ impl Metrics {
         self.paused.set(if hashi.config.paused() { 1 } else { 0 });
         self.deposit_queue_size
             .set(hashi.bitcoin().deposit_queue.requests().len() as i64);
-        let (requested, approved) = hashi
-            .bitcoin()
-            .withdrawal_queue
-            .requests()
-            .values()
-            .partition::<Vec<_>, _>(|r| r.status.is_requested());
-        // Three on-chain withdrawal-txn states, distinguished for operator
-        // visibility now that signing spans a multi-checkpoint window:
-        //   signed  = fully signed (2-of-2 witness assembled), broadcast-ready
-        //   signing = some inputs MPC-signed but not yet finalized (in progress)
-        //   pending = committed on-chain but no inputs signed yet
+        // Four mirrored withdrawal-request states. With deferred archival a
+        // request stays in the mirrored `requests` map after commitment (BTC
+        // drained) until the archival GC moves it out, so the post-approval
+        // states must be split from the actionable queue:
+        //   requested                 = awaiting committee approval
+        //   approved                  = approved, awaiting commitment into a txn
+        //   committed                 = committed into a withdrawal txn
+        //                               (Processing or Signed)
+        //   confirmed_pending_archive = confirmed on Bitcoin, awaiting the
+        //                               archival GC
+        {
+            use crate::onchain::types::WithdrawalStatus;
+            let mut requested = Vec::new();
+            let mut approved = Vec::new();
+            let mut committed = Vec::new();
+            let mut confirmed_pending_archive = Vec::new();
+            for r in hashi.bitcoin().withdrawal_queue.requests().values() {
+                match r.status {
+                    WithdrawalStatus::Requested => requested.push(r),
+                    WithdrawalStatus::Approved => approved.push(r),
+                    WithdrawalStatus::Processing | WithdrawalStatus::Signed => committed.push(r),
+                    WithdrawalStatus::Confirmed => confirmed_pending_archive.push(r),
+                }
+            }
+            for (label, class) in [
+                ("requested", &requested),
+                ("approved", &approved),
+                ("committed", &committed),
+                ("confirmed_pending_archive", &confirmed_pending_archive),
+            ] {
+                self.withdrawal_queue_size
+                    .with_label_values(&[label])
+                    .set(class.len() as i64);
+                self.withdrawal_queue_value
+                    .with_label_values(&[label, "BTC"])
+                    .set(class.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
+            }
+        }
+        // Four on-chain withdrawal-txn states, distinguished for operator
+        // visibility now that signing spans a multi-checkpoint window and
+        // archival is deferred to a batched GC:
+        //   confirmed = Bitcoin-confirmed, lingering in `withdrawal_txns`
+        //               until the archival GC moves it out. This count is the
+        //               archival-backlog signal: a persistently growing value
+        //               means the archival GC is stalled.
+        //   signed    = fully signed (2-of-2 witness assembled), broadcast-ready
+        //   signing   = some inputs MPC-signed but not yet finalized (in progress)
+        //   pending   = committed on-chain but no inputs signed yet
+        let mut confirmed = Vec::new();
         let mut signed = Vec::new();
         let mut signing = Vec::new();
         let mut pending = Vec::new();
         for w in hashi.bitcoin().withdrawal_queue.withdrawal_txns().values() {
-            if w.is_fully_signed() {
+            if w.is_confirmed() {
+                confirmed.push(w);
+            } else if w.is_fully_signed() {
                 signed.push(w);
             } else if w.signing.signed_count() > 0 {
                 signing.push(w);
@@ -1397,54 +1437,25 @@ impl Metrics {
                 pending.push(w);
             }
         }
-        self.withdrawal_queue_size
-            .with_label_values(&["requested"])
-            .set(requested.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["requested", "BTC"])
-            .set(requested.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
-        self.withdrawal_queue_size
-            .with_label_values(&["approved"])
-            .set(approved.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["approved", "BTC"])
-            .set(approved.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
-        self.withdrawal_queue_size
-            .with_label_values(&["pending"])
-            .set(pending.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["pending", "BTC"])
-            .set(
-                pending
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
-        self.withdrawal_queue_size
-            .with_label_values(&["signing"])
-            .set(signing.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["signing", "BTC"])
-            .set(
-                signing
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
-        self.withdrawal_queue_size
-            .with_label_values(&["signed"])
-            .set(signed.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["signed", "BTC"])
-            .set(
-                signed
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
+        for (label, class) in [
+            ("confirmed", &confirmed),
+            ("signed", &signed),
+            ("signing", &signing),
+            ("pending", &pending),
+        ] {
+            self.withdrawal_queue_size
+                .with_label_values(&[label])
+                .set(class.len() as i64);
+            self.withdrawal_queue_value
+                .with_label_values(&[label, "BTC"])
+                .set(
+                    class
+                        .iter()
+                        .flat_map(|w| &w.withdrawal_outputs)
+                        .map(|o| o.amount)
+                        .sum::<u64>() as i64,
+                );
+        }
         // Track three views of utxo_records:
         // - available:         all selectable UTXOs (spent_by = None), whether
         //                      confirmed or not; this is the coin-selection pool

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1385,22 +1385,62 @@ impl Metrics {
         self.paused.set(if hashi.config.paused() { 1 } else { 0 });
         self.deposit_queue_size
             .set(hashi.bitcoin().deposit_queue.requests().len() as i64);
-        let (requested, approved) = hashi
-            .bitcoin()
-            .withdrawal_queue
-            .requests()
-            .values()
-            .partition::<Vec<_>, _>(|r| r.status.is_requested());
-        // Three on-chain withdrawal-txn states, distinguished for operator
-        // visibility now that signing spans a multi-checkpoint window:
-        //   signed  = fully signed (2-of-2 witness assembled), broadcast-ready
-        //   signing = some inputs MPC-signed but not yet finalized (in progress)
-        //   pending = committed on-chain but no inputs signed yet
+        // Four mirrored withdrawal-request states. With deferred archival a
+        // request stays in the mirrored `requests` map after commitment (BTC
+        // drained) until the archival GC moves it out, so the post-approval
+        // states must be split from the actionable queue:
+        //   requested                 = awaiting committee approval
+        //   approved                  = approved, awaiting commitment into a txn
+        //   committed                 = committed into a withdrawal txn
+        //                               (Processing or Signed)
+        //   confirmed_pending_archive = confirmed on Bitcoin, awaiting the
+        //                               archival GC
+        {
+            use crate::onchain::types::WithdrawalStatus;
+            let mut requested = Vec::new();
+            let mut approved = Vec::new();
+            let mut committed = Vec::new();
+            let mut confirmed_pending_archive = Vec::new();
+            for r in hashi.bitcoin().withdrawal_queue.requests().values() {
+                match r.status {
+                    WithdrawalStatus::Requested => requested.push(r),
+                    WithdrawalStatus::Approved => approved.push(r),
+                    WithdrawalStatus::Processing | WithdrawalStatus::Signed => committed.push(r),
+                    WithdrawalStatus::Confirmed => confirmed_pending_archive.push(r),
+                }
+            }
+            for (label, class) in [
+                ("requested", &requested),
+                ("approved", &approved),
+                ("committed", &committed),
+                ("confirmed_pending_archive", &confirmed_pending_archive),
+            ] {
+                self.withdrawal_queue_size
+                    .with_label_values(&[label])
+                    .set(class.len() as i64);
+                self.withdrawal_queue_value
+                    .with_label_values(&[label, "BTC"])
+                    .set(class.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
+            }
+        }
+        // Four on-chain withdrawal-txn states, distinguished for operator
+        // visibility now that signing spans a multi-checkpoint window and
+        // archival is deferred to a batched GC:
+        //   confirmed = Bitcoin-confirmed, lingering in `withdrawal_txns`
+        //               until the archival GC moves it out. This count is the
+        //               archival-backlog signal: a persistently growing value
+        //               means the archival GC is stalled.
+        //   signed    = fully signed (2-of-2 witness assembled), broadcast-ready
+        //   signing   = some inputs MPC-signed but not yet finalized (in progress)
+        //   pending   = committed on-chain but no inputs signed yet
+        let mut confirmed = Vec::new();
         let mut signed = Vec::new();
         let mut signing = Vec::new();
         let mut pending = Vec::new();
         for w in hashi.bitcoin().withdrawal_queue.withdrawal_txns().values() {
-            if w.is_fully_signed() {
+            if w.is_confirmed() {
+                confirmed.push(w);
+            } else if w.is_fully_signed() {
                 signed.push(w);
             } else if w.signing.signed_count() > 0 {
                 signing.push(w);
@@ -1408,54 +1448,25 @@ impl Metrics {
                 pending.push(w);
             }
         }
-        self.withdrawal_queue_size
-            .with_label_values(&["requested"])
-            .set(requested.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["requested", "BTC"])
-            .set(requested.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
-        self.withdrawal_queue_size
-            .with_label_values(&["approved"])
-            .set(approved.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["approved", "BTC"])
-            .set(approved.iter().map(|r| r.btc_amount).sum::<u64>() as i64);
-        self.withdrawal_queue_size
-            .with_label_values(&["pending"])
-            .set(pending.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["pending", "BTC"])
-            .set(
-                pending
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
-        self.withdrawal_queue_size
-            .with_label_values(&["signing"])
-            .set(signing.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["signing", "BTC"])
-            .set(
-                signing
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
-        self.withdrawal_queue_size
-            .with_label_values(&["signed"])
-            .set(signed.len() as i64);
-        self.withdrawal_queue_value
-            .with_label_values(&["signed", "BTC"])
-            .set(
-                signed
-                    .iter()
-                    .flat_map(|w| &w.withdrawal_outputs)
-                    .map(|o| o.amount)
-                    .sum::<u64>() as i64,
-            );
+        for (label, class) in [
+            ("confirmed", &confirmed),
+            ("signed", &signed),
+            ("signing", &signing),
+            ("pending", &pending),
+        ] {
+            self.withdrawal_queue_size
+                .with_label_values(&[label])
+                .set(class.len() as i64);
+            self.withdrawal_queue_value
+                .with_label_values(&[label, "BTC"])
+                .set(
+                    class
+                        .iter()
+                        .flat_map(|w| &w.withdrawal_outputs)
+                        .map(|o| o.amount)
+                        .sum::<u64>() as i64,
+                );
+        }
         // Track three views of utxo_records:
         // - available:         all selectable UTXOs (spent_by = None), whether
         //                      confirmed or not; this is the coin-selection pool

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1391,21 +1391,41 @@ impl Metrics {
         // states must be split from the actionable queue:
         //   requested                 = awaiting committee approval
         //   approved                  = approved, awaiting commitment into a txn
-        //   committed                 = committed into a withdrawal txn
-        //                               (Processing or Signed)
-        //   confirmed_pending_archive = confirmed on Bitcoin, awaiting the
-        //                               archival GC
+        //   committed                 = committed into a withdrawal txn that
+        //                               is not yet Bitcoin-confirmed
+        //   confirmed_pending_archive = the request's withdrawal txn is
+        //                               Bitcoin-confirmed, awaiting the
+        //                               archival GC. The request's own status
+        //                               stays Signed until archival (confirm
+        //                               only stamps the txn), so this is
+        //                               derived from the txn's confirmed
+        //                               timestamp.
         {
             use crate::onchain::types::WithdrawalStatus;
             let mut requested = Vec::new();
             let mut approved = Vec::new();
             let mut committed = Vec::new();
             let mut confirmed_pending_archive = Vec::new();
+            let txns = hashi.bitcoin().withdrawal_queue.withdrawal_txns();
             for r in hashi.bitcoin().withdrawal_queue.requests().values() {
                 match r.status {
                     WithdrawalStatus::Requested => requested.push(r),
                     WithdrawalStatus::Approved => approved.push(r),
-                    WithdrawalStatus::Processing | WithdrawalStatus::Signed => committed.push(r),
+                    WithdrawalStatus::Processing | WithdrawalStatus::Signed => {
+                        if r.withdrawal_txn_id
+                            .as_ref()
+                            .and_then(|id| txns.get(id))
+                            .is_some_and(|t| t.is_confirmed())
+                        {
+                            confirmed_pending_archive.push(r)
+                        } else {
+                            committed.push(r)
+                        }
+                    }
+                    // Defensive: `archive_request` flips a request to
+                    // Confirmed in the same Move call that moves it out of
+                    // the hot bag, so this arm is unreachable from mirrored
+                    // post-transaction state.
                     WithdrawalStatus::Confirmed => confirmed_pending_archive.push(r),
                 }
             }

--- a/crates/hashi/src/onchain/apply.rs
+++ b/crates/hashi/src/onchain/apply.rs
@@ -216,6 +216,13 @@ pub(super) enum Effect {
     /// transaction (2-of-2 witness complete). Drives the local limiter
     /// and the pick-to-sign metric.
     WithdrawalTxnFullySigned(Box<types::WithdrawalTransaction>),
+    /// A withdrawal transaction's `confirmed_timestamp_ms` went from
+    /// `None` to `Some` in this transaction: the v2 in-place confirm,
+    /// which leaves the txn in the in-flight bag until a later archival
+    /// GC moves it out. Drives the sign-to-confirm and total duration
+    /// metrics in the deferred-archival world (under v1 bytecode the
+    /// confirm moves the txn instead, so this never fires there).
+    WithdrawalTxnConfirmed(Box<types::WithdrawalTransaction>),
     /// A withdrawal transaction left the in-flight bag (confirmed and
     /// moved to the historical record, or deleted).
     WithdrawalTxnRemoved(Box<types::WithdrawalTransaction>),
@@ -624,13 +631,16 @@ fn apply_write(
             decode::<move_types::WithdrawalTransaction>(contents, &id).map(|txn| {
                 let txn_id = txn.id;
                 let withdrawal_queue = &mut hashi.bitcoin_mut().withdrawal_queue;
-                let was_fully_signed = withdrawal_queue
-                    .withdrawal_txns
-                    .get(&txn_id)
-                    .is_some_and(|t| t.is_fully_signed());
+                let old = withdrawal_queue.withdrawal_txns.get(&txn_id);
+                let was_fully_signed = old.is_some_and(|t| t.is_fully_signed());
+                let was_confirmed = old.is_some_and(|t| t.confirmed_timestamp_ms.is_some());
                 if !was_fully_signed && txn.is_fully_signed() {
                     out.effects
                         .push(Effect::WithdrawalTxnFullySigned(Box::new(txn.clone())));
+                }
+                if !was_confirmed && txn.is_confirmed() {
+                    out.effects
+                        .push(Effect::WithdrawalTxnConfirmed(Box::new(txn.clone())));
                 }
                 withdrawal_queue.withdrawal_txns.insert(txn_id, txn);
                 TrackedKind::WithdrawalTxn(txn_id)
@@ -1403,8 +1413,10 @@ mod tests {
         ))]));
         assert!(out.effects.is_empty());
 
-        // Confirmed: the value moves to the confirmed_txns bag (new
-        // wrapper, old wrapper deleted).
+        // Confirmed the v1 way: the value moves to the confirmed_txns
+        // bag (new wrapper, old wrapper deleted) with no prior in-place
+        // confirm, so the removal carries `confirmed_timestamp_ms:
+        // None` — the mirror observes the durations at this point.
         let wrapper2 = addr(0x53);
         let out = fixture.apply(&tx(vec![
             written(wrapper_object(wrapper2, value_id, 3, confirmed_txns_id())),
@@ -1412,7 +1424,61 @@ mod tests {
             TxChange::Deleted { id: wrapper1 },
         ]));
         assert!(
-            matches!(out.effects.as_slice(), [Effect::WithdrawalTxnRemoved(txn)] if txn.id == value_id)
+            matches!(out.effects.as_slice(), [Effect::WithdrawalTxnRemoved(txn)]
+                if txn.id == value_id && txn.confirmed_timestamp_ms.is_none())
+        );
+        assert!(
+            fixture
+                .hashi
+                .bitcoin()
+                .withdrawal_queue
+                .withdrawal_txns
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn withdrawal_txn_in_place_confirm_then_deferred_archival() {
+        let mut fixture = Fixture::new();
+        let wrapper1 = addr(0x51);
+        let value_id = addr(0x52);
+
+        let signed = withdrawal_txn(value_id, true);
+        fixture.apply(&tx(vec![
+            written(wrapper_object(wrapper1, value_id, 1, withdrawal_txns_id())),
+            written(withdrawal_txn_object(&signed, 1, wrapper1)),
+        ]));
+
+        // v2 in-place confirm: a value-only mutation flips
+        // `confirmed_timestamp_ms` None -> Some exactly once.
+        let mut confirmed = signed.clone();
+        confirmed.confirmed_timestamp_ms = Some(8);
+        let out = fixture.apply(&tx(vec![written(withdrawal_txn_object(
+            &confirmed, 2, wrapper1,
+        ))]));
+        assert!(
+            matches!(out.effects.as_slice(), [Effect::WithdrawalTxnConfirmed(txn)]
+                if txn.id == value_id && txn.confirmed_timestamp_ms == Some(8))
+        );
+
+        // Replay of the same frame (Some -> Some): no duplicate effect.
+        let out = fixture.apply(&tx(vec![written(withdrawal_txn_object(
+            &confirmed, 2, wrapper1,
+        ))]));
+        assert!(out.effects.is_empty());
+
+        // The later archival GC moves the value to the confirmed_txns
+        // bag; the removal carries the mirror copy's Some timestamp —
+        // the key the mirror's duration-dedup skip relies on.
+        let wrapper2 = addr(0x53);
+        let out = fixture.apply(&tx(vec![
+            written(wrapper_object(wrapper2, value_id, 3, confirmed_txns_id())),
+            written(withdrawal_txn_object(&confirmed, 3, wrapper2)),
+            TxChange::Deleted { id: wrapper1 },
+        ]));
+        assert!(
+            matches!(out.effects.as_slice(), [Effect::WithdrawalTxnRemoved(txn)]
+                if txn.id == value_id && txn.confirmed_timestamp_ms == Some(8))
         );
         assert!(
             fixture

--- a/crates/hashi/src/onchain/mirror.rs
+++ b/crates/hashi/src/onchain/mirror.rs
@@ -461,6 +461,9 @@ fn handle_effects(state: &OnchainState, timestamp_ms: u64, effects: Vec<apply::E
             apply::Effect::WithdrawalTxnFullySigned(txn) => {
                 withdrawal_txn_fully_signed(state, timestamp_ms, &txn);
             }
+            apply::Effect::WithdrawalTxnConfirmed(txn) => {
+                withdrawal_txn_confirmed(state, timestamp_ms, &txn);
+            }
             apply::Effect::WithdrawalTxnRemoved(txn) => {
                 withdrawal_txn_removed(state, timestamp_ms, &txn);
             }
@@ -540,9 +543,41 @@ fn withdrawal_txn_fully_signed(
     }
 }
 
-/// A withdrawal transaction left the in-flight bag (confirmed and
-/// moved to the historical record, or deleted): observe the
-/// sign-to-confirm and total durations.
+/// A withdrawal transaction was confirmed in place (the v2 deferred
+/// archival: `confirmed_timestamp_ms` set while the txn stays in the
+/// in-flight bag): observe the sign-to-confirm and total durations. The
+/// later archival move skips them (`withdrawal_txn_removed`).
+fn withdrawal_txn_confirmed(
+    state: &OnchainState,
+    timestamp_ms: u64,
+    txn: &types::WithdrawalTransaction,
+) {
+    tracing::info!(withdrawal_txn_id = %txn.id, "Withdrawal confirmed on-chain");
+    let signed_at = state.state_mut().withdrawal_signed_at_ms.remove(&txn.id);
+    let Some(metrics) = state.metrics() else {
+        return;
+    };
+    if let Some(signed_at) = signed_at {
+        let sign_to_confirm = timestamp_ms.saturating_sub(signed_at);
+        metrics
+            .withdrawal_duration_seconds
+            .with_label_values(&["sign_to_confirm"])
+            .observe(Duration::from_millis(sign_to_confirm).as_secs_f64());
+    }
+    let total = timestamp_ms.saturating_sub(txn.created_timestamp_ms);
+    metrics
+        .withdrawal_duration_seconds
+        .with_label_values(&["total"])
+        .observe(Duration::from_millis(total).as_secs_f64());
+}
+
+/// A withdrawal transaction left the in-flight bag. Under v1 bytecode
+/// the confirm itself archives it, so the sign-to-confirm and total
+/// durations are observed here. Under v2 the confirm wrote
+/// `confirmed_timestamp_ms` in place and the durations were already
+/// observed then (`withdrawal_txn_confirmed`); observing again at the
+/// archival move would fold GC latency into the histograms, so an
+/// already-confirmed txn only clears its bookkeeping.
 fn withdrawal_txn_removed(
     state: &OnchainState,
     timestamp_ms: u64,
@@ -550,6 +585,9 @@ fn withdrawal_txn_removed(
 ) {
     tracing::info!(withdrawal_txn_id = %txn.id, "Withdrawal transaction left the in-flight bag");
     let signed_at = state.state_mut().withdrawal_signed_at_ms.remove(&txn.id);
+    if txn.confirmed_timestamp_ms.is_some() {
+        return;
+    }
     let Some(metrics) = state.metrics() else {
         return;
     };

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -317,6 +317,40 @@ impl OnchainState {
         Some((id, version))
     }
 
+    /// The package version the withdrawal flow operates at:
+    /// [`Self::active_package_version`] held down to v1 while the bootstrap
+    /// window keeps v1 in the enabled set (see
+    /// [`crate::withdrawals::withdrawal_effective_version`]). Resolved from a
+    /// single read guard: pairing the active version with an enabled set from
+    /// a different snapshot could open the dormancy gate early.
+    pub fn withdrawal_effective_version(&self) -> Option<u64> {
+        let state = self.state();
+        let active = state
+            .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
+            .active_version()?;
+        Some(crate::withdrawals::withdrawal_effective_version(
+            active,
+            &state.hashi().config.enabled_versions,
+        ))
+    }
+
+    /// The package the withdrawal flow's entry calls route through, paired
+    /// with its version: [`Self::active_package`] under the
+    /// [`Self::withdrawal_effective_version`] gate, from one read guard for
+    /// the same torn-read reason.
+    pub fn withdrawal_package(&self) -> Option<(Address, u64)> {
+        let state = self.state();
+        let active = state
+            .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
+            .active_version()?;
+        let version = crate::withdrawals::withdrawal_effective_version(
+            active,
+            &state.hashi().config.enabled_versions,
+        );
+        let id = state.package_versions.get(version)?;
+        Some((id, version))
+    }
+
     /// Reason autonomous on-chain work must halt (governance pause, or an
     /// unsupported on-chain version), or `None` to proceed. Reads state once so
     /// callers get a single consistent snapshot. Mirrors — and subsumes — the

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1856,57 +1856,106 @@ impl SuiTxExecutor {
             .ok_or_else(|| anyhow::anyhow!("active version {version} has no published package"))
     }
 
-    /// Submit `withdraw::archive_confirmed_withdrawals` for the given
-    /// confirmed txns, greedily packed so every transaction stays inside the
-    /// runtime-object budget (a whole txn's requests archive together, so
-    /// packing is by per-victim cost, not count). `victims` pairs each txn id
-    /// with its request count. Returns the max landed checkpoint.
+    /// Archive the given confirmed withdrawal txns, packed into a plan of
+    /// GC transactions that each stay inside the runtime-object budget.
+    /// Victims that fit a single transaction go through the atomic
+    /// `archive_confirmed_withdrawals` entry; oversized ones (request cost
+    /// beyond one transaction) archive through `archive_withdrawal_requests`
+    /// chunks followed by `finish_archive_withdrawal_txns`. Returns the max
+    /// landed checkpoint.
     ///
-    /// The entry only exists in the v2 package; the caller gates on the
+    /// The entries only exist in the v2 package; the caller gates on the
     /// active version, and the target resolves through it.
-    pub async fn execute_archive_confirmed_withdrawals(
+    pub(crate) async fn execute_archive_confirmed_withdrawals(
         &mut self,
-        victims: &[(Address, usize)],
+        victims: &[ArchiveVictim],
     ) -> anyhow::Result<u64> {
         let package_id = self.active_version_package()?;
         let mut max_checkpoint = 0;
-        for chunk in chunk_archive_victims(victims) {
+        for call in plan_archive_calls(victims) {
             let mut builder = TransactionBuilder::new();
             let hashi_arg = builder.object(
                 ObjectInput::new(self.hashi_ids.hashi_object_id)
                     .as_shared()
                     .with_mutable(true),
             );
-            let ids_arg = builder.pure(&chunk);
+            let (function, args) = match &call {
+                ArchiveCall::Atomic(txn_ids) => {
+                    let ids_arg = builder.pure(txn_ids);
+                    ("archive_confirmed_withdrawals", vec![hashi_arg, ids_arg])
+                }
+                ArchiveCall::Requests {
+                    txn_id,
+                    request_ids,
+                } => {
+                    let txn_arg = builder.pure(txn_id);
+                    let ids_arg = builder.pure(request_ids);
+                    (
+                        "archive_withdrawal_requests",
+                        vec![hashi_arg, txn_arg, ids_arg],
+                    )
+                }
+                ArchiveCall::Finish(txn_ids) => {
+                    let ids_arg = builder.pure(txn_ids);
+                    ("finish_archive_withdrawal_txns", vec![hashi_arg, ids_arg])
+                }
+            };
             builder.move_call(
                 Function::new(
                     package_id,
                     Identifier::from_static("withdraw"),
-                    Identifier::from_static("archive_confirmed_withdrawals"),
+                    Identifier::new(function)?,
                 ),
-                vec![hashi_arg, ids_arg],
+                args,
             );
 
             let response = self.execute(builder).await?;
             if !response.transaction().effects().status().success() {
                 anyhow::bail!(
-                    "archive_confirmed_withdrawals failed: {:?}",
+                    "{function} failed: {:?}",
                     response.transaction().effects().status()
                 );
             }
-            let checkpoint = response.transaction().checkpoint_opt().ok_or_else(|| {
-                anyhow::anyhow!("archive_confirmed_withdrawals response missing checkpoint")
-            })?;
+            let checkpoint = response
+                .transaction()
+                .checkpoint_opt()
+                .ok_or_else(|| anyhow::anyhow!("{function} response missing checkpoint"))?;
             max_checkpoint = max_checkpoint.max(checkpoint);
         }
         Ok(max_checkpoint)
     }
 }
 
-/// Greedy-pack archival victims into per-transaction chunks under the
-/// runtime-object budget. A single victim always fits alone (the
-/// `withdrawals.rs` compile-time assert guarantees a max-size txn does).
-fn chunk_archive_victims(victims: &[(Address, usize)]) -> Vec<Vec<Address>> {
+/// A confirmed withdrawal txn awaiting archival, with its request ids so the
+/// planner can price and, when oversized, chunk it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ArchiveVictim {
+    pub txn_id: Address,
+    pub request_ids: Vec<Address>,
+}
+
+/// One GC transaction of an archival plan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ArchiveCall {
+    /// Whole txns archived atomically, several per transaction.
+    Atomic(Vec<Address>),
+    /// One request chunk of an oversized txn.
+    Requests {
+        txn_id: Address,
+        request_ids: Vec<Address>,
+    },
+    /// Move fully-chunk-archived txns to the cold bag. Emitted after every
+    /// chunk of the txns it finishes, so in-order execution completes them.
+    Finish(Vec<Address>),
+}
+
+/// Pack archival victims into per-transaction calls under the runtime-object
+/// budget. Victims whose whole cost fits one transaction greedy-pack into
+/// atomic calls; oversized ones split into request chunks plus a batched
+/// finish (the `withdrawals.rs` compile-time asserts guarantee every chunk
+/// makes progress and a max-size finish walk fits one transaction).
+fn plan_archive_calls(victims: &[ArchiveVictim]) -> Vec<ArchiveCall> {
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST;
     use crate::withdrawals::WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS;
     use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET;
     use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST;
@@ -1914,63 +1963,139 @@ fn chunk_archive_victims(victims: &[(Address, usize)]) -> Vec<Vec<Address>> {
 
     let budget =
         WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET - WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS;
-    let mut chunks = Vec::new();
-    let mut current = Vec::new();
-    let mut used = 0usize;
-    for (id, request_count) in victims {
+    let requests_per_chunk = (budget - WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN)
+        / WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST;
+
+    let mut calls = Vec::new();
+    let mut atomic: Vec<Address> = Vec::new();
+    let mut atomic_used = 0usize;
+    let mut finish: Vec<Address> = Vec::new();
+    let mut finish_used = 0usize;
+    for victim in victims {
         let cost = WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
-            + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST * request_count;
-        if !current.is_empty() && used + cost > budget {
-            chunks.push(std::mem::take(&mut current));
-            used = 0;
+            + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST * victim.request_ids.len();
+        if cost <= budget {
+            if atomic_used + cost > budget {
+                calls.push(ArchiveCall::Atomic(std::mem::take(&mut atomic)));
+                atomic_used = 0;
+            }
+            atomic.push(victim.txn_id);
+            atomic_used += cost;
+        } else {
+            for chunk in victim.request_ids.chunks(requests_per_chunk) {
+                calls.push(ArchiveCall::Requests {
+                    txn_id: victim.txn_id,
+                    request_ids: chunk.to_vec(),
+                });
+            }
+            let finish_cost = WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+                + WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST * victim.request_ids.len();
+            if finish_used + finish_cost > budget {
+                calls.push(ArchiveCall::Finish(std::mem::take(&mut finish)));
+                finish_used = 0;
+            }
+            finish.push(victim.txn_id);
+            finish_used += finish_cost;
         }
-        current.push(*id);
-        used += cost;
     }
-    if !current.is_empty() {
-        chunks.push(current);
+    if !atomic.is_empty() {
+        calls.push(ArchiveCall::Atomic(atomic));
     }
-    chunks
+    if !finish.is_empty() {
+        calls.push(ArchiveCall::Finish(finish));
+    }
+    calls
 }
 
 #[cfg(test)]
-mod archive_chunking_tests {
+mod archive_planning_tests {
     use super::*;
+    use crate::utxo_pool::CoinSelectionParams;
 
     fn addr(byte: u8) -> Address {
         Address::new([byte; 32])
     }
 
-    #[test]
-    fn empty_input_yields_no_chunks() {
-        assert!(chunk_archive_victims(&[]).is_empty());
+    fn victim(byte: u8, request_count: usize) -> ArchiveVictim {
+        // Planning depends only on counts; the ids themselves are opaque.
+        ArchiveVictim {
+            txn_id: addr(byte),
+            request_ids: (0..request_count).map(|i| addr(i as u8)).collect(),
+        }
     }
 
     #[test]
-    fn one_max_size_txn_fits_alone() {
-        use crate::utxo_pool::CoinSelectionParams;
-        let chunks =
-            chunk_archive_victims(&[(addr(1), CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)]);
-        assert_eq!(chunks, vec![vec![addr(1)]]);
+    fn empty_input_yields_no_calls() {
+        assert!(plan_archive_calls(&[]).is_empty());
     }
 
     #[test]
-    fn small_victims_pack_together() {
-        let victims: Vec<_> = (0..10u8).map(|i| (addr(i), 1usize)).collect();
-        let chunks = chunk_archive_victims(&victims);
-        assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0].len(), 10);
+    fn small_victims_pack_into_one_atomic_call() {
+        let victims: Vec<_> = (0..10u8).map(|i| victim(i, 1)).collect();
+        let calls = plan_archive_calls(&victims);
+        assert_eq!(calls.len(), 1);
+        assert!(matches!(&calls[0], ArchiveCall::Atomic(ids) if ids.len() == 10));
     }
 
     #[test]
-    fn budget_boundary_splits() {
+    fn atomic_budget_boundary_splits() {
         // Each 100-request victim costs 3 + 300 = 303; the 910-object budget
-        // fits three (909) and the fourth spills into a second chunk.
-        let victims: Vec<_> = (0..4u8).map(|i| (addr(i), 100usize)).collect();
-        let chunks = chunk_archive_victims(&victims);
-        assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0].len(), 3);
-        assert_eq!(chunks[1].len(), 1);
+        // fits three (909) and the fourth spills into a second call.
+        let victims: Vec<_> = (0..4u8).map(|i| victim(i, 100)).collect();
+        let calls = plan_archive_calls(&victims);
+        assert_eq!(calls.len(), 2);
+        assert!(matches!(&calls[0], ArchiveCall::Atomic(ids) if ids.len() == 3));
+        assert!(matches!(&calls[1], ArchiveCall::Atomic(ids) if ids.len() == 1));
+    }
+
+    #[test]
+    fn max_size_txn_chunks_then_finishes() {
+        // A 447-request txn costs 3 + 1341, beyond one transaction: it must
+        // split into request chunks (302 per chunk at 3/request under the
+        // 910 budget) followed by one finish.
+        let victims = [victim(1, CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)];
+        let calls = plan_archive_calls(&victims);
+        assert_eq!(calls.len(), 3);
+        let (mut chunked, mut finished) = (0usize, Vec::new());
+        for call in &calls {
+            match call {
+                ArchiveCall::Requests {
+                    txn_id,
+                    request_ids,
+                } => {
+                    assert_eq!(*txn_id, addr(1));
+                    chunked += request_ids.len();
+                }
+                ArchiveCall::Finish(ids) => finished = ids.clone(),
+                ArchiveCall::Atomic(_) => panic!("oversized victim must not go atomic"),
+            }
+        }
+        assert_eq!(chunked, CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS);
+        assert_eq!(finished, vec![addr(1)]);
+        // The finish must come after every chunk of the txn it completes.
+        assert!(matches!(calls.last(), Some(ArchiveCall::Finish(_))));
+    }
+
+    #[test]
+    fn mixed_sizes_route_by_cost() {
+        let victims = [
+            victim(1, 5),
+            victim(2, CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS),
+            victim(3, 5),
+        ];
+        let calls = plan_archive_calls(&victims);
+        let atomics: Vec<_> = calls
+            .iter()
+            .filter(|c| matches!(c, ArchiveCall::Atomic(_)))
+            .collect();
+        assert_eq!(atomics.len(), 1);
+        assert!(matches!(atomics[0], ArchiveCall::Atomic(ids) if ids.len() == 2));
+        assert!(
+            calls
+                .iter()
+                .any(|c| matches!(c, ArchiveCall::Requests { .. }))
+        );
+        assert!(matches!(calls.last(), Some(ArchiveCall::Finish(ids)) if ids == &vec![addr(2)]));
     }
 }
 

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -431,10 +431,12 @@ pub struct SuiTxExecutor {
     /// Present for node-internal executors (built via [`SuiTxExecutor::from_config`]
     /// / [`SuiTxExecutor::from_hashi`]). Supplies both the call target and the
     /// ABI shape (see [`Self::call_target`]), and refuses to submit when this
-    /// binary supports no live on-chain package version. `None` for CLI/ad-hoc
-    /// executors built via [`SuiTxExecutor::new`]: they are not version-gated
-    /// and call `hashi_ids.package_id`, the *original* package, so on an
-    /// upgraded chain they run v1 bytecode.
+    /// binary supports no live on-chain package version. CLI executors attach
+    /// a one-shot governance reader via [`SuiTxExecutor::with_onchain_state`]
+    /// for the same routing. `None` for ad-hoc executors built via
+    /// [`SuiTxExecutor::new`] that never attach one: those are not
+    /// version-gated and call `hashi_ids.package_id`, the *original* package,
+    /// so on an upgraded chain they run v1 bytecode.
     onchain_state: Option<OnchainState>,
 }
 
@@ -2077,6 +2079,38 @@ mod archive_planning_tests {
     }
 
     #[test]
+    fn two_max_size_victims_finish_in_separate_calls() {
+        // Each finish walk costs 3 + 2 * 447 = 897 runtime objects, so two
+        // max-size victims must not share one Finish call (1794 would blow
+        // the 910-object budget on-chain).
+        let victims = [
+            victim(1, CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS),
+            victim(2, CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS),
+        ];
+        let calls = plan_archive_calls(&victims);
+        let finishes: Vec<_> = calls
+            .iter()
+            .filter_map(|c| match c {
+                ArchiveCall::Finish(ids) => Some(ids.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(finishes, [vec![addr(1)], vec![addr(2)]]);
+        // Each finish must come after every chunk of the txn it completes.
+        let position = |pred: &dyn Fn(&ArchiveCall) -> bool| {
+            calls.iter().rposition(pred).expect("call must be present")
+        };
+        for byte in [1u8, 2u8] {
+            let last_chunk = position(
+                &|c| matches!(c, ArchiveCall::Requests { txn_id, .. } if *txn_id == addr(byte)),
+            );
+            let finish =
+                position(&|c| matches!(c, ArchiveCall::Finish(ids) if ids == &vec![addr(byte)]));
+            assert!(last_chunk < finish);
+        }
+    }
+
+    #[test]
     fn mixed_sizes_route_by_cost() {
         let victims = [
             victim(1, 5),
@@ -2098,10 +2132,6 @@ mod archive_planning_tests {
         assert!(matches!(calls.last(), Some(ArchiveCall::Finish(ids)) if ids == &vec![addr(2)]));
     }
 }
-
-// TODO: the builders below take the call target, but `cli/commands/{deposit,
-// withdraw}.rs` still pass the original package id, so those commands abort once
-// v1 is disabled. They need an `OnchainState` to resolve one.
 
 /// Build the PTB for a single deposit request. Pure (no signer / no network),
 /// so it can be signed/executed by [`SuiTxExecutor::execute`] or serialized

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -982,7 +982,7 @@ impl SuiTxExecutor {
     ) -> anyhow::Result<Address> {
         let builder = build_create_withdrawal_request(
             self.hashi_ids,
-            self.active_call_package_id(),
+            self.withdrawal_call_package(),
             withdrawal_amount_sats,
             destination_bytes,
         );
@@ -1019,7 +1019,7 @@ impl SuiTxExecutor {
         let total_sats = total_sats as u64;
 
         let mut builder = TransactionBuilder::new();
-        let package_id = self.active_call_package_id();
+        let package_id = self.withdrawal_call_package();
 
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
@@ -1100,6 +1100,20 @@ impl SuiTxExecutor {
 
     pub(crate) fn active_call_package_id(&self) -> Address {
         self.call_target().0
+    }
+
+    /// Package id the withdrawal entry calls route through:
+    /// [`Self::active_call_package_id`] held at v1 while the bootstrap
+    /// window keeps v1 enabled (see
+    /// [`crate::withdrawals::withdrawal_effective_version`]), so this
+    /// binary's withdrawal writes always execute the bytecode generation
+    /// whose commit layout the chain is operating under. Falls back like
+    /// [`Self::call_target`] when no version resolves.
+    pub(crate) fn withdrawal_call_package(&self) -> Address {
+        self.onchain_state
+            .as_ref()
+            .and_then(OnchainState::withdrawal_package)
+            .map_or(self.hashi_ids.package_id, |(id, _)| id)
     }
 
     #[tracing::instrument(level = "info", skip_all)]
@@ -1225,7 +1239,7 @@ impl SuiTxExecutor {
         let withdrawal_id_arg = builder.pure(withdrawal_id);
         builder.move_call(
             Function::new(
-                self.active_call_package_id(),
+                self.withdrawal_call_package(),
                 Identifier::from_static("withdraw"),
                 Identifier::from_static("reallocate_presigs"),
             ),
@@ -1392,7 +1406,7 @@ impl SuiTxExecutor {
         approvals: &[(Address, &CommitteeSignature)],
     ) -> anyhow::Result<()> {
         let mut builder = TransactionBuilder::new();
-        let package_id = self.active_call_package_id();
+        let package_id = self.withdrawal_call_package();
 
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
@@ -1445,7 +1459,7 @@ impl SuiTxExecutor {
         cert: &CommitteeSignature,
     ) -> anyhow::Result<()> {
         let mut builder = TransactionBuilder::new();
-        let package_id = self.active_call_package_id();
+        let package_id = self.withdrawal_call_package();
 
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
@@ -1567,7 +1581,7 @@ impl SuiTxExecutor {
         cert: &CommitteeSignature,
     ) -> anyhow::Result<u64> {
         let mut builder = TransactionBuilder::new();
-        let package_id = self.active_call_package_id();
+        let package_id = self.withdrawal_call_package();
 
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
@@ -1625,7 +1639,7 @@ impl SuiTxExecutor {
         cert: &CommitteeSignature,
     ) -> anyhow::Result<u64> {
         let mut builder = TransactionBuilder::new();
-        let package_id = self.active_call_package_id();
+        let package_id = self.withdrawal_call_package();
 
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
@@ -1689,7 +1703,7 @@ impl SuiTxExecutor {
     ) -> anyhow::Result<()> {
         let builder = build_cancel_withdrawal(
             self.hashi_ids,
-            self.active_call_package_id(),
+            self.withdrawal_call_package(),
             withdrawal_id,
             self.sender(),
         );
@@ -1723,7 +1737,7 @@ impl SuiTxExecutor {
         cert: &CommitteeSignature,
     ) -> anyhow::Result<u64> {
         let mut builder = TransactionBuilder::new();
-        let package_id = self.active_call_package_id();
+        let package_id = self.withdrawal_call_package();
 
         let hashi_arg = builder.object(
             ObjectInput::new(self.hashi_ids.hashi_object_id)
@@ -1782,7 +1796,7 @@ impl SuiTxExecutor {
         let mut max_checkpoint = 0;
         for chunk in utxo_ids.chunks(MAX_PER_TX) {
             let mut builder = TransactionBuilder::new();
-            let package_id = self.active_call_package_id();
+            let package_id = self.withdrawal_call_package();
             let hashi_arg = builder.object(
                 ObjectInput::new(self.hashi_ids.hashi_object_id)
                     .as_shared()
@@ -1838,24 +1852,21 @@ impl SuiTxExecutor {
         Ok(max_checkpoint)
     }
 
-    /// Package id of the version this binary operates at. Entry functions
+    /// Package id of the version the withdrawal flow operates at (the
+    /// dormancy-gated [`OnchainState::withdrawal_package`]). Entry functions
     /// introduced by an upgrade only exist in the upgraded bytecode, so
-    /// calling them through the original package id fails; targets for such
-    /// calls must resolve through the active version.
-    fn active_version_package(&self) -> anyhow::Result<Address> {
+    /// callers targeting such entries must gate on the effective version
+    /// first; a dormant flow resolving here targets v1, where a v2-only
+    /// entry fails loudly instead of running the wrong bytecode.
+    fn withdrawal_version_package(&self) -> anyhow::Result<Address> {
         let onchain_state = self
             .onchain_state
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("executor has no onchain state to resolve versions"))?;
-        let state = onchain_state.state();
-        let version = state
-            .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
-            .active_version()
-            .ok_or_else(|| anyhow::anyhow!("no active package version resolved"))?;
-        state
-            .package_versions()
-            .get(version)
-            .ok_or_else(|| anyhow::anyhow!("active version {version} has no published package"))
+        onchain_state
+            .withdrawal_package()
+            .map(|(id, _)| id)
+            .ok_or_else(|| anyhow::anyhow!("no withdrawal-effective package version resolved"))
     }
 
     /// Archive the given confirmed withdrawal txns, packed into a plan of
@@ -1867,12 +1878,12 @@ impl SuiTxExecutor {
     /// landed checkpoint.
     ///
     /// The entries only exist in the v2 package; the caller gates on the
-    /// active version, and the target resolves through it.
+    /// withdrawal-effective version, and the target resolves through it.
     pub(crate) async fn execute_archive_confirmed_withdrawals(
         &mut self,
         victims: &[ArchiveVictim],
     ) -> anyhow::Result<u64> {
-        let package_id = self.active_version_package()?;
+        let package_id = self.withdrawal_version_package()?;
         let mut max_checkpoint = 0;
         for call in plan_archive_calls(victims) {
             let mut builder = TransactionBuilder::new();

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -2238,6 +2238,12 @@ pub fn withdrawal_request_id_from_response(
 /// Build the PTB for cancelling a withdrawal. The refunded `Balance<BTC>` is
 /// sent to `sender`'s address balance, so `sender` must be the same address the
 /// transaction is finalized for.
+///
+/// `call_package` must be the active version's package id (or the original
+/// id while only v1 is live): v1 cancel bytecode gates on `processed`-bag
+/// membership, which misses requests the v2 in-place commit left in
+/// `requests` — cancelling one there would destroy a request a live
+/// withdrawal txn still references.
 pub fn build_cancel_withdrawal(
     hashi_ids: HashiIds,
     call_package: Address,

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1835,6 +1835,143 @@ impl SuiTxExecutor {
         }
         Ok(max_checkpoint)
     }
+
+    /// Package id of the version this binary operates at. Entry functions
+    /// introduced by an upgrade only exist in the upgraded bytecode, so
+    /// calling them through the original package id fails; targets for such
+    /// calls must resolve through the active version.
+    fn active_version_package(&self) -> anyhow::Result<Address> {
+        let onchain_state = self
+            .onchain_state
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("executor has no onchain state to resolve versions"))?;
+        let state = onchain_state.state();
+        let version = state
+            .version_support(crate::constants::SUPPORTED_PACKAGE_VERSIONS)
+            .active_version()
+            .ok_or_else(|| anyhow::anyhow!("no active package version resolved"))?;
+        state
+            .package_versions()
+            .get(version)
+            .ok_or_else(|| anyhow::anyhow!("active version {version} has no published package"))
+    }
+
+    /// Submit `withdraw::archive_confirmed_withdrawals` for the given
+    /// confirmed txns, greedily packed so every transaction stays inside the
+    /// runtime-object budget (a whole txn's requests archive together, so
+    /// packing is by per-victim cost, not count). `victims` pairs each txn id
+    /// with its request count. Returns the max landed checkpoint.
+    ///
+    /// The entry only exists in the v2 package; the caller gates on the
+    /// active version, and the target resolves through it.
+    pub async fn execute_archive_confirmed_withdrawals(
+        &mut self,
+        victims: &[(Address, usize)],
+    ) -> anyhow::Result<u64> {
+        let package_id = self.active_version_package()?;
+        let mut max_checkpoint = 0;
+        for chunk in chunk_archive_victims(victims) {
+            let mut builder = TransactionBuilder::new();
+            let hashi_arg = builder.object(
+                ObjectInput::new(self.hashi_ids.hashi_object_id)
+                    .as_shared()
+                    .with_mutable(true),
+            );
+            let ids_arg = builder.pure(&chunk);
+            builder.move_call(
+                Function::new(
+                    package_id,
+                    Identifier::from_static("withdraw"),
+                    Identifier::from_static("archive_confirmed_withdrawals"),
+                ),
+                vec![hashi_arg, ids_arg],
+            );
+
+            let response = self.execute(builder).await?;
+            if !response.transaction().effects().status().success() {
+                anyhow::bail!(
+                    "archive_confirmed_withdrawals failed: {:?}",
+                    response.transaction().effects().status()
+                );
+            }
+            let checkpoint = response.transaction().checkpoint_opt().ok_or_else(|| {
+                anyhow::anyhow!("archive_confirmed_withdrawals response missing checkpoint")
+            })?;
+            max_checkpoint = max_checkpoint.max(checkpoint);
+        }
+        Ok(max_checkpoint)
+    }
+}
+
+/// Greedy-pack archival victims into per-transaction chunks under the
+/// runtime-object budget. A single victim always fits alone (the
+/// `withdrawals.rs` compile-time assert guarantees a max-size txn does).
+fn chunk_archive_victims(victims: &[(Address, usize)]) -> Vec<Vec<Address>> {
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS;
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET;
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST;
+    use crate::withdrawals::WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN;
+
+    let budget =
+        WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET - WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS;
+    let mut chunks = Vec::new();
+    let mut current = Vec::new();
+    let mut used = 0usize;
+    for (id, request_count) in victims {
+        let cost = WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+            + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST * request_count;
+        if !current.is_empty() && used + cost > budget {
+            chunks.push(std::mem::take(&mut current));
+            used = 0;
+        }
+        current.push(*id);
+        used += cost;
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod archive_chunking_tests {
+    use super::*;
+
+    fn addr(byte: u8) -> Address {
+        Address::new([byte; 32])
+    }
+
+    #[test]
+    fn empty_input_yields_no_chunks() {
+        assert!(chunk_archive_victims(&[]).is_empty());
+    }
+
+    #[test]
+    fn one_max_size_txn_fits_alone() {
+        use crate::utxo_pool::CoinSelectionParams;
+        let chunks =
+            chunk_archive_victims(&[(addr(1), CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS)]);
+        assert_eq!(chunks, vec![vec![addr(1)]]);
+    }
+
+    #[test]
+    fn small_victims_pack_together() {
+        let victims: Vec<_> = (0..10u8).map(|i| (addr(i), 1usize)).collect();
+        let chunks = chunk_archive_victims(&victims);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), 10);
+    }
+
+    #[test]
+    fn budget_boundary_splits() {
+        // Each 100-request victim costs 3 + 300 = 303; the 910-object budget
+        // fits three (909) and the fourth spills into a second chunk.
+        let victims: Vec<_> = (0..4u8).map(|i| (addr(i), 100usize)).collect();
+        let chunks = chunk_archive_victims(&victims);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), 3);
+        assert_eq!(chunks[1].len(), 1);
+    }
 }
 
 // TODO: the builders below take the call target, but `cli/commands/{deposit,

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -356,15 +356,16 @@ impl CoinSelectionParams {
     pub const DEFAULT_MAX_INPUTS: usize = 400;
 
     /// Maximum number of withdrawal requests per batch, derived from the
-    /// Sui commit transaction's runtime-object budget: at 3 runtime objects
-    /// per request, `(922 budget - 12 fixed - 16 reserved funding inputs) /
-    /// 3 = 298`. The reserve keeps room for the largest-first funding
+    /// Sui commit transaction's runtime-object budget: at the v2 (in-place
+    /// commit) cost of 2 runtime objects per request, `(922 budget - 12
+    /// fixed - 16 reserved funding inputs) / 2 = 447`. The reserve keeps
+    /// room for the largest-first funding
     /// inputs when a batch is at this cap (a compile-time assertion in
     /// `withdrawals.rs` ties this value to those constants); the descending
     /// retry loop in `build_withdrawal_tx_commitment` shrinks the batch if
     /// even the reserve is not enough.
     ///
-    /// Bitcoin-side limits do not bind here: a 298-output batch with 16
+    /// Bitcoin-side limits do not bind here: a 447-output batch with 16
     /// taproot script-path inputs is ~58 kWU, well under the 400 kWU
     /// standardness cap, and leaves ample room under the 101 kvB mempool
     /// cluster budget for a direct child.
@@ -376,7 +377,13 @@ impl CoinSelectionParams {
     /// commit budget in `safe_withdrawal_flow_max_inputs` automatically
     /// squeezes the input side down toward the funding reserve (optimizing
     /// withdrawal throughput).
-    pub const MAX_WITHDRAWAL_REQUESTS: usize = 298;
+    /// The v2 (deferred-archival) cap: with commit writing request status in
+    /// place, each request costs 2 runtime objects instead of the 3 the
+    /// v1 bag move paid, and the archival GC chunks oversized txns, so the
+    /// commit budget alone binds. Chains still operating at package v1 are
+    /// capped at `LEGACY_MAX_WITHDRAWAL_REQUESTS` (298, in `withdrawals.rs`) via
+    /// `max_withdrawal_requests`.
+    pub const MAX_WITHDRAWAL_REQUESTS: usize = 447;
 
     /// Default minimum fee rate floor (3 sat/vB), deliberately above
     /// Bitcoin Core's 1 sat/vB relay minimum.

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -355,15 +355,16 @@ impl CoinSelectionParams {
     pub const DEFAULT_MAX_INPUTS: usize = 400;
 
     /// Maximum number of withdrawal requests per batch, derived from the
-    /// Sui commit transaction's runtime-object budget: at 3 runtime objects
-    /// per request, `(922 budget - 12 fixed - 16 reserved funding inputs) /
-    /// 3 = 298`. The reserve keeps room for the largest-first funding
+    /// Sui commit transaction's runtime-object budget: at the v2 (in-place
+    /// commit) cost of 2 runtime objects per request, `(922 budget - 12
+    /// fixed - 16 reserved funding inputs) / 2 = 447`. The reserve keeps
+    /// room for the largest-first funding
     /// inputs when a batch is at this cap (a compile-time assertion in
     /// `withdrawals.rs` ties this value to those constants); the descending
     /// retry loop in `build_withdrawal_tx_commitment` shrinks the batch if
     /// even the reserve is not enough.
     ///
-    /// Bitcoin-side limits do not bind here: a 298-output batch with 16
+    /// Bitcoin-side limits do not bind here: a 447-output batch with 16
     /// taproot script-path inputs is ~58 kWU, well under the 400 kWU
     /// standardness cap, and leaves ample room under the 101 kvB mempool
     /// cluster budget for a direct child.
@@ -375,7 +376,13 @@ impl CoinSelectionParams {
     /// commit budget in `safe_withdrawal_flow_max_inputs` automatically
     /// squeezes the input side down toward the funding reserve (optimizing
     /// withdrawal throughput).
-    pub const MAX_WITHDRAWAL_REQUESTS: usize = 298;
+    /// The v2 (deferred-archival) cap: with commit writing request status in
+    /// place, each request costs 2 runtime objects instead of the 3 the
+    /// v1 bag move paid, and the archival GC chunks oversized txns, so the
+    /// commit budget alone binds. Chains still operating at package v1 are
+    /// capped at `LEGACY_MAX_WITHDRAWAL_REQUESTS` (298, in `withdrawals.rs`) via
+    /// `max_withdrawal_requests`.
+    pub const MAX_WITHDRAWAL_REQUESTS: usize = 447;
 
     /// Default minimum fee rate floor (3 sat/vB), deliberately above
     /// Bitcoin Core's 1 sat/vB relay minimum.

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -155,6 +155,29 @@ const WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS: usize = 43;
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
 
+/// Runtime-object cost model for the deferred `archive_confirmed_withdrawals`
+/// GC (v2 package): ~3 objects per archived txn (hot-bag `Field` + child
+/// borrow, new cold-bag `Field`; the remove reuses the cache) and ~3 per
+/// request (the `requests` removal `Field` + child + the new `processed`
+/// `Field`; the pre-upgrade-leftover fallback path costs the same bound).
+/// Conservative upper bounds pending sui-replay measurement; the executor's
+/// greedy packer sizes each GC transaction from these.
+pub(crate) const WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS: usize = 12;
+pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN: usize = 3;
+pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET: usize = WITHDRAWAL_RUNTIME_OBJECT_BUDGET;
+
+// A whole txn's requests archive together (the entry has no partial-archival
+// mode), so the largest committable batch must fit one GC transaction.
+const _: () = assert!(
+    WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS
+        + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+        + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST
+            * CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        <= WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET,
+    "a max-size withdrawal txn must archive in a single GC transaction"
+);
+
 /// How many inputs fit in [`WITHDRAWAL_RUNTIME_OBJECT_BUDGET`] after the
 /// fixed overhead and the per-request cost of `request_count` requests.
 fn runtime_object_input_budget(

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -213,9 +213,11 @@ pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET: usize = WITHDRAWAL_RUNTIME_OBJECT_BUDGET;
 
-/// Cost of `finish_archive_withdrawal_txn`'s completeness walk: one
-/// `contains` probe per request, on top of the txn borrow.
-pub(crate) const WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST: usize = 1;
+/// Cost of `finish_archive_withdrawal_txn`'s completeness walk: the walk
+/// probes only the `processed` bag, and its per-request ObjectBag borrow
+/// touches two runtime objects (the `Field` wrapper plus the child
+/// request), on top of the txn borrow.
+pub(crate) const WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
 
 // A txn whose requests exceed one GC transaction archives through the
 // chunked entries (`archive_withdrawal_requests` + finish); the packer only

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -131,14 +131,35 @@ pub(crate) const LEGACY_MAX_WITHDRAWAL_REQUESTS: usize = 298;
 /// the archival GC gate and the batch-cap switch.
 pub(crate) const DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION: u64 = 2;
 
-/// The request cap for the active package version. The larger v2 cap is
-/// only safe once the chain executes v2 bytecode (in-place commit) AND the
-/// fleet runs binaries that accept it — the same rollout discipline the
-/// upgrade train already requires: binaries first, then the upgrade tx.
-/// Gating on the resolved active version makes the flip atomic with the
-/// upgrade checkpoint on every node.
-pub(crate) fn max_withdrawal_requests(active_package_version: Option<u64>) -> usize {
-    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+/// The package version the withdrawal flow operates at: v1 while package
+/// version 1 is still in the on-chain enabled set, otherwise the active
+/// version.
+///
+/// The bootstrap v1 -> v2 legacy upgrade leaves both versions enabled
+/// until a separate DisableVersion(1) governance action, and during that
+/// window a direct v1 entry call can corrupt the v2 in-place commit
+/// layout (v1's cancel/approve guards predate it). Holding the whole
+/// withdrawal flow at v1 semantics until v1 leaves the enabled set closes
+/// that window. Every later upgrade uses the exclusive mechanism, where
+/// the predecessor leaves the enabled set atomically with publication, so
+/// this gate is inert outside the bootstrap window.
+///
+/// TODO(pre-mainnet-wipe): dies at the mainnet squash; a squashed chain
+/// never has the both-enabled v1 window.
+pub fn withdrawal_effective_version(active: u64, enabled: &BTreeSet<u64>) -> u64 {
+    if enabled.contains(&1) { 1 } else { active }
+}
+
+/// The request cap for the package version the withdrawal flow operates
+/// at (callers resolve it via
+/// [`crate::onchain::OnchainState::withdrawal_effective_version`]). The
+/// larger v2 cap is only safe once the withdrawal flow executes v2
+/// bytecode (in-place commit) AND the fleet runs binaries that accept it,
+/// the same rollout discipline the upgrade train already requires:
+/// binaries first, then the upgrade tx. Gating on the resolved version
+/// makes the flip atomic with the gating checkpoint on every node.
+pub(crate) fn max_withdrawal_requests(package_version: Option<u64>) -> usize {
+    if package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
         CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
     } else {
         LEGACY_MAX_WITHDRAWAL_REQUESTS
@@ -254,21 +275,22 @@ fn runtime_object_input_budget(
     input_objects / objects_per_input
 }
 
-/// Per-request commit cost for the version the chain executes: v1 bytecode
-/// moves each request between bags (3 objects), v2 mutates in place (2).
-fn commit_objects_per_request(active_package_version: Option<u64>) -> usize {
-    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+/// Per-request commit cost for the version the withdrawal flow executes:
+/// v1 bytecode moves each request between bags (3 objects), v2 mutates in
+/// place (2).
+fn commit_objects_per_request(package_version: Option<u64>) -> usize {
+    if package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
         WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST
     } else {
         LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST
     }
 }
 
-/// Per-request confirm cost for the version the chain executes: v1 bytecode
-/// borrows every request to set its status (2 objects), v2 defers the
-/// status writes to the archival GC (0).
-fn confirm_objects_per_request(active_package_version: Option<u64>) -> usize {
-    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+/// Per-request confirm cost for the version the withdrawal flow executes:
+/// v1 bytecode borrows every request to set its status (2 objects), v2
+/// defers the status writes to the archival GC (0).
+fn confirm_objects_per_request(package_version: Option<u64>) -> usize {
+    if package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
         WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST
     } else {
         LEGACY_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST
@@ -278,11 +300,11 @@ fn confirm_objects_per_request(active_package_version: Option<u64>) -> usize {
 fn safe_withdrawal_commit_max_inputs(
     request_count: usize,
     configured_max_inputs: usize,
-    active_package_version: Option<u64>,
+    package_version: Option<u64>,
 ) -> usize {
     configured_max_inputs.min(runtime_object_input_budget(
         WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS,
-        commit_objects_per_request(active_package_version),
+        commit_objects_per_request(package_version),
         WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT,
         request_count,
     ))
@@ -291,11 +313,11 @@ fn safe_withdrawal_commit_max_inputs(
 fn safe_withdrawal_confirm_max_inputs(
     request_count: usize,
     configured_max_inputs: usize,
-    active_package_version: Option<u64>,
+    package_version: Option<u64>,
 ) -> usize {
     configured_max_inputs.min(runtime_object_input_budget(
         WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS,
-        confirm_objects_per_request(active_package_version),
+        confirm_objects_per_request(package_version),
         WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT,
         request_count,
     ))
@@ -303,12 +325,12 @@ fn safe_withdrawal_confirm_max_inputs(
 
 /// The input cap for the whole withdrawal flow at a given request count:
 /// the configured cap, the per-request consolidation budget, and the
-/// runtime-object budgets of both the commit and confirm transactions —
-/// each priced for the bytecode the active package version executes.
+/// runtime-object budgets of both the commit and confirm transactions,
+/// each priced for the bytecode the effective package version executes.
 fn safe_withdrawal_flow_max_inputs(
     request_count: usize,
     configured_max_inputs: usize,
-    active_package_version: Option<u64>,
+    package_version: Option<u64>,
 ) -> usize {
     let request_input_budget =
         request_count.saturating_mul(CoinSelectionParams::DEFAULT_INPUT_BUDGET);
@@ -317,12 +339,12 @@ fn safe_withdrawal_flow_max_inputs(
         .min(safe_withdrawal_commit_max_inputs(
             request_count,
             configured_max_inputs,
-            active_package_version,
+            package_version,
         ))
         .min(safe_withdrawal_confirm_max_inputs(
             request_count,
             configured_max_inputs,
-            active_package_version,
+            package_version,
         ))
 }
 
@@ -358,10 +380,10 @@ const _: () = assert!(
 fn withdrawal_batch_request_cap(
     pending_requests: usize,
     available_utxos: usize,
-    active_package_version: Option<u64>,
+    package_version: Option<u64>,
 ) -> usize {
     if pending_requests > available_utxos {
-        max_withdrawal_requests(active_package_version)
+        max_withdrawal_requests(package_version)
     } else {
         CONSOLIDATION_MODE_MAX_REQUESTS
     }
@@ -400,9 +422,9 @@ fn validate_commitment_shape(
     request_count: usize,
     input_count: usize,
     outputs: &[OutputUtxo],
-    active_package_version: Option<u64>,
+    package_version: Option<u64>,
 ) -> anyhow::Result<()> {
-    let max_requests = max_withdrawal_requests(active_package_version);
+    let max_requests = max_withdrawal_requests(package_version);
     anyhow::ensure!(
         request_count <= max_requests,
         "Commitment has {request_count} requests, exceeding the batch cap of {max_requests}",
@@ -411,7 +433,7 @@ fn validate_commitment_shape(
     let max_inputs = safe_withdrawal_flow_max_inputs(
         request_count,
         CoinSelectionParams::DEFAULT_MAX_INPUTS,
-        active_package_version,
+        package_version,
     );
     anyhow::ensure!(
         input_count <= max_inputs,
@@ -573,11 +595,14 @@ impl Hashi {
             "Duplicate UTXO IDs"
         );
 
+        // The effective (dormancy-gated) version, not the active one: the
+        // leader sizes batches by the same resolution below, so leader and
+        // validators must agree on the cap through the bootstrap window.
         validate_commitment_shape(
             approval.request_ids.len(),
             approval.selected_utxos.len(),
             &approval.outputs,
-            self.onchain_state().active_package_version(),
+            self.onchain_state().withdrawal_effective_version(),
         )?;
 
         // 1. Verify each request_id exists and is approved
@@ -1473,12 +1498,17 @@ impl Hashi {
         // Drain versus consolidate: size the batch cap by comparing the
         // queue depth to the available pool. `candidates` counts every
         // unlocked UTXO — the same set coin selection draws from. The cap
-        // (and the input models below) follow the active package version,
-        // so the leader proposes only shapes the executing bytecode can
-        // afford and every validator generation will certify.
-        let active_package_version = self.onchain_state().active_package_version();
-        let batch_request_cap =
-            withdrawal_batch_request_cap(requests.len(), candidates.len(), active_package_version);
+        // (and the input models below) follow the withdrawal-effective
+        // package version (the active version, held at v1 through the
+        // bootstrap both-enabled window), so the leader proposes only
+        // shapes the executing bytecode can afford and every validator
+        // generation will certify.
+        let effective_package_version = self.onchain_state().withdrawal_effective_version();
+        let batch_request_cap = withdrawal_batch_request_cap(
+            requests.len(),
+            candidates.len(),
+            effective_package_version,
+        );
         let configured_max_requests = self
             .config
             .withdrawal_max_batch_size()
@@ -1488,7 +1518,7 @@ impl Hashi {
             pending_requests = requests.len(),
             available_utxos = candidates.len(),
             batch_request_cap,
-            active_package_version,
+            effective_package_version,
             configured_max_requests,
             "Sized the withdrawal batch cap from queue depth versus pool size",
         );
@@ -1514,7 +1544,7 @@ impl Hashi {
             let max_inputs = safe_withdrawal_flow_max_inputs(
                 request_count,
                 configured_max_inputs,
-                active_package_version,
+                effective_package_version,
             );
             if max_inputs == 0 {
                 continue;
@@ -2335,10 +2365,55 @@ mod tests {
         }
     }
 
-    /// Active-version shorthand for the model tests: the deferred-archival
-    /// package and the legacy chain.
+    /// Effective-version shorthand for the model tests: the
+    /// deferred-archival package and the legacy chain.
     const V2: Option<u64> = Some(DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION);
     const V1: Option<u64> = Some(1);
+
+    fn enabled(versions: &[u64]) -> BTreeSet<u64> {
+        versions.iter().copied().collect()
+    }
+
+    /// The dormancy truth table: the effective version is held at 1 while
+    /// v1 is in the enabled set, regardless of the active version, and is
+    /// the active version otherwise.
+    #[test]
+    fn effective_version_holds_v1_while_v1_is_enabled() {
+        // The bootstrap window: legacy upgrade left both enabled.
+        assert_eq!(withdrawal_effective_version(2, &enabled(&[1, 2])), 1);
+        // Pre-upgrade steady state.
+        assert_eq!(withdrawal_effective_version(1, &enabled(&[1])), 1);
+        // Post-DisableVersion(1) steady state: the gate is open.
+        assert_eq!(withdrawal_effective_version(2, &enabled(&[2])), 2);
+        // Exclusive upgrades retire the predecessor atomically, so the
+        // gate is inert on every post-bootstrap chain.
+        assert_eq!(withdrawal_effective_version(3, &enabled(&[3])), 3);
+        assert_eq!(withdrawal_effective_version(3, &enabled(&[2, 3])), 3);
+        // A re-enabled v1 (break-glass) re-engages dormancy at any height.
+        assert_eq!(withdrawal_effective_version(3, &enabled(&[1, 3])), 1);
+    }
+
+    /// Both-enabled means v1 semantics at the capacity seam: the cap the
+    /// leader sizes batches by (and validators enforce) resolves to the
+    /// legacy 298 while v1 is enabled, even with active version 2.
+    #[test]
+    fn effective_version_resolves_legacy_cap_while_v1_is_enabled() {
+        let both = Some(withdrawal_effective_version(2, &enabled(&[1, 2])));
+        assert_eq!(
+            max_withdrawal_requests(both),
+            LEGACY_MAX_WITHDRAWAL_REQUESTS
+        );
+        assert_eq!(commit_objects_per_request(both), 3);
+        assert_eq!(confirm_objects_per_request(both), 2);
+
+        let open = Some(withdrawal_effective_version(2, &enabled(&[2])));
+        assert_eq!(
+            max_withdrawal_requests(open),
+            CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        );
+        assert_eq!(commit_objects_per_request(open), 2);
+        assert_eq!(confirm_objects_per_request(open), 0);
+    }
 
     #[test]
     fn batch_cap_drains_when_queue_outnumbers_pool() {

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -107,16 +107,43 @@ pub(crate) fn withdrawal_limiter_consumption_amount(txn: &WithdrawalTransaction)
 /// Target 922 to leave 7.8% headroom below the hard cap.
 const WITHDRAWAL_RUNTIME_OBJECT_BUDGET: usize = 922;
 
-/// Runtime-object cost model for `commit_withdrawal_tx`. Empirical
-/// measurements put commit transactions at roughly
-/// `3 * requests + 1 * selected_utxos + fixed_overhead` runtime objects:
-/// each request is removed from the `requests` ObjectBag and re-added to
-/// `processed` (the `Field` wrapper, the child request object, and the new
+/// Runtime-object cost model for the v2 (deferred-archival)
+/// `commit_withdrawal_tx`: each request is mutated in place in the
+/// `requests` ObjectBag (the `Field` wrapper plus the child request object,
+/// 2 per request — the v1 bag move paid a third for the new `processed`
 /// `Field`), and each input borrows and locks its `utxo_records` entry (one
-/// `Field` per input).
+/// `Field` per input). The v1 empirical baseline was `3 * requests +
+/// 1 * selected_utxos + fixed_overhead`; the 2/request coefficient follows
+/// from removing the `Field` creation and should be confirmed by sui-replay
+/// before the upgrade ships.
 const WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS: usize = 12;
-const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
 const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
+
+/// The pre-deferred-archival batch cap, still enforced while the chain
+/// operates at package v1: v1 bytecode's commit pays 3 runtime objects per
+/// request, and pre-v2 validators have this bound compiled in. See
+/// [`max_withdrawal_requests`].
+pub(crate) const LEGACY_MAX_WITHDRAWAL_REQUESTS: usize = 298;
+
+/// The package version at which the deferred-archival flow (in-place
+/// commit, chunked archival GC) is live; the canonical constant for both
+/// the archival GC gate and the batch-cap switch.
+pub(crate) const DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION: u64 = 2;
+
+/// The request cap for the active package version. The larger v2 cap is
+/// only safe once the chain executes v2 bytecode (in-place commit) AND the
+/// fleet runs binaries that accept it — the same rollout discipline the
+/// upgrade train already requires: binaries first, then the upgrade tx.
+/// Gating on the resolved active version makes the flip atomic with the
+/// upgrade checkpoint on every node.
+pub(crate) fn max_withdrawal_requests(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+    } else {
+        LEGACY_MAX_WITHDRAWAL_REQUESTS
+    }
+}
 
 /// Funding-input reserve at the request-count cap. With largest-first
 /// selection a batch is normally funded by a handful of inputs; 16 leaves
@@ -152,8 +179,27 @@ const _: () = assert!(
 /// checked alongside it so a future change to either cost cannot silently
 /// regress the other.
 const WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS: usize = 43;
-const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
+/// v2 confirm defers every request-status write to the archival GC, so its
+/// object cost no longer scales with the request count.
+const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 0;
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
+
+/// v1 bytecode coefficients, still applied while the chain operates at
+/// package v1: commit moved each request between bags (3 objects) and
+/// confirm borrowed each request to set its status (2 objects).
+const LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+const LEGACY_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
+
+// Pin the legacy cap to the v1 commit derivation the same way the current
+// cap is pinned below: refuse to compile if either drifts from its model.
+const _: () = assert!(
+    LEGACY_MAX_WITHDRAWAL_REQUESTS
+        == (WITHDRAWAL_RUNTIME_OBJECT_BUDGET
+            - WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS
+            - WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS * WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT)
+            / LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST,
+    "LEGACY_MAX_WITHDRAWAL_REQUESTS must equal the v1 commit object-budget derivation"
+);
 
 /// Runtime-object cost model for the deferred `archive_confirmed_withdrawals`
 /// GC (v2 package): ~3 objects per archived txn (hot-bag `Field` + child
@@ -167,15 +213,28 @@ pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET: usize = WITHDRAWAL_RUNTIME_OBJECT_BUDGET;
 
-// A whole txn's requests archive together (the entry has no partial-archival
-// mode), so the largest committable batch must fit one GC transaction.
+/// Cost of `finish_archive_withdrawal_txn`'s completeness walk: one
+/// `contains` probe per request, on top of the txn borrow.
+pub(crate) const WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST: usize = 1;
+
+// A txn whose requests exceed one GC transaction archives through the
+// chunked entries (`archive_withdrawal_requests` + finish); the packer only
+// needs each chunk to make progress and the finisher's probe walk to fit a
+// single transaction at the largest committable batch.
 const _: () = assert!(
     WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS
         + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
         + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST
+        <= WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET,
+    "an archival chunk must fit at least one request per GC transaction"
+);
+const _: () = assert!(
+    WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS
+        + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+        + WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST
             * CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
         <= WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET,
-    "a max-size withdrawal txn must archive in a single GC transaction"
+    "a max-size txn's archival finish walk must fit a single GC transaction"
 );
 
 /// How many inputs fit in [`WITHDRAWAL_RUNTIME_OBJECT_BUDGET`] after the
@@ -193,19 +252,48 @@ fn runtime_object_input_budget(
     input_objects / objects_per_input
 }
 
-fn safe_withdrawal_commit_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+/// Per-request commit cost for the version the chain executes: v1 bytecode
+/// moves each request between bags (3 objects), v2 mutates in place (2).
+fn commit_objects_per_request(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST
+    } else {
+        LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST
+    }
+}
+
+/// Per-request confirm cost for the version the chain executes: v1 bytecode
+/// borrows every request to set its status (2 objects), v2 defers the
+/// status writes to the archival GC (0).
+fn confirm_objects_per_request(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST
+    } else {
+        LEGACY_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST
+    }
+}
+
+fn safe_withdrawal_commit_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     configured_max_inputs.min(runtime_object_input_budget(
         WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS,
-        WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST,
+        commit_objects_per_request(active_package_version),
         WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT,
         request_count,
     ))
 }
 
-fn safe_withdrawal_confirm_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+fn safe_withdrawal_confirm_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     configured_max_inputs.min(runtime_object_input_budget(
         WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS,
-        WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST,
+        confirm_objects_per_request(active_package_version),
         WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT,
         request_count,
     ))
@@ -213,8 +301,13 @@ fn safe_withdrawal_confirm_max_inputs(request_count: usize, configured_max_input
 
 /// The input cap for the whole withdrawal flow at a given request count:
 /// the configured cap, the per-request consolidation budget, and the
-/// runtime-object budgets of both the commit and confirm transactions.
-fn safe_withdrawal_flow_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+/// runtime-object budgets of both the commit and confirm transactions —
+/// each priced for the bytecode the active package version executes.
+fn safe_withdrawal_flow_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     let request_input_budget =
         request_count.saturating_mul(CoinSelectionParams::DEFAULT_INPUT_BUDGET);
     configured_max_inputs
@@ -222,10 +315,12 @@ fn safe_withdrawal_flow_max_inputs(request_count: usize, configured_max_inputs: 
         .min(safe_withdrawal_commit_max_inputs(
             request_count,
             configured_max_inputs,
+            active_package_version,
         ))
         .min(safe_withdrawal_confirm_max_inputs(
             request_count,
             configured_max_inputs,
+            active_package_version,
         ))
 }
 
@@ -258,9 +353,13 @@ const _: () = assert!(
 /// Otherwise pool health is the scarce resource: cap the batch at
 /// [`CONSOLIDATION_MODE_MAX_REQUESTS`] so the full per-request
 /// consolidation budget stays available (consolidation mode).
-fn withdrawal_batch_request_cap(pending_requests: usize, available_utxos: usize) -> usize {
+fn withdrawal_batch_request_cap(
+    pending_requests: usize,
+    available_utxos: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     if pending_requests > available_utxos {
-        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        max_withdrawal_requests(active_package_version)
     } else {
         CONSOLIDATION_MODE_MAX_REQUESTS
     }
@@ -299,15 +398,19 @@ fn validate_commitment_shape(
     request_count: usize,
     input_count: usize,
     outputs: &[OutputUtxo],
+    active_package_version: Option<u64>,
 ) -> anyhow::Result<()> {
+    let max_requests = max_withdrawal_requests(active_package_version);
     anyhow::ensure!(
-        request_count <= CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
-        "Commitment has {request_count} requests, exceeding the batch cap of {}",
-        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
+        request_count <= max_requests,
+        "Commitment has {request_count} requests, exceeding the batch cap of {max_requests}",
     );
 
-    let max_inputs =
-        safe_withdrawal_flow_max_inputs(request_count, CoinSelectionParams::DEFAULT_MAX_INPUTS);
+    let max_inputs = safe_withdrawal_flow_max_inputs(
+        request_count,
+        CoinSelectionParams::DEFAULT_MAX_INPUTS,
+        active_package_version,
+    );
     anyhow::ensure!(
         input_count <= max_inputs,
         "Commitment has {input_count} inputs for {request_count} requests, \
@@ -472,6 +575,7 @@ impl Hashi {
             approval.request_ids.len(),
             approval.selected_utxos.len(),
             &approval.outputs,
+            self.onchain_state().active_package_version(),
         )?;
 
         // 1. Verify each request_id exists and is approved
@@ -1366,8 +1470,13 @@ impl Hashi {
 
         // Drain versus consolidate: size the batch cap by comparing the
         // queue depth to the available pool. `candidates` counts every
-        // unlocked UTXO — the same set coin selection draws from.
-        let batch_request_cap = withdrawal_batch_request_cap(requests.len(), candidates.len());
+        // unlocked UTXO — the same set coin selection draws from. The cap
+        // (and the input models below) follow the active package version,
+        // so the leader proposes only shapes the executing bytecode can
+        // afford and every validator generation will certify.
+        let active_package_version = self.onchain_state().active_package_version();
+        let batch_request_cap =
+            withdrawal_batch_request_cap(requests.len(), candidates.len(), active_package_version);
         let configured_max_requests = self
             .config
             .withdrawal_max_batch_size()
@@ -1398,7 +1507,11 @@ impl Hashi {
         let mut representative_errors = BTreeMap::<&'static str, String>::new();
         let mut attempted_request_counts = 0usize;
         for request_count in (1..=configured_max_requests).rev() {
-            let max_inputs = safe_withdrawal_flow_max_inputs(request_count, configured_max_inputs);
+            let max_inputs = safe_withdrawal_flow_max_inputs(
+                request_count,
+                configured_max_inputs,
+                active_package_version,
+            );
             if max_inputs == 0 {
                 continue;
             }
@@ -2218,18 +2331,32 @@ mod tests {
         }
     }
 
+    /// Active-version shorthand for the model tests: the deferred-archival
+    /// package and the legacy chain.
+    const V2: Option<u64> = Some(DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION);
+    const V1: Option<u64> = Some(1);
+
     #[test]
     fn batch_cap_drains_when_queue_outnumbers_pool() {
         assert_eq!(
-            withdrawal_batch_request_cap(5_000, 1_000),
+            withdrawal_batch_request_cap(5_000, 1_000, V2),
             CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        );
+        assert_eq!(
+            withdrawal_batch_request_cap(5_000, 1_000, V1),
+            LEGACY_MAX_WITHDRAWAL_REQUESTS
+        );
+        assert_eq!(
+            withdrawal_batch_request_cap(5_000, 1_000, None),
+            LEGACY_MAX_WITHDRAWAL_REQUESTS,
+            "an unresolved active version must fall back to the legacy cap",
         );
     }
 
     #[test]
     fn batch_cap_consolidates_when_pool_outnumbers_queue() {
         assert_eq!(
-            withdrawal_batch_request_cap(10, 1_000),
+            withdrawal_batch_request_cap(10, 1_000, V2),
             CONSOLIDATION_MODE_MAX_REQUESTS
         );
     }
@@ -2237,7 +2364,7 @@ mod tests {
     #[test]
     fn batch_cap_prefers_consolidation_at_parity() {
         assert_eq!(
-            withdrawal_batch_request_cap(500, 500),
+            withdrawal_batch_request_cap(500, 500, V2),
             CONSOLIDATION_MODE_MAX_REQUESTS
         );
     }
@@ -2343,21 +2470,34 @@ mod tests {
 
     #[test]
     fn withdrawal_flow_budget_at_absolute_cap() {
-        assert_eq!(CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS, 298);
+        assert_eq!(CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS, 447);
         assert_eq!(CoinSelectionParams::DEFAULT_MAX_INPUTS, 400);
+        // Both caps leave exactly the funding-input reserve under their own
+        // commit coefficients: 922 - 12 - 2*447 = 922 - 12 - 3*298 = 16.
         assert_eq!(
             safe_withdrawal_commit_max_inputs(
                 CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
                 CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V2,
             ),
             WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
-            "at the request cap, the commit object budget leaves exactly \
+            "at the v2 request cap, the commit object budget leaves exactly \
              the funding-input reserve",
+        );
+        assert_eq!(
+            safe_withdrawal_commit_max_inputs(
+                LEGACY_MAX_WITHDRAWAL_REQUESTS,
+                CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V1,
+            ),
+            WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
+            "at the legacy request cap under v1 coefficients, likewise",
         );
         assert_eq!(
             safe_withdrawal_flow_max_inputs(
                 CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
                 CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V2,
             ),
             WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
             "a full drain-mode batch spends the object budget on requests, \
@@ -2372,7 +2512,7 @@ mod tests {
     #[test]
     fn withdrawal_flow_budget_at_legacy_batch_size() {
         assert_eq!(
-            safe_withdrawal_flow_max_inputs(40, CoinSelectionParams::DEFAULT_MAX_INPUTS),
+            safe_withdrawal_flow_max_inputs(40, CoinSelectionParams::DEFAULT_MAX_INPUTS, V2),
             400,
             "40 requests × 10 inputs/request still fills the configured input cap",
         );
@@ -2381,7 +2521,7 @@ mod tests {
     #[test]
     fn withdrawal_flow_budget_scales_inputs_with_request_count() {
         assert_eq!(
-            safe_withdrawal_flow_max_inputs(10, CoinSelectionParams::DEFAULT_MAX_INPUTS),
+            safe_withdrawal_flow_max_inputs(10, CoinSelectionParams::DEFAULT_MAX_INPUTS, V2),
             10 * CoinSelectionParams::DEFAULT_INPUT_BUDGET,
             "at low request counts, the per-request input budget is binding",
         );
@@ -2401,16 +2541,21 @@ mod tests {
     #[test]
     fn commitment_shape_accepts_production_envelopes() {
         // (requests, inputs): the consolidation-heavy legacy shape, the
-        // drain-mode shape at the request cap, and a minimal batch.
-        for (requests, inputs) in [(40, 400), (298, 16), (1, 10)] {
-            validate_commitment_shape(requests, inputs, &p2tr_outputs(requests + 1))
+        // drain-mode shapes at both request caps, and a minimal batch.
+        for (requests, inputs) in [(40, 400), (298, 16), (447, 16), (1, 10)] {
+            validate_commitment_shape(requests, inputs, &p2tr_outputs(requests + 1), V2)
                 .unwrap_or_else(|e| panic!("{requests} requests / {inputs} inputs rejected: {e}"));
         }
+        // A v1-active chain keeps the legacy envelope and refuses the larger one.
+        validate_commitment_shape(298, 16, &p2tr_outputs(299), V1)
+            .expect("legacy cap batch must validate on a v1-active chain");
+        let err = validate_commitment_shape(299, 16, &p2tr_outputs(300), V1).unwrap_err();
+        assert!(err.to_string().contains("exceeding the batch cap"), "{err}");
     }
 
     #[test]
     fn commitment_shape_rejects_request_count_above_cap() {
-        let err = validate_commitment_shape(299, 1, &p2tr_outputs(299)).unwrap_err();
+        let err = validate_commitment_shape(448, 1, &p2tr_outputs(448), V2).unwrap_err();
         assert!(err.to_string().contains("exceeding the batch cap"), "{err}");
     }
 
@@ -2418,9 +2563,9 @@ mod tests {
     fn commitment_shape_rejects_inputs_above_flow_cap() {
         // One over the per-request consolidation budget, the configured
         // input cap, and the commit object budget's funding reserve.
-        for (requests, inputs) in [(1, 11), (40, 401), (298, 17)] {
-            let err =
-                validate_commitment_shape(requests, inputs, &p2tr_outputs(requests)).unwrap_err();
+        for (requests, inputs) in [(1, 11), (40, 401), (447, 17)] {
+            let err = validate_commitment_shape(requests, inputs, &p2tr_outputs(requests), V2)
+                .unwrap_err();
             assert!(
                 err.to_string().contains("exceeding the flow cap"),
                 "{requests} requests / {inputs} inputs: {err}"
@@ -2433,22 +2578,28 @@ mod tests {
         // Request and input counts inside their caps, but enough change
         // outputs to push the transaction past the 400 kWU standardness
         // limit (~2,300 P2TR outputs).
-        let err = validate_commitment_shape(298, 16, &p2tr_outputs(3_000)).unwrap_err();
+        let err = validate_commitment_shape(447, 16, &p2tr_outputs(3_000), V2).unwrap_err();
         assert!(err.to_string().contains("standardness limit"), "{err}");
     }
 
     #[test]
     fn commitment_shape_accepts_change_outputs_at_cap() {
-        validate_commitment_shape(40, 400, &p2tr_outputs(40 + WITHDRAWAL_MAX_CHANGE_OUTPUTS))
-            .expect("a commitment at the change-output cap must validate");
+        validate_commitment_shape(
+            40,
+            400,
+            &p2tr_outputs(40 + WITHDRAWAL_MAX_CHANGE_OUTPUTS),
+            V2,
+        )
+        .expect("a commitment at the change-output cap must validate");
     }
 
     #[test]
     fn commitment_shape_rejects_change_outputs_above_cap() {
         let err = validate_commitment_shape(
-            298,
+            447,
             16,
-            &p2tr_outputs(298 + WITHDRAWAL_MAX_CHANGE_OUTPUTS + 1),
+            &p2tr_outputs(447 + WITHDRAWAL_MAX_CHANGE_OUTPUTS + 1),
+            V2,
         )
         .unwrap_err();
         assert!(err.to_string().contains("change outputs"), "{err}");
@@ -2476,16 +2627,22 @@ mod tests {
     /// safety net.
     #[test]
     fn withdrawal_confirm_budget_never_binds() {
-        for request_count in 1..=1000 {
-            let configured = CoinSelectionParams::DEFAULT_MAX_INPUTS;
-            let without_confirm = configured
-                .min(request_count * CoinSelectionParams::DEFAULT_INPUT_BUDGET)
-                .min(safe_withdrawal_commit_max_inputs(request_count, configured));
-            assert_eq!(
-                safe_withdrawal_flow_max_inputs(request_count, configured),
-                without_confirm,
-                "confirm budget unexpectedly binds at {request_count} requests",
-            );
+        for active in [V1, V2] {
+            for request_count in 1..=1000 {
+                let configured = CoinSelectionParams::DEFAULT_MAX_INPUTS;
+                let without_confirm = configured
+                    .min(request_count * CoinSelectionParams::DEFAULT_INPUT_BUDGET)
+                    .min(safe_withdrawal_commit_max_inputs(
+                        request_count,
+                        configured,
+                        active,
+                    ));
+                assert_eq!(
+                    safe_withdrawal_flow_max_inputs(request_count, configured, active),
+                    without_confirm,
+                    "confirm budget unexpectedly binds at {request_count} requests ({active:?})",
+                );
+            }
         }
     }
 

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -107,16 +107,43 @@ pub(crate) fn withdrawal_limiter_consumption_amount(txn: &WithdrawalTransaction)
 /// Target 922 to leave 7.8% headroom below the hard cap.
 const WITHDRAWAL_RUNTIME_OBJECT_BUDGET: usize = 922;
 
-/// Runtime-object cost model for `commit_withdrawal_tx`. Empirical
-/// measurements put commit transactions at roughly
-/// `3 * requests + 1 * selected_utxos + fixed_overhead` runtime objects:
-/// each request is removed from the `requests` ObjectBag and re-added to
-/// `processed` (the `Field` wrapper, the child request object, and the new
+/// Runtime-object cost model for the v2 (deferred-archival)
+/// `commit_withdrawal_tx`: each request is mutated in place in the
+/// `requests` ObjectBag (the `Field` wrapper plus the child request object,
+/// 2 per request — the v1 bag move paid a third for the new `processed`
 /// `Field`), and each input borrows and locks its `utxo_records` entry (one
-/// `Field` per input).
+/// `Field` per input). The v1 empirical baseline was `3 * requests +
+/// 1 * selected_utxos + fixed_overhead`; the 2/request coefficient follows
+/// from removing the `Field` creation and should be confirmed by sui-replay
+/// before the upgrade ships.
 const WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS: usize = 12;
-const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
 const WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
+
+/// The pre-deferred-archival batch cap, still enforced while the chain
+/// operates at package v1: v1 bytecode's commit pays 3 runtime objects per
+/// request, and pre-v2 validators have this bound compiled in. See
+/// [`max_withdrawal_requests`].
+pub(crate) const LEGACY_MAX_WITHDRAWAL_REQUESTS: usize = 298;
+
+/// The package version at which the deferred-archival flow (in-place
+/// commit, chunked archival GC) is live; the canonical constant for both
+/// the archival GC gate and the batch-cap switch.
+pub(crate) const DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION: u64 = 2;
+
+/// The request cap for the active package version. The larger v2 cap is
+/// only safe once the chain executes v2 bytecode (in-place commit) AND the
+/// fleet runs binaries that accept it — the same rollout discipline the
+/// upgrade train already requires: binaries first, then the upgrade tx.
+/// Gating on the resolved active version makes the flip atomic with the
+/// upgrade checkpoint on every node.
+pub(crate) fn max_withdrawal_requests(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+    } else {
+        LEGACY_MAX_WITHDRAWAL_REQUESTS
+    }
+}
 
 /// Funding-input reserve at the request-count cap. With largest-first
 /// selection a batch is normally funded by a handful of inputs; 16 leaves
@@ -152,8 +179,27 @@ const _: () = assert!(
 /// checked alongside it so a future change to either cost cannot silently
 /// regress the other.
 const WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS: usize = 43;
-const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
+/// v2 confirm defers every request-status write to the archival GC, so its
+/// object cost no longer scales with the request count.
+const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 0;
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
+
+/// v1 bytecode coefficients, still applied while the chain operates at
+/// package v1: commit moved each request between bags (3 objects) and
+/// confirm borrowed each request to set its status (2 objects).
+const LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
+const LEGACY_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
+
+// Pin the legacy cap to the v1 commit derivation the same way the current
+// cap is pinned below: refuse to compile if either drifts from its model.
+const _: () = assert!(
+    LEGACY_MAX_WITHDRAWAL_REQUESTS
+        == (WITHDRAWAL_RUNTIME_OBJECT_BUDGET
+            - WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS
+            - WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS * WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT)
+            / LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST,
+    "LEGACY_MAX_WITHDRAWAL_REQUESTS must equal the v1 commit object-budget derivation"
+);
 
 /// Runtime-object cost model for the deferred `archive_confirmed_withdrawals`
 /// GC (v2 package): ~3 objects per archived txn (hot-bag `Field` + child
@@ -167,15 +213,28 @@ pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET: usize = WITHDRAWAL_RUNTIME_OBJECT_BUDGET;
 
-// A whole txn's requests archive together (the entry has no partial-archival
-// mode), so the largest committable batch must fit one GC transaction.
+/// Cost of `finish_archive_withdrawal_txn`'s completeness walk: one
+/// `contains` probe per request, on top of the txn borrow.
+pub(crate) const WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST: usize = 1;
+
+// A txn whose requests exceed one GC transaction archives through the
+// chunked entries (`archive_withdrawal_requests` + finish); the packer only
+// needs each chunk to make progress and the finisher's probe walk to fit a
+// single transaction at the largest committable batch.
 const _: () = assert!(
     WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS
         + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
         + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST
+        <= WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET,
+    "an archival chunk must fit at least one request per GC transaction"
+);
+const _: () = assert!(
+    WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS
+        + WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_TXN
+        + WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST
             * CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
         <= WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET,
-    "a max-size withdrawal txn must archive in a single GC transaction"
+    "a max-size txn's archival finish walk must fit a single GC transaction"
 );
 
 /// How many inputs fit in [`WITHDRAWAL_RUNTIME_OBJECT_BUDGET`] after the
@@ -193,19 +252,48 @@ fn runtime_object_input_budget(
     input_objects / objects_per_input
 }
 
-fn safe_withdrawal_commit_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+/// Per-request commit cost for the version the chain executes: v1 bytecode
+/// moves each request between bags (3 objects), v2 mutates in place (2).
+fn commit_objects_per_request(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST
+    } else {
+        LEGACY_COMMIT_RUNTIME_OBJECTS_PER_REQUEST
+    }
+}
+
+/// Per-request confirm cost for the version the chain executes: v1 bytecode
+/// borrows every request to set its status (2 objects), v2 defers the
+/// status writes to the archival GC (0).
+fn confirm_objects_per_request(active_package_version: Option<u64>) -> usize {
+    if active_package_version.is_some_and(|v| v >= DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION) {
+        WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST
+    } else {
+        LEGACY_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST
+    }
+}
+
+fn safe_withdrawal_commit_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     configured_max_inputs.min(runtime_object_input_budget(
         WITHDRAWAL_COMMIT_FIXED_RUNTIME_OBJECTS,
-        WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_REQUEST,
+        commit_objects_per_request(active_package_version),
         WITHDRAWAL_COMMIT_RUNTIME_OBJECTS_PER_INPUT,
         request_count,
     ))
 }
 
-fn safe_withdrawal_confirm_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+fn safe_withdrawal_confirm_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     configured_max_inputs.min(runtime_object_input_budget(
         WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS,
-        WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST,
+        confirm_objects_per_request(active_package_version),
         WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT,
         request_count,
     ))
@@ -213,8 +301,13 @@ fn safe_withdrawal_confirm_max_inputs(request_count: usize, configured_max_input
 
 /// The input cap for the whole withdrawal flow at a given request count:
 /// the configured cap, the per-request consolidation budget, and the
-/// runtime-object budgets of both the commit and confirm transactions.
-fn safe_withdrawal_flow_max_inputs(request_count: usize, configured_max_inputs: usize) -> usize {
+/// runtime-object budgets of both the commit and confirm transactions —
+/// each priced for the bytecode the active package version executes.
+fn safe_withdrawal_flow_max_inputs(
+    request_count: usize,
+    configured_max_inputs: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     let request_input_budget =
         request_count.saturating_mul(CoinSelectionParams::DEFAULT_INPUT_BUDGET);
     configured_max_inputs
@@ -222,10 +315,12 @@ fn safe_withdrawal_flow_max_inputs(request_count: usize, configured_max_inputs: 
         .min(safe_withdrawal_commit_max_inputs(
             request_count,
             configured_max_inputs,
+            active_package_version,
         ))
         .min(safe_withdrawal_confirm_max_inputs(
             request_count,
             configured_max_inputs,
+            active_package_version,
         ))
 }
 
@@ -258,9 +353,13 @@ const _: () = assert!(
 /// Otherwise pool health is the scarce resource: cap the batch at
 /// [`CONSOLIDATION_MODE_MAX_REQUESTS`] so the full per-request
 /// consolidation budget stays available (consolidation mode).
-fn withdrawal_batch_request_cap(pending_requests: usize, available_utxos: usize) -> usize {
+fn withdrawal_batch_request_cap(
+    pending_requests: usize,
+    available_utxos: usize,
+    active_package_version: Option<u64>,
+) -> usize {
     if pending_requests > available_utxos {
-        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        max_withdrawal_requests(active_package_version)
     } else {
         CONSOLIDATION_MODE_MAX_REQUESTS
     }
@@ -299,15 +398,19 @@ fn validate_commitment_shape(
     request_count: usize,
     input_count: usize,
     outputs: &[OutputUtxo],
+    active_package_version: Option<u64>,
 ) -> anyhow::Result<()> {
+    let max_requests = max_withdrawal_requests(active_package_version);
     anyhow::ensure!(
-        request_count <= CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
-        "Commitment has {request_count} requests, exceeding the batch cap of {}",
-        CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
+        request_count <= max_requests,
+        "Commitment has {request_count} requests, exceeding the batch cap of {max_requests}",
     );
 
-    let max_inputs =
-        safe_withdrawal_flow_max_inputs(request_count, CoinSelectionParams::DEFAULT_MAX_INPUTS);
+    let max_inputs = safe_withdrawal_flow_max_inputs(
+        request_count,
+        CoinSelectionParams::DEFAULT_MAX_INPUTS,
+        active_package_version,
+    );
     anyhow::ensure!(
         input_count <= max_inputs,
         "Commitment has {input_count} inputs for {request_count} requests, \
@@ -472,6 +575,7 @@ impl Hashi {
             approval.request_ids.len(),
             approval.selected_utxos.len(),
             &approval.outputs,
+            self.onchain_state().active_package_version(),
         )?;
 
         // 1. Verify each request_id exists and is approved
@@ -1366,8 +1470,13 @@ impl Hashi {
 
         // Drain versus consolidate: size the batch cap by comparing the
         // queue depth to the available pool. `candidates` counts every
-        // unlocked UTXO — the same set coin selection draws from.
-        let batch_request_cap = withdrawal_batch_request_cap(requests.len(), candidates.len());
+        // unlocked UTXO — the same set coin selection draws from. The cap
+        // (and the input models below) follow the active package version,
+        // so the leader proposes only shapes the executing bytecode can
+        // afford and every validator generation will certify.
+        let active_package_version = self.onchain_state().active_package_version();
+        let batch_request_cap =
+            withdrawal_batch_request_cap(requests.len(), candidates.len(), active_package_version);
         let configured_max_requests = self
             .config
             .withdrawal_max_batch_size()
@@ -1398,7 +1507,11 @@ impl Hashi {
         let mut representative_errors = BTreeMap::<&'static str, String>::new();
         let mut attempted_request_counts = 0usize;
         for request_count in (1..=configured_max_requests).rev() {
-            let max_inputs = safe_withdrawal_flow_max_inputs(request_count, configured_max_inputs);
+            let max_inputs = safe_withdrawal_flow_max_inputs(
+                request_count,
+                configured_max_inputs,
+                active_package_version,
+            );
             if max_inputs == 0 {
                 continue;
             }
@@ -2217,18 +2330,32 @@ mod tests {
         }
     }
 
+    /// Active-version shorthand for the model tests: the deferred-archival
+    /// package and the legacy chain.
+    const V2: Option<u64> = Some(DEFERRED_ARCHIVAL_MIN_PACKAGE_VERSION);
+    const V1: Option<u64> = Some(1);
+
     #[test]
     fn batch_cap_drains_when_queue_outnumbers_pool() {
         assert_eq!(
-            withdrawal_batch_request_cap(5_000, 1_000),
+            withdrawal_batch_request_cap(5_000, 1_000, V2),
             CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS
+        );
+        assert_eq!(
+            withdrawal_batch_request_cap(5_000, 1_000, V1),
+            LEGACY_MAX_WITHDRAWAL_REQUESTS
+        );
+        assert_eq!(
+            withdrawal_batch_request_cap(5_000, 1_000, None),
+            LEGACY_MAX_WITHDRAWAL_REQUESTS,
+            "an unresolved active version must fall back to the legacy cap",
         );
     }
 
     #[test]
     fn batch_cap_consolidates_when_pool_outnumbers_queue() {
         assert_eq!(
-            withdrawal_batch_request_cap(10, 1_000),
+            withdrawal_batch_request_cap(10, 1_000, V2),
             CONSOLIDATION_MODE_MAX_REQUESTS
         );
     }
@@ -2236,7 +2363,7 @@ mod tests {
     #[test]
     fn batch_cap_prefers_consolidation_at_parity() {
         assert_eq!(
-            withdrawal_batch_request_cap(500, 500),
+            withdrawal_batch_request_cap(500, 500, V2),
             CONSOLIDATION_MODE_MAX_REQUESTS
         );
     }
@@ -2342,21 +2469,34 @@ mod tests {
 
     #[test]
     fn withdrawal_flow_budget_at_absolute_cap() {
-        assert_eq!(CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS, 298);
+        assert_eq!(CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS, 447);
         assert_eq!(CoinSelectionParams::DEFAULT_MAX_INPUTS, 400);
+        // Both caps leave exactly the funding-input reserve under their own
+        // commit coefficients: 922 - 12 - 2*447 = 922 - 12 - 3*298 = 16.
         assert_eq!(
             safe_withdrawal_commit_max_inputs(
                 CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
                 CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V2,
             ),
             WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
-            "at the request cap, the commit object budget leaves exactly \
+            "at the v2 request cap, the commit object budget leaves exactly \
              the funding-input reserve",
+        );
+        assert_eq!(
+            safe_withdrawal_commit_max_inputs(
+                LEGACY_MAX_WITHDRAWAL_REQUESTS,
+                CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V1,
+            ),
+            WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
+            "at the legacy request cap under v1 coefficients, likewise",
         );
         assert_eq!(
             safe_withdrawal_flow_max_inputs(
                 CoinSelectionParams::MAX_WITHDRAWAL_REQUESTS,
                 CoinSelectionParams::DEFAULT_MAX_INPUTS,
+                V2,
             ),
             WITHDRAWAL_COMMIT_MIN_FUNDING_INPUTS,
             "a full drain-mode batch spends the object budget on requests, \
@@ -2371,7 +2511,7 @@ mod tests {
     #[test]
     fn withdrawal_flow_budget_at_legacy_batch_size() {
         assert_eq!(
-            safe_withdrawal_flow_max_inputs(40, CoinSelectionParams::DEFAULT_MAX_INPUTS),
+            safe_withdrawal_flow_max_inputs(40, CoinSelectionParams::DEFAULT_MAX_INPUTS, V2),
             400,
             "40 requests × 10 inputs/request still fills the configured input cap",
         );
@@ -2380,7 +2520,7 @@ mod tests {
     #[test]
     fn withdrawal_flow_budget_scales_inputs_with_request_count() {
         assert_eq!(
-            safe_withdrawal_flow_max_inputs(10, CoinSelectionParams::DEFAULT_MAX_INPUTS),
+            safe_withdrawal_flow_max_inputs(10, CoinSelectionParams::DEFAULT_MAX_INPUTS, V2),
             10 * CoinSelectionParams::DEFAULT_INPUT_BUDGET,
             "at low request counts, the per-request input budget is binding",
         );
@@ -2400,16 +2540,21 @@ mod tests {
     #[test]
     fn commitment_shape_accepts_production_envelopes() {
         // (requests, inputs): the consolidation-heavy legacy shape, the
-        // drain-mode shape at the request cap, and a minimal batch.
-        for (requests, inputs) in [(40, 400), (298, 16), (1, 10)] {
-            validate_commitment_shape(requests, inputs, &p2tr_outputs(requests + 1))
+        // drain-mode shapes at both request caps, and a minimal batch.
+        for (requests, inputs) in [(40, 400), (298, 16), (447, 16), (1, 10)] {
+            validate_commitment_shape(requests, inputs, &p2tr_outputs(requests + 1), V2)
                 .unwrap_or_else(|e| panic!("{requests} requests / {inputs} inputs rejected: {e}"));
         }
+        // A v1-active chain keeps the legacy envelope and refuses the larger one.
+        validate_commitment_shape(298, 16, &p2tr_outputs(299), V1)
+            .expect("legacy cap batch must validate on a v1-active chain");
+        let err = validate_commitment_shape(299, 16, &p2tr_outputs(300), V1).unwrap_err();
+        assert!(err.to_string().contains("exceeding the batch cap"), "{err}");
     }
 
     #[test]
     fn commitment_shape_rejects_request_count_above_cap() {
-        let err = validate_commitment_shape(299, 1, &p2tr_outputs(299)).unwrap_err();
+        let err = validate_commitment_shape(448, 1, &p2tr_outputs(448), V2).unwrap_err();
         assert!(err.to_string().contains("exceeding the batch cap"), "{err}");
     }
 
@@ -2417,9 +2562,9 @@ mod tests {
     fn commitment_shape_rejects_inputs_above_flow_cap() {
         // One over the per-request consolidation budget, the configured
         // input cap, and the commit object budget's funding reserve.
-        for (requests, inputs) in [(1, 11), (40, 401), (298, 17)] {
-            let err =
-                validate_commitment_shape(requests, inputs, &p2tr_outputs(requests)).unwrap_err();
+        for (requests, inputs) in [(1, 11), (40, 401), (447, 17)] {
+            let err = validate_commitment_shape(requests, inputs, &p2tr_outputs(requests), V2)
+                .unwrap_err();
             assert!(
                 err.to_string().contains("exceeding the flow cap"),
                 "{requests} requests / {inputs} inputs: {err}"
@@ -2432,22 +2577,28 @@ mod tests {
         // Request and input counts inside their caps, but enough change
         // outputs to push the transaction past the 400 kWU standardness
         // limit (~2,300 P2TR outputs).
-        let err = validate_commitment_shape(298, 16, &p2tr_outputs(3_000)).unwrap_err();
+        let err = validate_commitment_shape(447, 16, &p2tr_outputs(3_000), V2).unwrap_err();
         assert!(err.to_string().contains("standardness limit"), "{err}");
     }
 
     #[test]
     fn commitment_shape_accepts_change_outputs_at_cap() {
-        validate_commitment_shape(40, 400, &p2tr_outputs(40 + WITHDRAWAL_MAX_CHANGE_OUTPUTS))
-            .expect("a commitment at the change-output cap must validate");
+        validate_commitment_shape(
+            40,
+            400,
+            &p2tr_outputs(40 + WITHDRAWAL_MAX_CHANGE_OUTPUTS),
+            V2,
+        )
+        .expect("a commitment at the change-output cap must validate");
     }
 
     #[test]
     fn commitment_shape_rejects_change_outputs_above_cap() {
         let err = validate_commitment_shape(
-            298,
+            447,
             16,
-            &p2tr_outputs(298 + WITHDRAWAL_MAX_CHANGE_OUTPUTS + 1),
+            &p2tr_outputs(447 + WITHDRAWAL_MAX_CHANGE_OUTPUTS + 1),
+            V2,
         )
         .unwrap_err();
         assert!(err.to_string().contains("change outputs"), "{err}");
@@ -2475,16 +2626,22 @@ mod tests {
     /// safety net.
     #[test]
     fn withdrawal_confirm_budget_never_binds() {
-        for request_count in 1..=1000 {
-            let configured = CoinSelectionParams::DEFAULT_MAX_INPUTS;
-            let without_confirm = configured
-                .min(request_count * CoinSelectionParams::DEFAULT_INPUT_BUDGET)
-                .min(safe_withdrawal_commit_max_inputs(request_count, configured));
-            assert_eq!(
-                safe_withdrawal_flow_max_inputs(request_count, configured),
-                without_confirm,
-                "confirm budget unexpectedly binds at {request_count} requests",
-            );
+        for active in [V1, V2] {
+            for request_count in 1..=1000 {
+                let configured = CoinSelectionParams::DEFAULT_MAX_INPUTS;
+                let without_confirm = configured
+                    .min(request_count * CoinSelectionParams::DEFAULT_INPUT_BUDGET)
+                    .min(safe_withdrawal_commit_max_inputs(
+                        request_count,
+                        configured,
+                        active,
+                    ));
+                assert_eq!(
+                    safe_withdrawal_flow_max_inputs(request_count, configured, active),
+                    without_confirm,
+                    "confirm budget unexpectedly binds at {request_count} requests ({active:?})",
+                );
+            }
         }
     }
 

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -1486,6 +1486,8 @@ impl Hashi {
             pending_requests = requests.len(),
             available_utxos = candidates.len(),
             batch_request_cap,
+            active_package_version,
+            configured_max_requests,
             "Sized the withdrawal batch cap from queue depth versus pool size",
         );
 

--- a/design/docs/move-upgrades.mdx
+++ b/design/docs/move-upgrades.mdx
@@ -126,21 +126,30 @@ withdrawal queue does not need to drain first.
 
 1. Create and fully vote the pause, v2 upgrade, and `DisableVersion(1)`
    proposals while v1 is active. Proposal creation permits targeting the
-   current version; only execution rejects disabling it. Do not pre-vote the
-   unpause: proposal execution checks only quorum, not the caller, so a
-   quorum-complete unpause is executable by any account, and an adversary
-   could unpause and commit through v2 in one transaction inside the window.
-2. Execute the pause. Governance entries are not pause-gated, so the remaining
-   steps execute while paused.
-3. Execute, publish, and finalize v2 through the legacy v1 upgrade path.
+   current version; only execution rejects disabling it.
+2. Execute the pause once the remaining proposals are near quorum. Governance
+   entries are not pause-gated, so the remaining steps execute while paused.
+3. Verify the bridge is still paused, then execute, publish, and finalize v2
+   through the legacy v1 upgrade path.
 4. Wait for that transaction to succeed and obtain the newly published v2
    package ID.
 5. Immediately execute the already-approved disable-v1 proposal through the v2
-   package.
+   package. Pre-build this transaction so only the package ID needs filling.
 6. Verify that v1 calls fail with `EVersionDisabled` and that validators route
    ordinary work through v2.
-7. Only then create, vote, and execute the unpause proposal. The bridge stays
-   paused through the unpause vote; we accept that for this one migration.
+7. Create, vote, and execute the unpause.
+
+Proposal execution checks only quorum, not the caller, so any quorum-complete
+proposal is executable by any account. The strict ordering therefore votes the
+unpause only after `DisableVersion(1)` is verified: a pre-voted unpause would
+let an adversary unpause and commit through v2 in one transaction inside the
+window. On testnet we relax this and pre-vote the unpause alongside the other
+proposals, accepting the theoretical window: nothing of value is at stake, the
+window is seconds wide, and every proposal executed to date has been executed
+by the proposing operators. Any future migration that carries real value must
+use the strict ordering; on mainnet the question should not arise at all,
+because exclusive upgrades replace the enabled set atomically and leave no
+window to protect.
 
 The upgrade and disable are necessarily two transactions. They must not be
 submitted concurrently because shared-object ordering is not guaranteed;

--- a/design/docs/move-upgrades.mdx
+++ b/design/docs/move-upgrades.mdx
@@ -143,16 +143,16 @@ Proposal execution checks only quorum, not the caller, so any quorum-complete
 proposal is executable by any account. The strict ordering therefore votes the
 unpause only after `DisableVersion(1)` is verified: a pre-voted unpause would
 let an adversary unpause and commit through v2 in one transaction inside the
-window. On testnet we relax this and pre-vote the unpause alongside the other
-proposals, accepting the theoretical window: nothing of value is at stake, the
-window is seconds wide, and every proposal executed to date has been executed
-by the proposing operators. Any future migration that carries real value must
-use the strict ordering; on mainnet the question should not arise at all,
-because exclusive upgrades replace the enabled set atomically and leave no
-window to protect.
+window. The Testnet migration relaxes this and pre-votes the unpause
+alongside the other proposals, accepting the theoretical window: nothing of
+value is at stake, the window is seconds wide, and the proposing operators
+have executed every proposal to date. Any future migration that carries real
+value must use the strict ordering; on Mainnet the question should not arise
+at all, because exclusive upgrades replace the enabled set atomically and
+leave no window to protect.
 
-The upgrade and disable are necessarily two transactions. They must not be
-submitted concurrently because shared-object ordering is not guaranteed;
+The upgrade and disable are necessarily two transactions. Do not submit them
+concurrently: the network does not guarantee shared-object ordering, and
 disable-v1 must execute through v2 after publication.
 
 The pause is what makes the window between them safe for withdrawals.
@@ -160,12 +160,13 @@ Commitment and approval certificates bind no package version, so while both
 versions are enabled a live certificate can be replayed through v2's
 `commit_withdrawal_tx`. That commits the request in place, where v1's
 pause-exempt `cancel_withdrawal` (which checks only the `processed` bag) can
-destroy it: hBTC burned with no BTC released, and the referencing withdrawal
-transaction wedged forever. Every corrupting interleaving requires such a v2
-commit to land while v1 is still enabled. `commit_withdrawal_tx` and
-`approve_request` honor the pause in both packages, so holding the pause
-across the window means that state can never be created, and the pause-exempt
-v1 cancel has nothing corruptible to act on. In-flight withdrawals ride
+destroy it, burning the user's hBTC while releasing no BTC and wedging the
+referencing withdrawal transaction forever. Every corrupting interleaving
+requires such a v2 commit to land while v1 is still enabled.
+`commit_withdrawal_tx` and `approve_request` honor the pause in both
+packages, so holding the pause across the window means no transaction can
+create that state, and the pause-exempt v1 cancel has nothing corruptible to
+act on. In-flight withdrawals ride
 through the flip without draining: committed batches sign, confirm, and
 archive from their v1 locations, and approved or requested entries commit
 v2-style afterward.

--- a/design/docs/move-upgrades.mdx
+++ b/design/docs/move-upgrades.mdx
@@ -124,9 +124,12 @@ race window for this one migration. Run the migration under the emergency
 pause, which closes the withdrawal-replay surface described below; the
 withdrawal queue does not need to drain first.
 
-1. Create and fully vote the pause, v2 upgrade, `DisableVersion(1)`, and
-   unpause proposals while v1 is active. Proposal creation permits targeting
-   the current version; only execution rejects disabling it.
+1. Create and fully vote the pause, v2 upgrade, and `DisableVersion(1)`
+   proposals while v1 is active. Proposal creation permits targeting the
+   current version; only execution rejects disabling it. Do not pre-vote the
+   unpause: proposal execution checks only quorum, not the caller, so a
+   quorum-complete unpause is executable by any account, and an adversary
+   could unpause and commit through v2 in one transaction inside the window.
 2. Execute the pause. Governance entries are not pause-gated, so the remaining
    steps execute while paused.
 3. Execute, publish, and finalize v2 through the legacy v1 upgrade path.
@@ -135,7 +138,9 @@ withdrawal queue does not need to drain first.
 5. Immediately execute the already-approved disable-v1 proposal through the v2
    package.
 6. Verify that v1 calls fail with `EVersionDisabled` and that validators route
-   ordinary work through v2, then execute the unpause.
+   ordinary work through v2.
+7. Only then create, vote, and execute the unpause proposal. The bridge stays
+   paused through the unpause vote; we accept that for this one migration.
 
 The upgrade and disable are necessarily two transactions. They must not be
 submitted concurrently because shared-object ordering is not guaranteed;

--- a/design/docs/move-upgrades.mdx
+++ b/design/docs/move-upgrades.mdx
@@ -120,27 +120,41 @@ an exclusive publication causes old binaries to stop writing.
 The deployed testnet v1 package only has the legacy `upgrade` proposal. That
 proposal always leaves previous versions enabled, so it cannot make the first
 v1-to-v2 transition atomic. Testnet carries no real funds, and we accept a small
-race window for this one migration.
+race window for this one migration. Run the migration under the emergency
+pause, which closes the withdrawal-replay surface described below; the
+withdrawal queue does not need to drain first.
 
-Minimize that window as follows:
-
-1. Avoid active withdrawals during the rollout window.
-2. Create and fully vote both the v2 upgrade proposal and a
-   `DisableVersion(1)` proposal while v1 is active. Proposal creation permits
-   targeting the current version; only execution rejects disabling it.
+1. Create and fully vote the pause, v2 upgrade, `DisableVersion(1)`, and
+   unpause proposals while v1 is active. Proposal creation permits targeting
+   the current version; only execution rejects disabling it.
+2. Execute the pause. Governance entries are not pause-gated, so the remaining
+   steps execute while paused.
 3. Execute, publish, and finalize v2 through the legacy v1 upgrade path.
 4. Wait for that transaction to succeed and obtain the newly published v2
    package ID.
 5. Immediately execute the already-approved disable-v1 proposal through the v2
    package.
 6. Verify that v1 calls fail with `EVersionDisabled` and that validators route
-   ordinary work through v2.
+   ordinary work through v2, then execute the unpause.
 
-These are necessarily two transactions. They must not be submitted
-concurrently because shared-object ordering is not guaranteed; disable-v1 must
-execute through v2 after publication. Emergency pause is not a complete
-substitute because the legacy v1 withdrawal cancellation entry does not honor
-the pause flag.
+The upgrade and disable are necessarily two transactions. They must not be
+submitted concurrently because shared-object ordering is not guaranteed;
+disable-v1 must execute through v2 after publication.
+
+The pause is what makes the window between them safe for withdrawals.
+Commitment and approval certificates bind no package version, so while both
+versions are enabled a live certificate can be replayed through v2's
+`commit_withdrawal_tx`. That commits the request in place, where v1's
+pause-exempt `cancel_withdrawal` (which checks only the `processed` bag) can
+destroy it: hBTC burned with no BTC released, and the referencing withdrawal
+transaction wedged forever. Every corrupting interleaving requires such a v2
+commit to land while v1 is still enabled. `commit_withdrawal_tx` and
+`approve_request` honor the pause in both packages, so holding the pause
+across the window means that state can never be created, and the pause-exempt
+v1 cancel has nothing corruptible to act on. In-flight withdrawals ride
+through the flip without draining: committed batches sign, confirm, and
+archive from their v1 locations, and approved or requested entries commit
+v2-style afterward.
 
 Before the first mainnet publish, remove the legacy `upgrade` module, rename
 `upgrade_v2` to `upgrade`, and squash testnet-only package-version and storage


### PR DESCRIPTION
Stacked on #1003 (Move base). Rust side of the deferred withdrawal archival — the leader-driven archival GC, the active-version routing that makes v2's in-place-commit semantics reachable, and the capacity bump (batch cap 298 → 447) it unlocks.

The shared version-framework plumbing — `SUPPORTED_PACKAGE_VERSIONS = [1, 2]`, the executor's generic active-version resolution (`active_call_package_id`), `fetch_initial_shared_version`, `HashiClient::latest_package_id` — now lives in **main** via the extracted base #1026, so this PR no longer carries it. What remains here is withdrawal-flow-specific and reads that already-in-place support set.

## Change — version routing (all keyed on the resolved active version, atomic with the upgrade checkpoint)

1. **Active-package resolvers.** `active_version_package()` resolves the active version against the already-`[1, 2]` support set and returns its published package id; `withdrawal_call_package()` wraps it with an original-id fallback pre-resolution — at active=1 it returns the original id, preserving today's behavior byte-for-byte. Every withdrawal-flow entry call (finalize, confirm, cancel, and the committee-signature args) routes through this one resolver, so a batch's whole lifecycle executes one consistent bytecode generation: v2's in-place commit leaves requests where v1's finalize/confirm wouldn't find them, and the v1 cancel bytecode's processed-bag gate misses v2 in-place-committed requests and would destroy a request a live txn references. All calls within a PTB use the same resolution (Sui links one version of a package per transaction; mixed targets fail with `INVALID_LINKAGE`). A resolution torn across the upgrade flip fails simulation and self-heals via the callers' retry machinery. The CLI cancel path resolves the same way through a governance-only reader.

2. **Capacity.** `max_withdrawal_requests(active)`: 447 under v2 (in-place commit = 2 runtime objects/request, confirm = 0/request), legacy `LEGACY_MAX_WITHDRAWAL_REQUESTS = 298` with v1 coefficients otherwise — used by BOTH leader sizing and validator shape checks, so mixed generations always agree. Compile-asserted: `922 budget − 12 fixed − 2·447 = 16` reserved funding inputs (v1: `− 3·298 = 16`).

3. **Archival GC driver.** The GC spawn gates on active ≥ 2; victims (`ArchiveVictim`) carry request ids and `execute_archive_confirmed_withdrawals` plans per victim — atomic packing via `archive_confirmed_withdrawals` for txns that fit one GC transaction, `archive_withdrawal_requests` chunks followed by `finish_archive_withdrawal_txns` for oversized ones. The entries exist only in the v2 package; both the gate and the call target resolve through the active version.

## Change — both-worlds (unconditional)

Status-derived `Effect::WithdrawalTxnConfirmed` + retire dedup (duration histograms exact in both worlds), confirmed-txn exclusion in leader selection, a still-approvable retry probe, a metrics `confirmed` class (the archival-backlog alert signal), and status-accurate CLI (a request stays in the mirrored map for its whole live lifecycle, so status renders "Signing (X/N)" / confirmed rather than a flat "Committed").

## Tests

The v2 path genuinely executes end-to-end — an earlier revision's e2e greens were vacuous (with the binary effectively pinned to v1 the GC never spawned and v1 archived inline; the CI drain-mode failure exposed it):
- `test_drain_mode_max_request_batch`: 447-request batch through v2 commit at the modeled 922-object budget, signed, confirmed, chunk-archived — 102s
- `test_bitcoin_withdrawal_e2e_flow` (98s) and `test_batch_withdrawal` (99s) with the archival GC live
- `test_withdrawal_committed_under_v1_completes_after_upgrade` (70s): cross-version state through the real routed upgrade flip
- 633/633 unit tests (both-version cost models, version-aware shape checks, archival planning)

## Follow-up

sui-replay measurement of the real commit/archive coefficients before the upgrade ships — the drain e2e empirically pins commit ≤ 1000 objects at N=447, but the model margin still needs to be measured precisely.