### PR TITLE
cli: resolve the governance identity by exact validator match, error on ambiguous delegation

### DIFF
--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -459,23 +459,20 @@ impl HashiClient {
     // Transaction builders (proposal/governance)
     // ========================================================================
 
-    /// Resolve the committee member (validator address) the signer is acting for:
-    /// the signer's own address if it is a validator member, otherwise the member
-    /// that has delegated its operator address to the signer.
-    fn resolve_validator_address(&self) -> anyhow::Result<Address> {
+    /// The address of the configured signing keypair, if any.
+    pub fn signer_address(&self) -> Option<Address> {
+        self.executor.as_ref().map(|e| e.sender())
+    }
+
+    /// Resolve the committee member (validator address) the configured
+    /// keypair acts for in governance calls: an exact validator match wins,
+    /// otherwise exactly one operator delegation; more than one is an error
+    /// (see `resolve_governance_identity`).
+    pub fn resolve_validator_address(&self) -> anyhow::Result<Address> {
         let sender = self
-            .executor
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Cannot resolve validator: no keypair configured"))?
-            .sender();
-        let members = self.fetch_committee_members();
-        members
-            .iter()
-            .find(|m| *m.validator_address() == sender || *m.operator_address() == sender)
-            .map(|m| *m.validator_address())
-            .ok_or_else(|| {
-                anyhow::anyhow!("signer {sender} is not a committee member or delegated operator")
-            })
+            .signer_address()
+            .ok_or_else(|| anyhow::anyhow!("Cannot resolve validator: no keypair configured"))?;
+        resolve_governance_identity(&self.fetch_committee_members(), sender)
     }
 
     /// Build a vote transaction for a proposal.
@@ -1088,6 +1085,49 @@ impl HashiClient {
     }
 }
 
+/// Resolve the committee member `sender` acts for in governance calls
+/// (propose, vote, remove_vote, resign, withdraw_resignation).
+///
+/// An exact validator-address match always wins. Otherwise `sender` may be
+/// the delegated operator of exactly one member. On chain,
+/// `validator::update_operator_address` only checks that the caller is
+/// authorized for the member being updated, so any member can point its
+/// operator address at another member's signing address; a first-match scan
+/// would then let that stray or malicious delegation redirect the signer's
+/// vote to the wrong member (SEC-546). Two or more delegations to the same
+/// signer are therefore an error naming the candidates rather than a guess.
+fn resolve_governance_identity(members: &[MemberInfo], sender: Address) -> Result<Address> {
+    if let Some(member) = members.iter().find(|m| *m.validator_address() == sender) {
+        return Ok(*member.validator_address());
+    }
+
+    let delegating: Vec<Address> = members
+        .iter()
+        .filter(|m| *m.operator_address() == sender)
+        .map(|m| *m.validator_address())
+        .collect();
+
+    match delegating.as_slice() {
+        [] => anyhow::bail!("signer {sender} is not a committee member or delegated operator"),
+        [validator_address] => Ok(*validator_address),
+        candidates => {
+            let count = candidates.len();
+            let candidates = candidates
+                .iter()
+                .map(Address::to_hex)
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "signer {sender} is the delegated operator of {count} committee members \
+                 ({candidates}); the CLI cannot tell which one to act for. Sign with that \
+                 member's validator key instead, or have the other members point their \
+                 operator address elsewhere (validator::update_operator_address, \
+                 `hashi register --operator-address`)."
+            )
+        }
+    }
+}
+
 /// Build a `proposal::vote<T>` transaction as a standalone. Reusable outside
 /// `HashiClient` — e2e test infra needs to build vote PTBs for every
 /// committee member.
@@ -1176,3 +1216,7 @@ pub fn get_proposal_type_arg(
         vec![],
     ))))
 }
+
+#[cfg(test)]
+#[path = "client_tests.rs"]
+mod tests;

