### PR TITLE
cli: execute-upgrade runs the execute + publish + finalize PTB

### DIFF
--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -20,6 +20,11 @@ use crate::cli::print_info;
 use crate::cli::print_warning;
 use crate::cli::types::Proposal;
 use crate::cli::types::display;
+use crate::cli::upgrade::build_upgrade_execution_transaction;
+use crate::cli::upgrade::build_upgrade_package;
+use crate::cli::upgrade::build_upgrade_v2_execution_transaction;
+use crate::cli::upgrade::extract_new_package_id_from_response;
+use crate::onchain::types::ProposalType;
 
 /// Print metadata if present
 fn print_metadata(metadata: &[(String, String)]) {
@@ -237,14 +242,10 @@ pub async fn vote(
 
     // Upgrade proposals require the dedicated upgrade flow — the generic
     // `<module>::execute` path can't construct an UpgradeTicket.
-    use crate::onchain::types::ProposalType;
-    if matches!(
-        proposal.proposal_type,
-        ProposalType::Upgrade | ProposalType::UpgradeV2
-    ) {
+    if upgrade_proposal_kind(&proposal.proposal_type).is_some() {
         print_warning(
-            "--execute is not supported for Upgrade proposals; run the \
-             dedicated upgrade flow once quorum is reached.",
+            "--execute is not supported for Upgrade proposals; run \
+             `proposal execute-upgrade` once quorum is reached.",
         );
         return Ok(());
     }
@@ -350,14 +351,10 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
     let proposal_type = &proposal.proposal_type;
     let proposal_type_str = display::format_proposal_type(proposal_type);
 
-    use crate::onchain::types::ProposalType;
-    if matches!(
-        proposal_type,
-        ProposalType::Upgrade | ProposalType::UpgradeV2
-    ) {
+    if upgrade_proposal_kind(proposal_type).is_some() {
         anyhow::bail!(
-            "Upgrade proposals cannot be executed via the CLI. \
-             Use the full upgrade flow (execute + publish + finalize) instead."
+            "Upgrade proposals publish a package as part of their execution; \
+             use `proposal execute-upgrade {proposal_id} --package-path <dir>` instead."
         );
     }
 
@@ -376,6 +373,195 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
     ));
 
     execute_or_simulate(&mut client, tx, tx_opts).await?;
+    Ok(())
+}
+
+/// Which upgrade proposal module an approved proposal executes through.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpgradeProposalKind {
+    /// `hashi::upgrade`: the legacy proposal, which leaves every previously
+    /// enabled package version enabled.
+    Legacy,
+    /// `hashi::upgrade_v2`: carries the committee-approved exclusive or
+    /// non-exclusive version policy.
+    V2,
+}
+
+impl UpgradeProposalKind {
+    /// The Move module whose `execute` and `finalize_upgrade` the PTB calls.
+    pub fn module(self) -> &'static str {
+        match self {
+            UpgradeProposalKind::Legacy => "upgrade",
+            UpgradeProposalKind::V2 => "upgrade_v2",
+        }
+    }
+}
+
+/// The upgrade module an approved proposal executes through, or `None` for
+/// every proposal type that goes through the generic `proposal execute` path.
+pub fn upgrade_proposal_kind(proposal_type: &ProposalType) -> Option<UpgradeProposalKind> {
+    match proposal_type {
+        ProposalType::Upgrade => Some(UpgradeProposalKind::Legacy),
+        ProposalType::UpgradeV2 => Some(UpgradeProposalKind::V2),
+        _ => None,
+    }
+}
+
+/// Inputs for [`execute_upgrade`]: where to build the package from and which
+/// `sui` binary to build it with.
+pub struct ExecuteUpgradeArgs<'a> {
+    pub package_path: &'a std::path::Path,
+    pub sui_binary: &'a std::path::Path,
+    pub sui_client_config: Option<&'a std::path::Path>,
+}
+
+/// Execute an approved upgrade proposal.
+///
+/// One programmable transaction: `<module>::execute` consumes the proposal and
+/// returns the `UpgradeTicket`, the `Upgrade` command publishes the freshly
+/// built modules against that ticket, and `<module>::finalize_upgrade` commits
+/// the receipt (which also enables the new version). The ticket and receipt
+/// are hot potatoes, so the three steps cannot be split across transactions.
+///
+/// The package is built here, from `package_path`, and must be byte-identical
+/// to the build whose digest went into the proposal: same commit, same `sui`.
+/// The chain enforces that when it processes the `Upgrade` command, so a
+/// mismatch fails at simulation rather than costing gas.
+pub async fn execute_upgrade(
+    config: &CliConfig,
+    proposal_id: &str,
+    args: ExecuteUpgradeArgs<'_>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let ExecuteUpgradeArgs {
+        package_path,
+        sui_binary,
+        sui_client_config,
+    } = args;
+    let mut client = HashiClient::new(config).await?;
+
+    let proposal_addr = Address::from_hex(proposal_id)
+        .with_context(|| format!("Invalid proposal ID: {}", proposal_id))?;
+
+    print_info(&format!("Fetching proposal {}...", proposal_id));
+
+    let proposal = client
+        .fetch_proposal(&proposal_addr)
+        .ok_or_else(|| anyhow::anyhow!("Proposal not found: {}", proposal_id))?;
+
+    let kind = upgrade_proposal_kind(&proposal.proposal_type).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{} is a {} proposal, not an upgrade; use `proposal execute` instead",
+            proposal_id,
+            display::format_proposal_type(&proposal.proposal_type)
+        )
+    })?;
+    let module = kind.module();
+
+    let current_version = client.highest_package_version().context(
+        "could not determine current package version from on-chain state; \
+         is the package deployed?",
+    )?;
+    let expected_version = current_version + 1;
+    let current_package_id = client.latest_package_id()?;
+
+    print_detail(&format!("\n{}", "Execute Upgrade Proposal:".bold()));
+    print_detail(&format!(
+        "  Type:            {}",
+        display::format_proposal_type(&proposal.proposal_type).cyan()
+    ));
+    print_detail(&format!("  ID:              {}", proposal_id));
+    print_detail(&format!("  Module:          {}", module));
+    print_detail(&format!(
+        "  Current package: v{} at {}",
+        current_version,
+        current_package_id.to_hex()
+    ));
+    print_detail(&format!("  Package path:    {}", package_path.display()));
+    print_detail(&format!(
+        "  Expects:         PACKAGE_VERSION = {expected_version}"
+    ));
+
+    print_info(&format!(
+        "Building upgrade package at {} with {}",
+        package_path.display(),
+        sui_binary.display()
+    ));
+    let (compiled, digest) = build_upgrade_package(
+        sui_binary,
+        package_path,
+        sui_client_config,
+        expected_version,
+    )
+    .context("failed to build upgrade package")?;
+    print_detail(&format!("  Built digest:    0x{}", hex::encode(&digest)));
+    print_detail(
+        "  The publish is accepted only if this digest matches the proposal's; \
+         build from the same commit with the same `sui` that produced the proposal.",
+    );
+
+    prompt_continue(
+        "execute this upgrade (execute + publish + finalize in one transaction)",
+        tx_opts,
+    )
+    .await?;
+
+    let hashi_ids = *client.hashi_ids();
+    let tx = match kind {
+        UpgradeProposalKind::Legacy => build_upgrade_execution_transaction(
+            hashi_ids,
+            current_package_id,
+            proposal_addr,
+            compiled,
+        ),
+        UpgradeProposalKind::V2 => build_upgrade_v2_execution_transaction(
+            hashi_ids,
+            current_package_id,
+            proposal_addr,
+            compiled,
+        ),
+    };
+
+    print_info(&format!(
+        "Transaction: {module}::execute + Upgrade + {module}::finalize_upgrade on {}",
+        proposal_id
+    ));
+
+    let Some(response) = execute_or_simulate(&mut client, tx, tx_opts).await? else {
+        return Ok(());
+    };
+
+    let new_package_id = extract_new_package_id_from_response(&response)?;
+    println!(
+        "  {} {}",
+        "New package ID:".bold(),
+        new_package_id.to_hex().cyan()
+    );
+
+    // Re-read the chain so the operator sees what the commit enabled, rather
+    // than the pre-upgrade snapshot this client was built from.
+    let refreshed = HashiClient::new(config).await?;
+    let mut enabled: Vec<u64> = refreshed
+        .onchain_state()
+        .state()
+        .hashi()
+        .config
+        .enabled_versions
+        .iter()
+        .copied()
+        .collect();
+    enabled.sort_unstable();
+    println!("  {} {:?}", "Enabled versions:".bold(), enabled);
+    if let Some(latest) = refreshed.highest_package_version() {
+        println!("  {} v{latest}", "Latest package:".bold());
+    }
+    if kind == UpgradeProposalKind::Legacy && enabled.contains(&current_version) {
+        print_warning(&format!(
+            "v{current_version} stays enabled: the legacy upgrade proposal never retires \
+             versions. Execute the DisableVersion({current_version}) proposal through \
+             the new package when the fleet is ready."
+        ));
+    }
     Ok(())
 }
 

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -160,6 +160,31 @@ pub enum ProposalCommands {
         proposal_id: String,
     },
 
