### PR TITLE
cli: route `hashi register` at the highest enabled package version

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -3698,4 +3698,165 @@ mod tests {
         info!("=== Drain Mode Max Batch Test Passed ===");
         Ok(())
     }
+
+    /// `hashi register` (the CLI path through
+    /// `build_register_or_update_validator_tx`) must target a live package:
+    /// every `validator::*` entry gates on the called package's
+    /// `assert_version_enabled`, so the original publish id aborts once its
+    /// version is retired. The node's startup registration already routes
+    /// past it; this pins the CLI resolver to the highest enabled published
+    /// version on a chain where v1 is disabled (IOP-558). The disable is
+    /// driven here rather than by the harness boot because the fresh-cycle
+    /// binary supports v1 only, and the resolver must not depend on that.
+    #[tokio::test]
+    async fn test_cli_register_targets_the_enabled_package() -> Result<()> {
+        use sui_crypto::SuiSigner as _;
+        use sui_rpc::proto::sui::rpc::v2::ExecuteTransactionRequest;
+
+        init_test_logging();
+
+        let networks =
+            setup_test_networks(TestNetworksBuilder::new().with_nodes(4).keep_v1_enabled()).await?;
+        let hashi_ids = networks.hashi_network.ids();
+        let sui_rpc_url = networks.sui_network.rpc_url.clone();
+        let mut client = networks.sui_network.client.clone();
+        let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+            &mut client,
+            hashi_ids.hashi_object_id,
+        )
+        .await?;
+
+        // Retire v1 through governance, executed through the upgraded
+        // package, so the configured (original) id is a dead target.
+        let upgraded_package_id = {
+            let nodes = networks.hashi_network.nodes();
+            let upgraded_package_id = nodes[0]
+                .hashi()
+                .onchain_state()
+                .package_id()
+                .ok_or_else(|| anyhow!("no package versions known"))?;
+            assert_ne!(upgraded_package_id, hashi_ids.package_id);
+            let mut executors: Vec<SuiTxExecutor> = nodes
+                .iter()
+                .map(|node| {
+                    let hashi = node.hashi();
+                    SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())
+                })
+                .collect::<Result<_>>()?;
+            crate::upgrade_flow::disable_version(
+                &mut executors,
+                hashi_ids,
+                hashi_isv,
+                1,
+                upgraded_package_id,
+            )
+            .await?;
+            upgraded_package_id
+        };
+        crate::upgrade_flow::wait_for_version_disabled(&networks, 1, Duration::from_secs(30))
+            .await?;
+        info!(%upgraded_package_id, "v1 retired; exercising the CLI register path");
+
+        // The runbook's operator-key rotation: a validator points its member
+        // record at a new operator address. In e2e the node signs with its
+        // validator key, so the rotation never locks the node out.
+        let node = networks.hashi_network.nodes()[3].hashi().clone();
+        let config = &node.config;
+        let signer = config.operator_private_key()?;
+        let new_operator = Address::new(rand::random::<[u8; 32]>());
+
+        // Against the configured (original) id the build's simulation must
+        // abort inside `versioning::assert_version_enabled`.
+        let err = hashi::sui_tx_executor::build_register_or_update_validator_tx(
+            &mut client,
+            &hashi_ids,
+            hashi_ids.package_id,
+            config,
+            Some(new_operator),
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("a v1-targeted update_operator_address must not build");
+        let simulation = err
+            .chain()
+            .find_map(
+                |e| match e.downcast_ref::<sui_transaction_builder::Error>() {
+                    Some(sui_transaction_builder::Error::SimulationFailure(failure)) => {
+                        Some(failure)
+                    }
+                    _ => None,
+                },
+            )
+            .unwrap_or_else(|| panic!("expected a simulation failure, got: {err:#}"));
+        let abort = simulation
+            .execution_error()
+            .abort_opt()
+            .expect("the retired package must abort, not fail some other way");
+        assert_eq!(
+            abort.location().module_opt(),
+            Some("versioning"),
+            "abort must come from assert_version_enabled"
+        );
+        if let Some(constant) = abort
+            .clever_error
+            .as_ref()
+            .and_then(|clever| clever.constant_name.as_deref())
+        {
+            assert_eq!(constant, "EVersionDisabled");
+        }
+
+        // The CLI's resolver picks the highest enabled published version
+        // (the upgraded package), and the same transaction lands through it.
+        let call_package =
+            hashi::cli::commands::resolve_latest_enabled_package(&sui_rpc_url, hashi_ids).await?;
+        assert_eq!(call_package, upgraded_package_id);
+        let tx = hashi::sui_tx_executor::build_register_or_update_validator_tx(
+            &mut client,
+            &hashi_ids,
+            call_package,
+            config,
+            Some(new_operator),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .expect("the rotation is a real metadata change");
+        let signature = signer.sign_transaction(&tx)?;
+        let response = client
+            .execute_transaction_and_wait_for_checkpoint(
+                ExecuteTransactionRequest::new(tx.into())
+                    .with_signatures(vec![signature.into()])
+                    .with_read_mask(FieldMask::from_str("*")),
+                Duration::from_secs(30),
+            )
+            .await?
+            .into_inner();
+        anyhow::ensure!(
+            response.transaction().effects().status().success(),
+            "update_operator_address through the enabled package failed: {:?}",
+            response.transaction().effects().status()
+        );
+
+        // The member record now carries the rotation: a second build against
+        // the same config has nothing left to send.
+        let again = hashi::sui_tx_executor::build_register_or_update_validator_tx(
+            &mut client,
+            &hashi_ids,
+            call_package,
+            config,
+            Some(new_operator),
+            None,
+            None,
+            None,
+        )
+        .await?;
+        assert!(
+            again.is_none(),
+            "member record must already reflect the rotated operator address"
+        );
+        Ok(())
+    }
 }

