### PR TITLE
[Guardian] Bind verified sessions to reader bucket

### DIFF
--- a/crates/hashi-guardian/src/s3_reader/mod.rs
+++ b/crates/hashi-guardian/src/s3_reader/mod.rs
@@ -10,7 +10,6 @@
 use crate::s3_client::GuardianS3Client;
 use crate::s3_client::ImmutabilityCheck;
 use hashi_types::guardian::s3::S3HourScopedDirectory;
-use hashi_types::guardian::BuildPcrs;
 use hashi_types::guardian::CeremonyLogMessage;
 use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
@@ -38,25 +37,6 @@ mod verified;
 
 pub use verified::VerifiedLogRecord;
 pub use verified::VerifiedSessionInfo;
-
-/// Internal policy for sharing read implementations that differ only in which
-/// attested guardian builds they accept.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum BuildPolicy {
-    /// Require the configured current build.
-    Current,
-    /// Accept any build represented in the PCR allowlist.
-    AnyAllowlisted,
-}
-
-impl BuildPolicy {
-    fn enforce(self, allowlist: &PcrAllowlist, build_pcrs: &BuildPcrs) -> GuardianResult<()> {
-        match self {
-            Self::Current => allowlist.require_current_build(build_pcrs),
-            Self::AnyAllowlisted => Ok(()),
-        }
-    }
-}
 
 /// Verified reader over the guardian's S3 logs.
 ///