+    /// Execute an approved upgrade proposal: `<module>::execute`, publish the
+    /// package, and `<module>::finalize_upgrade` in one transaction.
+    ///
+    /// Builds the package with `sui move build` first and verifies that its
+    /// `PACKAGE_VERSION` constant is exactly +1 of the currently published
+    /// version. Build from the same commit, with the same `sui`, that produced
+    /// the proposal's digest: the chain rejects the publish otherwise. Works
+    /// for both `upgrade` and `upgrade-v2` proposals.
+    ExecuteUpgrade {
+        /// The proposal object ID to execute
+        proposal_id: String,
+
+        /// Path to the upgrade package source (the directory with `Move.toml`).
+        #[clap(long, value_name = "PATH")]
+        package_path: std::path::PathBuf,
+
+        /// Path to the `sui` CLI binary.
+        #[clap(long, env = "SUI_BINARY", default_value = "sui")]
+        sui_binary: std::path::PathBuf,
+
+        /// Optional path to a sui `client.yaml` for dependency resolution.
+        #[clap(long)]
+        sui_client_config: Option<std::path::PathBuf>,
+    },
+
     /// Create a new proposal
     Create {
         #[clap(subcommand)]
@@ -1020,6 +1045,24 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
             }
             ProposalCommands::Execute { proposal_id } => {
                 commands::proposal::execute(&config, &proposal_id, &tx_opts).await?;
+            }
+            ProposalCommands::ExecuteUpgrade {
+                proposal_id,
+                package_path,
+                sui_binary,
+                sui_client_config,
+            } => {
+                commands::proposal::execute_upgrade(
+                    &config,
+                    &proposal_id,
+                    commands::proposal::ExecuteUpgradeArgs {
+                        package_path: &package_path,
+                        sui_binary: &sui_binary,
+                        sui_client_config: sui_client_config.as_deref(),
+                    },
+                    &tx_opts,
+                )
+                .await?;
             }
             ProposalCommands::Create { proposal } => match proposal {
                 CreateProposalCommands::Upgrade {

--- a/crates/hashi/tests/cli_execute_upgrade.rs
+++ b/crates/hashi/tests/cli_execute_upgrade.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `proposal execute-upgrade` dispatches on the proposal's type: the two
+//! upgrade payloads go through their own module's `execute` and
+//! `finalize_upgrade`; everything else belongs to `proposal execute`.
+
+use hashi::cli::commands::proposal::UpgradeProposalKind;
+use hashi::cli::commands::proposal::upgrade_proposal_kind;
+use hashi::onchain::types::ProposalType;
+
+#[test]
+fn upgrade_payloads_map_to_their_module() {
+    assert_eq!(
+        upgrade_proposal_kind(&ProposalType::Upgrade),
+        Some(UpgradeProposalKind::Legacy)
+    );
+    assert_eq!(
+        upgrade_proposal_kind(&ProposalType::UpgradeV2),
+        Some(UpgradeProposalKind::V2)
+    );
+    assert_eq!(UpgradeProposalKind::Legacy.module(), "upgrade");
+    assert_eq!(UpgradeProposalKind::V2.module(), "upgrade_v2");
+}
+
+#[test]
+fn non_upgrade_payloads_are_refused() {
+    for proposal_type in [
+        ProposalType::UpdateConfig,
+        ProposalType::EnableVersion,
+        ProposalType::DisableVersion,
+        ProposalType::EmergencyPause,
+        ProposalType::AbortReconfig,
+        ProposalType::UpdateGuardian,
+        ProposalType::IgnoreMember,
+        ProposalType::Unknown("something_new".to_string()),
+    ] {
+        assert_eq!(
+            upgrade_proposal_kind(&proposal_type),
+            None,
+            "{proposal_type:?} must not reach the upgrade flow"
+        );
+    }
+}

--- a/design/docs/move-upgrades.mdx
+++ b/design/docs/move-upgrades.mdx
@@ -107,8 +107,10 @@ Use this sequence for every upgrade:
    on the current package before casting its vote.
 4. Confirm that upgraded validators represent at least two thirds of committee
    **weight**, not merely two thirds of node count.
-5. Reach proposal quorum, then separately execute and publish the upgrade.
-   Votes never auto-publish a package.
+5. Reach proposal quorum, then separately execute and publish the upgrade with
+   `hashi proposal execute-upgrade <proposal-id> --package-path <dir>`, built
+   from the same commit and `sui` binary as the proposal's digest. Votes never
+   auto-publish a package.
 6. Verify the package-upgrade checkpoint, enabled-version set, active routing,
    and validator health before resuming ordinary rollout work.
 
@@ -130,7 +132,7 @@ withdrawal queue does not need to drain first.
 2. Execute the pause once the remaining proposals are near quorum. Governance
    entries are not pause-gated, so the remaining steps execute while paused.
 3. Verify the bridge is still paused, then execute, publish, and finalize v2
-   through the legacy v1 upgrade path.
+   through the legacy v1 upgrade path (`hashi proposal execute-upgrade`).
 4. Wait for that transaction to succeed and obtain the newly published v2
    package ID.
 5. Immediately execute the already-approved disable-v1 proposal through the v2

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -813,6 +813,7 @@ hashi proposal view <proposal-id>
 hashi proposal vote <proposal-id> [--execute]
 hashi proposal remove-vote <proposal-id>
 hashi proposal execute <proposal-id>
+hashi proposal execute-upgrade <proposal-id> --package-path <path>   # upgrade proposals only
 ```
 
 Create proposals:
@@ -957,9 +958,11 @@ hashi proposal create upgrade-v2 --exclusive true --package-path /path/to/packag
 # Vote (--execute is NOT supported for Upgrade proposals)
 hashi proposal vote 0x<proposal-id>
 
-# After quorum: use the release tooling to build and submit one programmable
-# transaction containing proposal execution, package publication, and upgrade
-# finalization. The generic `proposal execute` command rejects upgrade types.
+# After quorum: one programmable transaction executes the proposal, publishes
+# the package, and finalizes the upgrade. Build from the same commit, with the
+# same `sui`, that produced the proposal's digest. The generic
+# `proposal execute` command rejects upgrade types.
+hashi proposal execute-upgrade 0x<proposal-id> --package-path /path/to/packages/hashi
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds the operator command that runs an approved upgrade proposal to completion. Closes [IOP-664](https://linear.app/mysten-labs/issue/IOP-664/cli-execute-upgrade-runs-the-execute-publish-finalize-ptb-for-an); needed for the first testnet package upgrade.

Until now `hashi proposal execute` refused upgrade proposals ("use the full upgrade flow"), `vote --execute` skipped them, and the only code that drove the transaction they need was the e2e harness, which requires a `TestNetworks` and cannot point at a live network. `sui client upgrade` cannot do it either: the `UpgradeCap` sits in Hashi custody and the `UpgradeTicket` comes out of `upgrade::execute` inside the same PTB.

```
hashi proposal execute-upgrade <proposal-id> --package-path packages/hashi [--sui-binary <path>] [--sui-client-config <client.yaml>]
```

- Reads the proposal and dispatches on its type: the legacy `upgrade` module (what the deployed v1 has) or `upgrade_v2`; any other type is refused with a pointer to `proposal execute`.
- Builds the package with `build_upgrade_package`, so the same pre-flight as `create upgrade` applies: `PACKAGE_VERSION` must be exactly +1 of the highest published version.
- One PTB: `<module>::execute` (returns the `UpgradeTicket`), `Upgrade(modules, deps, ticket)`, `<module>::finalize_upgrade` (commits the receipt and enables the new version). Built by the existing `build_upgrade_execution_transaction` / `build_upgrade_v2_execution_transaction` against the chain's latest package id.
- Honors the shared `TxOptions`: `--dry-run`, `--serialize-unsigned-transaction` for a multisig sender, `-y`.
- Prints the built digest before the confirmation prompt (the chain accepts the publish only if it matches the proposal's, so build from the same commit with the same `sui`), then the new package id and the enabled-version set read back from the chain. After a legacy upgrade it reminds the operator that the previous version stays enabled until `DisableVersion` runs through the new package.

The two refusal messages in `execute` and `vote --execute` now name the command; the runbook and `move-upgrades.mdx` do too, where they used to defer to "the release tooling".

## Tests

- `crates/hashi/tests/cli_execute_upgrade.rs`: the type dispatch (both upgrade payloads map to their module, every other payload is refused).
- Localnet acceptance run on a manual v1 localnet with this binary: register and launch four validators, `hashi launch`, DKG, `create upgrade --package-path`, three votes, `execute-upgrade`, then `create disable-version 1` executed through the new package via `vote --execute`, ending with `enabled_versions == [2]`. Both negative paths checked on the way (`execute` refuses the upgrade proposal, `execute-upgrade` refuses the disable proposal). Passed on this branch (built package digest `0x61b6c0e9…431ca1`, v2 published, `[1, 2]` then `[2]`); the run found and depends on the governance-only scrape fix this PR is stacked on.
- `cargo clippy -p hashi --all-features --all-targets` and CI's rustfmt config clean.

Stacked on the governance-only scrape fix (IOP-665): without it, every governance-only `HashiClient` from today's main panics at startup, this command included.

No Move or node change; the command runs from an operator machine.
