### PR TITLE
test(e2e): tear nodes down before deleting the environment directory

### DIFF
--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -31,6 +31,48 @@ pub struct HashiNodeHandle {
     service: Option<(Service, Arc<Hashi>)>,
 }
 
+impl Drop for HashiNodeHandle {
+    /// Tear the node down and wait (bounded) until nothing holds its database
+    /// any more.
+    ///
+    /// Dropping the `Service` aborts the node's tasks, but a `spawn_blocking`
+    /// closure that a task already queued (e.g. the post-reconfig major
+    /// compaction) keeps running on the blocking pool with its own `db`
+    /// clone. The test's environment directory is deleted right after the
+    /// handles drop; if that happens under such a closure, its storage
+    /// workers crash on the missing files and the closure can wedge, and the
+    /// test runtime then waits on it forever (nextest kills the test at
+    /// terminate-after). The database lock is released only once every
+    /// handle is gone, so a successful re-open is the exact "no DB work in
+    /// flight" signal; the same idiom `create_hashi_retry` uses for restarts.
+    fn drop(&mut self) {
+        const MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
+        const STEP: std::time::Duration = std::time::Duration::from_millis(100);
+
+        if self.service.take().is_none() {
+            return;
+        }
+        let Some(db_path) = self.config.db.as_deref() else {
+            return;
+        };
+        let started = std::time::Instant::now();
+        loop {
+            match hashi::db::Database::open(db_path) {
+                Ok(_probe) => return,
+                Err(_) if started.elapsed() < MAX_WAIT => std::thread::sleep(STEP),
+                Err(e) => {
+                    tracing::warn!(
+                        "Hashi node database still locked {:?} after shutdown; \
+                         tearing down anyway: {e}",
+                        started.elapsed()
+                    );
+                    return;
+                }
+            }
+        }
+    }
+}
+
 impl HashiNodeHandle {
     pub fn new(config: HashiConfig) -> Result<Self> {
         Ok(Self {

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -63,12 +63,18 @@ pub(crate) fn tail_logs(files: &[(&str, &Path)]) -> String {
 }
 
 pub struct TestNetworks {
-    #[allow(unused)]
-    dir: TempDir,
     pub sui_network: SuiNetworkHandle,
     pub hashi_network: HashiNetwork,
     pub bitcoin_node: BitcoinNodeHandle,
     pub guardian_harness: Option<guardian_harness::GuardianHarness>,
+    /// The environment directory (node DBs, Sui and Bitcoin data). Declared
+    /// LAST on purpose: fields drop in declaration order, and deleting the
+    /// directory while a node is still running crashes its storage workers,
+    /// which can wedge a queued blocking compaction and hang the test past
+    /// nextest's terminate-after. Every process and node handle above must be
+    /// torn down first (see `HashiNodeHandle`'s `Drop`).
+    #[allow(unused)]
+    dir: TempDir,
 }
 
 impl TestNetworks {


### PR DESCRIPTION
## Summary

Fixes [IOP-661](https://linear.app/mysten-labs/issue/IOP-661/e2e-teardown-testnetworks-drops-tempdir-before-live-nodes): `test_resigned_member_excluded_then_removed_permissionlessly` has timed out at nextest's 720s cap, on both tries, in three unrelated CI runs since Friday (main at 1774ddbb8, PR #1067's first attempt, PR #1070). All six occurrences stop at the identical point with the identical log signature.

The test body completes (~105s: both epoch boundaries closed, `end_reconfig complete for epoch 2` logged, final assertions reached). Then `TestNetworks` drops, and `dir: TempDir` is its first-declared field, so the whole test environment directory is deleted before the four in-process hashi nodes, the sui process, and bitcoind shut down. The nodes' fjall workers hit the deleted paths (`Flush error: Io(NotFound)`, `Worker #0 crashed`, then a storm of `Failed to cleanup deleted table` warnings, the literal last output of every occurrence) and teardown wedges until nextest terminates the test.

This test triggers the race far more than others because it forces two reconfigs, and `MpcService` queues `spawn_blocking(db.major_compact())` after every `end_reconfig` (`mpc/service.rs`), so a compaction holding a DB handle is in flight exactly when the body returns. The test passes in isolation locally (82s) because the race needs CI's load to lose.

## Fix

Harness-only, two parts:

- `TestNetworks` declares `dir: TempDir` as its last field, so node, sui and bitcoind shutdown runs before the directory is deleted.
- `HashiNodeHandle` gains a `Drop` impl that drops the node's service and then polls re-opening the node's database for up to 5s in 100ms steps; a successful open proves no `spawn_blocking` closure still holds the fjall lock, so the queued post-reconfig compaction has drained. On expiry it warns and continues rather than hanging.

## Tests

- `cargo nextest run -p e2e-tests -E 'test(test_resigned_member_excluded_then_removed_permissionlessly)'` on this branch: passes.
- The wedge itself only reproduces under CI load, so the proof is structural (nothing can touch a deleted directory once nothing is deleted before shutdown) plus the CI runs of this PR.

No change outside `crates/e2e-tests`; no effect on the release binary or the Move package.
