### PR TITLE
Harden committee handoff reconfiguration

### DIFF
--- a/crates/hashi/src/grpc/bridge_service.rs
+++ b/crates/hashi/src/grpc/bridge_service.rs
@@ -159,7 +159,7 @@ impl BridgeService for HttpService {
         tracing::Span::current().record("from_epoch", from_epoch);
         let member_signature = self
             .inner
-            .validate_and_sign_committee_transition(from_epoch)
+            .validate_and_sign_committee_transition(from_epoch, caller)
             .map_err(|e| Status::failed_precondition(e.to_string()))?;
         tracing::info!(from_epoch, "Signed committee transition");
         Ok(Response::new(SignCommitteeTransitionResponse {

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -72,8 +72,6 @@ pub struct Hashi {
     guardian_last_finalized: RwLock<Option<(u64, sui_sdk_types::Address)>>,
     /// Reconfig completion signatures by epoch.
     reconfig_signatures: RwLock<HashMap<u64, Vec<u8>>>,
-    /// Committee handoff member signatures by outgoing epoch.
-    committee_handoff_signatures: RwLock<HashMap<u64, hashi_types::proto::MemberSignature>>,
 }
 
 impl Hashi {
@@ -106,7 +104,6 @@ impl Hashi {
             local_limiter: OnceLock::new(),
             guardian_last_finalized: RwLock::new(None),
             reconfig_signatures: RwLock::new(HashMap::new()),
-            committee_handoff_signatures: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -140,7 +137,6 @@ impl Hashi {
             local_limiter: OnceLock::new(),
             guardian_last_finalized: RwLock::new(None),
             reconfig_signatures: RwLock::new(HashMap::new()),
-            committee_handoff_signatures: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -241,28 +237,6 @@ impl Hashi {
             .read()
             .unwrap()
             .get(&epoch)
-            .cloned()
-    }
-
-    pub fn store_committee_handoff_signature(
-        &self,
-        from_epoch: u64,
-        signature: hashi_types::proto::MemberSignature,
-    ) {
-        self.committee_handoff_signatures
-            .write()
-            .unwrap()
-            .insert(from_epoch, signature);
-    }
-
-    pub fn get_committee_handoff_signature(
-        &self,
-        from_epoch: u64,
-    ) -> Option<hashi_types::proto::MemberSignature> {
-        self.committee_handoff_signatures
-            .read()
-            .unwrap()
-            .get(&from_epoch)
             .cloned()
     }
 

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -14,6 +14,7 @@ use futures::future::join_all;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use sui_futures::service::Service;
+use sui_rpc::proto::sui::rpc::v2::ExecutionError;
 use sui_rpc::proto::sui::rpc::v2::execution_error::ExecutionErrorKind;
 use tokio::sync::watch;
 use tracing::debug;
@@ -1942,7 +1943,7 @@ impl MpcService {
                 }
             }
         };
-        let committee_handoff_cert = self.collect_committee_handoff_if_needed(epoch).await?;
+        let mut committee_handoff_cert = self.collect_committee_handoff_if_needed(epoch).await?;
         loop {
             if self.get_pending_epoch_change() != Some(epoch) {
                 return Err(anyhow::anyhow!("epoch {} no longer pending", epoch));
@@ -1975,8 +1976,20 @@ impl MpcService {
                             )
                         })?;
                     }
-                    ReconfigSubmissionErrorKind::NonRetryableMoveAbort
-                    | ReconfigSubmissionErrorKind::CommitteeHandoffAlreadySubmitted => {
+                    ReconfigSubmissionErrorKind::CommitteeHandoffAlreadySubmitted => {
+                        if committee_handoff_cert.take().is_some() {
+                            warn!(
+                                "end_reconfig submission for epoch {epoch} found handoff already submitted; retrying without the handoff call: {e:#}"
+                            );
+                            continue;
+                        }
+                        Err(e).with_context(|| {
+                            format!(
+                                "end_reconfig submission for epoch {epoch} failed because a handoff was already submitted, but this transaction did not submit one"
+                            )
+                        })?;
+                    }
+                    ReconfigSubmissionErrorKind::NonRetryableMoveAbort => {
                         Err(e).with_context(|| {
                             format!(
                                 "end_reconfig submission for epoch {epoch} failed with non-retryable error"
@@ -2177,6 +2190,7 @@ fn certified_nonce_weight<T: NonceCertTimestamp>(
         .weight()
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ReconfigSubmissionErrorKind {
     NonMoveAbort,
     NonRetryableMoveAbort,
@@ -2185,14 +2199,13 @@ enum ReconfigSubmissionErrorKind {
 }
 
 fn classify_reconfig_submission_error(err: &anyhow::Error) -> ReconfigSubmissionErrorKind {
-    let Some(tx_err) = err.downcast_ref::<crate::sui_tx_executor::TransactionExecutionError>()
-    else {
+    let Some(error) = crate::sui_tx_executor::transaction_execution_error(err) else {
         return ReconfigSubmissionErrorKind::NonMoveAbort;
     };
+    classify_reconfig_execution_error(error)
+}
 
-    let Some(error) = tx_err.status().error_opt() else {
-        return ReconfigSubmissionErrorKind::NonMoveAbort;
-    };
+fn classify_reconfig_execution_error(error: &ExecutionError) -> ReconfigSubmissionErrorKind {
     if error
         .kind
         .and_then(|kind| ExecutionErrorKind::try_from(kind).ok())

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -1970,11 +1970,10 @@ impl MpcService {
                         if self.get_pending_epoch_change() != Some(epoch) {
                             return Ok(());
                         }
-                        Err(e).with_context(|| {
-                            format!(
-                                "end_reconfig submission for epoch {epoch} failed with ENotReconfiguring, but epoch is still pending after waiting for the watcher"
-                            )
-                        })?;
+                        warn!(
+                            "end_reconfig for epoch {epoch} is complete on chain, but the watcher still reports it pending after the visibility wait; retrying"
+                        );
+                        continue;
                     }
                     ReconfigSubmissionErrorKind::CommitteeHandoffAlreadySubmitted => {
                         if committee_handoff_cert.take().is_some() {

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -54,6 +54,7 @@ use fastcrypto_tbls::threshold_schnorr::presigning::Presignatures;
 use hashi_types::committee::BLS12381Signature;
 use hashi_types::committee::BlsSignatureAggregator;
 use hashi_types::committee::Committee;
+use hashi_types::committee::CommitteeSignature;
 use hashi_types::committee::certificate_threshold;
 use hashi_types::move_types;
 use hashi_types::move_types::ReconfigCompletionMessage;
@@ -1941,7 +1942,7 @@ impl MpcService {
                 }
             }
         };
-        self.submit_committee_handoff_if_needed(epoch).await?;
+        let committee_handoff_cert = self.collect_committee_handoff_if_needed(epoch).await?;
         loop {
             if self.get_pending_epoch_change() != Some(epoch) {
                 return Err(anyhow::anyhow!("epoch {} no longer pending", epoch));
@@ -1950,7 +1951,11 @@ impl MpcService {
                 let mut executor =
                     crate::sui_tx_executor::SuiTxExecutor::from_hashi(self.inner.clone())?;
                 executor
-                    .execute_end_reconfig(&mpc_public_key, cert.committee_signature())
+                    .execute_end_reconfig(
+                        &mpc_public_key,
+                        cert.committee_signature(),
+                        committee_handoff_cert.as_ref(),
+                    )
                     .await
             };
             match result.await {
@@ -1990,7 +1995,10 @@ impl MpcService {
         }
     }
 
-    async fn submit_committee_handoff_if_needed(&self, epoch: u64) -> anyhow::Result<()> {
+    async fn collect_committee_handoff_if_needed(
+        &self,
+        epoch: u64,
+    ) -> anyhow::Result<Option<CommitteeSignature>> {
         let from_epoch = self.inner.onchain_state().epoch();
         let requires_committee_handoff = !self
             .inner
@@ -2001,7 +2009,7 @@ impl MpcService {
             .mpc_public_key()
             .is_empty();
         if !requires_committee_handoff {
-            return Ok(());
+            return Ok(None);
         }
 
         let committee_handoff = loop {
@@ -2024,44 +2032,7 @@ impl MpcService {
                 }
             }
         };
-        loop {
-            if self.get_pending_epoch_change() != Some(epoch) {
-                return Err(anyhow::anyhow!("epoch {} no longer pending", epoch));
-            }
-            let result = async {
-                let mut executor =
-                    crate::sui_tx_executor::SuiTxExecutor::from_hashi(self.inner.clone())?;
-                executor
-                    .execute_submit_committee_handoff(committee_handoff.committee_signature())
-                    .await
-            };
-            match result.await {
-                Ok(()) => return Ok(()),
-                Err(e) => match classify_reconfig_submission_error(&e) {
-                    ReconfigSubmissionErrorKind::CommitteeHandoffAlreadySubmitted => {
-                        warn!(
-                            "submit_committee_handoff submission for epoch {epoch} found handoff already submitted: {e:#}"
-                        );
-                        return Ok(());
-                    }
-                    ReconfigSubmissionErrorKind::NonRetryableMoveAbort
-                    | ReconfigSubmissionErrorKind::EndReconfigAlreadyCompleted => {
-                        Err(e).with_context(|| {
-                            format!(
-                                "submit_committee_handoff submission for epoch {epoch} failed with non-retryable error"
-                            )
-                        })?;
-                    }
-                    ReconfigSubmissionErrorKind::NonMoveAbort => {
-                        warn!(
-                            "submit_committee_handoff submission for epoch {} failed: {e:#}, retrying...",
-                            epoch
-                        );
-                        self.sleep_if_still_pending(epoch).await;
-                    }
-                },
-            }
-        }
+        Ok(Some(committee_handoff.into_parts().0))
     }
 
     async fn collect_reconfig_signatures(
@@ -2247,9 +2218,11 @@ fn classify_reconfig_submission_error(err: &anyhow::Error) -> ReconfigSubmission
         (Some("committee_set"), Some("set_pending_committee_handoff_cert"), _) => {
             ReconfigSubmissionErrorKind::CommitteeHandoffAlreadySubmitted
         }
-        (Some("reconfig"), Some("end_reconfig"), Some(RECONFIG_E_NOT_RECONFIGURING)) => {
-            ReconfigSubmissionErrorKind::EndReconfigAlreadyCompleted
-        }
+        (
+            Some("reconfig"),
+            Some("submit_committee_handoff") | Some("end_reconfig"),
+            Some(RECONFIG_E_NOT_RECONFIGURING),
+        ) => ReconfigSubmissionErrorKind::EndReconfigAlreadyCompleted,
         _ => ReconfigSubmissionErrorKind::NonRetryableMoveAbort,
     }
 }

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -385,6 +385,21 @@ fn builder_error(e: &anyhow::Error) -> Option<&sui_transaction_builder::Error> {
         TxFailure::Submit(_) => None,
     }
 }
+/// Return the structured execution error from either transaction simulation or
+/// an executed transaction's failed status.
+pub(crate) fn transaction_execution_error(
+    err: &anyhow::Error,
+) -> Option<&sui_rpc::proto::sui::rpc::v2::ExecutionError> {
+    if let Some(tx_err) = err.downcast_ref::<TransactionExecutionError>() {
+        return tx_err.status().error_opt();
+    }
+    match builder_error(err) {
+        Some(sui_transaction_builder::Error::SimulationFailure(failure)) => {
+            Some(failure.execution_error())
+        }
+        _ => None,
+    }
+}
 
 /// Whether `e` is a failure of transaction *execution* (a failed simulation
 /// inside the SDK build, or a failed on-chain status) rather than of building

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -63,6 +63,34 @@ fn build_committee_signature_arg(
     )
 }
 
+fn add_end_reconfig_calls(
+    builder: &mut TransactionBuilder,
+    package_id: Address,
+    hashi_arg: sui_transaction_builder::Argument,
+    committee_handoff_cert_arg: Option<sui_transaction_builder::Argument>,
+    mpc_public_key_arg: sui_transaction_builder::Argument,
+    mpc_cert_arg: sui_transaction_builder::Argument,
+) {
+    if let Some(committee_handoff_cert_arg) = committee_handoff_cert_arg {
+        builder.move_call(
+            Function::new(
+                package_id,
+                Identifier::from_static("reconfig"),
+                Identifier::from_static("submit_committee_handoff"),
+            ),
+            vec![hashi_arg, committee_handoff_cert_arg],
+        );
+    }
+    builder.move_call(
+        Function::new(
+            package_id,
+            Identifier::from_static("reconfig"),
+            Identifier::from_static("end_reconfig"),
+        ),
+        vec![hashi_arg, mpc_public_key_arg, mpc_cert_arg],
+    );
+}
+
 /// Maximum size in bytes for a single pure argument in a Sui PTB.
 ///
 /// Sui enforces a 16 KiB (16384 byte) limit per pure argument. We use a 4 KiB
@@ -1162,11 +1190,14 @@ impl SuiTxExecutor {
         Ok(())
     }
 
+    /// Submit the outgoing committee handoff and activate its successor in one
+    /// PTB, so the handoff certificate is never committed before activation.
     #[tracing::instrument(level = "info", skip_all)]
     pub async fn execute_end_reconfig(
         &mut self,
         mpc_public_key: &[u8],
         mpc_cert: &CommitteeSignature,
+        committee_handoff_cert: Option<&CommitteeSignature>,
     ) -> anyhow::Result<()> {
         let mut builder = TransactionBuilder::new();
         let package_id = self.active_call_package_id();
@@ -1175,55 +1206,23 @@ impl SuiTxExecutor {
                 .as_shared()
                 .with_mutable(true),
         );
+        let committee_handoff_cert_arg = committee_handoff_cert
+            .map(|cert| build_committee_signature_arg(&mut builder, package_id, cert));
         let mpc_public_key_arg = builder.pure(&mpc_public_key.to_vec());
         let mpc_cert_arg = build_committee_signature_arg(&mut builder, package_id, mpc_cert);
-        builder.move_call(
-            Function::new(
-                package_id,
-                Identifier::from_static("reconfig"),
-                Identifier::from_static("end_reconfig"),
-            ),
-            vec![hashi_arg, mpc_public_key_arg, mpc_cert_arg],
+        add_end_reconfig_calls(
+            &mut builder,
+            package_id,
+            hashi_arg,
+            committee_handoff_cert_arg,
+            mpc_public_key_arg,
+            mpc_cert_arg,
         );
         let response = self.execute(builder).await?;
         let status = response.transaction().effects().status();
         if !status.success() {
             return Err(TransactionExecutionError {
                 function: "end_reconfig",
-                status: status.clone(),
-            }
-            .into());
-        }
-        Ok(())
-    }
-
-    #[tracing::instrument(level = "info", skip_all)]
-    pub async fn execute_submit_committee_handoff(
-        &mut self,
-        committee_handoff_cert: &CommitteeSignature,
-    ) -> anyhow::Result<()> {
-        let mut builder = TransactionBuilder::new();
-        let package_id = self.active_call_package_id();
-        let hashi_arg = builder.object(
-            ObjectInput::new(self.hashi_ids.hashi_object_id)
-                .as_shared()
-                .with_mutable(true),
-        );
-        let committee_handoff_cert_arg =
-            build_committee_signature_arg(&mut builder, package_id, committee_handoff_cert);
-        builder.move_call(
-            Function::new(
-                package_id,
-                Identifier::from_static("reconfig"),
-                Identifier::from_static("submit_committee_handoff"),
-            ),
-            vec![hashi_arg, committee_handoff_cert_arg],
-        );
-        let response = self.execute(builder).await?;
-        let status = response.transaction().effects().status();
-        if !status.success() {
-            return Err(TransactionExecutionError {
-                function: "submit_committee_handoff",
                 status: status.clone(),
             }
             .into());
@@ -2846,6 +2845,56 @@ pub async fn sweep_to_address_balance(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn build_reconfig_commands(with_handoff: bool) -> Vec<sui_sdk_types::Command> {
+        let mut builder = TransactionBuilder::new();
+        let hashi_arg = builder.pure(&0u8);
+        let handoff_arg = with_handoff.then(|| builder.pure(&1u8));
+        let mpc_public_key_arg = builder.pure(&2u8);
+        let mpc_cert_arg = builder.pure(&3u8);
+        add_end_reconfig_calls(
+            &mut builder,
+            Address::TWO,
+            hashi_arg,
+            handoff_arg,
+            mpc_public_key_arg,
+            mpc_cert_arg,
+        );
+        builder.set_sender(Address::ZERO);
+        builder.set_gas_budget(1);
+        builder.set_gas_price(1);
+        builder.add_gas_objects([ObjectInput::owned(
+            Address::from_static("0x1"),
+            1,
+            sui_sdk_types::Digest::ZERO,
+        )]);
+
+        match builder.try_build().expect("offline PTB must build").kind {
+            sui_sdk_types::TransactionKind::ProgrammableTransaction(pt) => pt.commands,
+            _ => panic!("expected programmable transaction"),
+        }
+    }
+
+    #[test]
+    fn end_reconfig_calls_are_atomic() {
+        let commands = build_reconfig_commands(true);
+        let [
+            sui_sdk_types::Command::MoveCall(submit),
+            sui_sdk_types::Command::MoveCall(end),
+        ] = commands.as_slice()
+        else {
+            panic!("expected handoff followed by end_reconfig");
+        };
+        assert_eq!(submit.function.as_str(), "submit_committee_handoff");
+        assert_eq!(end.function.as_str(), "end_reconfig");
+        assert_eq!(submit.arguments[0], end.arguments[0]);
+
+        let genesis_commands = build_reconfig_commands(false);
+        assert!(matches!(
+            genesis_commands.as_slice(),
+            [sui_sdk_types::Command::MoveCall(end)] if end.function.as_str() == "end_reconfig"
+        ));
+    }
 
     #[test]
     fn destroy_tob_splits_only_on_execution_failures() {

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -1069,10 +1069,6 @@ impl Hashi {
         &self,
         from_epoch: u64,
     ) -> anyhow::Result<hashi_types::proto::MemberSignature> {
-        if let Some(signature) = self.get_committee_handoff_signature(from_epoch) {
-            return Ok(signature);
-        }
-
         let validator_address = self
             .config
             .validator_address()
@@ -1096,9 +1092,7 @@ impl Hashi {
         // committee, so these are the only bytes worth signing.
         let transition = hashi_types::guardian::CommitteeTransitionRequest { new_committee };
 
-        let signature = self.sign_message_proto_at_epoch(&transition, from_epoch)?;
-        self.store_committee_handoff_signature(from_epoch, signature.clone());
-        Ok(signature)
+        self.sign_message_proto_at_epoch(&transition, from_epoch)
     }
 
     // --- MPC BTC tx signing ---

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -1068,6 +1068,7 @@ impl Hashi {
     pub fn validate_and_sign_committee_transition(
         &self,
         from_epoch: u64,
+        caller: Address,
     ) -> anyhow::Result<hashi_types::proto::MemberSignature> {
         let validator_address = self
             .config
@@ -1078,6 +1079,13 @@ impl Hashi {
             .onchain_state()
             .committee_transition(from_epoch)
             .ok_or_else(|| anyhow!("no on-chain committee transition from epoch {from_epoch}"))?;
+        if !from_committee
+            .members()
+            .iter()
+            .any(|m| m.validator_address() == caller)
+        {
+            anyhow::bail!("caller {caller} is not a member of the committee at epoch {from_epoch}");
+        }
         if !from_committee
             .members()
             .iter()


### PR DESCRIPTION
- Remove stale handoff cache so reconfiguration retries sign current state
- Submit handoff atomically to prevent exposing unactivated committee certificates
- Handle already submitted committee handoffs