--- a/crates/hashi/src/cli/commands/mod.rs
+++ b/crates/hashi/src/cli/commands/mod.rs
@@ -39,3 +39,43 @@ pub(crate) async fn resolve_active_call_package(
     )?;
     Ok((state, package))
 }
+
+/// The package `hashi register` calls: the highest version that is both
+/// governance-enabled and published on-chain, resolved from a one-shot
+/// governance read and deliberately NOT intersected with this binary's
+/// [`crate::constants::SUPPORTED_PACKAGE_VERSIONS`]. That list gates what a
+/// node may decode and mutate autonomously; the registration transaction is a
+/// fixed set of `validator::*` entry calls whose only version dependency is
+/// the called package's `assert_version_enabled`, so the live package is the
+/// correct target even for a CLI built before the chain's latest upgrade. A
+/// chain with no enabled+published version is a hard error, never a fallback
+/// to the original package id (`hashi_ids.package_id`), whose entries abort
+/// once its version is retired.
+pub async fn resolve_latest_enabled_package(
+    sui_rpc_url: &str,
+    hashi_ids: crate::config::HashiIds,
+) -> anyhow::Result<sui_sdk_types::Address> {
+    let state = crate::onchain::OnchainState::new_reader(
+        sui_rpc_url,
+        hashi_ids,
+        None,
+        crate::onchain::ScrapeScope::GovernanceOnly,
+    )
+    .await
+    .context("failed to read on-chain governance state to resolve the enabled package")?;
+    let state = state.state();
+    let published: Vec<u64> = state
+        .package_versions()
+        .versions()
+        .keys()
+        .copied()
+        .collect();
+    let version = state
+        .version_support(&published)
+        .active_version()
+        .context("no on-chain package version is both enabled and published")?;
+    state
+        .package_versions()
+        .get(version)
+        .with_context(|| format!("package id for enabled version {version} is not known"))
+}

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -1917,18 +1917,26 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
     print_info(&format!("Validator address: {validator_address}"));
     print_info(&format!("Sui RPC: {sui_rpc_url}"));
 
