### PR TITLE
move: add atomic package upgrade policy

### DIFF
--- a/crates/e2e-tests/src/upgrade_flow.rs
+++ b/crates/e2e-tests/src/upgrade_flow.rs
@@ -14,6 +14,7 @@ use hashi::cli::client::build_vote_transaction;
 use hashi::cli::upgrade::build_execute_proposal_transaction;
 use hashi::cli::upgrade::build_upgrade_execution_transaction;
 use hashi::cli::upgrade::build_upgrade_package;
+use hashi::cli::upgrade::build_upgrade_v2_execution_transaction;
 use hashi::cli::upgrade::extract_new_package_id_from_response;
 use hashi::cli::upgrade::extract_proposal_id_from_response;
 use hashi::config::HashiIds;
@@ -290,10 +291,36 @@ fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
-/// Run the full upgrade lifecycle: prepare → build → propose → vote → execute+publish+finalize.
+#[derive(Clone, Copy)]
+enum UpgradeProposal {
+    Legacy,
+    V2 { exclusive: bool },
+}
+
+/// Run the full legacy upgrade lifecycle.
 ///
+/// This is the only path available for the deployed v1 → v2 transition.
 /// Returns the new package ID on success.
 pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address> {
+    execute_full_upgrade_with_proposal(networks, UpgradeProposal::Legacy).await
+}
+
+/// Run the full `upgrade_v2` lifecycle with an explicit version policy.
+///
+/// The chain must already have package v2, which introduced the proposal
+/// payload type. Returns the new package ID on success.
+pub async fn execute_full_upgrade_v2(
+    networks: &mut TestNetworks,
+    exclusive: bool,
+) -> Result<Address> {
+    execute_full_upgrade_with_proposal(networks, UpgradeProposal::V2 { exclusive }).await
+}
+
+/// Run prepare → build → propose → vote → execute+publish+finalize.
+async fn execute_full_upgrade_with_proposal(
+    networks: &mut TestNetworks,
+    proposal: UpgradeProposal,
+) -> Result<Address> {
     // Running nodes only: a pending member (started mid-test by the
     // key-rotation tests) has no Hashi instance to read state from or vote
     // with — and is not a registered committee member yet anyway.
@@ -341,31 +368,54 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
         build_upgrade_package_cached(&upgrade_path, client_config, target_version)?;
     tracing::info!("upgrade package built, digest: {digest:?}");
 
-    // 3. Propose the upgrade
+    // 3. Propose the upgrade. Calls execute through the latest package, while
+    // the proposal type argument below retains the package address where that
+    // payload type was first defined.
     tracing::info!("proposing upgrade...");
     let creator = executors[0].sender();
-    let create_tx = build_create_proposal_transaction(
-        hashi_ids,
-        hashi_ids.package_id,
-        creator,
-        CreateProposalParams::Upgrade {
-            digest: digest.clone(),
-            metadata: vec![("reason".to_string(), "upgrade test".to_string())],
-        },
-    );
+    let (proposal_params, proposal_type_package, proposal_module) = match proposal {
+        UpgradeProposal::Legacy => (
+            CreateProposalParams::Upgrade {
+                digest: digest.clone(),
+                metadata: vec![("reason".to_string(), "upgrade test".to_string())],
+            },
+            hashi_ids.package_id,
+            "upgrade",
+        ),
+        UpgradeProposal::V2 { exclusive } => {
+            let type_package = nodes[0]
+                .hashi()
+                .onchain_state()
+                .state()
+                .package_versions()
+                .get(2)
+                .ok_or_else(|| anyhow::anyhow!("upgrade_v2 requires published package v2"))?;
+            (
+                CreateProposalParams::UpgradeV2 {
+                    digest: digest.clone(),
+                    exclusive,
+                    metadata: vec![("reason".to_string(), "upgrade_v2 test".to_string())],
+                },
+                type_package,
+                "upgrade_v2",
+            )
+        }
+    };
+    let create_tx =
+        build_create_proposal_transaction(hashi_ids, current_package_id, creator, proposal_params);
     let response = executors[0].execute(create_tx).await?;
     anyhow::ensure!(
         response.transaction().effects().status().success(),
-        "create Upgrade proposal failed"
+        "create {proposal_module} proposal failed"
     );
 
     let proposal_id = extract_proposal_id_from_response(&response)?;
     tracing::info!("upgrade proposal {proposal_id} created");
 
-    // 4. All other nodes vote (upgrade requires 100% quorum)
+    // 4. All other nodes vote.
     let upgrade_type_tag = TypeTag::Struct(Box::new(StructTag::new(
-        hashi_ids.package_id,
-        Identifier::from_static("upgrade"),
+        proposal_type_package,
+        Identifier::new(proposal_module)?,
         Identifier::from_static("Upgrade"),
         vec![],
     )));
@@ -374,7 +424,7 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
         let voter = executor.sender();
         let vote_tx = build_vote_transaction(
             hashi_ids,
-            hashi_ids.package_id,
+            current_package_id,
             voter,
             proposal_id,
             upgrade_type_tag.clone(),
@@ -382,15 +432,27 @@ pub async fn execute_full_upgrade(networks: &mut TestNetworks) -> Result<Address
         let vote_resp = executor.execute(vote_tx).await?;
         anyhow::ensure!(
             vote_resp.transaction().effects().status().success(),
-            "vote on Upgrade proposal failed"
+            "vote on {proposal_module} proposal failed"
         );
     }
     tracing::info!("all nodes voted on upgrade proposal");
 
     // 5. Execute upgrade + publish + finalize in one PTB
     tracing::info!("executing upgrade (execute + publish + finalize in one PTB)...");
-    let upgrade_tx =
-        build_upgrade_execution_transaction(hashi_ids, current_package_id, proposal_id, compiled);
+    let upgrade_tx = match proposal {
+        UpgradeProposal::Legacy => build_upgrade_execution_transaction(
+            hashi_ids,
+            current_package_id,
+            proposal_id,
+            compiled,
+        ),
+        UpgradeProposal::V2 { .. } => build_upgrade_v2_execution_transaction(
+            hashi_ids,
+            current_package_id,
+            proposal_id,
+            compiled,
+        ),
+    };
     let upgrade_resp = executors[0].execute(upgrade_tx).await?;
     anyhow::ensure!(
         upgrade_resp.transaction().effects().status().success(),

--- a/crates/e2e-tests/tests/upgrade_tests.rs
+++ b/crates/e2e-tests/tests/upgrade_tests.rs
@@ -16,6 +16,7 @@ use e2e_tests::test_helpers::get_hbtc_balance;
 use e2e_tests::test_helpers::init_test_logging;
 use e2e_tests::upgrade_flow;
 use hashi::sui_tx_executor::SuiTxExecutor;
+use std::collections::BTreeSet;
 use std::time::Duration;
 use sui_sdk_types::Address;
 use sui_sdk_types::Identifier;
@@ -23,6 +24,67 @@ use sui_transaction_builder::Function;
 use sui_transaction_builder::ObjectInput;
 use sui_transaction_builder::TransactionBuilder;
 use tracing::info;
+
+/// Upgrade v2 binds the committee-approved exclusivity policy to publication.
+///
+/// The default builder first performs the unavoidable legacy v1 → v2 upgrade.
+/// This test then publishes v3 through `upgrade_v2` with `exclusive = true`
+/// and verifies that the same transaction leaves only v3 enabled. Because the
+/// test binary supports v1 and v2, it must halt autonomous writes afterward.
+#[tokio::test]
+async fn test_upgrade_v2_exclusive_via_proposal() -> Result<()> {
+    init_test_logging();
+    let mut networks = TestNetworksBuilder::new().with_nodes(4).build().await?;
+
+    networks.hashi_network.nodes()[0]
+        .wait_for_mpc_key(Duration::from_secs(120))
+        .await?;
+
+    let (current_version, current_package_id) = {
+        let state = networks.hashi_network.nodes()[0]
+            .hashi()
+            .onchain_state()
+            .state();
+        let versions = state.package_versions();
+        (
+            versions
+                .latest_version()
+                .expect("default builder publishes package v2"),
+            versions
+                .latest_id()
+                .expect("default builder publishes package v2"),
+        )
+    };
+    assert_eq!(current_version, 2, "upgrade_v2 is introduced in package v2");
+
+    let new_package_id = upgrade_flow::execute_full_upgrade_v2(&mut networks, true).await?;
+    assert_ne!(new_package_id, current_package_id);
+    upgrade_flow::wait_for_package_convergence(&networks, new_package_id, Duration::from_secs(30))
+        .await?;
+
+    let target_version = current_version + 1;
+    for (i, node) in networks.hashi_network.nodes().iter().enumerate() {
+        let onchain = node.hashi().onchain_state();
+        let state = onchain.state();
+        assert_eq!(
+            state.package_versions().latest_version(),
+            Some(target_version)
+        );
+        assert_eq!(state.package_versions().latest_id(), Some(new_package_id));
+        assert_eq!(
+            state.hashi().config.enabled_versions,
+            BTreeSet::from([target_version]),
+            "node {i}: exclusive publication must atomically retire every older version"
+        );
+        assert!(
+            onchain.version_support().must_halt(),
+            "node {i}: a v1+v2 binary must halt after exclusive v3 publication"
+        );
+    }
+
+    info!("=== UPGRADE V2 EXCLUSIVE TEST PASSED ===");
+    Ok(())
+}
 
 /// Explicit upgrade via governance proposal, exercising real cascading effects.
 ///

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -884,6 +884,13 @@ pub struct Upgrade {
     pub digest: Vec<u8>,
 }
 
+/// Rust version of the Move hashi::upgrade_v2::Upgrade type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct UpgradeV2 {
+    pub digest: Vec<u8>,
+    pub exclusive: bool,
+}
+
 /// Rust version of the Move hashi::emergency_pause::EmergencyPause type.
 #[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct EmergencyPause {
@@ -1079,6 +1086,7 @@ impl HashiEvent {
             ReconfigStarted::MODULE_NAME => ReconfigStarted::from_bcs(bcs.value())?.into(),
             ReconfigEnded::MODULE_NAME => ReconfigEnded::from_bcs(bcs.value())?.into(),
             PackageUpgraded::MODULE_NAME => PackageUpgraded::from_bcs(bcs.value())?.into(),
+            ("upgrade_v2", "PackageUpgraded") => PackageUpgraded::from_bcs(bcs.value())?.into(),
             _ => {
                 return Ok(None);
             }

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -36,6 +36,11 @@ pub enum CreateProposalParams {
         digest: Vec<u8>,
         metadata: Vec<(String, String)>,
     },
+    UpgradeV2 {
+        digest: Vec<u8>,
+        exclusive: bool,
+        metadata: Vec<(String, String)>,
+    },
     UpdateConfig {
         key: String,
         value: hashi_types::move_types::ConfigValue,
@@ -357,6 +362,11 @@ impl HashiClient {
                             bcs::from_bytes(value_bytes).context("deserialize Upgrade")?;
                         (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
                     }
+                    ProposalType::UpgradeV2 => {
+                        let p: move_types::Proposal<move_types::UpgradeV2> =
+                            bcs::from_bytes(value_bytes).context("deserialize UpgradeV2")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
                     ProposalType::EmergencyPause => {
                         let p: move_types::Proposal<move_types::EmergencyPause> =
                             bcs::from_bytes(value_bytes).context("deserialize EmergencyPause")?;
@@ -542,7 +552,7 @@ impl HashiClient {
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::AbortReconfig => "abort_reconfig",
             ProposalType::UpdateGuardian => "update_guardian",
-            ProposalType::Upgrade => {
+            ProposalType::Upgrade | ProposalType::UpgradeV2 => {
                 anyhow::bail!(
                     "Upgrade proposals require the full upgrade flow (execute + publish + finalize)"
                 );
@@ -575,6 +585,29 @@ impl HashiClient {
         );
 
         Ok(builder)
+    }
+
+    /// Resolve the defining package ID for a proposal payload and construct
+    /// the exact Move type argument used by vote/remove-vote.
+    pub fn proposal_type_arg(
+        &self,
+        proposal_type: &crate::onchain::types::ProposalType,
+    ) -> anyhow::Result<TypeTag> {
+        let package_version = proposal_type.package_version().ok_or_else(|| {
+            anyhow::anyhow!("unknown proposal type has no defining package version")
+        })?;
+        let package_id = self
+            .onchain_state
+            .state()
+            .package_versions()
+            .get(package_version)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "package version {package_version} defining proposal type {} is not published",
+                    proposal_type.as_str()
+                )
+            })?;
+        get_proposal_type_arg(package_id, proposal_type)
     }
 }
 
@@ -615,6 +648,30 @@ pub fn build_create_proposal_transaction(
                     hashi_arg,
                     validator_address_arg,
                     digest_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
+            );
+        }
+        CreateProposalParams::UpgradeV2 {
+            digest,
+            exclusive,
+            metadata,
+        } => {
+            let digest_arg = builder.pure(&digest);
+            let exclusive_arg = builder.pure(&exclusive);
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    call_package,
+                    Identifier::from_static("upgrade_v2"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    digest_arg,
+                    exclusive_arg,
                     metadata_arg,
                     clock_arg,
                 ],
@@ -949,6 +1006,7 @@ pub fn get_proposal_type_arg(
 
     let (module, name) = match proposal_type {
         ProposalType::Upgrade => ("upgrade", "Upgrade"),
+        ProposalType::UpgradeV2 => ("upgrade_v2", "Upgrade"),
         ProposalType::UpdateConfig => ("update_config", "UpdateConfig"),
         ProposalType::EnableVersion => ("enable_version", "EnableVersion"),
         ProposalType::DisableVersion => ("disable_version", "DisableVersion"),

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -386,14 +386,39 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
 /// and verifies that its `PACKAGE_VERSION` constant is exactly +1 of the
 /// currently published version (pre-flight check) before submitting the
 /// proposal. The `--digest` path skips that check and is retained only for
-/// callers with a pre-built package.
+/// callers with a pre-built package; combined with an exclusive upgrade it is
+/// refused unless `allow_unverified_exclusive` acknowledges the skipped check.
 pub struct CreateUpgradeProposalArgs<'a> {
     pub digest: Option<&'a str>,
     pub package_path: Option<&'a std::path::Path>,
     pub sui_binary: &'a std::path::Path,
     pub sui_client_config: Option<&'a std::path::Path>,
     pub upgrade_v2_exclusive: Option<bool>,
+    pub allow_unverified_exclusive: bool,
     pub metadata: Vec<(String, String)>,
+}
+
+/// Refuse the brick-capable flag combination: an exclusive upgrade proposed
+/// from a pre-built `--digest`, whose `PACKAGE_VERSION` constant was therefore
+/// never checked against the chain, unless the operator explicitly
+/// acknowledged the bypass.
+fn check_exclusive_digest_acknowledged(
+    digest: Option<&str>,
+    upgrade_v2_exclusive: Option<bool>,
+    allow_unverified_exclusive: bool,
+) -> Result<()> {
+    if digest.is_some() && upgrade_v2_exclusive == Some(true) && !allow_unverified_exclusive {
+        anyhow::bail!(
+            "--digest skips the PACKAGE_VERSION pre-flight, and an exclusive upgrade \
+             publishing a package whose PACKAGE_VERSION does not match the new \
+             on-chain version permanently bricks the contract with no on-chain \
+             recovery. Use --package-path so the constant is verified, or pass \
+             --allow-unverified-exclusive after manually verifying that the \
+             pre-built package declares PACKAGE_VERSION = current on-chain \
+             version + 1."
+        );
+    }
+    Ok(())
 }
 
 pub async fn create_upgrade_proposal(
@@ -407,8 +432,10 @@ pub async fn create_upgrade_proposal(
         sui_binary,
         sui_client_config,
         upgrade_v2_exclusive,
+        allow_unverified_exclusive,
         metadata,
     } = args;
+    check_exclusive_digest_acknowledged(digest, upgrade_v2_exclusive, allow_unverified_exclusive)?;
     let mut client = HashiClient::new(config).await?;
 
     let digest_bytes = match (digest, package_path) {
@@ -858,4 +885,33 @@ async fn prompt_continue(action: &str, tx_opts: &TxOptions) -> Result<()> {
     let mut input = String::new();
     reader.read_line(&mut input).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusive_digest_is_refused_without_acknowledgement() {
+        let err = check_exclusive_digest_acknowledged(Some("ab"), Some(true), false).unwrap_err();
+        // Pin both remedies the message offers: the verified path and the
+        // explicit acknowledgement.
+        assert!(err.to_string().contains("--package-path"));
+        assert!(err.to_string().contains("--allow-unverified-exclusive"));
+    }
+
+    #[test]
+    fn exclusive_digest_is_allowed_with_acknowledgement() {
+        check_exclusive_digest_acknowledged(Some("ab"), Some(true), true).unwrap();
+    }
+
+    #[test]
+    fn other_flag_combinations_are_unaffected() {
+        // Legacy upgrade proposals carry no exclusivity policy.
+        check_exclusive_digest_acknowledged(Some("ab"), None, false).unwrap();
+        // A non-exclusive upgrade_v2 digest stays recoverable on-chain.
+        check_exclusive_digest_acknowledged(Some("ab"), Some(false), false).unwrap();
+        // --package-path runs the pre-flight, so nothing needs acknowledging.
+        check_exclusive_digest_acknowledged(None, Some(true), false).unwrap();
+    }
 }

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -14,7 +14,6 @@ use tabled::Tabled;
 use crate::cli::TxOptions;
 use crate::cli::client::CreateProposalParams;
 use crate::cli::client::HashiClient;
-use crate::cli::client::get_proposal_type_arg;
 use crate::cli::config::CliConfig;
 use crate::cli::print_detail;
 use crate::cli::print_info;
@@ -216,7 +215,7 @@ pub async fn vote(
     print_info("Building vote transaction...");
 
     // Infer the type tag from the on-chain proposal type
-    let type_arg = get_proposal_type_arg(client.hashi_ids().package_id, &proposal.proposal_type)?;
+    let type_arg = client.proposal_type_arg(&proposal.proposal_type)?;
     let tx = client.build_vote_transaction(proposal_addr, type_arg)?;
 
     print_info(&format!(
@@ -239,7 +238,10 @@ pub async fn vote(
     // Upgrade proposals require the dedicated upgrade flow — the generic
     // `<module>::execute` path can't construct an UpgradeTicket.
     use crate::onchain::types::ProposalType;
-    if matches!(proposal.proposal_type, ProposalType::Upgrade) {
+    if matches!(
+        proposal.proposal_type,
+        ProposalType::Upgrade | ProposalType::UpgradeV2
+    ) {
         print_warning(
             "--execute is not supported for Upgrade proposals; run the \
              dedicated upgrade flow once quorum is reached.",
@@ -320,7 +322,7 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
     print_info("Building remove_vote transaction...");
 
     // Infer the type tag from the on-chain proposal type
-    let type_arg = get_proposal_type_arg(client.hashi_ids().package_id, &proposal.proposal_type)?;
+    let type_arg = client.proposal_type_arg(&proposal.proposal_type)?;
     let tx = client.build_remove_vote_transaction(proposal_addr, type_arg)?;
 
     print_info(&format!(
@@ -349,7 +351,10 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
     let proposal_type_str = display::format_proposal_type(proposal_type);
 
     use crate::onchain::types::ProposalType;
-    if matches!(proposal_type, ProposalType::Upgrade) {
+    if matches!(
+        proposal_type,
+        ProposalType::Upgrade | ProposalType::UpgradeV2
+    ) {
         anyhow::bail!(
             "Upgrade proposals cannot be executed via the CLI. \
              Use the full upgrade flow (execute + publish + finalize) instead."
@@ -382,15 +387,28 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
 /// currently published version (pre-flight check) before submitting the
 /// proposal. The `--digest` path skips that check and is retained only for
 /// callers with a pre-built package.
+pub struct CreateUpgradeProposalArgs<'a> {
+    pub digest: Option<&'a str>,
+    pub package_path: Option<&'a std::path::Path>,
+    pub sui_binary: &'a std::path::Path,
+    pub sui_client_config: Option<&'a std::path::Path>,
+    pub upgrade_v2_exclusive: Option<bool>,
+    pub metadata: Vec<(String, String)>,
+}
+
 pub async fn create_upgrade_proposal(
     config: &CliConfig,
-    digest: Option<&str>,
-    package_path: Option<&std::path::Path>,
-    sui_binary: &std::path::Path,
-    sui_client_config: Option<&std::path::Path>,
-    metadata: Vec<(String, String)>,
+    args: CreateUpgradeProposalArgs<'_>,
     tx_opts: &TxOptions,
 ) -> Result<()> {
+    let CreateUpgradeProposalArgs {
+        digest,
+        package_path,
+        sui_binary,
+        sui_client_config,
+        upgrade_v2_exclusive,
+        metadata,
+    } = args;
     let mut client = HashiClient::new(config).await?;
 
     let digest_bytes = match (digest, package_path) {
@@ -426,18 +444,43 @@ pub async fn create_upgrade_proposal(
         (Some(_), Some(_)) => unreachable!("clap enforces mutual exclusion"),
     };
 
-    print_detail(&format!("\n{}", "Creating Upgrade Proposal:".bold()));
+    let proposal_name = if upgrade_v2_exclusive.is_some() {
+        "UpgradeV2"
+    } else {
+        "Upgrade"
+    };
+    print_detail(&format!(
+        "\n{}",
+        format!("Creating {proposal_name} Proposal:").bold()
+    ));
     print_detail(&format!("  Digest: 0x{}", hex::encode(&digest_bytes)));
+    if let Some(exclusive) = upgrade_v2_exclusive {
+        print_detail(&format!("  Exclusive: {exclusive}"));
+    }
     print_metadata(&metadata);
 
     prompt_continue("create this upgrade proposal", tx_opts).await?;
 
-    let tx = client.build_create_proposal_transaction(CreateProposalParams::Upgrade {
-        digest: digest_bytes,
-        metadata,
-    })?;
+    let (tx, module) = if let Some(exclusive) = upgrade_v2_exclusive {
+        (
+            client.build_create_proposal_transaction(CreateProposalParams::UpgradeV2 {
+                digest: digest_bytes,
+                exclusive,
+                metadata,
+            })?,
+            "upgrade_v2",
+        )
+    } else {
+        (
+            client.build_create_proposal_transaction(CreateProposalParams::Upgrade {
+                digest: digest_bytes,
+                metadata,
+            })?,
+            "upgrade",
+        )
+    };
 
-    print_info("Transaction: upgrade::propose");
+    print_info(&format!("Transaction: {module}::propose"));
     let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
     print_created_proposal_id(response.as_ref());
     Ok(())

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -199,6 +199,40 @@ pub enum CreateProposalCommands {
         metadata: MetadataArgs,
     },
 
+    /// Propose a package upgrade with an explicit version-retirement policy
+    ///
+    /// This proposal type is available starting with package v2.
+    /// `--exclusive true` atomically disables every previous package version;
+    /// `--exclusive false` deliberately leaves them callable.
+    UpgradeV2 {
+        /// The digest of a pre-built package (hex encoded). Skips pre-flight
+        /// checks — prefer `--package-path`.
+        #[clap(long, conflicts_with = "package_path")]
+        digest: Option<String>,
+
+        /// Path to the upgrade package source. The CLI will run `sui move
+        /// build` and verify the `PACKAGE_VERSION` constant before submitting.
+        #[clap(long, value_name = "PATH")]
+        package_path: Option<std::path::PathBuf>,
+
+        /// Path to the `sui` CLI binary. Only used with `--package-path`.
+        #[clap(long, env = "SUI_BINARY", default_value = "sui")]
+        sui_binary: std::path::PathBuf,
+
+        /// Optional path to a sui `client.yaml` for dependency resolution.
+        /// Only used with `--package-path`.
+        #[clap(long)]
+        sui_client_config: Option<std::path::PathBuf>,
+
+        /// Whether to atomically disable every previous package version when
+        /// publishing. Required so every upgrade is explicitly classified.
+        #[clap(long, action = clap::ArgAction::Set, required = true)]
+        exclusive: bool,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
+
     /// Propose updating a configuration value
     ///
     /// Known config keys and their expected value types:
@@ -898,11 +932,36 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                 } => {
                     commands::proposal::create_upgrade_proposal(
                         &config,
-                        digest.as_deref(),
-                        package_path.as_deref(),
-                        &sui_binary,
-                        sui_client_config.as_deref(),
-                        parse_metadata(metadata.metadata),
+                        commands::proposal::CreateUpgradeProposalArgs {
+                            digest: digest.as_deref(),
+                            package_path: package_path.as_deref(),
+                            sui_binary: &sui_binary,
+                            sui_client_config: sui_client_config.as_deref(),
+                            upgrade_v2_exclusive: None,
+                            metadata: parse_metadata(metadata.metadata),
+                        },
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::UpgradeV2 {
+                    digest,
+                    package_path,
+                    sui_binary,
+                    sui_client_config,
+                    exclusive,
+                    metadata,
+                } => {
+                    commands::proposal::create_upgrade_proposal(
+                        &config,
+                        commands::proposal::CreateUpgradeProposalArgs {
+                            digest: digest.as_deref(),
+                            package_path: package_path.as_deref(),
+                            sui_binary: &sui_binary,
+                            sui_client_config: sui_client_config.as_deref(),
+                            upgrade_v2_exclusive: Some(exclusive),
+                            metadata: parse_metadata(metadata.metadata),
+                        },
                         &tx_opts,
                     )
                     .await?;

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -229,6 +229,14 @@ pub enum CreateProposalCommands {
         #[clap(long, action = clap::ArgAction::Set, required = true)]
         exclusive: bool,
 
+        /// Allow `--digest` together with `--exclusive true`. A pre-built
+        /// digest cannot be pre-flight checked, and an exclusive upgrade
+        /// publishing a package whose `PACKAGE_VERSION` constant does not
+        /// match the new on-chain version bricks the contract with no on-chain
+        /// recovery, so skipping the check must be an explicit choice.
+        #[clap(long, requires = "digest", conflicts_with = "package_path")]
+        allow_unverified_exclusive: bool,
+
         #[clap(flatten)]
         metadata: MetadataArgs,
     },
@@ -938,6 +946,7 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                             sui_binary: &sui_binary,
                             sui_client_config: sui_client_config.as_deref(),
                             upgrade_v2_exclusive: None,
+                            allow_unverified_exclusive: false,
                             metadata: parse_metadata(metadata.metadata),
                         },
                         &tx_opts,
@@ -950,6 +959,7 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                     sui_binary,
                     sui_client_config,
                     exclusive,
+                    allow_unverified_exclusive,
                     metadata,
                 } => {
                     commands::proposal::create_upgrade_proposal(
@@ -960,6 +970,7 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                             sui_binary: &sui_binary,
                             sui_client_config: sui_client_config.as_deref(),
                             upgrade_v2_exclusive: Some(exclusive),
+                            allow_unverified_exclusive,
                             metadata: parse_metadata(metadata.metadata),
                         },
                         &tx_opts,

--- a/crates/hashi/src/cli/types.rs
+++ b/crates/hashi/src/cli/types.rs
@@ -50,6 +50,7 @@ pub mod display {
     pub fn format_proposal_type(proposal_type: &ProposalType) -> String {
         match proposal_type {
             ProposalType::Upgrade => "Upgrade".to_string(),
+            ProposalType::UpgradeV2 => "UpgradeV2".to_string(),
             ProposalType::UpdateConfig => "UpdateConfig".to_string(),
             ProposalType::EnableVersion => "EnableVersion".to_string(),
             ProposalType::DisableVersion => "DisableVersion".to_string(),

--- a/crates/hashi/src/cli/upgrade.rs
+++ b/crates/hashi/src/cli/upgrade.rs
@@ -3,8 +3,8 @@
 
 //! Reusable helpers for the package-upgrade governance flow.
 //!
-//! Covers the non-orchestrating pieces that both the CLI (`hashi proposal
-//! create upgrade` + `proposal execute`) and the e2e test harness need:
+//! Covers the non-orchestrating pieces that both the release tooling and the
+//! e2e test harness need after an upgrade proposal has been created:
 //!
 //! - Building an upgrade package via `sui move build`
 //! - Constructing the `execute + publish + finalize` PTB
@@ -208,6 +208,70 @@ pub fn build_upgrade_execution_transaction(
             Identifier::from_static("finalize_upgrade"),
         ),
         vec![hashi_arg2, receipt],
+    );
+
+    builder
+}
+
+/// Build the PTB that executes an `upgrade_v2::Upgrade` proposal:
+/// `upgrade_v2::execute` → `builder.upgrade(...)` →
+/// `upgrade_v2::finalize_upgrade`.
+///
+/// `execute` returns two values. The first is the Sui `UpgradeTicket`; the
+/// second is a hot-potato authorization carrying the committee-approved
+/// `exclusive` setting. Passing both results through the same PTB prevents the
+/// publisher from changing the version policy after voting has completed.
+pub fn build_upgrade_v2_execution_transaction(
+    hashi_ids: HashiIds,
+    current_package_id: Address,
+    proposal_id: Address,
+    compiled: Publish,
+) -> TransactionBuilder {
+    let mut builder = TransactionBuilder::new();
+    let hashi_arg = builder.object(
+        ObjectInput::new(hashi_ids.hashi_object_id)
+            .as_shared()
+            .with_mutable(true),
+    );
+    let proposal_id_arg = builder.pure(&proposal_id);
+    let clock_arg = builder.object(
+        ObjectInput::new(SUI_CLOCK_OBJECT_ID)
+            .as_shared()
+            .with_mutable(false),
+    );
+
+    let execute_results = builder
+        .move_call(
+            Function::new(
+                current_package_id,
+                Identifier::from_static("upgrade_v2"),
+                Identifier::from_static("execute"),
+            ),
+            vec![hashi_arg, proposal_id_arg, clock_arg],
+        )
+        .to_nested(2);
+    let ticket = execute_results[0];
+    let authorization = execute_results[1];
+
+    let receipt = builder.upgrade(
+        compiled.modules,
+        compiled.dependencies,
+        current_package_id,
+        ticket,
+    );
+
+    let hashi_arg2 = builder.object(
+        ObjectInput::new(hashi_ids.hashi_object_id)
+            .as_shared()
+            .with_mutable(true),
+    );
+    builder.move_call(
+        Function::new(
+            current_package_id,
+            Identifier::from_static("upgrade_v2"),
+            Identifier::from_static("finalize_upgrade"),
+        ),
+        vec![hashi_arg2, receipt, authorization],
     );
 
     builder

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -259,6 +259,7 @@ impl LeaderService {
 
         let mut executor = SuiTxExecutor::from_hashi(inner.clone())?;
         let hashi_ids = inner.config.hashi_ids();
+        let package_versions = inner.onchain_state().state().package_versions().clone();
 
         let mut builder = TransactionBuilder::new();
 
@@ -279,46 +280,69 @@ impl LeaderService {
         for proposal in &expired_proposals {
             let proposal_id_arg = builder.pure(&proposal.id);
 
+            let Some(package_version) = proposal.proposal_type.package_version() else {
+                error!(
+                    "Cannot delete proposal {:?} with unknown type: {:?}",
+                    proposal.id, proposal.proposal_type
+                );
+                continue;
+            };
+            let Some(type_package_id) = package_versions.get(package_version) else {
+                error!(
+                    "Cannot delete proposal {:?}: defining package version {} for {} is not published",
+                    proposal.id,
+                    package_version,
+                    proposal.proposal_type.as_str()
+                );
+                continue;
+            };
+
             // Get the type argument for the proposal
             let type_arg = match &proposal.proposal_type {
                 ProposalType::UpdateConfig => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
+                    type_package_id,
                     Identifier::from_static("update_config"),
                     Identifier::from_static("UpdateConfig"),
                     vec![],
                 ))),
                 ProposalType::EnableVersion => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
+                    type_package_id,
                     Identifier::from_static("enable_version"),
                     Identifier::from_static("EnableVersion"),
                     vec![],
                 ))),
                 ProposalType::DisableVersion => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
+                    type_package_id,
                     Identifier::from_static("disable_version"),
                     Identifier::from_static("DisableVersion"),
                     vec![],
                 ))),
                 ProposalType::Upgrade => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
+                    type_package_id,
                     Identifier::from_static("upgrade"),
                     Identifier::from_static("Upgrade"),
                     vec![],
                 ))),
+                ProposalType::UpgradeV2 => TypeTag::Struct(Box::new(StructTag::new(
+                    type_package_id,
+                    Identifier::from_static("upgrade_v2"),
+                    Identifier::from_static("Upgrade"),
+                    vec![],
+                ))),
                 ProposalType::EmergencyPause => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
+                    type_package_id,
                     Identifier::from_static("emergency_pause"),
                     Identifier::from_static("EmergencyPause"),
                     vec![],
                 ))),
                 ProposalType::AbortReconfig => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
+                    type_package_id,
                     Identifier::from_static("abort_reconfig"),
                     Identifier::from_static("AbortReconfig"),
                     vec![],
                 ))),
                 ProposalType::UpdateGuardian => TypeTag::Struct(Box::new(StructTag::new(
-                    hashi_ids.package_id,
+                    type_package_id,
                     Identifier::from_static("update_guardian"),
                     Identifier::from_static("UpdateGuardian"),
                     vec![],

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -2128,6 +2128,7 @@ fn decode_proposal(type_tag: &TypeTag, contents: &[u8]) -> Option<types::Proposa
         types::ProposalType::EnableVersion => parse::<move_types::EnableVersion>(contents),
         types::ProposalType::DisableVersion => parse::<move_types::DisableVersion>(contents),
         types::ProposalType::Upgrade => parse::<move_types::Upgrade>(contents),
+        types::ProposalType::UpgradeV2 => parse::<move_types::UpgradeV2>(contents),
         types::ProposalType::EmergencyPause => parse::<move_types::EmergencyPause>(contents),
         types::ProposalType::AbortReconfig => parse::<move_types::AbortReconfig>(contents),
         types::ProposalType::UpdateGuardian => parse::<move_types::UpdateGuardian>(contents),
@@ -2163,10 +2164,85 @@ pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
         ("enable_version", "EnableVersion") => types::ProposalType::EnableVersion,
         ("disable_version", "DisableVersion") => types::ProposalType::DisableVersion,
         ("upgrade", "Upgrade") => types::ProposalType::Upgrade,
+        ("upgrade_v2", "Upgrade") => types::ProposalType::UpgradeV2,
         ("emergency_pause", "EmergencyPause") => types::ProposalType::EmergencyPause,
         ("abort_reconfig", "AbortReconfig") => types::ProposalType::AbortReconfig,
         ("update_guardian", "UpdateGuardian") => types::ProposalType::UpdateGuardian,
         _ => types::ProposalType::Unknown(format!("{}::{}", inner_tag.module(), inner_tag.name())),
+    }
+}
+
+#[cfg(test)]
+mod upgrade_v2_proposal_tests {
+    use super::*;
+
+    fn proposal_tag(module: &str) -> TypeTag {
+        let v1_package = Address::from_static("0x41");
+        let payload_package = if module == "upgrade_v2" {
+            Address::from_static("0x42")
+        } else {
+            v1_package
+        };
+        TypeTag::Struct(Box::new(StructTag::new(
+            v1_package,
+            Identifier::from_static("proposal"),
+            Identifier::from_static("Proposal"),
+            vec![TypeTag::Struct(Box::new(StructTag::new(
+                payload_package,
+                Identifier::new(module).unwrap(),
+                Identifier::from_static("Upgrade"),
+                vec![],
+            )))],
+        )))
+    }
+
+    #[test]
+    fn upgrade_v2_proposal_type_and_layout_decode() {
+        let tag = proposal_tag("upgrade_v2");
+        assert_eq!(parse_proposal_type(&tag), types::ProposalType::UpgradeV2);
+        assert_eq!(types::ProposalType::UpgradeV2.package_version(), Some(2));
+
+        let proposal = move_types::Proposal {
+            id: Address::from_static("0x11"),
+            creator: Address::from_static("0x22"),
+            votes: vec![Address::from_static("0x22")],
+            quorum_threshold_bps: 6667,
+            created_timestamp_ms: 123,
+            executed_timestamp_ms: None,
+            metadata: move_types::VecMap { contents: vec![] },
+            data: move_types::UpgradeV2 {
+                digest: vec![1, 2, 3],
+                exclusive: true,
+            },
+        };
+        let bytes = bcs::to_bytes(&proposal).unwrap();
+        let decoded = decode_proposal(&tag, &bytes).unwrap();
+
+        assert_eq!(decoded.id, proposal.id);
+        assert_eq!(decoded.timestamp_ms, 123);
+        assert_eq!(decoded.proposal_type, types::ProposalType::UpgradeV2);
+    }
+
+    #[test]
+    fn legacy_upgrade_proposal_still_decodes_with_its_original_layout() {
+        let tag = proposal_tag("upgrade");
+        let proposal = move_types::Proposal {
+            id: Address::from_static("0x33"),
+            creator: Address::from_static("0x44"),
+            votes: vec![],
+            quorum_threshold_bps: 6667,
+            created_timestamp_ms: 456,
+            executed_timestamp_ms: None,
+            metadata: move_types::VecMap { contents: vec![] },
+            data: move_types::Upgrade {
+                digest: vec![4, 5, 6],
+            },
+        };
+        let bytes = bcs::to_bytes(&proposal).unwrap();
+        let decoded = decode_proposal(&tag, &bytes).unwrap();
+
+        assert_eq!(decoded.id, proposal.id);
+        assert_eq!(decoded.proposal_type, types::ProposalType::Upgrade);
     }
 }
 

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -571,6 +571,7 @@ pub enum ProposalType {
     EnableVersion,
     DisableVersion,
     Upgrade,
+    UpgradeV2,
     EmergencyPause,
     AbortReconfig,
     UpdateGuardian,
@@ -578,12 +579,26 @@ pub enum ProposalType {
 }
 
 impl ProposalType {
+    /// Package version that introduced this proposal payload type.
+    ///
+    /// Move types retain their defining package address across later package
+    /// upgrades, so callers constructing a type argument must resolve this
+    /// version to its published package ID rather than always using v1.
+    pub fn package_version(&self) -> Option<u64> {
+        match self {
+            ProposalType::UpgradeV2 => Some(2),
+            ProposalType::Unknown(_) => None,
+            _ => Some(1),
+        }
+    }
+
     pub fn as_str(&self) -> &str {
         match self {
             ProposalType::UpdateConfig => "update_config",
             ProposalType::EnableVersion => "enable_version",
             ProposalType::DisableVersion => "disable_version",
             ProposalType::Upgrade => "upgrade",
+            ProposalType::UpgradeV2 => "upgrade_v2",
             ProposalType::EmergencyPause => "emergency_pause",
             ProposalType::AbortReconfig => "abort_reconfig",
             ProposalType::UpdateGuardian => "update_guardian",
@@ -597,6 +612,7 @@ impl ProposalType {
             "enable_version",
             "disable_version",
             "upgrade",
+            "upgrade_v2",
             "emergency_pause",
             "abort_reconfig",
             "update_guardian",

--- a/design/docs/governance-actions.mdx
+++ b/design/docs/governance-actions.mdx
@@ -48,7 +48,17 @@ The following is the current set of available proposal types.
 
 ## `Upgrade`
 
-Authorizes a package upgrade.
+Authorizes a package upgrade through the legacy testnet proposal type. It does
+not retire earlier package versions atomically.
+
+## `UpgradeV2`
+
+Authorizes a package upgrade and records whether it is exclusive. An exclusive
+upgrade atomically disables all previous versions as the new package is
+committed; a non-exclusive upgrade deliberately leaves them callable. Every
+upgrade must make this classification explicitly. See
+[Move Package Upgrades](move-upgrades.mdx) for the decision criteria and
+validator rollout contract.
 
 ## `EnableVersion`
 

--- a/design/docs/move-upgrades.mdx
+++ b/design/docs/move-upgrades.mdx
@@ -1,0 +1,143 @@
+---
+title: Move Package Upgrades
+description: >-
+  How Hashi classifies Move upgrades as exclusive or non-exclusive, rolls out
+  validator binaries, and retires old package versions safely.
+keywords:
+  - Move upgrade
+  - package version
+  - exclusive upgrade
+  - validator rollout
+  - governance
+goal:
+  description: >-
+    Reader can classify a Hashi Move upgrade, coordinate the validator binary
+    rollout, and execute the matching onchain governance process safely
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 500
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - When must a Hashi Move upgrade be exclusive?
+  - What happens to an old validator binary after an exclusive upgrade?
+  - How should validators coordinate a Move package upgrade?
+  - What is the testnet v1 to v2 upgrade plan?
+answer: >-
+  Every Hashi Move upgrade must explicitly be classified as exclusive or
+  non-exclusive. Exclusive upgrades atomically enable only the new package
+  version and are the safe default when versions share mutable state.
+  Non-exclusive upgrades are allowed only after review proves that old and new
+  entry functions can safely operate on the same state. Validators representing
+  at least two thirds of committee weight upgrade their binaries and verify
+  health before voting; reaching vote quorum does not publish the package.
+---
+
+Hashi package versions are separate callable Sui packages, but they operate on
+the same shared `Hashi` object. Publishing a new package therefore does not make
+an old package harmless. If an old entry function interprets shared state using
+an obsolete invariant, it can overwrite or destroy work performed by the new
+version.
+
+The withdrawal v2 work exposed a concrete example. A request committed by v2
+could remain in a location that v1 treated as cancellable. While v1 remained
+enabled, its cancellation path could destroy that committed request, stranding
+burned hBTC and locked UTXOs. This is why package publication and version
+retirement sometimes need to be one atomic governance action.
+
+## Required classification
+
+Every upgrade proposal must be labeled **exclusive** or **non-exclusive** in
+its design and rollout plan. Reviewers should treat a missing classification as
+an incomplete upgrade.
+
+Use an **exclusive upgrade** when any of the following is true:
+
+- The new version changes the meaning, location, or lifecycle of shared state.
+- An old entry function could undo, overwrite, replay, or misclassify a new
+  version's write.
+- Safety depends on all callers using the new validation or authorization rule.
+- Cross-version behavior has not been tested directly.
+
+Exclusive should be the default when there is doubt. It atomically replaces the
+enabled-version set with the newly committed version, so no transaction can
+observe the new version enabled while an older version is still callable.
+
+Use a **non-exclusive upgrade** only when retaining an older version is an
+intentional compatibility feature. The review must explain why old and new
+entry functions are safe against the same shared state and include direct
+cross-version tests for state both versions can mutate. A desire to let old
+validator binaries keep working is not, by itself, enough: binary rollout is an
+operational concern and must not weaken an onchain safety invariant.
+
+The `upgrade_v2::Upgrade` proposal records this decision in its `exclusive`
+field. Execution returns the Sui `UpgradeTicket` together with a non-droppable
+authorization carrying the approved setting. Finalization consumes both in the
+same programmable transaction, binding the committee vote to the version policy
+that is applied when the package is committed. The CLI requires
+`--exclusive true` or `--exclusive false`; omission is rejected so the
+classification cannot be an accidental default.
+
+## Validator rollout contract
+
+An exclusive upgrade deliberately makes old binaries unable to perform normal
+writes once the upgrade checkpoint is observed. An old binary does not contain
+the code or ABI routing for the newest package, and the previous package is no
+longer enabled. Updated Hashi nodes detect that they support no enabled package
+version and halt autonomous mutations instead of falling back unsafely.
+
+Use this sequence for every upgrade:
+
+1. Build the exact Move package and record its digest in the proposal.
+2. Release a node binary that understands both the currently active package and
+   the proposed package.
+3. Restart validators one at a time. Each validator verifies healthy operation
+   on the current package before casting its vote.
+4. Confirm that upgraded validators represent at least two thirds of committee
+   **weight**, not merely two thirds of node count.
+5. Reach proposal quorum, then separately execute and publish the upgrade.
+   Votes never auto-publish a package.
+6. Verify the package-upgrade checkpoint, enabled-version set, active routing,
+   and validator health before resuming ordinary rollout work.
+
+This ordering means the network retains quorum-capable updated software before
+an exclusive publication causes old binaries to stop writing.
+
+## Current testnet v1 to v2 plan
+
+The deployed testnet v1 package only has the legacy `upgrade` proposal. That
+proposal always leaves previous versions enabled, so it cannot make the first
+v1-to-v2 transition atomic. Testnet carries no real funds, and we accept a small
+race window for this one migration.
+
+Minimize that window as follows:
+
+1. Avoid active withdrawals during the rollout window.
+2. Create and fully vote both the v2 upgrade proposal and a
+   `DisableVersion(1)` proposal while v1 is active. Proposal creation permits
+   targeting the current version; only execution rejects disabling it.
+3. Execute, publish, and finalize v2 through the legacy v1 upgrade path.
+4. Wait for that transaction to succeed and obtain the newly published v2
+   package ID.
+5. Immediately execute the already-approved disable-v1 proposal through the v2
+   package.
+6. Verify that v1 calls fail with `EVersionDisabled` and that validators route
+   ordinary work through v2.
+
+These are necessarily two transactions. They must not be submitted
+concurrently because shared-object ordering is not guaranteed; disable-v1 must
+execute through v2 after publication. Emergency pause is not a complete
+substitute because the legacy v1 withdrawal cancellation entry does not honor
+the pause flag.
+
+Before the first mainnet publish, remove the legacy `upgrade` module, rename
+`upgrade_v2` to `upgrade`, and squash testnet-only package-version and storage
+assumptions. Mainnet should begin with the atomic proposal type as its only
+upgrade path.

--- a/design/docs/move-upgrades.mdx
+++ b/design/docs/move-upgrades.mdx
@@ -95,7 +95,12 @@ version and halt autonomous mutations instead of falling back unsafely.
 
 Use this sequence for every upgrade:
 
-1. Build the exact Move package and record its digest in the proposal.
+1. Build the exact Move package and record its digest in the proposal. Create
+   exclusive proposals with `--package-path`, which verifies the package's
+   `PACKAGE_VERSION` constant against the chain before proposing; the CLI
+   refuses `--digest` for an exclusive upgrade unless
+   `--allow-unverified-exclusive` explicitly acknowledges that the constant
+   was not machine-checked.
 2. Release a node binary that understands both the currently active package and
    the proposed package.
 3. Restart validators one at a time. Each validator verifies healthy operation

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -821,7 +821,7 @@ Create proposals:
 hashi proposal create update-config <key> <value> [-m key=value]
 hashi proposal create update-mpc-config [--threshold-bps <N>] [--max-faulty-bps <N>] [--weight-reduction-allowed-delta <N>] [-m key=value]
 hashi proposal create upgrade [--package-path <path> | --digest <hex>] [-m key=value]
-hashi proposal create upgrade-v2 [--package-path <path> | --digest <hex>] --exclusive <true|false> [-m key=value]
+hashi proposal create upgrade-v2 [--package-path <path> | --digest <hex> [--allow-unverified-exclusive]] --exclusive <true|false> [-m key=value]
 hashi proposal create enable-version <version> [-m key=value]
 hashi proposal create disable-version <version> [-m key=value]
 hashi proposal create abort-reconfig [--epoch <N>] [-m key=value]
@@ -899,7 +899,7 @@ Builds, publishes, and initializes the Hashi Move package (including its onchain
 | **UpdateConfig** | 2/3 | Change protocol parameters | `key` and type-prefixed `value` |
 | **UpdateMpcConfig** | 2/3 | Change MPC threshold/faulty/delta | `--threshold-bps`, `--max-faulty-bps`, `--weight-reduction-allowed-delta` |
 | **Upgrade** | 2/3 | Publish a new package version | `--package-path` or `--digest` |
-| **UpgradeV2** | 2/3 | Publish with an explicit version-retirement policy | `--package-path` or `--digest`; required boolean `--exclusive` value |
+| **UpgradeV2** | 2/3 | Publish with an explicit version-retirement policy | `--package-path` or `--digest`; required boolean `--exclusive` value; `--digest` with `--exclusive true` additionally requires `--allow-unverified-exclusive` |
 | **EnableVersion** | 2/3 | Re-enable a disabled package version | `version` number |
 | **DisableVersion** | 2/3 | Disable a package version | `version` number (cannot disable active version) |
 | **AbortReconfig** | 2/3 | Abort a stuck reconfiguration | `--epoch` of pending reconfig |

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -821,6 +821,7 @@ Create proposals:
 hashi proposal create update-config <key> <value> [-m key=value]
 hashi proposal create update-mpc-config [--threshold-bps <N>] [--max-faulty-bps <N>] [--weight-reduction-allowed-delta <N>] [-m key=value]
 hashi proposal create upgrade [--package-path <path> | --digest <hex>] [-m key=value]
+hashi proposal create upgrade-v2 [--package-path <path> | --digest <hex>] --exclusive <true|false> [-m key=value]
 hashi proposal create enable-version <version> [-m key=value]
 hashi proposal create disable-version <version> [-m key=value]
 hashi proposal create abort-reconfig [--epoch <N>] [-m key=value]
@@ -898,6 +899,7 @@ Builds, publishes, and initializes the Hashi Move package (including its onchain
 | **UpdateConfig** | 2/3 | Change protocol parameters | `key` and type-prefixed `value` |
 | **UpdateMpcConfig** | 2/3 | Change MPC threshold/faulty/delta | `--threshold-bps`, `--max-faulty-bps`, `--weight-reduction-allowed-delta` |
 | **Upgrade** | 2/3 | Publish a new package version | `--package-path` or `--digest` |
+| **UpgradeV2** | 2/3 | Publish with an explicit version-retirement policy | `--package-path` or `--digest`; required boolean `--exclusive` value |
 | **EnableVersion** | 2/3 | Re-enable a disabled package version | `version` number |
 | **DisableVersion** | 2/3 | Disable a package version | `version` number (cannot disable active version) |
 | **AbortReconfig** | 2/3 | Abort a stuck reconfiguration | `--epoch` of pending reconfig |
@@ -944,15 +946,20 @@ hashi config on-chain
 
 ### 7.4 Package upgrade flow
 
+Every package upgrade must first be classified as exclusive or non-exclusive.
+See [Move Package Upgrades](move-upgrades.mdx) for the safety criteria, binary
+rollout contract, and the special testnet v1-to-v2 sequence.
+
 ```bash
 # Build and propose (CLI verifies PACKAGE_VERSION is incremented)
-hashi proposal create upgrade --package-path /path/to/packages/hashi
+hashi proposal create upgrade-v2 --exclusive true --package-path /path/to/packages/hashi
 
 # Vote (--execute is NOT supported for Upgrade proposals)
 hashi proposal vote 0x<proposal-id>
 
-# After quorum: execute the upgrade
-hashi proposal execute 0x<proposal-id>
+# After quorum: use the release tooling to build and submit one programmable
+# transaction containing proposal execution, package publication, and upgrade
+# finalization. The generic `proposal execute` command rejects upgrade types.
 ```
 
 ---

--- a/design/scripts/generate-llmstxt.js
+++ b/design/scripts/generate-llmstxt.js
@@ -35,6 +35,7 @@ const SECTIONS = [
     items: [
       "committee",
       "governance-actions",
+      "move-upgrades",
       "sanctions",
       "service",
       "mpc-protocol",

--- a/design/sidebars.js
+++ b/design/sidebars.js
@@ -12,6 +12,7 @@ const sidebars = {
       items: [
         'committee',
         'governance-actions',
+        'move-upgrades',
         'sanctions',
         'service',
         'mpc-protocol',

--- a/packages/hashi/sources/core/proposal/types/upgrade_v2.move
+++ b/packages/hashi/sources/core/proposal/types/upgrade_v2.move
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Versioned package-upgrade governance with an atomic version policy.
+///
+/// The legacy `upgrade` proposal only authorizes package bytecode and always
+/// leaves older package versions enabled. This proposal also records whether
+/// the new version must be exclusive. The approved choice is carried from
+/// `execute` to `finalize_upgrade` in a hot potato, so the transaction sender
+/// cannot substitute a different policy while publishing the package.
+///
+/// An exclusive upgrade commits the new package and replaces the enabled set
+/// with the new version in the same programmable transaction. A non-exclusive
+/// upgrade preserves every enabled version and adds the new one.
+///
+/// TODO(mainnet): Before the first mainnet publish, delete the legacy
+/// `upgrade` module and rename this module to `upgrade`. The v2 name exists
+/// only to preserve the deployed testnet v1 proposal ABI during migration.
+module hashi::upgrade_v2;
+
+use hashi::{hashi::Hashi, proposal};
+use std::string::String;
+use sui::{clock::Clock, package::{UpgradeTicket, UpgradeReceipt}, vec_map::VecMap};
+
+// ~~~~~~~ Constants ~~~~~~~
+
+const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Structs ~~~~~~~
+
+public struct Upgrade has copy, drop, store {
+    digest: vector<u8>,
+    exclusive: bool,
+}
+
+/// Binds the committee-approved version policy to the upgrade transaction.
+///
+/// No abilities are intentional: callers cannot forge, copy, drop, or store
+/// this value and must consume it in `finalize_upgrade` in the same PTB.
+public struct UpgradeAuthorization {
+    exclusive: bool,
+}
+
+// ~~~~~~~ Events ~~~~~~~
+
+public struct PackageUpgraded has copy, drop {
+    package: ID,
+    version: u64,
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
+
+public fun propose(
+    hashi: &mut Hashi,
+    validator_address: address,
+    digest: vector<u8>,
+    exclusive: bool,
+    metadata: VecMap<String, String>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    hashi.versioning().assert_version_enabled();
+    proposal::create(
+        hashi,
+        validator_address,
+        Upgrade { digest, exclusive },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
+}
+
+/// Execute an approved proposal and bind its version policy to the ticket.
+public fun execute(
+    hashi: &mut Hashi,
+    proposal_id: ID,
+    clock: &Clock,
+): (UpgradeTicket, UpgradeAuthorization) {
+    let Upgrade { digest, exclusive } = proposal::execute(hashi, proposal_id, clock);
+    let ticket = hashi.versioning_mut().authorize_upgrade(digest);
+    (ticket, UpgradeAuthorization { exclusive })
+}
+
+/// Commit the package and its approved version policy atomically.
+public fun finalize_upgrade(
+    hashi: &mut Hashi,
+    receipt: UpgradeReceipt,
+    authorization: UpgradeAuthorization,
+) {
+    hashi.versioning().assert_version_enabled();
+    let UpgradeAuthorization { exclusive } = authorization;
+    let upgrade_package = receipt.package();
+    hashi.versioning_mut().commit_upgrade_v2(receipt, exclusive);
+    let version = hashi.versioning().upgrade_cap().version();
+    sui::event::emit(PackageUpgraded { package: upgrade_package, version });
+}

--- a/packages/hashi/sources/core/versioning.move
+++ b/packages/hashi/sources/core/versioning.move
@@ -89,6 +89,25 @@ public(package) fun commit_upgrade(self: &mut Versioning, receipt: UpgradeReceip
     self.enabled_versions.insert(version);
 }
 
+/// Commit an upgrade and apply the version policy approved with it.
+///
+/// Exclusive upgrades atomically retire every previously enabled package
+/// version as the new version is committed. Non-exclusive upgrades retain the
+/// legacy behavior and add the new version alongside the existing set.
+public(package) fun commit_upgrade_v2(
+    self: &mut Versioning,
+    receipt: UpgradeReceipt,
+    exclusive: bool,
+) {
+    package::commit_upgrade(self.upgrade_cap.borrow_mut(), receipt);
+    let version = self.upgrade_cap.borrow().version();
+    if (exclusive) {
+        self.enabled_versions = vec_set::singleton(version);
+    } else {
+        self.enabled_versions.insert(version);
+    };
+}
+
 public(package) fun set_upgrade_cap(self: &mut Versioning, upgrade_cap: UpgradeCap) {
     self.upgrade_cap.fill(upgrade_cap);
 }

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -11,9 +11,10 @@ use hashi::{
     mpc_config,
     proposal,
     test_utils,
-    update_config::UpdateConfig
+    update_config::UpdateConfig,
+    upgrade_v2
 };
-use sui::{bls12381, clock};
+use sui::{bls12381, clock, package, vec_map};
 
 // ======== Test Addresses ========
 const VOTER1: address = @0x1;
@@ -845,6 +846,76 @@ fun test_enable_already_enabled_version_fails() {
     hashi::enable_version::execute(&mut hashi, proposal_id, &clock);
 
     // Won't reach here
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+// ======== Upgrade V2 Tests ========
+
+/// Build an upgrade cap whose next receipt will commit package version 3.
+fun test_upgrade_cap_at_v2(ctx: &mut TxContext): sui::package::UpgradeCap {
+    let mut cap = package::test_publish(@0x42.to_id(), ctx);
+    let ticket = cap.authorize_upgrade(package::compatible_policy(), b"bootstrap v2");
+    cap.commit_upgrade(ticket.test_upgrade());
+    cap
+}
+
+#[test]
+/// An exclusive upgrade atomically retires every previously enabled version.
+fun test_upgrade_v2_exclusive_replaces_enabled_versions() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    hashi.versioning_mut().set_upgrade_cap(test_upgrade_cap_at_v2(ctx));
+    hashi.versioning_mut().enable_version(1);
+
+    let proposal_id = upgrade_v2::propose(
+        &mut hashi,
+        VOTER1,
+        b"exclusive v3",
+        true,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    let (ticket, authorization) = upgrade_v2::execute(&mut hashi, proposal_id, &clock);
+    upgrade_v2::finalize_upgrade(&mut hashi, ticket.test_upgrade(), authorization);
+
+    assert!(!hashi.versioning().is_version_enabled(1));
+    assert!(!hashi.versioning().is_version_enabled(2));
+    assert!(hashi.versioning().is_version_enabled(3));
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// A non-exclusive upgrade preserves the legacy multi-version behavior.
+fun test_upgrade_v2_non_exclusive_preserves_enabled_versions() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    hashi.versioning_mut().set_upgrade_cap(test_upgrade_cap_at_v2(ctx));
+    hashi.versioning_mut().enable_version(1);
+
+    let proposal_id = upgrade_v2::propose(
+        &mut hashi,
+        VOTER1,
+        b"non-exclusive v3",
+        false,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    let (ticket, authorization) = upgrade_v2::execute(&mut hashi, proposal_id, &clock);
+    upgrade_v2::finalize_upgrade(&mut hashi, ticket.test_upgrade(), authorization);
+
+    assert!(hashi.versioning().is_version_enabled(1));
+    assert!(hashi.versioning().is_version_enabled(2));
+    assert!(hashi.versioning().is_version_enabled(3));
+
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
 }


### PR DESCRIPTION
## Motivation

Publishing a Sui package upgrade does not make the previous package uncallable. Hashi package versions share the same mutable `Hashi` object, so an old entry function can violate an invariant introduced by a newer package.

#1003  exposed a concrete case: a request committed through v2 can remain in a location that v1 considers cancellable. If v1 remains enabled, its cancellation path can destroy the committed request and potentially strand burned hBTC and locked UTXOs.

Adding `exclusive` directly to the deployed `upgrade::Upgrade` struct would change the BCS layout of existing proposal objects. This PR therefore introduces a temporary `upgrade_v2` proposal type for testnet and leaves the legacy type unchanged.

## What changed

- Add `upgrade_v2::Upgrade { digest, exclusive }`.
- Bind the approved policy to publication with a no-abilities `UpgradeAuthorization` returned alongside the Sui `UpgradeTicket`.
- Finalize publication and the version policy in the same PTB:
  - `exclusive = true` replaces the enabled set with only the newly committed version.
  - `exclusive = false` deliberately preserves older enabled versions.
- Require callers to provide `--exclusive true|false` when creating an `upgrade-v2` proposal.
- Resolve proposal type arguments from the package version that introduced the type, so voting, vote removal, decoding, and garbage collection work for both legacy and v2 proposal payloads.
- Add Move coverage for both policies and an e2e test that bootstraps v1 -> v2 through the legacy path, publishes v3 through `UpgradeV2(exclusive = true)`, verifies only v3 remains enabled, and verifies the v1+v2 binary halts autonomous writes.
- Add a Move-upgrade guide requiring every future upgrade to classify itself as exclusive or non-exclusive, plus operator-runbook and governance documentation.

## Rollout contract

For a future exclusive upgrade:

1. Create the proposal for the exact Move package digest.
2. Release a binary that understands both the current and proposed packages.
3. Restart validators individually and verify healthy operation on the current package before voting.
4. Confirm upgraded validators represent at least two thirds of committee **weight**, not merely node count.
5. Reach vote quorum, then manually execute/publish. Votes do not auto-execute an upgrade.
6. Publication atomically enables only the new version. Old binaries observe that they support no enabled package and halt writes.

A non-exclusive upgrade is allowed only when review and cross-version tests establish that old and new entry functions can safely mutate the same shared state. Binary compatibility alone is not sufficient justification.

## Current testnet v1 -> v2 plan

The deployed v1 package cannot use `UpgradeV2`, so the first transition necessarily has a small two-transaction gap. Testnet has no real funds, and we accept that risk for this migration:

1. Keep withdrawals quiet during the rollout.
2. Release the v1+v2-capable binary and upgrade validators representing at least two thirds of committee weight.
3. Create and fully vote the exact-digest legacy upgrade proposal and `DisableVersion(1)` proposal while v1 is active.
4. Execute/publish/finalize v2 through the legacy upgrade proposal and wait for success and the new v2 package ID.
5. Immediately execute the already-approved disable-v1 proposal through v2.
6. Verify v1 calls fail with `EVersionDisabled` and normal routing uses v2.

The two executions must not be submitted concurrently because their shared-object ordering is not guaranteed. Emergency pause is not a complete substitute because the legacy v1 withdrawal-cancellation path does not honor it.

## Before mainnet

Delete the original legacy `upgrade` module, rename `upgrade_v2` to `upgrade`, and squash the testnet-only package-version and storage assumptions before the first mainnet publish. The new module includes a source-level TODO recording this requirement.

## Verification

Passed locally:

- `make fmt-move`
- `make check-fmt`
- `make buf-lint`
- `make proto` (no generated drift)
- `RUSTFLAGS=-Dwarnings make clippy`
- `sui move build --path packages/hashi -e testnet`
- `sui move test --path packages/hashi -e testnet` (157 passed)
- `cargo test --locked -p hashi --test move_upgrade_compat -- --nocapture` (9 passed)
- `RUSTFLAGS=-Dwarnings cargo test --workspace --all-features --doc`
- `RUSTFLAGS=-Dwarnings make doc`
- `cd design && npm ci && npm run build`
- `make -C docker/hashi-guardian enclave-lock`
- `RUSTFLAGS=-Dwarnings cargo nextest run -p e2e-tests --test upgrade_tests test_upgrade_v2_exclusive_via_proposal --profile ci`
- `test_drain_mode_max_request_batch` in the aggregate nextest run
- `make is-dirty`

The full local `cargo nextest run --workspace --all-features --profile ci` did not finish green. Under aggregate load, `test_nonce_accumulation_window_open` observed stale enabled-version state (it passed when rerun in isolation), and `test_large_withdrawal_signature_chunking` timed out. The latter progressed further in isolation but later hit `ENotReconfiguring` in committee handoff and timed out waiting for `WithdrawalSigned`; I believe these are local contention/existing e2e failures, but did not reproduce them on `main` to verify that conclusion.

Local tools differ from pinned CI: Sui 1.76.1 locally vs 1.73.2 in Move CI, and Node 22 locally vs Node 20 in docs CI. Pinned GitHub CI should be treated as authoritative for those environments.
