### PR TITLE
Enforce coinbase deposit maturity and tracking

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -9,6 +9,7 @@ mod tests {
     use bitcoin::Txid;
 
     use futures::StreamExt;
+    use hashi::deposits::UnapprovedDepositError;
     use hashi::sui_tx_executor::SuiTxExecutor;
     use hashi_types::bitcoin::BitcoinAddress;
     use hashi_types::move_types::ProtocolType;
@@ -266,6 +267,26 @@ mod tests {
         .await
     }
 
+    async fn wait_for_kyoto_height(
+        networks: &TestNetworks,
+        expected_height: u64,
+        timeout: Duration,
+    ) -> Result<()> {
+        let expected_height = i64::try_from(expected_height)?;
+        wait_until(
+            &format!("every synced Kyoto node to reach Bitcoin height {expected_height}"),
+            timeout,
+            || {
+                networks.hashi_network.nodes().iter().all(|node| {
+                    let metrics = &node.hashi().metrics;
+                    metrics.kyoto_synced.get() == 1
+                        && metrics.kyoto_best_height.get() >= expected_height
+                })
+            },
+        )
+        .await
+    }
+
     fn outpoints_with_status(networks: &TestNetworks, status: &str) -> Vec<i64> {
         networks
             .hashi_network
@@ -322,6 +343,37 @@ mod tests {
             },
         )
         .await
+    }
+
+    async fn assert_deposit_requires_confirmations(
+        networks: &TestNetworks,
+        request_id: Address,
+        confirmations: u32,
+        required_confirmations: u32,
+    ) -> Result<()> {
+        let expected = format!("has {confirmations}/{required_confirmations} confirmations");
+        for (index, node) in networks.hashi_network.nodes().iter().enumerate() {
+            let node_hashi = node.hashi();
+            let deposit_request = node_hashi
+                .onchain_state()
+                .deposit_requests()
+                .into_iter()
+                .find(|request| request.id == request_id)
+                .ok_or_else(|| anyhow!("node {index} has no deposit request {request_id}"))?;
+            match node_hashi.validate_deposit_request(&deposit_request).await {
+                Err(UnapprovedDepositError::BitcoinNotConfirmed(error)) => assert!(
+                    error.to_string().contains(&expected),
+                    "node {index} reported an unexpected confirmation error: {error}"
+                ),
+                Err(error) => panic!(
+                    "node {index} returned an unexpected validation error at {confirmations} confirmations: {error}"
+                ),
+                Ok(()) => panic!(
+                    "node {index} accepted the deposit at {confirmations}/{required_confirmations} confirmations"
+                ),
+            }
+        }
+        Ok(())
     }
 
     fn assert_deposit_request_unapproved(networks: &TestNetworks, request_id: Address) {
@@ -577,6 +629,91 @@ mod tests {
         wait_for_deposit_approval(&networks, request_id, Duration::from_secs(120)).await?;
 
         info!("=== Passive Bitcoin Deposit Discovery Test Passed ===");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_coinbase_deposit_waits_for_maturity() -> Result<()> {
+        init_test_logging();
+        info!("=== Starting Coinbase Deposit Maturity Test ===");
+
+        let networks = setup_test_networks(
+            TestNetworksBuilder::new()
+                .with_nodes(4)
+                .with_onchain_config(
+                    "bitcoin_deposit_time_delay_ms",
+                    hashi_types::move_types::ConfigValue::U64(600_000),
+                ),
+        )
+        .await?;
+        let user_key = networks.sui_network.user_keys.first().unwrap().clone();
+        let hbtc_recipient = user_key.public_key().derive_address();
+        let hashi = networks.hashi_network.nodes()[0].hashi().clone();
+        let deposit_address = hashi.get_deposit_address(Some(&hbtc_recipient))?;
+        let rpc = networks.bitcoin_node.rpc_client();
+
+        let block_hashes = rpc
+            .generate_to_address(1, &deposit_address)?
+            .into_model()?
+            .0;
+        let [block_hash] = block_hashes.as_slice() else {
+            return Err(anyhow!(
+                "generate_to_address returned {} blocks instead of one",
+                block_hashes.len()
+            ));
+        };
+        let block = rpc.get_block(*block_hash)?;
+        let coinbase_tx = block
+            .txdata
+            .first()
+            .ok_or_else(|| anyhow!("generated block {block_hash} has no transactions"))?;
+        assert!(
+            coinbase_tx.is_coinbase(),
+            "first transaction in generated block {block_hash} is not coinbase"
+        );
+        let (vout, txout) = coinbase_tx
+            .output
+            .iter()
+            .enumerate()
+            .find(|(_, txout)| txout.script_pubkey == deposit_address.script_pubkey())
+            .ok_or_else(|| {
+                anyhow!(
+                    "coinbase transaction {} has no output for {deposit_address}",
+                    coinbase_tx.compute_txid()
+                )
+            })?;
+        let txid = coinbase_tx.compute_txid();
+        let vout = u32::try_from(vout)?;
+        let amount_sats = txout.value.to_sat();
+
+        let mut executor = SuiTxExecutor::from_config(&hashi.config, hashi.onchain_state())?
+            .with_signer(user_key.into());
+        let request_id = executor
+            .execute_create_deposit_request(
+                txid_to_address(&txid),
+                vout,
+                amount_sats,
+                Some(hbtc_recipient),
+            )
+            .await?;
+        wait_for_deposit_request_mirrored(&networks, request_id, Duration::from_secs(30)).await?;
+
+        networks.bitcoin_node.generate_blocks(5)?;
+        let height = networks.bitcoin_node.get_block_count()?;
+        wait_for_kyoto_height(&networks, height, Duration::from_secs(120)).await?;
+        assert_deposit_requires_confirmations(&networks, request_id, 6, 100).await?;
+
+        networks.bitcoin_node.generate_blocks(93)?;
+        let height = networks.bitcoin_node.get_block_count()?;
+        wait_for_kyoto_height(&networks, height, Duration::from_secs(120)).await?;
+        assert_deposit_requires_confirmations(&networks, request_id, 99, 100).await?;
+
+        networks.bitcoin_node.generate_blocks(1)?;
+        let height = networks.bitcoin_node.get_block_count()?;
+        wait_for_kyoto_height(&networks, height, Duration::from_secs(120)).await?;
+        wait_for_deposit_approval(&networks, request_id, Duration::from_secs(120)).await?;
+
+        info!("=== Coinbase Deposit Maturity Test Passed ===");
         Ok(())
     }
 

--- a/crates/hashi/examples/testnet_monitor.rs
+++ b/crates/hashi/examples/testnet_monitor.rs
@@ -166,11 +166,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 Ok(
                                     hashi::btc_monitor::monitor::DepositConfirmation::InsufficientConfirmations {
                                         confirmations,
+                                        required_confirmations,
                                     },
                                 ) => {
                                     info!(
-                                        "Deposit has {confirmations} confirmations for {}",
-                                        outpoint
+                                        "Deposit has {confirmations}/{required_confirmations} confirmations for {outpoint}"
                                     );
                                 }
                                 Err(e) => {

--- a/crates/hashi/src/btc_monitor/monitor.rs
+++ b/crates/hashi/src/btc_monitor/monitor.rs
@@ -37,6 +37,7 @@ use crate::deposit_tracker::DepositDiscovery;
 use crate::deposit_tracker::DepositStatus;
 use crate::deposit_tracker::DepositTracker;
 use crate::deposit_tracker::DiscoveryResolution;
+use crate::deposit_tracker::effective_deposit_confirmation_threshold;
 use crate::metrics::Metrics;
 
 /// 1 sat/vB expressed as sat/kwu.
@@ -93,7 +94,10 @@ pub enum DepositConfirmation {
     Confirmed(bitcoin::TxOut),
     NotFound,
     InMempool,
-    InsufficientConfirmations { confirmations: u32 },
+    InsufficientConfirmations {
+        confirmations: u32,
+        required_confirmations: u32,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,6 +111,12 @@ enum TxBlockLookup {
     Confirmed(HashCheckpoint),
     InMempool,
     NotFound,
+}
+
+#[derive(serde::Deserialize)]
+struct RawTransactionLocation {
+    #[serde(rename = "blockhash")]
+    block_hash: Option<bitcoin::BlockHash>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1456,13 +1466,22 @@ async fn check_result_from_status(
             txid: outpoint.txid,
             vout: outpoint.vout,
         }),
-        DepositStatus::InBlock { checkpoint, txout } => {
+        DepositStatus::InBlock {
+            checkpoint,
+            is_coinbase,
+            txout,
+        } => {
             let confirmations = tip
                 .height
                 .saturating_add(1)
                 .saturating_sub(checkpoint.height);
-            if confirmations < confirmation_threshold {
-                return Ok(DepositConfirmation::InsufficientConfirmations { confirmations });
+            let required_confirmations =
+                effective_deposit_confirmation_threshold(confirmation_threshold, is_coinbase);
+            if confirmations < required_confirmations {
+                return Ok(DepositConfirmation::InsufficientConfirmations {
+                    confirmations,
+                    required_confirmations,
+                });
             }
             check_unspent_at_tip(
                 bitcoind_rpc,
@@ -1470,7 +1489,7 @@ async fn check_result_from_status(
                 outpoint,
                 txout,
                 confirmations,
-                confirmation_threshold,
+                required_confirmations,
             )
             .await
         }
@@ -1491,7 +1510,13 @@ async fn lookup_tx_block(
     debug!("Looking up block for transaction {txid}");
     require_core_checkpoint(&bitcoind_rpc, tip, "before transaction lookup").await?;
     let tx_info = match btc_rpc_call(&bitcoind_rpc, move |rpc| {
-        rpc.get_raw_transaction_verbose(txid)
+        rpc.call::<RawTransactionLocation>(
+            "getrawtransaction",
+            &[
+                serde_json::Value::String(txid.to_string()),
+                serde_json::Value::Bool(true),
+            ],
+        )
     })
     .await
     {
@@ -1510,9 +1535,6 @@ async fn lookup_tx_block(
             return Err(anyhow::anyhow!("Failed to look up txid {txid}: {e}").into());
         }
     };
-    let tx_info = tx_info
-        .into_model()
-        .map_err(|e| anyhow::anyhow!("Failed to parse transaction info for {txid}: {e}"))?;
     let Some(block_hash) = tx_info.block_hash else {
         require_core_checkpoint(&bitcoind_rpc, tip, "after transaction lookup").await?;
         return Ok(TxBlockLookup::InMempool);
@@ -1638,6 +1660,7 @@ async fn discover_deposit(
         deposit_lookup_cache.put_transaction(txid, transaction.clone());
         transaction
     };
+    let is_coinbase = transaction.is_coinbase();
 
     let Some(txout) = transaction.output.get(outpoint.vout as usize) else {
         return Ok(DepositStatus::InvalidVout {
@@ -1646,6 +1669,7 @@ async fn discover_deposit(
     };
     Ok(DepositStatus::InBlock {
         checkpoint: block_info,
+        is_coinbase,
         txout: txout.clone(),
     })
 }
@@ -1728,7 +1752,7 @@ async fn check_unspent_at_tip(
     outpoint: bitcoin::OutPoint,
     txout: bitcoin::TxOut,
     confirmations: u32,
-    confirmation_threshold: u32,
+    required_confirmations: u32,
 ) -> Result<DepositConfirmation, DepositConfirmError> {
     // Always make this check fresh; neither successful nor spent results clear
     // the tracker's independently established InBlock observation.
@@ -1773,7 +1797,7 @@ async fn check_unspent_at_tip(
                 .into());
             }
             info!(
-                "Deposit {}:{} confirmed with {confirmations}/{confirmation_threshold} confirmations",
+                "Deposit {}:{} confirmed with {confirmations}/{required_confirmations} confirmations",
                 outpoint.txid, outpoint.vout,
             );
             Ok(DepositConfirmation::Confirmed(txout))
@@ -2463,6 +2487,7 @@ mod tests {
             &outpoint,
             DepositStatus::InBlock {
                 checkpoint: block_info,
+                is_coinbase: false,
                 txout: bitcoin::TxOut {
                     value: bitcoin::Amount::from_sat(1),
                     script_pubkey: bitcoin::ScriptBuf::new(),
@@ -2496,7 +2521,10 @@ mod tests {
 
         assert_eq!(
             result_rxs.remove(0).await.unwrap().unwrap(),
-            DepositConfirmation::InsufficientConfirmations { confirmations: 9 }
+            DepositConfirmation::InsufficientConfirmations {
+                confirmations: 9,
+                required_confirmations: 100,
+            }
         );
         assert_eq!(
             result_rxs.remove(0).await.unwrap().unwrap(),
@@ -2504,6 +2532,37 @@ mod tests {
         );
         assert_eq!(cache_requests(&metrics, "tx_block", "hit"), 0);
         assert_eq!(cache_requests(&metrics, "tx_block", "miss"), 0);
+    }
+
+    #[tokio::test]
+    async fn coinbase_deposit_check_reports_maturity_requirement() {
+        let outpoint = make_outpoint(1);
+        let result = check_result_from_status(
+            DepositStatus::InBlock {
+                checkpoint: HashCheckpoint::new(42, block_hash(2)),
+                is_coinbase: true,
+                txout: bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(1),
+                    script_pubkey: bitcoin::ScriptBuf::new(),
+                },
+            },
+            HashCheckpoint::new(140, block_hash(3)),
+            6,
+            Arc::new(corepc_client::client_sync::v29::Client::new(
+                "http://127.0.0.1:1",
+            )),
+            outpoint,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result,
+            DepositConfirmation::InsufficientConfirmations {
+                confirmations: 99,
+                required_confirmations: 100,
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/hashi/src/deposit_tracker.rs
+++ b/crates/hashi/src/deposit_tracker.rs
@@ -19,6 +19,7 @@ pub(crate) enum DepositStatus {
     InMempool,
     InBlock {
         checkpoint: kyoto::HashCheckpoint,
+        is_coinbase: bool,
         txout: bitcoin::TxOut,
     },
     InvalidVout {
@@ -380,8 +381,13 @@ impl DepositTracker {
             .values()
             .filter(|entry| match &entry.status {
                 DepositStatus::Unchecked => true,
-                DepositStatus::InBlock { checkpoint, .. } => tip_height.is_some_and(|tip_height| {
-                    confirmations(checkpoint.height, tip_height) >= threshold
+                DepositStatus::InBlock {
+                    checkpoint,
+                    is_coinbase,
+                    ..
+                } => tip_height.is_some_and(|tip_height| {
+                    confirmations(checkpoint.height, tip_height)
+                        >= effective_deposit_confirmation_threshold(threshold, *is_coinbase)
                 }),
                 DepositStatus::NotFound
                 | DepositStatus::InMempool
@@ -418,11 +424,13 @@ impl TrackerState {
             let Some(outpoints) = self.scan_candidates_by_txid.get(txid).cloned() else {
                 continue;
             };
+            let is_coinbase = transaction.is_coinbase();
             for outpoint in outpoints {
                 let status = transaction.output.get(outpoint.vout as usize).map_or(
                     DepositStatus::InvalidVout { checkpoint },
                     |txout| DepositStatus::InBlock {
                         checkpoint,
+                        is_coinbase,
                         txout: txout.clone(),
                     },
                 );
@@ -505,6 +513,19 @@ impl TrackerState {
         if old_status == status {
             return false;
         }
+        if matches!(
+            &status,
+            DepositStatus::InBlock {
+                is_coinbase: true,
+                ..
+            }
+        ) && let Some(metrics) = &self.metrics
+        {
+            metrics
+                .coinbase_deposit_observations_total
+                .with_label_values(&[&outpoint.to_string()])
+                .inc();
+        }
         self.adjust_metric(&old_status, -1);
         self.adjust_metric(&status, 1);
         match (is_scan_candidate(&old_status), is_scan_candidate(&status)) {
@@ -569,6 +590,14 @@ fn in_block_bucket(block_height: u32, tip_height: u32) -> usize {
 
 fn confirmations(block_height: u32, tip_height: u32) -> u32 {
     tip_height.saturating_add(1).saturating_sub(block_height)
+}
+
+pub(crate) fn effective_deposit_confirmation_threshold(configured: u32, is_coinbase: bool) -> u32 {
+    if is_coinbase {
+        configured.max(bitcoin::constants::COINBASE_MATURITY)
+    } else {
+        configured
+    }
 }
 
 #[cfg(test)]
@@ -701,6 +730,36 @@ mod tests {
     }
 
     #[test]
+    fn effective_deposit_confirmation_threshold_respects_coinbase_maturity() {
+        assert_eq!(effective_deposit_confirmation_threshold(6, false), 6);
+        assert_eq!(effective_deposit_confirmation_threshold(6, true), 100);
+        assert_eq!(effective_deposit_confirmation_threshold(144, true), 144);
+    }
+
+    #[test]
+    fn coinbase_request_becomes_actionable_at_maturity() {
+        let (tracker, _) = tracker();
+        let tracked = outpoint(1);
+        tracker.upsert_request(request(1), tracked);
+        let token = start_discovery(&tracker, &tracked);
+        record_discovery(
+            &tracker,
+            token,
+            DepositStatus::InBlock {
+                checkpoint: checkpoint(10, 1),
+                is_coinbase: true,
+                txout: txout(),
+            },
+        );
+
+        tracker.set_tip(checkpoint(108, 2));
+        assert!(tracker.actionable_requests(6).is_empty());
+
+        tracker.set_tip(checkpoint(109, 3));
+        assert_eq!(tracker.actionable_requests(6), HashSet::from([request(1)]));
+    }
+
+    #[test]
     fn passive_and_underconfirmed_requests_are_not_actionable() {
         let (tracker, _) = tracker();
         for seed in 1..=4 {
@@ -711,6 +770,7 @@ mod tests {
             DepositStatus::InMempool,
             DepositStatus::InBlock {
                 checkpoint: checkpoint(10, 1),
+                is_coinbase: false,
                 txout: txout(),
             },
         ];
@@ -725,7 +785,7 @@ mod tests {
 
     #[test]
     fn block_scan_promotes_passive_statuses_without_overwriting_terminal_statuses() {
-        let (tracker, _) = tracker();
+        let (tracker, metrics) = tracker();
         let block = bitcoin::blockdata::constants::genesis_block(bitcoin::Network::Bitcoin);
         let block_outpoint = bitcoin::OutPoint::new(block.txdata[0].compute_txid(), 0);
         tracker.upsert_request(request(1), block_outpoint);
@@ -733,6 +793,10 @@ mod tests {
         record_discovery(&tracker, token, DepositStatus::NotFound);
         let mut work = tracker.subscribe_work();
         let block_checkpoint = kyoto::HashCheckpoint::new(0, block.block_hash());
+        let outpoint_label = block_outpoint.to_string();
+        let coinbase_observations = metrics
+            .coinbase_deposit_observations_total
+            .with_label_values(&[&outpoint_label]);
 
         tracker.apply_block_if_current(tracker.bitcoin_generation(), block_checkpoint, &block);
         assert!(work.has_changed().unwrap());
@@ -741,11 +805,14 @@ mod tests {
             tracker.status(&block_outpoint),
             Some(DepositStatus::InBlock {
                 checkpoint: block_checkpoint,
+                is_coinbase: true,
                 txout: block.txdata[0].output[0].clone(),
             })
         );
+        assert_eq!(coinbase_observations.get(), 1);
         tracker.apply_block_if_current(tracker.bitcoin_generation(), block_checkpoint, &block);
         assert!(!work.has_changed().unwrap());
+        assert_eq!(coinbase_observations.get(), 1);
     }
 
     #[test]
@@ -870,6 +937,7 @@ mod tests {
                 token,
                 DepositStatus::InBlock {
                     checkpoint: block,
+                    is_coinbase: false,
                     txout: txout(),
                 },
             );
@@ -895,6 +963,7 @@ mod tests {
             token,
             DepositStatus::InBlock {
                 checkpoint: checkpoint(10, 1),
+                is_coinbase: false,
                 txout: txout(),
             },
         );

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -176,9 +176,12 @@ impl Hashi {
                     outpoint.txid
                 )));
             }
-            Ok(DepositConfirmation::InsufficientConfirmations { confirmations }) => {
+            Ok(DepositConfirmation::InsufficientConfirmations {
+                confirmations,
+                required_confirmations,
+            }) => {
                 return Err(UnapprovedDepositError::BitcoinNotConfirmed(anyhow!(
-                    "transaction {} has {confirmations}/{confirmation_threshold} confirmations",
+                    "transaction {} has {confirmations}/{required_confirmations} confirmations",
                     outpoint.txid
                 )));
             }

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -120,6 +120,7 @@ pub struct Metrics {
     /// metrics still look alive.
     task_last_iteration_timestamp_seconds: IntGaugeVec,
 
+    pub(crate) coinbase_deposit_observations_total: IntCounterVec,
     pub deposits_confirmed_total: IntCounter,
     pub deposits_rejected_utxo_spent: IntCounter,
     pub deposit_lookup_cache_requests_total: IntCounterVec,
@@ -802,6 +803,13 @@ impl Metrics {
                 "hashi_task_last_iteration_timestamp_seconds",
                 "unix seconds of each task loop's last iteration; stale = task wedged",
                 &["task"],
+                registry,
+            )
+            .unwrap(),
+            coinbase_deposit_observations_total: register_int_counter_vec_with_registry!(
+                "hashi_coinbase_deposit_observations_total",
+                "Total times a tracked deposit outpoint was classified as a coinbase output, labeled by Bitcoin outpoint",
+                &["outpoint"],
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
- Enforces Bitcoin’s 100-confirmation maturity requirement for coinbase deposits while preserving the configured threshold for ordinary deposits.
 - Applies the effective threshold consistently during scheduling and final validation, with accurate current/required confirmation errors and logs.
 - Tracks observed coinbase deposits with an outpoint-labeled Prometheus metric.
 - Adds focused unit and regtest coverage for the 99/100 boundary and confirms ordinary deposit behavior remains unchanged.
 - Linear ticket: https://linear.app/mysten-labs/issue/SEC-545/hashi-reject-immature-bitcoin-coinbase-deposits