--- a/crates/hashi/src/cli/client_tests.rs
+++ b/crates/hashi/src/cli/client_tests.rs
@@ -1,0 +1,94 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the governance identity resolution in `cli::client`.
+
+use fastcrypto::bls12381::min_pk::BLS12381KeyPair;
+use fastcrypto::traits::KeyPair;
+use sui_sdk_types::Address;
+
+use super::resolve_governance_identity;
+use crate::onchain::types::MemberInfo;
+
+fn addr(byte: u8) -> Address {
+    Address::new([byte; 32])
+}
+
+/// A registered member whose operator address is `operator`. The keys are
+/// irrelevant to resolution; one throwaway BLS key satisfies the struct.
+fn member(validator: Address, operator: Address) -> MemberInfo {
+    let keypair = BLS12381KeyPair::generate(&mut rand::thread_rng());
+    MemberInfo {
+        validator_address: validator,
+        operator_address: operator,
+        next_epoch_public_key: keypair.public().clone(),
+        endpoint_url: None,
+        tls_public_key: None,
+        next_epoch_encryption_public_key: None,
+        ignored: false,
+        resigned: false,
+    }
+}
+
+#[test]
+fn exact_validator_match_beats_an_earlier_operator_delegation() {
+    // M sorts before V and has pointed its operator address at V's signing
+    // address. V's key must still act as V, not as M.
+    let m = addr(1);
+    let v = addr(2);
+    let members = [member(m, v), member(v, v)];
+
+    assert_eq!(resolve_governance_identity(&members, v).unwrap(), v);
+}
+
+#[test]
+fn exact_validator_match_wins_over_any_number_of_delegations() {
+    let v = addr(5);
+    let members = [member(addr(1), v), member(addr(2), v), member(v, addr(9))];
+
+    assert_eq!(resolve_governance_identity(&members, v).unwrap(), v);
+}
+
+#[test]
+fn single_operator_delegation_resolves_to_the_delegating_member() {
+    let m = addr(3);
+    let operator = addr(9);
+    let members = [member(addr(1), addr(1)), member(m, operator)];
+
+    assert_eq!(resolve_governance_identity(&members, operator).unwrap(), m);
+}
+
+#[test]
+fn two_delegations_to_the_same_signer_are_an_error_naming_both() {
+    let a = addr(1);
+    let b = addr(2);
+    let operator = addr(9);
+    let members = [
+        member(a, operator),
+        member(b, operator),
+        member(addr(3), addr(3)),
+    ];
+
+    let err = resolve_governance_identity(&members, operator)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains(&operator.to_hex()), "{err}");
+    assert!(err.contains(&a.to_hex()), "{err}");
+    assert!(err.contains(&b.to_hex()), "{err}");
+    assert!(err.contains("2 committee members"), "{err}");
+}
+
+#[test]
+fn unknown_signer_is_rejected() {
+    let members = [member(addr(1), addr(1)), member(addr(2), addr(8))];
+    let stranger = addr(7);
+
+    let err = resolve_governance_identity(&members, stranger)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains(&stranger.to_hex()), "{err}");
+    assert!(
+        err.contains("not a committee member or delegated operator"),
+        "{err}"
+    );
+}

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -35,6 +35,26 @@ fn print_metadata(metadata: &[(String, String)]) {
     }
 }
 
+/// Resolve and show the committee member the configured keypair acts for, so
+/// the operator sees which member the transaction is attributed to before
+/// confirming it. The signer may be a member's validator address or an
+/// operator address a member delegated to it; see
+/// [`HashiClient::resolve_validator_address`] for the rules.
+pub(crate) fn print_acting_validator(client: &HashiClient) -> Result<()> {
+    let validator_address = client.resolve_validator_address()?;
+    let via_operator = match client.signer_address() {
+        Some(signer) if signer != validator_address => {
+            format!(" (delegated operator {})", signer.to_hex().dimmed())
+        }
+        _ => String::new(),
+    };
+    print_detail(&format!(
+        "  Acting as validator: {}{via_operator}",
+        validator_address.to_hex().cyan()
+    ));
+    Ok(())
+}
+
 /// Finalize a transaction according to `tx_opts`: serialize it unsigned,
 /// dry-run it, or sign and submit it.
 ///
