### PR TITLE
[Guardian] Require prior heartbeat leases to expire before activation scans

### DIFF
--- a/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
+++ b/crates/hashi-guardian/src/s3_reader/heartbeat_checks.rs
@@ -7,9 +7,9 @@ use crate::HEARTBEAT_INTERVAL;
 use crate::LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE;
 use crate::OTHER_SESSION_QUIET_PERIOD;
 use hashi_types::guardian::s3::S3HourScopedDirectory;
-use hashi_types::guardian::time::now_timestamp_secs;
+use hashi_types::guardian::time::now_timestamp_ms;
 use hashi_types::guardian::time::unix_millis_to_seconds;
-use hashi_types::guardian::time::UnixSeconds;
+use hashi_types::guardian::time::UnixMillis;
 use hashi_types::guardian::GuardianError::CurrentSessionHeartbeatNotLive;
 use hashi_types::guardian::GuardianError::InvalidS3Log;
 use hashi_types::guardian::GuardianError::PriorSessionHeartbeatStillRecent;
@@ -20,19 +20,37 @@ use hashi_types::guardian::SessionID;
 use hashi_types::guardian::VersionedLogMessage::V1;
 use hashi_types::guardian::VersionedLogMessage::V2;
 use std::collections::BTreeMap;
+use std::time::Duration;
 use tracing::info;
