### PR TITLE
[guardian-proxy] upgrade stagex version to match hashi node

### DIFF
--- a/docker/hashi-guardian-proxy/Containerfile
+++ b/docker/hashi-guardian-proxy/Containerfile
@@ -5,7 +5,7 @@
 # docker/hashi-guardian/Containerfile is the Nitro enclave build and produces
 # an EIF, not a runnable OCI image — do not conflate the two.
 
-FROM stagex/pallet-rust@sha256:84621c4c29330c8a969489671d46227a0a43f52cdae243f5b91e95781dbfe5ed AS pallet-rust
+FROM stagex/pallet-rust@sha256:abe9b95c93a5afa271f69fcd5eb18c8cd405fe5df6491a63c9418e3a170573dc AS pallet-rust
 FROM stagex/busybox@sha256:3d128909dbc8e7b6c4b8c3c31f4583f01a307907ea179934bb42c4ef056c7efd AS busybox
 FROM stagex/core-filesystem@sha256:da28831927652291b0fa573092fd41c8c96ca181ea224df7bff40e1833c3db13 AS core-filesystem
 


### PR DESCRIPTION
## Summary

The proxy image was pinned to `stagex/pallet-rust` `sx2026.01.0` (rustc 1.91.1) while `docker/hashi` and `docker/hashi-screener` build on `sx2026.06.0` (rustc 1.96.0), which is also the workspace's `rust-toolchain` channel. Align it so all three OCI images compile on the same toolchain.

## Changes

- `docker/hashi-guardian-proxy/Containerfile`: bump the `pallet-rust` digest to the one the node and screener images use. Nothing else changes.

hashi CI does not build this image (the deterministic-build matrix covers `hashi` and `hashi-screener`); the next `hashi-guardian-proxy-deploy` run on devnet is the deployed test.

Local `docker build --platform linux/amd64` of the Containerfile at this commit: deps stage 193s, source stage 24s, 13.4 MB image. The binary embeds `rustc version 1.96.0`, is 33,211,816 bytes, and starts up to the expected `GUARDIAN_BACKEND_URL must be set` config error.