@@ -213,6 +233,7 @@ pub async fn vote(
 
     print_detail(&format!("\n{}", "Proposal Details:".bold()));
     print_detail(&format!("  Type: {}", proposal_type_str.cyan()));
+    print_acting_validator(&client)?;
 
     prompt_continue("vote on this proposal", tx_opts).await?;
 
@@ -316,6 +337,7 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
 
     print_detail(&format!("\n{}", "Proposal Details:".bold()));
     print_detail(&format!("  Type: {}", proposal_type_str.cyan()));
+    print_acting_validator(&client)?;
 
     prompt_continue("remove your vote from this proposal", tx_opts).await?;
 
@@ -623,6 +645,7 @@ pub async fn create_upgrade_proposal(
     print_detail(&format!("  Digest: 0x{}", hex::encode(&digest_bytes)));
     print_detail(&format!("  Exclusive: {exclusive}"));
     print_metadata(&metadata);
+    print_acting_validator(&client)?;
 
     prompt_continue("create this upgrade proposal", tx_opts).await?;
 
@@ -655,9 +678,11 @@ pub async fn create_update_config_proposal(
     print_detail(&format!("  Value: {}", value_str));
     print_metadata(&metadata);
 
+    let mut client = HashiClient::new(config).await?;
+    print_acting_validator(&client)?;
+
     prompt_continue("create this config update proposal", tx_opts).await?;
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateConfig {
         key: key.to_string(),
         value,
@@ -721,9 +746,11 @@ pub async fn create_update_mpc_config_proposal(
         );
     }
 
+    let mut client = HashiClient::new(config).await?;
+    print_acting_validator(&client)?;
+
     prompt_continue("create this MPC config update proposal", tx_opts).await?;
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateMpcConfig {
         max_faulty_bps,
         weight_reduction_allowed_delta,
@@ -769,9 +796,11 @@ pub async fn create_enable_version_proposal(
     print_detail(&format!("  Version: {}", version));
     print_metadata(&metadata);
 
+    let mut client = HashiClient::new(config).await?;
+    print_acting_validator(&client)?;
+
     prompt_continue("create this enable version proposal", tx_opts).await?;
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::EnableVersion {
         version,
         metadata,
@@ -797,9 +826,11 @@ pub async fn create_disable_version_proposal(
     print_detail(&format!("  Version: {}", version));
     print_metadata(&metadata);
 
+    let mut client = HashiClient::new(config).await?;
+    print_acting_validator(&client)?;
+
     prompt_continue("create this disable version proposal", tx_opts).await?;
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::DisableVersion {
         version,
         metadata,
@@ -822,9 +853,11 @@ pub async fn create_abort_reconfig_proposal(
     print_info(&format!("Target epoch: {epoch}"));
     print_metadata(&metadata);
 
+    let mut client = HashiClient::new(config).await?;
+    print_acting_validator(&client)?;
+
     prompt_continue("create this abort reconfig proposal", tx_opts).await?;
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::AbortReconfig {
         epoch,
         metadata,
@@ -850,9 +883,11 @@ pub async fn create_update_guardian_proposal(
     print_detail(&format!("  URL:        {}", url));
     print_metadata(&metadata);
 
+    let mut client = HashiClient::new(config).await?;
+    print_acting_validator(&client)?;
+
     prompt_continue("create this update guardian proposal", tx_opts).await?;
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateGuardian {
         url: url.to_string(),
         metadata,
@@ -881,13 +916,15 @@ pub async fn create_emergency_pause_proposal(
     print_detail(&format!("  Action: {action}"));
     print_metadata(&metadata);
 
+    let mut client = HashiClient::new(config).await?;
+    print_acting_validator(&client)?;
+
     prompt_continue(
         &format!("create this emergency {} proposal", action.to_lowercase()),
         tx_opts,
     )
     .await?;
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::EmergencyPause {
         pause: !unpause,
         metadata,
@@ -946,6 +983,8 @@ pub async fn create_ignore_member_proposal(
             }
         }
     }
+
+    print_acting_validator(&client)?;
 
     prompt_continue(
         &format!("create this {} member proposal", action.to_lowercase()),

--- a/crates/hashi/src/cli/commands/validator.rs
+++ b/crates/hashi/src/cli/commands/validator.rs
@@ -9,6 +9,7 @@ use colored::Colorize;
 use crate::cli::TxOptions;
 use crate::cli::client::HashiClient;
 use crate::cli::commands::proposal::execute_or_simulate;
+use crate::cli::commands::proposal::print_acting_validator;
 use crate::cli::commands::proposal::prompt_continue;
 use crate::cli::config::CliConfig;
 use crate::cli::print_detail;
@@ -34,6 +35,7 @@ pub async fn resign(config: &CliConfig, tx_opts: &TxOptions) -> Result<()> {
          duties. The node suppresses its own auto-registration while the resignation is \
          pending; after removal, re-joining requires `hashi register` again.",
     );
+    print_acting_validator(&client)?;
 
     prompt_continue("resign from the committee", tx_opts).await?;
 
@@ -55,6 +57,7 @@ pub async fn withdraw_resignation(config: &CliConfig, tx_opts: &TxOptions) -> Re
         "  If the next committee was already formed without this node, it keeps its \
          registration but sits out that one epoch.",
     );
+    print_acting_validator(&client)?;
 
     prompt_continue("withdraw the resignation", tx_opts).await?;
 


### PR DESCRIPTION
## Summary

Audit finding SEC-546 (scanner F25). `resolve_validator_address` in `crates/hashi/src/cli/client.rs` mapped the signer to the first committee member whose validator or operator address matched, in member order. On chain, `validator::update_operator_address` only checks that the caller is authorized for the member being updated, so any member M can set its operator address to another member V's signing address. If M sorts before V, V's CLI then creates proposals, votes, removes votes and resigns as M: the vote is counted for M, or fails with `EVoteAlreadyCounted`, while V never sees its own vote land.

## Change

- Resolution is a pure function over the member list: an exact validator-address match always wins; otherwise exactly one operator delegation resolves to that member; more than one is an error that lists the candidate validator addresses and points at `validator::update_operator_address` (`hashi register --operator-address`) as the remedy. The CLI has no identity-override flag and this PR does not add one. No match keeps the existing error.
- `HashiClient::resolve_validator_address` delegates to it; `HashiClient::signer_address` exposes the configured keypair's address.
- `proposal create-*`, `proposal vote`, `proposal remove-vote`, `validator resign` and `validator withdraw-resignation` print the member the keypair acts for, with the signer appended when acting through a delegation, before the confirmation prompt, so the attributed identity is visible before anything is signed. The create commands that built the client after the prompt now build it before it (a read-only governance scrape moves earlier; no behaviour change otherwise).
- `proposal execute` and `execute-upgrade` are permissionless and take no identity, so they are unchanged.

## Tests

`cargo test -p hashi --lib cli::` with five new tests in `crates/hashi/src/cli/client_tests.rs`: exact validator match beats an earlier operator delegation; exact match wins over any number of delegations; a single delegation resolves to the delegating member; two delegations to the same signer error naming both candidates; an unknown signer errors. Clippy, fmt and `cargo doc` with warnings denied are clean. No e2e exercises the resolver directly; the governance e2e tests cover the propose and vote path.

## Known limitation, pre-existing

The identity is resolved from the configured keypair, not from `--sender`. A serialize-unsigned run with `--sender` set to a different address prints the keypair's identity while the unsigned transaction carries the other sender, exactly as before this change. Resolving from `--sender` for the offline-signing flow is a separate follow-up.

## Not included

The on-chain cross-member check on `update_operator_address` (refusing an operator address that is another member's validator address) is deliberately left out; the CLI fix stands on its own.
