### PR TITLE
cli: route `hashi register` at the highest enabled package version (testnet backport)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6294,8 +6294,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-crypto"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b8f54c4405002c9ece67cb848479f80837185a55a59d8c0a105240f737d0da"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -6347,8 +6346,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617504d5c6b748af0494b73db80fb893840522329788c48c826d8298e7edb0aa"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -6372,8 +6370,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22266119e43d3da1a8bc9945c8b569a513e7682f561265d70ef8b6e198dd664"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64ct",
  "bcs",
@@ -6394,8 +6391,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39697547ef9a6c03725dca449c33c3b47619b0a76ca5df827e4501944ebdaebb"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "async-trait",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 # sui sdk crates
-sui-sdk-types = { version = "0.3.2", features = ["serde", "hash"] }
-sui-crypto = { version = "0.3.1", features = ["ed25519", "secp256k1", "secp256r1", "pem", "bech32"] }
-sui-rpc = "0.3.2"
-sui-transaction-builder = "0.3.2"
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d71f9d6f788afc6b30baef85a342e0e7867c0019", features = ["serde", "hash"] }
+sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d71f9d6f788afc6b30baef85a342e0e7867c0019", features = ["ed25519", "secp256k1", "secp256r1", "pem", "bech32"] }
+sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d71f9d6f788afc6b30baef85a342e0e7867c0019" }
+sui-transaction-builder = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d71f9d6f788afc6b30baef85a342e0e7867c0019" }
 
 sui-http = "0.3.1"
 bitcoin = { version = "0.32.8", features =["serde"] }

--- a/crates/hashi/src/cli/commands/mod.rs
+++ b/crates/hashi/src/cli/commands/mod.rs
@@ -68,3 +68,43 @@ pub(crate) async fn resolve_withdrawal_call_package(
         )?;
     Ok((state, package))
 }
+
+/// The package `hashi register` calls: the highest version that is both
+/// governance-enabled and published on-chain, resolved from a one-shot
+/// governance read and deliberately NOT intersected with this binary's
+/// [`crate::constants::SUPPORTED_PACKAGE_VERSIONS`]. That list gates what a
+/// node may decode and mutate autonomously; the registration transaction is a
+/// fixed set of `validator::*` entry calls whose only version dependency is
+/// the called package's `assert_version_enabled`, so the live package is the
+/// correct target even for a CLI built before the chain's latest upgrade. A
+/// chain with no enabled+published version is a hard error, never a fallback
+/// to the original package id (`hashi_ids.package_id`), whose entries abort
+/// once its version is retired.
+pub async fn resolve_latest_enabled_package(
+    sui_rpc_url: &str,
+    hashi_ids: crate::config::HashiIds,
+) -> anyhow::Result<sui_sdk_types::Address> {
+    let state = crate::onchain::OnchainState::new_reader(
+        sui_rpc_url,
+        hashi_ids,
+        None,
+        crate::onchain::ScrapeScope::GovernanceOnly,
+    )
+    .await
+    .context("failed to read on-chain governance state to resolve the enabled package")?;
+    let state = state.state();
+    let published: Vec<u64> = state
+        .package_versions()
+        .versions()
+        .keys()
+        .copied()
+        .collect();
+    let version = state
+        .version_support(&published)
+        .active_version()
+        .context("no on-chain package version is both enabled and published")?;
+    state
+        .package_versions()
+        .get(version)
+        .with_context(|| format!("package id for enabled version {version} is not known"))
+}

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -1970,18 +1970,26 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
     print_info(&format!("Validator address: {validator_address}"));
     print_info(&format!("Sui RPC: {sui_rpc_url}"));
 