@@ -169,7 +149,7 @@ impl GuardianReader {
     /// lexicographically greatest key identifies the latest ceremony.
     async fn read_latest_ceremony_log(
         &mut self,
-        build_policy: BuildPolicy,
+        require_current: bool,
     ) -> GuardianResult<Option<CeremonyLogMessage>> {
         let keys = self
             .s3
@@ -179,7 +159,10 @@ impl GuardianReader {
             return Ok(None);
         };
         let verified_record = self.read_verified_record(&key).await?;
-        build_policy.enforce(&self.allowlist, verified_record.build_pcrs())?;
+        if require_current {
+            self.allowlist
+                .require_current_build(verified_record.build_pcrs())?;
+        }
         let session_id = verified_record.entry().session_id().clone();
         let msg = match verified_record.into_entry().into_message() {
             V1(LogMessageV1::Ceremony(msg)) | V2(LogMessageV2::Ceremony(msg)) => msg,
@@ -200,7 +183,7 @@ impl GuardianReader {
     async fn read_latest_kp_share_state_log(
         &mut self,
         sharing_seq: u64,
-        build_policy: BuildPolicy,
+        require_current: bool,
     ) -> GuardianResult<Option<KpShareStateLogMessage>> {
         let prefix = KpShareStateLogMessage::object_key_dir(sharing_seq);
         let keys = self.s3.list_keys(&prefix, false).await?;
@@ -208,7 +191,7 @@ impl GuardianReader {
             return Ok(None);
         };
         let msg = self
-            .read_kp_share_state_log_at_key(&key, build_policy)
+            .read_kp_share_state_log_at_key(&key, require_current)
             .await?;
         if msg.sharing_seq != sharing_seq {
             return Err(InvalidS3Log(format!(
@@ -232,15 +215,14 @@ impl GuardianReader {
         cert_seq: u64,
     ) -> GuardianResult<KpShareStateLogMessage> {
         let key = KpShareStateLogMessage::object_key(session_id, sharing_seq, cert_seq);
-        self.read_kp_share_state_log_at_key(&key, BuildPolicy::Current)
-            .await
+        self.read_kp_share_state_log_at_key(&key, true).await
     }
 
     /// Read and verify one KP-share object under the requested build policy.
     async fn read_kp_share_state_log_at_key(
         &mut self,
         key: &str,
-        build_policy: BuildPolicy,
+        require_current: bool,
     ) -> GuardianResult<KpShareStateLogMessage> {
         // KP-share locks are expected to expire, so authenticate the record
         // without claiming that S3 still makes it immutable.
@@ -249,7 +231,10 @@ impl GuardianReader {
             .get_log_record_inner(key, ImmutabilityCheck::Skipped)
             .await?;
         let verified_record = self.verify_record(record).await?;
-        build_policy.enforce(&self.allowlist, verified_record.build_pcrs())?;
+        if require_current {
+            self.allowlist
+                .require_current_build(verified_record.build_pcrs())?;
+        }
         let session_id = verified_record.entry().session_id().clone();
         let msg = match verified_record.into_entry().into_message() {
             V1(LogMessageV1::KpShareState(msg)) => (*msg)
@@ -267,7 +252,7 @@ impl GuardianReader {
     /// Read the latest ceremony together with the latest KP-share state for its
     /// `sharing_seq`, accepting any allowlisted build.
     pub async fn read_latest_ceremony_state(&mut self) -> GuardianResult<CeremonyState> {
-        self.read_latest_ceremony_state_with_build_policy(BuildPolicy::AnyAllowlisted)
+        self.read_latest_ceremony_state_with_build_requirement(false)
             .await
     }
 
@@ -276,25 +261,25 @@ impl GuardianReader {
     pub async fn read_latest_ceremony_state_from_current_build(
         &mut self,
     ) -> GuardianResult<CeremonyState> {
-        self.read_latest_ceremony_state_with_build_policy(BuildPolicy::Current)
+        self.read_latest_ceremony_state_with_build_requirement(true)
             .await
     }
 
     /// Once a ceremony is present, its matching KP-share state must also exist
     /// because writers publish `kp-shares/` before `ceremony/`.
-    async fn read_latest_ceremony_state_with_build_policy(
+    async fn read_latest_ceremony_state_with_build_requirement(
         &mut self,
-        build_policy: BuildPolicy,
+        require_current: bool,
     ) -> GuardianResult<CeremonyState> {
         let ceremony = self
-            .read_latest_ceremony_log(build_policy)
+            .read_latest_ceremony_log(require_current)
             .await?
             .ok_or_else(|| {
                 InvalidInputs("no ceremony log found; setup_new_key has not run".into())
             })?;
         let sharing_seq = ceremony.sharing_seq();
         let kp_share_state = self
-            .read_latest_kp_share_state_log(sharing_seq, build_policy)
+            .read_latest_kp_share_state_log(sharing_seq, require_current)
             .await?
             .ok_or_else(|| {
                 InvalidS3Log(format!(

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -13,6 +13,7 @@ use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
 use hashi_types::guardian::PcrAllowlist;
+use hashi_types::guardian::S3BucketInfo;
 use hashi_types::guardian::VersionedLogMessage::V1;
 use hashi_types::guardian::VersionedLogMessage::V2;
 
@@ -84,6 +85,8 @@ impl VerifiedSessionInfo {
             .verify_replay(&signing_pubkey, &build_pcrs)
             .map_err(|e| InvalidS3Log(format!("attestation at key {att_key}: {e}")))?;
 
+        ensure_bucket_info_matches(session_id, info.bucket_info.as_ref(), s3.bucket_info())?;
+
         Ok(Self {
             signing_pubkey,
             info,
@@ -113,6 +116,24 @@ impl VerifiedSessionInfo {
     }
 }
 
+fn ensure_bucket_info_matches(
+    session_id: &str,
+    reported: Option<&S3BucketInfo>,
+    expected: &S3BucketInfo,
+) -> GuardianResult<()> {
+    let reported = reported.ok_or_else(|| {
+        InvalidS3Log(format!(
+            "session {session_id} GuardianInfo is missing bucket_info"
+        ))
+    })?;
+    if reported != expected {
+        return Err(InvalidS3Log(format!(
+            "session {session_id} GuardianInfo bucket_info {reported:?} does not match reader bucket_info {expected:?}"
+        )));
+    }
+    Ok(())
+}
+
 /// A log record whose message signature and writing session's attestation/PCRs
 /// have both been verified. The exact versioned entry is retained so callers
 /// can choose which schema versions they accept and how to interpret them.
@@ -138,5 +159,40 @@ impl VerifiedLogRecord {
 
     pub fn into_entry(self) -> LogEntry {
         self.entry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bucket_info(bucket: &str, region: &str) -> S3BucketInfo {
+        S3BucketInfo {
+            bucket: bucket.into(),
+            region: region.into(),
+        }
+    }
+
+    #[test]
+    fn matching_bucket_info_is_accepted() {
+        let expected = bucket_info("guardian-bucket", "us-east-1");
+        ensure_bucket_info_matches("session", Some(&expected), &expected).unwrap();
+    }
+
+    #[test]
+    fn mismatched_bucket_info_is_rejected() {
+        let expected = bucket_info("guardian-bucket", "us-east-1");
+        let reported = bucket_info("other-bucket", "us-west-2");
+
+        let error = ensure_bucket_info_matches("session", Some(&reported), &expected).unwrap_err();
+        assert!(matches!(error, InvalidS3Log(message) if message.contains("does not match")));
+    }
+
+    #[test]
+    fn missing_bucket_info_is_rejected() {
+        let expected = bucket_info("guardian-bucket", "us-east-1");
+
+        let error = ensure_bucket_info_matches("session", None, &expected).unwrap_err();
+        assert!(matches!(error, InvalidS3Log(message) if message.contains("missing bucket_info")));
     }
 }

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -99,6 +99,8 @@ pub struct GuardianInfo {
     pub secret_sharing_instance: Option<SecretSharingInstance>,
     /// S3 bucket name (if set). Used by KPs to check S3 bucket info.
     pub bucket_info: Option<S3BucketInfo>,
+    // TODO(SEC-525): Include the Bitcoin network in signed GuardianInfo so
+    // readers with a trusted expected network can validate it.
     /// Encryption key. Used by KPs to encrypt their shares.
     #[serde(with = "hex::serde")]
     pub encryption_pubkey: EncPubKeyBytes,


### PR DESCRIPTION
## Summary

- Bind every verified session to the reader S3 bucket and region by comparing the signed 02 `GuardianInfo.bucket_info` before caching the session.
- Reject missing or mismatched bucket metadata, with focused coverage for matching, missing, and mismatched values.
- Replace the two-variant build-policy enum with an explicit `require_current` flag while preserving the default any-allowlisted behavior and current-build-only paths.
- Leave Bitcoin-network binding documented as a broader SEC-525 follow-up.

## Testing

- `make fmt`
- `cargo check`

Fixes SEC-525. Post-activation record hardening is tracked separately in IOP-651.
