### PR TITLE
Make `MpcManager`'s target-epoch identity optional

### DIFF
--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -993,7 +993,11 @@ mod tests {
             .map(|node| {
                 let mpc_mgr = node.hashi().mpc_manager().unwrap();
                 let mgr = mpc_mgr.read().unwrap();
-                let share_ids = mgr.mpc_config.nodes.share_ids_of(mgr.party_id).unwrap();
+                let share_ids = mgr
+                    .mpc_config
+                    .nodes
+                    .share_ids_of(mgr.party_id().unwrap())
+                    .unwrap();
                 NodeDkgInfo {
                     address: mgr.address,
                     share_ids,

--- a/crates/hashi/src/mpc/mpc_except_signing.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing.rs
@@ -177,15 +177,20 @@ pub struct NoncePartyOutcome {
     pub local_skips: u32,
 }
 
+struct TargetIdentity {
+    party_id: PartyId,
+    encryption_key: PrivateKey<EncryptionGroupElement>,
+    signing_key: Bls12381PrivateKey,
+}
+
 pub struct MpcManager {
     // Immutable during the epoch
-    pub party_id: PartyId,
+    /// Identity in the target epoch's committee, absent when this node is not one of its members.
+    identity: Option<TargetIdentity>,
     pub address: Address,
     pub mpc_config: MpcConfig,
     protocol_type: ProtocolType,
-    pub encryption_key: PrivateKey<EncryptionGroupElement>,
     pub previous_encryption_key: Option<PrivateKey<EncryptionGroupElement>>,
-    pub signing_key: Bls12381PrivateKey,
     pub committee: Committee,
     pub previous_committee: Option<Committee>,
     pub previous_nodes: Option<Nodes<EncryptionGroupElement>>,
@@ -273,6 +278,27 @@ impl<T> VerifiedNonceCerts<T> {
 }
 
 impl MpcManager {
+    fn identity(&self) -> MpcResult<&TargetIdentity> {
+        self.identity.as_ref().ok_or_else(|| {
+            MpcError::InvalidConfig(format!(
+                "node {} is not in the committee for epoch {}",
+                self.address, self.mpc_config.epoch
+            ))
+        })
+    }
+
+    pub fn party_id(&self) -> MpcResult<PartyId> {
+        Ok(self.identity()?.party_id)
+    }
+
+    fn encryption_key(&self) -> MpcResult<&PrivateKey<EncryptionGroupElement>> {
+        Ok(&self.identity()?.encryption_key)
+    }
+
+    fn signing_key(&self) -> MpcResult<&Bls12381PrivateKey> {
+        Ok(&self.identity()?.signing_key)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         address: Address,
@@ -314,20 +340,23 @@ impl MpcManager {
             nonce_generation_protocol,
             committee.mpc_nonce_accumulation_window_ms(),
         );
-        let party_id = committee
-            .index_of(&address)
-            .expect("address not in committee") as u16;
+        let party_id_opt = committee.index_of(&address).map(|i| i as u16);
         let my_pk = PublicKey::<EncryptionGroupElement>::from_private_key(&encryption_key);
-        let committee_pk = &mpc_config
-            .nodes
-            .node_id_to_node(party_id as PartyId)
-            .expect("party_id not in nodes")
-            .pk;
-        let keys_match =
-            my_pk.as_element().to_byte_array() == committee_pk.as_element().to_byte_array();
+        // Both are member-only: a non-member has no committee record to compare against.
+        let committee_pk = party_id_opt.map(|pid| {
+            mpc_config
+                .nodes
+                .node_id_to_node(pid as PartyId)
+                .expect("party_id not in nodes")
+                .pk
+                .clone()
+        });
+        let keys_match = committee_pk
+            .as_ref()
+            .map(|pk| my_pk.as_element().to_byte_array() == pk.as_element().to_byte_array());
         tracing::info!(
             epoch,
-            party_id,
+            party_id = party_id_opt,
             address = %address,
             threshold,
             total_weight,
@@ -335,20 +364,27 @@ impl MpcManager {
             num_nodes = mpc_config.nodes.num_nodes(),
             encryption_keys_match = keys_match,
             my_encryption_pk = hex::encode(my_pk.as_element().to_byte_array()),
-            committee_encryption_pk = hex::encode(committee_pk.as_element().to_byte_array()),
+            committee_encryption_pk = committee_pk
+                .as_ref()
+                .map(|pk| hex::encode(pk.as_element().to_byte_array())),
             "MpcManager initialized"
         );
-        metrics.mpc_party_reduced_weight.set(
-            mpc_config
-                .nodes
-                .weight_of(party_id)
-                .expect("party_id was just derived from this committee") as i64,
-        );
-        if !keys_match {
+        if let Some(pid) = party_id_opt {
+            metrics.mpc_party_reduced_weight.set(
+                mpc_config
+                    .nodes
+                    .weight_of(pid)
+                    .expect("nodes holds one entry per committee index") as i64,
+            );
+        }
+        if keys_match == Some(false) {
             return Err(MpcError::InvalidConfig(format!(
                 "encryption key mismatch at epoch {epoch}: local {my} vs on-chain {chain}",
                 my = hex::encode(my_pk.as_element().to_byte_array()),
-                chain = hex::encode(committee_pk.as_element().to_byte_array()),
+                chain = committee_pk
+                    .as_ref()
+                    .map(|pk| hex::encode(pk.as_element().to_byte_array()))
+                    .unwrap_or_default(),
             )));
         }
         let (previous_epoch, previous_committee) =
@@ -399,14 +435,17 @@ impl MpcManager {
                     .ok()
                     .map(|(_, threshold, _)| threshold)
             });
-        let mut manager = Self {
+        let identity = party_id_opt.map(|party_id| TargetIdentity {
             party_id,
+            encryption_key,
+            signing_key,
+        });
+        let mut manager = Self {
+            identity,
             address,
             mpc_config,
             protocol_type,
-            encryption_key,
             previous_encryption_key,
-            signing_key,
             committee,
             previous_committee,
             previous_nodes,
@@ -741,7 +780,7 @@ impl MpcManager {
                     params,
                     session_id.to_vec(),
                     None,
-                    self.encryption_key.clone(),
+                    self.encryption_key()?.clone(),
                 )?;
                 let ProtocolComplaint::Avss(complaint) = &request.complaint else {
                     return Err(MpcError::InvalidMessage {
@@ -787,7 +826,7 @@ impl MpcManager {
                     params,
                     session_id.to_vec(),
                     None,
-                    self.encryption_key.clone(),
+                    self.encryption_key()?.clone(),
                 )?;
                 let ProtocolComplaint::Avss(complaint) = &request.complaint else {
                     return Err(MpcError::InvalidMessage {
@@ -1120,7 +1159,7 @@ impl MpcManager {
                 let indices = mgr
                     .mpc_config
                     .nodes
-                    .share_ids_of(mgr.party_id)
+                    .share_ids_of(mgr.party_id()?)
                     .map_err(|e| MpcError::CryptoError(e.to_string()))?;
                 consume_certified_nonce_outputs(
                     &mut mgr.dealer_avid_nonce_outputs,
@@ -2510,9 +2549,9 @@ impl MpcManager {
         };
         let dealer_session_id = self.current_session_id().dealer_session_id(&dealer);
         let result = process_avss_message(
-            &self.encryption_key,
+            self.encryption_key()?,
             self.mpc_config.nodes.clone(),
-            self.party_id,
+            self.party_id()?,
             Parameters {
                 t: self.mpc_config.threshold,
                 f: self.mpc_config.max_faulty,
@@ -2530,7 +2569,7 @@ impl MpcManager {
                     messages_hash: messages.compute_hash(),
                 };
                 let signature =
-                    self.signing_key
+                    self.signing_key()?
                         .sign(self.mpc_config.epoch, self.address, &dkg_message);
                 Ok(signature.signature().clone())
             }
@@ -2561,11 +2600,11 @@ impl MpcManager {
         );
         batch_avss::Receiver::new(
             self.mpc_config.nodes.clone(),
-            self.party_id,
+            self.party_id()?,
             dealer_party_id,
             self.mpc_config.threshold,
             dealer_session_id.to_vec(),
-            self.encryption_key.clone(),
+            self.encryption_key()?.clone(),
             self.batch_size_per_weight,
         )
         .map_err(|e| MpcError::CryptoError(e.to_string()))
@@ -2585,7 +2624,7 @@ impl MpcManager {
         let nodes = self.maybe_corrupt_nodes_for_testing(&self.mpc_config.nodes);
         let dealer = batch_avss::Dealer::new(
             nodes,
-            self.party_id,
+            self.party_id()?,
             self.mpc_config.threshold,
             dealer_sid.to_vec(),
             self.batch_size_per_weight,
@@ -2625,7 +2664,7 @@ impl MpcManager {
                     messages_hash: messages.compute_hash(),
                 };
                 let signature =
-                    self.signing_key
+                    self.signing_key()?
                         .sign(self.mpc_config.epoch, self.address, &nonce_message);
                 Ok(signature.signature().clone())
             }
@@ -2656,14 +2695,14 @@ impl MpcManager {
         );
         batch_avss_avid::Receiver::new(
             self.mpc_config.nodes.clone(),
-            self.party_id,
+            self.party_id()?,
             dealer_party_id,
             Parameters {
                 t: self.mpc_config.threshold,
                 f: self.mpc_config.max_faulty,
             },
             dealer_session_id.to_vec(),
-            self.encryption_key.clone(),
+            self.encryption_key()?.clone(),
             self.batch_size_per_weight,
         )
         .map_err(|e| MpcError::CryptoError(e.to_string()))
@@ -2683,7 +2722,7 @@ impl MpcManager {
         let nodes = self.maybe_corrupt_nodes_for_testing(&self.mpc_config.nodes);
         let dealer = batch_avss_avid::Dealer::new(
             nodes,
-            self.party_id,
+            self.party_id()?,
             Parameters {
                 t: self.mpc_config.threshold,
                 f: self.mpc_config.max_faulty,
@@ -2748,7 +2787,7 @@ impl MpcManager {
             batch_index,
         };
         let signature = self
-            .signing_key
+            .signing_key()?
             .sign(self.mpc_config.epoch, self.address, &confirm);
         Ok(signature.signature().clone())
     }
@@ -2768,7 +2807,7 @@ impl MpcManager {
         let nodes = self.maybe_corrupt_nodes_for_testing(&self.mpc_config.nodes);
         let dealer = batch_avss_avid::Dealer::new(
             nodes,
-            self.party_id,
+            self.party_id()?,
             Parameters {
                 t: self.mpc_config.threshold,
                 f: self.mpc_config.max_faulty,
@@ -2842,7 +2881,7 @@ impl MpcManager {
             batch_index,
         };
         let vote = self
-            .signing_key
+            .signing_key()?
             .sign(self.mpc_config.epoch, self.address, &target)
             .signature()
             .clone();
@@ -4255,7 +4294,7 @@ impl MpcManager {
         let session_id = self.current_session_id().dealer_session_id(&dealer);
         self.process_and_store_message(
             self.mpc_config.nodes.clone(),
-            self.party_id,
+            self.party_id()?,
             self.mpc_config.threshold,
             &session_id,
             &message,
@@ -4293,11 +4332,11 @@ impl MpcManager {
         );
         let receiver = batch_avss::Receiver::new(
             self.mpc_config.nodes.clone(),
-            self.party_id,
+            self.party_id()?,
             dealer_party_id,
             self.mpc_config.threshold,
             dealer_sid.to_vec(),
-            self.encryption_key.clone(),
+            self.encryption_key()?.clone(),
             self.batch_size_per_weight,
         )
         .map_err(|e| MpcError::CryptoError(e.to_string()))?;
@@ -4356,7 +4395,7 @@ impl MpcManager {
             )?);
             self.process_and_store_message(
                 self.mpc_config.nodes.clone(),
-                self.party_id,
+                self.party_id()?,
                 self.mpc_config.threshold,
                 &session_id,
                 &message,
@@ -4395,7 +4434,7 @@ impl MpcManager {
         complaint_key: ComplaintsToProcessKey,
     ) -> MpcResult<()> {
         match process_avss_message(
-            &self.encryption_key,
+            self.encryption_key()?,
             nodes,
             party_id,
             Parameters {
@@ -4779,7 +4818,7 @@ impl MpcManager {
                 params,
                 dealer_session_id.to_vec(),
                 None,
-                mgr.encryption_key.clone(),
+                mgr.encryption_key()?.clone(),
             )?;
             (complaint_request, receiver, committee)
         };
@@ -4882,7 +4921,7 @@ impl MpcManager {
                 dealer_party_id,
                 params.t,
                 dealer_sid.to_vec(),
-                mgr.encryption_key.clone(),
+                mgr.encryption_key()?.clone(),
                 mgr.batch_size_per_weight,
             )
             .map_err(|e| MpcError::CryptoError(e.to_string()))?;
@@ -5198,9 +5237,9 @@ impl MpcManager {
                 share_index,
             )?);
             match process_avss_message(
-                &self.encryption_key,
+                self.encryption_key()?,
                 self.mpc_config.nodes.clone(),
-                self.party_id,
+                self.party_id()?,
                 Parameters {
                     t: self.mpc_config.threshold,
                     f: self.mpc_config.max_faulty,
@@ -5226,7 +5265,7 @@ impl MpcManager {
             messages_hash,
         };
         let signature = self
-            .signing_key
+            .signing_key()?
             .sign(self.mpc_config.epoch, self.address, &rotation_message)
             .signature()
             .clone();
@@ -5272,7 +5311,7 @@ impl MpcManager {
             .collect::<Result<_, MpcError>>()?;
         let combined = avss::DkOutput::complete_key_rotation(
             threshold,
-            self.party_id,
+            self.party_id()?,
             &self.mpc_config.nodes,
             &indexed_outputs,
         )
@@ -5367,11 +5406,16 @@ impl MpcManager {
         }
         let candidate = {
             let mgr = mpc_manager.read().unwrap();
+            // Not `Suspicious`: a non-member has no current share to rebuild, which contradicts
+            // nothing on chain.
+            let Ok(identity) = mgr.identity() else {
+                return MpcOutputRecoveryOutcome::NotApplicable;
+            };
             let context = DkgReconstructionContext {
                 committee: &mgr.committee,
                 nodes: &mgr.mpc_config.nodes,
-                party_id: mgr.party_id,
-                encryption_key: &mgr.encryption_key,
+                party_id: identity.party_id,
+                encryption_key: &identity.encryption_key,
                 output_threshold: mgr.mpc_config.threshold,
                 output_max_faulty: mgr.mpc_config.max_faulty,
                 epoch: mgr.mpc_config.epoch,
@@ -5413,10 +5457,15 @@ impl MpcManager {
             let Some(input_threshold) = mgr.previous_reconfig_output_threshold else {
                 return MpcOutputRecoveryOutcome::NotApplicable;
             };
+            // Not `Suspicious`: a non-member has no current share to rebuild, which contradicts
+            // nothing on chain.
+            let Ok(identity) = mgr.identity() else {
+                return MpcOutputRecoveryOutcome::NotApplicable;
+            };
             let current_context = RotationReconstructionContext {
                 nodes: &mgr.mpc_config.nodes,
-                party_id: mgr.party_id,
-                encryption_key: &mgr.encryption_key,
+                party_id: identity.party_id,
+                encryption_key: &identity.encryption_key,
                 output_threshold: mgr.mpc_config.threshold,
                 output_max_faulty: mgr.mpc_config.max_faulty,
                 input_threshold,
@@ -6467,7 +6516,7 @@ impl MpcManager {
         if epoch == self.mpc_config.epoch {
             Ok((
                 self.mpc_config.nodes.clone(),
-                self.party_id,
+                self.party_id()?,
                 Parameters {
                     t: self.mpc_config.threshold,
                     f: self.mpc_config.max_faulty,
@@ -6593,7 +6642,7 @@ impl MpcManager {
         epoch: u64,
     ) -> MpcResult<&PrivateKey<EncryptionGroupElement>> {
         if epoch == self.mpc_config.epoch {
-            Ok(&self.encryption_key)
+            Ok(self.encryption_key()?)
         } else if epoch == self.previous_epoch {
             self.previous_encryption_key.as_ref().ok_or_else(|| {
                 MpcError::InvalidConfig(

--- a/crates/hashi/src/mpc/mpc_except_signing_tests.rs
+++ b/crates/hashi/src/mpc/mpc_except_signing_tests.rs
@@ -1050,12 +1050,39 @@ fn test_mpc_manager_new_from_committee_set() {
     .expect("Should create manager from CommitteeSet");
 
     // Verify party_id is assigned based on canonical ordering
-    assert_eq!(manager.party_id, 0);
+    assert_eq!(manager.party_id().unwrap(), 0);
     assert_eq!(manager.address, address);
 
     // Verify DkgConfig was built correctly
     assert_eq!(manager.mpc_config.epoch, setup.epoch());
     assert_eq!(manager.mpc_config.nodes.num_nodes(), 5);
+    assert_eq!(manager.committee.members().len(), 5);
+}
+
+#[test]
+fn test_mpc_manager_new_succeeds_for_non_member_without_identity() {
+    let setup = TestSetup::new(5);
+    let non_member = Address::new([99u8; 32]);
+
+    let manager = MpcManager::new(
+        non_member,
+        &setup.committee_set,
+        setup.epoch(),
+        ProtocolType::Dkg,
+        setup.encryption_keys[0].clone(),
+        None,
+        setup.signing_keys[0].clone(),
+        Arc::new(InMemoryPublicMessagesStore::new()),
+        TEST_CHAIN_ID,
+        None,
+        TEST_BATCH_SIZE_PER_WEIGHT,
+        None,
+        &test_metrics(),
+    )
+    .expect("non-member must construct rather than panic");
+
+    assert!(manager.party_id().is_err());
+    assert_eq!(manager.address, non_member);
     assert_eq!(manager.committee.members().len(), 5);
 }
 
@@ -1464,7 +1491,8 @@ fn test_mpc_manager_new_party_id_follows_canonical_order() {
         let manager = setup.create_manager(i);
 
         assert_eq!(
-            manager.party_id, i as u16,
+            manager.party_id().unwrap(),
+            i as u16,
             "Party ID should match canonical order index for validator {}",
             i
         );
@@ -2699,7 +2727,11 @@ async fn test_run_as_party_recovers_from_hash_mismatch() {
                 dealer_address: dealer_addr_0,
                 messages_hash,
             };
-            setup.signing_keys[mgr.party_id as usize].sign(setup.epoch(), mgr.address, &dkg_message)
+            setup.signing_keys[mgr.party_id().unwrap() as usize].sign(
+                setup.epoch(),
+                mgr.address,
+                &dkg_message,
+            )
         })
         .collect();
     let cert_0 = create_test_certificate(
@@ -3314,7 +3346,7 @@ async fn test_run_as_party_with_reduced_weights() {
     let reduced_weight = manager
         .mpc_config
         .nodes
-        .weight_of(manager.party_id)
+        .weight_of(manager.party_id().unwrap())
         .unwrap();
 
     assert_ne!(
@@ -6461,7 +6493,7 @@ impl RotationTestSetup {
         }
         manager.previous_committee = previous_committee;
         // Tests reuse the same key across epochs.
-        manager.previous_encryption_key = Some(manager.encryption_key.clone());
+        manager.previous_encryption_key = Some(manager.encryption_key().unwrap().clone());
     }
 
     /// Creates a manager that has completed DKG and is ready for rotation.
@@ -8600,14 +8632,14 @@ fn test_process_certified_rotation_message_skips_processed_shares() {
         .rotation_session_id(&rotation_dealer_addr, share3_index);
     let receiver = avss::Receiver::new(
         receiver_manager.mpc_config.nodes.clone(),
-        receiver_manager.party_id,
+        receiver_manager.party_id().unwrap(),
         Parameters {
             t: receiver_manager.mpc_config.threshold,
             f: receiver_manager.mpc_config.max_faulty,
         },
         session_id.to_vec(),
         None,
-        receiver_manager.encryption_key.clone(),
+        receiver_manager.encryption_key().unwrap().clone(),
     )
     .unwrap();
     let complaint = match receiver
@@ -8768,14 +8800,14 @@ async fn test_recover_rotation_shares_via_complaint_success() {
         .rotation_session_id(&dealer_addr, first_share_index);
     let receiver = avss::Receiver::new(
         test_manager.mpc_config.nodes.clone(),
-        test_manager.party_id,
+        test_manager.party_id().unwrap(),
         Parameters {
             t: test_manager.mpc_config.threshold,
             f: test_manager.mpc_config.max_faulty,
         },
         session_id.to_vec(),
         None, // No expected commitment
-        test_manager.encryption_key.clone(),
+        test_manager.encryption_key().unwrap().clone(),
     )
     .unwrap();
     let valid_complaint = match receiver
@@ -8939,14 +8971,14 @@ fn test_rotation_complaints_are_scoped_to_the_epoch_in_their_key() {
         .rotation_session_id(&dealer_addr, first_share_index);
     let receiver = avss::Receiver::new(
         test_manager.mpc_config.nodes.clone(),
-        test_manager.party_id,
+        test_manager.party_id().unwrap(),
         Parameters {
             t: test_manager.mpc_config.threshold,
             f: test_manager.mpc_config.max_faulty,
         },
         session_id.to_vec(),
         None,
-        test_manager.encryption_key.clone(),
+        test_manager.encryption_key().unwrap().clone(),
     )
     .unwrap();
     let complaint = match receiver
@@ -9079,14 +9111,14 @@ fn test_handle_complain_request_success() {
         .copied();
     let receiver = avss::Receiver::new(
         victim_manager.mpc_config.nodes.clone(),
-        victim_manager.party_id,
+        victim_manager.party_id().unwrap(),
         Parameters {
             t: victim_manager.mpc_config.threshold,
             f: victim_manager.mpc_config.max_faulty,
         },
         session_id.to_vec(),
         commitment,
-        victim_manager.encryption_key.clone(),
+        victim_manager.encryption_key().unwrap().clone(),
     )
     .unwrap();
     let complaint = match receiver
@@ -9237,14 +9269,14 @@ fn test_handle_complain_request_rejects_dealer_that_does_not_own_the_share_index
         .copied();
     let receiver = avss::Receiver::new(
         victim_manager.mpc_config.nodes.clone(),
-        victim_manager.party_id,
+        victim_manager.party_id().unwrap(),
         Parameters {
             t: victim_manager.mpc_config.threshold,
             f: victim_manager.mpc_config.max_faulty,
         },
         session_id.to_vec(),
         commitment,
-        victim_manager.encryption_key.clone(),
+        victim_manager.encryption_key().unwrap().clone(),
     )
     .unwrap();
     let complaint = match receiver
@@ -9810,7 +9842,7 @@ fn test_party_restart_uses_stored_rotation_messages() {
             party_manager
                 .process_and_store_message(
                     party_manager.mpc_config.nodes.clone(),
-                    party_manager.party_id,
+                    party_manager.party_id().unwrap(),
                     party_manager.mpc_config.threshold,
                     &session_id,
                     message,
@@ -9969,7 +10001,11 @@ fn test_reconstruct_previous_dkg_output_with_shifted_party_ids() {
     .unwrap();
 
     // Verify the party_id shift
-    assert_eq!(manager.party_id, 5, "Target party_id should be 5");
+    assert_eq!(
+        manager.party_id().unwrap(),
+        5,
+        "Target party_id should be 5"
+    );
     assert_eq!(
         manager
             .previous_committee
@@ -10459,8 +10495,8 @@ fn test_recover_current_dkg() {
         let context = crate::mpc::types::DkgReconstructionContext {
             committee: &guard.committee,
             nodes: &guard.mpc_config.nodes,
-            party_id: guard.party_id,
-            encryption_key: &guard.encryption_key,
+            party_id: guard.party_id().unwrap(),
+            encryption_key: guard.encryption_key().unwrap(),
             output_threshold: guard.mpc_config.threshold,
             output_max_faulty: guard.mpc_config.max_faulty,
             epoch: guard.mpc_config.epoch,
@@ -10819,7 +10855,11 @@ fn test_reconstruct_previous_rotation_output_with_shifted_party_ids() {
     .unwrap();
 
     // Verify the party_id shift
-    assert_eq!(manager.party_id, 5, "Target party_id should be 5");
+    assert_eq!(
+        manager.party_id().unwrap(),
+        5,
+        "Target party_id should be 5"
+    );
     assert_eq!(
         manager
             .previous_committee
@@ -11678,7 +11718,7 @@ fn test_handle_complain_request_rotation_no_message_from_dealer() {
     let msg = map.get(&share_index).unwrap();
     let avss_receiver = avss::Receiver::new(
         receiver.mpc_config.nodes.clone(),
-        receiver.party_id,
+        receiver.party_id().unwrap(),
         Parameters {
             t: receiver.mpc_config.threshold,
             f: receiver.mpc_config.max_faulty,
@@ -11744,7 +11784,7 @@ fn test_handle_complain_request_rotation_rederives_output_rejects_invalid_proof(
     let msg = map.get(&share_index).unwrap();
     let avss_receiver = avss::Receiver::new(
         receiver.mpc_config.nodes.clone(),
-        receiver.party_id,
+        receiver.party_id().unwrap(),
         Parameters {
             t: receiver.mpc_config.threshold,
             f: receiver.mpc_config.max_faulty,
@@ -11832,14 +11872,14 @@ fn test_handle_complain_request_rotation_caches_response() {
         .copied();
     let receiver = avss::Receiver::new(
         victim_manager.mpc_config.nodes.clone(),
-        victim_manager.party_id,
+        victim_manager.party_id().unwrap(),
         Parameters {
             t: victim_manager.mpc_config.threshold,
             f: victim_manager.mpc_config.max_faulty,
         },
         session_id.to_vec(),
         commitment,
-        victim_manager.encryption_key.clone(),
+        victim_manager.encryption_key().unwrap().clone(),
     )
     .unwrap();
     let complaint = match receiver
@@ -12881,7 +12921,11 @@ async fn test_run_as_nonce_party_recovers_from_hash_mismatch() {
                 dealer_address: dealer_addr_0,
                 messages_hash,
             };
-            setup.signing_keys[mgr.party_id as usize].sign(setup.epoch(), mgr.address, &dkg_message)
+            setup.signing_keys[mgr.party_id().unwrap() as usize].sign(
+                setup.epoch(),
+                mgr.address,
+                &dkg_message,
+            )
         })
         .collect();
     let cert_0 = create_test_certificate(
@@ -12905,7 +12949,7 @@ async fn test_run_as_nonce_party_recovers_from_hash_mismatch() {
                     dealer_address: dealer_addr,
                     messages_hash,
                 };
-                setup.signing_keys[mgr.party_id as usize].sign(
+                setup.signing_keys[mgr.party_id().unwrap() as usize].sign(
                     setup.epoch(),
                     mgr.address,
                     &dkg_message,
@@ -12994,7 +13038,7 @@ async fn test_vanilla_nonce_dealer_phase_skips_at_zero_weight() {
         .map(|n| Node {
             id: n.id,
             pk: n.pk.clone(),
-            weight: if n.id == test_manager.party_id {
+            weight: if n.id == test_manager.party_id().unwrap() {
                 0
             } else {
                 n.weight
@@ -13006,7 +13050,7 @@ async fn test_vanilla_nonce_dealer_phase_skips_at_zero_weight() {
         test_manager
             .mpc_config
             .nodes
-            .weight_of(test_manager.party_id)
+            .weight_of(test_manager.party_id().unwrap())
             .unwrap(),
         0
     );
@@ -13057,7 +13101,7 @@ async fn test_avid_nonce_dealer_phase_skips_at_zero_weight() {
         .map(|n| Node {
             id: n.id,
             pk: n.pk.clone(),
-            weight: if n.id == test_manager.party_id {
+            weight: if n.id == test_manager.party_id().unwrap() {
                 0
             } else {
                 n.weight
@@ -13069,7 +13113,7 @@ async fn test_avid_nonce_dealer_phase_skips_at_zero_weight() {
         test_manager
             .mpc_config
             .nodes
-            .weight_of(test_manager.party_id)
+            .weight_of(test_manager.party_id().unwrap())
             .unwrap(),
         0
     );
@@ -15866,7 +15910,7 @@ fn test_decoded_shares_match_optimistic_shares() {
     let indices = decoder
         .mpc_config
         .nodes
-        .share_ids_of(decoder.party_id)
+        .share_ids_of(decoder.party_id().unwrap())
         .unwrap();
     let decoded = decoded.into_legacy(&indices);
     let direct = direct.into_legacy(&indices);


### PR DESCRIPTION
#95 