### PR TITLE
move: refuse the pinned keys on the UpdateConfig path

### DIFF
--- a/design/docs/config.mdx
+++ b/design/docs/config.mdx
@@ -211,6 +211,17 @@ The 32-byte Bitcoin chain identifier as defined by
 (the genesis block hash). Set at genesis and not updatable through the
 `UpdateConfig` proposal.
 
+### `guardian_btc_public_key`
+
+| | |
+|---|---|
+| **Type** | `bytes` |
+
+The guardian's x-only BTC public key (32 bytes), pinned at genesis. Every
+2-of-2 deposit address is derived against it, so it is write-once and not
+updatable through the `UpdateConfig` proposal. The guardian URL
+(`guardian_url`) remains governable.
+
 ## Derived values
 
 Several values are computed from the configurable parameters above rather than

--- a/design/docs/governance-actions.mdx
+++ b/design/docs/governance-actions.mdx
@@ -72,9 +72,17 @@ active version cannot be disabled, to avoid bricking the protocol.
 
 ## `UpdateConfig`
 
-Updates a protocol configuration parameter by key. Supports any config
-key-value pair (for example, deposit fee, rate limits). See
+Updates one or more protocol configuration parameters by key. See
 [Configuration](config.mdx) for the full list of keys and defaults.
+
+Every entry is validated when the proposal executes, and the whole proposal
+aborts if any entry fails: the key must already exist, the value must have the
+same type as the current entry, MPC keys must pass their range check
+(`EInvalidConfigEntry`), and the key must be governable. The guardian BTC
+public key and the Bitcoin chain id are pinned for the deployment's lifetime
+and cannot be written through this proposal (`EProtectedConfigKey`). Values
+themselves are otherwise not bounded onchain: a proposal needs a supermajority
+of committee weight, and reviewing the proposed value is part of voting.
 
 ## `EmergencyPause`
 

--- a/packages/hashi/sources/btc/btc_config.move
+++ b/packages/hashi/sources/btc/btc_config.move
@@ -3,9 +3,11 @@
 
 /// Bitcoin-specific configuration accessors and fee calculation functions.
 /// Operates on the shared Config store via public(package) get/upsert.
+#[allow(implicit_const_copy)]
 module hashi::btc_config;
 
 use hashi::{config::Config, config_value};
+use std::string::String;
 
 // ~~~~~~~ Constants ~~~~~~~
 
@@ -13,38 +15,54 @@ use hashi::{config::Config, config_value};
 /// Uses the highest threshold (P2PKH 546 sats) as a conservative floor.
 const DUST_RELAY_MIN_VALUE: u64 = 546;
 
