### PR TITLE
[e2e] drop the move-* deps left behind by the snapshot removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,8 +2190,6 @@ dependencies = [
  "hashi-guardian",
  "hashi-screener",
  "hashi-types",
- "move-binary-format",
- "move-core-types",
  "nix",
  "prometheus",
  "rand 0.8.5",

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -26,10 +26,6 @@ sui-rpc.workspace = true
 sui-crypto.workspace = true
 sui-sdk-types.workspace = true
 sui-transaction-builder.workspace = true
-# Needed by src/snapshot.rs to deserialize/rebase/re-serialize the checked-in
-# Move bytecode snapshot before publishing it.
-move-binary-format.workspace = true
-move-core-types.workspace = true
 base64ct.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true

--- a/crates/hashi/src/published.rs
+++ b/crates/hashi/src/published.rs
@@ -4,11 +4,10 @@
 //! Parse `packages/hashi/Published.toml` — the Move tooling's record of
 //! where (and at what version) the package is deployed per network.
 //!
-//! This file is the source of truth both the upgrade-compatibility CI gate
-//! (`crates/hashi/tests/move_upgrade_compat.rs`) and the e2e bytecode-snapshot
-//! tests (`crates/e2e-tests/src/snapshot.rs`) derive their snapshot locations
+//! This file is the source of truth the upgrade-compatibility CI gate
+//! (`crates/hashi/tests/move_upgrade_compat.rs`) derives its snapshot locations
 //! from, so a version bump there without a matching snapshot capture fails
-//! those checks instead of silently exercising an obsolete package.
+//! that check instead of silently exercising an obsolete package.
 
 use std::collections::BTreeMap;
 use std::path::Path;


### PR DESCRIPTION
## Changes

- `crates/e2e-tests/Cargo.toml`: drop `move-binary-format` and `move-core-types` and the comment citing `src/snapshot.rs`
- `crates/hashi/src/published.rs`: the doc comment no longer lists the deleted e2e snapshot tests as a consumer
- `Cargo.lock`: only the `e2e-tests` entry changes; the move closure itself stays pinned through `crates/hashi`'s dev-deps
