### PR TITLE
chore: bump the sui SDK crates to a rev that knows `TransactionExpiration::Validity` (testnet backport)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6294,8 +6294,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-crypto"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b8f54c4405002c9ece67cb848479f80837185a55a59d8c0a105240f737d0da"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -6347,8 +6346,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617504d5c6b748af0494b73db80fb893840522329788c48c826d8298e7edb0aa"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -6372,8 +6370,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22266119e43d3da1a8bc9945c8b569a513e7682f561265d70ef8b6e198dd664"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64ct",
  "bcs",
@@ -6394,8 +6391,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39697547ef9a6c03725dca449c33c3b47619b0a76ca5df827e4501944ebdaebb"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "async-trait",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 # sui sdk crates
-sui-sdk-types = { version = "0.3.2", features = ["serde", "hash"] }
-sui-crypto = { version = "0.3.1", features = ["ed25519", "secp256k1", "secp256r1", "pem", "bech32"] }
-sui-rpc = "0.3.2"
-sui-transaction-builder = "0.3.2"
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d71f9d6f788afc6b30baef85a342e0e7867c0019", features = ["serde", "hash"] }
+sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d71f9d6f788afc6b30baef85a342e0e7867c0019", features = ["ed25519", "secp256k1", "secp256r1", "pem", "bech32"] }
+sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d71f9d6f788afc6b30baef85a342e0e7867c0019" }
+sui-transaction-builder = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "d71f9d6f788afc6b30baef85a342e0e7867c0019" }
 
 sui-http = "0.3.1"
 bitcoin = { version = "0.32.8", features =["serde"] }

--- a/docker/hashi-guardian/enclave-Cargo.lock
+++ b/docker/hashi-guardian/enclave-Cargo.lock
@@ -5924,8 +5924,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-crypto"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b8f54c4405002c9ece67cb848479f80837185a55a59d8c0a105240f737d0da"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64ct",
  "bech32 0.11.1",
@@ -5977,8 +5976,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617504d5c6b748af0494b73db80fb893840522329788c48c826d8298e7edb0aa"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -6002,8 +6000,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22266119e43d3da1a8bc9945c8b569a513e7682f561265d70ef8b6e198dd664"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "base64ct",
  "bcs",
@@ -6024,8 +6021,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39697547ef9a6c03725dca449c33c3b47619b0a76ca5df827e4501944ebdaebb"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d71f9d6f788afc6b30baef85a342e0e7867c0019#d71f9d6f788afc6b30baef85a342e0e7867c0019"
 dependencies = [
  "async-trait",
  "bcs",


### PR DESCRIPTION
## Summary

Backport of 8a74540c1 from main (Zhou, 2026-09-01): move the four sui SDK crates from the crates.io 0.3.x releases to the sui-rust-sdk revision that knows the new `TransactionExpiration` variant.

CI installs the newest published Sui testnet release for the localnet (`.github/scripts/install-sui.sh`, unpinned). `testnet-v1.79.0` landed on 2026-09-01, and every e2e boot on this branch has failed since with

```
Conversion error due to input issue: invalid value: integer `3`, expected variant index 0 <= i < 3
```

because the 0.3.x SDK decodes a three-variant enum the 1.79 node now emits four variants for. #1097 and #1098 both hit it on tests their changes do not touch.

## Verification

Reproduced locally with the `testnet-v1.79.0` binary as `SUI_BINARY`: `test_passive_bitcoin_deposit_discovery` fails at boot with the exact CI error on this branch as-is, and passes with this change. `cargo clippy --workspace --all-features --tests -D warnings` is clean.

## Compat

Dependency revision only; no hashi code changes and no Move changes, so nothing an operator builds from this branch changes behaviour on the live network. The enclave lock (`docker/hashi-guardian/enclave-Cargo.lock`) is updated the same way main did it.
