### PR TITLE
rust: mirror the epoch config store and the AddConfig / UpdateEpochConfig proposals

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -2650,6 +2650,12 @@ mod tests {
         use hashi::onchain::types::DEFAULT_MPC_MAX_FAULTY_IN_BASIS_POINTS;
         use hashi::onchain::types::DEFAULT_MPC_WEIGHT_REDUCTION_ALLOWED_DELTA;
 
+        // Governance-added keys the Move package knows nothing about.
+        const EPOCH_KNOB: &str = "e2e_epoch_knob";
+        const EPOCH_KNOB_VALUE: u64 = 7;
+        const INSTANT_KNOB: &str = "e2e_instant_knob";
+        const INSTANT_KNOB_VALUE: u64 = 9;
+
         // Wait for DKG (epoch 1 committee created with defaults).
         let nodes = networks.hashi_network.nodes();
         let futs: Vec<_> = nodes
@@ -2699,6 +2705,60 @@ mod tests {
             ],
         )
         .await?;
+
+        // Add one key to each store. The epoch key rides the wholesale pin
+        // into the next committee; the instant key applies at once and never
+        // reaches a committee.
+        {
+            use hashi::cli::client::CreateProposalParams;
+            use hashi::sui_tx_executor::SuiTxExecutor;
+            use hashi_types::move_types::ConfigValue;
+
+            let nodes = networks.hashi_network.nodes();
+            let hashi_ids = networks.hashi_network.ids();
+            let latest_package_id = nodes[0]
+                .hashi()
+                .onchain_state()
+                .package_id()
+                .unwrap_or(hashi_ids.package_id);
+            let hashi_isv = hashi::cli::client::fetch_initial_shared_version(
+                &mut networks.sui_network.client.clone(),
+                hashi_ids.hashi_object_id,
+            )
+            .await?;
+            let mut executors: Vec<SuiTxExecutor> = nodes
+                .iter()
+                .map(|node| {
+                    let hashi = node.hashi();
+                    SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())
+                })
+                .collect::<Result<_>>()?;
+            let add_config_type_tag = hashi::cli::client::get_proposal_type_arg(
+                latest_package_id,
+                &hashi::onchain::types::ProposalType::AddConfig,
+            )?;
+            for (epoch, key, value) in [
+                (true, EPOCH_KNOB, EPOCH_KNOB_VALUE),
+                (false, INSTANT_KNOB, INSTANT_KNOB_VALUE),
+            ] {
+                crate::submit_proposal_through_quorum(
+                    hashi_ids,
+                    hashi_isv,
+                    latest_package_id,
+                    &mut executors,
+                    CreateProposalParams::AddConfig {
+                        epoch,
+                        key: key.to_string(),
+                        value: ConfigValue::U64(value),
+                        metadata: vec![],
+                    },
+                    add_config_type_tag.clone(),
+                    "add_config",
+                    &format!("AddConfig({key})"),
+                )
+                .await?;
+            }
+        }
 
         // Force key rotation → epoch 2 committee created with new config.
         let target_epoch = initial_epoch + 1;
@@ -2762,6 +2822,41 @@ mod tests {
             new_max_faulty as u16,
             "epoch {target_epoch} committee should have updated max_faulty_basis_points"
         );
+
+        // The governance-added keys landed in exactly their stores.
+        assert_eq!(
+            epoch2.config().get_u64(EPOCH_KNOB, 0),
+            EPOCH_KNOB_VALUE,
+            "epoch {target_epoch} committee should carry the governance-added epoch key"
+        );
+        assert_eq!(
+            epoch1.config().get_u64(EPOCH_KNOB, 0),
+            0,
+            "epoch {initial_epoch} committee predates the epoch key and must not carry it"
+        );
+        assert!(
+            !epoch2
+                .config()
+                .entries()
+                .iter()
+                .any(|(key, _)| key == INSTANT_KNOB),
+            "instant keys never reach a committee"
+        );
+        let (instant, governed_epoch) = {
+            let s = state.state();
+            (
+                s.hashi().config.config.get(INSTANT_KNOB).cloned(),
+                s.hashi().epoch_config.get_u64(EPOCH_KNOB, 0),
+            )
+        };
+        assert_eq!(
+            instant,
+            Some(hashi_types::move_types::ConfigValue::U64(
+                INSTANT_KNOB_VALUE
+            )),
+            "instant key should be readable from the Hashi object right away"
+        );
+        assert_eq!(governed_epoch, EPOCH_KNOB_VALUE);
 
         Ok(())
     }

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -637,6 +637,28 @@ pub(crate) async fn apply_onchain_config_overrides(
         Identifier::from_static("UpdateConfig"),
         vec![],
     )));
