### PR TITLE
config: split the governed config into instant and epoch stores, mirror it in the node and CLI

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -2706,7 +2706,7 @@ mod tests {
         )
         .await?;
 
-        // Add one key to each store. The epoch key rides the wholesale pin
+        // Add one key to each store. The epoch key rides the verbatim copy
         // into the next committee; the instant key applies at once and never
         // reaches a committee.
         {

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -2650,6 +2650,12 @@ mod tests {
         use hashi::onchain::types::DEFAULT_MPC_MAX_FAULTY_IN_BASIS_POINTS;
         use hashi::onchain::types::DEFAULT_MPC_WEIGHT_REDUCTION_ALLOWED_DELTA;
 
+        // Governance-added keys the Move package knows nothing about.
+        const EPOCH_KNOB: &str = "e2e_epoch_knob";
+        const EPOCH_KNOB_VALUE: u64 = 7;
+        const INSTANT_KNOB: &str = "e2e_instant_knob";
+        const INSTANT_KNOB_VALUE: u64 = 9;
+
         // Wait for DKG (epoch 1 committee created with defaults).
         let nodes = networks.hashi_network.nodes();
         let futs: Vec<_> = nodes
@@ -2699,6 +2705,60 @@ mod tests {
             ],
         )
         .await?;
+
+        // Add one key to each store. The epoch key rides the wholesale pin
+        // into the next committee; the instant key applies at once and never
+        // reaches a committee.
+        {
+            use hashi::cli::client::CreateProposalParams;
+            use hashi::sui_tx_executor::SuiTxExecutor;
+            use hashi_types::move_types::ConfigValue;
+
+            let nodes = networks.hashi_network.nodes();
+            let hashi_ids = networks.hashi_network.ids();
+            let latest_package_id = nodes[0]
+                .hashi()
+                .onchain_state()
+                .package_id()
+                .unwrap_or(hashi_ids.package_id);
+            let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+                &mut networks.sui_network.client.clone(),
+                hashi_ids.hashi_object_id,
+            )
+            .await?;
+            let mut executors: Vec<SuiTxExecutor> = nodes
+                .iter()
+                .map(|node| {
+                    let hashi = node.hashi();
+                    SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())
+                })
+                .collect::<Result<_>>()?;
+            let add_config_type_tag = hashi::cli::client::get_proposal_type_arg(
+                latest_package_id,
+                &hashi::onchain::types::ProposalType::AddConfig,
+            )?;
+            for (epoch, key, value) in [
+                (true, EPOCH_KNOB, EPOCH_KNOB_VALUE),
+                (false, INSTANT_KNOB, INSTANT_KNOB_VALUE),
+            ] {
+                crate::submit_proposal_through_quorum(
+                    hashi_ids,
+                    hashi_isv,
+                    latest_package_id,
+                    &mut executors,
+                    CreateProposalParams::AddConfig {
+                        epoch,
+                        key: key.to_string(),
+                        value: ConfigValue::U64(value),
+                        metadata: vec![],
+                    },
+                    add_config_type_tag.clone(),
+                    "add_config",
+                    &format!("AddConfig({key})"),
+                )
+                .await?;
+            }
+        }
 
         // Force key rotation → epoch 2 committee created with new config.
         let target_epoch = initial_epoch + 1;
@@ -2762,6 +2822,41 @@ mod tests {
             new_max_faulty as u16,
             "epoch {target_epoch} committee should have updated max_faulty_basis_points"
         );
+
+        // The governance-added keys landed in exactly their stores.
+        assert_eq!(
+            epoch2.config().get_u64(EPOCH_KNOB, 0),
+            EPOCH_KNOB_VALUE,
+            "epoch {target_epoch} committee should carry the governance-added epoch key"
+        );
+        assert_eq!(
+            epoch1.config().get_u64(EPOCH_KNOB, 0),
+            0,
+            "epoch {initial_epoch} committee predates the epoch key and must not carry it"
+        );
+        assert!(
+            !epoch2
+                .config()
+                .entries()
+                .iter()
+                .any(|(key, _)| key == INSTANT_KNOB),
+            "instant keys never reach a committee"
+        );
+        let (instant, governed_epoch) = {
+            let s = state.state();
+            (
+                s.hashi().config.config.get(INSTANT_KNOB).cloned(),
+                s.hashi().epoch_config.get_u64(EPOCH_KNOB, 0),
+            )
+        };
+        assert_eq!(
+            instant,
+            Some(hashi_types::move_types::ConfigValue::U64(
+                INSTANT_KNOB_VALUE
+            )),
+            "instant key should be readable from the Hashi object right away"
+        );
+        assert_eq!(governed_epoch, EPOCH_KNOB_VALUE);
 
         Ok(())
     }

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -637,6 +637,28 @@ pub(crate) async fn apply_onchain_config_overrides(
         Identifier::from_static("UpdateConfig"),
         vec![],
     )));
