### PR TITLE
rust: version-framework enablement + upgrade-safe transaction plumbing

### DIFF
--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -104,6 +104,31 @@ pub struct HashiClient {
     executor: Option<SuiTxExecutor>,
 }
 
+/// Fetch a shared object's initial shared version from its owner field.
+///
+/// Needed to build fully-resolved shared inputs: pre-resolving a shared input's
+/// initial version + mutability keeps sui >= 1.76 fullnodes from having to
+/// inspect an upgrade-introduced module's signature at simulate time (that
+/// inspection fails with `INVALID_LINKAGE`).
+pub async fn fetch_initial_shared_version(
+    client: &mut sui_rpc::Client,
+    object_id: Address,
+) -> Result<u64> {
+    use sui_rpc::field::FieldMask;
+    use sui_rpc::field::FieldMaskUtil;
+    use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
+
+    let response = client
+        .ledger_client()
+        .get_object(
+            GetObjectRequest::new(&object_id).with_read_mask(FieldMask::from_paths(["owner"])),
+        )
+        .await
+        .with_context(|| format!("fetching owner of shared object {object_id}"))?
+        .into_inner();
+    Ok(response.object().owner().version())
+}
+
 impl HashiClient {
     /// Client for governance and config commands. Skips the Bitcoin
     /// collections, which none of them read.
@@ -216,6 +241,15 @@ impl HashiClient {
             .state()
             .package_versions()
             .latest_version()
+    }
+
+    /// The latest published package id. Transactions whose type args may name an
+    /// upgrade-introduced type must be called through the latest package (v1-era
+    /// type args unify fine under a newer call, but not vice versa).
+    pub fn latest_package_id(&self) -> anyhow::Result<Address> {
+        self.onchain_state
+            .package_id()
+            .context("no package versions known on-chain")
     }
 
     /// Fetch current epoch from on-chain state

--- a/crates/hashi/src/constants.rs
+++ b/crates/hashi/src/constants.rs
@@ -36,7 +36,13 @@ pub const PRESIG_REFILL_DIVISOR: usize = 2;
 /// Add the next version here in the same change that teaches this binary to
 /// run it (e.g. a package upgrade); never list a version whose semantics this
 /// build does not implement.
-pub const SUPPORTED_PACKAGE_VERSIONS: &[u64] = &[1];
+///
+/// Enabling v2 lets this binary drive the published v2 package: version-
+/// dependent calls (e.g. `start_reconfig`) execute the active version's code
+/// through `SuiTxExecutor::active_call_package_id` instead of the original
+/// publish id, and shared inputs are pre-resolved so upgrade-introduced
+/// modules never trip the fullnode's simulate-time linkage check.
+pub const SUPPORTED_PACKAGE_VERSIONS: &[u64] = &[1, 2];
 
 pub fn is_production_sui_chain(chain_id: &str) -> bool {
     chain_id == SUI_MAINNET_CHAIN_ID || chain_id == SUI_TESTNET_CHAIN_ID

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -1066,6 +1066,22 @@ impl SuiTxExecutor {
         Ok(request_ids)
     }
 
+    /// The package id whose code should execute for version-SEMANTIC calls
+    /// (committee formation, and anything else whose behavior differs across
+    /// package versions). Resolves the highest enabled on-chain version this
+    /// binary supports through the version framework; falls back to the
+    /// original package when no state is attached (CLI-built executors) or
+    /// nothing is resolved yet.
+    fn active_call_package_id(&self) -> Address {
+        self.onchain_state
+            .as_ref()
+            .and_then(|onchain_state| {
+                let version = onchain_state.active_package_version()?;
+                onchain_state.state().package_versions().get(version)
+            })
+            .unwrap_or(self.hashi_ids.package_id)
+    }
+
     #[tracing::instrument(level = "info", skip_all)]
     pub async fn execute_start_reconfig(&mut self) -> anyhow::Result<()> {
         let mut builder = TransactionBuilder::new();
@@ -1079,9 +1095,13 @@ impl SuiTxExecutor {
                 .as_shared()
                 .with_mutable(false),
         );
+        // Committee formation runs inside start_reconfig, and its semantics
+        // are version-dependent (v2 skips governance-ignored members) — so
+        // this call must execute the ACTIVE version's code, not the original
+        // package's.
         builder.move_call(
             Function::new(
-                self.hashi_ids.package_id,
+                self.active_call_package_id(),
                 Identifier::from_static("reconfig"),
                 Identifier::from_static("start_reconfig"),
             ),


### PR DESCRIPTION
The version-framework enablement and shared linkage helpers that both the governance stack (#991 → #993) and the TOB-pruning stack (#1001 → #1002) build on, so each can land as an independent 2-stack on top of this base instead of a single 4-deep chain.

## What this does (3 files, +62)

- **`SUPPORTED_PACKAGE_VERSIONS` gains `2`** (`constants.rs`) — teaches the binary it may drive the already-published v2 package (`versioning.move` has pinned `PACKAGE_VERSION = 2` on `main` for a while; this is the binary-side counterpart).
- **`SuiTxExecutor::active_call_package_id` + `start_reconfig` routed through the active version's package** (`sui_tx_executor.rs`) — committee-formation semantics are version-dependent, so the reconfig call must not be pinned to the original publish id.
- **`fetch_initial_shared_version` and `HashiClient::latest_package_id`** (`client.rs`) — the shared helpers the downstream stacks consume (the proposal/GC linkage fixes in #991, the TOB GC driver in #1002). Defined here so neither stack redefines them.

## Why it's safe to land on its own

- **Behavioral no-op until v2 is enabled on-chain.** Active version is `max(enabled ∩ published ∩ SUPPORTED)`, so while governance keeps `enabled = {1}` the active version stays `1` and routing is unchanged.
- No Move changes, no governance logic, no proposal-tx signature changes. `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check`, and `cargo doc -D warnings` all clean.

## Deliberately NOT here (stays in the feature PRs)

- The fully-resolved-shared-input fixes on the **proposal** PTBs and the version-dependent execute/create/`delete_expired` → latest routing key off the v2 `IgnoreMember` type — they live in **#991** (which also carries the matching e2e caller updates). Those only matter once a v2-introduced module is being called, so they belong with the feature, not the base.

## Follow-ups (rebase onto this base)

- Governance: **#991** (committee-voted ignore/un-ignore) → **#993** (voluntary resignation).
- TOB pruning: **#1001** (Move GC entries) → **#1002** (leader GC driver), which consume `active_call_package_id`, `fetch_initial_shared_version`, `latest_package_id`, and the `[1, 2]` support set.
