### PR TITLE
[btc-monitor] Drop the unused Kyoto data_dir

### DIFF
--- a/crates/hashi/src/btc_monitor/config.rs
+++ b/crates/hashi/src/btc_monitor/config.rs
@@ -29,9 +29,6 @@ pub struct MonitorConfig {
 
     /// bitcoind JSON-RPC server auth config
     pub bitcoind_rpc_auth: corepc_client::client_sync::Auth,
-
-    /// Directory for storing BTC light client data
-    pub data_dir: Option<PathBuf>,
 }
 
 impl Default for MonitorConfig {
@@ -42,7 +39,6 @@ impl Default for MonitorConfig {
             start_height: DEFAULT_START_HEIGHT,
             bitcoind_rpc_url: "http://localhost:8332".to_string(),
             bitcoind_rpc_auth: corepc_client::client_sync::Auth::None,
-            data_dir: None,
         }
     }
 }
@@ -62,7 +58,6 @@ pub struct MonitorConfigBuilder {
     start_height: u32,
     bitcoind_rpc_url: Option<String>,
     bitcoind_rpc_auth: Option<corepc_client::client_sync::Auth>,
-    data_dir: Option<PathBuf>,
 }
 
 impl MonitorConfigBuilder {
@@ -96,12 +91,6 @@ impl MonitorConfigBuilder {
         self
     }
 
-    /// Set the directory for storing BTC light client data.
-    pub fn data_dir(mut self, path: impl Into<PathBuf>) -> Self {
-        self.data_dir = Some(path.into());
-        self
-    }
-
     pub fn build(self) -> MonitorConfig {
         let default = MonitorConfig::default();
 
@@ -111,7 +100,6 @@ impl MonitorConfigBuilder {
             start_height: self.start_height,
             bitcoind_rpc_url: self.bitcoind_rpc_url.unwrap_or(default.bitcoind_rpc_url),
             bitcoind_rpc_auth: self.bitcoind_rpc_auth.unwrap_or(default.bitcoind_rpc_auth),
-            data_dir: self.data_dir,
         }
     }
 }

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -601,7 +601,7 @@ impl Monitor {
         config: &MonitorConfig,
         checkpoint: HashCheckpoint,
     ) -> (kyoto::Node, kyoto::Client) {
-        let mut builder = kyoto::Builder::new(config.network)
+        kyoto::Builder::new(config.network)
             .add_peers(config.trusted_peers.iter().cloned())
             // Only connect to the configured trusted peers. Prevents Kyoto from
             // discovering additional peers via DNS seeding or addr gossip.
@@ -609,13 +609,8 @@ impl Monitor {
             // drains, the node exits and the supervision loop rebuilds it.
             .whitelist_only()
             .maximum_connection_time(Duration::MAX)
-            .chain_state(kyoto::ChainState::Checkpoint(checkpoint));
-
-        if let Some(data_dir) = &config.data_dir {
-            builder = builder.data_dir(data_dir.clone());
-        }
-
-        builder.build()
+            .chain_state(kyoto::ChainState::Checkpoint(checkpoint))
+            .build()
     }
 
     /// Kyoto re-syncs from its checkpoint on every build, so anchoring at genesis

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -792,13 +792,6 @@ impl Hashi {
                 self.config.bitcoin_rpc_auth(),
             )
             .trusted_peers(self.config.bitcoin_trusted_peers()?)
-            .data_dir(
-                self.config
-                    .db
-                    .as_deref()
-                    .expect("Db path is not set")
-                    .join("btc-monitor"),
-            )
             .build();
         let (client, service) = crate::btc_monitor::monitor::Monitor::run_with_tracker(
             monitor_config,


### PR DESCRIPTION
## Summary

bip157's `Builder::data_dir` has accepted a path and discarded it since 0.2.0, when the header and peer stores went away with rusqlite (2140-dev/kyoto#600). Upstream has now deleted the setter after 0.6.3, so the next bump will not compile with our call in place. 

## Changes

- Drop the `data_dir` field, default and builder method from `MonitorConfig`.
- Stop threading `<db>/btc-monitor` into the Kyoto builder from `lib.rs` and `build_kyoto_node`.
