### PR TITLE
move: require committee membership to create and vote; announce creator votes and deletions

### DIFF
--- a/packages/hashi/sources/core/proposal/proposal.move
+++ b/packages/hashi/sources/core/proposal/proposal.move
@@ -34,6 +34,8 @@ const EProposalNotExpired: vector<u8> = b"Proposal not expired";
 const EProposalExpired: vector<u8> = b"Proposal expired";
 #[error(code = 6)]
 const EProposalAlreadyExecuted: vector<u8> = b"Proposal already executed";
+#[error(code = 7)]
+const ENotCommitteeMember: vector<u8> = b"Validator is not a member of the current committee";
 
 // ~~~~~~~ Structs ~~~~~~~
 
@@ -93,6 +95,10 @@ entry fun vote<T: store>(
 ) {
     hashi.versioning().assert_version_enabled();
     assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
+    // Registration authorizes the key; only current-committee membership
+    // carries weight. A registered validator outside the committee (rotated
+    // out, or not yet seated) must not record a weightless vote.
+    assert!(hashi.current_committee().has_member(&validator_address), ENotCommitteeMember);
 
     let proposal: &mut Proposal<T> = hashi.proposals_mut().active_mut().borrow_mut(proposal_id);
 
@@ -145,6 +151,7 @@ public fun delete_expired<T: store>(hashi: &mut Hashi, proposal_id: ID, clock: &
     let proposal: Proposal<T> = hashi.proposals_mut().active_mut().remove(proposal_id);
 
     assert!(proposal.is_expired(clock), EProposalNotExpired);
+    sui::event::emit(ProposalDeleted<T> { proposal_id });
     proposal.delete()
 }
 
@@ -163,6 +170,18 @@ public(package) fun create<T: store>(
     // operator key it has delegated to. The vote is recorded under
     // `validator_address` so quorum weight is computed correctly.
     assert!(hashi.committee_set().member_authorized(validator_address, ctx), EUnauthorizedCaller);
+    // Before genesis no committee exists yet: the registered validators are
+    // the future committee and registration is the only authority. Once one
+    // exists, the same membership rule as `vote` applies to the creator's
+    // automatic vote.
+    let has_committee = {
+        let committee_set = hashi.committee_set();
+        committee_set.has_committee(committee_set.epoch())
+    };
+    assert!(
+        !has_committee || hashi.current_committee().has_member(&validator_address),
+        ENotCommitteeMember,
+    );
 
     let votes = vector[validator_address];
     let created_timestamp_ms = clock.timestamp_ms();
@@ -179,8 +198,21 @@ public(package) fun create<T: store>(
     };
 
     let proposal_id = object::id(&proposal);
+
+    // The creator's vote alone can satisfy the threshold (a single-member
+    // committee, or one member holding the whole quorum), so check it here
+    // the way `vote` does. Skipped before genesis: no committee exists yet,
+    // so nothing can reach quorum and there is no committee to weigh against.
+    let quorum_reached = has_committee && proposal.quorum_reached(hashi);
+
     hashi.proposals_mut().active_mut().add(proposal_id, proposal);
     sui::event::emit(ProposalCreated<T> { proposal_id, timestamp_ms: created_timestamp_ms });
+    // The creator's vote is recorded above; announce it like any other vote so
+    // event consumers can attribute it.
+    sui::event::emit(VoteCast<T> { proposal_id, voter: validator_address });
+    if (quorum_reached) {
+        sui::event::emit(QuorumReached<T> { proposal_id });
+    };
     proposal_id
 }
 
@@ -249,4 +281,19 @@ public(package) fun votes<T>(proposal: &Proposal<T>): &vector<address> {
 #[test_only]
 public fun data<T>(proposal: &Proposal<T>): &T {
     &proposal.data
+}
+
+#[test_only]
+public fun vote_cast_for_testing<T>(proposal_id: ID, voter: address): VoteCast<T> {
+    VoteCast { proposal_id, voter }
+}
+
+#[test_only]
+public fun quorum_reached_for_testing<T>(proposal_id: ID): QuorumReached<T> {
+    QuorumReached { proposal_id }
+}
+
+#[test_only]
+public fun proposal_deleted_for_testing<T>(proposal_id: ID): ProposalDeleted<T> {
+    ProposalDeleted { proposal_id }
 }

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -919,3 +919,226 @@ fun test_upgrade_non_exclusive_preserves_enabled_versions() {
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
 }
+
+// ======== Event Tests ========
+
+#[test]
+/// The creator's automatic vote is announced like any other vote, and quorum
+/// reached by that vote alone is announced at creation.
+fun test_create_emits_creator_vote_and_quorum() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VOTER1,
+        1000,
+        &clock,
+        ctx,
+    );
+
+    let votes = sui::event::events_by_type<proposal::VoteCast<UpdateConfig>>();
+    assert!(votes.length() == 1);
+    assert!(votes[0] == proposal::vote_cast_for_testing<UpdateConfig>(proposal_id, VOTER1));
+    let quorum = sui::event::events_by_type<proposal::QuorumReached<UpdateConfig>>();
+    assert!(quorum.length() == 1);
+    assert!(quorum[0] == proposal::quorum_reached_for_testing<UpdateConfig>(proposal_id));
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// A creator vote that does not reach quorum announces the vote only; the
+/// quorum event still comes from the vote that crosses the threshold.
+fun test_create_below_quorum_emits_vote_only() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VOTER1,
+        1000,
+        &clock,
+        ctx,
+    );
+    assert!(sui::event::events_by_type<proposal::VoteCast<UpdateConfig>>().length() == 1);
+    assert!(sui::event::events_by_type<proposal::QuorumReached<UpdateConfig>>().length() == 0);
+
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
+    let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER3, proposal_id, &clock, ctx3);
+    assert!(sui::event::events_by_type<proposal::VoteCast<UpdateConfig>>().length() == 3);
+    assert!(sui::event::events_by_type<proposal::QuorumReached<UpdateConfig>>().length() == 1);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// Before genesis there is no committee to weigh votes against. Creating a
+/// proposal must still work (registration alone authorizes it) and must not
+/// announce quorum.
+fun test_create_before_genesis_emits_no_quorum() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let sk = test_utils::bls_sk_for_testing();
+    let pub_key = bls12381::g1_from_bytes(&test_utils::bls_min_pk_from_sk(&sk));
+    let committee_set = hashi::committee_set::create_pre_genesis_for_testing(
+        vector[VOTER1],
+        *pub_key.bytes(),
+        sk,
+        ctx,
+    );
+    let mut config = hashi::config::create();
+    hashi::btc_config::init_defaults(&mut config);
+    hashi::mpc_config::init_defaults(&mut config);
+    let mut hashi = hashi::hashi::create_for_testing(
+        committee_set,
+        config,
+        hashi::versioning::create(),
+        hashi::treasury::create(ctx),
+        hashi::proposals::create(ctx),
+        sui::bag::new(ctx),
+        ctx,
+    );
+    let clock = clock::create_for_testing(ctx);
+
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VOTER1,
+        1000,
+        &clock,
+        ctx,
+    );
+    assert!(hashi.proposals().active().contains(proposal_id));
+    assert!(sui::event::events_by_type<proposal::VoteCast<UpdateConfig>>().length() == 1);
+    assert!(sui::event::events_by_type<proposal::QuorumReached<UpdateConfig>>().length() == 0);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// Deleting an expired proposal announces the deletion.
+fun test_delete_expired_emits_proposal_deleted() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut clock = clock::create_for_testing(ctx);
+
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VOTER1,
+        1000,
+        &clock,
+        ctx,
+    );
+    clock::increment_for_testing(&mut clock, MAX_PROPOSAL_DURATION_MS + 1);
+    let data = proposal::delete_expired<UpdateConfig>(&mut hashi, proposal_id, &clock);
+    std::unit_test::destroy(data);
+
+    let deleted = sui::event::events_by_type<proposal::ProposalDeleted<UpdateConfig>>();
+    assert!(deleted.length() == 1);
+    assert!(deleted[0] == proposal::proposal_deleted_for_testing<UpdateConfig>(proposal_id));
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+// ======== Committee Membership Tests (Certora L-03) ========
+
+#[test]
+#[expected_failure(abort_code = proposal::ENotCommitteeMember)]
+/// A validator that is registered but not in the current committee cannot
+/// create a proposal once a committee exists.
+fun test_create_by_registered_non_member_fails() {
+    let ctx = &mut test_utils::new_tx_context(NON_VOTER, 0);
+    let mut hashi = test_utils::create_hashi_with_committee_and_registry(
+        vector[VOTER1, VOTER2, VOTER3],
+        vector[VOTER1, VOTER2, VOTER3, NON_VOTER],
+        ctx,
+    );
+    let clock = clock::create_for_testing(ctx);
+
+    // Registered, authorized by its own key, but outside the committee.
+    let _proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        NON_VOTER,
+        1000,
+        &clock,
+        ctx,
+    );
+
+    // Won't reach here
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = proposal::ENotCommitteeMember)]
+/// A validator that is registered but not in the current committee cannot
+/// vote; its vote would carry no weight and must not be recorded.
+fun test_vote_by_registered_non_member_fails() {
+    let ctx1 = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee_and_registry(
+        vector[VOTER1, VOTER2, VOTER3],
+        vector[VOTER1, VOTER2, VOTER3, NON_VOTER],
+        ctx1,
+    );
+    let clock = clock::create_for_testing(ctx1);
+
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VOTER1,
+        1000,
+        &clock,
+        ctx1,
+    );
+
+    let ctx_non = &mut test_utils::new_tx_context(NON_VOTER, 0);
+    proposal::vote<UpdateConfig>(&mut hashi, NON_VOTER, proposal_id, &clock, ctx_non);
+
+    // Won't reach here
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+/// A registered validator outside the committee can still retract a vote it
+/// cast while seated: `remove_vote` stays registration-gated so a rotated-out
+/// member can withdraw support from a proposal it no longer backs.
+fun test_remove_vote_by_rotated_out_member_succeeds() {
+    let ctx1 = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee_and_registry(
+        vector[VOTER1, VOTER2, VOTER3],
+        vector[VOTER1, VOTER2, VOTER3, NON_VOTER],
+        ctx1,
+    );
+    let clock = clock::create_for_testing(ctx1);
+
+    let proposal_id = test_utils::create_deposit_minimum_proposal(
+        &mut hashi,
+        VOTER1,
+        1000,
+        &clock,
+        ctx1,
+    );
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    proposal::vote<UpdateConfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
+    assert!(
+        hashi.proposals().active().borrow<_, proposal::Proposal<UpdateConfig>>(proposal_id).votes().length() == 2,
+    );
+
+    // Retraction needs registration only.
+    proposal::remove_vote<UpdateConfig>(&mut hashi, VOTER2, proposal_id, ctx2);
+    assert!(
+        hashi.proposals().active().borrow<_, proposal::Proposal<UpdateConfig>>(proposal_id).votes().length() == 1,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}


### PR DESCRIPTION
## Summary

Three Certora governance findings on the proposal module, one PR.

- **L-03 (IOP-627)**: `proposal::create` and `proposal::vote` authorized on registration alone (`member_authorized` checks the registry and the key), so a validator that is registered but not in the current committee could create proposals and record votes. Those votes carried no weight (`get_member_weight` is 0 for non-members), so this was noise rather than a threshold break, but it let stale keys touch governance state and emit `VoteCast` for members that had rotated out. Both entries now also require current-committee membership (`ENotCommitteeMember`). `create` keeps the pre-genesis exception: before the first committee exists, the registered validators are the future committee and registration is the only authority. `remove_vote` stays registration-gated so a rotated-out member can still retract a vote it cast while seated.
- **I-02 (IOP-628)**: `delete_expired` now emits the `ProposalDeleted` event it already declared.
- **I-05 (IOP-631)**: `create` emits `VoteCast` for the creator's automatic vote, and `QuorumReached` when that vote alone meets the threshold (single-member committees, or one member holding the whole quorum), matching what `vote` announces. Skipped before genesis, where nothing can reach quorum.

The I-03 change that shared the parked branch with these (same-epoch re-approval as a no-op) is intentionally not here: #1082 landed the opposite semantics (abort with `EApprovalCertNotNewer`, one approval per transaction) and closed IOP-629 and IOP-662.

## Tests

`proposal_tests.move`: creator vote and quorum events, below-quorum creation, pre-genesis creation (no quorum event, still allowed), deletion event, registered non-member create and vote abort with `ENotCommitteeMember`, rotated-out member can still `remove_vote`. Existing `EUnauthorizedCaller` tests are unchanged: the registry check still fires first for unregistered callers.

No Rust changes: the node never creates proposals outside the CLI, the e2e config overrides run from committee executors after DKG, and the IgnoreMember e2e asserts its creator is seated.
