### PR TITLE
onchain: skip the deposit-tracker reconcile on governance-only mirrors

### DIFF
--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -499,9 +499,13 @@ impl OnchainState {
     fn reconcile_deposit_tracker(&self) {
         let requests = {
             let state = self.state();
-            state
-                .hashi
-                .bitcoin()
+            // A `ScrapeScope::GovernanceOnly` mirror (the CLI, `hashi launch`)
+            // carries no Bitcoin collections and runs no deposit tracker
+            // consumer, so there is nothing to reconcile.
+            let Some(bitcoin) = state.hashi.try_bitcoin() else {
+                return;
+            };
+            bitcoin
                 .deposit_queue
                 .requests()
                 .iter()


### PR DESCRIPTION
## Summary

Fixes [IOP-665](https://linear.app/mysten-labs/issue/IOP-665/cli-and-hashi-launch-panic-on-a-governance-only-scrape-since-912): a `hashi` binary built from main after #912 panics at startup for every `hashi proposal ...` command and for `hashi launch`.

```
thread 'main' panicked at crates/hashi/src/onchain/mod.rs:504:18:
Bitcoin state was not scraped (ScrapeScope::GovernanceOnly)
```

`OnchainState::new` reconciles the deposit tracker from the mirrored deposit queue on every scrape (#912), and `reconcile_deposit_tracker` read the Bitcoin collections through the accessor that expects them to be present. A `ScrapeScope::GovernanceOnly` mirror leaves them `None`, and that scope is what `HashiClient::new` (all governance and config commands), the two governance-only scrapes in `cli/commands/mod.rs`, and `run_launch` use.

A governance-only mirror runs no deposit-tracker consumer, so there is nothing to reconcile: return early when the collections are absent.

## Impact

The testnet pods run the pre-#912 release, so live governance is unaffected until the next release ships. Anything built from main since #912 is affected: the laptop-built CLI for the 2026-09-01 upgrade and the genesis launch switch for the pre-mainnet release.

## Tests

Found by, and verified with, the localnet acceptance run for the `execute-upgrade` command (the PR stacked on this one): on a manual v1 localnet, `hashi launch` panicked before this change and completes after it, followed by the full propose, vote, execute-upgrade, disable-v1 sequence through governance-only `HashiClient` instances. There is no offline `OnchainState` constructor (both paths scrape RPC), so a unit test would need an RPC mock; not added here.