+
+#[derive(Debug)]
+struct HeartbeatScan {
+    sessions: Vec<GuardianSessionInfo>,
+    started_at: UnixMillis,
+    completed_at: UnixMillis,
+}
+
+#[derive(Debug, Clone)]
+struct GuardianSessionInfo {
+    session_id: SessionID,
+    first_heartbeat: UnixMillis,
+    last_heartbeat: UnixMillis,
+}
 
 impl GuardianReader {
     /// Enforces that `live_session` has heartbeated recently.
     pub async fn ensure_session_live(&mut self, live_session: &str) -> GuardianResult<()> {
-        let (summary, now) = self.read_recent_heartbeat_summary().await?;
-        let live_session_info = validate_session_live(&summary, now, live_session)?;
+        let scan = self.read_recent_heartbeat_summary().await?;
+        let live_session_info =
+            validate_session_live(&scan.sessions, scan.completed_at, live_session)?;
 
         info!(
             session_id = %live_session,
-            first_heartbeat = live_session_info.first_heartbeat,
-            last_heartbeat = live_session_info.last_heartbeat,
-            age_secs = now.saturating_sub(live_session_info.last_heartbeat),
+            first_heartbeat_ms = live_session_info.first_heartbeat,
+            last_heartbeat_ms = live_session_info.last_heartbeat,
+            age_secs = unix_millis_to_seconds(
+                scan.completed_at.saturating_sub(live_session_info.last_heartbeat)
+            ),
             "session heartbeat check passed"
         );
         Ok(())
@@ -45,38 +63,49 @@ impl GuardianReader {
         &mut self,
         live_session: &str,
     ) -> GuardianResult<()> {
-        let (summary, now) = self.read_recent_heartbeat_summary().await?;
+        let scan = self.read_recent_heartbeat_summary().await?;
 
-        let live_session_info = validate_session_live(&summary, now, live_session)?;
+        let live_session_info =
+            validate_session_live(&scan.sessions, scan.completed_at, live_session)?;
+        // The quiet boundary must already have passed when the final scan
+        // begins; crossing it while reading S3 is not sufficient.
         validate_other_sessions_quiet(
-            &summary,
-            now,
+            &scan.sessions,
+            scan.started_at,
             live_session,
-            OTHER_SESSION_QUIET_PERIOD.as_secs(),
+            OTHER_SESSION_QUIET_PERIOD,
         )?;
 
         info!(
             session_id = %live_session,
-            first_heartbeat = live_session_info.first_heartbeat,
-            last_heartbeat = live_session_info.last_heartbeat,
-            age_secs = now.saturating_sub(live_session_info.last_heartbeat),
+            first_heartbeat_ms = live_session_info.first_heartbeat,
+            last_heartbeat_ms = live_session_info.last_heartbeat,
+            age_secs = unix_millis_to_seconds(
+                scan.completed_at.saturating_sub(live_session_info.last_heartbeat)
+            ),
             "activation heartbeat check passed"
         );
         Ok(())
     }
 
-    async fn read_recent_heartbeat_summary(
-        &mut self,
-    ) -> GuardianResult<(Vec<GuardianSessionInfo>, UnixSeconds)> {
-        let recent_heartbeats = self.read_recent_heartbeat_logs().await?;
-        let summary = summarize_heartbeats_by_session(recent_heartbeats)?;
-        Ok((summary, now_timestamp_secs()))
+    async fn read_recent_heartbeat_summary(&mut self) -> GuardianResult<HeartbeatScan> {
+        let started_at = now_timestamp_ms();
+        let recent_heartbeats = self.read_recent_heartbeat_logs(started_at).await?;
+        let sessions = summarize_heartbeats_by_session(recent_heartbeats)?;
+        Ok(HeartbeatScan {
+            sessions,
+            started_at,
+            completed_at: now_timestamp_ms(),
+        })
     }
 
-    async fn read_recent_heartbeat_logs(&mut self) -> GuardianResult<Vec<VerifiedLogRecord>> {
+    async fn read_recent_heartbeat_logs(
+        &mut self,
+        reference_time: UnixMillis,
+    ) -> GuardianResult<Vec<VerifiedLogRecord>> {
         // Read from the previous, current, and next hour-scoped prefixes to
         // cover clock-boundary cases and moderate clock skew.
-        let one_hour_ago = now_timestamp_secs().saturating_sub(60 * 60);
+        let one_hour_ago = unix_millis_to_seconds(reference_time).saturating_sub(60 * 60);
         let mut cursor = S3HourScopedDirectory::heartbeat(one_hour_ago);
         let mut logs = Vec::new();
         for _ in 0..3 {
@@ -87,22 +116,15 @@ impl GuardianReader {
     }
 }
 
-#[derive(Debug, Clone)]
-struct GuardianSessionInfo {
-    session_id: SessionID,
-    first_heartbeat: UnixSeconds,
-    last_heartbeat: UnixSeconds,
-}
-
 fn summarize_heartbeats_by_session(
     logs: Vec<VerifiedLogRecord>,
 ) -> GuardianResult<Vec<GuardianSessionInfo>> {
-    let mut map: BTreeMap<SessionID, (UnixSeconds, UnixSeconds)> = BTreeMap::new();
+    let mut map: BTreeMap<SessionID, (UnixMillis, UnixMillis)> = BTreeMap::new();
 
     for log in logs {
         let entry = log.into_entry();
         let session_id = entry.session_id().clone();
-        let ts = unix_millis_to_seconds(entry.timestamp_ms());
+        let ts = entry.timestamp_ms();
         match entry.into_message() {
             V1(LogMessageV1::Heartbeat(..)) | V2(LogMessageV2::Heartbeat(..)) => {}
             V1(_) | V2(_) => {
@@ -134,21 +156,22 @@ fn summarize_heartbeats_by_session(
 
 fn validate_other_sessions_quiet(
     summary: &[GuardianSessionInfo],
-    now: UnixSeconds,
+    scan_started_at: UnixMillis,
     live_session: &str,
-    other_session_quiet_secs: UnixSeconds,
+    other_session_quiet_period: Duration,
 ) -> GuardianResult<()> {
     if let Some(most_recent_other_session) = summary
         .iter()
         .filter(|s| s.session_id.as_str() != live_session)
         .max_by_key(|s| s.last_heartbeat)
     {
-        let heartbeat_age_secs = now.saturating_sub(most_recent_other_session.last_heartbeat);
-        if heartbeat_age_secs < other_session_quiet_secs {
+        let heartbeat_age_ms =
+            scan_started_at.saturating_sub(most_recent_other_session.last_heartbeat);
+        if u128::from(heartbeat_age_ms) < other_session_quiet_period.as_millis() {
             return Err(PriorSessionHeartbeatStillRecent {
                 session_id: most_recent_other_session.session_id.clone(),
-                heartbeat_age_secs,
-                required_quiet_secs: other_session_quiet_secs,
+                heartbeat_age_secs: unix_millis_to_seconds(heartbeat_age_ms),
+                required_quiet_secs: other_session_quiet_period.as_secs(),
             });
         }
     }
@@ -157,7 +180,7 @@ fn validate_other_sessions_quiet(
 
 fn validate_session_live<'a>(
     summary: &'a [GuardianSessionInfo],
-    now: UnixSeconds,
+    now: UnixMillis,
     live_session: &str,
 ) -> GuardianResult<&'a GuardianSessionInfo> {
     let live_session_info = summary
@@ -168,11 +191,11 @@ fn validate_session_live<'a>(
             heartbeat_age_secs: None,
             retry_after_secs: HEARTBEAT_INTERVAL.as_secs(),
         })?;
-    let live_session_age_secs = now.saturating_sub(live_session_info.last_heartbeat);
-    if live_session_age_secs > LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE.as_secs() {
+    let live_session_age_ms = now.saturating_sub(live_session_info.last_heartbeat);
+    if u128::from(live_session_age_ms) > LIVE_SESSION_LATEST_HEARTBEAT_MAX_AGE.as_millis() {
         return Err(CurrentSessionHeartbeatNotLive {
             session_id: live_session.into(),
-            heartbeat_age_secs: Some(live_session_age_secs),
+            heartbeat_age_secs: Some(unix_millis_to_seconds(live_session_age_ms)),
             retry_after_secs: HEARTBEAT_INTERVAL.as_secs(),
         });
     }
@@ -192,10 +215,10 @@ mod tests {
         BuildPcrs::new("current", vec![0])
     }
 
-    fn heartbeat_log(session_id: &str, timestamp_secs: UnixSeconds) -> VerifiedLogRecord {
+    fn heartbeat_log(session_id: &str, timestamp_ms: UnixMillis) -> VerifiedLogRecord {
         verified_log(
             session_id,
-            timestamp_secs * 1_000,
+            timestamp_ms,
             LogMessage::Heartbeat(HeartbeatLogMessage::new(0)),
         )
     }
@@ -229,19 +252,19 @@ mod tests {
     #[test]
     fn summarize_heartbeats_tracks_latest_per_session() {
         let summary = summarize_heartbeats_by_session(vec![
-            heartbeat_log("b", 20),
-            heartbeat_log("a", 10),
-            heartbeat_log("a", 30),
+            heartbeat_log("b", 20_000),
+            heartbeat_log("a", 10_000),
+            heartbeat_log("a", 30_000),
         ])
         .unwrap();
 
         assert_eq!(summary.len(), 2);
         assert_eq!(summary[0].session_id.as_str(), "a");
-        assert_eq!(summary[0].first_heartbeat, 10);
-        assert_eq!(summary[0].last_heartbeat, 30);
+        assert_eq!(summary[0].first_heartbeat, 10_000);
+        assert_eq!(summary[0].last_heartbeat, 30_000);
         assert_eq!(summary[1].session_id.as_str(), "b");
-        assert_eq!(summary[1].first_heartbeat, 20);
-        assert_eq!(summary[1].last_heartbeat, 20);
+        assert_eq!(summary[1].first_heartbeat, 20_000);
+        assert_eq!(summary[1].last_heartbeat, 20_000);
     }
 
     #[test]
@@ -256,18 +279,37 @@ mod tests {
         let summary = vec![
             GuardianSessionInfo {
                 session_id: "live".into(),
-                first_heartbeat: 990,
-                last_heartbeat: 990,
+                first_heartbeat: 990_000,
+                last_heartbeat: 990_000,
             },
             GuardianSessionInfo {
                 session_id: "old".into(),
-                first_heartbeat: 200,
-                last_heartbeat: 200,
+                first_heartbeat: 400_000,
+                last_heartbeat: 400_000,
             },
         ];
 
-        validate_other_sessions_quiet(&summary, 1_000, "live", 600)
-            .expect("other session is quiet");
+        validate_other_sessions_quiet(&summary, 1_000_000, "live", Duration::from_secs(600))
+            .expect("other session is quiet at the exact millisecond boundary");
+    }
+
+    #[test]
+    fn validate_other_sessions_quiet_rejects_one_millisecond_short() {
+        let summary = vec![
+            GuardianSessionInfo {
+                session_id: "live".into(),
+                first_heartbeat: 990_000,
+                last_heartbeat: 990_000,
+            },
+            GuardianSessionInfo {
+                session_id: "old".into(),
+                first_heartbeat: 400_001,
+                last_heartbeat: 400_001,
+            },
+        ];
+
+        validate_other_sessions_quiet(&summary, 1_000_000, "live", Duration::from_secs(600))
+            .expect_err("the complete quiet period must pass before the scan starts");
     }
 
     #[test]
@@ -275,17 +317,17 @@ mod tests {
         let summary = vec![
             GuardianSessionInfo {
                 session_id: "target".into(),
-                first_heartbeat: 990,
-                last_heartbeat: 990,
+                first_heartbeat: 990_000,
+                last_heartbeat: 990_000,
             },
             GuardianSessionInfo {
                 session_id: "active".into(),
-                first_heartbeat: 995,
-                last_heartbeat: 995,
+                first_heartbeat: 995_000,
+                last_heartbeat: 995_000,
             },
         ];
 
-        validate_session_live(&summary, 1_000, "target")
+        validate_session_live(&summary, 1_000_000, "target")
             .expect("target session is live even while the active session also heartbeats");
     }
 
@@ -294,19 +336,19 @@ mod tests {
         let summary = vec![
             GuardianSessionInfo {
                 session_id: "live".into(),
-                first_heartbeat: 820,
-                last_heartbeat: 820,
+                first_heartbeat: 820_000,
+                last_heartbeat: 820_000,
             },
             GuardianSessionInfo {
                 session_id: "old".into(),
-                first_heartbeat: 400,
-                last_heartbeat: 400,
+                first_heartbeat: 400_000,
+                last_heartbeat: 400_000,
             },
         ];
 
-        validate_session_live(&summary, 1_000, "live")
+        validate_session_live(&summary, 1_000_000, "live")
             .expect("live session heartbeat is at the age boundary");
-        validate_other_sessions_quiet(&summary, 1_000, "live", 600)
+        validate_other_sessions_quiet(&summary, 1_000_000, "live", Duration::from_secs(600))
             .expect("other session heartbeat is at the quiet boundary");
     }
 
@@ -314,11 +356,11 @@ mod tests {
     fn validate_session_live_fails_when_session_missing() {
         let summary = vec![GuardianSessionInfo {
             session_id: "old".into(),
-            first_heartbeat: 200,
-            last_heartbeat: 200,
+            first_heartbeat: 200_000,
+            last_heartbeat: 200_000,
         }];
 
-        let err = validate_session_live(&summary, 1_000, "live")
+        let err = validate_session_live(&summary, 1_000_000, "live")
             .expect_err("must require heartbeat for live session");
         assert_eq!(
             err,
@@ -334,11 +376,11 @@ mod tests {
     fn validate_session_live_fails_when_session_stale() {
         let summary = vec![GuardianSessionInfo {
             session_id: "live".into(),
-            first_heartbeat: 800,
-            last_heartbeat: 800,
+            first_heartbeat: 800_000,
+            last_heartbeat: 800_000,
         }];
 
-        let err = validate_session_live(&summary, 1_000, "live")
+        let err = validate_session_live(&summary, 1_000_001, "live")
             .expect_err("must reject stale live session");
         assert_eq!(
             err,
@@ -355,23 +397,24 @@ mod tests {
         let summary = vec![
             GuardianSessionInfo {
                 session_id: "live".into(),
-                first_heartbeat: 990,
-                last_heartbeat: 990,
+                first_heartbeat: 990_000,
+                last_heartbeat: 990_000,
             },
             GuardianSessionInfo {
                 session_id: "other-older".into(),
-                first_heartbeat: 920,
-                last_heartbeat: 920,
+                first_heartbeat: 920_000,
+                last_heartbeat: 920_000,
             },
             GuardianSessionInfo {
                 session_id: "other-newer".into(),
-                first_heartbeat: 950,
-                last_heartbeat: 950,
+                first_heartbeat: 950_000,
+                last_heartbeat: 950_000,
             },
         ];
 
-        let err = validate_other_sessions_quiet(&summary, 1_000, "live", 100)
-            .expect_err("must reject a recent heartbeat from another session");
+        let err =
+            validate_other_sessions_quiet(&summary, 1_000_000, "live", Duration::from_secs(100))
+                .expect_err("must reject a recent heartbeat from another session");
         assert_eq!(
             err,
             PriorSessionHeartbeatStillRecent {


### PR DESCRIPTION
## Summary

- keep heartbeats as the sole reader-visible session lease
- retain the existing scan of the previous, current, and next hourly heartbeat prefixes
- evaluate the activation candidate's heartbeat freshness when the scan completes
- require every prior session's ten-minute quiet boundary to have passed before the final scan begins
- compare signed heartbeat timestamps at millisecond precision

The scan-start rule closes a race in which a scan could begin before the old lease expired, read a prefix, cross the boundary, and then accept without seeing a renewal written after that prefix was read.

This is a standalone one-file reader hardening change. It complements #1016's writer fence but has no code dependency and can be reviewed or merged independently.

## Assumptions

The signed-timestamp comparison assumes the activating enclave's wall clock is not ahead of the prior writer. As with #1016, a platform-independent hard fence ultimately requires a server-side generation or expiry primitive.

## Verification

- `make fmt`
- `cargo check`
- `cargo test -p hashi-guardian s3_reader::heartbeat_checks::tests` — 9 passed
