### PR TITLE
launch, node: refuse a Sui chain / Bitcoin chain pairing the protocol never deploys

### DIFF
--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -1757,6 +1757,14 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
         deposit_time_delay_ms: opts.bitcoin_deposit_time_delay_ms,
     };
 
+    // The chain the launch lands on, from the fullnode itself (the RPC URL
+    // defaults to mainnet). Refuse a Bitcoin chain the protocol never pairs
+    // with it here, before the UpgradeCap lookup and the confirmation
+    // prompt; the builder's own check only runs after the operator answers.
+    let sui_chain_id = crate::sui_rpc_client::fetch_sui_chain_id(&mut client).await?;
+    print_info(&format!("Sui chain ID: {sui_chain_id}"));
+    crate::constants::check_sui_bitcoin_chain_pairing(&sui_chain_id, &bitcoin_chain_id)?;
+
     // Resolve the sender (the UpgradeCap owner): a local keypair, or an
     // explicit --sender for the serialize-unsigned (multisig) path.
     let signer = opts
@@ -1798,6 +1806,7 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
             &ids,
             upgrade_cap_id,
             &bitcoin_chain_id,
+            &sui_chain_id,
             &guardian,
             &bitcoin_overrides,
         )
@@ -1843,6 +1852,7 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
         &ids,
         upgrade_cap_id,
         &bitcoin_chain_id,
+        &sui_chain_id,
         &guardian,
         &bitcoin_overrides,
     )
@@ -1896,8 +1906,14 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
     // In serialize mode keep stdout clean (base64 only); notes go to stderr.
     set_notes_to_stderr(opts.serialize_unsigned);
 
-    // Load the validator config
+    // Load the validator config and refuse a chain pairing the protocol
+    // never deploys. The config's Sui chain ID is confirmed against the RPC
+    // below, as the node does at startup.
     let config = crate::config::Config::load(&opts.config)?;
+    crate::constants::check_sui_bitcoin_chain_pairing(
+        config.sui_chain_id(),
+        config.bitcoin_chain_id(),
+    )?;
 
     // Resolve Sui RPC URL: CLI flag > config file
     let sui_rpc_url = opts
@@ -1917,6 +1933,14 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
     print_info(&format!("Validator address: {validator_address}"));
     print_info(&format!("Sui RPC: {sui_rpc_url}"));
 
+    let mut client = crate::sui_rpc_client::new_sui_rpc_client(&sui_rpc_url)?;
+    let rpc_chain_id = crate::sui_rpc_client::fetch_sui_chain_id(&mut client).await?;
+    anyhow::ensure!(
+        rpc_chain_id == config.sui_chain_id(),
+        "Sui chain ID mismatch: config has {}, but RPC endpoint reports {rpc_chain_id}",
+        config.sui_chain_id()
+    );
+
     // Every `validator::*` entry gates on the CALLED package's
     // `assert_version_enabled`, so the calls must target a live package.
     // `hashi_ids.package_id` is the original publish id, whose entries abort
@@ -1930,8 +1954,6 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
         // Build the transaction without executing: print it as base64
         // (serialize) or report the simulated gas estimate (dry-run).
         // No private key is required for either path.
-        let mut client = crate::sui_rpc_client::new_sui_rpc_client(&sui_rpc_url)?;
-
         print_info("Building registration transaction ...");
         let transaction = crate::sui_tx_executor::build_register_or_update_validator_tx(
             &mut client,
@@ -1977,7 +1999,6 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
         }
     }
 
-    let mut client = crate::sui_rpc_client::new_sui_rpc_client(&sui_rpc_url)?;
     let signer = config.operator_private_key()?;
     let sender = signer.verifying_key().derive_address();
 

--- a/crates/hashi/src/constants.rs
+++ b/crates/hashi/src/constants.rs
@@ -49,6 +49,47 @@ pub fn is_production_sui_chain(chain_id: &str) -> bool {
     chain_id == SUI_MAINNET_CHAIN_ID || chain_id == SUI_TESTNET_CHAIN_ID
 }
 
