### PR TITLE
executor: always pass the clock to submit_nonce_cert; drop the vacuous stamped-cert version gate

### DIFF
--- a/crates/hashi/src/constants.rs
+++ b/crates/hashi/src/constants.rs
@@ -49,12 +49,6 @@ pub fn is_production_sui_chain(chain_id: &str) -> bool {
     chain_id == SUI_MAINNET_CHAIN_ID || chain_id == SUI_TESTNET_CHAIN_ID
 }
 
-/// The `versioning::PACKAGE_VERSION` at which the stamped nonce-cert path becomes available
-/// on-chain: from the first publish of the squashed package. Compared against the *active*
-/// version, which is already intersected with `SUPPORTED_PACKAGE_VERSIONS` and the published
-/// set — so a version merely `enable_version`d ahead of its deployment cannot switch the ABI
-/// on early.
-pub const STAMPED_NONCE_CERTS_MIN_PACKAGE_VERSION: u64 = 1;
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hashi/src/sui_tx_executor.rs
+++ b/crates/hashi/src/sui_tx_executor.rs
@@ -494,8 +494,8 @@ pub struct SuiTxExecutor {
     hashi_ids: HashiIds,
     timeout: Duration,
     /// Present for node-internal executors (built via [`SuiTxExecutor::from_config`]
-    /// / [`SuiTxExecutor::from_hashi`]). Supplies both the call target and the
-    /// ABI shape (see [`Self::call_target`]), and refuses to submit when this
+    /// / [`SuiTxExecutor::from_hashi`]). Supplies the call target (see
+    /// [`Self::active_call_package_id`]) and refuses to submit when this
     /// binary supports no live on-chain package version. CLI executors attach
     /// a one-shot governance reader via [`SuiTxExecutor::with_onchain_state`]
     /// for the same routing. `None` for ad-hoc executors built via
@@ -553,17 +553,6 @@ impl SuiTxExecutor {
     pub fn with_onchain_state(mut self, onchain_state: &OnchainState) -> Self {
         self.onchain_state = Some(onchain_state.clone());
         self
-    }
-
-    fn call_target(&self) -> (Address, Option<u64>) {
-        match self
-            .onchain_state
-            .as_ref()
-            .and_then(OnchainState::active_package)
-        {
-            Some((id, version)) => (id, Some(version)),
-            None => (self.hashi_ids.package_id, None),
-        }
     }
 
     /// Get the sender address (derived from the signer's public key).
@@ -1170,8 +1159,17 @@ impl SuiTxExecutor {
         Ok(request_ids)
     }
 
+    /// The package id governance, certificate and validator calls target: the
+    /// active on-chain package when an [`OnchainState`] is attached, otherwise
+    /// the original publish id. Withdrawal-archival entries resolve through
+    /// [`Self::withdrawal_version_package`] instead, which refuses to fall
+    /// back. Only the target varies by version; no call shapes its argument
+    /// list by package version.
     pub(crate) fn active_call_package_id(&self) -> Address {
-        self.call_target().0
+        self.onchain_state
+            .as_ref()
+            .and_then(OnchainState::active_package)
+            .map_or(self.hashi_ids.package_id, |(id, _version)| id)
     }
 
     #[tracing::instrument(level = "info", skip_all)]
@@ -1349,7 +1347,11 @@ impl SuiTxExecutor {
     ///
     /// This submits a DKG, rotation, or nonce generation certificate to the on-chain
     /// certificate store. The certificate contains the dealer's message hash and
-    /// committee signature.
+    /// committee signature. Nonce certs additionally pass the Sui `Clock`:
+    /// `submit_nonce_cert` takes it on every published version (stamping the
+    /// submission with chain time), so the argument is unconditional, not
+    /// version-gated (a gate could only ever drop a required argument and
+    /// fail the call). DKG and rotation certs are submitted bare by design.
     #[tracing::instrument(
         level = "info",
         skip_all,
@@ -1389,13 +1391,10 @@ impl SuiTxExecutor {
         }
         let dealer_arg = builder.pure(&dealer);
         let message_hash_arg = builder.pure(&message_hash);
-        let (package_id, version) = self.call_target();
+        let package_id = self.active_call_package_id();
         let cert_arg = build_committee_signature_arg(&mut builder, package_id, committee_sig);
         args.extend([dealer_arg, message_hash_arg, cert_arg]);
-        if batch_index.is_some()
-            && version
-                .is_some_and(|v| v >= crate::constants::STAMPED_NONCE_CERTS_MIN_PACKAGE_VERSION)
-        {
+        if batch_index.is_some() {
             let clock_arg = builder.object(
                 ObjectInput::new(SUI_CLOCK_OBJECT_ID)
                     .as_shared()


### PR DESCRIPTION
## Summary

On the fresh cycle every published package version stamps nonce certs: Move `submit_nonce_cert` takes `clock: &Clock` unconditionally. The executor still carried `STAMPED_NONCE_CERTS_MIN_PACKAGE_VERSION = 1` and only pushed the Clock when `batch_index.is_some() && version.is_some_and(|v| v >= 1)`.

With `SUPPORTED_PACKAGE_VERSIONS = [1]` that comparison is vacuous whenever a version is known. When the executor had no on-chain state attached, or no active package resolved, the Clock was omitted, which is an arity mismatch against the only entry signature that exists rather than a fallback to an older ABI. The gate could only ever drop a required argument and fail the call.

It was a real gate when it landed (#953: supported versions `[1, 2]`, gate at 2, testnet v1 bare and v2 stamped); #1075's reset to a single fresh v1 is what made it dead.

## Changes

- `execute_submit_certificate` pushes the Clock whenever a nonce cert is submitted; the doc comment says why the argument is unconditional.
- `STAMPED_NONCE_CERTS_MIN_PACKAGE_VERSION` and its doc comment are deleted from `constants.rs`.
- The private `call_target()` is folded into `active_call_package_id()`, since the version half of its return value had no consumer other than the gate. Callers are unchanged; the doc now also points at `withdrawal_version_package`, which the archival entries use instead and which refuses to fall back.

Not touched: the Move bare-bucket read and write paths and `TobCertLayout`. DKG and rotation buckets are bare by design; the remaining bare-nonce write path, the zero-stamp mirror convention and the processed-bag fallbacks are explicitly deferred on IOP-660.

## Tests

`cargo clippy -p hashi --tests -- -D warnings` and `cargo nextest run -p hashi --lib -E 'test(sui_tx_executor)'` are clean. Every node executor that submits certs attaches on-chain state (verified from the single call site in `communication/sui_tob.rs`), so on current main the omitted-Clock path was latent rather than live.

Refs IOP-660.