+    // Every `validator::*` entry gates on the CALLED package's
+    // `assert_version_enabled`, so the calls must target a live package.
+    // `hashi_ids.package_id` is the original publish id, whose entries abort
+    // with `EVersionDisabled` once its version is retired; the node's own
+    // startup registration already routes past it. Resolution failure is a
+    // hard error, never a fallback to the original id.
+    let hashi_ids = config.hashi_ids();
+    let call_package = commands::resolve_latest_enabled_package(&sui_rpc_url, hashi_ids).await?;
+
     if opts.serialize_unsigned || opts.dry_run {
         // Build the transaction without executing: print it as base64
         // (serialize) or report the simulated gas estimate (dry-run).
         // No private key is required for either path.
         let mut client = crate::sui_rpc_client::new_sui_rpc_client(&sui_rpc_url)?;
-        let hashi_ids = config.hashi_ids();
 
         print_info("Building registration transaction ...");
         let transaction = crate::sui_tx_executor::build_register_or_update_validator_tx(
             &mut client,
             &hashi_ids,
-            hashi_ids.package_id,
+            call_package,
             &config,
             operator_address,
             None,
@@ -1971,14 +1979,13 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
 
     let mut client = crate::sui_rpc_client::new_sui_rpc_client(&sui_rpc_url)?;
     let signer = config.operator_private_key()?;
-    let hashi_ids = config.hashi_ids();
     let sender = signer.verifying_key().derive_address();
 
     print_info("Registering validator ...");
     let transaction = crate::sui_tx_executor::build_register_or_update_validator_tx(
         &mut client,
         &hashi_ids,
-        hashi_ids.package_id,
+        call_package,
         &config,
         operator_address,
         Some(sender),

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -289,7 +289,7 @@ Make sure the file is readable by the user running `hashi` (for example, `chmod 
 
 Your **Sui validator account key must sign and broadcast the initial registration transaction.** Onchain, `validator::register` sets the member's `validator_address = ctx.sender()` and asserts the sender is in the Sui active validator set, so no operator key can substitute for this first transaction. Registration places no constraint on the account's key scheme (Ed25519, multisig, secp256k1, or zkLogin all work); it requires only that the sender is an active Sui validator.
 
-Because that key is typically in cold storage or a hardware wallet, use the **offline signing flow**: `hashi register --print-only` builds the unsigned transaction and prints it as base64 **without needing any private key**. Sign it externally with the account key and broadcast. (`hashi register --dry-run` builds and simulates the same transaction without executing it, reporting the gas estimate.)
+Because that key is typically in cold storage or a hardware wallet, use the **offline signing flow**: `hashi register --print-only` builds the unsigned transaction and prints it as base64 **without needing any private key**. Sign it externally with the account key and broadcast. (`hashi register --dry-run` builds and simulates the same transaction without executing it, reporting the gas estimate.) Both forms resolve the network's highest enabled package version on-chain before building, so the transaction targets the live package even after an upgrade; a build against a retired package fails in simulation instead of being emitted.
 
 ```bash
 # Emit the unsigned registration tx (no private key required)


### PR DESCRIPTION
## Summary

`hashi register` built every `validator::*` entry call against the configured package id, which is the original publish. Every one of those entries gates on the called package's `assert_version_enabled`, so once that version is retired the whole transaction aborts with `EVersionDisabled`. On the live testnet v1 has been disabled since the 2026-09-01 upgrade, which means first registration (`hashi register --print-only`) and operator-key rotation, the two flows the runbook routes through the CLI, do not work today. The node's own startup registration was unaffected because `execute_register_or_update_validator` already routes through `active_call_package_id()`.

Closes IOP-558.

## Change

- `cli/commands/mod.rs`: `resolve_latest_enabled_package`, a one-shot governance read that returns the package of the highest version that is both governance-enabled and published. It deliberately does not intersect with `SUPPORTED_PACKAGE_VERSIONS`: that list gates what a node may decode and mutate autonomously, while the registration transaction is a fixed set of `validator::*` calls whose only version dependency is the called package's enable check, so the live package is the right target even for a CLI built before the chain's latest upgrade. No enabled published version is a hard error, never a fallback to the original id. This is the same rule `latest_package_id` already applies to the other `validator::*` lifecycle entries in the CLI client.
- `cli/mod.rs` `run_register`: resolve once, before the serialize/dry-run and execute paths split, and pass the result as the builder's `call_package`.
- `node-operator-runbook.mdx`: one sentence noting that `hashi register` resolves the highest enabled version on-chain and that a build against a retired package fails in simulation instead of being emitted.

`build_register_or_update_validator_tx` and the node path are untouched. Type tags still use the original package id, which is correct.

## Test

`test_cli_register_targets_the_enabled_package` (e2e): boots with both versions enabled, retires v1 through governance executed via the upgraded package, then runs the runbook's operator-address rotation. Building against the configured id fails in simulation with a Move abort in `versioning` (the live bug). Resolving through the new resolver yields the upgraded package, the same transaction lands, and a second build against the same config has nothing left to send.

The test drives the disable itself rather than using `with_upgraded_chain()`: on the fresh cycle the binary supports v1 only, so that boot's own assertion that active version 2 resolves cannot hold on main. Nothing on main currently uses that boot; noting it here rather than changing the harness in this PR.

## Backport

The live break is on the `testnet` maintenance branch, where operators build from. A cherry-pick of the CLI change follows as a separate PR against `testnet`; the e2e test stays on main.
