### PR TITLE
Select oldest confirmed utxo for withdrawals

### DIFF
--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::VecDeque;
+use std::future::Future;
 use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
@@ -13,6 +16,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use futures::FutureExt;
+use futures::StreamExt;
+use futures::TryStreamExt;
 use kyoto::FeeRate;
 use kyoto::HashCheckpoint;
 use kyoto::Warning;
@@ -54,6 +59,9 @@ const DEPOSIT_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 // minutes after every caller's own `DEPOSIT_CHECK_TIMEOUT` budget expired.
 const DEPOSIT_CHECK_TIMEOUT: Duration = Duration::from_secs(45);
 const MAX_PENDING_DEPOSIT_CHECKS_PER_OUTPOINT: usize = 100;
+// At most 16 concurrent txid lookups: bitcoind's default rpcworkqueue is 16,
+// and overflowing it fails calls outright ("Work queue depth exceeded").
+const UTXO_HEIGHT_LOOKUP_CONCURRENCY: usize = 16;
 
 fn next_restart_delay() -> Duration {
     let jitter = Duration::from_millis(
@@ -75,6 +83,19 @@ pub enum DepositConfirmation {
     NotFound,
     InMempool,
     InsufficientConfirmations { confirmations: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UtxoHeightSnapshot {
+    pub(crate) tip: HashCheckpoint,
+    pub(crate) confirmation_height_by_txid: BTreeMap<bitcoin::Txid, u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TxBlockLookup {
+    Confirmed(HashCheckpoint),
+    InMempool,
+    NotFound,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -216,6 +237,15 @@ struct DepositDiscoveryContext {
     requester: kyoto::Requester,
     deposit_lookup_cache: SharedDepositLookupCache,
     generation: u64,
+}
+
+struct UtxoHeightResolutionContext {
+    tip: HashCheckpoint,
+    bitcoind_rpc: Arc<corepc_client::client_sync::v29::Client>,
+    requester: kyoto::Requester,
+    deposit_lookup_cache: SharedDepositLookupCache,
+    block_sequence: Arc<AtomicU64>,
+    captured_sequence: u64,
 }
 
 enum KyotoEventLoopExit {
@@ -715,6 +745,21 @@ impl Monitor {
         ))
     }
 
+    /// Invalidate Bitcoin-tip-dependent work before resetting Kyoto state.
+    fn reset_bitcoin_state_for_restart(&mut self) {
+        self.block_sequence.fetch_add(1, Ordering::SeqCst);
+        self.synced = false;
+        self.tip = None;
+        self.cancel_deposit_workers();
+        self.block_scan_queue.clear();
+        self.deposit_lookup_cache = self.deposit_lookup_cache.fresh();
+        self.deposit_tracker.reset_bitcoin_state();
+        self.metrics.kyoto_restarts.inc();
+        self.metrics.kyoto_connected_peers.set(0);
+        self.metrics.kyoto_synced.set(0);
+        self.metrics.kyoto_consecutive_failures.set(0);
+    }
+
     /// Run the monitor with automatic Kyoto restart on connectivity loss.
     async fn run_with_supervision(
         &mut self,
@@ -769,16 +814,7 @@ impl Monitor {
                 }
             }
 
-            self.synced = false;
-            self.tip = None;
-            self.cancel_deposit_workers();
-            self.block_scan_queue.clear();
-            self.deposit_lookup_cache = self.deposit_lookup_cache.fresh();
-            self.deposit_tracker.reset_bitcoin_state();
-            self.metrics.kyoto_restarts.inc();
-            self.metrics.kyoto_connected_peers.set(0);
-            self.metrics.kyoto_synced.set(0);
-            self.metrics.kyoto_consecutive_failures.set(0);
+            self.reset_bitcoin_state_for_restart();
 
             tokio::time::sleep(next_restart_delay()).await;
 
@@ -1042,6 +1078,26 @@ impl Monitor {
             MonitorMessage::CheckDeposit(request) => {
                 self.confirm_deposit(request);
             }
+            MonitorMessage::ResolveUtxoConfirmationHeights(txids, result_tx) => {
+                let Some(tip) = self.tip.filter(|_| self.synced) else {
+                    let _ = result_tx.send(Err(anyhow::anyhow!(
+                        "Bitcoin monitor is not synced to a chain tip"
+                    )));
+                    return;
+                };
+                let context = UtxoHeightResolutionContext {
+                    tip,
+                    bitcoind_rpc: self.bitcoind_rpc.clone(),
+                    requester: self.requester.clone(),
+                    deposit_lookup_cache: self.deposit_lookup_cache.clone(),
+                    block_sequence: self.block_sequence.clone(),
+                    captured_sequence: self.block_sequence.load(Ordering::SeqCst),
+                };
+                self.rpc_workers
+                    .spawn(Self::resolve_utxo_confirmation_heights(
+                        context, txids, result_tx,
+                    ));
+            }
             MonitorMessage::GetRecentFeeRate(conf_target, result_tx) => {
                 self.rpc_workers.spawn(Self::get_recent_fee_rate(
                     self.bitcoind_rpc.clone(),
@@ -1065,6 +1121,38 @@ impl Monitor {
                 ));
             }
         }
+    }
+
+    async fn resolve_utxo_confirmation_heights(
+        context: UtxoHeightResolutionContext,
+        txids: BTreeSet<bitcoin::Txid>,
+        result_tx: oneshot::Sender<Result<UtxoHeightSnapshot>>,
+    ) {
+        let UtxoHeightResolutionContext {
+            tip,
+            bitcoind_rpc,
+            requester,
+            deposit_lookup_cache,
+            block_sequence,
+            captured_sequence,
+        } = context;
+        let result = assemble_utxo_height_snapshot(
+            tip,
+            block_sequence,
+            captured_sequence,
+            txids,
+            move |txid| {
+                lookup_tx_block(
+                    bitcoind_rpc.clone(),
+                    requester.clone(),
+                    deposit_lookup_cache.clone(),
+                    txid,
+                    tip,
+                )
+            },
+        )
+        .await;
+        let _ = result_tx.send(result);
     }
 
     async fn get_recent_fee_rate(
@@ -1286,6 +1374,110 @@ async fn check_result_from_status(
     }
 }
 
+async fn lookup_tx_block(
+    bitcoind_rpc: Arc<corepc_client::client_sync::v29::Client>,
+    requester: kyoto::Requester,
+    deposit_lookup_cache: SharedDepositLookupCache,
+    txid: bitcoin::Txid,
+    tip: HashCheckpoint,
+) -> Result<TxBlockLookup, DepositConfirmError> {
+    if let Some(block_info) = deposit_lookup_cache.get_tx_block(&txid) {
+        return Ok(TxBlockLookup::Confirmed(block_info));
+    }
+
+    debug!("Looking up block for transaction {txid}");
+    require_core_checkpoint(&bitcoind_rpc, tip, "before transaction lookup").await?;
+    let tx_info = match btc_rpc_call(&bitcoind_rpc, move |rpc| {
+        rpc.get_raw_transaction_verbose(txid)
+    })
+    .await
+    {
+        Ok(tx_info) => tx_info,
+        // -5 also covers "-txindex off" and "txindex still indexing";
+        // only the ready-index message is a durable not-found.
+        Err(corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(e)))
+            if e.code == -5
+                && e.message
+                    .starts_with("No such mempool or blockchain transaction") =>
+        {
+            require_core_checkpoint(&bitcoind_rpc, tip, "after transaction lookup").await?;
+            return Ok(TxBlockLookup::NotFound);
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!("Failed to look up txid {txid}: {e}").into());
+        }
+    };
+    let tx_info = tx_info
+        .into_model()
+        .map_err(|e| anyhow::anyhow!("Failed to parse transaction info for {txid}: {e}"))?;
+    let Some(block_hash) = tx_info.block_hash else {
+        require_core_checkpoint(&bitcoind_rpc, tip, "after transaction lookup").await?;
+        return Ok(TxBlockLookup::InMempool);
+    };
+    let height = if let Some(height) = deposit_lookup_cache.get_block_height(&block_hash) {
+        height
+    } else {
+        let height = requester
+            .height_of_hash(block_hash)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to look up block hash {block_hash} in Kyoto: {e}")
+            })?
+            .ok_or_else(|| {
+                anyhow::anyhow!("Block hash {block_hash} from bitcoind is not on Kyoto's chain")
+            })?;
+        deposit_lookup_cache.put_block_height(block_hash, height);
+        height
+    };
+    let block_info = HashCheckpoint::new(height, block_hash);
+    deposit_lookup_cache.put_tx_block(txid, block_info);
+    Ok(TxBlockLookup::Confirmed(block_info))
+}
+
+async fn assemble_utxo_height_snapshot<F, Fut>(
+    tip: HashCheckpoint,
+    block_sequence: Arc<AtomicU64>,
+    captured_sequence: u64,
+    txids: BTreeSet<bitcoin::Txid>,
+    mut lookup: F,
+) -> Result<UtxoHeightSnapshot>
+where
+    F: FnMut(bitcoin::Txid) -> Fut,
+    Fut: Future<Output = Result<TxBlockLookup, DepositConfirmError>>,
+{
+    let confirmation_height_by_txid = futures::stream::iter(txids)
+        .map(move |txid| {
+            let lookup = lookup(txid);
+            async move {
+                match lookup.await? {
+                    TxBlockLookup::Confirmed(checkpoint) => Ok((txid, checkpoint.height)),
+                    TxBlockLookup::InMempool => {
+                        Err(anyhow::anyhow!("transaction {txid} is in the mempool"))
+                    }
+                    TxBlockLookup::NotFound => {
+                        Err(anyhow::anyhow!("transaction {txid} was not found"))
+                    }
+                }
+            }
+        })
+        .buffer_unordered(UTXO_HEIGHT_LOOKUP_CONCURRENCY)
+        .try_collect::<BTreeMap<_, _>>()
+        .await?;
+
+    let completed_sequence = block_sequence.load(Ordering::SeqCst);
+    if completed_sequence != captured_sequence {
+        anyhow::bail!(
+            "Bitcoin chain tip changed while resolving UTXO confirmation heights \
+             (sequence {captured_sequence} to {completed_sequence})"
+        );
+    }
+
+    Ok(UtxoHeightSnapshot {
+        tip,
+        confirmation_height_by_txid,
+    })
+}
+
 async fn discover_deposit(
     bitcoind_rpc: Arc<corepc_client::client_sync::v29::Client>,
     requester: kyoto::Requester,
@@ -1294,54 +1486,18 @@ async fn discover_deposit(
     tip: HashCheckpoint,
 ) -> Result<DepositStatus, DepositConfirmError> {
     let txid = outpoint.txid;
-    let block_info = if let Some(block_info) = deposit_lookup_cache.get_tx_block(&txid) {
-        block_info
-    } else {
-        debug!("Looking up block for transaction {txid}");
-        require_core_checkpoint(&bitcoind_rpc, tip, "before transaction lookup").await?;
-        let tx_info = match btc_rpc_call(&bitcoind_rpc, move |rpc| {
-            rpc.get_raw_transaction_verbose(txid)
-        })
-        .await
-        {
-            Ok(tx_info) => tx_info,
-            // -5 also covers "-txindex off" and "txindex still indexing";
-            // only the ready-index message is a durable not-found.
-            Err(corepc_client::client_sync::Error::JsonRpc(jsonrpc::error::Error::Rpc(e)))
-                if e.code == -5
-                    && e.message
-                        .starts_with("No such mempool or blockchain transaction") =>
-            {
-                require_core_checkpoint(&bitcoind_rpc, tip, "after transaction lookup").await?;
-                return Ok(DepositStatus::NotFound);
-            }
-            Err(e) => return Err(anyhow::anyhow!("Failed to look up txid {txid}: {e}").into()),
-        };
-        let tx_info = tx_info
-            .into_model()
-            .map_err(|e| anyhow::anyhow!("Failed to parse transaction info for {txid}: {e}"))?;
-        let Some(block_hash) = tx_info.block_hash else {
-            require_core_checkpoint(&bitcoind_rpc, tip, "after transaction lookup").await?;
-            return Ok(DepositStatus::InMempool);
-        };
-        let height = if let Some(height) = deposit_lookup_cache.get_block_height(&block_hash) {
-            height
-        } else {
-            let height = requester
-                .height_of_hash(block_hash)
-                .await
-                .map_err(|e| {
-                    anyhow::anyhow!("Failed to look up block hash {block_hash} in Kyoto: {e}")
-                })?
-                .ok_or_else(|| {
-                    anyhow::anyhow!("Block hash {block_hash} from bitcoind is not on Kyoto's chain")
-                })?;
-            deposit_lookup_cache.put_block_height(block_hash, height);
-            height
-        };
-        let block_info = HashCheckpoint::new(height, block_hash);
-        deposit_lookup_cache.put_tx_block(txid, block_info);
-        block_info
+    let block_info = match lookup_tx_block(
+        bitcoind_rpc,
+        requester.clone(),
+        deposit_lookup_cache.clone(),
+        txid,
+        tip,
+    )
+    .await?
+    {
+        TxBlockLookup::Confirmed(block_info) => block_info,
+        TxBlockLookup::InMempool => return Ok(DepositStatus::InMempool),
+        TxBlockLookup::NotFound => return Ok(DepositStatus::NotFound),
     };
 
     let transaction = if let Some(transaction) = deposit_lookup_cache.get_transaction(&txid) {
@@ -1583,6 +1739,18 @@ impl MonitorClient {
         .map_err(|_| DepositConfirmError::TimedOut)?
     }
 
+    pub(crate) async fn resolve_utxo_confirmation_heights(
+        &self,
+        txids: BTreeSet<bitcoin::Txid>,
+    ) -> Result<UtxoHeightSnapshot> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(MonitorMessage::ResolveUtxoConfirmationHeights(txids, tx))
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
+        rx.await.map_err(|e| anyhow::anyhow!(e))?
+    }
+
     pub async fn get_recent_fee_rate(&self, conf_target: u16) -> Result<FeeRate> {
         let (tx, rx) = oneshot::channel();
         self.tx
@@ -1614,6 +1782,12 @@ impl MonitorClient {
 enum MonitorMessage {
     // Checks the given OutPoint against the monitor's current Bitcoin tip.
     CheckDeposit(DepositCheckRequest),
+
+    // Resolves confirmation heights against one stable, synced Bitcoin tip.
+    ResolveUtxoConfirmationHeights(
+        BTreeSet<bitcoin::Txid>,
+        oneshot::Sender<Result<UtxoHeightSnapshot>>,
+    ),
 
     // Returns an estimated fee rate targeting confirmation within `conf_target` blocks.
     GetRecentFeeRate(u16, oneshot::Sender<Result<FeeRate>>),
@@ -1716,6 +1890,150 @@ mod tests {
             rpc_workers: JoinSet::new(),
             trusted_peer_rotation: Vec::new().into_iter().cycle(),
         }
+    }
+
+    #[tokio::test]
+    async fn lookup_tx_block_returns_cached_confirmation_without_rpc() {
+        let metrics = Arc::new(fresh_metrics());
+        let tracker = DepositTracker::new(metrics.clone());
+        let monitor = test_monitor(metrics.clone(), tracker);
+        let txid = make_outpoint(1).txid;
+        let cached = HashCheckpoint::new(42, block_hash(2));
+        monitor.deposit_lookup_cache.put_tx_block(txid, cached);
+
+        let result = lookup_tx_block(
+            monitor.bitcoind_rpc.clone(),
+            monitor.requester.clone(),
+            monitor.deposit_lookup_cache.clone(),
+            txid,
+            HashCheckpoint::new(100, block_hash(3)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, TxBlockLookup::Confirmed(cached));
+        assert_eq!(cache_requests(&metrics, "tx_block", "hit"), 1);
+    }
+
+    #[tokio::test]
+    async fn cached_utxo_height_batch_returns_captured_tip_and_all_heights() {
+        let metrics = Arc::new(fresh_metrics());
+        let tracker = DepositTracker::new(metrics.clone());
+        let mut monitor = test_monitor(metrics.clone(), tracker);
+        let tip = HashCheckpoint::new(100, block_hash(3));
+        let first_txid = make_outpoint(1).txid;
+        let second_txid = make_outpoint(2).txid;
+        monitor.synced = true;
+        monitor.tip = Some(tip);
+        monitor
+            .deposit_lookup_cache
+            .put_tx_block(first_txid, HashCheckpoint::new(40, block_hash(4)));
+        monitor
+            .deposit_lookup_cache
+            .put_tx_block(second_txid, HashCheckpoint::new(75, block_hash(5)));
+        let (result_tx, result_rx) = oneshot::channel();
+
+        monitor.process_client_message(MonitorMessage::ResolveUtxoConfirmationHeights(
+            BTreeSet::from([first_txid, second_txid]),
+            result_tx,
+        ));
+        assert_eq!(monitor.rpc_workers.len(), 1);
+        monitor.rpc_workers.join_next().await.unwrap().unwrap();
+        let snapshot = result_rx.await.unwrap().unwrap();
+
+        assert_eq!(snapshot.tip, tip);
+        assert_eq!(
+            snapshot.confirmation_height_by_txid,
+            BTreeMap::from([(first_txid, 40), (second_txid, 75)])
+        );
+        assert_eq!(cache_requests(&metrics, "tx_block", "hit"), 2);
+    }
+
+    #[tokio::test]
+    async fn unsynced_monitor_rejects_utxo_height_batch_without_worker() {
+        let metrics = Arc::new(fresh_metrics());
+        let tracker = DepositTracker::new(metrics.clone());
+        let mut monitor = test_monitor(metrics, tracker);
+        let (result_tx, result_rx) = oneshot::channel();
+
+        monitor.process_client_message(MonitorMessage::ResolveUtxoConfirmationHeights(
+            BTreeSet::from([make_outpoint(1).txid]),
+            result_tx,
+        ));
+
+        assert!(monitor.rpc_workers.is_empty());
+        assert!(
+            result_rx
+                .await
+                .unwrap()
+                .unwrap_err()
+                .to_string()
+                .contains("not synced")
+        );
+    }
+
+    #[tokio::test]
+    async fn utxo_height_batch_rejects_mempool_and_not_found_transactions() {
+        let tip = HashCheckpoint::new(100, block_hash(3));
+        let txid = make_outpoint(1).txid;
+
+        for (lookup, expected) in [
+            (TxBlockLookup::InMempool, "mempool"),
+            (TxBlockLookup::NotFound, "not found"),
+        ] {
+            let result = assemble_utxo_height_snapshot(
+                tip,
+                Arc::new(AtomicU64::new(0)),
+                0,
+                BTreeSet::from([txid]),
+                move |_| async move { Ok::<_, DepositConfirmError>(lookup) },
+            )
+            .await;
+
+            assert!(result.unwrap_err().to_string().contains(expected));
+        }
+    }
+
+    #[tokio::test]
+    async fn utxo_height_batch_rejects_monitor_restart_during_lookup() {
+        let metrics = Arc::new(fresh_metrics());
+        let tracker = DepositTracker::new(metrics.clone());
+        let mut monitor = test_monitor(metrics, tracker);
+        let tip = HashCheckpoint::new(100, block_hash(3));
+        let txid = make_outpoint(1).txid;
+        let captured_sequence = monitor.block_sequence.load(Ordering::SeqCst);
+        let lookup_started = Arc::new(tokio::sync::Notify::new());
+        let release_lookup = Arc::new(tokio::sync::Notify::new());
+        // Hold one uncached-style lookup in flight so the restart is deterministic.
+        let worker = tokio::spawn(assemble_utxo_height_snapshot(
+            tip,
+            monitor.block_sequence.clone(),
+            captured_sequence,
+            BTreeSet::from([txid]),
+            {
+                let lookup_started = lookup_started.clone();
+                let release_lookup = release_lookup.clone();
+                move |_| {
+                    let lookup_started = lookup_started.clone();
+                    let release_lookup = release_lookup.clone();
+                    async move {
+                        lookup_started.notify_one();
+                        release_lookup.notified().await;
+                        Ok::<_, DepositConfirmError>(TxBlockLookup::Confirmed(HashCheckpoint::new(
+                            42,
+                            block_hash(2),
+                        )))
+                    }
+                }
+            },
+        ));
+
+        lookup_started.notified().await;
+        monitor.reset_bitcoin_state_for_restart();
+        release_lookup.notify_one();
+        let error = worker.await.unwrap().unwrap_err();
+
+        assert!(error.to_string().contains("chain tip changed"));
     }
 
     #[test]

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -936,6 +936,7 @@ impl Hashi {
             tracing::error!("Failed to initialize BtcMonitor: {e}");
             e
         })?;
+        let utxo_age_metrics_service = self.clone().start_utxo_age_metrics();
 
         // Start services
         let (_http_addr, http_service) = grpc::HttpService::new(self.clone()).start().await;
@@ -949,6 +950,7 @@ impl Hashi {
         let service = Service::new()
             .merge(onchain_service)
             .merge(btc_monitor_service)
+            .merge(utxo_age_metrics_service)
             .merge(http_service)
             .merge(leader_service)
             .merge(backup_service)
@@ -1186,6 +1188,99 @@ impl Hashi {
                 "Local guardian limiter bucket reconciled after a mirror re-bootstrap",
             );
         }
+    }
+
+    async fn sample_utxo_pool_ages(&self) -> anyhow::Result<(i64, i64)> {
+        // Snapshot both maps under one state lock so promotion of confirmed
+        // withdrawal change cannot race the pool membership calculation.
+        let (withdrawal_txns, utxo_records) = {
+            let state = self.onchain_state().state();
+            (
+                state
+                    .hashi()
+                    .bitcoin()
+                    .withdrawal_queue
+                    .withdrawal_txns()
+                    .clone(),
+                state.hashi().bitcoin().utxo_pool.utxo_records().clone(),
+            )
+        };
+        let confirmed_unlocked_ids =
+            withdrawals::confirmed_unlocked_utxo_ids(&utxo_records, &withdrawal_txns);
+        if confirmed_unlocked_ids.is_empty() {
+            return Ok((0, 0));
+        }
+
+        let txids = confirmed_unlocked_ids
+            .iter()
+            .map(|id| id.txid.into())
+            .collect();
+        let height_snapshot = self
+            .btc_monitor()
+            .resolve_utxo_confirmation_heights(txids)
+            .await?;
+
+        metrics::calculate_utxo_pool_ages(
+            height_snapshot.tip.height,
+            confirmed_unlocked_ids.iter().map(|id| {
+                let txid: bitcoin::Txid = id.txid.into();
+                height_snapshot
+                    .confirmation_height_by_txid
+                    .get(&txid)
+                    .copied()
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Bitcoin confirmation-height snapshot omitted UTXO {id:?} transaction {txid}"
+                        )
+                    })
+            }),
+        )
+    }
+
+    fn start_utxo_age_metrics(self: Arc<Self>) -> Service {
+        /// Retry cadence after a failed sample (unsynced monitor, a block
+        /// arriving mid-lookup), instead of holding the -1 sentinel until
+        /// the next Bitcoin block triggers a resample.
+        const SAMPLE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+        // Subscribe synchronously before the startup sample so a block arriving
+        // during that sample makes `changed()` immediately trigger a resample.
+        let mut block_height_rx = self.btc_monitor().subscribe_block_height();
+        // The startup sample accounts for the value present at subscription;
+        // only notifications published after this point should trigger another.
+        drop(block_height_rx.borrow_and_update());
+        Service::new().spawn_aborting(async move {
+            loop {
+                let failed = match self.sample_utxo_pool_ages().await {
+                    Ok((average_age_blocks, oldest_age_blocks)) => {
+                        self.metrics
+                            .set_utxo_pool_ages(average_age_blocks, oldest_age_blocks);
+                        false
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            ?error,
+                            "Failed to sample confirmed unlocked UTXO pool ages"
+                        );
+                        self.metrics.set_utxo_pool_ages(-1, -1);
+                        true
+                    }
+                };
+
+                if failed {
+                    tokio::select! {
+                        changed = block_height_rx.changed() => {
+                            if changed.is_err() {
+                                return Ok(());
+                            }
+                        }
+                        _ = tokio::time::sleep(SAMPLE_RETRY_INTERVAL) => {}
+                    }
+                } else if block_height_rx.changed().await.is_err() {
+                    return Ok(());
+                }
+            }
+        })
     }
 
     /// Poll the operator gas wallet's total SUI balance (owned coins plus

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -128,9 +128,9 @@ pub struct Metrics {
     pub leader_retries_total: IntCounterVec,
     pub leader_items_in_backoff: IntGaugeVec,
     pub utxo_selection_attempt_failures_total: IntCounterVec,
-    /// Failures to resolve the oldest confirmed UTXO for a withdrawal's
-    /// required input; the withdrawal proceeds without one.
-    pub utxo_required_input_resolution_failures_total: IntCounter,
+    /// Withdrawal builds that fell back to ordinary consolidation ordering
+    /// because confirmation-age resolution failed.
+    pub utxo_confirmation_age_resolution_failures_total: IntCounter,
 
     /// Withdrawals skipped because their gross amount exceeds the
     /// guardian's `max_bucket_capacity`. The request stays approved
@@ -862,9 +862,9 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
-            utxo_required_input_resolution_failures_total: register_int_counter_with_registry!(
-                "hashi_utxo_required_input_resolution_failures_total",
-                "Withdrawal builds that proceeded without a required input because oldest-UTXO resolution failed",
+            utxo_confirmation_age_resolution_failures_total: register_int_counter_with_registry!(
+                "hashi_utxo_confirmation_age_resolution_failures_total",
+                "Withdrawal builds that used ordinary consolidation order because UTXO confirmation-age resolution failed",
                 registry,
             )
             .unwrap(),

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -90,6 +90,8 @@ pub struct Metrics {
     withdrawal_queue_value: IntGaugeVec,
     utxo_pool_size: IntGaugeVec,
     utxo_pool_value: IntGaugeVec,
+    utxo_pool_average_age_blocks: IntGauge,
+    utxo_pool_oldest_age_blocks: IntGauge,
     proposals: IntGaugeVec,
     num_consumed_presigs: IntGauge,
     treasury_supply: IntGaugeVec,
@@ -126,6 +128,9 @@ pub struct Metrics {
     pub leader_retries_total: IntCounterVec,
     pub leader_items_in_backoff: IntGaugeVec,
     pub utxo_selection_attempt_failures_total: IntCounterVec,
+    /// Failures to resolve the oldest confirmed UTXO for a withdrawal's
+    /// required input; the withdrawal proceeds without one.
+    pub utxo_required_input_resolution_failures_total: IntCounter,
 
     /// Withdrawals skipped because their gross amount exceeds the
     /// guardian's `max_bucket_capacity`. The request stays approved
@@ -270,6 +275,34 @@ const MESSAGE_SIZE_BYTES_BUCKETS: &[f64] = &[
     16_777_216.,
     33_554_432.,
 ];
+/// Calculate the integer-floor average and maximum UTXO ages at `tip_height`.
+///
+/// Each iterator item corresponds to one UTXO, so multiple outputs from the
+/// same transaction are counted independently. A failed height lookup is
+/// propagated without publishing a partial sample.
+pub(crate) fn calculate_utxo_pool_ages<E>(
+    tip_height: u32,
+    confirmation_heights: impl IntoIterator<Item = Result<u32, E>>,
+) -> Result<(i64, i64), E> {
+    let mut count = 0u128;
+    let mut total_age = 0u128;
+    let mut oldest_age = 0u32;
+
+    for confirmation_height in confirmation_heights {
+        let age = tip_height.saturating_sub(confirmation_height?);
+        count += 1;
+        total_age += u128::from(age);
+        oldest_age = oldest_age.max(age);
+    }
+
+    if count == 0 {
+        return Ok((0, 0));
+    }
+
+    let average_age = (total_age / count).min(i64::MAX as u128) as i64;
+    let oldest_age = u128::from(oldest_age).min(i64::MAX as u128) as i64;
+    Ok((average_age, oldest_age))
+}
 
 impl Metrics {
     pub fn new_default() -> Self {
@@ -663,6 +696,18 @@ impl Metrics {
                 registry,
             )
             .unwrap(),
+            utxo_pool_average_age_blocks: register_int_gauge_with_registry!(
+                "hashi_utxo_pool_average_age_blocks",
+                "Average age in Bitcoin blocks of unlocked, confirmation-threshold-confirmed UTXOs",
+                registry,
+            )
+            .unwrap(),
+            utxo_pool_oldest_age_blocks: register_int_gauge_with_registry!(
+                "hashi_utxo_pool_oldest_age_blocks",
+                "Age in Bitcoin blocks of the oldest unlocked, confirmation-threshold-confirmed UTXO",
+                registry,
+            )
+            .unwrap(),
             proposals: register_int_gauge_vec_with_registry!(
                 "hashi_proposals",
                 "number of active proposals by type",
@@ -814,6 +859,12 @@ impl Metrics {
                 "hashi_utxo_selection_attempt_failures_total",
                 "Failed UTXO selection attempts by concrete selector error kind",
                 &["error_kind"],
+                registry,
+            )
+            .unwrap(),
+            utxo_required_input_resolution_failures_total: register_int_counter_with_registry!(
+                "hashi_utxo_required_input_resolution_failures_total",
+                "Withdrawal builds that proceeded without a required input because oldest-UTXO resolution failed",
                 registry,
             )
             .unwrap(),
@@ -1367,6 +1418,11 @@ impl Metrics {
             .inc();
     }
 
+    pub fn set_utxo_pool_ages(&self, average_age_blocks: i64, oldest_age_blocks: i64) {
+        self.utxo_pool_average_age_blocks.set(average_age_blocks);
+        self.utxo_pool_oldest_age_blocks.set(oldest_age_blocks);
+    }
+
     pub fn update_onchain_state(&self, state: &crate::onchain::OnchainState) {
         self.latest_checkpoint_height
             .set(state.latest_checkpoint_height() as i64);
@@ -1813,5 +1869,42 @@ mod tests {
                 metrics.record_guardian_rpc(method, outcome, 0.1);
             }
         }
+    }
+
+    #[test]
+    fn utxo_pool_age_metrics_publish_average_and_oldest_ages() {
+        let metrics = Metrics::new(&Registry::new());
+        let ages = calculate_utxo_pool_ages(1_000, [Ok::<u32, ()>(100), Ok(400), Ok(700)]).unwrap();
+
+        metrics.set_utxo_pool_ages(ages.0, ages.1);
+
+        assert_eq!(metrics.utxo_pool_average_age_blocks.get(), 600);
+        assert_eq!(metrics.utxo_pool_oldest_age_blocks.get(), 900);
+    }
+
+    #[test]
+    fn utxo_pool_age_metrics_saturate_age_at_zero_above_tip() {
+        assert_eq!(
+            calculate_utxo_pool_ages(1_000, [Ok::<u32, ()>(1_001)]).unwrap(),
+            (0, 0)
+        );
+    }
+
+    #[test]
+    fn utxo_pool_age_metrics_report_zero_for_an_empty_pool() {
+        assert_eq!(
+            calculate_utxo_pool_ages(1_000, std::iter::empty::<Result<u32, ()>>()).unwrap(),
+            (0, 0)
+        );
+    }
+
+    #[test]
+    fn utxo_pool_age_metrics_publish_failure_sentinel() {
+        let metrics = Metrics::new(&Registry::new());
+
+        metrics.set_utxo_pool_ages(-1, -1);
+
+        assert_eq!(metrics.utxo_pool_average_age_blocks.get(), -1);
+        assert_eq!(metrics.utxo_pool_oldest_age_blocks.get(), -1);
     }
 }

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -258,6 +258,13 @@ pub struct CoinSelectionParams {
     /// Step 3.
     pub max_inputs: usize,
 
+    /// UTXO that must be included in selection.
+    ///
+    /// An absent or ineligible required input causes selection to fail. When
+    /// eligible, it is selected before the otherwise largest-first funding
+    /// inputs and counts toward [`Self::max_inputs`].
+    pub required_input: Option<UtxoId>,
+
     /// Maximum number of withdrawal requests that may be batched into a single
     /// transaction.
     pub max_withdrawal_requests: usize,
@@ -459,6 +466,7 @@ impl CoinSelectionParams {
             max_tx_weight: Self::DEFAULT_MAX_TX_WEIGHT,
             max_ancestor_package_weight: Self::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT,
             max_inputs: Self::DEFAULT_MAX_INPUTS,
+            required_input: None,
             max_withdrawal_requests: Self::MAX_WITHDRAWAL_REQUESTS,
             max_fee_per_request,
             min_fee_rate: Self::DEFAULT_MIN_FEE_RATE,
@@ -530,6 +538,11 @@ pub enum CoinSelectionError {
     /// No withdrawal requests were provided to the algorithm.
     #[error("no withdrawal requests provided")]
     NoRequests,
+
+    /// The required input is absent from the supplied pool or does not satisfy
+    /// the normal input eligibility rules.
+    #[error("required input {0:?} is unavailable")]
+    RequiredInputUnavailable(UtxoId),
 
     /// The final per-request fee share exceeds `params.max_fee_per_request`.
     ///
@@ -663,6 +676,7 @@ impl CoinSelectionError {
         match self {
             Self::EmptyPool => "empty_pool",
             Self::NoRequests => "no_requests",
+            Self::RequiredInputUnavailable(_) => "required_input_unavailable",
             Self::FeeExceedsCap { .. } => "fee_exceeds_cap",
             Self::SubDustChange { .. } => "sub_dust_change",
             Self::InsufficientFunds { .. } => "insufficient_funds",
@@ -736,8 +750,9 @@ fn fee_for_weight(fee_rate: FeeRate, weight: Weight) -> u64 {
 /// 1. **Request selection** — up to `max_withdrawal_requests` requests
 ///    are taken oldest-first by timestamp.
 ///
-/// 2. **Input selection** — UTXOs are sorted largest-first and selected
-///    greedily until `input_total >= total_requested`. Both confirmed
+/// 2. **Input selection** — UTXOs are sorted largest-first. If
+///    `required_input` is configured, it is moved to the front, then inputs are
+///    selected greedily until `input_total >= total_requested`. Both confirmed
 ///    and pending UTXOs are eligible, subject to the
 ///    `max_mempool_chain_depth` filter.
 ///
@@ -767,7 +782,12 @@ pub fn select_coins(
 ) -> Result<CoinSelectionResult, CoinSelectionError> {
     // ── Early validation ────────────────────────────────────────────────────
     if utxos.is_empty() {
-        return Err(CoinSelectionError::EmptyPool);
+        return match params.required_input {
+            Some(required_input) => {
+                Err(CoinSelectionError::RequiredInputUnavailable(required_input))
+            }
+            None => Err(CoinSelectionError::EmptyPool),
+        };
     }
     if requests.is_empty() {
         return Err(CoinSelectionError::NoRequests);
@@ -802,13 +822,14 @@ pub fn select_coins(
     }
     let total_requested = builder.total_requested();
 
-    // ── Step 2: Input selection (largest-first) ────────────────────────────
+    // ── Step 2: Input selection (required first, then largest-first) ────────
     //
-    // Sort all UTXOs by descending value, then by id for determinism.
-    // Both confirmed and pending UTXOs are eligible — pending ones may
-    // require CPFP fee boosting, accounted for in Step 4. UTXOs with
-    // too many mempool-only (0-confirmation) ancestors are excluded to
-    // stay within Bitcoin's relay policy limits.
+    // Sort all UTXOs by descending value, then by id for determinism. Both
+    // confirmed and pending UTXOs are eligible — pending ones may require CPFP
+    // fee boosting, accounted for in Step 4. UTXOs with too many mempool-only
+    // (0-confirmation) ancestors are excluded to stay within Bitcoin's relay
+    // policy limits. A configured required input is moved to the front after
+    // eligibility filtering.
     let mut pool: Vec<&UtxoCandidate> = utxos
         .iter()
         .filter(|u| {
@@ -826,6 +847,14 @@ pub fn select_coins(
         })
         .collect();
     pool.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| a.id.cmp(&b.id)));
+
+    if let Some(required_input) = params.required_input {
+        let Some(required_index) = pool.iter().position(|utxo| utxo.id == required_input) else {
+            return Err(CoinSelectionError::RequiredInputUnavailable(required_input));
+        };
+        let required = pool.remove(required_index);
+        pool.insert(0, required);
+    }
 
     let mut input_total = 0u64;
 

--- a/crates/hashi/src/utxo_pool/mod.rs
+++ b/crates/hashi/src/utxo_pool/mod.rs
@@ -61,6 +61,10 @@ pub const TR_DUST_RELAY_MIN_VALUE: u64 = 330;
 /// threshold at Bitcoin's default dust relay fee of 3 sat/vByte.
 const WPKH_DUST_RELAY_MIN_VALUE: u64 = 294;
 
+/// 4,320 blocks is a ten-minute-target estimate of half the fixed 60-day
+/// time-based CSV delay, not consensus recovery eligibility.
+const RECOVERY_PRIORITY_AGE_BLOCKS: u32 = 30 * 24 * 6;
+
 // ── Spend Path ───────────────────────────────────────────────────────────────
 
 /// Describes the spend path for a UTXO, used to calculate the witness
@@ -206,6 +210,9 @@ pub struct UtxoCandidate {
     pub id: UtxoId,
     /// The value of this UTXO in satoshis.
     pub amount: u64,
+    /// Best-effort confirmation age sampled from one stable Bitcoin height
+    /// snapshot. Pending or unavailable ages are `None`.
+    pub confirmation_age_blocks: Option<u32>,
     /// The spend path for this UTXO, used to compute the weight contribution
     /// of this input to the transaction.
     pub spend_path: SpendPath,
@@ -257,13 +264,6 @@ pub struct CoinSelectionParams {
     /// primary inputs selected in Step 2 and any consolidation inputs added in
     /// Step 3.
     pub max_inputs: usize,
-
-    /// UTXO that must be included in selection.
-    ///
-    /// An absent or ineligible required input causes selection to fail. When
-    /// eligible, it is selected before the otherwise largest-first funding
-    /// inputs and counts toward [`Self::max_inputs`].
-    pub required_input: Option<UtxoId>,
 
     /// Maximum number of withdrawal requests that may be batched into a single
     /// transaction.
@@ -466,7 +466,6 @@ impl CoinSelectionParams {
             max_tx_weight: Self::DEFAULT_MAX_TX_WEIGHT,
             max_ancestor_package_weight: Self::DEFAULT_MAX_ANCESTOR_PACKAGE_WEIGHT,
             max_inputs: Self::DEFAULT_MAX_INPUTS,
-            required_input: None,
             max_withdrawal_requests: Self::MAX_WITHDRAWAL_REQUESTS,
             max_fee_per_request,
             min_fee_rate: Self::DEFAULT_MIN_FEE_RATE,
@@ -538,11 +537,6 @@ pub enum CoinSelectionError {
     /// No withdrawal requests were provided to the algorithm.
     #[error("no withdrawal requests provided")]
     NoRequests,
-
-    /// The required input is absent from the supplied pool or does not satisfy
-    /// the normal input eligibility rules.
-    #[error("required input {0:?} is unavailable")]
-    RequiredInputUnavailable(UtxoId),
 
     /// The final per-request fee share exceeds `params.max_fee_per_request`.
     ///
@@ -676,7 +670,6 @@ impl CoinSelectionError {
         match self {
             Self::EmptyPool => "empty_pool",
             Self::NoRequests => "no_requests",
-            Self::RequiredInputUnavailable(_) => "required_input_unavailable",
             Self::FeeExceedsCap { .. } => "fee_exceeds_cap",
             Self::SubDustChange { .. } => "sub_dust_change",
             Self::InsufficientFunds { .. } => "insufficient_funds",
@@ -750,16 +743,16 @@ fn fee_for_weight(fee_rate: FeeRate, weight: Weight) -> u64 {
 /// 1. **Request selection** — up to `max_withdrawal_requests` requests
 ///    are taken oldest-first by timestamp.
 ///
-/// 2. **Input selection** — UTXOs are sorted largest-first. If
-///    `required_input` is configured, it is moved to the front, then inputs are
-///    selected greedily until `input_total >= total_requested`. Both confirmed
-///    and pending UTXOs are eligible, subject to the
-///    `max_mempool_chain_depth` filter.
+/// 2. **Input selection** — UTXOs are sorted largest-first, then selected
+///    greedily until `input_total >= total_requested`. Both confirmed and
+///    pending UTXOs are eligible, subject to the `max_mempool_chain_depth`
+///    filter. Confirmation age never affects funding order.
 ///
 /// 3. **Consolidation** — if there is change (excess input value) and
-///    the fee rate is favourable, extra *confirmed* UTXOs are pulled in
-///    smallest-first to reduce the UTXO set. Aggressiveness depends on
-///    the fee environment:
+///    the fee rate is favourable, extra *confirmed* UTXOs are pulled in to
+///    reduce the UTXO set. Recovery-risk candidates older than 4,320 blocks
+///    are considered oldest-first, then ordinary candidates smallest-first.
+///    Aggressiveness depends on the fee environment:
 ///    - Below `long_term_fee_rate`: up to `input_budget × N` extras.
 ///    - Between long-term and `high_fee_rate_threshold`: up to
 ///      `input_budget × N / 2` extras.
@@ -782,12 +775,7 @@ pub fn select_coins(
 ) -> Result<CoinSelectionResult, CoinSelectionError> {
     // ── Early validation ────────────────────────────────────────────────────
     if utxos.is_empty() {
-        return match params.required_input {
-            Some(required_input) => {
-                Err(CoinSelectionError::RequiredInputUnavailable(required_input))
-            }
-            None => Err(CoinSelectionError::EmptyPool),
-        };
+        return Err(CoinSelectionError::EmptyPool);
     }
     if requests.is_empty() {
         return Err(CoinSelectionError::NoRequests);
@@ -822,14 +810,13 @@ pub fn select_coins(
     }
     let total_requested = builder.total_requested();
 
-    // ── Step 2: Input selection (required first, then largest-first) ────────
+    // ── Step 2: Input selection (largest-first) ─────────────────────────────
     //
     // Sort all UTXOs by descending value, then by id for determinism. Both
     // confirmed and pending UTXOs are eligible — pending ones may require CPFP
     // fee boosting, accounted for in Step 4. UTXOs with too many mempool-only
     // (0-confirmation) ancestors are excluded to stay within Bitcoin's relay
-    // policy limits. A configured required input is moved to the front after
-    // eligibility filtering.
+    // policy limits.
     let mut pool: Vec<&UtxoCandidate> = utxos
         .iter()
         .filter(|u| {
@@ -847,14 +834,6 @@ pub fn select_coins(
         })
         .collect();
     pool.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| a.id.cmp(&b.id)));
-
-    if let Some(required_input) = params.required_input {
-        let Some(required_index) = pool.iter().position(|utxo| utxo.id == required_input) else {
-            return Err(CoinSelectionError::RequiredInputUnavailable(required_input));
-        };
-        let required = pool.remove(required_index);
-        pool.insert(0, required);
-    }
 
     let mut input_total = 0u64;
 
@@ -890,11 +869,12 @@ pub fn select_coins(
 
     // ── Step 3: Consolidation ──────────────────────────────────────────
     //
-    // Pull in extra *confirmed* inputs (smallest-first) to reduce the
-    // UTXO set toward a single output. Only confirmed UTXOs are
-    // eligible — pending UTXOs would add unaccounted ancestors to the
-    // CPFP calculation. Consolidation only runs when there is already
-    // a change output (raw_change > 0).
+    // Pull in extra *confirmed* inputs to reduce the UTXO set toward a single
+    // output. Recovery-risk UTXOs are considered oldest-first before ordinary
+    // candidates are considered smallest-first. Pending UTXOs remain
+    // ineligible because they would add unaccounted ancestors to the CPFP
+    // calculation. Consolidation only runs when there is already a change
+    // output (raw_change > 0).
     //
     // The aggressiveness depends on the fee environment:
     // - Below long-term rate: up to `input_budget × N` extras.
@@ -920,7 +900,24 @@ pub fn select_coins(
             })
             .copied()
             .collect();
-        remaining.sort_by_key(|u| u.amount);
+        remaining.sort_by(|a, b| {
+            let a_urgent = a
+                .confirmation_age_blocks
+                .is_some_and(|age| age > RECOVERY_PRIORITY_AGE_BLOCKS);
+            let b_urgent = b
+                .confirmation_age_blocks
+                .is_some_and(|age| age > RECOVERY_PRIORITY_AGE_BLOCKS);
+            match (a_urgent, b_urgent) {
+                (true, true) => b
+                    .confirmation_age_blocks
+                    .cmp(&a.confirmation_age_blocks)
+                    .then_with(|| a.amount.cmp(&b.amount))
+                    .then_with(|| a.id.cmp(&b.id)),
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                (false, false) => a.amount.cmp(&b.amount).then_with(|| a.id.cmp(&b.id)),
+            }
+        });
 
         for utxo in remaining.into_iter().take(max_consolidation) {
             if builder.inputs.len() >= params.max_inputs {
@@ -931,7 +928,7 @@ pub fn select_coins(
 
             // If adding this input pushed fees or weight over the
             // limit, undo it and stop consolidating. This is a
-            // greedy heuristic: inputs are sorted smallest-first and
+            // greedy heuristic: prioritized inputs are deterministic and
             // transaction weight increases monotonically.
             if builder.check_fees().is_err() || builder.exceeds_any_weight_limit() {
                 builder.inputs.pop();

--- a/crates/hashi/src/utxo_pool/sim.rs
+++ b/crates/hashi/src/utxo_pool/sim.rs
@@ -570,6 +570,7 @@ impl Simulator {
             let candidate = UtxoCandidate {
                 id,
                 amount,
+                confirmation_age_blocks: None,
                 spend_path: SpendPath::TaprootScriptPath2of2,
                 status: UtxoStatus::Pending {
                     chain: vec![AncestorTx {
@@ -773,6 +774,7 @@ impl Simulator {
             let candidate = UtxoCandidate {
                 id,
                 amount: change,
+                confirmation_age_blocks: None,
                 spend_path: SpendPath::TaprootScriptPath2of2,
                 status: UtxoStatus::Pending {
                     chain: vec![AncestorTx {

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -1202,6 +1202,162 @@ fn test_largest_first_input_selection() {
 }
 
 #[test]
+fn test_required_small_input_is_selected_before_largest_funding_input() {
+    let required = confirmed_utxo(1, 1_000);
+    let required_id = required.id;
+    let utxos = vec![confirmed_utxo(2, 100_000), required];
+    let requests = vec![make_request(1, 50_000, 0)];
+    let params = CoinSelectionParams {
+        required_input: Some(required_id),
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &requests,
+        &params,
+        CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD,
+    )
+    .expect("required input and funding input should be selected");
+
+    assert_eq!(
+        result.inputs.iter().map(|utxo| utxo.id).collect::<Vec<_>>(),
+        vec![required_id, make_utxo_id(2)]
+    );
+    assert_conservation(&result);
+}
+
+#[test]
+fn test_required_input_that_funds_request_is_selected_alone() {
+    let required = confirmed_utxo(1, 100_000);
+    let required_id = required.id;
+    let utxos = vec![confirmed_utxo(2, 1_000_000), required];
+    let requests = vec![make_request(1, 50_000, 0)];
+    let params = CoinSelectionParams {
+        required_input: Some(required_id),
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &requests,
+        &params,
+        CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD,
+    )
+    .expect("required input should fund the request");
+
+    assert_eq!(result.inputs.len(), 1);
+    assert_eq!(result.inputs[0].id, required_id);
+    assert_conservation(&result);
+}
+
+#[test]
+fn test_non_required_inputs_remain_largest_first() {
+    let required = confirmed_utxo(1, 1_000);
+    let required_id = required.id;
+    let utxos = vec![
+        confirmed_utxo(5, 60_000),
+        confirmed_utxo(3, 90_000),
+        required,
+        confirmed_utxo(4, 70_000),
+        confirmed_utxo(2, 100_000),
+    ];
+    let requests = vec![make_request(1, 250_000, 0)];
+    let params = CoinSelectionParams {
+        required_input: Some(required_id),
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &requests,
+        &params,
+        CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD,
+    )
+    .expect("required and largest remaining inputs should fund the request");
+
+    assert_eq!(
+        result.inputs.iter().map(|utxo| utxo.id).collect::<Vec<_>>(),
+        vec![
+            required_id,
+            make_utxo_id(2),
+            make_utxo_id(3),
+            make_utxo_id(4),
+        ]
+    );
+    assert_conservation(&result);
+}
+
+#[test]
+fn test_required_input_counts_against_max_inputs() {
+    let required = confirmed_utxo(1, 1_000);
+    let required_id = required.id;
+    let utxos = vec![required, confirmed_utxo(2, 100_000)];
+    let requests = vec![make_request(1, 50_000, 0)];
+    let params = CoinSelectionParams {
+        required_input: Some(required_id),
+        max_inputs: 1,
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &requests,
+        &params,
+        CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CoinSelectionError::InsufficientFunds {
+            available: 101_000,
+            selected: 1_000,
+            required: 50_000,
+            selected_inputs: 1,
+            max_inputs: 1,
+        })
+    ));
+}
+
+#[test]
+fn test_absent_required_input_is_unavailable() {
+    let required_id = make_utxo_id(9);
+    let utxos = vec![confirmed_utxo(1, 100_000)];
+    let requests = vec![make_request(1, 50_000, 0)];
+    let params = CoinSelectionParams {
+        required_input: Some(required_id),
+        ..default_params()
+    };
+
+    let result = select_coins(&utxos, &requests, &params, default_fee_rate());
+
+    assert!(matches!(
+        result,
+        Err(CoinSelectionError::RequiredInputUnavailable(id)) if id == required_id
+    ));
+}
+
+#[test]
+fn test_ineligible_required_input_is_unavailable() {
+    let required = pending_utxo(1, 100_000);
+    let required_id = required.id;
+    let utxos = vec![required, confirmed_utxo(2, 100_000)];
+    let requests = vec![make_request(1, 50_000, 0)];
+    let params = CoinSelectionParams {
+        required_input: Some(required_id),
+        max_mempool_chain_depth: 0,
+        ..default_params()
+    };
+
+    let result = select_coins(&utxos, &requests, &params, default_fee_rate());
+
+    assert!(matches!(
+        result,
+        Err(CoinSelectionError::RequiredInputUnavailable(id)) if id == required_id
+    ));
+}
+
+#[test]
 fn test_multiple_inputs_needed_largest_first() {
     let utxos: Vec<UtxoCandidate> = (0u8..10).map(|i| confirmed_utxo(i, 50_000)).collect();
     let requests = vec![make_request(1, 300_000, 0)];

--- a/crates/hashi/src/utxo_pool/tests.rs
+++ b/crates/hashi/src/utxo_pool/tests.rs
@@ -47,9 +47,16 @@ fn confirmed_utxo(n: u8, amount: u64) -> UtxoCandidate {
     UtxoCandidate {
         id: make_utxo_id(n),
         amount,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Confirmed,
     }
+}
+
+fn confirmed_utxo_with_age(n: u8, amount: u64, age: u32) -> UtxoCandidate {
+    let mut utxo = confirmed_utxo(n, amount);
+    utxo.confirmation_age_blocks = Some(age);
+    utxo
 }
 
 fn confirmed_utxo_with_vout(vout: u32, amount: u64) -> UtxoCandidate {
@@ -59,6 +66,7 @@ fn confirmed_utxo_with_vout(vout: u32, amount: u64) -> UtxoCandidate {
             vout,
         },
         amount,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Confirmed,
     }
@@ -80,6 +88,7 @@ fn pending_utxo(n: u8, amount: u64) -> UtxoCandidate {
     UtxoCandidate {
         id: make_utxo_id(n),
         amount,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
@@ -107,6 +116,7 @@ fn pending_utxo_deep(n: u8, amount: u64, depth: usize, fee_per_ancestor: u64) ->
     UtxoCandidate {
         id: make_utxo_id(n),
         amount,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending { chain },
     }
@@ -128,6 +138,7 @@ fn pending_utxo_mixed(n: u8, amount: u64, ancestors: &[(u32, u64, u64)]) -> Utxo
     UtxoCandidate {
         id: make_utxo_id(n),
         amount,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending { chain },
     }
@@ -395,6 +406,7 @@ fn test_cpfp_pending_utxo_increases_fee() {
     let low_fee_ancestor = UtxoCandidate {
         id: make_utxo_id(1),
         amount: 5_000_000,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
@@ -451,6 +463,7 @@ fn test_cpfp_multiple_pending_utxos_summed() {
     let utxo1 = UtxoCandidate {
         id: make_utxo_id(1),
         amount: 200_000,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
@@ -464,6 +477,7 @@ fn test_cpfp_multiple_pending_utxos_summed() {
     let utxo2 = UtxoCandidate {
         id: make_utxo_id(2),
         amount: 200_000,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
@@ -559,6 +573,113 @@ fn test_low_fee_consolidation_active_smallest_first() {
             "second-smallest should be consolidated: {extra_amounts:?}"
         );
     }
+    assert_conservation(&result);
+}
+
+#[test]
+fn test_urgent_consolidation_starts_strictly_above_boundary() {
+    let utxos = vec![
+        confirmed_utxo(1, 1_000_000),
+        confirmed_utxo_with_age(2, 5_000, 4_320),
+        confirmed_utxo_with_age(3, 20_000, 4_321),
+    ];
+    let params = CoinSelectionParams {
+        max_inputs: 2,
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &[make_request(1, 500_000, 0)],
+        &params,
+        FeeRate::from_sat_per_vb_unchecked(1),
+    )
+    .expect("urgent candidate should fit the consolidation envelope");
+
+    assert_eq!(
+        result.inputs.iter().map(|u| u.id).collect::<Vec<_>>(),
+        vec![make_utxo_id(1), make_utxo_id(3)]
+    );
+    assert_conservation(&result);
+}
+
+#[test]
+fn test_multiple_urgent_consolidation_candidates_are_oldest_first() {
+    let utxos = vec![
+        confirmed_utxo(1, 1_000_000),
+        confirmed_utxo_with_age(2, 10_000, 5_000),
+        confirmed_utxo_with_age(3, 20_000, 6_000),
+    ];
+    let params = CoinSelectionParams {
+        max_inputs: 2,
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &[make_request(1, 500_000, 0)],
+        &params,
+        FeeRate::from_sat_per_vb_unchecked(1),
+    )
+    .expect("oldest urgent candidate should fit");
+
+    assert_eq!(result.inputs[1].id, make_utxo_id(3));
+    assert_conservation(&result);
+}
+
+#[test]
+fn test_equal_age_urgent_candidates_use_amount_then_id() {
+    let utxos = vec![
+        confirmed_utxo(1, 1_000_000),
+        confirmed_utxo_with_age(4, 10_000, 5_000),
+        confirmed_utxo_with_age(3, 20_000, 5_000),
+        confirmed_utxo_with_age(2, 10_000, 5_000),
+    ];
+    let params = CoinSelectionParams {
+        max_inputs: 3,
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &[make_request(1, 500_000, 0)],
+        &params,
+        FeeRate::from_sat_per_vb_unchecked(1),
+    )
+    .expect("equal-age urgent candidates should consolidate deterministically");
+
+    assert_eq!(
+        result.inputs.iter().map(|u| u.id).collect::<Vec<_>>(),
+        vec![make_utxo_id(1), make_utxo_id(2), make_utxo_id(4)]
+    );
+    assert_conservation(&result);
+}
+
+#[test]
+fn test_unknown_and_non_urgent_consolidation_remain_smallest_first() {
+    let utxos = vec![
+        confirmed_utxo(1, 1_000_000),
+        confirmed_utxo_with_age(2, 20_000, 4_320),
+        confirmed_utxo(3, 5_000),
+        confirmed_utxo_with_age(4, 10_000, 100),
+    ];
+    let params = CoinSelectionParams {
+        max_inputs: 3,
+        ..default_params()
+    };
+
+    let result = select_coins(
+        &utxos,
+        &[make_request(1, 500_000, 0)],
+        &params,
+        FeeRate::from_sat_per_vb_unchecked(1),
+    )
+    .expect("ordinary candidates should consolidate smallest-first");
+
+    assert_eq!(
+        result.inputs.iter().map(|u| u.id).collect::<Vec<_>>(),
+        vec![make_utxo_id(1), make_utxo_id(3), make_utxo_id(4)]
+    );
     assert_conservation(&result);
 }
 
@@ -666,17 +787,24 @@ fn test_no_consolidation_when_raw_change_zero() {
 
 #[test]
 fn test_consolidation_only_confirmed_utxos() {
-    // Consolidation should only pull in confirmed UTXOs, never pending.
+    let mut urgent_pending = pending_utxo(2, 5_000);
+    urgent_pending.confirmation_age_blocks = Some(10_000);
     let utxos = vec![
-        confirmed_utxo(1, 1_000_000), // covers request
-        pending_utxo(2, 5_000),       // pending, should not be consolidated
-        confirmed_utxo(3, 10_000),    // confirmed, eligible for consolidation
+        confirmed_utxo(1, 1_000_000),
+        urgent_pending,
+        confirmed_utxo(3, 10_000),
     ];
     let requests = vec![make_request(1, 200_000, 0)];
 
     let low_fee = FeeRate::from_sat_per_vb_unchecked(1);
     let result =
         select_coins(&utxos, &requests, &default_params(), low_fee).expect("should succeed");
+    assert!(
+        !result
+            .inputs
+            .iter()
+            .any(|input| input.id == make_utxo_id(2))
+    );
 
     // All extra inputs (beyond the first) must be confirmed.
     for input in &result.inputs {
@@ -867,6 +995,7 @@ fn arb_pending_utxo() -> impl Strategy<Value = UtxoCandidate> {
             UtxoCandidate {
                 id: make_utxo_id(id),
                 amount,
+                confirmation_age_blocks: None,
                 spend_path: SpendPath::TaprootScriptPath2of2,
                 status: UtxoStatus::Pending { chain },
             }
@@ -1202,100 +1331,14 @@ fn test_largest_first_input_selection() {
 }
 
 #[test]
-fn test_required_small_input_is_selected_before_largest_funding_input() {
-    let required = confirmed_utxo(1, 1_000);
-    let required_id = required.id;
-    let utxos = vec![confirmed_utxo(2, 100_000), required];
+fn test_age_metadata_does_not_displace_largest_funding_input() {
+    let mut aged = confirmed_utxo(1, 1_000);
+    aged.confirmation_age_blocks = Some(10_000);
+    let newer = confirmed_utxo(2, 100_000);
+    let newer_id = newer.id;
+    let utxos = vec![aged, newer];
     let requests = vec![make_request(1, 50_000, 0)];
     let params = CoinSelectionParams {
-        required_input: Some(required_id),
-        ..default_params()
-    };
-
-    let result = select_coins(
-        &utxos,
-        &requests,
-        &params,
-        CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD,
-    )
-    .expect("required input and funding input should be selected");
-
-    assert_eq!(
-        result.inputs.iter().map(|utxo| utxo.id).collect::<Vec<_>>(),
-        vec![required_id, make_utxo_id(2)]
-    );
-    assert_conservation(&result);
-}
-
-#[test]
-fn test_required_input_that_funds_request_is_selected_alone() {
-    let required = confirmed_utxo(1, 100_000);
-    let required_id = required.id;
-    let utxos = vec![confirmed_utxo(2, 1_000_000), required];
-    let requests = vec![make_request(1, 50_000, 0)];
-    let params = CoinSelectionParams {
-        required_input: Some(required_id),
-        ..default_params()
-    };
-
-    let result = select_coins(
-        &utxos,
-        &requests,
-        &params,
-        CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD,
-    )
-    .expect("required input should fund the request");
-
-    assert_eq!(result.inputs.len(), 1);
-    assert_eq!(result.inputs[0].id, required_id);
-    assert_conservation(&result);
-}
-
-#[test]
-fn test_non_required_inputs_remain_largest_first() {
-    let required = confirmed_utxo(1, 1_000);
-    let required_id = required.id;
-    let utxos = vec![
-        confirmed_utxo(5, 60_000),
-        confirmed_utxo(3, 90_000),
-        required,
-        confirmed_utxo(4, 70_000),
-        confirmed_utxo(2, 100_000),
-    ];
-    let requests = vec![make_request(1, 250_000, 0)];
-    let params = CoinSelectionParams {
-        required_input: Some(required_id),
-        ..default_params()
-    };
-
-    let result = select_coins(
-        &utxos,
-        &requests,
-        &params,
-        CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD,
-    )
-    .expect("required and largest remaining inputs should fund the request");
-
-    assert_eq!(
-        result.inputs.iter().map(|utxo| utxo.id).collect::<Vec<_>>(),
-        vec![
-            required_id,
-            make_utxo_id(2),
-            make_utxo_id(3),
-            make_utxo_id(4),
-        ]
-    );
-    assert_conservation(&result);
-}
-
-#[test]
-fn test_required_input_counts_against_max_inputs() {
-    let required = confirmed_utxo(1, 1_000);
-    let required_id = required.id;
-    let utxos = vec![required, confirmed_utxo(2, 100_000)];
-    let requests = vec![make_request(1, 50_000, 0)];
-    let params = CoinSelectionParams {
-        required_input: Some(required_id),
         max_inputs: 1,
         ..default_params()
     };
@@ -1305,56 +1348,12 @@ fn test_required_input_counts_against_max_inputs() {
         &requests,
         &params,
         CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD,
-    );
+    )
+    .expect("largest input should fund the request");
 
-    assert!(matches!(
-        result,
-        Err(CoinSelectionError::InsufficientFunds {
-            available: 101_000,
-            selected: 1_000,
-            required: 50_000,
-            selected_inputs: 1,
-            max_inputs: 1,
-        })
-    ));
-}
-
-#[test]
-fn test_absent_required_input_is_unavailable() {
-    let required_id = make_utxo_id(9);
-    let utxos = vec![confirmed_utxo(1, 100_000)];
-    let requests = vec![make_request(1, 50_000, 0)];
-    let params = CoinSelectionParams {
-        required_input: Some(required_id),
-        ..default_params()
-    };
-
-    let result = select_coins(&utxos, &requests, &params, default_fee_rate());
-
-    assert!(matches!(
-        result,
-        Err(CoinSelectionError::RequiredInputUnavailable(id)) if id == required_id
-    ));
-}
-
-#[test]
-fn test_ineligible_required_input_is_unavailable() {
-    let required = pending_utxo(1, 100_000);
-    let required_id = required.id;
-    let utxos = vec![required, confirmed_utxo(2, 100_000)];
-    let requests = vec![make_request(1, 50_000, 0)];
-    let params = CoinSelectionParams {
-        required_input: Some(required_id),
-        max_mempool_chain_depth: 0,
-        ..default_params()
-    };
-
-    let result = select_coins(&utxos, &requests, &params, default_fee_rate());
-
-    assert!(matches!(
-        result,
-        Err(CoinSelectionError::RequiredInputUnavailable(id)) if id == required_id
-    ));
+    assert_eq!(result.inputs.len(), 1);
+    assert_eq!(result.inputs[0].id, newer_id);
+    assert_conservation(&result);
 }
 
 #[test]
@@ -1508,6 +1507,7 @@ fn test_cpfp_no_deficit_for_well_paying_ancestor() {
     let well_paid = UtxoCandidate {
         id: make_utxo_id(1),
         amount: 5_000_000,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
@@ -1553,6 +1553,7 @@ fn test_cpfp_deficit_exhausts_fee_cap() {
     let heavy_low_fee = UtxoCandidate {
         id: make_utxo_id(1),
         amount: 5_000_000,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
@@ -1632,6 +1633,7 @@ fn test_fund_balance_with_cpfp() {
     let utxo = UtxoCandidate {
         id: make_utxo_id(1),
         amount: 2_000_000,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootScriptPath2of2,
         status: UtxoStatus::Pending {
             chain: vec![AncestorTx {
@@ -1805,6 +1807,7 @@ fn test_custom_spend_path_weight() {
     let utxo = UtxoCandidate {
         id: make_utxo_id(1),
         amount: 1_000_000,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::Custom(Weight::from_wu(100)),
         status: UtxoStatus::Confirmed,
     };
@@ -1828,6 +1831,7 @@ fn test_taproot_key_path_spend() {
     let utxo = UtxoCandidate {
         id: make_utxo_id(1),
         amount: 1_000_000,
+        confirmation_age_blocks: None,
         spend_path: SpendPath::TaprootKeyPath,
         status: UtxoStatus::Confirmed,
     };

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -1474,6 +1474,11 @@ impl Hashi {
             )
         };
 
+        let confirmed_unlocked_ids = confirmed_unlocked_utxo_ids(&utxo_records, &withdrawal_txns);
+        let required_input = self
+            .resolve_oldest_confirmed_utxo(&confirmed_unlocked_ids)
+            .await;
+
         // Query Bitcoin in parallel for the confirmation count of every
         // pending withdrawal so we can accurately fill AncestorTx::confirmations
         // instead of always hardcoding 0.
@@ -1552,6 +1557,7 @@ impl Hashi {
 
             let params = CoinSelectionParams {
                 max_inputs,
+                required_input,
                 min_fee_rate,
                 long_term_fee_rate: configured_long_term_fee_rate,
                 max_fee_per_request: self.onchain_state().worst_case_network_fee(),
@@ -1667,6 +1673,41 @@ impl Hashi {
             outputs,
             txid,
         })
+    }
+
+    /// Resolve the oldest confirmed unlocked UTXO to require as a withdrawal
+    /// input, so no pool UTXO ages toward the MPC-only recovery window.
+    ///
+    /// Best-effort: resolution failures (monitor not synced, a reorg or new
+    /// block mid-lookup, RPC errors) degrade to `None` so withdrawals keep
+    /// flowing without a required input rather than blocking on Bitcoin
+    /// lookups.
+    async fn resolve_oldest_confirmed_utxo(&self, ids: &[UtxoId]) -> Option<UtxoId> {
+        if ids.is_empty() {
+            return None;
+        }
+        let txids: BTreeSet<bitcoin::Txid> = ids.iter().map(|id| id.txid.into()).collect();
+        let result = self
+            .btc_monitor()
+            .resolve_utxo_confirmation_heights(txids)
+            .await
+            .and_then(|snapshot| {
+                oldest_confirmed_utxo_id(ids, &snapshot.confirmation_height_by_txid)
+            });
+        match result {
+            Ok(oldest) => oldest,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "Failed to resolve the oldest confirmed UTXO; \
+                     building the withdrawal without a required input",
+                );
+                self.metrics
+                    .utxo_required_input_resolution_failures_total
+                    .inc();
+                None
+            }
+        }
     }
 
     /// Run AML/Sanctions checks for a withdrawal request.
@@ -1853,6 +1894,47 @@ fn withdrawal_input_signing_id(withdrawal_txn_id: &Address, input_index: u32) ->
     let bytes =
         bcs::to_bytes(&(withdrawal_txn_id, input_index)).expect("serialization should succeed");
     Address::new(Blake2b256::digest(&bytes).digest)
+}
+
+/// Return the unlocked UTXOs that are known to be confirmed by the on-chain
+/// snapshot.
+///
+/// Change outputs are pending while their producing withdrawal remains in the
+/// same snapshot. Once that withdrawal has been removed, they are promoted to
+/// confirmed, matching [`build_utxo_status`].
+pub(crate) fn confirmed_unlocked_utxo_ids(
+    records: &BTreeMap<UtxoId, UtxoRecord>,
+    withdrawal_txns: &BTreeMap<Address, WithdrawalTransaction>,
+) -> Vec<UtxoId> {
+    records
+        .values()
+        .filter(|record| {
+            record.spent_by.is_none()
+                && record
+                    .produced_by
+                    .is_none_or(|producer| !withdrawal_txns.contains_key(&producer))
+        })
+        .map(|record| record.utxo.id)
+        .collect()
+}
+
+fn oldest_confirmed_utxo_id(
+    ids: &[UtxoId],
+    heights: &BTreeMap<bitcoin::Txid, u32>,
+) -> anyhow::Result<Option<UtxoId>> {
+    let mut oldest = None;
+    for &id in ids {
+        let txid: bitcoin::Txid = id.txid.into();
+        let height = heights
+            .get(&txid)
+            .copied()
+            .ok_or_else(|| anyhow!("missing confirmation height for UTXO {id:?}"))?;
+        let candidate = (height, id);
+        if oldest.is_none_or(|current| candidate < current) {
+            oldest = Some(candidate);
+        }
+    }
+    Ok(oldest.map(|(_, id)| id))
 }
 
 /// Query Bitcoin in parallel for the confirmation count of every pending
@@ -2354,6 +2436,136 @@ mod tests {
             },
             guardian_signatures: None,
         }
+    }
+
+    fn test_utxo_id(txid_byte: u8, vout: u32) -> UtxoId {
+        UtxoId {
+            txid: BitcoinTxid::new([txid_byte; 32]),
+            vout,
+        }
+    }
+
+    fn test_utxo_record(
+        id: UtxoId,
+        produced_by: Option<Address>,
+        spent_by: Option<Address>,
+    ) -> UtxoRecord {
+        UtxoRecord {
+            utxo: Utxo {
+                id,
+                amount: 1_000,
+                derivation_path: None,
+            },
+            produced_by,
+            spent_by,
+            spent_epoch: None,
+        }
+    }
+
+    fn test_confirmation_heights(entries: &[(UtxoId, u32)]) -> BTreeMap<bitcoin::Txid, u32> {
+        entries
+            .iter()
+            .map(|(id, height)| (id.txid.into(), *height))
+            .collect()
+    }
+
+    #[test]
+    fn oldest_confirmed_utxo_uses_lowest_confirmation_height() {
+        let newer = test_utxo_id(1, 0);
+        let older = test_utxo_id(2, 0);
+        let heights = test_confirmation_heights(&[(newer, 500), (older, 100)]);
+
+        assert_eq!(
+            oldest_confirmed_utxo_id(&[newer, older], &heights).unwrap(),
+            Some(older)
+        );
+    }
+
+    #[test]
+    fn oldest_confirmed_utxo_breaks_same_height_ties_by_id() {
+        let first = test_utxo_id(1, 1);
+        let second = test_utxo_id(2, 0);
+        let heights = test_confirmation_heights(&[(first, 100), (second, 100)]);
+
+        assert_eq!(
+            oldest_confirmed_utxo_id(&[second, first], &heights).unwrap(),
+            Some(first.min(second))
+        );
+    }
+
+    #[test]
+    fn oldest_confirmed_utxo_handles_outputs_sharing_a_txid() {
+        let first_output = test_utxo_id(3, 0);
+        let second_output = test_utxo_id(3, 1);
+        let heights = test_confirmation_heights(&[(first_output, 100)]);
+
+        assert_eq!(
+            oldest_confirmed_utxo_id(&[second_output, first_output], &heights).unwrap(),
+            Some(first_output)
+        );
+    }
+
+    #[test]
+    fn confirmed_unlocked_utxos_exclude_pending_and_locked_records() {
+        let confirmed = test_utxo_id(1, 0);
+        let pending = test_utxo_id(2, 0);
+        let locked = test_utxo_id(3, 0);
+        let pending_producer = Address::new([4; 32]);
+        let spender = Address::new([5; 32]);
+        let records = BTreeMap::from([
+            (confirmed, test_utxo_record(confirmed, None, None)),
+            (
+                pending,
+                test_utxo_record(pending, Some(pending_producer), None),
+            ),
+            (locked, test_utxo_record(locked, None, Some(spender))),
+        ]);
+        let withdrawal_txns =
+            BTreeMap::from([(pending_producer, make_txn(vec![], vec![], vec![]))]);
+
+        assert_eq!(
+            confirmed_unlocked_utxo_ids(&records, &withdrawal_txns),
+            vec![confirmed]
+        );
+    }
+
+    #[test]
+    fn confirmed_unlocked_utxos_include_change_with_absent_producer() {
+        let promoted = test_utxo_id(1, 0);
+        let removed_producer = Address::new([2; 32]);
+        let records = BTreeMap::from([(
+            promoted,
+            test_utxo_record(promoted, Some(removed_producer), None),
+        )]);
+
+        assert_eq!(
+            confirmed_unlocked_utxo_ids(&records, &BTreeMap::new()),
+            vec![promoted]
+        );
+    }
+
+    #[test]
+    fn confirmed_unlocked_and_oldest_helpers_handle_empty_pool() {
+        let ids = confirmed_unlocked_utxo_ids(&BTreeMap::new(), &BTreeMap::new());
+
+        assert!(ids.is_empty());
+        assert_eq!(
+            oldest_confirmed_utxo_id(&ids, &BTreeMap::new()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn oldest_confirmed_utxo_rejects_missing_height() {
+        let present = test_utxo_id(1, 0);
+        let missing = test_utxo_id(2, 0);
+        let heights = test_confirmation_heights(&[(present, 100)]);
+
+        let error = oldest_confirmed_utxo_id(&[present, missing], &heights).unwrap_err();
+        assert!(
+            error.to_string().contains("missing confirmation height"),
+            "unexpected error: {error}"
+        );
     }
 
     fn signing(

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -24,6 +24,7 @@ use sui_sdk_types::Address;
 
 use crate::Hashi;
 use crate::btc_monitor::monitor::TxStatus;
+use crate::btc_monitor::monitor::UtxoHeightSnapshot;
 use crate::leader::RetryPolicy;
 use crate::mpc::rpc::RpcP2PChannel;
 use crate::onchain::types::OutputUtxo;
@@ -1473,11 +1474,13 @@ impl Hashi {
                 state.hashi().bitcoin().utxo_pool.utxo_records().clone(),
             )
         };
-
         let confirmed_unlocked_ids = confirmed_unlocked_utxo_ids(&utxo_records, &withdrawal_txns);
-        let required_input = self
-            .resolve_oldest_confirmed_utxo(&confirmed_unlocked_ids)
-            .await;
+        let confirmation_ages = if fee_rate < CoinSelectionParams::DEFAULT_HIGH_FEE_RATE_THRESHOLD {
+            self.resolve_confirmed_utxo_ages(&confirmed_unlocked_ids)
+                .await
+        } else {
+            BTreeMap::new()
+        };
 
         // Query Bitcoin in parallel for the confirmation count of every
         // pending withdrawal so we can accurately fill AncestorTx::confirmations
@@ -1494,6 +1497,7 @@ impl Hashi {
                 UtxoCandidate {
                     id: r.utxo.id,
                     amount: r.utxo.amount,
+                    confirmation_age_blocks: confirmation_ages.get(&r.utxo.id).copied(),
                     spend_path: SpendPath::TaprootScriptPath2of2,
                     status,
                 }
@@ -1557,7 +1561,6 @@ impl Hashi {
 
             let params = CoinSelectionParams {
                 max_inputs,
-                required_input,
                 min_fee_rate,
                 long_term_fee_rate: configured_long_term_fee_rate,
                 max_fee_per_request: self.onchain_state().worst_case_network_fee(),
@@ -1675,37 +1678,32 @@ impl Hashi {
         })
     }
 
-    /// Resolve the oldest confirmed unlocked UTXO to require as a withdrawal
-    /// input, so no pool UTXO ages toward the MPC-only recovery window.
+    /// Resolve confirmation ages for confirmed unlocked UTXOs from one stable
+    /// Bitcoin height snapshot.
     ///
-    /// Best-effort: resolution failures (monitor not synced, a reorg or new
-    /// block mid-lookup, RPC errors) degrade to `None` so withdrawals keep
-    /// flowing without a required input rather than blocking on Bitcoin
-    /// lookups.
-    async fn resolve_oldest_confirmed_utxo(&self, ids: &[UtxoId]) -> Option<UtxoId> {
+    /// Best-effort: resolution failures degrade to an empty map so withdrawal
+    /// funding and ordinary smallest-first consolidation remain available.
+    async fn resolve_confirmed_utxo_ages(&self, ids: &[UtxoId]) -> BTreeMap<UtxoId, u32> {
         if ids.is_empty() {
-            return None;
+            return BTreeMap::new();
         }
         let txids: BTreeSet<bitcoin::Txid> = ids.iter().map(|id| id.txid.into()).collect();
         let result = self
             .btc_monitor()
             .resolve_utxo_confirmation_heights(txids)
             .await
-            .and_then(|snapshot| {
-                oldest_confirmed_utxo_id(ids, &snapshot.confirmation_height_by_txid)
-            });
+            .and_then(|snapshot| confirmation_age_blocks_by_utxo_id(ids, &snapshot));
         match result {
-            Ok(oldest) => oldest,
+            Ok(ages) => ages,
             Err(error) => {
                 tracing::warn!(
                     ?error,
-                    "Failed to resolve the oldest confirmed UTXO; \
-                     building the withdrawal without a required input",
+                    "Failed to resolve confirmed UTXO ages; using ordinary consolidation order",
                 );
                 self.metrics
-                    .utxo_required_input_resolution_failures_total
+                    .utxo_confirmation_age_resolution_failures_total
                     .inc();
-                None
+                BTreeMap::new()
             }
         }
     }
@@ -1918,23 +1916,21 @@ pub(crate) fn confirmed_unlocked_utxo_ids(
         .collect()
 }
 
-fn oldest_confirmed_utxo_id(
+fn confirmation_age_blocks_by_utxo_id(
     ids: &[UtxoId],
-    heights: &BTreeMap<bitcoin::Txid, u32>,
-) -> anyhow::Result<Option<UtxoId>> {
-    let mut oldest = None;
-    for &id in ids {
-        let txid: bitcoin::Txid = id.txid.into();
-        let height = heights
-            .get(&txid)
-            .copied()
-            .ok_or_else(|| anyhow!("missing confirmation height for UTXO {id:?}"))?;
-        let candidate = (height, id);
-        if oldest.is_none_or(|current| candidate < current) {
-            oldest = Some(candidate);
-        }
-    }
-    Ok(oldest.map(|(_, id)| id))
+    snapshot: &UtxoHeightSnapshot,
+) -> anyhow::Result<BTreeMap<UtxoId, u32>> {
+    ids.iter()
+        .map(|&id| {
+            let txid: bitcoin::Txid = id.txid.into();
+            let confirmation_height = snapshot
+                .confirmation_height_by_txid
+                .get(&txid)
+                .copied()
+                .ok_or_else(|| anyhow!("missing confirmation height for UTXO {id:?}"))?;
+            Ok((id, snapshot.tip.height.saturating_sub(confirmation_height)))
+        })
+        .collect()
 }
 
 /// Query Bitcoin in parallel for the confirmation count of every pending
@@ -2323,6 +2319,7 @@ mod tests {
     use crate::onchain::types::Utxo;
     use crate::onchain::types::UtxoId;
     use crate::utxo_pool::CoinSelectionParams;
+    use bitcoin::hashes::Hash as _;
     use hashi_types::bitcoin_txid::BitcoinTxid;
 
     fn a_signature() -> SchnorrSignature {
@@ -2469,39 +2466,45 @@ mod tests {
             .collect()
     }
 
+    fn test_height_snapshot(tip_height: u32, entries: &[(UtxoId, u32)]) -> UtxoHeightSnapshot {
+        UtxoHeightSnapshot {
+            tip: kyoto::HashCheckpoint::new(tip_height, bitcoin::BlockHash::all_zeros()),
+            confirmation_height_by_txid: test_confirmation_heights(entries),
+        }
+    }
+
     #[test]
-    fn oldest_confirmed_utxo_uses_lowest_confirmation_height() {
+    fn confirmation_ages_use_one_tip_for_different_heights() {
         let newer = test_utxo_id(1, 0);
         let older = test_utxo_id(2, 0);
-        let heights = test_confirmation_heights(&[(newer, 500), (older, 100)]);
+        let snapshot = test_height_snapshot(600, &[(newer, 500), (older, 100)]);
 
         assert_eq!(
-            oldest_confirmed_utxo_id(&[newer, older], &heights).unwrap(),
-            Some(older)
+            confirmation_age_blocks_by_utxo_id(&[newer, older], &snapshot).unwrap(),
+            BTreeMap::from([(newer, 100), (older, 500)])
         );
     }
 
     #[test]
-    fn oldest_confirmed_utxo_breaks_same_height_ties_by_id() {
-        let first = test_utxo_id(1, 1);
-        let second = test_utxo_id(2, 0);
-        let heights = test_confirmation_heights(&[(first, 100), (second, 100)]);
-
-        assert_eq!(
-            oldest_confirmed_utxo_id(&[second, first], &heights).unwrap(),
-            Some(first.min(second))
-        );
-    }
-
-    #[test]
-    fn oldest_confirmed_utxo_handles_outputs_sharing_a_txid() {
+    fn confirmation_ages_preserve_outputs_sharing_a_txid() {
         let first_output = test_utxo_id(3, 0);
         let second_output = test_utxo_id(3, 1);
-        let heights = test_confirmation_heights(&[(first_output, 100)]);
+        let snapshot = test_height_snapshot(600, &[(first_output, 100)]);
 
         assert_eq!(
-            oldest_confirmed_utxo_id(&[second_output, first_output], &heights).unwrap(),
-            Some(first_output)
+            confirmation_age_blocks_by_utxo_id(&[second_output, first_output], &snapshot,).unwrap(),
+            BTreeMap::from([(first_output, 500), (second_output, 500)])
+        );
+    }
+
+    #[test]
+    fn confirmation_age_saturates_when_height_exceeds_tip() {
+        let id = test_utxo_id(1, 0);
+        let snapshot = test_height_snapshot(100, &[(id, 101)]);
+
+        assert_eq!(
+            confirmation_age_blocks_by_utxo_id(&[id], &snapshot).unwrap(),
+            BTreeMap::from([(id, 0)])
         );
     }
 
@@ -2545,23 +2548,25 @@ mod tests {
     }
 
     #[test]
-    fn confirmed_unlocked_and_oldest_helpers_handle_empty_pool() {
+    fn confirmed_unlocked_and_confirmation_age_helpers_handle_empty_pool() {
         let ids = confirmed_unlocked_utxo_ids(&BTreeMap::new(), &BTreeMap::new());
+        let snapshot = test_height_snapshot(600, &[]);
 
         assert!(ids.is_empty());
-        assert_eq!(
-            oldest_confirmed_utxo_id(&ids, &BTreeMap::new()).unwrap(),
-            None
+        assert!(
+            confirmation_age_blocks_by_utxo_id(&ids, &snapshot)
+                .unwrap()
+                .is_empty()
         );
     }
 
     #[test]
-    fn oldest_confirmed_utxo_rejects_missing_height() {
+    fn confirmation_ages_reject_missing_height_for_complete_map() {
         let present = test_utxo_id(1, 0);
         let missing = test_utxo_id(2, 0);
-        let heights = test_confirmation_heights(&[(present, 100)]);
+        let snapshot = test_height_snapshot(600, &[(present, 100)]);
 
-        let error = oldest_confirmed_utxo_id(&[present, missing], &heights).unwrap_err();
+        let error = confirmation_age_blocks_by_utxo_id(&[present, missing], &snapshot).unwrap_err();
         assert!(
             error.to_string().contains("missing confirmation height"),
             "unexpected error: {error}"

--- a/design/docs/address-scheme.mdx
+++ b/design/docs/address-scheme.mdx
@@ -77,6 +77,13 @@ where:
   (`50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0`)
   with no known private key, ensuring all spends occur through the script path.
 
+Normal withdrawal funding remains largest-first. Within the existing
+fee-eligible consolidation budget, confirmed UTXOs older than 4,320 blocks are
+prioritized before ordinary smallest-first candidates. The 4,320-block
+threshold estimates 30 days using Bitcoin's ten-minute block target; actual
+MPC-only recovery eligibility remains governed by the time-based CSV script
+above.
+
 The key derivation is not BIP-32. It is a purpose-built unhardened derivation
 over secp256k1, keyed by the Sui address, giving each depositor a unique
 Bitcoin address while the master signing key remains shared across the MPC


### PR DESCRIPTION
Addresses [certora audit issue I-04](https://linear.app/mysten-labs/issue/IOP-630/mpc-only-recovery-path-becomes-available-while-the-guardian-is-still). The goal is to select old utxos to ensure none of them age past 60 days during normal operation.

This PR starts with a very simple naive solution, just adding the oldest utxo to each withdrawal tx as an input. If we want a more sophisticated solution we can add it as a subsequent PR.