+    // `UpdateEpochConfig` was introduced by the package the chain runs at
+    // boot, so its type tag carries that package.
+    let update_epoch_config_type_tag = TypeTag::Struct(Box::new(StructTag::new(
+        execute_package_id,
+        Identifier::from_static("update_epoch_config"),
+        Identifier::from_static("UpdateEpochConfig"),
+        vec![],
+    )));
+    // Overrides are routed to the store that holds the key: epoch keys (the
+    // MPC parameters and anything governance added there) go through
+    // `UpdateEpochConfig`, everything else through `UpdateConfig`.
+    let epoch_keys: std::collections::BTreeSet<String> = {
+        let hashi = nodes[0].hashi();
+        let state = hashi.onchain_state().state();
+        state
+            .hashi()
+            .epoch_config
+            .entries()
+            .iter()
+            .map(|(key, _)| key.clone())
+            .collect()
+    };
 
     if has_mpc_overrides {
         tracing::info!(
@@ -655,8 +677,8 @@ pub(crate) async fn apply_onchain_config_overrides(
                 nonce_generation_protocol: None,
                 metadata: vec![],
             },
-            update_config_type_tag.clone(),
-            "update_config",
+            update_epoch_config_type_tag.clone(),
+            "update_epoch_config",
             "UpdateMpcConfig",
         )
         .await?;
@@ -666,19 +688,38 @@ pub(crate) async fn apply_onchain_config_overrides(
     //one at a time?
     for (key, value) in &other_overrides {
         tracing::info!("applying on-chain config override: {key} = {value:?}");
+        let (params, type_tag, module, label) = if epoch_keys.contains(key) {
+            (
+                CreateProposalParams::UpdateEpochConfig {
+                    key: key.clone(),
+                    value: value.clone(),
+                    metadata: vec![],
+                },
+                update_epoch_config_type_tag.clone(),
+                "update_epoch_config",
+                format!("UpdateEpochConfig({key})"),
+            )
+        } else {
+            (
+                CreateProposalParams::UpdateConfig {
+                    key: key.clone(),
+                    value: value.clone(),
+                    metadata: vec![],
+                },
+                update_config_type_tag.clone(),
+                "update_config",
+                format!("UpdateConfig({key})"),
+            )
+        };
         exec_checkpoint = submit_proposal_through_quorum(
             hashi_ids,
             hashi_initial_shared_version,
             execute_package_id,
             &mut executors,
-            CreateProposalParams::UpdateConfig {
-                key: key.clone(),
-                value: value.clone(),
-                metadata: vec![],
-            },
-            update_config_type_tag.clone(),
-            "update_config",
-            &format!("UpdateConfig({key})"),
+            params,
+            type_tag,
+            module,
+            &label,
         )
         .await?;
     }

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -182,7 +182,10 @@ pub fn is_dof_wrapper(tag: &StructTag) -> bool {
 pub struct Hashi {
     pub id: Address,
     pub committees: CommitteeSet,
+    /// Governed values that apply the moment a proposal executes.
     pub config: Config,
+    /// Governed values copied wholesale onto each new committee.
+    pub epoch_config: Config,
     pub versioning: Versioning,
     pub treasury: Treasury,
     pub proposals: Proposals,
@@ -942,6 +945,30 @@ pub struct Proposal<T> {
 #[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct UpdateConfig {
     pub entries: VecMap<String, ConfigValue>,
+}
+
+/// Rust version of the Move hashi::update_epoch_config::UpdateEpochConfig type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct UpdateEpochConfig {
+    pub entries: VecMap<String, ConfigValue>,
+}
+
+impl MoveType for UpdateEpochConfig {
+    const MODULE: &'static str = "update_epoch_config";
+    const NAME: &'static str = "UpdateEpochConfig";
+}
+
+/// Rust version of the Move hashi::add_config::AddConfig type.
+#[derive(Debug, Clone, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct AddConfig {
+    /// `true` targets the epoch config, `false` the instant config.
+    pub epoch: bool,
+    pub entries: VecMap<String, ConfigValue>,
+}
+
+impl MoveType for AddConfig {
+    const MODULE: &'static str = "add_config";
+    const NAME: &'static str = "AddConfig";
 }
 
 /// Rust version of the Move hashi::enable_version::EnableVersion type.

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -42,6 +42,19 @@ pub enum CreateProposalParams {
         value: hashi_types::move_types::ConfigValue,
         metadata: Vec<(String, String)>,
     },
+    /// Update an existing key in the epoch config.
+    UpdateEpochConfig {
+        key: String,
+        value: hashi_types::move_types::ConfigValue,
+        metadata: Vec<(String, String)>,
+    },
+    /// Add a new key to the epoch (`epoch: true`) or instant config.
+    AddConfig {
+        epoch: bool,
+        key: String,
+        value: hashi_types::move_types::ConfigValue,
+        metadata: Vec<(String, String)>,
+    },
     UpdateMpcConfig {
         max_faulty_bps: Option<u64>,
         weight_reduction_allowed_delta: Option<u64>,
@@ -366,6 +379,17 @@ impl HashiClient {
                             bcs::from_bytes(value_bytes).context("deserialize UpdateConfig")?;
                         (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
                     }
+                    ProposalType::UpdateEpochConfig => {
+                        let p: move_types::Proposal<move_types::UpdateEpochConfig> =
+                            bcs::from_bytes(value_bytes)
+                                .context("deserialize UpdateEpochConfig")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
+                    ProposalType::AddConfig => {
+                        let p: move_types::Proposal<move_types::AddConfig> =
+                            bcs::from_bytes(value_bytes).context("deserialize AddConfig")?;
+                        (p.creator, p.votes, p.quorum_threshold_bps, p.metadata)
+                    }
                     ProposalType::EnableVersion => {
                         let p: move_types::Proposal<move_types::EnableVersion> =
                             bcs::from_bytes(value_bytes).context("deserialize EnableVersion")?;
@@ -581,6 +605,8 @@ impl HashiClient {
 
         let module_name = match proposal_type {
             ProposalType::UpdateConfig => "update_config",
+            ProposalType::UpdateEpochConfig => "update_epoch_config",
+            ProposalType::AddConfig => "add_config",
             ProposalType::EnableVersion => "enable_version",
             ProposalType::DisableVersion => "disable_version",
             ProposalType::EmergencyPause => "emergency_pause",
@@ -736,6 +762,63 @@ pub fn build_create_proposal_transaction(
                 ],
             );
         }
+        CreateProposalParams::UpdateEpochConfig {
+            key,
+            value,
+            metadata,
+        } => {
+            let entries_arg = build_config_entries(
+                &mut builder,
+                hashi_ids.package_id,
+                call_package,
+                &[(key, value)],
+            );
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    call_package,
+                    Identifier::from_static("update_epoch_config"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    entries_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
+            );
+        }
+        CreateProposalParams::AddConfig {
+            epoch,
+            key,
+            value,
+            metadata,
+        } => {
+            let epoch_arg = builder.pure(&epoch);
+            let entries_arg = build_config_entries(
+                &mut builder,
+                hashi_ids.package_id,
+                call_package,
+                &[(key, value)],
+            );
+            let metadata_arg = build_metadata(&mut builder, &metadata);
+            builder.move_call(
+                Function::new(
+                    call_package,
+                    Identifier::from_static("add_config"),
+                    Identifier::from_static("propose"),
+                ),
+                vec![
+                    hashi_arg,
+                    validator_address_arg,
+                    epoch_arg,
+                    entries_arg,
+                    metadata_arg,
+                    clock_arg,
+                ],
+            );
+        }
         CreateProposalParams::UpdateMpcConfig {
             max_faulty_bps,
             weight_reduction_allowed_delta,
@@ -756,10 +839,11 @@ pub fn build_create_proposal_transaction(
             let entries_arg =
                 build_config_entries(&mut builder, hashi_ids.package_id, call_package, &entries);
             let metadata_arg = build_metadata(&mut builder, &metadata);
+            // The MPC parameters live in the epoch config.
             builder.move_call(
                 Function::new(
                     call_package,
-                    Identifier::from_static("update_config"),
+                    Identifier::from_static("update_epoch_config"),
                     Identifier::from_static("propose"),
                 ),
                 vec![
@@ -1154,6 +1238,8 @@ pub fn get_proposal_type_arg(
     let (module, name) = match proposal_type {
         ProposalType::Upgrade => ("upgrade", "Upgrade"),
         ProposalType::UpdateConfig => ("update_config", "UpdateConfig"),
+        ProposalType::UpdateEpochConfig => ("update_epoch_config", "UpdateEpochConfig"),
+        ProposalType::AddConfig => ("add_config", "AddConfig"),
         ProposalType::EnableVersion => ("enable_version", "EnableVersion"),
         ProposalType::DisableVersion => ("disable_version", "DisableVersion"),
         ProposalType::EmergencyPause => ("emergency_pause", "EmergencyPause"),

--- a/crates/hashi/src/cli/commands/config.rs
+++ b/crates/hashi/src/cli/commands/config.rs
@@ -149,16 +149,32 @@ pub async fn show_onchain_config(config: &CliConfig) -> Result<()> {
         epoch.to_string().green()
     );
 
-    // TODO: Fetch and display more configuration details using hashi::onchain::OnchainState:
-    // - Enabled versions
-    // - Deposit fee
-    // - Paused state
-    // - Committee info
-    // - etc.
+    let state = client.onchain_state().state();
+    let hashi = state.hashi();
+
+    println!(
+        "  {} {:?}",
+        "Enabled Versions:".bold(),
+        hashi.config.enabled_versions
+    );
+
+    println!(
+        "\n  {}",
+        "Instant config (applies when a proposal executes):".bold()
+    );
+    for (key, value) in &hashi.config.config {
+        println!("    {} = {:?}", key.cyan(), value);
+    }
+
+    println!(
+        "\n  {}",
+        "Epoch config (copied onto each new committee):".bold()
+    );
+    for (key, value) in hashi.epoch_config.entries() {
+        println!("    {} = {:?}", key.cyan(), value);
+    }
 
     println!("{}", "━".repeat(60).dimmed());
-
-    print_info("Full configuration fetching is a TODO - will use OnchainState for more details.");
 
     Ok(())
 }

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -670,6 +670,82 @@ pub async fn create_update_config_proposal(
     Ok(())
 }
 
+/// Create an update epoch config proposal
+pub async fn create_update_epoch_config_proposal(
+    config: &CliConfig,
+    key: &str,
+    value_str: &str,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let value = parse_config_value(value_str)
+        .context("Invalid value format. Use type:value, e.g. u64:1000 or bool:true")?;
+
+    print_detail(&format!(
+        "\n{}",
+        "Creating Update Epoch Config Proposal:".bold()
+    ));
+    print_detail(&format!("  Key:   {}", key));
+    print_detail(&format!("  Value: {}", value_str));
+    print_detail("  Takes effect: next committee formed after execution");
+    print_metadata(&metadata);
+
+    prompt_continue("create this epoch config update proposal", tx_opts).await?;
+
+    let mut client = HashiClient::new(config).await?;
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateEpochConfig {
+        key: key.to_string(),
+        value,
+        metadata,
+    })?;
+
+    print_info("Transaction: update_epoch_config::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
+/// Create an add config proposal
+pub async fn create_add_config_proposal(
+    config: &CliConfig,
+    key: &str,
+    value_str: &str,
+    epoch: bool,
+    metadata: Vec<(String, String)>,
+    tx_opts: &TxOptions,
+) -> Result<()> {
+    let value = parse_config_value(value_str)
+        .context("Invalid value format. Use type:value, e.g. u64:1000 or bool:true")?;
+
+    print_detail(&format!("\n{}", "Creating Add Config Proposal:".bold()));
+    print_detail(&format!("  Key:   {}", key));
+    print_detail(&format!("  Value: {}", value_str));
+    print_detail(&format!(
+        "  Store: {}",
+        if epoch {
+            "epoch config (copied onto each new committee)"
+        } else {
+            "instant config (applies on execute)"
+        }
+    ));
+    print_metadata(&metadata);
+
+    prompt_continue("create this add config proposal", tx_opts).await?;
+
+    let mut client = HashiClient::new(config).await?;
+    let tx = client.build_create_proposal_transaction(CreateProposalParams::AddConfig {
+        epoch,
+        key: key.to_string(),
+        value,
+        metadata,
+    })?;
+
+    print_info("Transaction: add_config::propose");
+    let response = execute_or_simulate(&mut client, tx, tx_opts).await?;
+    print_created_proposal_id(response.as_ref());
+    Ok(())
+}
+
 pub async fn create_update_mpc_config_proposal(
     config: &CliConfig,
     max_faulty_bps: Option<u64>,

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -235,19 +235,61 @@ pub enum CreateProposalCommands {
         metadata: MetadataArgs,
     },
 
-    /// Propose updating a configuration value
+    /// Propose updating an existing instant config value (applies as soon as
+    /// the proposal executes)
     ///
     /// Known config keys and their expected value types:
     ///   bitcoin_deposit_minimum (u64),
     ///   bitcoin_withdrawal_minimum (u64),
     ///   bitcoin_confirmation_threshold (u64),
     ///   withdrawal_cancellation_cooldown_ms (u64), paused (bool)
+    ///
+    /// The MPC parameters live in the epoch config: see `update-epoch-config`
+    /// and `update-mpc-config`.
     UpdateConfig {
         /// The config key to update
         key: String,
 
         /// The new value. Prefix with the type: u64:123, bool:true
         value: String,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
+
+    /// Propose updating an existing epoch config value (the MPC parameters
+    /// and any epoch-scoped keys governance added)
+    ///
+    /// The change is copied onto the next committee formed after execution;
+    /// the active committee keeps its pinned copy.
+    UpdateEpochConfig {
+        /// The epoch config key to update
+        key: String,
+
+        /// The new value. Prefix with the type: u64:123, bool:true
+        value: String,
+
+        #[clap(flatten)]
+        metadata: MetadataArgs,
+    },
+
+    /// Propose adding a NEW config key
+    ///
+    /// Insert-only: the proposal aborts if the key already exists in the
+    /// target store, and the first value fixes the key's type for later
+    /// updates. Use this to make a node-side setting governable without a
+    /// package upgrade.
+    AddConfig {
+        /// The config key to add
+        key: String,
+
+        /// The initial value. Prefix with the type: u64:123, bool:true
+        value: String,
+
+        /// Add the key to the epoch config (copied onto each new committee)
+        /// instead of the instant config.
+        #[clap(long)]
+        epoch: bool,
 
         #[clap(flatten)]
         metadata: MetadataArgs,
@@ -1067,6 +1109,36 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
                         &config,
                         &key,
                         &value,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::UpdateEpochConfig {
+                    key,
+                    value,
+                    metadata,
+                } => {
+                    commands::proposal::create_update_epoch_config_proposal(
+                        &config,
+                        &key,
+                        &value,
+                        parse_metadata(metadata.metadata),
+                        &tx_opts,
+                    )
+                    .await?;
+                }
+                CreateProposalCommands::AddConfig {
+                    key,
+                    value,
+                    epoch,
+                    metadata,
+                } => {
+                    commands::proposal::create_add_config_proposal(
+                        &config,
+                        &key,
+                        &value,
+                        epoch,
                         parse_metadata(metadata.metadata),
                         &tx_opts,
                     )

--- a/crates/hashi/src/cli/types.rs
+++ b/crates/hashi/src/cli/types.rs
@@ -51,6 +51,8 @@ pub mod display {
         match proposal_type {
             ProposalType::Upgrade => "Upgrade".to_string(),
             ProposalType::UpdateConfig => "UpdateConfig".to_string(),
+            ProposalType::UpdateEpochConfig => "UpdateEpochConfig".to_string(),
+            ProposalType::AddConfig => "AddConfig".to_string(),
             ProposalType::EnableVersion => "EnableVersion".to_string(),
             ProposalType::DisableVersion => "DisableVersion".to_string(),
             ProposalType::EmergencyPause => "EmergencyPause".to_string(),

--- a/crates/hashi/src/leader/garbage_collection.rs
+++ b/crates/hashi/src/leader/garbage_collection.rs
@@ -524,6 +524,18 @@ impl LeaderService {
                     Identifier::from_static("UpdateConfig"),
                     vec![],
                 ))),
+                ProposalType::UpdateEpochConfig => TypeTag::Struct(Box::new(StructTag::new(
+                    type_package_id,
+                    Identifier::from_static("update_epoch_config"),
+                    Identifier::from_static("UpdateEpochConfig"),
+                    vec![],
+                ))),
+                ProposalType::AddConfig => TypeTag::Struct(Box::new(StructTag::new(
+                    type_package_id,
+                    Identifier::from_static("add_config"),
+                    Identifier::from_static("AddConfig"),
+                    vec![],
+                ))),
                 ProposalType::EnableVersion => TypeTag::Struct(Box::new(StructTag::new(
                     type_package_id,
                     Identifier::from_static("enable_version"),

--- a/crates/hashi/src/onchain/apply.rs
+++ b/crates/hashi/src/onchain/apply.rs
@@ -390,6 +390,7 @@ fn apply_root(
         id: _,
         committees,
         config,
+        epoch_config,
         versioning,
         treasury: _,
         proposals: _,
@@ -413,6 +414,7 @@ fn apply_root(
         packages.insert(cap.version, cap.package);
     }
     hashi.config = new_config;
+    hashi.epoch_config = epoch_config;
     hashi.num_consumed_presigs = num_consumed_presigs;
 
     let new_pending = committees.pending_epoch_change.as_ref().map(|p| p.epoch);
@@ -1163,6 +1165,7 @@ mod tests {
                     enabled_versions: BTreeSet::new(),
                     upgrade_cap: None,
                 },
+                epoch_config: move_types::Config::default(),
                 treasury: types::Treasury {
                     id: treasury_id(),
                     treasury_caps: BTreeMap::new(),
@@ -1336,6 +1339,7 @@ mod tests {
         id: Address,
         committees: CommitteeSetEnc,
         config: move_types::Config,
+        epoch_config: move_types::Config,
         versioning: VersioningEnc,
         treasury: TreasuryEnc,
         proposals: ProposalsEnc,
@@ -1393,6 +1397,7 @@ mod tests {
                 mpc_public_key: vec![9u8; 4],
             },
             config: move_types::Config::from_entries(vec![]),
+            epoch_config: move_types::Config::from_entries(vec![]),
             versioning: VersioningEnc {
                 enabled_versions: VecSetEnc { contents: vec![1] },
                 upgrade_cap: upgrade_cap.map(|(package, version)| UpgradeCapEnc {

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -952,19 +952,28 @@ impl OnchainState {
         self.state().hashi().config.bitcoin_deposit_time_delay_ms()
     }
 
+    /// The governed MPC parameters from the epoch config: what the NEXT
+    /// committee will be formed with. The active committee reads its own
+    /// pinned copy via [`Committee::config`](hashi_types::committee::Committee::config).
     pub fn mpc_nonce_generation_protocol(&self) -> u16 {
-        self.state().hashi().config.mpc_nonce_generation_protocol()
+        self.state()
+            .hashi()
+            .epoch_config
+            .mpc_nonce_generation_protocol()
     }
 
     pub fn mpc_weight_reduction_allowed_delta(&self) -> u16 {
         self.state()
             .hashi()
-            .config
+            .epoch_config
             .mpc_weight_reduction_allowed_delta()
     }
 
     pub fn mpc_max_faulty_in_basis_points(&self) -> u16 {
-        self.state().hashi().config.mpc_max_faulty_in_basis_points()
+        self.state()
+            .hashi()
+            .epoch_config
+            .mpc_max_faulty_in_basis_points()
     }
 
     pub fn guardian_url(&self) -> Option<String> {
@@ -1352,6 +1361,7 @@ async fn scrape_hashi(
         id,
         committees,
         config,
+        epoch_config,
         versioning,
         treasury,
         proposals,
@@ -1443,6 +1453,7 @@ async fn scrape_hashi(
             id,
             committees: committee_set,
             config: convert_move_config(config, versioning),
+            epoch_config,
             treasury,
             bitcoin,
             proposals,
@@ -2319,6 +2330,8 @@ fn decode_proposal(type_tag: &TypeTag, contents: &[u8]) -> Option<types::Proposa
     let proposal_type = parse_proposal_type(type_tag);
     let (id, timestamp_ms) = match &proposal_type {
         types::ProposalType::UpdateConfig => parse::<move_types::UpdateConfig>(contents),
+        types::ProposalType::UpdateEpochConfig => parse::<move_types::UpdateEpochConfig>(contents),
+        types::ProposalType::AddConfig => parse::<move_types::AddConfig>(contents),
         types::ProposalType::EnableVersion => parse::<move_types::EnableVersion>(contents),
         types::ProposalType::DisableVersion => parse::<move_types::DisableVersion>(contents),
         types::ProposalType::Upgrade => parse::<move_types::Upgrade>(contents),
@@ -2355,6 +2368,8 @@ pub(crate) fn parse_proposal_type(type_tag: &TypeTag) -> types::ProposalType {
 
     match (inner_tag.module().as_str(), inner_tag.name().as_str()) {
         ("update_config", "UpdateConfig") => types::ProposalType::UpdateConfig,
+        ("update_epoch_config", "UpdateEpochConfig") => types::ProposalType::UpdateEpochConfig,
+        ("add_config", "AddConfig") => types::ProposalType::AddConfig,
         ("enable_version", "EnableVersion") => types::ProposalType::EnableVersion,
         ("disable_version", "DisableVersion") => types::ProposalType::DisableVersion,
         ("upgrade", "Upgrade") => types::ProposalType::Upgrade,
@@ -2486,6 +2501,39 @@ mod tests {
             vec![inner],
         )));
         assert_eq!(parse_proposal_type(&tag), types::ProposalType::IgnoreMember);
+    }
+
+    #[test]
+    fn test_parse_proposal_type_config_stores() {
+        use sui_sdk_types::Identifier;
+        use sui_sdk_types::StructTag;
+
+        let package =
+            Address::from_hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+                .unwrap();
+        for (module, name, expected) in [
+            ("add_config", "AddConfig", types::ProposalType::AddConfig),
+            (
+                "update_epoch_config",
+                "UpdateEpochConfig",
+                types::ProposalType::UpdateEpochConfig,
+            ),
+        ] {
+            let inner = TypeTag::Struct(Box::new(StructTag::new(
+                package,
+                Identifier::new(module).unwrap(),
+                Identifier::new(name).unwrap(),
+                vec![],
+            )));
+            let tag = TypeTag::Struct(Box::new(StructTag::new(
+                package,
+                Identifier::new("proposal").unwrap(),
+                Identifier::new("Proposal").unwrap(),
+                vec![inner],
+            )));
+            assert_eq!(parse_proposal_type(&tag), expected);
+            assert_eq!(expected.package_version(), Some(1));
+        }
     }
 
     #[test]

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -50,7 +50,12 @@ pub struct BitcoinCollections {
 pub struct Hashi {
     pub id: Address,
     pub committees: CommitteeSet,
+    /// Governed values that apply the moment a proposal executes.
     pub config: Config,
+    /// Governed values copied wholesale onto each new committee. The active
+    /// committee reads its own pinned copy; this is what the NEXT committee
+    /// will be formed with.
+    pub epoch_config: hashi_types::move_types::Config,
     pub treasury: Treasury,
     /// `None` under `ScrapeScope::GovernanceOnly`. An `Option` rather than
     /// empty collections so a scope mistake can't read as "no withdrawals".
@@ -686,6 +691,8 @@ pub struct Proposal {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProposalType {
     UpdateConfig,
+    UpdateEpochConfig,
+    AddConfig,
     EnableVersion,
     DisableVersion,
     Upgrade,
@@ -714,6 +721,8 @@ impl ProposalType {
     pub fn as_str(&self) -> &str {
         match self {
             ProposalType::UpdateConfig => "update_config",
+            ProposalType::UpdateEpochConfig => "update_epoch_config",
+            ProposalType::AddConfig => "add_config",
             ProposalType::EnableVersion => "enable_version",
             ProposalType::DisableVersion => "disable_version",
             ProposalType::Upgrade => "upgrade",
@@ -728,6 +737,8 @@ impl ProposalType {
     pub fn all_labels() -> &'static [&'static str] {
         &[
             "update_config",
+            "update_epoch_config",
+            "add_config",
             "enable_version",
             "disable_version",
             "upgrade",
@@ -803,33 +814,6 @@ impl Config {
         match self.config.get("bitcoin_deposit_time_delay_ms") {
             Some(ConfigValue::U64(v)) => *v,
             _ => 0,
-        }
-    }
-
-    pub fn mpc_weight_reduction_allowed_delta(&self) -> u16 {
-        match self.config.get("mpc_weight_reduction_allowed_delta") {
-            Some(ConfigValue::U64(v)) => {
-                u16::try_from(*v).expect("mpc_weight_reduction_allowed_delta exceeds u16::MAX")
-            }
-            _ => DEFAULT_MPC_WEIGHT_REDUCTION_ALLOWED_DELTA,
-        }
-    }
-
-    pub fn mpc_max_faulty_in_basis_points(&self) -> u16 {
-        match self.config.get("mpc_max_faulty_in_basis_points") {
-            Some(ConfigValue::U64(v)) => {
-                u16::try_from(*v).expect("mpc_max_faulty_in_basis_points exceeds u16::MAX")
-            }
-            _ => DEFAULT_MPC_MAX_FAULTY_IN_BASIS_POINTS,
-        }
-    }
-
-    pub fn mpc_nonce_generation_protocol(&self) -> u16 {
-        match self.config.get("mpc_nonce_generation_protocol") {
-            Some(ConfigValue::U64(v)) => {
-                u16::try_from(*v).expect("mpc_nonce_generation_protocol exceeds u16::MAX")
-            }
-            _ => hashi_types::move_types::VANILLA_MPC_NONCE_GENERATION_PROTOCOL,
         }
     }
 

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -821,6 +821,8 @@ Create proposals:
 ```bash
 hashi proposal create update-config <key> <value> [-m key=value]
 hashi proposal create update-mpc-config [--max-faulty-bps <N>] [--weight-reduction-allowed-delta <N>] [-m key=value]
+hashi proposal create update-epoch-config <key> <value> [-m key=value]
+hashi proposal create add-config <key> <value> [--epoch] [-m key=value]
 hashi proposal create upgrade [--package-path <path> | --digest <hex>] [-m key=value]
 hashi proposal create upgrade [--package-path <path> | --digest <hex> [--allow-unverified-exclusive]] --exclusive <true|false> [-m key=value]
 hashi proposal create enable-version <version> [-m key=value]
@@ -897,8 +899,10 @@ Builds, publishes, and initializes the Hashi Move package (including its onchain
 
 | Type | Threshold | Purpose | Parameters |
 |------|-----------|---------|-----------|
-| **UpdateConfig** | 2/3 | Change protocol parameters | `key` and type-prefixed `value` |
-| **UpdateMpcConfig** | 2/3 | Change MPC faulty bound / delta | `--max-faulty-bps`, `--weight-reduction-allowed-delta` |
+| **UpdateConfig** | 2/3 | Change an existing instant config parameter (applies on execute) | `key` and type-prefixed `value` |
+| **UpdateEpochConfig** | 2/3 | Change an existing epoch config parameter (lands in the next committee) | `key` and type-prefixed `value` |
+| **AddConfig** | 2/3 | Add a new config key to either store (insert-only) | `key`, type-prefixed `value`, `--epoch` for the epoch store |
+| **UpdateMpcConfig** | 2/3 | Change MPC faulty bound / delta (epoch config) | `--max-faulty-bps`, `--weight-reduction-allowed-delta` |
 | **Upgrade** | 2/3 | Publish a new package version with an explicit version-retirement policy | `--package-path` or `--digest`; required boolean `--exclusive` value; `--digest` with `--exclusive true` additionally requires `--allow-unverified-exclusive` |
 | **EnableVersion** | 2/3 | Re-enable a disabled package version | `version` number |
 | **DisableVersion** | 2/3 | Disable a package version | `version` number (cannot disable active version) |


### PR DESCRIPTION
## Summary

Rust half of the IOP-455 stack, on top of the Move split. The on-chain mirror carries `Hashi.epoch_config`, the node reads epoch keys from the committee's pinned copy and instant keys from the root config, the CLI gains `create update-epoch-config` and `create add-config` (with `--epoch`), the mirror and GC know the two new proposal types, and the e2e config-override driver routes each key by which store holds it.

Rebased from the pre-cut branch onto current main. Three things the fresh cycle changed under it, none flagged by the merge: the `UpgradeV2` proposal arm no longer exists (main renamed the module), the two new `MoveType` impls carried `PACKAGE_VERSION = 2` overrides from the v2 era and now use the trait default of 1 like every other type on the squashed chain, and the proposal-type parsing test expected version 2. All three are back to the v1 baseline. The runbook's proposal table keeps main's single `Upgrade` row with the `--exclusive` semantics and adds the three config rows.

## Tests

Clippy clean across `hashi`, `hashi-types` and `e2e-tests`; the onchain and CLI unit tests; and the three config-store e2e tests (`test_create_update_config_proposal`, `test_mpc_config_defaults_match_rust`, `test_varying_t_and_allowed_delta_across_epochs`) against a fresh v1 boot.

Closes IOP-455.