+    // Every `validator::*` entry gates on the CALLED package's
+    // `assert_version_enabled`, so the calls must target a live package.
+    // `hashi_ids.package_id` is the original publish id, whose entries abort
+    // with `EVersionDisabled` once its version is retired; the node's own
+    // startup registration already routes past it. Resolution failure is a
+    // hard error, never a fallback to the original id.
+    let hashi_ids = config.hashi_ids();
+    let call_package = commands::resolve_latest_enabled_package(&sui_rpc_url, hashi_ids).await?;
+
     if opts.serialize_unsigned || opts.dry_run {
         // Build the transaction without executing: print it as base64
         // (serialize) or report the simulated gas estimate (dry-run).
         // No private key is required for either path.
         let mut client = crate::sui_rpc_client::new_sui_rpc_client(&sui_rpc_url)?;
-        let hashi_ids = config.hashi_ids();
 
         print_info("Building registration transaction ...");
         let transaction = crate::sui_tx_executor::build_register_or_update_validator_tx(
             &mut client,
             &hashi_ids,
-            hashi_ids.package_id,
+            call_package,
             &config,
             operator_address,
             None,
@@ -2024,14 +2032,13 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
 
     let mut client = crate::sui_rpc_client::new_sui_rpc_client(&sui_rpc_url)?;
     let signer = config.operator_private_key()?;
-    let hashi_ids = config.hashi_ids();
     let sender = signer.verifying_key().derive_address();
 
     print_info("Registering validator ...");
     let transaction = crate::sui_tx_executor::build_register_or_update_validator_tx(
         &mut client,
         &hashi_ids,
-        hashi_ids.package_id,
+        call_package,
         &config,
         operator_address,
         Some(sender),

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -289,7 +289,7 @@ Make sure the file is readable by the user running `hashi` (for example, `chmod 
 
 Your **Sui validator account key must sign and broadcast the initial registration transaction.** Onchain, `validator::register` sets the member's `validator_address = ctx.sender()` and asserts the sender is in the Sui active validator set, so no operator key can substitute for this first transaction. Registration places no constraint on the account's key scheme (Ed25519, multisig, secp256k1, or zkLogin all work); it requires only that the sender is an active Sui validator.
 
-Because that key is typically in cold storage or a hardware wallet, use the **offline signing flow**: `hashi register --print-only` builds the unsigned transaction and prints it as base64 **without needing any private key**. Sign it externally with the account key and broadcast. (`hashi register --dry-run` builds and simulates the same transaction without executing it, reporting the gas estimate.)
+Because that key is typically in cold storage or a hardware wallet, use the **offline signing flow**: `hashi register --print-only` builds the unsigned transaction and prints it as base64 **without needing any private key**. Sign it externally with the account key and broadcast. (`hashi register --dry-run` builds and simulates the same transaction without executing it, reporting the gas estimate.) Both forms resolve the network's highest enabled package version on-chain before building, so the transaction targets the live package even after an upgrade; a build against a retired package fails in simulation instead of being emitted.
 
 ```bash
 # Emit the unsigned registration tx (no private key required)

--- a/docker/hashi-guardian/enclave-Cargo.lock
+++ b/docker/hashi-guardian/enclave-Cargo.lock
@@ -5924,8 +5924,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-crypto"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b8f54c4405002c9ece67cb848479f80837185a55a59d8c0a105240f737d0da"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -5977,8 +5976,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617504d5c6b748af0494b73db80fb893840522329788c48c826d8298e7edb0aa"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -6002,8 +6000,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22266119e43d3da1a8bc9945c8b569a513e7682f561265d70ef8b6e198dd664"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64ct",
  "bcs",
@@ -6024,8 +6021,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39697547ef9a6c03725dca449c33c3b47619b0a76ca5df827e4501944ebdaebb"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "async-trait",
  "bcs",


### PR DESCRIPTION
## Summary

Backport of #1096 to the `testnet` maintenance branch, where operators build the CLI from.

`hashi register` builds every `validator::*` entry call against the configured package id, which is the original v1 publish. Those entries gate on the called package's `assert_version_enabled`, and v1 has been disabled on testnet since the 2026-09-01 upgrade, so first registration (`hashi register --print-only`) and operator-key rotation through the CLI abort with `EVersionDisabled` today. Node startup registration is unaffected because it already routes through the active package.

## Change

Same as #1096: resolve the highest governance-enabled published version from a one-shot governance read and build against it on both the serialize/dry-run and execute paths, with no fallback to the original id. On this branch the resolver yields the v2 package `0x8f7efd743897fde48cc35b6203cd72c7ad4248f0eb02a9ad378e4a2d39cc2c7e`.

The e2e test from #1096 is not carried over: this branch's harness boots from the deployed snapshot rather than the fresh-cycle upgrade path the test drives.

## Operator note

Any unsigned registration transaction serialized with an earlier CLI build encodes the v1 package and will abort when broadcast. Re-generate with a build that includes this change.

Refs IOP-558.
