### PR TITLE
move: promote MemberInfo ignored/resigned flags to root-level fields

### DIFF
--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -284,9 +284,16 @@ pub struct MemberInfo {
     /// beginning of the next epoch.
     pub next_epoch_encryption_public_key: Vec<u8>,
 
-    /// Open-ended per-member extension slot. Carries the governance flags
-    /// ([`MEMBER_IGNORED_KEY`]) as typed values while `MemberInfo`'s layout
-    /// is frozen on the deployed network.
+    /// Governance "ignored" flag: when set, the next committee formation
+    /// skips this member.
+    pub ignored: bool,
+
+    /// Voluntary "resigned" flag: when set, the next committee formation
+    /// skips this member.
+    pub resigned: bool,
+
+    /// Open-ended per-member extension slot for member data added after the
+    /// layout freezes at mainnet. Empty today.
     pub extra_fields: Config,
 }
 
@@ -985,14 +992,6 @@ impl MoveType for IgnoreMember {
     const MODULE: &'static str = "ignore_member";
     const NAME: &'static str = "IgnoreMember";
 }
-
-/// `MemberInfo.extra_fields` key holding the governance "ignored" flag.
-/// Mirrors `MEMBER_IGNORED_KEY` in `committee_set.move`.
-pub const MEMBER_IGNORED_KEY: &str = "ignored";
-
-/// `MemberInfo.extra_fields` key holding the voluntary "resigned" flag.
-/// Mirrors `MEMBER_RESIGNED_KEY` in `committee_set.move`.
-pub const MEMBER_RESIGNED_KEY: &str = "resigned";
 
 /// Rust version of the Move hashi::validator::ValidatorResigned event.
 #[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]

--- a/crates/hashi/src/onchain/apply.rs
+++ b/crates/hashi/src/onchain/apply.rs
@@ -1362,6 +1362,8 @@ mod tests {
         endpoint_url: String,
         tls_public_key: Vec<u8>,
         next_epoch_encryption_public_key: Vec<u8>,
+        ignored: bool,
+        resigned: bool,
         extra_fields: move_types::Config,
     }
 
@@ -1726,6 +1728,8 @@ mod tests {
                 endpoint_url: "https://validator.example.com".to_owned(),
                 tls_public_key: vec![7u8; 32],
                 next_epoch_encryption_public_key: vec![0u8; 32],
+                ignored: false,
+                resigned: false,
                 extra_fields: move_types::Config::from_entries(vec![]),
             },
         })

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -1741,7 +1741,9 @@ fn convert_move_member_info(info: move_types::MemberInfo) -> types::MemberInfo {
         endpoint_url,
         tls_public_key,
         next_epoch_encryption_public_key,
-        extra_fields,
+        ignored,
+        resigned,
+        extra_fields: _,
     } = info;
     types::MemberInfo {
         validator_address,
@@ -1753,8 +1755,8 @@ fn convert_move_member_info(info: move_types::MemberInfo) -> types::MemberInfo {
             next_epoch_encryption_public_key.as_slice(),
         )
         .map(Into::into),
-        ignored: extra_fields.get_bool(move_types::MEMBER_IGNORED_KEY, false),
-        resigned: extra_fields.get_bool(move_types::MEMBER_RESIGNED_KEY, false),
+        ignored,
+        resigned,
     }
 }
 