+/// Refuse a Sui chain / Bitcoin chain pairing the protocol never deploys:
+/// Bitcoin mainnet if and only if Sui mainnet. On Sui mainnet anything but
+/// Bitcoin mainnet would mint a real `hashi::btc` against free signet or
+/// regtest deposits; on any other Sui network Bitcoin mainnet would lock real
+/// Bitcoin behind a non-mainnet package (SEC-510, audit D-13).
+///
+/// Move cannot enforce this (`finish_publish` stores whichever id it is
+/// handed and the Sui framework exposes no chain identifier to Move), so it
+/// runs in every Rust path that produces or consumes the pair. The Bitcoin
+/// side is decided by the network the hash resolves to, as every consumer of
+/// the id does, not by string equality, so letter case cannot dodge it. An
+/// empty or unrecognised id fails closed.
+pub fn check_sui_bitcoin_chain_pairing(
+    sui_chain_id: &str,
+    bitcoin_chain_id: &str,
+) -> anyhow::Result<()> {
+    use crate::btc_monitor::config::Network;
+    use crate::btc_monitor::config::network_from_chain_id;
+
+    anyhow::ensure!(
+        !sui_chain_id.is_empty(),
+        "Sui chain ID is empty; refusing to pair it with Bitcoin chain {bitcoin_chain_id}"
+    );
+    let network = network_from_chain_id(bitcoin_chain_id)
+        .ok_or_else(|| anyhow::anyhow!("unrecognized bitcoin chain id: {bitcoin_chain_id}"))?;
+    let sui_is_mainnet = sui_chain_id == SUI_MAINNET_CHAIN_ID;
+    let bitcoin_is_mainnet = network == Network::Bitcoin;
+    anyhow::ensure!(
+        !sui_is_mainnet || bitcoin_is_mainnet,
+        "refusing Bitcoin {network:?} ({bitcoin_chain_id}) on Sui mainnet: \
+         Sui mainnet requires Bitcoin mainnet"
+    );
+    anyhow::ensure!(
+        !bitcoin_is_mainnet || sui_is_mainnet,
+        "refusing Bitcoin mainnet ({bitcoin_chain_id}) on Sui chain {sui_chain_id}: \
+         Bitcoin mainnet is allowed on Sui mainnet only; every other Sui network \
+         needs a non-mainnet bitcoin_chain_id, which defaults to mainnet when unset"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hashi/src/constants.rs
+++ b/crates/hashi/src/constants.rs
@@ -76,18 +76,18 @@ pub fn check_sui_bitcoin_chain_pairing(
         .ok_or_else(|| anyhow::anyhow!("unrecognized bitcoin chain id: {bitcoin_chain_id}"))?;
     let sui_is_mainnet = sui_chain_id == SUI_MAINNET_CHAIN_ID;
     let bitcoin_is_mainnet = network == Network::Bitcoin;
-    anyhow::ensure!(
-        !sui_is_mainnet || bitcoin_is_mainnet,
-        "refusing Bitcoin {network:?} ({bitcoin_chain_id}) on Sui mainnet: \
-         Sui mainnet requires Bitcoin mainnet"
-    );
-    anyhow::ensure!(
-        !bitcoin_is_mainnet || sui_is_mainnet,
-        "refusing Bitcoin mainnet ({bitcoin_chain_id}) on Sui chain {sui_chain_id}: \
-         Bitcoin mainnet is allowed on Sui mainnet only; every other Sui network \
-         needs a non-mainnet bitcoin_chain_id, which defaults to mainnet when unset"
-    );
-    Ok(())
+    match (sui_is_mainnet, bitcoin_is_mainnet) {
+        (true, true) | (false, false) => Ok(()),
+        (true, false) => anyhow::bail!(
+            "refusing Bitcoin {network:?} ({bitcoin_chain_id}) on Sui mainnet: \
+             Sui mainnet requires Bitcoin mainnet"
+        ),
+        (false, true) => anyhow::bail!(
+            "refusing Bitcoin mainnet ({bitcoin_chain_id}) on Sui chain {sui_chain_id}: \
+             Bitcoin mainnet is allowed on Sui mainnet only; every other Sui network \
+             needs a non-mainnet bitcoin_chain_id, which defaults to mainnet when unset"
+        ),
+    }
 }
 
 #[cfg(test)]

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -691,6 +691,22 @@ impl Hashi {
         Ok(())
     }
 
+    /// Refuse to run on a Sui chain / Bitcoin chain pairing the protocol
+    /// never deploys (`constants::check_sui_bitcoin_chain_pairing`). Reads
+    /// only the local config (whose `sui_chain_id` `verify_sui_chain_id` has
+    /// just confirmed against the RPC) and no on-chain state, so it runs on
+    /// every boot including the pre-launch key-registration boots.
+    /// Deliberately separate from `verify_bitcoin_chain_id`, which skips
+    /// before the launch tx: this is the check that keeps a signet-configured
+    /// node from ever joining a mainnet committee.
+    pub fn verify_chain_pairing(&self) -> anyhow::Result<()> {
+        let sui_chain_id = self.config.sui_chain_id();
+        let bitcoin_chain_id = self.config.bitcoin_chain_id();
+        constants::check_sui_bitcoin_chain_pairing(sui_chain_id, bitcoin_chain_id)?;
+        tracing::info!("Sui/Bitcoin chain pairing verified: {sui_chain_id} / {bitcoin_chain_id}");
+        Ok(())
+    }
+
     /// Verify the local config's `bitcoin_chain_id` matches the value stored on-chain.
     ///
     /// Before the launch tx (`finish_publish`) the value does not exist
@@ -808,8 +824,10 @@ impl Hashi {
             .set(screener)
             .map_err(|_| anyhow!("Screener client already initialized"))?;
 
-        // Verify Sui RPC is on the expected chain before loading any state.
+        // Verify Sui RPC is on the expected chain before loading any state,
+        // then that the chain pair is one the protocol deploys.
         self.verify_sui_chain_id().await?;
+        self.verify_chain_pairing()?;
 
         // Initialize on-chain state first so we can read guardian config from it.
         let onchain_service = self.initialize_onchain_state().await?;

--- a/crates/hashi/src/publish.rs
+++ b/crates/hashi/src/publish.rs
@@ -217,12 +217,19 @@ pub async fn publish_package(
 /// Build the unsigned `hashi::finish_publish` transaction (the launch
 /// switch). Exposed separately from [`finish_publish`] for offline /
 /// multisig signing.
+///
+/// `sui_chain_id` is the chain the transaction will land on, as reported by
+/// the fullnode (`sui_rpc_client::fetch_sui_chain_id`); the builder refuses a
+/// Bitcoin chain that the protocol never pairs with it
+/// (`constants::check_sui_bitcoin_chain_pairing`) before touching the network.
+#[allow(clippy::too_many_arguments)]
 pub async fn build_finish_publish_tx(
     client: &mut Client,
     sender: Address,
     ids: &HashiIds,
     upgrade_cap_id: Address,
     bitcoin_chain_id: &str,
+    sui_chain_id: &str,
     guardian: &GuardianConfig,
     bitcoin_overrides: &BitcoinConfigOverrides,
 ) -> Result<sui_sdk_types::Transaction> {
@@ -231,6 +238,7 @@ pub async fn build_finish_publish_tx(
         network_from_chain_id(bitcoin_chain_id).is_some(),
         "unrecognized bitcoin chain id: {bitcoin_chain_id}"
     );
+    crate::constants::check_sui_bitcoin_chain_pairing(sui_chain_id, bitcoin_chain_id)?;
     let block_hash = BlockHash::from_str(bitcoin_chain_id)?;
     let bitcoin_chain_id_addr = Address::new(*block_hash.as_byte_array());
 
@@ -291,12 +299,14 @@ pub async fn finish_publish(
     bitcoin_overrides: &BitcoinConfigOverrides,
 ) -> Result<()> {
     let sender = signer.verifying_key().derive_address();
+    let sui_chain_id = crate::sui_rpc_client::fetch_sui_chain_id(client).await?;
     let transaction = build_finish_publish_tx(
         client,
         sender,
         ids,
         upgrade_cap_id,
         bitcoin_chain_id,
+        &sui_chain_id,
         guardian,
         bitcoin_overrides,
     )

--- a/crates/hashi/src/sui_rpc_client.rs
+++ b/crates/hashi/src/sui_rpc_client.rs
@@ -16,6 +16,25 @@ fn new_client_with_deadline(
     Ok(sui_rpc::Client::new(url)?.request_layer(tower::timeout::TimeoutLayer::new(deadline)))
 }
 
+/// The chain id (genesis checkpoint digest) the fullnode behind `client`
+/// reports. Fails closed on an empty answer: the accessor returns `""` when
+/// the field is absent, and an empty id must never pass as "not mainnet".
+pub async fn fetch_sui_chain_id(client: &mut sui_rpc::Client) -> anyhow::Result<String> {
+    use sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest;
+
+    let service_info = client
+        .ledger_client()
+        .get_service_info(GetServiceInfoRequest::default())
+        .await?
+        .into_inner();
+    let chain_id = service_info.chain_id();
+    anyhow::ensure!(
+        !chain_id.is_empty(),
+        "Sui RPC endpoint reported an empty chain ID"
+    );
+    Ok(chain_id.to_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hashi/tests/chain_pairing_tests.rs
+++ b/crates/hashi/tests/chain_pairing_tests.rs
@@ -1,0 +1,238 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The Sui chain / Bitcoin chain pairing rule (SEC-510, audit D-13): Bitcoin
+//! mainnet if and only if Sui mainnet. Enforced by the launch transaction
+//! builder before any network I/O, and by the node from its local config at
+//! startup.
+
+use std::time::Duration;
+
+use hashi::Hashi;
+use hashi::ServerVersion;
+use hashi::config::Config;
+use hashi::config::HashiIds;
+use hashi::constants::BITCOIN_MAINNET_CHAIN_ID;
+use hashi::constants::BITCOIN_REGTEST_CHAIN_ID;
+use hashi::constants::BITCOIN_SIGNET_CHAIN_ID;
+use hashi::constants::BITCOIN_TESTNET4_CHAIN_ID;
+use hashi::constants::SUI_MAINNET_CHAIN_ID;
+use hashi::constants::SUI_TESTNET_CHAIN_ID;
+use hashi::constants::check_sui_bitcoin_chain_pairing;
+use hashi::publish::BitcoinConfigOverrides;
+use hashi::publish::GuardianConfig;
+use hashi::publish::build_finish_publish_tx;
+use sui_sdk_types::Address;
+
+/// Stands in for a localnet or devnet genesis digest.
+const SUI_LOCALNET_CHAIN_ID: &str = "8ipsdC3P9bE1oVsr9cpzFRBcV1ZmvPzMwqFwEiwLCbfw";
+
+const NON_MAINNET_BITCOIN: [&str; 3] = [
+    BITCOIN_SIGNET_CHAIN_ID,
+    BITCOIN_TESTNET4_CHAIN_ID,
+    BITCOIN_REGTEST_CHAIN_ID,
+];
+const NON_MAINNET_SUI: [&str; 2] = [SUI_TESTNET_CHAIN_ID, SUI_LOCALNET_CHAIN_ID];
+
+#[test]
+fn bitcoin_mainnet_pairs_with_sui_mainnet_only() {
+    check_sui_bitcoin_chain_pairing(SUI_MAINNET_CHAIN_ID, BITCOIN_MAINNET_CHAIN_ID).unwrap();
+    for sui in NON_MAINNET_SUI {
+        let err = check_sui_bitcoin_chain_pairing(sui, BITCOIN_MAINNET_CHAIN_ID).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Bitcoin mainnet is allowed on Sui mainnet only"),
+            "{sui}: {err}"
+        );
+    }
+}
+
+#[test]
+fn sui_mainnet_requires_bitcoin_mainnet() {
+    for btc in NON_MAINNET_BITCOIN {
+        let err = check_sui_bitcoin_chain_pairing(SUI_MAINNET_CHAIN_ID, btc).unwrap_err();
+        assert!(
+            err.to_string().contains("Sui mainnet requires"),
+            "{btc}: {err}"
+        );
+    }
+}
+
+#[test]
+fn non_mainnet_sui_pairs_with_any_non_mainnet_bitcoin_chain() {
+    for sui in NON_MAINNET_SUI {
+        for btc in NON_MAINNET_BITCOIN {
+            check_sui_bitcoin_chain_pairing(sui, btc).unwrap();
+        }
+    }
+}
+
+/// The Bitcoin side is decided by the network the hash resolves to, as every
+/// consumer of the id does, so letter case cannot dodge the rule.
+#[test]
+fn an_uppercase_mainnet_hash_is_still_bitcoin_mainnet() {
+    let upper = BITCOIN_MAINNET_CHAIN_ID.to_uppercase();
+    let err = check_sui_bitcoin_chain_pairing(SUI_TESTNET_CHAIN_ID, &upper).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Bitcoin mainnet is allowed on Sui mainnet only"),
+        "{err}"
+    );
+    check_sui_bitcoin_chain_pairing(SUI_MAINNET_CHAIN_ID, &upper).unwrap();
+}
+
+#[test]
+fn an_unrecognised_bitcoin_chain_id_fails_closed() {
+    for sui in [SUI_MAINNET_CHAIN_ID, SUI_TESTNET_CHAIN_ID] {
+        let err = check_sui_bitcoin_chain_pairing(sui, "not-a-genesis-hash").unwrap_err();
+        assert!(
+            err.to_string().contains("unrecognized bitcoin chain id"),
+            "{sui}: {err}"
+        );
+    }
+}
+
+#[test]
+fn an_empty_sui_chain_id_fails_closed() {
+    for btc in [BITCOIN_MAINNET_CHAIN_ID, BITCOIN_SIGNET_CHAIN_ID] {
+        let err = check_sui_bitcoin_chain_pairing("", btc).unwrap_err();
+        assert!(err.to_string().contains("empty"), "{btc}: {err}");
+    }
+}
+
+/// The builder's only RPC is the final `build`, so a lazily connected client
+/// to a closed port is never used when the pairing is refused.
+async fn try_build_launch_tx(bitcoin_chain_id: &str, sui_chain_id: &str) -> anyhow::Result<()> {
+    let mut client = sui_rpc::Client::new("http://127.0.0.1:1")?;
+    let ids = HashiIds {
+        package_id: Address::ZERO,
+        hashi_object_id: Address::ZERO,
+    };
+    let guardian = GuardianConfig {
+        url: "http://guardian.invalid".to_owned(),
+        btc_public_key: vec![0; 32],
+    };
+    build_finish_publish_tx(
+        &mut client,
+        Address::ZERO,
+        &ids,
+        Address::ZERO,
+        bitcoin_chain_id,
+        sui_chain_id,
+        &guardian,
+        &BitcoinConfigOverrides::default(),
+    )
+    .await
+    .map(|_| ())
+}
+
+#[tokio::test]
+async fn launch_tx_refuses_signet_bitcoin_on_sui_mainnet() {
+    let err = try_build_launch_tx(BITCOIN_SIGNET_CHAIN_ID, SUI_MAINNET_CHAIN_ID)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("Sui mainnet requires"), "{err}");
+}
+
+#[tokio::test]
+async fn launch_tx_refuses_mainnet_bitcoin_on_sui_testnet() {
+    let err = try_build_launch_tx(BITCOIN_MAINNET_CHAIN_ID, SUI_TESTNET_CHAIN_ID)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Bitcoin mainnet is allowed on Sui mainnet only"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn launch_tx_still_refuses_an_unknown_bitcoin_chain_first() {
+    let err = try_build_launch_tx("not-a-genesis-hash", SUI_MAINNET_CHAIN_ID)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("unrecognized bitcoin chain id"),
+        "{err}"
+    );
+}
+
+/// A permitted pair gets past the check and on to the network: the only
+/// error left is the closed port.
+#[tokio::test]
+async fn launch_tx_with_a_permitted_pair_reaches_the_network() {
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        try_build_launch_tx(BITCOIN_REGTEST_CHAIN_ID, SUI_LOCALNET_CHAIN_ID),
+    )
+    .await
+    .expect("a closed loopback port refuses immediately");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        !err.contains("refusing") && !err.contains("requires"),
+        "pairing check fired on a permitted pair: {err}"
+    );
+}
+
+fn node_with(
+    sui_chain_id: Option<&str>,
+    bitcoin_chain_id: Option<&str>,
+) -> (std::sync::Arc<Hashi>, tempfile::TempDir) {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let mut config = Config::new_for_testing();
+    config.db = Some(tmpdir.path().into());
+    config.sui_chain_id = sui_chain_id.map(str::to_owned);
+    config.bitcoin_chain_id = bitcoin_chain_id.map(str::to_owned);
+    let hashi = Hashi::new_with_registry(
+        ServerVersion::new("test", "test"),
+        None,
+        config,
+        &prometheus::Registry::new(),
+    )
+    .unwrap();
+    (hashi, tmpdir)
+}
+
+#[test]
+fn node_refuses_signet_bitcoin_on_sui_mainnet() {
+    let (hashi, _dir) = node_with(Some(SUI_MAINNET_CHAIN_ID), Some(BITCOIN_SIGNET_CHAIN_ID));
+    let err = hashi.verify_chain_pairing().unwrap_err();
+    assert!(err.to_string().contains("Sui mainnet requires"), "{err}");
+}
+
+#[test]
+fn node_refuses_mainnet_bitcoin_on_sui_testnet() {
+    let (hashi, _dir) = node_with(Some(SUI_TESTNET_CHAIN_ID), Some(BITCOIN_MAINNET_CHAIN_ID));
+    let err = hashi.verify_chain_pairing().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Bitcoin mainnet is allowed on Sui mainnet only"),
+        "{err}"
+    );
+}
+
+/// Both config keys default to mainnet, so a Sui testnet config that omits
+/// `bitcoin_chain_id` presents as testnet plus Bitcoin mainnet and is refused
+/// at boot instead of later against bitcoind.
+#[test]
+fn node_on_sui_testnet_must_set_a_non_mainnet_bitcoin_chain_id() {
+    let (hashi, _dir) = node_with(Some(SUI_TESTNET_CHAIN_ID), None);
+    let err = hashi.verify_chain_pairing().unwrap_err();
+    assert!(
+        err.to_string().contains("defaults to mainnet when unset"),
+        "{err}"
+    );
+}
+
+#[test]
+fn node_accepts_the_deployed_pairs() {
+    for (sui, btc) in [
+        (None, None),
+        (Some(SUI_MAINNET_CHAIN_ID), Some(BITCOIN_MAINNET_CHAIN_ID)),
+        (Some(SUI_TESTNET_CHAIN_ID), Some(BITCOIN_SIGNET_CHAIN_ID)),
+        (Some(SUI_LOCALNET_CHAIN_ID), Some(BITCOIN_REGTEST_CHAIN_ID)),
+    ] {
+        let (hashi, _dir) = node_with(sui, btc);
+        hashi.verify_chain_pairing().unwrap();
+    }
+}

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -95,6 +95,8 @@ For the protocol behavior behind these operations, see [Committee](committee.mdx
 
 Hashi is network-specific: the Sui chain, the Bitcoin chain, and their endpoints all differ per deployment. The runbook's examples use **Testnet** (Sui Testnet + Bitcoin Signet); for any other network, substitute the values from this table. Adding a network later is just a matter of filling in a column here.
 
+The pairing is enforced, not just documented: Bitcoin mainnet goes with Sui mainnet and nothing else. `hashi launch` refuses to build the launch transaction when its `--bitcoin-chain-id` does not match the chain the fullnode reports under that rule, and a node refuses to start (as does `hashi register`) when the validator config's `bitcoin-chain-id` is mainnet on any other Sui network or is not mainnet on Sui mainnet.
+
 | Parameter | Testnet (current) | Mainnet |
 |-----------|-------------------|---------|
 | Sui network | Testnet | Mainnet |
@@ -1134,6 +1136,14 @@ thread 'main' panicked at ...: called `Option::unwrap()` on a `None` value
 sui-rpc = "https://fullnode.testnet.sui.io:443"
 bitcoin-chain-id = "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6"  # signet genesis
 ```
+
+---
+
+**Symptom:** startup fails with `refusing Bitcoin mainnet (...) on Sui chain ...: Bitcoin mainnet is allowed on Sui mainnet only ...` or `refusing Bitcoin Signet (...) on Sui mainnet: Sui mainnet requires Bitcoin mainnet`.
+
+**Likely cause:** the validator config pairs a Sui network with the wrong Bitcoin network. On Sui Testnet the usual case is a missing `bitcoin-chain-id`, which defaults to Bitcoin mainnet. `hashi register` reports the same error for the same config.
+
+**Fix:** set `bitcoin-chain-id` to the genesis hash from the [Networks](#networks) table for your Sui network.
 
 ---
 


### PR DESCRIPTION
## Summary

Audit finding SEC-510 (D-13, launch blocker). The four Bitcoin values in the deploy workflow travel as a matched set, and every launch-time and startup validation was an internal consistency check: `publish.rs` only asserted that the Bitcoin chain id was one of the four known networks, and Move `finish_publish` stores whatever it is handed. Pointing the deploy at Sui mainnet with the Bitcoin values still on signet would mint a real `hashi::btc` coin against free signet deposits.

Move cannot enforce the pairing (the Sui framework exposes no chain identifier to Move), so this enforces it in every Rust path that produces or consumes the pair.

## Rule

`constants::check_sui_bitcoin_chain_pairing`: Bitcoin mainnet if and only if Sui mainnet. Sui testnet, devnet and localnet must pair with a non-mainnet Bitcoin chain. This is stricter than the ticket's wording ("refuse mainnet BTC on a non-production Sui chain"), which maps onto `is_production_sui_chain` and would have allowed Sui testnet plus Bitcoin mainnet; no deployment or runbook pairs testnet with real BTC.

The Bitcoin side is decided by the network the hash resolves to (`network_from_chain_id`), as every consumer of the id does, not by string equality, so letter case cannot dodge the rule. An empty Sui chain id fails closed, since the RPC accessor yields `""` when a fullnode omits the field, and so does an unrecognised Bitcoin id. Each direction has its own message naming the Bitcoin network and, for the common Sui testnet mistake, the fact that `bitcoin_chain_id` defaults to mainnet when unset.

## Where it runs

- `build_finish_publish_tx` takes the Sui chain id and checks before its only RPC, so a refusal costs no network round trip and the ticket's test is hermetic.
- `hashi launch` fetches the id from the fullnode (`sui_rpc_client::fetch_sui_chain_id`) after the `--status` early return, so the `LAUNCH_STATUS` contract is untouched, prints it beside the RPC line, checks before resolving the sender or the UpgradeCap, and passes it to both builder call sites (dry-run, serialize-unsigned, execute). The RPC URL defaults to the mainnet fullnode, which is the foot-gun the audit describes; the printed id makes it visible.
- `publish::finish_publish` fetches the id itself, so the e2e harness is unchanged.
- `hashi register` checks the config it loads, and confirms the config's Sui chain id against the RPC it registers through, as the node does at startup. The client it builds for that is reused for the transaction.
- Node startup: `Hashi::verify_chain_pairing` right after `verify_sui_chain_id` has confirmed the local config against the RPC. It is a separate check from `verify_bitcoin_chain_id`, whose pre-launch skip would otherwise silence it in the key-registration window. This node-side check is the load-bearing control: Move never reads the pinned Bitcoin chain id, so which chain deposits are attested against is decided by each node's local config.

## Tests

`crates/hashi/tests/chain_pairing_tests.rs`: the predicate table including an uppercase mainnet hash and an unrecognised id; the launch builder refusing signet on Sui mainnet and Bitcoin mainnet on Sui testnet against a lazily connected client to a closed port; a permitted pair getting past the check to the network; the node refusing or accepting each pair from its config, including a Sui testnet config that omits `bitcoin_chain_id` and so defaults to Bitcoin mainnet (both config keys default to mainnet, so that config now fails at boot instead of later against bitcoind).

The e2e harness publishes with the localnet digest and regtest, which the rule permits, so every existing e2e boot and launch exercises the pass path.

## Residual, permanent

`finish_publish` is a Move entry that accepts any chain id, so a raw PTB or an older `hashi` binary holding the UpgradeCap bypasses the launch check, and node binaries older than this change still run a mismatched pair. This closes the operational foot-gun in the shipped tooling; it is not a protocol guarantee. The runbook's Networks section now says the pairing is enforced.

Closes IOP-663. Closes SEC-510.