+const KEY_BITCOIN_CHAIN_ID: vector<u8> = b"bitcoin_chain_id";
+const KEY_BITCOIN_DEPOSIT_TIME_DELAY_MS: vector<u8> = b"bitcoin_deposit_time_delay_ms";
+const KEY_BITCOIN_DEPOSIT_MINIMUM: vector<u8> = b"bitcoin_deposit_minimum";
+const KEY_BITCOIN_WITHDRAWAL_MINIMUM: vector<u8> = b"bitcoin_withdrawal_minimum";
+const KEY_BITCOIN_CONFIRMATION_THRESHOLD: vector<u8> = b"bitcoin_confirmation_threshold";
+const KEY_WITHDRAWAL_CANCELLATION_COOLDOWN_MS: vector<u8> = b"withdrawal_cancellation_cooldown_ms";
+
 // ~~~~~~~ Package Functions ~~~~~~~
 
 // === Initialization ===
 
 /// Initialize BTC-specific config defaults. Called after config::create().
 public(package) fun init_defaults(config: &mut Config) {
-    config.upsert(b"bitcoin_deposit_time_delay_ms", config_value::new_u64(10 * 60 * 1_000)); // 10 minutes
-    config.upsert(b"bitcoin_deposit_minimum", config_value::new_u64(30_000));
-    config.upsert(b"bitcoin_withdrawal_minimum", config_value::new_u64(30_000));
-    config.upsert(b"bitcoin_confirmation_threshold", config_value::new_u64(6));
-    config.upsert(b"withdrawal_cancellation_cooldown_ms", config_value::new_u64(1000 * 60 * 60)); // 1 hour
+    config.upsert(KEY_BITCOIN_DEPOSIT_TIME_DELAY_MS, config_value::new_u64(10 * 60 * 1_000)); // 10 minutes
+    config.upsert(KEY_BITCOIN_DEPOSIT_MINIMUM, config_value::new_u64(30_000));
+    config.upsert(KEY_BITCOIN_WITHDRAWAL_MINIMUM, config_value::new_u64(30_000));
+    config.upsert(KEY_BITCOIN_CONFIRMATION_THRESHOLD, config_value::new_u64(6));
+    config.upsert(KEY_WITHDRAWAL_CANCELLATION_COOLDOWN_MS, config_value::new_u64(1000 * 60 * 60)); // 1 hour
+}
+
+// === Governance ===
+
+/// Whether `UpdateConfig` may write `key`. The chain id is pinned at
+/// `finish_publish` and verified by every node at startup; changing it
+/// on-chain would only desynchronize the fleet from the object.
+public(package) fun is_governable_key(key: &String): bool {
+    key.as_bytes() != &KEY_BITCOIN_CHAIN_ID
 }
 
 // === Accessors ===
 
 public(package) fun bitcoin_chain_id(self: &Config): address {
-    self.get(b"bitcoin_chain_id").as_address()
+    self.get(KEY_BITCOIN_CHAIN_ID).as_address()
 }
 
 public(package) fun set_bitcoin_chain_id(self: &mut Config, bitcoin_chain_id: address) {
-    self.upsert(b"bitcoin_chain_id", config_value::new_address(bitcoin_chain_id))
+    self.upsert(KEY_BITCOIN_CHAIN_ID, config_value::new_address(bitcoin_chain_id))
 }
 
 /// Minimum total withdrawal amount (satoshis). The worst-case network
 /// fee is derived from this value minus the dust threshold. The floor
 /// ensures the worst-case network fee is always at least 1 sat.
 public(package) fun bitcoin_withdrawal_minimum(self: &Config): u64 {
-    self.get(b"bitcoin_withdrawal_minimum").as_u64().max(DUST_RELAY_MIN_VALUE + 1)
+    self.get(KEY_BITCOIN_WITHDRAWAL_MINIMUM).as_u64().max(DUST_RELAY_MIN_VALUE + 1)
 }
 
 public(package) fun set_bitcoin_withdrawal_minimum(self: &mut Config, min_withdrawal: u64) {
-    self.upsert(b"bitcoin_withdrawal_minimum", config_value::new_u64(min_withdrawal))
+    self.upsert(KEY_BITCOIN_WITHDRAWAL_MINIMUM, config_value::new_u64(min_withdrawal))
 }
 
 /// The dust relay minimum value as a pure constant accessor.
