### PR TITLE
[Guardian] Verify initialization prerequisites when serving logs

### DIFF
--- a/crates/hashi-guardian/src/s3_reader/mod.rs
+++ b/crates/hashi-guardian/src/s3_reader/mod.rs
@@ -4,8 +4,8 @@
 //! Verified reads from the guardian's S3 logs.
 //!
 //! [`GuardianReader`] applies each log stream's S3 immutability policy, verifies
-//! records with their writing session's attestation-anchored key, and caches the
-//! verified session info for reuse.
+//! records with their writing session's attestation-anchored key and required
+//! initialization logs, and caches the verified session info for reuse.
 
 use crate::s3_client::GuardianS3Client;
 use crate::s3_client::ImmutabilityCheck;
@@ -66,28 +66,27 @@ impl GuardianReader {
         }
     }
 
-    /// Load and verify a session's attestation and guardian info on first use,
-    /// then return the cached result.
-    async fn get_or_load_session_info(
-        &mut self,
-        session_id: &str,
-    ) -> GuardianResult<&VerifiedSessionInfo> {
+    /// Load and verify a session's attestation and guardian info on first use.
+    async fn ensure_session_info_loaded(&mut self, session_id: &str) -> GuardianResult<()> {
         if !self.sessions.contains_key(session_id) {
             let session_info =
                 VerifiedSessionInfo::read_from_s3(&self.s3, session_id, &self.allowlist).await?;
             self.sessions.insert(session_id.into(), session_info);
         }
-        Ok(&self.sessions[session_id])
+        Ok(())
     }
 
-    /// Verify a record with its session's attestation-anchored signing key.
+    /// Verify a record and the initialization checkpoint required to emit it.
     async fn verify_record(&mut self, record: LogRecord) -> GuardianResult<VerifiedLogRecord> {
-        let session_info = self.get_or_load_session_info(record.session_id()).await?;
-        session_info.verify_record(record)
+        self.ensure_session_info_loaded(record.session_id()).await?;
+        let session_info = self
+            .sessions
+            .get_mut(record.session_id())
+            .expect("session info was loaded above");
+        session_info.verify_record(&self.s3, record).await
     }
 
-    /// Read an immutable S3 record and verify it with its session's
-    /// attestation-anchored signing key.
+    /// Read an immutable S3 record and verify it against its writing session.
     async fn read_verified_record(&mut self, key: &str) -> GuardianResult<VerifiedLogRecord> {
         let record = self.s3.get_log_record(key).await?;
         self.verify_record(record).await
@@ -137,10 +136,14 @@ impl GuardianReader {
         &mut self,
         session_id: &str,
     ) -> GuardianResult<VerifiedSessionInfo> {
-        let session_info = self.get_or_load_session_info(session_id).await?.clone();
+        self.ensure_session_info_loaded(session_id).await?;
+        let session_info = self
+            .sessions
+            .get(session_id)
+            .expect("session info was loaded above");
         self.allowlist
             .require_current_build(session_info.build_pcrs())?;
-        Ok(session_info)
+        Ok(session_info.clone())
     }
 
     /// Read and verify the latest ceremony, or return `None` if none exists.

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -3,6 +3,7 @@
 
 use crate::s3_client::GuardianS3Client;
 use hashi_types::guardian::BuildPcrs;
+use hashi_types::guardian::EnclaveMode;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianInfo;
 use hashi_types::guardian::GuardianPubKey;
@@ -12,21 +13,77 @@ use hashi_types::guardian::LogEntry;
 use hashi_types::guardian::LogMessageV1;
 use hashi_types::guardian::LogMessageV2;
 use hashi_types::guardian::LogRecord;
+use hashi_types::guardian::LogType;
 use hashi_types::guardian::PcrAllowlist;
 use hashi_types::guardian::S3BucketInfo;
 use hashi_types::guardian::VersionedLogMessage::V1;
 use hashi_types::guardian::VersionedLogMessage::V2;
 
-/// A session's verified guardian info: the attestation-anchored signing key,
-/// the signed [`GuardianInfo`], and the build PCRs proven by attestation.
+/// Initialization checkpoint required by or verified for a session.
+///
+/// Variants are ordered by the durable log prefix each checkpoint proves.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum InitCheckpoint {
+    /// OI attestation and info (01-02), verified while initializing VerifiedSessionInfo.
+    OperatorInitialized,
+    /// The complete withdraw-mode initialization sequence (01-04).
+    OperatorActivated,
+}
+
+/// A session's attestation-anchored signing key, signed [`GuardianInfo`], build
+/// PCRs, and highest verified initialization checkpoint.
 #[derive(Debug, Clone)]
 pub struct VerifiedSessionInfo {
     signing_pubkey: GuardianPubKey,
     info: GuardianInfo,
     build_pcrs: BuildPcrs,
+    verified_init_checkpoint: InitCheckpoint,
+}
+
+/// A log record whose message signature, writing session's attestation/PCRs,
+/// and required initialization checkpoint have been verified. The exact
+/// versioned entry is retained so callers can choose which schema versions they
+/// accept and how to interpret them.
+#[derive(Debug)]
+pub struct VerifiedLogRecord {
+    entry: LogEntry,
+    build_pcrs: BuildPcrs,
+}
+
+impl InitCheckpoint {
+    /// Return the initialization checkpoint required before serving a log.
+    /// Withdrawal and committee-update logs require 01-04; heartbeat, ceremony,
+    /// and genesis logs require only 01-02. KP-share state is mode-dependent.
+    /// Init logs use the dedicated init-log reader and are rejected here.
+    fn required_for(log_type: LogType, mode: EnclaveMode) -> GuardianResult<Self> {
+        let required = match log_type {
+            LogType::Init => {
+                return Err(InvalidS3Log(
+                    "unexpected init log in non-init-log reader".into(),
+                ));
+            }
+            LogType::Withdrawal | LogType::CommitteeUpdate => Self::OperatorActivated,
+            LogType::KpShareState => match mode {
+                EnclaveMode::Ceremony => Self::OperatorInitialized,
+                EnclaveMode::Withdraw => Self::OperatorActivated,
+            },
+            LogType::Heartbeat | LogType::Ceremony | LogType::Genesis => Self::OperatorInitialized,
+        };
+        Ok(required)
+    }
 }
 
 impl VerifiedSessionInfo {
+    #[cfg(test)]
+    pub(super) fn new_for_test(signing_pubkey: GuardianPubKey, build_pcrs: BuildPcrs) -> Self {
+        Self {
+            signing_pubkey,
+            info: GuardianInfo::mock_for_testing(),
+            build_pcrs,
+            verified_init_checkpoint: InitCheckpoint::OperatorInitialized,
+        }
+    }
+
     pub(super) async fn read_from_s3(
         s3: &GuardianS3Client,
         session_id: &str,
@@ -35,16 +92,7 @@ impl VerifiedSessionInfo {
         // 1. Attestation (unsigned: authenticated by AWS, not the enclave key) →
         //    the signing pubkey it commits to.
         let att_key = InitLogMessage::attestation_object_key(session_id);
-        let attestation_record = s3.get_log_record(&att_key).await?;
-        let attestation_message = match attestation_record.validate_into_entry(None)?.into_message()
-        {
-            V1(LogMessageV1::Init(message)) | V2(LogMessageV2::Init(message)) => message,
-            V1(_) | V2(_) => {
-                return Err(InvalidS3Log(format!(
-                    "expected OIAttestationUnsigned at key {att_key}"
-                )));
-            }
-        };
+        let attestation_message = Self::read_init_log(s3, &att_key, None).await?;
         let InitLogMessage::OIAttestationUnsigned {
             attestation,
             signing_public_key: signing_pubkey,
@@ -57,18 +105,7 @@ impl VerifiedSessionInfo {
 
         // 2. GuardianInfo, signature-verified under that pubkey → the reported build.
         let info_key = InitLogMessage::guardian_info_object_key(session_id);
-        let info_record = s3.get_log_record(&info_key).await?;
-        let info_message = match info_record
-            .validate_into_entry(Some(&signing_pubkey))?
-            .into_message()
-        {
-            V1(LogMessageV1::Init(message)) | V2(LogMessageV2::Init(message)) => message,
-            V1(_) | V2(_) => {
-                return Err(InvalidS3Log(format!(
-                    "expected OIGuardianInfo at key {info_key}"
-                )));
-            }
-        };
+        let info_message = Self::read_init_log(s3, &info_key, Some(&signing_pubkey)).await?;
         let InitLogMessage::OIGuardianInfo(info) = *info_message else {
             return Err(InvalidS3Log(format!(
                 "expected OIGuardianInfo at key {info_key}"
@@ -91,16 +128,66 @@ impl VerifiedSessionInfo {
             signing_pubkey,
             info,
             build_pcrs,
+            verified_init_checkpoint: InitCheckpoint::OperatorInitialized,
         })
     }
 
-    /// Verify a record with this session's attestation-anchored signing key.
-    pub(super) fn verify_record(&self, record: LogRecord) -> GuardianResult<VerifiedLogRecord> {
+    /// Verify a record and the initialization checkpoint required to emit it.
+    pub(super) async fn verify_record(
+        &mut self,
+        s3: &GuardianS3Client,
+        record: LogRecord,
+    ) -> GuardianResult<VerifiedLogRecord> {
         let entry = record.validate_into_entry(Some(&self.signing_pubkey))?;
+        let required = InitCheckpoint::required_for(entry.log_type(), self.info.lifecycle.mode())?;
+        self.ensure_init_checkpoint(s3, entry.session_id(), required)
+            .await?;
         Ok(VerifiedLogRecord {
             entry,
             build_pcrs: self.build_pcrs.clone(),
         })
+    }
+
+    async fn ensure_init_checkpoint(
+        &mut self,
+        s3: &GuardianS3Client,
+        session_id: &str,
+        required: InitCheckpoint,
+    ) -> GuardianResult<()> {
+        if self.verified_init_checkpoint >= required {
+            return Ok(());
+        }
+
+        match required {
+            InitCheckpoint::OperatorInitialized => {
+                unreachable!("session construction verifies operator initialization")
+            }
+            InitCheckpoint::OperatorActivated => {
+                // Exact S3-key binding plus canonical init keys establishes each variant.
+                let pi_key = InitLogMessage::pi_fully_initialized_object_key(session_id);
+                Self::read_init_log(s3, &pi_key, Some(&self.signing_pubkey)).await?;
+
+                let oa_key = InitLogMessage::oa_activated_object_key(session_id);
+                Self::read_init_log(s3, &oa_key, Some(&self.signing_pubkey)).await?;
+            }
+        }
+
+        self.verified_init_checkpoint = required;
+        Ok(())
+    }
+
+    /// Read an init log and validate it with the supplied signing key, if any.
+    async fn read_init_log(
+        s3: &GuardianS3Client,
+        key: &str,
+        signing_pubkey: Option<&GuardianPubKey>,
+    ) -> GuardianResult<Box<InitLogMessage>> {
+        let record = s3.get_log_record(key).await?;
+        let entry = record.validate_into_entry(signing_pubkey)?;
+        match entry.into_message() {
+            V1(LogMessageV1::Init(message)) | V2(LogMessageV2::Init(message)) => Ok(message),
+            V1(_) | V2(_) => Err(InvalidS3Log(format!("expected an init log at key {key}"))),
+        }
     }
 
     pub fn signing_pubkey(&self) -> &GuardianPubKey {
@@ -134,15 +221,6 @@ fn ensure_bucket_info_matches(
     Ok(())
 }
 
-/// A log record whose message signature and writing session's attestation/PCRs
-/// have both been verified. The exact versioned entry is retained so callers
-/// can choose which schema versions they accept and how to interpret them.
-#[derive(Debug)]
-pub struct VerifiedLogRecord {
-    entry: LogEntry,
-    build_pcrs: BuildPcrs,
-}
-
 impl VerifiedLogRecord {
     #[cfg(test)]
     pub(super) fn new_for_test(entry: LogEntry, build_pcrs: BuildPcrs) -> Self {
@@ -157,6 +235,10 @@ impl VerifiedLogRecord {
         &self.build_pcrs
     }
 
+    pub fn log_type(&self) -> LogType {
+        self.entry.log_type()
+    }
+
     pub fn into_entry(self) -> LogEntry {
         self.entry
     }
@@ -165,6 +247,23 @@ impl VerifiedLogRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_sdk_s3::operation::get_object::GetObjectOutput;
+    use aws_sdk_s3::operation::list_object_versions::ListObjectVersionsOutput;
+    use aws_sdk_s3::primitives::ByteStream;
+    use aws_sdk_s3::primitives::DateTime;
+    use aws_sdk_s3::types::ObjectLockMode;
+    use aws_sdk_s3::types::ObjectVersion;
+    use aws_sdk_s3::Client;
+    use aws_smithy_mocks::mock;
+    use aws_smithy_mocks::mock_client;
+    use aws_smithy_mocks::RuleMode;
+    use hashi_types::guardian::GuardianSignKeyPair;
+    use hashi_types::guardian::LimiterState;
+    use hashi_types::guardian::LogMessage;
+    use hashi_types::guardian::ResolvedS3Config;
+    use hashi_types::guardian::SessionID;
+    use std::time::Duration;
+    use std::time::SystemTime;
 
     fn bucket_info(bucket: &str, region: &str) -> S3BucketInfo {
         S3BucketInfo {
@@ -194,5 +293,128 @@ mod tests {
 
         let error = ensure_bucket_info_matches("session", None, &expected).unwrap_err();
         assert!(matches!(error, InvalidS3Log(message) if message.contains("missing bucket_info")));
+    }
+
+    fn build_pcrs() -> BuildPcrs {
+        BuildPcrs::new("current", vec![0])
+    }
+
+    fn listed_record(key: String) -> ListObjectVersionsOutput {
+        ListObjectVersionsOutput::builder()
+            .versions(ObjectVersion::builder().key(key).is_latest(true).build())
+            .build()
+    }
+
+    fn locked_record(body: Vec<u8>) -> GetObjectOutput {
+        GetObjectOutput::builder()
+            .object_lock_mode(ObjectLockMode::Compliance)
+            .object_lock_retain_until_date(DateTime::from(
+                SystemTime::now() + Duration::from_secs(60),
+            ))
+            .body(ByteStream::from(body))
+            .build()
+    }
+
+    #[test]
+    fn required_init_checkpoint_matches_log_type_and_mode() {
+        use InitCheckpoint::OperatorActivated;
+        use InitCheckpoint::OperatorInitialized;
+
+        for mode in [EnclaveMode::Ceremony, EnclaveMode::Withdraw] {
+            assert_eq!(
+                InitCheckpoint::required_for(LogType::Withdrawal, mode).unwrap(),
+                OperatorActivated
+            );
+            assert_eq!(
+                InitCheckpoint::required_for(LogType::CommitteeUpdate, mode).unwrap(),
+                OperatorActivated
+            );
+            for log_type in [LogType::Heartbeat, LogType::Ceremony, LogType::Genesis] {
+                assert_eq!(
+                    InitCheckpoint::required_for(log_type, mode).unwrap(),
+                    OperatorInitialized
+                );
+            }
+        }
+
+        assert!(InitCheckpoint::required_for(LogType::Init, EnclaveMode::Ceremony).is_err());
+        assert_eq!(
+            InitCheckpoint::required_for(LogType::KpShareState, EnclaveMode::Ceremony).unwrap(),
+            OperatorInitialized
+        );
+        assert_eq!(
+            InitCheckpoint::required_for(LogType::KpShareState, EnclaveMode::Withdraw).unwrap(),
+            OperatorActivated
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_activated_checkpoint_is_verified_once_per_session() {
+        let signing_key = GuardianSignKeyPair::from([8u8; 32]);
+        let signing_pubkey = signing_key.verification_key();
+        let session_id = SessionID::from_signing_pubkey(&signing_pubkey);
+        let pi_log = LogRecord::new_at_timestamp(
+            session_id.clone(),
+            LogMessage::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
+                sharing_seq: 3,
+                share_ids: vec![],
+                enclave_btc_pubkey: hashi_types::bitcoin::create_btc_keypair_for_test(&[1; 32])
+                    .x_only_public_key()
+                    .0,
+            })),
+            &signing_key,
+            0,
+        );
+        let oa_log = LogRecord::new_at_timestamp(
+            session_id.clone(),
+            LogMessage::Init(Box::new(InitLogMessage::OAActivated {
+                state_hash: [1; 32],
+                config_hash: [2; 32],
+                sharing_seq: 3,
+                committee_epoch: 4,
+                limiter_state: LimiterState {
+                    num_tokens_available: 5,
+                    last_updated_at: 6,
+                    next_seq: 7,
+                },
+            })),
+            &signing_key,
+            0,
+        );
+        let pi_key = pi_log.object_key().to_string();
+        let pi_body = serde_json::to_vec(&pi_log).unwrap();
+        let oa_key = oa_log.object_key().to_string();
+        let oa_body = serde_json::to_vec(&oa_log).unwrap();
+
+        let list_logs = mock!(Client::list_object_versions)
+            .sequence()
+            .output(move || listed_record(pi_key.clone()))
+            .output(move || listed_record(oa_key.clone()))
+            .build();
+        let get_logs = mock!(Client::get_object)
+            .sequence()
+            .output(move || locked_record(pi_body.clone()))
+            .output(move || locked_record(oa_body.clone()))
+            .build();
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&list_logs, &get_logs]);
+        let s3 =
+            GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client);
+        let mut session_info = VerifiedSessionInfo::new_for_test(signing_pubkey, build_pcrs());
+
+        session_info
+            .ensure_init_checkpoint(&s3, &session_id, InitCheckpoint::OperatorActivated)
+            .await
+            .unwrap();
+        session_info
+            .ensure_init_checkpoint(&s3, &session_id, InitCheckpoint::OperatorActivated)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            session_info.verified_init_checkpoint,
+            InitCheckpoint::OperatorActivated
+        );
+        assert_eq!(list_logs.num_calls(), 2);
+        assert_eq!(get_logs.num_calls(), 2);
     }
 }

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -163,12 +163,16 @@ impl VerifiedSessionInfo {
                 unreachable!("session construction verifies operator initialization")
             }
             InitCheckpoint::OperatorActivated => {
-                // Exact S3-key binding plus canonical init keys establishes each variant.
                 let pi_key = InitLogMessage::pi_fully_initialized_object_key(session_id);
-                Self::read_init_log(s3, &pi_key, Some(&self.signing_pubkey)).await?;
+                let pi_message =
+                    Self::read_init_log(s3, &pi_key, Some(&self.signing_pubkey)).await?;
 
                 let oa_key = InitLogMessage::oa_activated_object_key(session_id);
-                Self::read_init_log(s3, &oa_key, Some(&self.signing_pubkey)).await?;
+                let oa_message =
+                    Self::read_init_log(s3, &oa_key, Some(&self.signing_pubkey)).await?;
+                InitLogMessage::verify_oi_pi_consistency(&self.info, &pi_message)?;
+                InitLogMessage::verify_oi_oa_consistency(&self.info, &oa_message)?;
+                InitLogMessage::verify_pi_oa_consistency(&pi_message, &oa_message)?;
             }
         }
 
@@ -262,6 +266,8 @@ mod tests {
     use hashi_types::guardian::LogMessage;
     use hashi_types::guardian::ResolvedS3Config;
     use hashi_types::guardian::SessionID;
+    use hashi_types::guardian::SetupNewKeyResponse;
+    use hashi_types::guardian::ShareID;
     use std::time::Duration;
     use std::time::SystemTime;
 
@@ -297,6 +303,14 @@ mod tests {
 
     fn build_pcrs() -> BuildPcrs {
         BuildPcrs::new("current", vec![0])
+    }
+
+    fn session_info_ready_for_activation(signing_pubkey: GuardianPubKey) -> VerifiedSessionInfo {
+        let mut session_info = VerifiedSessionInfo::new_for_test(signing_pubkey, build_pcrs());
+        session_info.info.secret_sharing_instance =
+            Some(SetupNewKeyResponse::mock_for_testing().secret_sharing_instance);
+        session_info.info.config_hash = Some([2; 32]);
+        session_info
     }
 
     fn listed_record(key: String) -> ListObjectVersionsOutput {
@@ -356,8 +370,8 @@ mod tests {
         let pi_log = LogRecord::new_at_timestamp(
             session_id.clone(),
             LogMessage::Init(Box::new(InitLogMessage::PIEnclaveFullyInitialized {
-                sharing_seq: 3,
-                share_ids: vec![],
+                sharing_seq: 0,
+                share_ids: (1..=3).map(|id| ShareID::new(id).unwrap()).collect(),
                 enclave_btc_pubkey: hashi_types::bitcoin::create_btc_keypair_for_test(&[1; 32])
                     .x_only_public_key()
                     .0,
@@ -370,7 +384,7 @@ mod tests {
             LogMessage::Init(Box::new(InitLogMessage::OAActivated {
                 state_hash: [1; 32],
                 config_hash: [2; 32],
-                sharing_seq: 3,
+                sharing_seq: 0,
                 committee_epoch: 4,
                 limiter_state: LimiterState {
                     num_tokens_available: 5,
@@ -399,7 +413,7 @@ mod tests {
         let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&list_logs, &get_logs]);
         let s3 =
             GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client);
-        let mut session_info = VerifiedSessionInfo::new_for_test(signing_pubkey, build_pcrs());
+        let mut session_info = session_info_ready_for_activation(signing_pubkey);
 
         session_info
             .ensure_init_checkpoint(&s3, &session_id, InitCheckpoint::OperatorActivated)

--- a/crates/hashi-types/src/guardian/s3/log_messages/init.rs
+++ b/crates/hashi-types/src/guardian/s3/log_messages/init.rs
@@ -75,6 +75,14 @@ impl InitLogMessage {
         Self::object_key_for_suffix(session_id, Self::OI_GUARDIAN_INFO)
     }
 
+    pub fn pi_fully_initialized_object_key(session_id: &str) -> String {
+        Self::object_key_for_suffix(session_id, Self::PI_FULLY_INITIALIZED)
+    }
+
+    pub fn oa_activated_object_key(session_id: &str) -> String {
+        Self::object_key_for_suffix(session_id, Self::OA_ACTIVATED)
+    }
+
     fn object_key_for_suffix(session_id: &str, suffix: &str) -> String {
         format!("{S3_DIR_INIT}/{session_id}/{suffix}.json")
     }

--- a/crates/hashi-types/src/guardian/s3/log_messages/init.rs
+++ b/crates/hashi-types/src/guardian/s3/log_messages/init.rs
@@ -4,13 +4,16 @@
 use super::super::log_layout::ObjectKeyPattern;
 use super::super::log_layout::S3_DIR_INIT;
 use crate::bitcoin::BitcoinPubkey;
+use crate::guardian::GuardianError::InvalidS3Log;
 use crate::guardian::GuardianInfo;
 use crate::guardian::GuardianPubKey;
+use crate::guardian::GuardianResult;
 use crate::guardian::LimiterState;
 use crate::guardian::NitroAttestation;
 use crate::guardian::ShareID;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::BTreeSet;
 
 /// OI: operator_init
 /// PI: provisioner_init
@@ -83,7 +86,221 @@ impl InitLogMessage {
         Self::object_key_for_suffix(session_id, Self::OA_ACTIVATED)
     }
 
+    /// Verify facts repeated between 02 OIGuardianInfo and 03
+    /// PIEnclaveFullyInitialized.
+    pub fn verify_oi_pi_consistency(
+        oi_info: &GuardianInfo,
+        pi_message: &Self,
+    ) -> GuardianResult<()> {
+        let Self::PIEnclaveFullyInitialized {
+            sharing_seq: pi_sharing_seq,
+            share_ids,
+            ..
+        } = pi_message
+        else {
+            return Err(InvalidS3Log(
+                "expected PIEnclaveFullyInitialized init log".into(),
+            ));
+        };
+        let oi_instance = oi_info
+            .secret_sharing_instance
+            .as_ref()
+            .ok_or_else(|| InvalidS3Log("OIGuardianInfo missing secret-sharing instance".into()))?;
+        let oi_sharing_seq = oi_instance.sharing_seq();
+
+        if *pi_sharing_seq != oi_sharing_seq {
+            return Err(InvalidS3Log(format!(
+                "PIEnclaveFullyInitialized sharing_seq {pi_sharing_seq} differs from OIGuardianInfo sharing_seq {oi_sharing_seq}"
+            )));
+        }
+
+        let unique_share_ids = share_ids.iter().copied().collect::<BTreeSet<_>>();
+        if unique_share_ids.len() != share_ids.len() {
+            return Err(InvalidS3Log(
+                "PIEnclaveFullyInitialized contains duplicate share_ids".into(),
+            ));
+        }
+        if share_ids.len() < oi_instance.threshold() || share_ids.len() > oi_instance.num_shares() {
+            return Err(InvalidS3Log(format!(
+                "PIEnclaveFullyInitialized has {} share_ids; expected between {} and {}",
+                share_ids.len(),
+                oi_instance.threshold(),
+                oi_instance.num_shares(),
+            )));
+        }
+
+        let commitment_ids = oi_instance
+            .commitments()
+            .iter()
+            .map(|commitment| commitment.id)
+            .collect::<BTreeSet<_>>();
+        if !unique_share_ids.is_subset(&commitment_ids) {
+            return Err(InvalidS3Log(
+                "PIEnclaveFullyInitialized contains share_ids absent from OIGuardianInfo commitments"
+                    .into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Verify facts repeated between 02 OIGuardianInfo and 04 OAActivated.
+    pub fn verify_oi_oa_consistency(
+        oi_info: &GuardianInfo,
+        oa_message: &Self,
+    ) -> GuardianResult<()> {
+        let Self::OAActivated {
+            config_hash: oa_config_hash,
+            sharing_seq: oa_sharing_seq,
+            ..
+        } = oa_message
+        else {
+            return Err(InvalidS3Log("expected OAActivated init log".into()));
+        };
+        let oi_sharing_seq = oi_info
+            .secret_sharing_instance
+            .as_ref()
+            .ok_or_else(|| InvalidS3Log("OIGuardianInfo missing secret-sharing instance".into()))?
+            .sharing_seq();
+        let oi_config_hash = oi_info
+            .config_hash
+            .ok_or_else(|| InvalidS3Log("OIGuardianInfo missing config_hash".into()))?;
+
+        if *oa_sharing_seq != oi_sharing_seq {
+            return Err(InvalidS3Log(format!(
+                "OAActivated sharing_seq {oa_sharing_seq} differs from OIGuardianInfo sharing_seq {oi_sharing_seq}"
+            )));
+        }
+        if *oa_config_hash != oi_config_hash {
+            return Err(InvalidS3Log(
+                "OAActivated config_hash differs from OIGuardianInfo config_hash".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Verify facts repeated between 03 PIEnclaveFullyInitialized and 04
+    /// OAActivated.
+    pub fn verify_pi_oa_consistency(pi_message: &Self, oa_message: &Self) -> GuardianResult<()> {
+        let Self::PIEnclaveFullyInitialized {
+            sharing_seq: pi_sharing_seq,
+            ..
+        } = pi_message
+        else {
+            return Err(InvalidS3Log(
+                "expected PIEnclaveFullyInitialized init log".into(),
+            ));
+        };
+        let Self::OAActivated {
+            sharing_seq: oa_sharing_seq,
+            ..
+        } = oa_message
+        else {
+            return Err(InvalidS3Log("expected OAActivated init log".into()));
+        };
+
+        if oa_sharing_seq != pi_sharing_seq {
+            return Err(InvalidS3Log(format!(
+                "OAActivated sharing_seq {oa_sharing_seq} differs from PIEnclaveFullyInitialized sharing_seq {pi_sharing_seq}"
+            )));
+        }
+        Ok(())
+    }
+
     fn object_key_for_suffix(session_id: &str, suffix: &str) -> String {
         format!("{S3_DIR_INIT}/{session_id}/{suffix}.json")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitcoin::create_btc_keypair_for_test;
+    use crate::guardian::SetupNewKeyResponse;
+    use crate::guardian::ShareID;
+
+    fn oi_info() -> GuardianInfo {
+        let mut info = GuardianInfo::mock_for_testing();
+        info.secret_sharing_instance =
+            Some(SetupNewKeyResponse::mock_for_testing().secret_sharing_instance);
+        info.config_hash = Some([2; 32]);
+        info
+    }
+
+    fn pi_message_with_ids(sharing_seq: u64, share_ids: Vec<ShareID>) -> InitLogMessage {
+        InitLogMessage::PIEnclaveFullyInitialized {
+            sharing_seq,
+            share_ids,
+            enclave_btc_pubkey: create_btc_keypair_for_test(&[1; 32]).x_only_public_key().0,
+        }
+    }
+
+    fn share_ids(ids: &[u16]) -> Vec<ShareID> {
+        ids.iter().map(|id| ShareID::new(*id).unwrap()).collect()
+    }
+
+    fn pi_message(sharing_seq: u64) -> InitLogMessage {
+        pi_message_with_ids(sharing_seq, share_ids(&[1, 2, 3]))
+    }
+
+    fn oa_message(config_hash: [u8; 32], sharing_seq: u64) -> InitLogMessage {
+        InitLogMessage::OAActivated {
+            state_hash: [1; 32],
+            config_hash,
+            sharing_seq,
+            committee_epoch: 0,
+            limiter_state: LimiterState {
+                num_tokens_available: 0,
+                last_updated_at: 0,
+                next_seq: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn verifies_pairwise_init_log_consistency() {
+        let oi_info = oi_info();
+        let pi = pi_message(0);
+        let oa = oa_message([2; 32], 0);
+
+        InitLogMessage::verify_oi_pi_consistency(&oi_info, &pi).unwrap();
+        InitLogMessage::verify_oi_oa_consistency(&oi_info, &oa).unwrap();
+        InitLogMessage::verify_pi_oa_consistency(&pi, &oa).unwrap();
+
+        assert!(InitLogMessage::verify_oi_pi_consistency(&oi_info, &pi_message(1)).is_err());
+        assert!(
+            InitLogMessage::verify_oi_pi_consistency(
+                &oi_info,
+                &pi_message_with_ids(0, share_ids(&[1, 1, 2])),
+            )
+            .is_err()
+        );
+        assert!(
+            InitLogMessage::verify_oi_pi_consistency(
+                &oi_info,
+                &pi_message_with_ids(0, share_ids(&[1, 2])),
+            )
+            .is_err()
+        );
+        assert!(
+            InitLogMessage::verify_oi_pi_consistency(
+                &oi_info,
+                &pi_message_with_ids(0, share_ids(&[1, 2, 6])),
+            )
+            .is_err()
+        );
+        assert!(
+            InitLogMessage::verify_oi_pi_consistency(
+                &oi_info,
+                &pi_message_with_ids(0, share_ids(&[1, 2, 3, 4, 5, 6])),
+            )
+            .is_err()
+        );
+        assert!(
+            InitLogMessage::verify_oi_oa_consistency(&oi_info, &oa_message([3; 32], 0)).is_err()
+        );
+        assert!(
+            InitLogMessage::verify_oi_oa_consistency(&oi_info, &oa_message([2; 32], 1)).is_err()
+        );
+        assert!(InitLogMessage::verify_pi_oa_consistency(&pi, &oa_message([2; 32], 1)).is_err());
     }
 }

--- a/crates/hashi-types/src/guardian/s3/log_record.rs
+++ b/crates/hashi-types/src/guardian/s3/log_record.rs
@@ -15,6 +15,7 @@ use super::log_layout::ObjectKeyPattern;
 use super::log_schema::LogMessage;
 use super::log_schema::LogMessageV1;
 use super::log_schema::LogMessageV2;
+use super::log_schema::LogType;
 use super::log_schema::VersionedLogMessage;
 use crate::guardian::GuardianError::InvalidS3Log;
 use crate::guardian::GuardianPubKey;
@@ -159,6 +160,11 @@ impl LogEntry {
     /// Return the versioned log payload.
     pub fn message(&self) -> &VersionedLogMessage {
         &self.message
+    }
+
+    /// Return the log payload type.
+    pub fn log_type(&self) -> LogType {
+        self.message.log_type()
     }
 
     /// Consume the entry and return its versioned log payload.
@@ -309,6 +315,11 @@ impl LogRecord {
         &self.data().message
     }
 
+    /// Return the log payload type.
+    pub fn log_type(&self) -> LogType {
+        self.data().log_type()
+    }
+
     /// Validate the record against its externally established signing key.
     ///
     /// For a signed record, this binds the session to the caller-supplied key
@@ -352,7 +363,7 @@ impl LogRecord {
 
     /// Return the object-lock duration selected for the message type.
     pub fn object_lock_duration(&self, policy: S3ObjectLockPolicy) -> Duration {
-        self.data().message.log_type().object_lock_duration(policy)
+        self.log_type().object_lock_duration(policy)
     }
 
     /// Consume the record and extract its entry without validation.

--- a/crates/hashi-types/src/guardian/s3/log_schema.rs
+++ b/crates/hashi-types/src/guardian/s3/log_schema.rs
@@ -87,7 +87,9 @@ pub enum LogMessageV2 {
 /// Writer-facing alias for the log-message schema emitted by guardians.
 pub type LogMessage = LogMessageV2;
 
-pub(super) enum LogType {
+/// Schema-independent category of a Guardian log payload.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LogType {
     Heartbeat,
     Init,
     Withdrawal,
@@ -182,7 +184,7 @@ impl VersionedLogMessage {
         self.as_attestation_log().is_some()
     }
 
-    pub(super) fn log_type(&self) -> LogType {
+    pub fn log_type(&self) -> LogType {
         match self {
             Self::V1(message) => message.log_type(),
             Self::V2(message) => message.log_type(),


### PR DESCRIPTION
## Summary

- Model session initialization as cached operator-initialized (01-02) and operator-activated (01-04) checkpoints.
- Require and lazily cache 03 `PIEnclaveFullyInitialized` and 04 `OAActivated` before accepting withdrawals, committee updates, or withdraw-mode KP-share state.
- Continue requiring only 01-02 for heartbeat, ceremony, genesis, and ceremony-mode KP-share state.
- Validate every repeated fact across the 02-04 initialization chain: `sharing_seq` across 02/03/04 and `config_hash` across 02/04.
- Validate that 03 `share_ids` are unique, belong to the commitments recorded in 02, and have a count between the recorded threshold and share count.
- Keep pairwise initialization consistency rules beside `InitLogMessage` and expose schema-independent log-type accessors for checkpoint selection.

## Testing

- `make fmt`
- `cargo check`

Fixes IOP-651.
