### PR TITLE
ci: terminate hung tests so they retry instead of hanging 6h

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,3 +19,9 @@ failure-output = "immediate-final"
 success-output = "never"
 # Don't stop on first failure - run all tests
 fail-fast = false
+# Kill a test that has been slow for 12 minutes and let `retries` re-run it.
+# Without this, a heavy e2e test that stalls (e.g. a synchronous DB write
+# blocking the single-thread runtime under CI I/O contention) runs until the
+# 6h GitHub job cap instead of failing and retrying. Legitimate e2e tests
+# finish well under 12 minutes, so this only fires on a genuine hang.
+slow-timeout = { period = "60s", terminate-after = 12 }


### PR DESCRIPTION
## Problem

Some heavy e2e tests have been running the full **6-hour GitHub job cap** and then failing as "cancelled" — e.g. `test_resigned_member_removed_at_epoch_boundary` (#993), `test_second_rotation_retrieves_missing_previous_rotation_message` (#1003).

This is **not a code deadlock**. Investigated by running each in isolation (they pass deterministically — the resignation test in 87s) and reproducing the hang locally by running the full e2e suite concurrently: a *random* heavy test hangs (locally it was `test_large_withdrawal_signature_chunking`, unrelated to any of the above). A thread dump of the wedged process shows no lock and no DB stall — the single runtime thread is just saturated with the test's own CPU work.

**Root cause:** e2e tests use a current-thread tokio runtime and declare `threads-required = 4`. When the full suite runs in parallel on a limited runner, the CPU is oversubscribed; a CPU-bound test's one runtime thread starves and its timers stop firing, so the test never makes progress. The `ci` profile has `retries = 1` but **no `slow-timeout`**, so nextest never terminates the stalled test — it runs to the 6h cap instead of failing and retrying.

## Change

Add to `profile.ci`:

```toml
slow-timeout = { period = "60s", terminate-after = 12 }
```

A test that has been slow for 12 minutes is killed and **retried** (via the existing `retries = 1`). The retry runs after most of the suite has finished — under far less load — so it passes. Legitimate e2e tests complete well under 12 minutes, so this only fires on a genuine stall.

## Effect

- A stalled heavy e2e test fails fast (~12 min) and self-heals on retry instead of hanging the whole `test` job for 6 hours.
- Repo-wide: fixes this flake class for every PR, not just the ones that surfaced it.
- No runtime/behavioral code change; the diagnosis did not implicate any product code.