@@ -2427,7 +2429,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_convert_move_member_info_reads_ignored_flag() {
+    fn test_convert_move_member_info_carries_governance_flags() {
         let mut rng = rand::thread_rng();
         let validator_address =
             Address::from_hex("0x1234567890abcdef1234567890abcdef12345678").unwrap();
@@ -2438,26 +2440,29 @@ mod tests {
                 .serialize()
                 .to_vec();
 
-        let member = |extra_fields: move_types::Config| move_types::MemberInfo {
+        let member = |ignored: bool, resigned: bool| move_types::MemberInfo {
             validator_address,
             operator_address: validator_address,
             next_epoch_public_key: uncompressed_pubkey.clone(),
             endpoint_url: String::new(),
             tls_public_key: vec![],
             next_epoch_encryption_public_key: vec![],
-            extra_fields,
+            ignored,
+            resigned,
+            extra_fields: move_types::Config::from_entries(vec![]),
         };
 
-        // Absent key (the state of every member registered before the flag
-        // existed) means not ignored.
-        let converted = convert_move_member_info(member(move_types::Config::from_entries(vec![])));
+        let converted = convert_move_member_info(member(false, false));
         assert!(!converted.ignored);
+        assert!(!converted.resigned);
 
-        let converted = convert_move_member_info(member(move_types::Config::from_entries(vec![(
-            move_types::MEMBER_IGNORED_KEY.to_string(),
-            move_types::ConfigValue::Bool(true),
-        )])));
+        let converted = convert_move_member_info(member(true, false));
         assert!(converted.ignored);
+        assert!(!converted.resigned);
+
+        let converted = convert_move_member_info(member(false, true));
+        assert!(!converted.ignored);
+        assert!(converted.resigned);
     }
 
     #[test]

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -575,14 +575,13 @@ pub struct MemberInfo {
     /// beginning of the next epoch.
     pub next_epoch_encryption_public_key: Option<EncryptionPublicKey>,
 
-    /// Governance "ignored" flag from `extra_fields`: when set, the next
-    /// committee formation skips this member. The current epoch's committee
-    /// is unaffected.
+    /// Governance "ignored" flag: when set, the next committee formation
+    /// skips this member. The current epoch's committee is unaffected.
     pub ignored: bool,
 
-    /// Voluntary "resigned" flag from `extra_fields`: when set, the next
-    /// committee formation skips this member and the epoch transition
-    /// removes their registration.
+    /// Voluntary "resigned" flag: when set, the next committee formation
+    /// skips this member and the epoch transition removes their
+    /// registration.
     pub resigned: bool,
 }
 

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -11,7 +11,7 @@
 #[allow(unused_function, unused_field)]
 module hashi::committee_set;
 
-use hashi::{committee::{Self, Committee}, config::{Self, Config}, config_value};
+use hashi::{committee::{Self, Committee}, config::{Self, Config}};
 use std::string::String;
 use sui::{
     bag::Bag,
@@ -19,32 +19,6 @@ use sui::{
     bls12381::{UncompressedG1, bls12381_min_pk_verify, g1_from_bytes, g1_to_uncompressed_g1},
     group_ops::Element
 };
-
-// ~~~~~~~ Constants ~~~~~~~
-
-/// `MemberInfo.extra_fields` key holding the governance "ignored" flag as a
-/// `Bool` value. An absent key means not ignored, so members registered
-/// before this key existed need no migration.
-///
-/// The flag lives in `extra_fields` only because `MemberInfo`'s layout is
-/// frozen on the deployed network.
-///
-/// TODO(pre-mainnet-wipe): when testnet is wiped and the Move versions are
-/// squashed before mainnet, promote this to a root-level `ignored: bool`
-/// field on `MemberInfo` and delete this key (and its Rust mirror
-/// `MEMBER_IGNORED_KEY` / the `extra_fields` decode in
-/// `convert_move_member_info`).
-const MEMBER_IGNORED_KEY: vector<u8> = b"ignored";
-
-/// `MemberInfo.extra_fields` key holding the voluntary "resigned" flag as a
-/// `Bool` value. Set by `request_resignation`, cleared by
-/// `clear_resignation`, honored by committee formation (skip); the
-/// registration itself is deleted by the permissionless
-/// `remove_inactive_member` once the member holds no epoch duties.
-///
-/// TODO(pre-mainnet-wipe): promote to a root-level `resigned: bool` field on
-/// `MemberInfo` together with `MEMBER_IGNORED_KEY` above.
-const MEMBER_RESIGNED_KEY: vector<u8> = b"resigned";
 
 // ~~~~~~~ Errors ~~~~~~~
 
@@ -135,13 +109,19 @@ public struct MemberInfo has store {
     /// This public key can be rotated but will only take effect at the
     /// beginning of the next epoch.
     next_epoch_encryption_public_key: vector<u8>,
+    /// Governance "ignored" flag, set and cleared only through the
+    /// quorum-gated `ignore_member` proposal. Read at committee formation:
+    /// the next formation skips the member; the current epoch's committee is
+    /// never altered.
+    ignored: bool,
+    /// Voluntary "resigned" flag. Set by `request_resignation`, cleared by
+    /// `clear_resignation`, honored by committee formation (skip); the
+    /// registration itself is deleted by the permissionless
+    /// `remove_inactive_member` once the member holds no epoch duties.
+    resigned: bool,
     /// Open-ended per-member extension slot; lets future upgrades attach new
-    /// member data (e.g. per-protocol keys) without a MemberInfoV2 migration.
-    ///
-    /// Carries the governance flags (`MEMBER_IGNORED_KEY`) as typed values
-    /// because MemberInfo's layout is frozen on the deployed network. When
-    /// testnet is wiped before mainnet, promote them to real `bool` fields
-    /// on MemberInfo and delete the keys.
+    /// member data (e.g. per-protocol keys) without a MemberInfoV2 migration
+    /// once the layout freezes at mainnet. Empty today.
     extra_fields: Config,
 }
 
@@ -178,6 +158,8 @@ public(package) fun new_member(
         endpoint_url: std::vector::empty().to_string(),
         tls_public_key: std::vector::empty(),
         next_epoch_encryption_public_key: std::vector::empty(),
+        ignored: false,
+        resigned: false,
         extra_fields: config::empty(),
     };
 
@@ -298,10 +280,7 @@ public(package) fun set_member_ignored(
     ignored: bool,
 ) {
     assert!(self.has_member(validator_address), EMemberNotRegistered);
-    self
-        .member_mut(validator_address)
-        .extra_fields
-        .upsert(MEMBER_IGNORED_KEY, config_value::new_bool(ignored));
+    self.member_mut(validator_address).ignored = ignored;
 }
 
 /// Whether the registered member is currently flagged as ignored by
@@ -340,10 +319,7 @@ public(package) fun request_resignation(
     if (self.in_current_or_pending_committee(validator_address)) {
         self.assert_not_last_active_member(validator_address);
     };
-    self
-        .member_mut(validator_address)
-        .extra_fields
-        .upsert(MEMBER_RESIGNED_KEY, config_value::new_bool(true));
+    self.member_mut(validator_address).resigned = true;
 }
 
 /// Permissionless registry cleanup: delete the registration of a member who
@@ -380,10 +356,7 @@ public(package) fun clear_resignation(
     let member = self.member(validator_address);
     member.assert_authorized(ctx);
     assert!(member.is_resigned(), ENotResigned);
-    self
-        .member_mut(validator_address)
-        .extra_fields
-        .upsert(MEMBER_RESIGNED_KEY, config_value::new_bool(false));
+    self.member_mut(validator_address).resigned = false;
 }
 
 public(package) fun start_reconfig(
@@ -650,16 +623,14 @@ fun is_authorized(self: &MemberInfo, ctx: &TxContext): bool {
     sender == self.validator_address || sender == self.operator_address
 }
 
-/// Whether governance has flagged this member as ignored. An absent key
-/// means not ignored.
+/// Whether governance has flagged this member as ignored.
 fun is_ignored(self: &MemberInfo): bool {
-    self.extra_fields.try_get(MEMBER_IGNORED_KEY).map!(|value| value.as_bool()).destroy_or!(false)
+    self.ignored
 }
 
-/// Whether this member has a pending resignation. An absent key means not
-/// resigned.
+/// Whether this member has a pending resignation.
 fun is_resigned(self: &MemberInfo): bool {
-    self.extra_fields.try_get(MEMBER_RESIGNED_KEY).map!(|value| value.as_bool()).destroy_or!(false)
+    self.resigned
 }
 
 /// Whether the member currently serves an epoch: in the current committee,
@@ -715,6 +686,8 @@ fun remove_member(self: &mut CommitteeSet, validator_address: address) {
         endpoint_url: _,
         tls_public_key: _,
         next_epoch_encryption_public_key: _,
+        ignored: _,
+        resigned: _,
         extra_fields: _,
     } = self.members.remove(validator_address);
 }
@@ -914,6 +887,8 @@ fun create_member_info_for_testing(
         endpoint_url: std::vector::empty().to_string(),
         tls_public_key: std::vector::empty(),
         next_epoch_encryption_public_key: encryption_key,
+        ignored: false,
+        resigned: false,
         extra_fields: config::empty(),
     }
 }


### PR DESCRIPTION
## Summary

Promotes the governance `ignored` and voluntary `resigned` flags from `MemberInfo.extra_fields` keys to root-level `bool` fields on `MemberInfo`, and deletes the two key constants plus the `extra_fields` decode in the Rust mirror.

The flags only lived in `extra_fields` because `MemberInfo`'s layout was frozen on the deployed testnet package (see the `TODO(pre-mainnet-wipe)` comments this removes). Main now ships a fresh v1 (#1075), so the layout is open until the pre-mainnet publish. This is the `committee_set` promotion item from IOP-660, pulled forward because it is a layout change and therefore has to land before that publish, not after it.

`extra_fields` stays as the empty extension slot for member data added after the mainnet layout freeze, which is what it was added for in #754.

## Changes

- `committee_set.move`: `ignored: bool` and `resigned: bool` on `MemberInfo`, written directly by `set_member_ignored`, `request_resignation`, and `clear_resignation`; the `MEMBER_IGNORED_KEY` / `MEMBER_RESIGNED_KEY` constants and the `config_value` import are gone.
- `hashi-types` `move_types::MemberInfo`: matching fields in BCS order (before `extra_fields`); the two key constants deleted.
- `onchain`: `convert_move_member_info` reads the fields; the `MemberInfoEnc` test encoder and the conversion test updated.

No entry-function signature changes. Move and Rust field order agree, which the `apply.rs` encode/decode tests and the two e2e flows below exercise.

## Testing

- `sui move test -e testnet` under the CI-pinned sui 1.73.2: 236 passed.
- `cargo test -p hashi-types --lib`, `cargo test -p hashi --lib -- onchain`, `cargo clippy -p hashi -p hashi-types --all-targets -D warnings`, `cargo fmt --check`.
- e2e: `test_ignored_member_excluded_at_epoch_boundary` and `test_resigned_member_excluded_then_removed_permissionlessly`.

Related: IOP-660, IOP-455.
