### PR TITLE
Reject a resharing share when its previous key commitment is missing

### DIFF
--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -526,7 +526,9 @@ impl MpcManager {
             Messages::AvidNonceRetrieval(_) => unreachable!("rejected above"),
         }
         .map(|signature| SendMessagesResponse { signature });
-        self.message_responses.insert(cache_key, result.clone());
+        if !matches!(result, Err(MpcError::InvalidConfig(_))) {
+            self.message_responses.insert(cache_key, result.clone());
+        }
         result
     }
 
@@ -4339,7 +4341,11 @@ impl MpcManager {
                 continue;
             }
             let session_id = base_sid.rotation_session_id(dealer, share_index);
-            let commitment = previous_dkg_output.commitments.get(&share_index).copied();
+            let commitment = Some(required_previous_commitment(
+                previous_dkg_output,
+                dealer,
+                share_index,
+            )?);
             self.process_and_store_message(
                 self.mpc_config.nodes.clone(),
                 self.party_id,
@@ -5178,7 +5184,11 @@ impl MpcManager {
                 });
             }
             let session_id = base_sid.rotation_session_id(&dealer, share_index);
-            let commitment = previous_dkg_output.commitments.get(&share_index).copied();
+            let commitment = Some(required_previous_commitment(
+                previous_dkg_output,
+                &dealer,
+                share_index,
+            )?);
             match process_avss_message(
                 &self.encryption_key,
                 self.mpc_config.nodes.clone(),
@@ -6929,6 +6939,23 @@ async fn hedged_retrieve<'a, P: P2PChannel + 'a>(
         }
         round_size = round_size.saturating_mul(HEDGED_RETRIEVE_ROUND_GROWTH_FACTOR);
     }
+}
+
+fn required_previous_commitment(
+    previous_dkg_output: &MpcOutput,
+    dealer: &Address,
+    share_index: ShareIndex,
+) -> MpcResult<G> {
+    previous_dkg_output
+        .commitments
+        .get(&share_index)
+        .copied()
+        .ok_or_else(|| {
+            MpcError::InvalidConfig(format!(
+                "local previous-epoch output has no commitment for share index {share_index} \
+                 (owned by dealer {dealer}); cannot verify the dealt share reshares the existing key"
+            ))
+        })
 }
 
 fn process_avss_message(

--- a/crates/hashi/src/mpc/mpc_except_signing_tests.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing_tests.rs
@@ -6742,6 +6742,40 @@ fn test_try_sign_rotation_messages_all_or_nothing() {
 }
 
 #[test]
+fn try_sign_rotation_messages_rejects_a_share_with_no_previous_commitment() {
+    let rotation_setup = RotationTestSetup::new();
+    let (mut receiver_manager, mut receiver_dkg_output) =
+        rotation_setup.create_receiver_with_completed_dkg(2);
+    let (_, _, rotation_messages) = rotation_setup.create_rotation_dealer(0);
+    let rotation_dealer_addr = rotation_setup.setup.address(0);
+
+    let Messages::Rotation(rotation_map) = &rotation_messages else {
+        panic!("Expected rotation messages")
+    };
+    let dealt_index = *rotation_map
+        .keys()
+        .next()
+        .expect("dealer deals at least one share");
+    assert!(
+        receiver_dkg_output
+            .commitments
+            .remove(&dealt_index)
+            .is_some()
+    );
+
+    let result = receiver_manager.try_sign_rotation_messages(
+        &receiver_dkg_output,
+        rotation_dealer_addr,
+        &rotation_messages,
+    );
+
+    assert!(
+        matches!(result, Err(MpcError::InvalidConfig(_))),
+        "a dealt share with no previous-epoch commitment must be rejected, got {result:?}"
+    );
+}
+
+#[test]
 fn test_try_sign_rotation_messages_re_acks_identical_re_deal() {
     let rotation_setup = RotationTestSetup::new();
     let (mut receiver_manager, receiver_dkg_output) =


### PR DESCRIPTION
Not must-fix standalone, but a prerequisite for later change.

#95 