@@ -55,11 +73,11 @@ public(package) fun dust_relay_min_value(): u64 {
 /// Minimum deposit amount (satoshis). Returns the greater of configured
 /// value or DUST_RELAY_MIN_VALUE, ensuring deposits are never below dust.
 public(package) fun bitcoin_deposit_minimum(self: &Config): u64 {
-    self.get(b"bitcoin_deposit_minimum").as_u64().max(DUST_RELAY_MIN_VALUE)
+    self.get(KEY_BITCOIN_DEPOSIT_MINIMUM).as_u64().max(DUST_RELAY_MIN_VALUE)
 }
 
 public(package) fun set_bitcoin_deposit_minimum(self: &mut Config, min_deposit: u64) {
-    self.upsert(b"bitcoin_deposit_minimum", config_value::new_u64(min_deposit))
+    self.upsert(KEY_BITCOIN_DEPOSIT_MINIMUM, config_value::new_u64(min_deposit))
 }
 
 /// Minimum time (milliseconds) that must elapse between a deposit being
@@ -67,11 +85,11 @@ public(package) fun set_bitcoin_deposit_minimum(self: &mut Config, min_deposit: 
 /// which a fraudulent or erroneous approval can be detected and the
 /// service paused before funds are minted.
 public(package) fun bitcoin_deposit_time_delay_ms(self: &Config): u64 {
-    self.get(b"bitcoin_deposit_time_delay_ms").as_u64()
+    self.get(KEY_BITCOIN_DEPOSIT_TIME_DELAY_MS).as_u64()
 }
 
 public(package) fun set_bitcoin_deposit_time_delay_ms(self: &mut Config, time_delay_ms: u64) {
-    self.upsert(b"bitcoin_deposit_time_delay_ms", config_value::new_u64(time_delay_ms))
+    self.upsert(KEY_BITCOIN_DEPOSIT_TIME_DELAY_MS, config_value::new_u64(time_delay_ms))
 }
 
 /// Worst-case Bitcoin miner fee for a withdrawal transaction, derived
@@ -82,17 +100,17 @@ public(package) fun worst_case_network_fee(self: &Config): u64 {
 }
 
 public(package) fun bitcoin_confirmation_threshold(self: &Config): u64 {
-    self.get(b"bitcoin_confirmation_threshold").as_u64()
+    self.get(KEY_BITCOIN_CONFIRMATION_THRESHOLD).as_u64()
 }
 
 public(package) fun set_bitcoin_confirmation_threshold(self: &mut Config, confirmations: u64) {
-    self.upsert(b"bitcoin_confirmation_threshold", config_value::new_u64(confirmations))
+    self.upsert(KEY_BITCOIN_CONFIRMATION_THRESHOLD, config_value::new_u64(confirmations))
 }
 
 public(package) fun withdrawal_cancellation_cooldown_ms(self: &Config): u64 {
-    self.get(b"withdrawal_cancellation_cooldown_ms").as_u64()
+    self.get(KEY_WITHDRAWAL_CANCELLATION_COOLDOWN_MS).as_u64()
 }
 
 public(package) fun set_withdrawal_cancellation_cooldown_ms(self: &mut Config, cooldown_ms: u64) {
-    self.upsert(b"withdrawal_cancellation_cooldown_ms", config_value::new_u64(cooldown_ms))
+    self.upsert(KEY_WITHDRAWAL_CANCELLATION_COOLDOWN_MS, config_value::new_u64(cooldown_ms))
 }

--- a/packages/hashi/sources/core/config/config.move
+++ b/packages/hashi/sources/core/config/config.move
@@ -101,6 +101,15 @@ public(package) fun is_valid_config_update(self: &Config, key: &String, value: &
     self.config.get(key).same_variant(value)
 }
 
+/// Whether `UpdateConfig` may write `key`. The guardian BTC public key is
+/// write-once (see `set_guardian_btc_public_key`); rotating it through the
+/// generic update path would silently invalidate every derived deposit
+/// address, so the governance path refuses the key outright.
+#[allow(implicit_const_copy)]
+public(package) fun is_governable_key(key: &String): bool {
+    key.as_bytes() != &GUARDIAN_BTC_PUBLIC_KEY_KEY
+}
+
 // === Core Accessors ===
 
 public(package) fun paused(self: &Config): bool {

--- a/packages/hashi/sources/core/proposal/types/update_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_config.move
@@ -4,11 +4,13 @@
 /// Governance proposal for updating entries in the global config. A proposal
 /// carries a map of key/value entries; on execution every entry must refer to
 /// an existing key with a matching value type (and pass MPC-config range
-/// validation) before being upserted, so governance can tune parameters but
-/// never introduce unknown keys or change an entry's type.
+/// validation) and must not be one of the keys the package pins for the
+/// deployment's lifetime (the guardian BTC public key and the Bitcoin chain
+/// id) before being upserted, so governance can tune parameters but never
+/// introduce unknown keys, change an entry's type, or rewrite a pinned key.
 module hashi::update_config;
 
-use hashi::{config_value::Value, hashi::Hashi, mpc_config, proposal};
+use hashi::{btc_config, config, config_value::Value, hashi::Hashi, mpc_config, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
@@ -23,6 +25,9 @@ const EInvalidConfigEntry: vector<u8> = b"Unknown config key or wrong value type
 
 #[error]
 const ENoEntriesProvided: vector<u8> = b"UpdateConfig proposal must contain at least one entry";
+
+#[error]
+const EProtectedConfigKey: vector<u8> = b"Config key cannot be changed through UpdateConfig";
 
 // ~~~~~~~ Structs ~~~~~~~
 
@@ -61,6 +66,10 @@ public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
             hashi.config().is_valid_config_update(&key, &value)
                 && mpc_config::is_valid_value(&key, &value),
             EInvalidConfigEntry,
+        );
+        assert!(
+            config::is_governable_key(&key) && btc_config::is_governable_key(&key),
+            EProtectedConfigKey,
         );
         hashi.config_mut().upsert(*key.as_bytes(), value);
     });

--- a/packages/hashi/tests/update_config_protected_keys_tests.move
+++ b/packages/hashi/tests/update_config_protected_keys_tests.move
@@ -1,0 +1,156 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Keys the `UpdateConfig` governance path refuses to write.
+#[test_only]
+#[allow(implicit_const_copy, unused_variable)]
+module hashi::update_config_protected_keys_tests;
+
+use hashi::{
+    btc_config,
+    config,
+    config_value::{Self, Value},
+    hashi::Hashi,
+    test_utils,
+    update_config
+};
+use std::string::String;
+use sui::{clock, vec_map::{Self, VecMap}};
+
+const VOTER1: address = @0x1;
+
+fun guardian_btc_public_key_key(): String { b"guardian_btc_public_key".to_string() }
+
+fun guardian_url_key(): String { b"guardian_url".to_string() }
+
+fun bitcoin_chain_id_key(): String { b"bitcoin_chain_id".to_string() }
+
+fun deposit_minimum_key(): String { b"bitcoin_deposit_minimum".to_string() }
+
+fun new_hashi(ctx: &mut TxContext): Hashi {
+    test_utils::create_hashi_with_committee(vector[VOTER1], ctx)
+}
+
+fun single(key: String, value: Value): VecMap<String, Value> {
+    let mut entries = vec_map::empty();
+    entries.insert(key, value);
+    entries
+}
+
+/// Proposes `entries` from the single-member committee (whose creator vote
+/// meets quorum) and executes the proposal.
+fun propose_and_execute(hashi: &mut Hashi, entries: VecMap<String, Value>, ctx: &mut TxContext) {
+    let clock = clock::create_for_testing(ctx);
+    let proposal_id = update_config::propose(
+        hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    update_config::execute(hashi, proposal_id, &clock);
+    clock::destroy_for_testing(clock);
+}
+
+fun guardian_key(seed: u8): vector<u8> {
+    vector::tabulate!(32, |i| ((i as u8) + seed))
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EProtectedConfigKey)]
+fun test_guardian_btc_public_key_cannot_be_rotated() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = new_hashi(ctx);
+    config::set_guardian_btc_public_key(hashi.config_mut(), guardian_key(0));
+
+    propose_and_execute(
+        &mut hashi,
+        single(guardian_btc_public_key_key(), config_value::new_bytes(guardian_key(1))),
+        ctx,
+    );
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EProtectedConfigKey)]
+fun test_guardian_btc_public_key_cannot_be_rewritten_with_same_value() {
+    // The key is refused outright, not compared: governance has no business
+    // writing it at all.
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = new_hashi(ctx);
+    config::set_guardian_btc_public_key(hashi.config_mut(), guardian_key(0));
+
+    propose_and_execute(
+        &mut hashi,
+        single(guardian_btc_public_key_key(), config_value::new_bytes(guardian_key(0))),
+        ctx,
+    );
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EProtectedConfigKey)]
+fun test_bitcoin_chain_id_cannot_be_changed() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = new_hashi(ctx);
+    btc_config::set_bitcoin_chain_id(hashi.config_mut(), @0xA);
+
+    propose_and_execute(
+        &mut hashi,
+        single(bitcoin_chain_id_key(), config_value::new_address(@0xB)),
+        ctx,
+    );
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EProtectedConfigKey)]
+fun test_protected_key_aborts_the_whole_proposal() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = new_hashi(ctx);
+    config::set_guardian_btc_public_key(hashi.config_mut(), guardian_key(0));
+
+    let mut entries = vec_map::empty();
+    entries.insert(deposit_minimum_key(), config_value::new_u64(50_000));
+    entries.insert(guardian_btc_public_key_key(), config_value::new_bytes(guardian_key(1)));
+    propose_and_execute(&mut hashi, entries, ctx);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_guardian_url_stays_governable() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = new_hashi(ctx);
+    config::set_guardian_url(hashi.config_mut(), b"https://old.example".to_string());
+
+    propose_and_execute(
+        &mut hashi,
+        single(guardian_url_key(), config_value::new_string(b"https://new.example".to_string())),
+        ctx,
+    );
+    assert!(
+        config::guardian_url(hashi.config()).destroy_some() == b"https://new.example".to_string(),
+    );
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_other_keys_stay_governable() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = new_hashi(ctx);
+
+    propose_and_execute(
+        &mut hashi,
+        single(deposit_minimum_key(), config_value::new_u64(50_000)),
+        ctx,
+    );
+    assert!(btc_config::bitcoin_deposit_minimum(hashi.config()) == 50_000);
+
+    std::unit_test::destroy(hashi);
+}