+    // `UpdateEpochConfig` was introduced by the package the chain runs at
+    // boot, so its type tag carries that package.
+    let update_epoch_config_type_tag = TypeTag::Struct(Box::new(StructTag::new(
+        execute_package_id,
+        Identifier::from_static("update_epoch_config"),
+        Identifier::from_static("UpdateEpochConfig"),
+        vec![],
+    )));
+    // Overrides are routed to the store that holds the key: epoch keys (the
+    // MPC parameters and anything governance added there) go through
+    // `UpdateEpochConfig`, everything else through `UpdateConfig`.
+    let epoch_keys: std::collections::BTreeSet<String> = {
+        let hashi = nodes[0].hashi();
+        let state = hashi.onchain_state().state();
+        state
+            .hashi()
+            .epoch_config
+            .entries()
+            .iter()
+            .map(|(key, _)| key.clone())
+            .collect()
+    };
 
     if has_mpc_overrides {
         tracing::info!(
@@ -655,8 +677,8 @@ pub(crate) async fn apply_onchain_config_overrides(
                 nonce_generation_protocol: None,
                 metadata: vec![],
             },
-            update_config_type_tag.clone(),
-            "update_config",
+            update_epoch_config_type_tag.clone(),
+            "update_epoch_config",
             "UpdateMpcConfig",
         )
         .await?;
@@ -666,19 +688,38 @@ pub(crate) async fn apply_onchain_config_overrides(
     //one at a time?
     for (key, value) in &other_overrides {
         tracing::info!("applying on-chain config override: {key} = {value:?}");
+        let (params, type_tag, module, label) = if epoch_keys.contains(key) {
+            (
+                CreateProposalParams::UpdateEpochConfig {
+                    key: key.clone(),
+                    value: value.clone(),
+                    metadata: vec![],
+                },
+                update_epoch_config_type_tag.clone(),
+                "update_epoch_config",
+                format!("UpdateEpochConfig({key})"),
+            )
+        } else {
+            (
+                CreateProposalParams::UpdateConfig {
+                    key: key.clone(),
+                    value: value.clone(),
+                    metadata: vec![],
+                },
+                update_config_type_tag.clone(),
+                "update_config",
+                format!("UpdateConfig({key})"),
+            )
+        };
         exec_checkpoint = submit_proposal_through_quorum(
             hashi_ids,
             hashi_initial_shared_version,
             execute_package_id,
             &mut executors,
-            CreateProposalParams::UpdateConfig {
-                key: key.clone(),
-                value: value.clone(),
-                metadata: vec![],
-            },
-            update_config_type_tag.clone(),
-            "update_config",
-            &format!("UpdateConfig({key})"),
+            params,
+            type_tag,
+            module,
+            &label,
         )
         .await?;
     }

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -326,8 +326,9 @@ pub struct Committee {
     pub members: Vec<CommitteeMember>,
     /// Total voting weight of the committee.
     pub total_weight: u64,
-    /// The config pinned from the governed config at reconfig, BCS-mirroring the
-    /// Move `Committee.mpc: Config`. Carried verbatim end to end so the
+    /// The epoch config copied verbatim from the governed epoch config at
+    /// reconfig, BCS-mirroring the Move `Committee.epoch_config: Config`.
+    /// Carried verbatim end to end so the
     /// committee's signed BCS bytes match the on-chain committee exactly; never
     /// reconstructed from extracted fields.
     pub config: Config,
@@ -377,8 +378,8 @@ pub enum ConfigValue {
     Bytes(Vec<u8>),
 }
 
-/// MPC parameter keys, in the canonical order Move's `mpc_config::pin` writes
-/// them. Load-bearing for [`Config::from_mpc_params`].
+/// MPC parameter keys, in the order Move's `mpc_config::init_defaults` seeds
+/// them at genesis. Load-bearing for [`Config::from_mpc_params`].
 const KEY_MPC_WEIGHT_REDUCTION_ALLOWED_DELTA: &str = "mpc_weight_reduction_allowed_delta";
 const KEY_MPC_MAX_FAULTY_IN_BASIS_POINTS: &str = "mpc_max_faulty_in_basis_points";
 const KEY_MPC_NONCE_GENERATION_PROTOCOL: &str = "mpc_nonce_generation_protocol";
@@ -457,7 +458,7 @@ impl Config {
     // ===== MPC parameters (mirror Move's `mpc_config` accessors) =====
 
     /// Build a config holding the MPC parameters, inserting the full key set in
-    /// the same fixed order as Move's `mpc_config::pin`. For synthetic
+    /// the same fixed order as Move's `mpc_config::init_defaults`. For synthetic
     /// committees only (tests, fallbacks); the scrape/wire paths carry the
     /// on-chain config verbatim via [`Config::from_entries`].
     pub fn from_mpc_params(
@@ -2146,7 +2147,8 @@ mod tests {
     /// Pins the exact BCS bytes of a committee's pinned config so a change to the
     /// canonical key order, the `ConfigValue` encoding, or the entry set is
     /// caught here rather than silently breaking handoff-cert verification.
-    /// The expected vector must equal what Move's `mpc_config::pin` produces.
+    /// The expected vector must equal the epoch config Move's
+    /// `mpc_config::init_defaults` seeds, which `start_reconfig` copies verbatim.
     #[test]
     fn committee_mpc_config_bcs_is_pinned() {
         let mpc = Config::from_mpc_params(800, 3333, 1, 700);

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -182,7 +182,10 @@ pub fn is_dof_wrapper(tag: &StructTag) -> bool {
 pub struct Hashi {
     pub id: Address,
     pub committees: CommitteeSet,
+    /// Governed values that apply the moment a proposal executes.
     pub config: Config,
+    /// Governed values copied wholesale onto each new committee.
+    pub epoch_config: Config,
     pub versioning: Versioning,
     pub treasury: Treasury,
     pub proposals: Proposals,
@@ -942,6 +945,30 @@ pub struct Proposal<T> {
 #[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct UpdateConfig {
     pub entries: VecMap<String, ConfigValue>,
+}
+
+/// Rust version of the Move hashi::update_epoch_config::UpdateEpochConfig type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct UpdateEpochConfig {
+    pub entries: VecMap<String, ConfigValue>,
+}
+
+impl MoveType for UpdateEpochConfig {
+    const MODULE: &'static str = "update_epoch_config";
+    const NAME: &'static str = "UpdateEpochConfig";
+}
+
+/// Rust version of the Move hashi::add_config::AddConfig type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct AddConfig {
+    /// `true` targets the epoch config, `false` the instant config.
+    pub epoch: bool,
+    pub entries: VecMap<String, ConfigValue>,
+}
+
+impl MoveType for AddConfig {
+    const MODULE: &'static str = "add_config";
+    const NAME: &'static str = "AddConfig";
 }
 
 /// Rust version of the Move hashi::enable_version::EnableVersion type.

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -42,6 +42,19 @@ pub enum CreateProposalParams {
         value: hashi_types::move_types::ConfigValue,
         metadata: Vec<(String, String)>,
     },
+    /// Update an existing key in the epoch config.
+    UpdateEpochConfig {
+        key: String,
+        value: hashi_types::move_types::ConfigValue,
+        metadata: Vec<(String, String)>,
+    },
+    /// Add a new key to the epoch (`epoch: true`) or instant config.
+    AddConfig {
+        epoch: bool,
+        key: String,
+        value: hashi_types::move_types::ConfigValue,
+        metadata: Vec<(String, String)>,
+    },
     UpdateMpcConfig {
         max_faulty_bps: Option<u64>,
         weight_reduction_allowed_delta: Option<u64>,
@@ -366,6 +379,17 @@ impl HashiClient {
                             bcs::from_bytes(value_bytes).context("deserialize UpdateConfig")?;
                         (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
                     }
+                    ProposalType::UpdateEpochConfig => {
+                        let p: move_types::Proposal<move_types::UpdateEpochConfig> =
+                            bcs::from_bytes(value_bytes)
+                                .context("deserialize UpdateEpochConfig")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
+                    ProposalType::AddConfig => {
+                        let p: move_types::Proposal<move_types::AddConfig> =
+                            bcs::from_bytes(value_bytes).context("deserialize AddConfig")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
                     ProposalType::EnableVersion => {
                         let p: move_types::Proposal<move_types::EnableVersion> =
                             bcs::from_bytes(value_bytes).context("deserialize EnableVersion")?;
@@ -581,6 +605,8 @@ impl HashiClient {
 
         let module_name = match proposal_type {
             ProposalType::UpdateConfig => "update_config",
+            ProposalType::UpdateEpochConfig => "update_epoch_config",
+            ProposalType::AddConfig => "add_config",
             ProposalType::EnableVersion => "enable_version",
             ProposalType::DisableVersion => "disable_version",
             ProposalType::EmergencyPause => "emergency_pause",
@@ -736,6 +762,63 @@ pub fn build_create_proposal_transaction(
                 ],
             );
         }
+        CreateProposalParams::UpdateEpochConfig {
+            key,
+            value,
+            metadata,
+        } => {
+            let entries_arg = build_config_entries(
+                &mut builder,
+                hashi_ids.package_id,
+                call_package,
+                &[(key, value)],
+            );
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    call_package,
+                    Identifier::from_static("update_epoch_config"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    entries_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
+            );
+        }
+        CreateProposalParams::AddConfig {
+            epoch,
+            key,
+            value,
+            metadata,
+        } => {
+            let epoch_arg = builder.pure(&epoch);
+            let entries_arg = build_config_entries(
+                &mut builder,
+                hashi_ids.package_id,
+                call_package,
+                &[(key, value)],
+            );
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    call_package,
+                    Identifier::from_static("add_config"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    epoch_arg,
+                    entries_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
+            );
+        }
         CreateProposalParams::UpdateMpcConfig {
             max_faulty_bps,
             weight_reduction_allowed_delta,
@@ -756,10 +839,11 @@ pub fn build_create_proposal_transaction(
             let entries_arg =
                 build_config_entries(&mut builder, hashi_ids.package_id, call_package, &entries);
             let metadata_arg = build_metadata(&mut builder, &metadata);
+            // The MPC parameters live in the epoch config.
             builder.move_call(
                 Function::new(
                     call_package,
-                    Identifier::from_static("update_config"),
+                    Identifier::from_static("update_epoch_config"),
                     Identifier::from_static("propose"),
                 ),
                 vec![
@@ -1154,6 +1238,8 @@ pub fn get_proposal_type_arg(
     let (module, name) = match proposal_type {
         ProposalType::Upgrade => ("upgrade", "Upgrade"),
         ProposalType::UpdateConfig => ("update_config", "UpdateConfig"),
+        ProposalType::UpdateEpochConfig => ("update_epoch_config", "UpdateEpochConfig"),
+        ProposalType::AddConfig => ("add_config", "AddConfig"),
         ProposalType::EnableVersion => ("enable_version", "EnableVersion"),
         ProposalType::DisableVersion => ("disable_version", "DisableVersion"),
         ProposalType::EmergencyPause => ("emergency_pause", "EmergencyPause"),

--- a/crates/hashi/src/cli/commands/config.rs
+++ b/crates/hashi/src/cli/commands/config.rs
@@ -149,16 +149,32 @@ pub async fn show_onchain_config(config: &CliConfig) -> Result<()> {
         epoch.to_string().green()
     );
 
-    // TODO: Fetch and display more configuration details using hashi::onchain::OnchainState:
-    // - Enabled versions
-    // - Deposit fee
-    // - Paused state
-    // - Committee info
-    // - etc.
+    let state = client.onchain_state().state();
+    let hashi = state.hashi();
+
+    println!(
+        "  {} {:?}",
+        "Enabled Versions:".bold(),
+        hashi.config.enabled_versions
+    );
+
+    println!(
+        "\n  {}",
+        "Instant config (applies when a proposal executes):".bold()
+    );
+    for (key, value) in &hashi.config.config {
+        println!("    {} = {:?}", key.cyan(), value);
+    }
+
+    println!(
+        "\n  {}",
+        "Epoch config (copied onto each new committee):".bold()
+    );
+    for (key, value) in hashi.epoch_config.entries() {
+        println!("    {} = {:?}", key.cyan(), value);
+    }
 
     println!("{}", "━".repeat(60).dimmed());
-
-    print_info("Full configuration fetching is a TODO - will use OnchainState for more details.");
 
     Ok(())
 }

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -670,6 +670,82 @@ pub async fn create_update_config_proposal(
     Ok(())
 }
 
+/// Create an update epoch config proposal
+pub async fn create_update_epoch_config_proposal(
+    config: &CliConfig,
+    key: &str,
+    value_str: &str,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let value = parse_config_value(value_str)
+        .context("Invalid value format. Use type:value, e.g. u64:1000 or bool:true")?;
+
+    print_detail(&format!(
+        "\n{}",
+        "Creating Update Epoch Config Proposal:".bold()
+    ));
+    print_detail(&format!("  Key:   {}", key));
+    print_detail(&format!("  Value: {}", value_str));
+    print_detail("  Takes effect: next committee formed after execution");
+    print_metadata(&metadata);
+
+    prompt_continue("create this epoch config update proposal", tx_opts).await?;
+
+    let mut client = HashiClient::new(config).await?;
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateEpochConfig {
+        key: key.to_string(),
+        value,
+        metadata,
+    })?;
+
+    print_info("Transaction: update_epoch_config::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
+/// Create an add config proposal
+pub async fn create_add_config_proposal(
+    config: &CliConfig,
+    key: &str,
+    value_str: &str,
+    epoch: bool,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let value = parse_config_value(value_str)
+        .context("Invalid value format. Use type:value, e.g. u64:1000 or bool:true")?;
+
+    print_detail(&format!("\n{}", "Creating Add Config Proposal:".bold()));
+    print_detail(&format!("  Key:   {}", key));
+    print_detail(&format!("  Value: {}", value_str));
+    print_detail(&format!(
+        "  Store: {}",
+        if epoch {
+            "epoch config (copied onto each new committee)"
+        } else {
+            "instant config (applies on execute)"
+        }
+    ));
+    print_metadata(&metadata);
+
+    prompt_continue("create this add config proposal", tx_opts).await?;
+
+    let mut client = HashiClient::new(config).await?;
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::AddConfig {
+        epoch,
+        key: key.to_string(),
+        value,
+        metadata,
+    })?;
+
+    print_info("Transaction: add_config::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
 pub async fn create_update_mpc_config_proposal(
     config: &CliConfig,
     max_faulty_bps: Option<u64>,

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -235,19 +235,61 @@ pub enum CreateProposalCommands {
         metadata: MetadataArgs,
     },
 
-    /// Propose updating a configuration value
+    /// Propose updating an existing instant config value (applies as soon as
+    /// the proposal executes)
     ///
     /// Known config keys and their expected value types:
     ///   bitcoin_deposit_minimum (u64),
     ///   bitcoin_withdrawal_minimum (u64),
     ///   bitcoin_confirmation_threshold (u64),
     ///   withdrawal_cancellation_cooldown_ms (u64), paused (bool)
+    ///
+    /// The MPC parameters live in the epoch config: see `update-epoch-config`
+    /// and `update-mpc-config`.
     UpdateConfig {
         /// The config key to update
         key: String,
 
         /// The new value. Prefix with the type: u64:123, bool:true
         value: String,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
+
+    /// Propose updating an existing epoch config value (the MPC parameters
+    /// and any epoch-scoped keys governance added)
+    ///
+    /// The change is copied onto the next committee formed after execution;
+    /// the active committee keeps its pinned copy.
+    UpdateEpochConfig {
+        /// The epoch config key to update
+        key: String,
+
+        /// The new value. Prefix with the type: u64:123, bool:true
+        value: String,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
+
+    /// Propose adding a NEW config key
+    ///
+    /// Insert-only: the proposal aborts if the key already exists in the
+    /// target store, and the first value fixes the key's type for later
+    /// updates. Use this to make a node-side setting governable without a
+    /// package upgrade.
+    AddConfig {
+        /// The config key to add
+        key: String,
+
+        /// The initial value. Prefix with the type: u64:123, bool:true
+        value: String,
+
+        /// Add the key to the epoch config (copied onto each new committee)
+        /// instead of the instant config.
+        #[clap(long)]
+        epoch: bool,
 
         #[clap(flatten)]
         metadata: MetadataArgs,
@@ -1067,6 +1109,36 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                         &config,
                         &key,
                         &value,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::UpdateEpochConfig {
+                    key,
+                    value,
+                    metadata,
+                } => {
+                    commands::proposal::create_update_epoch_config_proposal(
+                        &config,
+                        &key,
+                        &value,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::AddConfig {
+                    key,
+                    value,
+                    epoch,
+                    metadata,
+                } => {
+                    commands::proposal::create_add_config_proposal(
+                        &config,
+                        &key,
+                        &value,
+                        epoch,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/types.rs
+++ b/crates/hashi/src/cli/types.rs
@@ -51,6 +51,8 @@ pub mod display {
         match proposal_type {
             ProposalType::Upgrade => "Upgrade".to_string(),
             ProposalType::UpdateConfig => "UpdateConfig".to_string(),
+            ProposalType::UpdateEpochConfig => "UpdateEpochConfig".to_string(),
+            ProposalType::AddConfig => "AddConfig".to_string(),
             ProposalType::EnableVersion => "EnableVersion".to_string(),
             ProposalType::DisableVersion => "DisableVersion".to_string(),
             ProposalType::EmergencyPause => "EmergencyPause".to_string(),

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -524,6 +524,18 @@ impl LeaderService {
                     Identifier::from_static("UpdateConfig"),
                     vec![],
                 ))),
+                ProposalType::UpdateEpochConfig => TypeTag::Struct(Box::new(StructTag::new(
+                    type_package_id,
+                    Identifier::from_static("update_epoch_config"),
+                    Identifier::from_static("UpdateEpochConfig"),
+                    vec![],
+                ))),
+                ProposalType::AddConfig => TypeTag::Struct(Box::new(StructTag::new(
+                    type_package_id,
+                    Identifier::from_static("add_config"),
+                    Identifier::from_static("AddConfig"),
+                    vec![],
+                ))),
                 ProposalType::EnableVersion => TypeTag::Struct(Box::new(StructTag::new(
                     type_package_id,
                     Identifier::from_static("enable_version"),

--- a/crates/hashi/src/onchain/apply.rs
+++ b/crates/hashi/src/onchain/apply.rs
@@ -390,6 +390,7 @@ fn apply_root(
         id: _,
         committees,
         config,
+        epoch_config,
         versioning,
         treasury: _,
         proposals: _,
@@ -413,6 +414,7 @@ fn apply_root(
         packages.insert(cap.version, cap.package);
     }
     hashi.config = new_config;
+    hashi.epoch_config = epoch_config;
     hashi.num_consumed_presigs = num_consumed_presigs;
 
     let new_pending = committees.pending_epoch_change.as_ref().map(|p| p.epoch);
@@ -1163,6 +1165,7 @@ mod tests {
                     enabled_versions: BTreeSet::new(),
                     upgrade_cap: None,
                 },
+                epoch_config: move_types::Config::default(),
                 treasury: types::Treasury {
                     id: treasury_id(),
                     treasury_caps: BTreeMap::new(),
@@ -1336,6 +1339,7 @@ mod tests {
         id: Address,
         committees: CommitteeSetEnc,
         config: move_types::Config,
+        epoch_config: move_types::Config,
         versioning: VersioningEnc,
         treasury: TreasuryEnc,
         proposals: ProposalsEnc,
@@ -1393,6 +1397,7 @@ mod tests {
                 mpc_public_key: vec![9u8; 4],
             },
             config: move_types::Config::from_entries(vec![]),
+            epoch_config: move_types::Config::from_entries(vec![]),
             versioning: VersioningEnc {
                 enabled_versions: VecSetEnc { contents: vec![1] },
                 upgrade_cap: upgrade_cap.map(|(package, version)| UpgradeCapEnc {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -952,19 +952,28 @@ impl OnchainState {
         self.state().hashi().config.bitcoin_deposit_time_delay_ms()
     }
 
+    /// The governed MPC parameters from the epoch config: what the NEXT
+    /// committee will be formed with. The active committee reads its own
+    /// pinned copy via [`Committee::config`](hashi_types::committee::Committee::config).
     pub fn mpc_nonce_generation_protocol(&self) -> u16 {
-        self.state().hashi().config.mpc_nonce_generation_protocol()
+        self.state()
+            .hashi()
+            .epoch_config
+            .mpc_nonce_generation_protocol()
     }
 
     pub fn mpc_weight_reduction_allowed_delta(&self) -> u16 {
         self.state()
             .hashi()
-            .config
+            .epoch_config
             .mpc_weight_reduction_allowed_delta()
     }
 
     pub fn mpc_max_faulty_in_basis_points(&self) -> u16 {
-        self.state().hashi().config.mpc_max_faulty_in_basis_points()
+        self.state()
+            .hashi()
+            .epoch_config
+            .mpc_max_faulty_in_basis_points()
     }
 
     pub fn guardian_url(&self) -> Option<String> {
@@ -1352,6 +1361,7 @@ async fn scrape_hashi(
         id,
         committees,
         config,
+        epoch_config,
         versioning,
         treasury,
         proposals,
@@ -1443,6 +1453,7 @@ async fn scrape_hashi(
             id,
             committees: committee_set,
             config: convert_move_config(config, versioning),
+            epoch_config,
             treasury,
             bitcoin,
             proposals,
@@ -2319,6 +2330,8 @@ fn decode_proposal(type_tag: &TypeTag, contents: &[u8]) -> Option<types::Proposa
     let proposal_type = parse_proposal_type(type_tag);
     let (id, timestamp_ms) = match &proposal_type {
         types::ProposalType::UpdateConfig => parse::<move_types::UpdateConfig>(contents),
+        types::ProposalType::UpdateEpochConfig => parse::<move_types::UpdateEpochConfig>(contents),
+        types::ProposalType::AddConfig => parse::<move_types::AddConfig>(contents),
         types::ProposalType::EnableVersion => parse::<move_types::EnableVersion>(contents),
         types::ProposalType::DisableVersion => parse::<move_types::DisableVersion>(contents),
         types::ProposalType::Upgrade => parse::<move_types::Upgrade>(contents),
@@ -2355,6 +2368,8 @@ pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
 
     match (inner_tag.module().as_str(), inner_tag.name().as_str()) {
         ("update_config", "UpdateConfig") => types::ProposalType::UpdateConfig,
+        ("update_epoch_config", "UpdateEpochConfig") => types::ProposalType::UpdateEpochConfig,
+        ("add_config", "AddConfig") => types::ProposalType::AddConfig,
         ("enable_version", "EnableVersion") => types::ProposalType::EnableVersion,
         ("disable_version", "DisableVersion") => types::ProposalType::DisableVersion,
         ("upgrade", "Upgrade") => types::ProposalType::Upgrade,
@@ -2486,6 +2501,39 @@ mod tests {
             vec![inner],
         )));
         assert_eq!(parse_proposal_type(&tag), types::ProposalType::IgnoreMember);
+    }
+
+    #[test]
+    fn test_parse_proposal_type_config_stores() {
+        use sui_sdk_types::Identifier;
+        use sui_sdk_types::StructTag;
+
+        let package =
+            Address::from_hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+                .unwrap();
+        for (module, name, expected) in [
+            ("add_config", "AddConfig", types::ProposalType::AddConfig),
+            (
+                "update_epoch_config",
+                "UpdateEpochConfig",
+                types::ProposalType::UpdateEpochConfig,
+            ),
+        ] {
+            let inner = TypeTag::Struct(Box::new(StructTag::new(
+                package,
+                Identifier::new(module).unwrap(),
+                Identifier::new(name).unwrap(),
+                vec![],
+            )));
+            let tag = TypeTag::Struct(Box::new(StructTag::new(
+                package,
+                Identifier::new("proposal").unwrap(),
+                Identifier::new("Proposal").unwrap(),
+                vec![inner],
+            )));
+            assert_eq!(parse_proposal_type(&tag), expected);
+            assert_eq!(expected.package_version(), Some(1));
+        }
     }
 
     #[test]

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -50,7 +50,12 @@ pub struct BitcoinCollections {
 pub struct Hashi {
     pub id: Address,
     pub committees: CommitteeSet,
+    /// Governed values that apply the moment a proposal executes.
     pub config: Config,
+    /// Governed values copied wholesale onto each new committee. The active
+    /// committee reads its own pinned copy; this is what the NEXT committee
+    /// will be formed with.
+    pub epoch_config: hashi_types::move_types::Config,
     pub treasury: Treasury,
     /// `None` under `ScrapeScope::GovernanceOnly`. An `Option` rather than
     /// empty collections so a scope mistake can't read as "no withdrawals".
@@ -686,6 +691,8 @@ pub struct Proposal {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProposalType {
     UpdateConfig,
+    UpdateEpochConfig,
+    AddConfig,
     EnableVersion,
     DisableVersion,
     Upgrade,
@@ -714,6 +721,8 @@ impl ProposalType {
     pub fn as_str(&self) -> &str {
         match self {
             ProposalType::UpdateConfig => "update_config",
+            ProposalType::UpdateEpochConfig => "update_epoch_config",
+            ProposalType::AddConfig => "add_config",
             ProposalType::EnableVersion => "enable_version",
             ProposalType::DisableVersion => "disable_version",
             ProposalType::Upgrade => "upgrade",
@@ -728,6 +737,8 @@ impl ProposalType {
     pub fn all_labels() -> &'static [&'static str] {
         &[
             "update_config",
+            "update_epoch_config",
+            "add_config",
             "enable_version",
             "disable_version",
             "upgrade",
@@ -803,33 +814,6 @@ impl Config {
         match self.config.get("bitcoin_deposit_time_delay_ms") {
             Some(ConfigValue::U64(v)) => *v,
             _ => 0,
-        }
-    }
-
-    pub fn mpc_weight_reduction_allowed_delta(&self) -> u16 {
-        match self.config.get("mpc_weight_reduction_allowed_delta") {
-            Some(ConfigValue::U64(v)) => {
-                u16::try_from(*v).expect("mpc_weight_reduction_allowed_delta exceeds u16::MAX")
-            }
-            _ => DEFAULT_MPC_WEIGHT_REDUCTION_ALLOWED_DELTA,
-        }
-    }
-
-    pub fn mpc_max_faulty_in_basis_points(&self) -> u16 {
-        match self.config.get("mpc_max_faulty_in_basis_points") {
-            Some(ConfigValue::U64(v)) => {
-                u16::try_from(*v).expect("mpc_max_faulty_in_basis_points exceeds u16::MAX")
-            }
-            _ => DEFAULT_MPC_MAX_FAULTY_IN_BASIS_POINTS,
-        }
-    }
-
-    pub fn mpc_nonce_generation_protocol(&self) -> u16 {
-        match self.config.get("mpc_nonce_generation_protocol") {
-            Some(ConfigValue::U64(v)) => {
-                u16::try_from(*v).expect("mpc_nonce_generation_protocol exceeds u16::MAX")
-            }
-            _ => hashi_types::move_types::VANILLA_MPC_NONCE_GENERATION_PROTOCOL,
         }
     }
 

--- a/design/docs/config.mdx
+++ b/design/docs/config.mdx
@@ -32,20 +32,33 @@ questions:
   - What is the minimum deposit amount for Hashi?
   - How does Hashi governance update configuration?
 answer: >-
-  Hashi maintains onchain configuration parameters in a Config object that
-  control deposit minimums, withdrawal minimums, confirmation thresholds, fee
-  estimation, and operational behavior. All parameters are updated through
-  UpdateConfig governance proposals requiring 2/3 of committee weight.
+  Hashi keeps its onchain configuration in two key-value stores on the Hashi
+  object: an instant config whose values apply as soon as a proposal executes
+  (deposit and withdrawal minimums, confirmation threshold, pause flag) and an
+  epoch config that is copied wholesale onto each new committee (the MPC
+  parameters). Existing keys are tuned with UpdateConfig or UpdateEpochConfig
+  and new keys are introduced with AddConfig, all requiring 2/3 of committee
+  weight.
 ---
 
-Hashi maintains a set of onchain configuration parameters stored in the
-`Config` object. These parameters control protocol behavior for deposits,
-withdrawals, fee estimation, and system operations.
+Hashi keeps its onchain configuration in two key-value stores on the `Hashi`
+object, distinguished by when a change takes effect:
 
-You can update all configurable parameters through the `UpdateConfig`
-governance proposal, which requires 2/3 of committee weight (see
-[Governance Actions](governance-actions.mdx)). Each key is validated against
-its expected type on update.
+- **Instant config** (`config`): values apply the moment the proposal that
+  changes them executes. Deposit and withdrawal minimums, the confirmation
+  threshold, the pause flag, and the guardian settings live here.
+- **Epoch config** (`epoch_config`): the whole store is copied onto the
+  committee formed at each reconfiguration, and nodes read these values from
+  their committee's pinned copy. A change lands in the next committee formed
+  after the proposal executes and never alters the active committee. The MPC
+  parameters live here.
+
+Existing parameters are tuned with `UpdateConfig` (instant) and
+`UpdateEpochConfig` (epoch). Both require 2/3 of committee weight, accept only
+keys that already exist in their store, and reject a change of value type. New
+keys are introduced with `AddConfig`, which names the store and is insert-only
+(see [Adding a parameter](#adding-a-parameter-without-a-package-upgrade) and
+[Governance Actions](governance-actions.mdx)).
 
 ## Parameters
 
@@ -152,9 +165,10 @@ operation requires a supermajority.
 
 ## MPC parameters
 
-The MPC parameters are snapshotted (pinned) onto each committee at
-reconfiguration. An `UpdateConfig` that changes them mid-epoch never affects
-the active committee; new values take effect when the next committee forms.
+The MPC parameters live in the epoch config and are tuned with
+`UpdateEpochConfig`. The store is pinned onto each committee at
+reconfiguration, so a change mid-epoch never affects the active committee; new
+values take effect when the next committee forms.
 
 ### `mpc_max_faulty_in_basis_points`
 
@@ -244,3 +258,13 @@ worst_case_network_fee = bitcoin_withdrawal_minimum - 546
 The maximum miner fee the contract accepts for a withdrawal transaction,
 derived from `bitcoin_withdrawal_minimum` minus the dust threshold. With
 defaults: `30,000 - 546 = 29,454 sats`.
+
+## Adding a parameter without a package upgrade
+
+The Move package reads only the keys documented on this page; any other key
+is opaque to it and is consumed by the node software. To make a node-side
+setting governable, pass an `AddConfig` proposal naming the key, its initial
+value (which fixes the key's type for later updates), and the store: the epoch
+config when every node must agree on the value for the whole epoch, the
+instant config otherwise. A node reads an absent key as its built-in default,
+so the key can be added before or after the node release that consumes it.

--- a/design/docs/governance-actions.mdx
+++ b/design/docs/governance-actions.mdx
@@ -34,7 +34,7 @@ answer: >-
   Hashi governance uses typed Proposal objects that committee members vote on
   with their validator stake weight. Available actions include Upgrade
   (package upgrades), EnableVersion/DisableVersion (version management),
-  UpdateConfig (parameter changes), and EmergencyPause (pause/unpause
+  UpdateConfig, UpdateEpochConfig, and AddConfig (parameter changes), and EmergencyPause (pause/unpause
   deposits and withdrawals).
 ---
 
@@ -67,17 +67,31 @@ active version cannot be disabled, to avoid bricking the protocol.
 
 ## `UpdateConfig`
 
-Updates one or more protocol configuration parameters by key. See
-[Configuration](config.mdx) for the full list of keys and defaults.
-
-Every entry is validated when the proposal executes, and the whole proposal
-aborts if any entry fails: the key must already exist, the value must have the
-same type as the current entry, MPC keys must pass their range check
+Updates existing parameters in the instant config by key; the new values apply
+when the proposal executes. Every entry is validated when the proposal
+executes, and the whole proposal aborts if any entry fails: the key must
+already exist in the store with a value of the same type
 (`EInvalidConfigEntry`), and the key must be governable. The guardian BTC
 public key and the Bitcoin chain id are pinned for the deployment's lifetime
-and cannot be written through this proposal (`EProtectedConfigKey`). Values
-themselves are otherwise not bounded onchain: a proposal needs a supermajority
-of committee weight, and reviewing the proposed value is part of voting.
+and cannot be written through any config proposal (`EProtectedConfigKey`).
+Values themselves are otherwise not bounded onchain: a proposal needs a
+supermajority of committee weight, and reviewing the proposed value is part of
+voting. See [Configuration](config.mdx) for the keys and defaults.
+
+## `UpdateEpochConfig`
+
+Updates existing parameters in the epoch config by key, including the MPC
+parameters, which must pass their range check (`EInvalidConfigEntry`). The new
+values are copied onto the next committee formed after execution; the active
+committee keeps its pinned copy. The pinned keys are refused here as well.
+
+## `AddConfig`
+
+Introduces new keys into the instant or epoch config, which is how a node-side
+setting becomes governable without a package upgrade. The proposal is
+insert-only: a key already present in the target store aborts, and the first
+value fixes the key's type for later updates. The pinned key names cannot be
+introduced into either store.
 
 ## `EmergencyPause`
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -821,6 +821,8 @@ Create proposals:
 ```bash
 hashi proposal create update-config <key> <value> [-m key=value]
 hashi proposal create update-mpc-config [--max-faulty-bps <N>] [--weight-reduction-allowed-delta <N>] [-m key=value]
+hashi proposal create update-epoch-config <key> <value> [-m key=value]
+hashi proposal create add-config <key> <value> [--epoch] [-m key=value]
 hashi proposal create upgrade [--package-path <path> | --digest <hex>] [-m key=value]
 hashi proposal create upgrade [--package-path <path> | --digest <hex> [--allow-unverified-exclusive]] --exclusive <true|false> [-m key=value]
 hashi proposal create enable-version <version> [-m key=value]
@@ -897,8 +899,10 @@ Builds, publishes, and initializes the Hashi Move package (including its onchain
 
 | Type | Threshold | Purpose | Parameters |
 |------|-----------|---------|-----------|
-| **UpdateConfig** | 2/3 | Change protocol parameters | `key` and type-prefixed `value` |
-| **UpdateMpcConfig** | 2/3 | Change MPC faulty bound / delta | `--max-faulty-bps`, `--weight-reduction-allowed-delta` |
+| **UpdateConfig** | 2/3 | Change an existing instant config parameter (applies on execute) | `key` and type-prefixed `value` |
+| **UpdateEpochConfig** | 2/3 | Change an existing epoch config parameter (lands in the next committee) | `key` and type-prefixed `value` |
+| **AddConfig** | 2/3 | Add a new config key to either store (insert-only) | `key`, type-prefixed `value`, `--epoch` for the epoch store |
+| **UpdateMpcConfig** | 2/3 | Change MPC faulty bound / delta (epoch config) | `--max-faulty-bps`, `--weight-reduction-allowed-delta` |
 | **Upgrade** | 2/3 | Publish a new package version with an explicit version-retirement policy | `--package-path` or `--digest`; required boolean `--exclusive` value; `--digest` with `--exclusive true` additionally requires `--allow-unverified-exclusive` |
 | **EnableVersion** | 2/3 | Re-enable a disabled package version | `version` number |
 | **DisableVersion** | 2/3 | Disable a package version | `version` number (cannot disable active version) |

--- a/packages/hashi/sources/core/committee/committee.move
+++ b/packages/hashi/sources/core/committee/committee.move
@@ -3,7 +3,7 @@
 
 /// BLS signing committees and certificate verification. A `Committee` pins an
 /// epoch's members (validator addresses, BLS public keys, encryption keys,
-/// voting weights) together with the MPC parameters snapshotted at reconfig
+/// voting weights) together with the epoch config snapshotted at reconfig
 /// time. `verify_certificate` checks an aggregate BLS12-381 min-pk signature
 /// against a signers bitmap, enforces the stake threshold, and wraps the
 /// payload in a `CertifiedMessage` as proof of committee approval.
@@ -46,9 +46,9 @@ public struct Committee has copy, drop, store {
     members: vector<CommitteeMember>,
     /// Total voting weight of the committee.
     total_weight: u64,
-    /// The config pinned for this epoch (the MPC parameters: threshold,
-    /// weight-reduction delta, max-faulty bound, nonce-generation protocol),
-    /// snapshotted from the governed config at reconfig time.
+    /// The epoch config pinned for this epoch (the MPC parameters plus any
+    /// epoch-scoped keys governance added), copied wholesale from the
+    /// governed epoch config at reconfig time.
     config: Config,
 }
 

--- a/packages/hashi/sources/core/committee/committee.move
+++ b/packages/hashi/sources/core/committee/committee.move
@@ -46,10 +46,10 @@ public struct Committee has copy, drop, store {
     members: vector<CommitteeMember>,
     /// Total voting weight of the committee.
     total_weight: u64,
-    /// The epoch config pinned for this epoch (the MPC parameters plus any
-    /// epoch-scoped keys governance added), copied wholesale from the
-    /// governed epoch config at reconfig time.
-    config: Config,
+    /// The epoch config for this epoch (the MPC parameters plus any
+    /// epoch-scoped keys governance added), copied verbatim from the governed
+    /// epoch config when the committee is formed.
+    epoch_config: Config,
 }
 
 public struct CommitteeSignature has copy, drop, store {
@@ -84,7 +84,7 @@ public fun new_committee_signature(
 public(package) fun new_committee(
     epoch: u64,
     members: vector<CommitteeMember>,
-    config: Config,
+    epoch_config: Config,
 ): Committee {
     assert!(!members.is_empty());
 
@@ -100,7 +100,7 @@ public(package) fun new_committee(
         members,
         total_weight,
         epoch,
-        config,
+        epoch_config,
     }
 }
 

--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -362,7 +362,7 @@ public(package) fun clear_resignation(
 public(package) fun start_reconfig(
     self: &mut CommitteeSet,
     sui_system: &sui_system::sui_system::SuiSystemState,
-    config: Config,
+    epoch_config: Config,
     ctx: &TxContext,
 ): u64 {
     // We can't trigger reconfig if we are already reconfiguring
@@ -376,7 +376,7 @@ public(package) fun start_reconfig(
 
     let committee = self.new_committee_from_validator_set(
         sui_system,
-        config,
+        epoch_config,
         ctx,
     );
 
@@ -537,13 +537,13 @@ fun remove_committee(self: &mut CommitteeSet, epoch: u64): Committee {
 fun new_committee_from_validator_set(
     self: &CommitteeSet,
     sui_system: &sui_system::sui_system::SuiSystemState,
-    config: Config,
+    epoch_config: Config,
     ctx: &TxContext,
 ): Committee {
     self.new_committee_from_voting_powers(
         ctx.epoch(),
         sui_system.active_validator_voting_powers(),
-        config,
+        epoch_config,
     )
 }
 
@@ -557,7 +557,7 @@ fun new_committee_from_voting_powers(
     self: &CommitteeSet,
     epoch: u64,
     mut validator_set: sui::vec_map::VecMap<address, u64>,
-    config: Config,
+    epoch_config: Config,
 ): Committee {
     let g1_identity = g1_to_uncompressed_g1(&sui::bls12381::g1_identity());
 
@@ -612,7 +612,7 @@ fun new_committee_from_voting_powers(
     committee::new_committee(
         epoch,
         committee_members,
-        config,
+        epoch_config,
     )
 }
 
@@ -801,9 +801,9 @@ public fun new_committee_from_voting_powers_for_testing(
     self: &CommitteeSet,
     epoch: u64,
     validator_set: sui::vec_map::VecMap<address, u64>,
-    config: Config,
+    epoch_config: Config,
 ): Committee {
-    self.new_committee_from_voting_powers(epoch, validator_set, config)
+    self.new_committee_from_voting_powers(epoch, validator_set, epoch_config)
 }
 
 #[test_only]

--- a/packages/hashi/sources/core/mpc_config.move
+++ b/packages/hashi/sources/core/mpc_config.move
@@ -86,51 +86,6 @@ public(package) fun nonce_accumulation_window_ms(config: &Config): u64 {
         .destroy_or!(DEFAULT_NONCE_ACCUMULATION_WINDOW_MS)
 }
 
-public(package) fun seed_absent_defaults(config: &mut Config) {
-    seed_if_absent(
-        config,
-        KEY_WEIGHT_REDUCTION_ALLOWED_DELTA,
-        DEFAULT_WEIGHT_REDUCTION_ALLOWED_DELTA,
-    );
-    seed_if_absent(config, KEY_MAX_FAULTY_IN_BASIS_POINTS, DEFAULT_MAX_FAULTY_IN_BASIS_POINTS);
-    seed_if_absent(config, KEY_NONCE_GENERATION_PROTOCOL, VANILLA_NONCE_GENERATION_PROTOCOL);
-    seed_if_absent(
-        config,
-        KEY_NONCE_ACCUMULATION_WINDOW_MS,
-        DEFAULT_NONCE_ACCUMULATION_WINDOW_MS,
-    );
-}
-
-fun reset_if_out_of_range(config: &mut Config, key: vector<u8>, lo: u64, hi: u64, default: u64) {
-    config.try_get(key).map!(|v| v.as_u64()).do!(|value| if (value < lo || value > hi) {
-        config.upsert(key, config_value::new_u64(default));
-    });
-}
-
-fun seed_if_absent(config: &mut Config, key: vector<u8>, default: u64) {
-    if (!config.contains(key)) {
-        config.upsert(key, config_value::new_u64(default));
-    };
-}
-
-fun repair_out_of_range(config: &mut Config) {
-    reset_if_out_of_range(
-        config,
-        KEY_MAX_FAULTY_IN_BASIS_POINTS,
-        1,
-        MAX_FAULTY_BPS,
-        DEFAULT_MAX_FAULTY_IN_BASIS_POINTS,
-    );
-    let max_delta = max_faulty_in_basis_points(config) - 1;
-    clamp_at_most(config, KEY_WEIGHT_REDUCTION_ALLOWED_DELTA, max_delta);
-}
-
-fun clamp_at_most(config: &mut Config, key: vector<u8>, hi: u64) {
-    config.try_get(key).map!(|v| v.as_u64()).do!(|value| if (value > hi) {
-        config.upsert(key, config_value::new_u64(hi));
-    });
-}
-
 public(package) fun init_defaults(config: &mut Config) {
     config.upsert(
         KEY_WEIGHT_REDUCTION_ALLOWED_DELTA,
@@ -150,15 +105,13 @@ public(package) fun init_defaults(config: &mut Config) {
     );
 }
 
-/// Normalize the MPC parameters in the epoch config (seed absent keys, repair
-/// out-of-range values in place) and return the whole store for pinning onto
-/// the committee being formed. Every epoch-scoped key, MPC or
-/// governance-added, is copied wholesale so nodes read one immutable snapshot
-/// per epoch.
-public(package) fun pin(epoch_config: &mut Config): Config {
-    seed_absent_defaults(epoch_config);
-    repair_out_of_range(epoch_config);
-    *epoch_config
+/// The one rule the per-entry range checks cannot see: the weight-reduction
+/// delta must stay below max-faulty. The proposals that write the epoch
+/// config check it on the store they leave behind, so a joint update of both
+/// keys is judged on its result rather than on entry order, and
+/// `start_reconfig` copies the store verbatim with nothing left to repair.
+public(package) fun is_consistent(config: &Config): bool {
+    weight_reduction_allowed_delta(config) < max_faulty_in_basis_points(config)
 }
 
 // ~~~~~~~ Test Helpers ~~~~~~~

--- a/packages/hashi/sources/core/mpc_config.move
+++ b/packages/hashi/sources/core/mpc_config.move
@@ -1,6 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// The MPC protocol parameters (`f`, weight-reduction delta, nonce protocol,
+/// nonce accumulation window) and their validation. They live in the
+/// package's EPOCH config: governance edits them through
+/// `update_epoch_config`, and `pin` snapshots the whole epoch config onto the
+/// committee formed at `start_reconfig`, so a committee's parameters never
+/// change under it.
 module hashi::mpc_config;
 
 use hashi::{config::{Self, Config}, config_value};
@@ -30,6 +36,10 @@ const KEY_NONCE_ACCUMULATION_WINDOW_MS: vector<u8> = b"mpc_nonce_accumulation_wi
 
 // ~~~~~~~ Package Functions ~~~~~~~
 
+/// Range-checks a value bound for the epoch config. Keys this module does not
+/// own pass unconditionally; the retired threshold key is rejected outright so
+/// it can never reappear in a pinned config (nodes treat its presence as the
+/// legacy threshold formula).
 #[allow(implicit_const_copy)]
 public(package) fun is_valid_value(key: &std::string::String, value: &config_value::Value): bool {
     let k = key.as_bytes();
@@ -140,26 +150,15 @@ public(package) fun init_defaults(config: &mut Config) {
     );
 }
 
-public(package) fun pin(config: &mut Config): Config {
-    repair_out_of_range(config);
-    let mut mpc = config::empty();
-    mpc.upsert(
-        KEY_WEIGHT_REDUCTION_ALLOWED_DELTA,
-        config_value::new_u64(weight_reduction_allowed_delta(config)),
-    );
-    mpc.upsert(
-        KEY_MAX_FAULTY_IN_BASIS_POINTS,
-        config_value::new_u64(max_faulty_in_basis_points(config)),
-    );
-    mpc.upsert(
-        KEY_NONCE_GENERATION_PROTOCOL,
-        config_value::new_u64(nonce_generation_protocol(config)),
-    );
-    mpc.upsert(
-        KEY_NONCE_ACCUMULATION_WINDOW_MS,
-        config_value::new_u64(nonce_accumulation_window_ms(config)),
-    );
-    mpc
+/// Normalize the MPC parameters in the epoch config (seed absent keys, repair
+/// out-of-range values in place) and return the whole store for pinning onto
+/// the committee being formed. Every epoch-scoped key, MPC or
+/// governance-added, is copied wholesale so nodes read one immutable snapshot
+/// per epoch.
+public(package) fun pin(epoch_config: &mut Config): Config {
+    seed_absent_defaults(epoch_config);
+    repair_out_of_range(epoch_config);
+    *epoch_config
 }
 
 // ~~~~~~~ Test Helpers ~~~~~~~

--- a/packages/hashi/sources/core/proposal/types/add_config.move
+++ b/packages/hashi/sources/core/proposal/types/add_config.move
@@ -1,0 +1,83 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Governance proposal for introducing NEW keys into either config store,
+/// which is how a node-side parameter becomes governable without a package
+/// upgrade: the Move package never reads the key, the node does.
+///
+/// `epoch` selects the store. Keys added to the epoch config are copied onto
+/// every committee formed from then on and are read by nodes from the
+/// committee's pinned snapshot, so they change only at epoch boundaries; keys
+/// added to the instant config are read live from the `Hashi` object.
+///
+/// The proposal is insert-only: every entry must name a key absent from the
+/// target store, so a typo can never silently create a second copy of an
+/// existing parameter (updates go through `update_config` and
+/// `update_epoch_config`, which are equally strict the other way). The value
+/// fixes the key's type for good, since the update proposals enforce type
+/// stability. Entries bound for the epoch config also pass
+/// `mpc_config::is_valid_value`, which keeps the reserved MPC keys out.
+module hashi::add_config;
+
+use hashi::{config_value::Value, hashi::Hashi, mpc_config, proposal};
+use std::string::String;
+use sui::{clock::Clock, vec_map::VecMap};
+
+// ~~~~~~~ Constants ~~~~~~~
+
+const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Errors ~~~~~~~
+
+#[error(code = 0)]
+const EKeyAlreadyExists: vector<u8> = b"Config key already exists in the target store";
+
+#[error(code = 1)]
+const EInvalidConfigEntry: vector<u8> = b"Proposed entry is not allowed in the epoch config";
+
+#[error(code = 2)]
+const ENoEntriesProvided: vector<u8> = b"AddConfig proposal must contain at least one entry";
+
+// ~~~~~~~ Structs ~~~~~~~
+
+public struct AddConfig has copy, drop, store {
+    /// `true` targets the epoch config, `false` the instant config.
+    epoch: bool,
+    entries: VecMap<String, Value>,
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
+
+public fun propose(
+    hashi: &mut Hashi,
+    validator_address: address,
+    epoch: bool,
+    entries: VecMap<String, Value>,
+    metadata: VecMap<String, String>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    hashi.versioning().assert_version_enabled();
+    assert!(!entries.is_empty(), ENoEntriesProvided);
+    proposal::create(
+        hashi,
+        validator_address,
+        AddConfig { epoch, entries },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
+}
+
+public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
+    hashi.versioning().assert_version_enabled();
+    let AddConfig { epoch, entries } = proposal::execute(hashi, proposal_id, clock);
+    let (keys, values) = entries.into_keys_values();
+    let store = if (epoch) hashi.epoch_config_mut() else hashi.config_mut();
+    keys.zip_do!(values, |key, value| {
+        assert!(!store.contains(*key.as_bytes()), EKeyAlreadyExists);
+        assert!(!epoch || mpc_config::is_valid_value(&key, &value), EInvalidConfigEntry);
+        store.upsert(*key.as_bytes(), value);
+    });
+}

--- a/packages/hashi/sources/core/proposal/types/add_config.move
+++ b/packages/hashi/sources/core/proposal/types/add_config.move
@@ -38,6 +38,10 @@ const EInvalidConfigEntry: vector<u8> = b"Proposed entry is not allowed in the e
 #[error(code = 2)]
 const ENoEntriesProvided: vector<u8> = b"AddConfig proposal must contain at least one entry";
 
+#[error(code = 4)]
+const EInconsistentMpcConfig: vector<u8> =
+    b"mpc_weight_reduction_allowed_delta must stay below mpc_max_faulty_in_basis_points";
+
 #[error(code = 3)]
 const EProtectedConfigKey: vector<u8> = b"Config key cannot be introduced through AddConfig";
 
@@ -89,4 +93,7 @@ public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
         assert!(!epoch || mpc_config::is_valid_value(&key, &value), EInvalidConfigEntry);
         store.upsert(*key.as_bytes(), value);
     });
+    if (epoch) {
+        assert!(mpc_config::is_consistent(hashi.epoch_config()), EInconsistentMpcConfig);
+    };
 }

--- a/packages/hashi/sources/core/proposal/types/add_config.move
+++ b/packages/hashi/sources/core/proposal/types/add_config.move
@@ -19,7 +19,7 @@
 /// `mpc_config::is_valid_value`, which keeps the reserved MPC keys out.
 module hashi::add_config;
 
-use hashi::{config_value::Value, hashi::Hashi, mpc_config, proposal};
+use hashi::{btc_config, config, config_value::Value, hashi::Hashi, mpc_config, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
@@ -37,6 +37,9 @@ const EInvalidConfigEntry: vector<u8> = b"Proposed entry is not allowed in the e
 
 #[error(code = 2)]
 const ENoEntriesProvided: vector<u8> = b"AddConfig proposal must contain at least one entry";
+
+#[error(code = 3)]
+const EProtectedConfigKey: vector<u8> = b"Config key cannot be introduced through AddConfig";
 
 // ~~~~~~~ Structs ~~~~~~~
 
@@ -76,6 +79,12 @@ public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
     let (keys, values) = entries.into_keys_values();
     let store = if (epoch) hashi.epoch_config_mut() else hashi.config_mut();
     keys.zip_do!(values, |key, value| {
+        // The pinned key names are refused in either store: a same-named epoch
+        // entry would shadow nothing today, but the rule stays one rule.
+        assert!(
+            config::is_governable_key(&key) && btc_config::is_governable_key(&key),
+            EProtectedConfigKey,
+        );
         assert!(!store.contains(*key.as_bytes()), EKeyAlreadyExists);
         assert!(!epoch || mpc_config::is_valid_value(&key, &value), EInvalidConfigEntry);
         store.upsert(*key.as_bytes(), value);

--- a/packages/hashi/sources/core/proposal/types/update_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_config.move
@@ -1,16 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Governance proposal for updating entries in the global config. A proposal
+/// Governance proposal for updating entries in the INSTANT config, the store
+/// whose values take effect the moment the proposal executes. A proposal
 /// carries a map of key/value entries; on execution every entry must refer to
-/// an existing key with a matching value type (and pass MPC-config range
-/// validation) and must not be one of the keys the package pins for the
-/// deployment's lifetime (the guardian BTC public key and the Bitcoin chain
-/// id) before being upserted, so governance can tune parameters but never
-/// introduce unknown keys, change an entry's type, or rewrite a pinned key.
+/// an existing key with a matching value type and must not be one of the keys
+/// the package pins for the deployment's lifetime (the guardian BTC public key
+/// and the Bitcoin chain id) before being upserted, so governance can tune
+/// parameters but never introduce unknown keys, change an entry's type, or
+/// rewrite a pinned key. New keys go through `add_config`; the epoch-scoped
+/// store, including the MPC parameters, through `update_epoch_config`.
 module hashi::update_config;
 
-use hashi::{btc_config, config, config_value::Value, hashi::Hashi, mpc_config, proposal};
+use hashi::{btc_config, config, config_value::Value, hashi::Hashi, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
@@ -21,7 +23,8 @@ const THRESHOLD_BPS: u64 = 6667;
 // ~~~~~~~ Errors ~~~~~~~
 
 #[error]
-const EInvalidConfigEntry: vector<u8> = b"Unknown config key or wrong value type in proposed entry";
+const EInvalidConfigEntry: vector<u8> =
+    b"Unknown instant config key or wrong value type in proposed entry";
 
 #[error]
 const ENoEntriesProvided: vector<u8> = b"UpdateConfig proposal must contain at least one entry";
@@ -63,14 +66,10 @@ public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
     let (keys, values) = entries.into_keys_values();
     keys.zip_do!(values, |key, value| {
         assert!(
-            hashi.config().is_valid_config_update(&key, &value)
-                && mpc_config::is_valid_value(&key, &value),
-            EInvalidConfigEntry,
-        );
-        assert!(
             config::is_governable_key(&key) && btc_config::is_governable_key(&key),
             EProtectedConfigKey,
         );
+        assert!(hashi.config().is_valid_config_update(&key, &value), EInvalidConfigEntry);
         hashi.config_mut().upsert(*key.as_bytes(), value);
     });
 }

--- a/packages/hashi/sources/core/proposal/types/update_epoch_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_epoch_config.move
@@ -9,10 +9,11 @@
 /// Every entry must refer to an existing key with a matching value type and
 /// pass `mpc_config::is_valid_value` (the MPC parameters live here), so
 /// governance can tune parameters but never introduce unknown keys or change
-/// an entry's type. New keys go through `add_config`.
+/// an entry's type. The keys the package pins for the deployment's lifetime
+/// are refused here as on `update_config`. New keys go through `add_config`.
 module hashi::update_epoch_config;
 
-use hashi::{config_value::Value, hashi::Hashi, mpc_config, proposal};
+use hashi::{btc_config, config, config_value::Value, hashi::Hashi, mpc_config, proposal};
 use std::string::String;
 use sui::{clock::Clock, vec_map::VecMap};
 
@@ -29,6 +30,9 @@ const EInvalidConfigEntry: vector<u8> =
 #[error(code = 1)]
 const ENoEntriesProvided: vector<u8> =
     b"UpdateEpochConfig proposal must contain at least one entry";
+
+#[error(code = 2)]
+const EProtectedConfigKey: vector<u8> = b"Config key cannot be changed through UpdateEpochConfig";
 
 // ~~~~~~~ Structs ~~~~~~~
 
@@ -64,6 +68,12 @@ public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
     let UpdateEpochConfig { entries } = proposal::execute(hashi, proposal_id, clock);
     let (keys, values) = entries.into_keys_values();
     keys.zip_do!(values, |key, value| {
+        // The keys the package pins for the deployment's lifetime are refused
+        // on every config proposal, whichever store they are aimed at.
+        assert!(
+            config::is_governable_key(&key) && btc_config::is_governable_key(&key),
+            EProtectedConfigKey,
+        );
         assert!(
             hashi.epoch_config().is_valid_config_update(&key, &value)
                 && mpc_config::is_valid_value(&key, &value),

--- a/packages/hashi/sources/core/proposal/types/update_epoch_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_epoch_config.move
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Governance proposal for updating entries in the EPOCH config, the store
+/// `start_reconfig` copies wholesale onto each new committee. A change lands
+/// in the next committee formed after execution and never touches the
+/// current epoch's committee, which keeps reading its own pinned copy.
+///
+/// Every entry must refer to an existing key with a matching value type and
+/// pass `mpc_config::is_valid_value` (the MPC parameters live here), so
+/// governance can tune parameters but never introduce unknown keys or change
+/// an entry's type. New keys go through `add_config`.
+module hashi::update_epoch_config;
+
+use hashi::{config_value::Value, hashi::Hashi, mpc_config, proposal};
+use std::string::String;
+use sui::{clock::Clock, vec_map::VecMap};
+
+// ~~~~~~~ Constants ~~~~~~~
+
+const THRESHOLD_BPS: u64 = 6667;
+
+// ~~~~~~~ Errors ~~~~~~~
+
+#[error(code = 0)]
+const EInvalidConfigEntry: vector<u8> =
+    b"Unknown epoch config key, wrong value type, or out-of-range value in proposed entry";
+
+#[error(code = 1)]
+const ENoEntriesProvided: vector<u8> =
+    b"UpdateEpochConfig proposal must contain at least one entry";
+
+// ~~~~~~~ Structs ~~~~~~~
+
+public struct UpdateEpochConfig has copy, drop, store {
+    entries: VecMap<String, Value>,
+}
+
+// ~~~~~~~ Public Functions ~~~~~~~
+
+public fun propose(
+    hashi: &mut Hashi,
+    validator_address: address,
+    entries: VecMap<String, Value>,
+    metadata: VecMap<String, String>,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    hashi.versioning().assert_version_enabled();
+    assert!(!entries.is_empty(), ENoEntriesProvided);
+    proposal::create(
+        hashi,
+        validator_address,
+        UpdateEpochConfig { entries },
+        THRESHOLD_BPS,
+        metadata,
+        clock,
+        ctx,
+    )
+}
+
+public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
+    hashi.versioning().assert_version_enabled();
+    let UpdateEpochConfig { entries } = proposal::execute(hashi, proposal_id, clock);
+    let (keys, values) = entries.into_keys_values();
+    keys.zip_do!(values, |key, value| {
+        assert!(
+            hashi.epoch_config().is_valid_config_update(&key, &value)
+                && mpc_config::is_valid_value(&key, &value),
+            EInvalidConfigEntry,
+        );
+        hashi.epoch_config_mut().upsert(*key.as_bytes(), value);
+    });
+}

--- a/packages/hashi/sources/core/proposal/types/update_epoch_config.move
+++ b/packages/hashi/sources/core/proposal/types/update_epoch_config.move
@@ -7,9 +7,11 @@
 /// current epoch's committee, which keeps reading its own pinned copy.
 ///
 /// Every entry must refer to an existing key with a matching value type and
-/// pass `mpc_config::is_valid_value` (the MPC parameters live here), so
-/// governance can tune parameters but never introduce unknown keys or change
-/// an entry's type. The keys the package pins for the deployment's lifetime
+/// pass `mpc_config::is_valid_value` (the MPC parameters live here), and the
+/// store the proposal leaves behind must pass `mpc_config::is_consistent`, so
+/// governance can tune parameters but never introduce unknown keys, change
+/// an entry's type, or leave the MPC parameters in a state `start_reconfig`
+/// would have to repair. The keys the package pins for the deployment's lifetime
 /// are refused here as on `update_config`. New keys go through `add_config`.
 module hashi::update_epoch_config;
 
@@ -33,6 +35,10 @@ const ENoEntriesProvided: vector<u8> =
 
 #[error(code = 2)]
 const EProtectedConfigKey: vector<u8> = b"Config key cannot be changed through UpdateEpochConfig";
+
+#[error(code = 3)]
+const EInconsistentMpcConfig: vector<u8> =
+    b"mpc_weight_reduction_allowed_delta must stay below mpc_max_faulty_in_basis_points";
 
 // ~~~~~~~ Structs ~~~~~~~
 
@@ -81,4 +87,7 @@ public fun execute(hashi: &mut Hashi, proposal_id: ID, clock: &Clock) {
         );
         hashi.epoch_config_mut().upsert(*key.as_bytes(), value);
     });
+    // Judged on the resulting store so both coupled keys can move in one
+    // proposal regardless of entry order.
+    assert!(mpc_config::is_consistent(hashi.epoch_config()), EInconsistentMpcConfig);
 }

--- a/packages/hashi/sources/core/reconfig.move
+++ b/packages/hashi/sources/core/reconfig.move
@@ -65,10 +65,9 @@ entry fun start_reconfig(
     // Assert that we are not already reconfiguring
     assert!(!self.committee_set().is_reconfiguring());
     assert_genesis_launch_authorized(self);
-    hashi::mpc_config::seed_absent_defaults(self.config_mut());
-    // Pin the current MPC parameters so they stay fixed for the new epoch even
-    // if governance changes them mid-epoch.
-    let config = hashi::mpc_config::pin(self.config_mut());
+    // Pin the epoch config wholesale so it stays fixed for the new epoch even
+    // if governance changes it mid-epoch.
+    let config = hashi::mpc_config::pin(self.epoch_config_mut());
     let epoch = self
         .committee_set_mut()
         .start_reconfig(

--- a/packages/hashi/sources/core/reconfig.move
+++ b/packages/hashi/sources/core/reconfig.move
@@ -65,14 +65,15 @@ entry fun start_reconfig(
     // Assert that we are not already reconfiguring
     assert!(!self.committee_set().is_reconfiguring());
     assert_genesis_launch_authorized(self);
-    // Pin the epoch config wholesale so it stays fixed for the new epoch even
-    // if governance changes it mid-epoch.
-    let config = hashi::mpc_config::pin(self.epoch_config_mut());
+    // Copy the epoch config verbatim onto the new committee so it stays fixed
+    // for the epoch even if governance changes the store mid-epoch. The
+    // proposals that write the store keep it valid; nothing is repaired here.
+    let epoch_config = *self.epoch_config();
     let epoch = self
         .committee_set_mut()
         .start_reconfig(
             sui_system,
-            config,
+            epoch_config,
             ctx,
         );
     sui::event::emit(ReconfigStarted { epoch });

--- a/packages/hashi/sources/hashi.move
+++ b/packages/hashi/sources/hashi.move
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// The root shared object of the bridge. `Hashi` aggregates every subsystem —
-/// committee set, config, versioning, treasury, governance proposals, and TOB
-/// certificate storage — and hangs per-chain state (e.g. `BitcoinState`) off
+/// committee set, the instant and epoch configs, versioning, treasury,
+/// governance proposals, and TOB certificate storage — and hangs per-chain
+/// state (e.g. `BitcoinState`) off
 /// its `UID` as dynamic fields. It also provides the package-wide guards
 /// (pause, reconfig, committee-signature verification) that entry functions
 /// in other modules call through, and the one-time `finish_publish` launch
@@ -39,7 +40,14 @@ const EWrongUpgradeCap: vector<u8> = b"Upgrade cap does not belong to this packa
 public struct Hashi has key {
     id: UID,
     committee_set: CommitteeSet,
+    /// Governed values that take effect the moment a proposal executes. Never
+    /// copied onto a committee.
     config: Config,
+    /// Governed values that take effect at the next committee formation:
+    /// `start_reconfig` copies the whole store onto the new committee, so
+    /// every key in it is fixed for that committee's lifetime. Holds the MPC
+    /// parameters plus any epoch-scoped keys governance adds.
+    epoch_config: Config,
     versioning: Versioning,
     treasury: Treasury,
     proposals: Proposals,
@@ -164,6 +172,14 @@ public(package) fun config_mut(self: &mut Hashi): &mut Config {
     &mut self.config
 }
 
+public(package) fun epoch_config(self: &Hashi): &Config {
+    &self.epoch_config
+}
+
+public(package) fun epoch_config_mut(self: &mut Hashi): &mut Config {
+    &mut self.epoch_config
+}
+
 public(package) fun versioning(self: &Hashi): &Versioning {
     &self.versioning
 }
@@ -271,8 +287,12 @@ fun init(ctx: &mut TxContext) {
         config: {
             let mut config = hashi::config::create();
             hashi::btc_config::init_defaults(&mut config);
-            hashi::mpc_config::init_defaults(&mut config);
             config
+        },
+        epoch_config: {
+            let mut epoch_config = hashi::config::empty();
+            hashi::mpc_config::init_defaults(&mut epoch_config);
+            epoch_config
         },
         versioning: versioning::create(),
         treasury: hashi::treasury::create(ctx),
@@ -314,6 +334,7 @@ public(package) fun epoch_certs_stamped_ref(
 public fun create_for_testing(
     committee_set: CommitteeSet,
     config: Config,
+    epoch_config: Config,
     versioning: Versioning,
     treasury: Treasury,
     proposals: Proposals,
@@ -324,6 +345,7 @@ public fun create_for_testing(
         id: object::new(ctx),
         committee_set,
         config,
+        epoch_config,
         versioning,
         treasury,
         proposals,

--- a/packages/hashi/tests/add_config_tests.move
+++ b/packages/hashi/tests/add_config_tests.move
@@ -55,7 +55,7 @@ fun test_add_instant_key_is_readable_immediately_and_never_pinned() {
 
     assert!(hashi.config().get(NEW_KEY).as_u64() == 64);
     assert!(!hashi.epoch_config().contains(NEW_KEY));
-    let pinned = mpc_config::pin(hashi.epoch_config_mut());
+    let pinned = *hashi.epoch_config();
     assert!(!pinned.contains(NEW_KEY));
 
     clock::destroy_for_testing(clock);
@@ -73,7 +73,7 @@ fun test_add_epoch_key_rides_the_wholesale_pin() {
     assert!(hashi.epoch_config().get(NEW_KEY).as_u64() == 64);
     assert!(!hashi.config().contains(NEW_KEY));
 
-    let pinned = mpc_config::pin(hashi.epoch_config_mut());
+    let pinned = *hashi.epoch_config();
     assert!(pinned.get(NEW_KEY).as_u64() == 64);
     // The MPC parameters are still in the snapshot alongside the new key.
     assert!(mpc_config::max_faulty_in_basis_points(&pinned) == 3333);

--- a/packages/hashi/tests/add_config_tests.move
+++ b/packages/hashi/tests/add_config_tests.move
@@ -1,0 +1,327 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// `add_config` semantics: new keys land in exactly the store selected by
+/// `epoch`, existing keys abort, epoch keys ride the wholesale pin, and an
+/// added key's type is stable under the update proposals.
+#[test_only]
+#[allow(implicit_const_copy, unused_variable)]
+module hashi::add_config_tests;
+
+use hashi::{
+    add_config::{Self, AddConfig},
+    config_value,
+    mpc_config,
+    test_utils,
+    update_config,
+    update_epoch_config
+};
+use sui::{clock, vec_map};
+
+const VOTER1: address = @0x1;
+const VOTER2: address = @0x2;
+const VOTER3: address = @0x3;
+
+const NEW_KEY: vector<u8> = b"node_signing_batch_size";
+const OTHER_KEY: vector<u8> = b"node_gc_interval_ms";
+
+fun add_and_execute(
+    hashi: &mut hashi::hashi::Hashi,
+    epoch: bool,
+    key: vector<u8>,
+    value: config_value::Value,
+    clock: &clock::Clock,
+    ctx: &mut TxContext,
+) {
+    let proposal_id = test_utils::create_add_config_proposal(
+        hashi,
+        VOTER1,
+        epoch,
+        key,
+        value,
+        clock,
+        ctx,
+    );
+    add_config::execute(hashi, proposal_id, clock);
+}
+
+#[test]
+fun test_add_instant_key_is_readable_immediately_and_never_pinned() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(&mut hashi, false, NEW_KEY, config_value::new_u64(64), &clock, ctx);
+
+    assert!(hashi.config().get(NEW_KEY).as_u64() == 64);
+    assert!(!hashi.epoch_config().contains(NEW_KEY));
+    let pinned = mpc_config::pin(hashi.epoch_config_mut());
+    assert!(!pinned.contains(NEW_KEY));
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_add_epoch_key_rides_the_wholesale_pin() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(&mut hashi, true, NEW_KEY, config_value::new_u64(64), &clock, ctx);
+
+    assert!(hashi.epoch_config().get(NEW_KEY).as_u64() == 64);
+    assert!(!hashi.config().contains(NEW_KEY));
+
+    let pinned = mpc_config::pin(hashi.epoch_config_mut());
+    assert!(pinned.get(NEW_KEY).as_u64() == 64);
+    // The MPC parameters are still in the snapshot alongside the new key.
+    assert!(mpc_config::max_faulty_in_basis_points(&pinned) == 3333);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_add_multiple_keys_in_one_proposal() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(NEW_KEY.to_string(), config_value::new_u64(64));
+    entries.insert(OTHER_KEY.to_string(), config_value::new_bool(true));
+    let proposal_id = add_config::propose(
+        &mut hashi,
+        VOTER1,
+        true,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    add_config::execute(&mut hashi, proposal_id, &clock);
+
+    assert!(hashi.epoch_config().get(NEW_KEY).as_u64() == 64);
+    assert!(hashi.epoch_config().get(OTHER_KEY).as_bool());
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+/// A key name is scoped to its store: adding it to both is two independent
+/// entries, each reachable only through its own update proposal.
+#[test]
+fun test_same_key_may_live_in_both_stores_independently() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(&mut hashi, false, NEW_KEY, config_value::new_u64(1), &clock, ctx);
+    add_and_execute(&mut hashi, true, NEW_KEY, config_value::new_u64(2), &clock, ctx);
+
+    assert!(hashi.config().get(NEW_KEY).as_u64() == 1);
+    assert!(hashi.epoch_config().get(NEW_KEY).as_u64() == 2);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = add_config::EKeyAlreadyExists)]
+fun test_add_existing_instant_key_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(
+        &mut hashi,
+        false,
+        b"bitcoin_deposit_minimum",
+        config_value::new_u64(1),
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = add_config::EKeyAlreadyExists)]
+fun test_add_existing_epoch_key_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(
+        &mut hashi,
+        true,
+        b"mpc_max_faulty_in_basis_points",
+        config_value::new_u64(2000),
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = add_config::EKeyAlreadyExists)]
+fun test_add_same_key_twice_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(&mut hashi, true, NEW_KEY, config_value::new_u64(64), &clock, ctx);
+    add_and_execute(&mut hashi, true, NEW_KEY, config_value::new_u64(65), &clock, ctx);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+/// The retired threshold key can never re-enter the epoch config, not even
+/// as a fresh insert.
+#[test]
+#[expected_failure(abort_code = add_config::EInvalidConfigEntry)]
+fun test_add_reserved_threshold_key_to_epoch_config_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(
+        &mut hashi,
+        true,
+        b"mpc_threshold_in_basis_points",
+        config_value::new_u64(3334),
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = add_config::ENoEntriesProvided)]
+fun test_empty_entries_aborts_at_propose() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let _ = add_config::propose(
+        &mut hashi,
+        VOTER1,
+        false,
+        vec_map::empty(),
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_added_instant_key_is_updatable_with_the_same_type() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(&mut hashi, false, NEW_KEY, config_value::new_u64(64), &clock, ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(NEW_KEY.to_string(), config_value::new_u64(128));
+    let proposal_id = update_config::propose(
+        &mut hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    update_config::execute(&mut hashi, proposal_id, &clock);
+    assert!(hashi.config().get(NEW_KEY).as_u64() == 128);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_added_key_type_is_fixed_by_its_first_value() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(&mut hashi, false, NEW_KEY, config_value::new_u64(64), &clock, ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(NEW_KEY.to_string(), config_value::new_bool(true));
+    let proposal_id = update_config::propose(
+        &mut hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+    update_config::execute(&mut hashi, proposal_id, &clock);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_added_epoch_key_is_updatable_via_update_epoch_config() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(&mut hashi, true, NEW_KEY, config_value::new_u64(64), &clock, ctx);
+
+    let proposal_id = test_utils::create_update_epoch_config_proposal(
+        &mut hashi,
+        VOTER1,
+        NEW_KEY,
+        config_value::new_u64(128),
+        &clock,
+        ctx,
+    );
+    update_epoch_config::execute(&mut hashi, proposal_id, &clock);
+    assert!(hashi.epoch_config().get(NEW_KEY).as_u64() == 128);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_propose_vote_execute_through_quorum() {
+    let ctx1 = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx1);
+    let clock = clock::create_for_testing(ctx1);
+
+    let proposal_id = test_utils::create_add_config_proposal(
+        &mut hashi,
+        VOTER1,
+        true,
+        NEW_KEY,
+        config_value::new_u64(64),
+        &clock,
+        ctx1,
+    );
+
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    hashi::proposal::vote<AddConfig>(&mut hashi, VOTER2, proposal_id, &clock, ctx2);
+    let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
+    hashi::proposal::vote<AddConfig>(&mut hashi, VOTER3, proposal_id, &clock, ctx3);
+
+    add_config::execute(&mut hashi, proposal_id, &clock);
+    assert!(hashi.epoch_config().get(NEW_KEY).as_u64() == 64);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/add_config_tests.move
+++ b/packages/hashi/tests/add_config_tests.move
@@ -325,3 +325,46 @@ fun test_propose_vote_execute_through_quorum() {
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
 }
+
+#[test]
+#[expected_failure(abort_code = add_config::EProtectedConfigKey)]
+/// A pinned key name cannot be introduced into the epoch store.
+fun test_pinned_key_cannot_be_added_to_epoch_store() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(
+        &mut hashi,
+        true,
+        b"guardian_btc_public_key",
+        config_value::new_bytes(vector::tabulate!(32, |i| i as u8)),
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = add_config::EProtectedConfigKey)]
+/// Nor into the instant store, where it would otherwise abort as an existing
+/// key: the pinned-key rule is checked first.
+fun test_pinned_key_cannot_be_added_to_instant_store() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    add_and_execute(
+        &mut hashi,
+        false,
+        b"bitcoin_chain_id",
+        config_value::new_bytes(vector::tabulate!(32, |i| i as u8)),
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/config_tests.move
+++ b/packages/hashi/tests/config_tests.move
@@ -177,15 +177,16 @@ fun test_config_value_same_variant_distinguishes_integer_widths() {
     assert!(!u256_value.same_variant(&u64_value));
 }
 
+/// The MPC accessors fall back to the genesis defaults for an absent key and
+/// read a present one as is; the Rust mirror does the same.
 #[test]
-fun test_seed_absent_defaults_fills_gaps_without_clobbering() {
+fun test_mpc_accessors_default_when_absent() {
     let mut config = config::empty();
     let custom_window = 7_777;
     config.upsert(b"mpc_nonce_accumulation_window_ms", config_value::new_u64(custom_window));
-    assert!(!config.contains(b"mpc_max_faulty_in_basis_points"));
-
-    hashi::mpc_config::seed_absent_defaults(&mut config);
 
     assert!(hashi::mpc_config::nonce_accumulation_window_ms(&config) == custom_window);
-    assert!(config.contains(b"mpc_max_faulty_in_basis_points"));
+    assert!(hashi::mpc_config::max_faulty_in_basis_points(&config) == 3333);
+    assert!(hashi::mpc_config::weight_reduction_allowed_delta(&config) == 800);
+    assert!(hashi::mpc_config::nonce_generation_protocol(&config) == 0);
 }

--- a/packages/hashi/tests/proposal_tests.move
+++ b/packages/hashi/tests/proposal_tests.move
@@ -995,10 +995,12 @@ fun test_create_before_genesis_emits_no_quorum() {
     );
     let mut config = hashi::config::create();
     hashi::btc_config::init_defaults(&mut config);
-    hashi::mpc_config::init_defaults(&mut config);
+    let mut epoch_config = hashi::config::empty();
+    hashi::mpc_config::init_defaults(&mut epoch_config);
     let mut hashi = hashi::hashi::create_for_testing(
         committee_set,
         config,
+        epoch_config,
         hashi::versioning::create(),
         hashi::treasury::create(ctx),
         hashi::proposals::create(ctx),

--- a/packages/hashi/tests/test_utils.move
+++ b/packages/hashi/tests/test_utils.move
@@ -8,6 +8,7 @@ module hashi::test_utils;
 
 use hashi::{
     abort_reconfig,
+    add_config,
     committee::{Self, CommitteeMember, CommitteeSignature},
     config_value,
     disable_version,
@@ -15,7 +16,8 @@ use hashi::{
     enable_version,
     hashi::Hashi,
     ignore_member,
-    update_config
+    update_config,
+    update_epoch_config
 };
 use sui::{bag, bls12381, clock::Clock, vec_map};
 
@@ -129,10 +131,11 @@ public fun create_hashi_with_weighted_committee(
         ctx,
     );
 
-    // Create config with BTC defaults + MPC defaults
+    // Instant config with BTC defaults; epoch config with MPC defaults
     let mut config = hashi::config::create();
     hashi::btc_config::init_defaults(&mut config);
-    hashi::mpc_config::init_defaults(&mut config);
+    let mut epoch_config = hashi::config::empty();
+    hashi::mpc_config::init_defaults(&mut epoch_config);
 
     // Create versioning (version gating + upgrade cap)
     let versioning = hashi::versioning::create();
@@ -149,6 +152,7 @@ public fun create_hashi_with_weighted_committee(
     hashi::hashi::create_for_testing(
         committee_set,
         config,
+        epoch_config,
         versioning,
         treasury,
         proposals,
@@ -187,7 +191,8 @@ public fun create_hashi_with_committee_and_registry(
 
     let mut config = hashi::config::create();
     hashi::btc_config::init_defaults(&mut config);
-    hashi::mpc_config::init_defaults(&mut config);
+    let mut epoch_config = hashi::config::empty();
+    hashi::mpc_config::init_defaults(&mut epoch_config);
     let versioning = hashi::versioning::create();
     let treasury = hashi::treasury::create(ctx);
     let proposals = hashi::proposals::create(ctx);
@@ -196,6 +201,7 @@ public fun create_hashi_with_committee_and_registry(
     hashi::hashi::create_for_testing(
         committee_set,
         config,
+        epoch_config,
         versioning,
         treasury,
         proposals,
@@ -279,6 +285,43 @@ public fun create_deposit_minimum_proposal(
         config_value::new_u64(minimum),
     );
     update_config::propose(hashi, validator_address, entries, vec_map::empty(), clock, ctx)
+}
+
+/// Creates an add config proposal for a single `key` in the store selected by
+/// `epoch` and returns its ID
+public fun create_add_config_proposal(
+    hashi: &mut Hashi,
+    validator_address: address,
+    epoch: bool,
+    key: vector<u8>,
+    value: config_value::Value,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    let mut entries = vec_map::empty();
+    entries.insert(key.to_string(), value);
+    add_config::propose(hashi, validator_address, epoch, entries, vec_map::empty(), clock, ctx)
+}
+
+/// Creates an update epoch config proposal for a single `key` and returns its ID
+public fun create_update_epoch_config_proposal(
+    hashi: &mut Hashi,
+    validator_address: address,
+    key: vector<u8>,
+    value: config_value::Value,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    let mut entries = vec_map::empty();
+    entries.insert(key.to_string(), value);
+    update_epoch_config::propose(
+        hashi,
+        validator_address,
+        entries,
+        vec_map::empty(),
+        clock,
+        ctx,
+    )
 }
 
 /// Creates an enable version proposal and returns its ID

--- a/packages/hashi/tests/update_config_multikey_tests.move
+++ b/packages/hashi/tests/update_config_multikey_tests.move
@@ -1,87 +1,60 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// `update_config` semantics on the instant config: multi-key batches apply
+/// atomically, unknown keys and type changes abort, and the MPC parameters
+/// (which live in the epoch config) are not reachable from here.
 #[test_only]
 #[allow(implicit_const_copy, unused_variable)]
 module hashi::update_config_multikey_tests;
 
-use hashi::{config_value, mpc_config, test_utils, update_config};
+use hashi::{btc_config, config_value, test_utils, update_config};
 use sui::{clock, vec_map};
 
 const VOTER1: address = @0x1;
 const VOTER2: address = @0x2;
 const VOTER3: address = @0x3;
 
-fun mpc_max_faulty_key(): std::string::String {
-    b"mpc_max_faulty_in_basis_points".to_string()
+fun deposit_minimum_key(): std::string::String {
+    b"bitcoin_deposit_minimum".to_string()
 }
 
-fun mpc_allowed_delta_key(): std::string::String {
-    b"mpc_weight_reduction_allowed_delta".to_string()
+fun withdrawal_minimum_key(): std::string::String {
+    b"bitcoin_withdrawal_minimum".to_string()
 }
 
-fun mpc_nonce_generation_protocol_key(): std::string::String {
-    b"mpc_nonce_generation_protocol".to_string()
-}
-
-fun mpc_nonce_accumulation_window_key(): std::string::String {
-    b"mpc_nonce_accumulation_window_ms".to_string()
+fun propose_and_execute(
+    hashi: &mut hashi::hashi::Hashi,
+    entries: vec_map::VecMap<std::string::String, config_value::Value>,
+    clock: &clock::Clock,
+    ctx: &mut TxContext,
+) {
+    let proposal_id = update_config::propose(
+        hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        clock,
+        ctx,
+    );
+    update_config::execute(hashi, proposal_id, clock);
 }
 
 #[test]
 fun test_single_key_update_via_multikey_propose() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
     let clock = clock::create_for_testing(ctx);
 
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 3333);
+    assert!(btc_config::bitcoin_deposit_minimum(hashi.config()) == 30_000);
 
     let mut entries = vec_map::empty();
-    entries.insert(mpc_max_faulty_key(), config_value::new_u64(2000));
+    entries.insert(deposit_minimum_key(), config_value::new_u64(50_000));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
 
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 2000);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.config()) == 800);
-    // Seeded by init_defaults and untouched by the update above.
-    assert!(mpc_config::nonce_generation_protocol(hashi.config()) == 0);
-
-    clock::destroy_for_testing(clock);
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-fun test_update_nonce_generation_protocol() {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let clock = clock::create_for_testing(ctx);
-
-    assert!(mpc_config::nonce_generation_protocol(hashi.config()) == 0);
-
-    let mut entries = vec_map::empty();
-    entries.insert(mpc_nonce_generation_protocol_key(), config_value::new_u64(1));
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    assert!(mpc_config::nonce_generation_protocol(hashi.config()) == 1);
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 3333);
+    assert!(btc_config::bitcoin_deposit_minimum(hashi.config()) == 50_000);
+    // Untouched by the update above.
+    assert!(btc_config::bitcoin_withdrawal_minimum(hashi.config()) == 30_000);
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
@@ -90,59 +63,32 @@ fun test_update_nonce_generation_protocol() {
 #[test]
 fun test_multi_key_update_applies_atomically() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
     let clock = clock::create_for_testing(ctx);
 
     let mut entries = vec_map::empty();
-    entries.insert(mpc_max_faulty_key(), config_value::new_u64(2000));
-    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(1500));
-    entries.insert(mpc_nonce_accumulation_window_key(), config_value::new_u64(5000));
+    entries.insert(deposit_minimum_key(), config_value::new_u64(50_000));
+    entries.insert(withdrawal_minimum_key(), config_value::new_u64(60_000));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
 
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 2000);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.config()) == 1500);
-    assert!(mpc_config::nonce_accumulation_window_ms(hashi.config()) == 5000);
+    assert!(btc_config::bitcoin_deposit_minimum(hashi.config()) == 50_000);
+    assert!(btc_config::bitcoin_withdrawal_minimum(hashi.config()) == 60_000);
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
 }
 
 #[test]
-fun test_mixed_domain_multi_key_update() {
+fun test_instant_update_never_touches_the_epoch_config() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
     let clock = clock::create_for_testing(ctx);
 
     let mut entries = vec_map::empty();
-    entries.insert(mpc_max_faulty_key(), config_value::new_u64(2000));
-    entries.insert(
-        b"bitcoin_deposit_minimum".to_string(),
-        config_value::new_u64(50_000),
-    );
+    entries.insert(deposit_minimum_key(), config_value::new_u64(50_000));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
 
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 2000);
-    assert!(hashi::btc_config::bitcoin_deposit_minimum(hashi.config()) == 50_000);
+    assert!(!hashi.epoch_config().contains(b"bitcoin_deposit_minimum"));
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
@@ -152,8 +98,7 @@ fun test_mixed_domain_multi_key_update() {
 #[expected_failure(abort_code = update_config::ENoEntriesProvided)]
 fun test_empty_entries_aborts_at_propose() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
     let clock = clock::create_for_testing(ctx);
 
     let _ = update_config::propose(
@@ -173,22 +118,29 @@ fun test_empty_entries_aborts_at_propose() {
 #[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
 fun test_unknown_key_aborts_at_execute() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
     let clock = clock::create_for_testing(ctx);
 
     let mut entries = vec_map::empty();
     entries.insert(b"does_not_exist".to_string(), config_value::new_u64(42));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
 
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+/// The MPC parameters live in the epoch config; naming one here is an
+/// unknown key for the instant store, not a silent no-op.
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_mpc_key_aborts_at_execute() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(b"mpc_max_faulty_in_basis_points".to_string(), config_value::new_u64(2000));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
@@ -198,22 +150,28 @@ fun test_unknown_key_aborts_at_execute() {
 #[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
 fun test_wrong_value_type_aborts_at_execute() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
     let clock = clock::create_for_testing(ctx);
 
     let mut entries = vec_map::empty();
-    entries.insert(mpc_max_faulty_key(), config_value::new_bool(true));
+    entries.insert(deposit_minimum_key(), config_value::new_bool(true));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
 
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
+fun test_batch_with_unknown_entry_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(deposit_minimum_key(), config_value::new_u64(50_000));
+    entries.insert(b"does_not_exist".to_string(), config_value::new_u64(42));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
@@ -227,8 +185,8 @@ fun test_propose_vote_execute_through_quorum() {
     let clock = clock::create_for_testing(ctx1);
 
     let mut entries = vec_map::empty();
-    entries.insert(mpc_max_faulty_key(), config_value::new_u64(2000));
-    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(1500));
+    entries.insert(deposit_minimum_key(), config_value::new_u64(50_000));
+    entries.insert(withdrawal_minimum_key(), config_value::new_u64(60_000));
 
     let proposal_id = update_config::propose(
         &mut hashi,
@@ -259,207 +217,9 @@ fun test_propose_vote_execute_through_quorum() {
 
     update_config::execute(&mut hashi, proposal_id, &clock);
 
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 2000);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.config()) == 1500);
+    assert!(btc_config::bitcoin_deposit_minimum(hashi.config()) == 50_000);
+    assert!(btc_config::bitcoin_withdrawal_minimum(hashi.config()) == 60_000);
 
     clock::destroy_for_testing(clock);
-    std::unit_test::destroy(hashi);
-}
-
-const MAX_BPS: u64 = 10000;
-const MAX_FAULTY_BPS: u64 = 3333;
-const DEFAULT_MAX_FAULTY_BPS: u64 = 3333;
-const MAX_NONCE_ACCUMULATION_WINDOW_MS: u64 = 10000;
-
-fun reject_single(key: std::string::String, value: config_value::Value) {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let clock = clock::create_for_testing(ctx);
-
-    let mut entries = vec_map::empty();
-    entries.insert(key, value);
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    clock::destroy_for_testing(clock);
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
-fun test_reject_max_faulty_above_max() {
-    reject_single(mpc_max_faulty_key(), config_value::new_u64(MAX_FAULTY_BPS + 1));
-}
-
-#[test]
-#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
-fun test_reject_allowed_delta_above_max() {
-    reject_single(mpc_allowed_delta_key(), config_value::new_u64(MAX_BPS + 1));
-}
-
-#[test]
-#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
-fun test_reject_nonce_protocol_above_one() {
-    reject_single(mpc_nonce_generation_protocol_key(), config_value::new_u64(2));
-}
-
-#[test]
-#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
-fun test_reject_nonce_window_above_max() {
-    reject_single(
-        mpc_nonce_accumulation_window_key(),
-        config_value::new_u64(MAX_NONCE_ACCUMULATION_WINDOW_MS + 1),
-    );
-}
-
-#[test]
-#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
-fun test_reject_max_faulty_zero() {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let clock = clock::create_for_testing(ctx);
-
-    let mut entries = vec_map::empty();
-    entries.insert(mpc_max_faulty_key(), config_value::new_u64(0));
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    clock::destroy_for_testing(clock);
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-fun test_accept_upper_boundary_values() {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let clock = clock::create_for_testing(ctx);
-
-    let mut entries = vec_map::empty();
-    entries.insert(mpc_max_faulty_key(), config_value::new_u64(MAX_FAULTY_BPS));
-    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(MAX_BPS));
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == MAX_FAULTY_BPS);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.config()) == MAX_BPS);
-
-    clock::destroy_for_testing(clock);
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
-fun test_batch_with_out_of_range_entry_aborts() {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let clock = clock::create_for_testing(ctx);
-
-    let mut entries = vec_map::empty();
-    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(1500));
-    entries.insert(mpc_max_faulty_key(), config_value::new_u64(MAX_BPS + 1));
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    clock::destroy_for_testing(clock);
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-#[expected_failure(abort_code = update_config::EInvalidConfigEntry)]
-fun test_reject_removed_threshold_key_even_when_present() {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-    let clock = clock::create_for_testing(ctx);
-
-    hashi.config_mut().upsert(b"mpc_threshold_in_basis_points", config_value::new_u64(3334));
-
-    let mut entries = vec_map::empty();
-    entries.insert(b"mpc_threshold_in_basis_points".to_string(), config_value::new_u64(5200));
-    let proposal_id = update_config::propose(
-        &mut hashi,
-        VOTER1,
-        entries,
-        vec_map::empty(),
-        &clock,
-        ctx,
-    );
-    update_config::execute(&mut hashi, proposal_id, &clock);
-
-    clock::destroy_for_testing(clock);
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-fun test_out_of_range_max_faulty_is_repaired_in_place_at_reconfig() {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-
-    hashi.config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(5000));
-    let _ = mpc_config::pin(hashi.config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == MAX_FAULTY_BPS);
-    let pinned = mpc_config::pin(hashi.config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(&pinned) == MAX_FAULTY_BPS);
-
-    hashi.config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(0));
-    let _ = mpc_config::pin(hashi.config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == DEFAULT_MAX_FAULTY_BPS);
-
-    hashi.config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(2000));
-    let _ = mpc_config::pin(hashi.config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 2000);
-
-    std::unit_test::destroy(hashi);
-}
-
-#[test]
-fun test_delta_is_clamped_below_max_faulty_at_reconfig() {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let voters = vector[VOTER1];
-    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
-
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == DEFAULT_MAX_FAULTY_BPS);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.config()) == 800);
-    let _ = mpc_config::pin(hashi.config_mut());
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.config()) == 800);
-
-    hashi.config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(500));
-    let _ = mpc_config::pin(hashi.config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.config()) == 500);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.config()) == 499);
-
     std::unit_test::destroy(hashi);
 }

--- a/packages/hashi/tests/update_epoch_config_tests.move
+++ b/packages/hashi/tests/update_epoch_config_tests.move
@@ -261,6 +261,8 @@ fun test_reject_max_faulty_zero() {
     reject_single(mpc_max_faulty_key(), config_value::new_u64(0));
 }
 
+/// Max-faulty at its cap and the delta one below it: the largest pair the
+/// per-entry ranges and the cross-key rule both accept.
 #[test]
 fun test_accept_upper_boundary_values() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
@@ -269,11 +271,11 @@ fun test_accept_upper_boundary_values() {
 
     let mut entries = vec_map::empty();
     entries.insert(mpc_max_faulty_key(), config_value::new_u64(MAX_FAULTY_BPS));
-    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(MAX_BPS));
+    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(MAX_FAULTY_BPS - 1));
     propose_and_execute(&mut hashi, entries, &clock, ctx);
 
     assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == MAX_FAULTY_BPS);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == MAX_BPS);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == MAX_FAULTY_BPS - 1);
 
     clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
@@ -314,61 +316,63 @@ fun test_reject_removed_threshold_key_even_when_present() {
     std::unit_test::destroy(hashi);
 }
 
+/// The per-entry range checks cannot see the cross-key rule (the delta must
+/// stay below max-faulty), so it is enforced on the store a proposal leaves
+/// behind: lowering max-faulty to the current delta is refused.
 #[test]
-fun test_out_of_range_max_faulty_is_repaired_in_place_at_reconfig() {
+#[expected_failure(abort_code = update_epoch_config::EInconsistentMpcConfig)]
+fun test_reject_max_faulty_at_or_below_delta() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
     let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 800);
 
-    hashi.epoch_config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(5000));
-    let _ = mpc_config::pin(hashi.epoch_config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == MAX_FAULTY_BPS);
-    let pinned = mpc_config::pin(hashi.epoch_config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(&pinned) == MAX_FAULTY_BPS);
+    let mut entries = vec_map::empty();
+    entries.insert(b"mpc_max_faulty_in_basis_points".to_string(), config_value::new_u64(800));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
 
-    hashi.epoch_config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(0));
-    let _ = mpc_config::pin(hashi.epoch_config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == DEFAULT_MAX_FAULTY_BPS);
-
-    hashi.epoch_config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(2000));
-    let _ = mpc_config::pin(hashi.epoch_config_mut());
-    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 2000);
-
+    clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
 }
 
 #[test]
-fun test_delta_is_clamped_below_max_faulty_at_reconfig() {
+#[expected_failure(abort_code = update_epoch_config::EInconsistentMpcConfig)]
+fun test_reject_delta_at_or_above_max_faulty() {
     let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
     let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
-
+    let clock = clock::create_for_testing(ctx);
     assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == DEFAULT_MAX_FAULTY_BPS);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 800);
-    let _ = mpc_config::pin(hashi.epoch_config_mut());
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 800);
 
-    hashi.epoch_config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(500));
-    let _ = mpc_config::pin(hashi.epoch_config_mut());
+    let mut entries = vec_map::empty();
+    entries.insert(
+        b"mpc_weight_reduction_allowed_delta".to_string(),
+        config_value::new_u64(DEFAULT_MAX_FAULTY_BPS),
+    );
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+/// Both coupled keys may drop below the other's old value in one proposal:
+/// the rule is judged on the resulting store, not per entry, so the entry
+/// order (max-faulty first here, while the old delta still exceeds it) does
+/// not matter.
+#[test]
+fun test_joint_update_of_both_coupled_keys_is_judged_on_the_result() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(b"mpc_max_faulty_in_basis_points".to_string(), config_value::new_u64(500));
+    entries.insert(b"mpc_weight_reduction_allowed_delta".to_string(), config_value::new_u64(400));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
     assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 500);
-    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 499);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 400);
 
-    std::unit_test::destroy(hashi);
-}
-
-/// `pin` seeds every MPC key an older epoch config may lack, so a pinned
-/// config is always complete.
-#[test]
-fun test_pin_seeds_absent_mpc_keys() {
-    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
-    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
-
-    let mut bare = hashi::config::empty();
-    let pinned = mpc_config::pin(&mut bare);
-    assert!(mpc_config::max_faulty_in_basis_points(&pinned) == DEFAULT_MAX_FAULTY_BPS);
-    assert!(mpc_config::weight_reduction_allowed_delta(&pinned) == 800);
-    assert!(mpc_config::nonce_generation_protocol(&pinned) == 0);
-    assert!(mpc_config::nonce_accumulation_window_ms(&pinned) == 2000);
-    assert!(bare.contains(b"mpc_max_faulty_in_basis_points"));
-
+    clock::destroy_for_testing(clock);
     std::unit_test::destroy(hashi);
 }
 

--- a/packages/hashi/tests/update_epoch_config_tests.move
+++ b/packages/hashi/tests/update_epoch_config_tests.move
@@ -1,0 +1,373 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// `update_epoch_config` semantics on the epoch config: the MPC parameters
+/// are tuned here (with range validation), batches apply atomically, unknown
+/// keys and type changes abort, and `pin` normalizes then snapshots the store.
+#[test_only]
+#[allow(implicit_const_copy, unused_variable)]
+module hashi::update_epoch_config_tests;
+
+use hashi::{config_value, mpc_config, test_utils, update_epoch_config};
+use sui::{clock, vec_map};
+
+const VOTER1: address = @0x1;
+const VOTER2: address = @0x2;
+const VOTER3: address = @0x3;
+
+const MAX_BPS: u64 = 10000;
+const MAX_FAULTY_BPS: u64 = 3333;
+const DEFAULT_MAX_FAULTY_BPS: u64 = 3333;
+const MAX_NONCE_ACCUMULATION_WINDOW_MS: u64 = 10000;
+
+fun mpc_max_faulty_key(): std::string::String {
+    b"mpc_max_faulty_in_basis_points".to_string()
+}
+
+fun mpc_allowed_delta_key(): std::string::String {
+    b"mpc_weight_reduction_allowed_delta".to_string()
+}
+
+fun mpc_nonce_generation_protocol_key(): std::string::String {
+    b"mpc_nonce_generation_protocol".to_string()
+}
+
+fun mpc_nonce_accumulation_window_key(): std::string::String {
+    b"mpc_nonce_accumulation_window_ms".to_string()
+}
+
+fun propose_and_execute(
+    hashi: &mut hashi::hashi::Hashi,
+    entries: vec_map::VecMap<std::string::String, config_value::Value>,
+    clock: &clock::Clock,
+    ctx: &mut TxContext,
+) {
+    let proposal_id = update_epoch_config::propose(
+        hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        clock,
+        ctx,
+    );
+    update_epoch_config::execute(hashi, proposal_id, clock);
+}
+
+fun reject_single(key: std::string::String, value: config_value::Value) {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(key, value);
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_single_key_update() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 3333);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(2000));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 2000);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 800);
+    // Seeded by init_defaults and untouched by the update above.
+    assert!(mpc_config::nonce_generation_protocol(hashi.epoch_config()) == 0);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_update_nonce_generation_protocol() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    assert!(mpc_config::nonce_generation_protocol(hashi.epoch_config()) == 0);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_nonce_generation_protocol_key(), config_value::new_u64(1));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    assert!(mpc_config::nonce_generation_protocol(hashi.epoch_config()) == 1);
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 3333);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_multi_key_update_applies_atomically() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(2000));
+    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(1500));
+    entries.insert(mpc_nonce_accumulation_window_key(), config_value::new_u64(5000));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 2000);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 1500);
+    assert!(mpc_config::nonce_accumulation_window_ms(hashi.epoch_config()) == 5000);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_epoch_update_never_touches_the_instant_config() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(2000));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    assert!(!hashi.config().contains(b"mpc_max_faulty_in_basis_points"));
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::ENoEntriesProvided)]
+fun test_empty_entries_aborts_at_propose() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let _ = update_epoch_config::propose(
+        &mut hashi,
+        VOTER1,
+        vec_map::empty(),
+        vec_map::empty(),
+        &clock,
+        ctx,
+    );
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_unknown_key_aborts_at_execute() {
+    reject_single(b"does_not_exist".to_string(), config_value::new_u64(42));
+}
+
+/// Instant keys are not reachable through the epoch store.
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_instant_key_aborts_at_execute() {
+    reject_single(b"bitcoin_deposit_minimum".to_string(), config_value::new_u64(50_000));
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_wrong_value_type_aborts_at_execute() {
+    reject_single(mpc_max_faulty_key(), config_value::new_bool(true));
+}
+
+#[test]
+fun test_propose_vote_execute_through_quorum() {
+    let ctx1 = &mut test_utils::new_tx_context(VOTER1, 0);
+    let voters = vector[VOTER1, VOTER2, VOTER3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx1);
+    let clock = clock::create_for_testing(ctx1);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(2000));
+    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(1500));
+
+    let proposal_id = update_epoch_config::propose(
+        &mut hashi,
+        VOTER1,
+        entries,
+        vec_map::empty(),
+        &clock,
+        ctx1,
+    );
+
+    let ctx2 = &mut test_utils::new_tx_context(VOTER2, 0);
+    hashi::proposal::vote<update_epoch_config::UpdateEpochConfig>(
+        &mut hashi,
+        VOTER2,
+        proposal_id,
+        &clock,
+        ctx2,
+    );
+
+    let ctx3 = &mut test_utils::new_tx_context(VOTER3, 0);
+    hashi::proposal::vote<update_epoch_config::UpdateEpochConfig>(
+        &mut hashi,
+        VOTER3,
+        proposal_id,
+        &clock,
+        ctx3,
+    );
+
+    update_epoch_config::execute(&mut hashi, proposal_id, &clock);
+
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 2000);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 1500);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_reject_max_faulty_above_max() {
+    reject_single(mpc_max_faulty_key(), config_value::new_u64(MAX_FAULTY_BPS + 1));
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_reject_allowed_delta_above_max() {
+    reject_single(mpc_allowed_delta_key(), config_value::new_u64(MAX_BPS + 1));
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_reject_nonce_protocol_above_one() {
+    reject_single(mpc_nonce_generation_protocol_key(), config_value::new_u64(2));
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_reject_nonce_window_above_max() {
+    reject_single(
+        mpc_nonce_accumulation_window_key(),
+        config_value::new_u64(MAX_NONCE_ACCUMULATION_WINDOW_MS + 1),
+    );
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_reject_max_faulty_zero() {
+    reject_single(mpc_max_faulty_key(), config_value::new_u64(0));
+}
+
+#[test]
+fun test_accept_upper_boundary_values() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(MAX_FAULTY_BPS));
+    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(MAX_BPS));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == MAX_FAULTY_BPS);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == MAX_BPS);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_batch_with_out_of_range_entry_aborts() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    let mut entries = vec_map::empty();
+    entries.insert(mpc_allowed_delta_key(), config_value::new_u64(1500));
+    entries.insert(mpc_max_faulty_key(), config_value::new_u64(MAX_BPS + 1));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+/// The retired threshold key is rejected even when a test has planted it,
+/// so it can never be tuned back into a pinned config.
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EInvalidConfigEntry)]
+fun test_reject_removed_threshold_key_even_when_present() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+    let clock = clock::create_for_testing(ctx);
+
+    hashi.epoch_config_mut().upsert(b"mpc_threshold_in_basis_points", config_value::new_u64(3334));
+
+    let mut entries = vec_map::empty();
+    entries.insert(b"mpc_threshold_in_basis_points".to_string(), config_value::new_u64(5200));
+    propose_and_execute(&mut hashi, entries, &clock, ctx);
+
+    clock::destroy_for_testing(clock);
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_out_of_range_max_faulty_is_repaired_in_place_at_reconfig() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+
+    hashi.epoch_config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(5000));
+    let _ = mpc_config::pin(hashi.epoch_config_mut());
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == MAX_FAULTY_BPS);
+    let pinned = mpc_config::pin(hashi.epoch_config_mut());
+    assert!(mpc_config::max_faulty_in_basis_points(&pinned) == MAX_FAULTY_BPS);
+
+    hashi.epoch_config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(0));
+    let _ = mpc_config::pin(hashi.epoch_config_mut());
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == DEFAULT_MAX_FAULTY_BPS);
+
+    hashi.epoch_config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(2000));
+    let _ = mpc_config::pin(hashi.epoch_config_mut());
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 2000);
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+fun test_delta_is_clamped_below_max_faulty_at_reconfig() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == DEFAULT_MAX_FAULTY_BPS);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 800);
+    let _ = mpc_config::pin(hashi.epoch_config_mut());
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 800);
+
+    hashi.epoch_config_mut().upsert(b"mpc_max_faulty_in_basis_points", config_value::new_u64(500));
+    let _ = mpc_config::pin(hashi.epoch_config_mut());
+    assert!(mpc_config::max_faulty_in_basis_points(hashi.epoch_config()) == 500);
+    assert!(mpc_config::weight_reduction_allowed_delta(hashi.epoch_config()) == 499);
+
+    std::unit_test::destroy(hashi);
+}
+
+/// `pin` seeds every MPC key an older epoch config may lack, so a pinned
+/// config is always complete.
+#[test]
+fun test_pin_seeds_absent_mpc_keys() {
+    let ctx = &mut test_utils::new_tx_context(VOTER1, 0);
+    let mut hashi = test_utils::create_hashi_with_committee(vector[VOTER1], ctx);
+
+    let mut bare = hashi::config::empty();
+    let pinned = mpc_config::pin(&mut bare);
+    assert!(mpc_config::max_faulty_in_basis_points(&pinned) == DEFAULT_MAX_FAULTY_BPS);
+    assert!(mpc_config::weight_reduction_allowed_delta(&pinned) == 800);
+    assert!(mpc_config::nonce_generation_protocol(&pinned) == 0);
+    assert!(mpc_config::nonce_accumulation_window_ms(&pinned) == 2000);
+    assert!(bare.contains(b"mpc_max_faulty_in_basis_points"));
+
+    std::unit_test::destroy(hashi);
+}

--- a/packages/hashi/tests/update_epoch_config_tests.move
+++ b/packages/hashi/tests/update_epoch_config_tests.move
@@ -371,3 +371,14 @@ fun test_pin_seeds_absent_mpc_keys() {
 
     std::unit_test::destroy(hashi);
 }
+
+#[test]
+#[expected_failure(abort_code = update_epoch_config::EProtectedConfigKey)]
+/// The keys the package pins for the deployment's lifetime are refused on the
+/// epoch path too, before the store is even consulted.
+fun test_pinned_key_is_refused() {
+    reject_single(
+        b"guardian_btc_public_key".to_string(),
+        config_value::new_bytes(vector::tabulate!(32, |i| i as u8)),
+    );
+}


### PR DESCRIPTION
## Summary

Split the governed config into two stores and mirror the split in the node. `Hashi.config` keeps the instant keys (Bitcoin parameters, guardian, pause, thresholds) and stays the target of `UpdateConfig`. A new `Hashi.epoch_config` holds the MPC parameters and is copied verbatim onto each new committee by `start_reconfig`, replacing the four-key `mpc_config::pin` snapshot; nothing is seeded or repaired in transit, and the one cross-key MPC rule (the weight-reduction delta stays below max-faulty) is enforced when a proposal writes the store (`mpc_config::is_consistent`, `EInconsistentMpcConfig`). Two proposal types join it: `UpdateEpochConfig` (existing epoch keys, MPC range validation, lands in the next committee) and `AddConfig { epoch, entries }` (insert-only into either store), which is how a node-side setting becomes governable without a package upgrade. Design is Brandon's.

Layout change to `Hashi`, so pre-mainnet only. Rebased from the pre-cut branch onto current main; the retired `mpc_threshold_in_basis_points` key stays rejected on add and update because the node treats its presence in a pinned config as the legacy threshold formula and the live testnet global config still carries it.

This was opened as a two-PR stack (Move here, Rust in #1106). The e2e job builds the tree's node against the tree's Move package, and `epoch_config` sits between `config` and `versioning`, so the Move half alone fails every test that decodes the `Hashi` object ("expected option type"). The two halves are one change. #1106 shows as merged only because its base branch was fast-forwarded to its head; nothing from it reached main, and its commit is the third one here. The commits still read in order: Move split, pinned keys, Rust mirror.

## Commit 4: review follow-up

Per review: `start_reconfig` no longer runs `mpc_config::pin`; the store is copied as is and the committee's field, the formation parameters and the local are renamed `epoch_config`. The seeding half of `pin` was dead on the fresh cycle (genesis seeds every key, nothing deletes one) and the per-key ranges were already refused at write, so only the cross-key rule moved: both epoch-store proposals assert `mpc_config::is_consistent` on the store they leave behind, after all entries, so a joint update of both coupled keys is judged on its result and not on entry order. Move 270 passed.

## Commit 1: Move split

`hashi.move`, `config.move`, `start_reconfig`, the `add_config` and `update_epoch_config` proposal modules, and the test utilities. `mpc_config::pin` is gone; the committee reads its parameters from the pinned copy.

## Commit 2: pinned keys on the new paths

#1062 made `UpdateConfig` refuse the guardian BTC public key and the Bitcoin chain id. The two new write paths apply the same rule, checked before the target store is consulted, so a same-named entry cannot be introduced into the epoch store either. Nothing reads a pinned key from the epoch store today; this keeps one rule in one place.

## Commit 3: Rust mirror, CLI, e2e

The on-chain mirror carries `Hashi.epoch_config`, the node reads epoch keys from the committee's pinned copy and instant keys from the root config, the CLI gains `create update-epoch-config` and `create add-config` (with `--epoch`), the mirror and GC know the two new proposal types, and the e2e config-override driver routes each key by which store holds it.

Three things the fresh cycle changed under the pre-cut branch, none flagged by the merge: the `UpgradeV2` proposal arm no longer exists, the two new `MoveType` impls carried `PACKAGE_VERSION = 2` overrides from the v2 era and now use the trait default of 1 like every other type on the squashed chain, and the proposal-type parsing test expected version 2. All three are back to the v1 baseline. The runbook's proposal table keeps main's single `Upgrade` row with the `--exclusive` semantics and adds the three config rows.

## Tests

Move: `sui move test` under the CI-pinned toolchain, 270 passed. New `add_config_tests` and `update_epoch_config_tests`, pinned-key refusals on both new paths, and the pre-genesis proposal test from #1099 adapted to the eight-argument `create_for_testing`.

Rust: clippy clean across `hashi`, `hashi-types` and `e2e-tests`; the onchain and CLI unit tests; the three config-store e2e tests (`test_create_update_config_proposal`, `test_mpc_config_defaults_match_rust`, `test_varying_t_and_allowed_delta_across_epochs`) against a fresh v1 boot.

Closes IOP-455.