### PR DESCRIPTION
## Summary

`UpdateConfig` proposals can no longer rewrite the two keys the package pins for a deployment's lifetime. Fixes [IOP-543](https://linear.app/mysten-labs/issue/IOP-543/securitygovernance-updateconfig-replaces-the-fixed-guardian-btc-key) (GitHub #882) and the guardian-key impact of [IOP-592](https://linear.app/mysten-labs/issue/IOP-592/update-config-accepts-any-value-for-non-mpc-governance-keys-add-a-per) (Certora, 2026-08-04); see also [SEC-547](https://linear.app/mysten-labs/issue/SEC-547/hashi-move-governance-stale-proposal-execution-and-a-write-once-config) F65 and [SEC-554](https://linear.app/mysten-labs/issue/SEC-554/hashi-governance-parameter-changes-apply-retroactively-to-in-flight).

`update_config::execute` writes every entry through `config::upsert` and never calls the dedicated setters, so a passing proposal could:

- rotate `guardian_btc_public_key`, which `set_guardian_btc_public_key` declares write-once because every 2-of-2 deposit address is derived against it;
- change `bitcoin_chain_id`, which every node pins at startup.

Both keys are now refused with a new `EProtectedConfigKey` abort, checked after the existing key-exists / same-type / MPC-range assert. The guardian key is refused even for a same-value rewrite: governance has no business writing it at all. `guardian_url` and every other key stay governable exactly as before.

## What this PR deliberately does not do

Certora also listed out-of-range values for the remaining keys (zero pause threshold, `u64::MAX` cooldown, and so on). Those are not bounded onchain by this change. An `UpdateConfig` proposal needs a supermajority of committee weight, and reviewing the proposed value is part of voting; a quorum willing to pass a harmful value can pass a harmful package upgrade just as easily, so onchain bounds would not protect against it. Documented in `governance-actions.mdx`.

## Upgrade safety

Body-only plus two new `public(package)` predicates and one error constant; no struct or public signature changes. `move_upgrade_compat` and `version_policy_tests` pass against the deployed testnet v1 snapshot.

## Tests

- 6 new Move tests in `packages/hashi/tests/update_config_protected_keys_tests.move`: guardian key rotation and same-value rewrite refused, chain id refused, a protected entry aborts a mixed proposal, guardian URL and other keys still governable
- `sui move test -e testnet`: 234 passed
- e2e `test_create_update_config_proposal` on a snapshot-v1 chain upgraded to this branch: passed (44 s)

## Follow-up

The pending epoch/instant config split ([IOP-455](https://linear.app/mysten-labs/issue/IOP-455/make-epoch-pinned-committee-config-extensible)) should route `UpdateEpochConfig` through the same governable-key check.
