### PR TITLE
[guardian-proxy] Relay KP ceremony confirmations

### DIFF
--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -377,7 +377,7 @@ mod tests {
         let (cert_armored, secret_armored) = mock_pgp_keypair();
         let cert = PgpPublicCert::new(cert_armored).unwrap();
         let store = StubStore::default();
-        seed_roster(&store, &[&cert.fingerprint().to_hex()]);
+        seed_roster(&store, 0, &[&cert.fingerprint().to_hex()]);
         let (stub, proxy) = spawn_stub_proxy(store).await;
 
         let status = proxy
@@ -404,7 +404,7 @@ mod tests {
         let (cert_armored, secret_armored) = mock_pgp_keypair();
         let cert = PgpPublicCert::new(cert_armored).unwrap();
         let store = StubStore::default();
-        seed_roster(&store, &["AAAABBBBCCCCDDDDEEEE11112222333344445555"]);
+        seed_roster(&store, 0, &["AAAABBBBCCCCDDDDEEEE11112222333344445555"]);
         let (stub, proxy) = spawn_stub_proxy(store).await;
 
         let err = proxy

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -5,8 +5,7 @@
 //! and rejects the operator surface with `PERMISSION_DENIED`: the proxy is
 //! internet-facing and `OperatorInit` is one-shot and unauthenticated, so
 //! exposing it would let anyone wedge the guardian. KP-signed RPCs are
-//! forwarded after a signature check, so a KP on its own machine reaches the
-//! guardian through the public endpoint. Wrapped by
+//! forwarded after a signature check. Wrapped by
 //! [`crate::cache::CachingGuardianGrpc`] to cache `StandardWithdrawal`.
 
 use std::sync::Arc;
@@ -52,20 +51,20 @@ fn denied(rpc: &str) -> Status {
     ))
 }
 
-/// Admission control for a KP-signed request: reject unsigned or corrupt
-/// traffic before an enclave round-trip. The enclave repeats the verification
-/// and authorizes the signer against the ceremony's committed roster.
+/// Admission control only: the enclave repeats the verification and
+/// authorizes the signer against its roster.
 fn verify_kp_signature<T, P>(request: &P) -> Result<(), Status>
 where
     T: KpSigningIntent,
     P: Clone,
     KpSigned<T>: TryFrom<P, Error = GuardianError>,
 {
+    // TODO: check the signer against the roster here too.
     let signed_request = KpSigned::<T>::try_from(request.clone())
         .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
     signed_request
         .verify_signature()
-        .map_err(|error| Status::unauthenticated(error.to_string()))?;
+        .map_err(|e| Status::unauthenticated(e.to_string()))?;
     Ok(())
 }
 
@@ -105,7 +104,6 @@ impl<L: LogStore> GuardianService for Forwarding<L> {
         &self,
         request: Request<proto::SignedProvisionerRotateCertRequest>,
     ) -> Result<Response<proto::SignedProvisionerRotateCertResponse>, Status> {
-        // TODO: check the signer against the roster here too.
         verify_kp_signature::<ProvisionerRotateCertRequest, _>(request.get_ref())?;
         let response = self.client.clone().provisioner_rotate_cert(request).await?;
         // The enclave has committed the replacement cert to the share log, so
@@ -115,10 +113,8 @@ impl<L: LogStore> GuardianService for Forwarding<L> {
         Ok(response)
     }
 
-    /// A KP's confirmation that it recovered its dealt share; the ceremony
-    /// guardian completes only once every KP has confirmed. The enclave
-    /// binds the confirmation to its session, the pending ceremony digest and
-    /// the roster, so forwarding exposes nothing an unsigned caller can act on.
+    // Safe to expose: the enclave binds each confirmation to its session, the
+    // ceremony digest and the dealt roster.
     async fn confirm_ceremony(
         &self,
         request: Request<proto::SignedCeremonyConfirmationRequest>,

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -2,14 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Forwards the node/KP-facing `GuardianService` RPCs to the enclave guardian
-//! and rejects the operator/ceremony surface with `PERMISSION_DENIED`: the proxy
-//! is internet-facing and `OperatorInit` is one-shot and unauthenticated, so
-//! exposing it would let anyone wedge the guardian. Wrapped by
+//! and rejects the operator surface with `PERMISSION_DENIED`: the proxy is
+//! internet-facing and `OperatorInit` is one-shot and unauthenticated, so
+//! exposing it would let anyone wedge the guardian. KP-signed RPCs are
+//! forwarded after a signature check, so a KP on its own machine reaches the
+//! guardian through the public endpoint. Wrapped by
 //! [`crate::cache::CachingGuardianGrpc`] to cache `StandardWithdrawal`.
 
 use std::sync::Arc;
 
+use hashi_types::guardian::CeremonyConfirmationRequest;
+use hashi_types::guardian::GuardianError;
 use hashi_types::guardian::KpSigned;
+use hashi_types::guardian::KpSigningIntent;
 use hashi_types::guardian::ProvisionerRotateCertRequest;
 use hashi_types::proto;
 use hashi_types::proto::guardian_service_client::GuardianServiceClient;
@@ -42,15 +47,21 @@ impl<L: LogStore> Forwarding<L> {
 
 fn denied(rpc: &str) -> Status {
     Status::permission_denied(format!(
-        "{rpc} is not served by the guardian proxy; operator/ceremony calls reach the \
+        "{rpc} is not served by the guardian proxy; operator calls reach the \
          guardian directly and KP shares use SingleProvisionerInit"
     ))
 }
 
-fn verify_provisioner_rotate_cert_signature(
-    request: &proto::SignedProvisionerRotateCertRequest,
-) -> Result<(), Status> {
-    let signed_request = KpSigned::<ProvisionerRotateCertRequest>::try_from(request.clone())
+/// Admission control for a KP-signed request: reject unsigned or corrupt
+/// traffic before an enclave round-trip. The enclave repeats the verification
+/// and authorizes the signer against the ceremony's committed roster.
+fn verify_kp_signature<T, P>(request: &P) -> Result<(), Status>
+where
+    T: KpSigningIntent,
+    P: Clone,
+    KpSigned<T>: TryFrom<P, Error = GuardianError>,
+{
+    let signed_request = KpSigned::<T>::try_from(request.clone())
         .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
     signed_request
         .verify_signature()
@@ -94,11 +105,8 @@ impl<L: LogStore> GuardianService for Forwarding<L> {
         &self,
         request: Request<proto::SignedProvisionerRotateCertRequest>,
     ) -> Result<Response<proto::SignedProvisionerRotateCertResponse>, Status> {
-        // Admission control only: reject unsigned or corrupt traffic before an
-        // enclave round-trip. The enclave repeats verification and authorizes
-        // the signer against the latest encrypted-share roster.
         // TODO: check the signer against the roster here too.
-        verify_provisioner_rotate_cert_signature(request.get_ref())?;
+        verify_kp_signature::<ProvisionerRotateCertRequest, _>(request.get_ref())?;
         let response = self.client.clone().provisioner_rotate_cert(request).await?;
         // The enclave has committed the replacement cert to the share log, so
         // drop the cached roster: otherwise the new cert is rejected until the
@@ -107,7 +115,19 @@ impl<L: LogStore> GuardianService for Forwarding<L> {
         Ok(response)
     }
 
-    // --- Rejected: operator/ceremony surface ---
+    /// A KP's confirmation that it recovered its dealt share; the ceremony
+    /// guardian completes only once every KP has confirmed. The enclave
+    /// binds the confirmation to its session, the pending ceremony digest and
+    /// the roster, so forwarding exposes nothing an unsigned caller can act on.
+    async fn confirm_ceremony(
+        &self,
+        request: Request<proto::SignedCeremonyConfirmationRequest>,
+    ) -> Result<Response<proto::CeremonyConfirmationResponse>, Status> {
+        verify_kp_signature::<CeremonyConfirmationRequest, _>(request.get_ref())?;
+        self.client.clone().confirm_ceremony(request).await
+    }
+
+    // --- Rejected: operator surface ---
 
     async fn operator_init(
         &self,
@@ -121,13 +141,6 @@ impl<L: LogStore> GuardianService for Forwarding<L> {
         _request: Request<proto::SetupNewKeyRequest>,
     ) -> Result<Response<proto::SignedSetupNewKeyResponse>, Status> {
         Err(denied("SetupNewKey"))
-    }
-
-    async fn confirm_ceremony(
-        &self,
-        _request: Request<proto::SignedCeremonyConfirmationRequest>,
-    ) -> Result<Response<proto::CeremonyConfirmationResponse>, Status> {
-        Err(denied("ConfirmCeremony"))
     }
 
     async fn provisioner_init(
@@ -175,6 +188,7 @@ mod tests {
     struct StubGuardian {
         standard_withdrawal_calls: Arc<AtomicUsize>,
         get_guardian_info_calls: Arc<AtomicUsize>,
+        confirm_ceremony_calls: Arc<AtomicUsize>,
     }
 
     #[tonic::async_trait]
@@ -212,7 +226,12 @@ mod tests {
             &self,
             _: Request<proto::SignedCeremonyConfirmationRequest>,
         ) -> Result<Response<proto::CeremonyConfirmationResponse>, Status> {
-            unimplemented!("a real guardian would serve this; the proxy must never reach it")
+            self.confirm_ceremony_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Response::new(proto::CeremonyConfirmationResponse {
+                have: Some(1),
+                need: Some(3),
+                completed: Some(false),
+            }))
         }
         async fn operator_init(
             &self,
@@ -329,10 +348,53 @@ mod tests {
         assert_eq!(stub.get_guardian_info_calls.load(Ordering::SeqCst), 1);
     }
 
+    fn signed_confirmation() -> proto::SignedCeremonyConfirmationRequest {
+        let (cert_armored, secret_armored) = mock_pgp_keypair();
+        let cert = PgpPublicCert::new(cert_armored).unwrap();
+        let domain = CeremonyConfirmationRequest::new("session".into(), [3u8; 32]);
+        let signature = sign_detached_in_process(&secret_armored, &KpSigned::signed_bytes(&domain));
+        proto::SignedCeremonyConfirmationRequest::from(KpSigned::from_parts(
+            domain, cert, signature,
+        ))
+    }
+
+    #[tokio::test]
+    async fn forwards_a_signed_ceremony_confirmation() {
+        let (stub, proxy) = spawn_stub_proxy().await;
+
+        let status = proxy
+            .confirm_ceremony(Request::new(signed_confirmation()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(status.have, Some(1));
+        assert_eq!(stub.confirm_ceremony_calls.load(Ordering::SeqCst), 1);
+
+        // A corrupt confirmation is refused before the backend sees it.
+        let err = proxy
+            .confirm_ceremony(Request::new(
+                proto::SignedCeremonyConfirmationRequest::default(),
+            ))
+            .await
+            .expect_err("an unsigned confirmation must not be forwarded");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert_eq!(stub.confirm_ceremony_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn verifies_ceremony_confirmation_signature_before_forwarding() {
+        let mut request = signed_confirmation();
+        verify_kp_signature::<CeremonyConfirmationRequest, _>(&request).unwrap();
+
+        request.expected_session_id.push('0');
+        let err = verify_kp_signature::<CeremonyConfirmationRequest, _>(&request).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
     // The stub `unimplemented!()`s the rejected RPCs, so a forwarded call would panic
     // the server rather than return `PERMISSION_DENIED` — proof the proxy short-circuits.
     #[tokio::test]
-    async fn rejects_operator_and_ceremony_rpcs() {
+    async fn rejects_operator_rpcs() {
         let (_stub, proxy) = spawn_stub_proxy().await;
 
         let denied = proxy
@@ -357,14 +419,6 @@ mod tests {
             .setup_new_key(Request::new(proto::SetupNewKeyRequest::default()))
             .await
             .expect_err("setup_new_key must be denied");
-        assert_eq!(denied.code(), tonic::Code::PermissionDenied);
-
-        let denied = proxy
-            .confirm_ceremony(Request::new(
-                proto::SignedCeremonyConfirmationRequest::default(),
-            ))
-            .await
-            .expect_err("confirm_ceremony must be denied");
         assert_eq!(denied.code(), tonic::Code::PermissionDenied);
 
         let denied = proxy
@@ -398,10 +452,10 @@ mod tests {
             domain, cert, signature,
         ));
 
-        verify_provisioner_rotate_cert_signature(&request).unwrap();
+        verify_kp_signature::<ProvisionerRotateCertRequest, _>(&request).unwrap();
 
         request.target_kp_pgp_fingerprint.push('0');
-        let err = verify_provisioner_rotate_cert_signature(&request).unwrap_err();
+        let err = verify_kp_signature::<ProvisionerRotateCertRequest, _>(&request).unwrap_err();
         assert_eq!(err.code(), tonic::Code::Unauthenticated);
     }
 }

--- a/crates/hashi-guardian-proxy/src/forward.rs
+++ b/crates/hashi-guardian-proxy/src/forward.rs
@@ -5,7 +5,7 @@
 //! and rejects the operator surface with `PERMISSION_DENIED`: the proxy is
 //! internet-facing and `OperatorInit` is one-shot and unauthenticated, so
 //! exposing it would let anyone wedge the guardian. KP-signed RPCs are
-//! forwarded after a signature check. Wrapped by
+//! forwarded after a signature and roster check. Wrapped by
 //! [`crate::cache::CachingGuardianGrpc`] to cache `StandardWithdrawal`.
 
 use std::sync::Arc;
@@ -31,7 +31,8 @@ use crate::widlog::LogStore;
 #[derive(Clone)]
 pub struct Forwarding<L> {
     client: GuardianServiceClient<Channel>,
-    /// Shared with the relay so a cert rotation can drop the cached roster.
+    /// Shared with the relay: one gate admits every KP-signed RPC, and a cert
+    /// rotation drops the cached roster for both.
     roster: Arc<RosterCache<L>>,
 }
 
@@ -42,6 +43,18 @@ impl<L: LogStore> Forwarding<L> {
             roster,
         }
     }
+
+    /// Admission control only: the enclave repeats both checks. Signature
+    /// first because it needs no roster read.
+    async fn admit<T, P>(&self, request: &P) -> Result<(), Status>
+    where
+        T: KpSigningIntent,
+        P: Clone,
+        KpSigned<T>: TryFrom<P, Error = GuardianError>,
+    {
+        let signer = verify_kp_signature::<T, P>(request)?.signer_fingerprint();
+        self.roster.authorize(&signer).await
+    }
 }
 
 fn denied(rpc: &str) -> Status {
@@ -51,21 +64,18 @@ fn denied(rpc: &str) -> Status {
     ))
 }
 
-/// Admission control only: the enclave repeats the verification and
-/// authorizes the signer against its roster.
-fn verify_kp_signature<T, P>(request: &P) -> Result<(), Status>
+fn verify_kp_signature<T, P>(request: &P) -> Result<KpSigned<T>, Status>
 where
     T: KpSigningIntent,
     P: Clone,
     KpSigned<T>: TryFrom<P, Error = GuardianError>,
 {
-    // TODO: check the signer against the roster here too.
     let signed_request = KpSigned::<T>::try_from(request.clone())
         .map_err(|e| Status::invalid_argument(format!("malformed request: {e}")))?;
     signed_request
         .verify_signature()
         .map_err(|e| Status::unauthenticated(e.to_string()))?;
-    Ok(())
+    Ok(signed_request)
 }
 
 // Each method clones the cheap channel-backed client and forwards the whole
@@ -104,7 +114,8 @@ impl<L: LogStore> GuardianService for Forwarding<L> {
         &self,
         request: Request<proto::SignedProvisionerRotateCertRequest>,
     ) -> Result<Response<proto::SignedProvisionerRotateCertResponse>, Status> {
-        verify_kp_signature::<ProvisionerRotateCertRequest, _>(request.get_ref())?;
+        self.admit::<ProvisionerRotateCertRequest, _>(request.get_ref())
+            .await?;
         let response = self.client.clone().provisioner_rotate_cert(request).await?;
         // The enclave has committed the replacement cert to the share log, so
         // drop the cached roster: otherwise the new cert is rejected until the
@@ -119,7 +130,8 @@ impl<L: LogStore> GuardianService for Forwarding<L> {
         &self,
         request: Request<proto::SignedCeremonyConfirmationRequest>,
     ) -> Result<Response<proto::CeremonyConfirmationResponse>, Status> {
-        verify_kp_signature::<CeremonyConfirmationRequest, _>(request.get_ref())?;
+        self.admit::<CeremonyConfirmationRequest, _>(request.get_ref())
+            .await?;
         self.client.clone().confirm_ceremony(request).await
     }
 
@@ -165,6 +177,7 @@ impl<L: LogStore> GuardianService for Forwarding<L> {
 mod tests {
     use super::*;
     use crate::cache::CachingGuardianGrpc;
+    use crate::roster::test_utils::seed_roster;
     use hashi_types::guardian::Ciphertext;
     use hashi_types::guardian::GuardianEncryptedShare;
     use hashi_types::guardian::ShareID;
@@ -287,7 +300,9 @@ mod tests {
 
     type StubStore = crate::widlog::test_store::MemStore;
 
-    async fn spawn_stub_proxy() -> (
+    async fn spawn_stub_proxy(
+        store: StubStore,
+    ) -> (
         StubGuardian,
         CachingGuardianGrpc<Forwarding<StubStore>, StubStore>,
     ) {
@@ -309,7 +324,7 @@ mod tests {
             .unwrap()
             .connect_lazy();
         let cache = CachingGuardianGrpc::new(
-            Forwarding::new(channel, Arc::new(RosterCache::new(StubStore::default()))),
+            Forwarding::new(channel, Arc::new(RosterCache::new(store))),
             StubStore::default(),
             bitcoin::Network::Regtest,
             std::sync::Arc::new(crate::metrics::ProxyMetrics::new()),
@@ -319,7 +334,7 @@ mod tests {
 
     #[tokio::test]
     async fn forwards_and_caches_over_real_grpc() {
-        let (stub, proxy) = spawn_stub_proxy().await;
+        let (stub, proxy) = spawn_stub_proxy(StubStore::default()).await;
 
         // First withdrawal forwards to the stub; a same-wid retry at a bumped
         // seq replays the cached response without re-calling the stub.
@@ -344,22 +359,29 @@ mod tests {
         assert_eq!(stub.get_guardian_info_calls.load(Ordering::SeqCst), 1);
     }
 
-    fn signed_confirmation() -> proto::SignedCeremonyConfirmationRequest {
-        let (cert_armored, secret_armored) = mock_pgp_keypair();
-        let cert = PgpPublicCert::new(cert_armored).unwrap();
+    fn signed_confirmation(
+        cert: &PgpPublicCert,
+        secret_armored: &str,
+    ) -> proto::SignedCeremonyConfirmationRequest {
         let domain = CeremonyConfirmationRequest::new("session".into(), [3u8; 32]);
-        let signature = sign_detached_in_process(&secret_armored, &KpSigned::signed_bytes(&domain));
+        let signature = sign_detached_in_process(secret_armored, &KpSigned::signed_bytes(&domain));
         proto::SignedCeremonyConfirmationRequest::from(KpSigned::from_parts(
-            domain, cert, signature,
+            domain,
+            cert.clone(),
+            signature,
         ))
     }
 
     #[tokio::test]
-    async fn forwards_a_signed_ceremony_confirmation() {
-        let (stub, proxy) = spawn_stub_proxy().await;
+    async fn forwards_a_rostered_ceremony_confirmation() {
+        let (cert_armored, secret_armored) = mock_pgp_keypair();
+        let cert = PgpPublicCert::new(cert_armored).unwrap();
+        let store = StubStore::default();
+        seed_roster(&store, &[&cert.fingerprint().to_hex()]);
+        let (stub, proxy) = spawn_stub_proxy(store).await;
 
         let status = proxy
-            .confirm_ceremony(Request::new(signed_confirmation()))
+            .confirm_ceremony(Request::new(signed_confirmation(&cert, &secret_armored)))
             .await
             .unwrap()
             .into_inner();
@@ -377,9 +399,27 @@ mod tests {
         assert_eq!(stub.confirm_ceremony_calls.load(Ordering::SeqCst), 1);
     }
 
+    #[tokio::test]
+    async fn rejects_an_unrostered_ceremony_confirmation() {
+        let (cert_armored, secret_armored) = mock_pgp_keypair();
+        let cert = PgpPublicCert::new(cert_armored).unwrap();
+        let store = StubStore::default();
+        seed_roster(&store, &["AAAABBBBCCCCDDDDEEEE11112222333344445555"]);
+        let (stub, proxy) = spawn_stub_proxy(store).await;
+
+        let err = proxy
+            .confirm_ceremony(Request::new(signed_confirmation(&cert, &secret_armored)))
+            .await
+            .expect_err("a signer outside the roster must not be forwarded");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert_eq!(stub.confirm_ceremony_calls.load(Ordering::SeqCst), 0);
+    }
+
     #[test]
     fn verifies_ceremony_confirmation_signature_before_forwarding() {
-        let mut request = signed_confirmation();
+        let (cert_armored, secret_armored) = mock_pgp_keypair();
+        let cert = PgpPublicCert::new(cert_armored).unwrap();
+        let mut request = signed_confirmation(&cert, &secret_armored);
         verify_kp_signature::<CeremonyConfirmationRequest, _>(&request).unwrap();
 
         request.expected_session_id.push('0');
@@ -391,7 +431,7 @@ mod tests {
     // the server rather than return `PERMISSION_DENIED` — proof the proxy short-circuits.
     #[tokio::test]
     async fn rejects_operator_rpcs() {
-        let (_stub, proxy) = spawn_stub_proxy().await;
+        let (_stub, proxy) = spawn_stub_proxy(StubStore::default()).await;
 
         let denied = proxy
             .operator_init(Request::new(proto::OperatorInitRequest::default()))

--- a/crates/hashi-guardian-proxy/src/relay.rs
+++ b/crates/hashi-guardian-proxy/src/relay.rs
@@ -30,7 +30,6 @@ use hashi_types::guardian::GetGuardianInfoResponse;
 use hashi_types::guardian::KpSigned;
 use hashi_types::guardian::ProvisionerInitRequest;
 use hashi_types::guardian::SessionID;
-use hashi_types::pgp::Fingerprint;
 use hashi_types::proto;
 use hashi_types::proto::guardian_relay_service_server::GuardianRelayService;
 use hashi_types::proto::guardian_service_client::GuardianServiceClient;
@@ -143,26 +142,10 @@ impl<L: LogStore> Relay<L> {
             .map_err(|error| Status::unauthenticated(error.to_string()))?;
         // The ceremony's committed roster, not deploy config: a rotation
         // re-deals shares without a proxy redeploy.
-        check_rostered(
-            &signed_request.signer_fingerprint(),
-            &self.authorized_kps().await?,
-        )?;
+        self.roster
+            .authorize(&signed_request.signer_fingerprint())
+            .await?;
         Ok(request)
-    }
-
-    /// The ceremony's committed roster, mapped onto the relay's failure modes:
-    /// no share log yet is a definitive "not ready", a read error is transient.
-    async fn authorized_kps(&self) -> Result<Arc<Vec<Fingerprint>>, Status> {
-        match self.roster.get().await {
-            Ok(Some(roster)) => Ok(roster),
-            Ok(None) => Err(Status::failed_precondition(
-                "no KP share log in the guardian bucket; run the key ceremony first",
-            )),
-            Err(e) => {
-                warn!(error = %format!("{e:#}"), "KP roster read failed");
-                Err(Status::unavailable("KP roster unavailable; retry"))
-            }
-        }
     }
 
     /// Backend's self-reported session, provisioning threshold, and provisioned flag.
@@ -260,15 +243,6 @@ fn match_backend<'a>(
         return Ok(Matched::Provisioned);
     }
     Ok(Matched::Armed(arming))
-}
-
-fn check_rostered(fingerprint: &Fingerprint, roster: &[Fingerprint]) -> Result<(), Status> {
-    if roster.contains(fingerprint) {
-        return Ok(());
-    }
-    Err(Status::permission_denied(format!(
-        "signer {fingerprint} is not in the relay's authorized KP roster"
-    )))
 }
 
 fn done() -> Response<proto::SingleProvisionerInitResponse> {
@@ -615,32 +589,6 @@ mod tests {
         let signed = KpSigned::from_parts(request("sess-a", 1), cert, good_sig);
         let err = relay.verify_kp_submission(&signed).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    }
-
-    #[test]
-    fn roster_membership_is_by_fingerprint_value() {
-        let cert = PgpPublicCert::new(mock_pgp_keypair().0).unwrap();
-        let fingerprint = cert.fingerprint();
-        check_rostered(&fingerprint, std::slice::from_ref(&fingerprint)).unwrap();
-
-        // Share-log labels are bare hex, so case must not matter.
-        let lowercase: Fingerprint = fingerprint.to_hex().to_lowercase().parse().unwrap();
-        check_rostered(&fingerprint, &[lowercase]).unwrap();
-
-        let err = check_rostered(&fingerprint, &[]).unwrap_err();
-        assert_eq!(err.code(), tonic::Code::PermissionDenied);
-    }
-
-    #[tokio::test]
-    async fn roster_store_failure_is_unavailable_and_unclassified() {
-        let store = MemStore::default();
-        store.fail_lists.store(true, Ordering::SeqCst);
-        let err = relay_with_roster(store).authorized_kps().await.unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Unavailable);
-        // The node classifies guardian errors by substring; this must stay in
-        // its retriable bucket.
-        assert!(!err.message().contains("seq mismatch"));
-        assert!(!err.message().contains("Rate limit exceeded"));
     }
 
     /// A stub guardian whose `GetGuardianInfo` carries a tag, so a test can

--- a/crates/hashi-guardian-proxy/src/roster.rs
+++ b/crates/hashi-guardian-proxy/src/roster.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! The relay's KP roster, read from the guardian's S3 share log. A ceremony
+//! The proxy's KP roster, read from the guardian's S3 share log. A ceremony
 //! commits who holds shares — every encrypted share is labeled with its
 //! recipient's PGP fingerprint — so the latest share log IS the authorization
 //! roster. The read is deliberately unverified: the bucket only admits enclave
 //! writes and this gate is DoS-tier, with the enclave still verifying every
-//! share cryptographically (config_hash AAD + commitments).
+//! KP-signed request against its own roster.
 //!
 //! Two layouts are in flight (#779 migrates the first to the second):
 //!   `shares/{sharing_seq:020}-{session}.json` (message `Shares`)
@@ -32,6 +32,8 @@ use hashi_types::guardian::log::KpShareStateLogMessage;
 use hashi_types::pgp::Fingerprint;
 use serde::Deserialize;
 use tokio::sync::Mutex;
+use tonic::Status;
+use tracing::warn;
 
 use crate::widlog::LogStore;
 
@@ -92,6 +94,66 @@ impl<L: LogStore> RosterCache<L> {
     /// Drop the cached roster so the next read observes a just-committed change.
     pub async fn invalidate(&self) {
         *self.cached.lock().await = None;
+    }
+
+    /// Admit `signer` only if the latest committed share set names it. No share
+    /// log yet is a definitive "not ready"; a read error is transient.
+    pub async fn authorize(&self, signer: &Fingerprint) -> Result<(), Status> {
+        let roster = match self.get().await {
+            Ok(Some(roster)) => roster,
+            Ok(None) => {
+                return Err(Status::failed_precondition(
+                    "no KP share log in the guardian bucket; run the key ceremony first",
+                ))
+            }
+            Err(e) => {
+                warn!(error = %format!("{e:#}"), "KP roster read failed");
+                return Err(Status::unavailable("KP roster unavailable; retry"));
+            }
+        };
+        if roster.contains(signer) {
+            return Ok(());
+        }
+        Err(Status::permission_denied(format!(
+            "signer {signer} is not in the ceremony's committed KP roster"
+        )))
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use crate::widlog::test_store::MemStore;
+
+    /// Commit a one-cert-per-share roster at sharing_seq 0, in the layout the
+    /// enclave writes today.
+    pub(crate) fn seed_roster(store: &MemStore, fingerprints: &[&str]) {
+        let shares: Vec<serde_json::Value> = fingerprints
+            .iter()
+            .enumerate()
+            .map(|(i, fp)| {
+                let ciphertexts: serde_json::Map<String, serde_json::Value> =
+                    std::iter::once(((*fp).to_string(), serde_json::json!(""))).collect();
+                serde_json::json!({ "id": i + 1, "ciphertexts_by_fingerprint": ciphertexts })
+            })
+            .collect();
+        let record = serde_json::json!({
+            "session_id": "test-session",
+            "timestamp_ms": 0,
+            "message": { "KpShareState": {
+                "sharing_seq": 0,
+                "cert_seq": 0,
+                "encrypted_shares": shares,
+            }},
+            "signature": null,
+        });
+        store.insert(
+            "kp-shares/00000000000000000000/00000000000000000000-test-session.json".to_string(),
+            serde_json::to_vec(&record).unwrap(),
+        );
+        store.insert(
+            "ceremony/00000000000000000000-test-session.json".to_string(),
+            b"{}".to_vec(),
+        );
     }
 }
 
@@ -564,6 +626,42 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn authorize_matches_fingerprints_by_value() {
+        let store = MemStore::default();
+        // Share-log labels are bare hex, so case must not matter.
+        super::test_utils::seed_roster(&store, &[&FP_A.to_lowercase()]);
+        let cache = RosterCache::new(store);
+
+        cache.authorize(&fp(FP_A)).await.unwrap();
+        let err = cache.authorize(&fp(FP_B)).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn authorize_before_any_ceremony_is_a_failed_precondition() {
+        let err = RosterCache::new(MemStore::default())
+            .authorize(&fp(FP_A))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn authorize_maps_a_store_failure_to_unavailable() {
+        let store = MemStore::default();
+        store.fail_lists.store(true, Ordering::SeqCst);
+        let err = RosterCache::new(store)
+            .authorize(&fp(FP_A))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unavailable);
+        // The node classifies guardian errors by substring; this must stay in
+        // its retriable bucket.
+        assert!(!err.message().contains("seq mismatch"));
+        assert!(!err.message().contains("Rate limit exceeded"));
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian-proxy/src/roster.rs
+++ b/crates/hashi-guardian-proxy/src/roster.rs
@@ -24,7 +24,6 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use anyhow::Context as _;
 use hashi_types::guardian::log::CeremonyLogMessage;
@@ -32,6 +31,7 @@ use hashi_types::guardian::log::KpShareStateLogMessage;
 use hashi_types::pgp::Fingerprint;
 use serde::Deserialize;
 use tokio::sync::Mutex;
+use tokio::time::Instant;
 use tonic::Status;
 use tracing::warn;
 
@@ -45,78 +45,99 @@ const LEGACY_SHARES_PREFIX: &str = "shares/";
 /// rotation — and rotation invalidates explicitly — so a minute of staleness
 /// costs nothing and bounds S3 reads under submission spam.
 const ROSTER_TTL: Duration = Duration::from_secs(60);
-/// "No ceremony yet" is cached far more briefly: the first ceremony should be
-/// authorized promptly once its log lands, but an unauthenticated caller must
-/// not be able to drive an S3 read per request while we wait.
-const MISSING_ROSTER_TTL: Duration = Duration::from_secs(5);
+/// A miss — no roster yet, or a signer the cached roster does not name — may
+/// be a share set the guardian committed since the last read: `SetupNewKey`
+/// and `RotateKpSet` run over the operator's tunnel, so nothing invalidates
+/// this cache for them. A miss re-reads at most this often, so a new roster
+/// admits its KPs on their first call while unrostered callers cannot force
+/// an S3 read each.
+const MISS_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
 
 struct Cached {
     at: Instant,
     roster: Option<Arc<Vec<Fingerprint>>>,
 }
 
+#[derive(Default)]
+struct State {
+    cached: Option<Cached>,
+    miss_refreshed_at: Option<Instant>,
+}
+
+impl State {
+    fn miss_refresh_due(&self) -> bool {
+        self.miss_refreshed_at
+            .is_none_or(|at| at.elapsed() >= MISS_REFRESH_INTERVAL)
+    }
+}
+
 /// TTL-cached view of [`latest_kp_roster`]. The mutex is held across the fetch,
 /// so concurrent misses collapse into one S3 read.
 pub struct RosterCache<L> {
     store: L,
-    cached: Mutex<Option<Cached>>,
+    state: Mutex<State>,
 }
 
 impl<L: LogStore> RosterCache<L> {
     pub fn new(store: L) -> Self {
         Self {
             store,
-            cached: Mutex::new(None),
+            state: Mutex::new(State::default()),
         }
-    }
-
-    /// `Ok(None)` means no ceremony has committed a share set yet.
-    pub async fn get(&self) -> anyhow::Result<Option<Arc<Vec<Fingerprint>>>> {
-        let mut cached = self.cached.lock().await;
-        if let Some(entry) = cached.as_ref() {
-            let ttl = if entry.roster.is_some() {
-                ROSTER_TTL
-            } else {
-                MISSING_ROSTER_TTL
-            };
-            if entry.at.elapsed() < ttl {
-                return Ok(entry.roster.clone());
-            }
-        }
-        let roster = latest_kp_roster(&self.store).await?.map(Arc::new);
-        *cached = Some(Cached {
-            at: Instant::now(),
-            roster: roster.clone(),
-        });
-        Ok(roster)
     }
 
     /// Drop the cached roster so the next read observes a just-committed change.
     pub async fn invalidate(&self) {
-        *self.cached.lock().await = None;
+        self.state.lock().await.cached = None;
     }
 
     /// Admit `signer` only if the latest committed share set names it. No share
     /// log yet is a definitive "not ready"; a read error is transient.
     pub async fn authorize(&self, signer: &Fingerprint) -> Result<(), Status> {
-        let roster = match self.get().await {
-            Ok(Some(roster)) => roster,
-            Ok(None) => {
-                return Err(Status::failed_precondition(
-                    "no KP share log in the guardian bucket; run the key ceremony first",
-                ))
-            }
-            Err(e) => {
-                warn!(error = %format!("{e:#}"), "KP roster read failed");
-                return Err(Status::unavailable("KP roster unavailable; retry"));
-            }
+        let mut state = self.state.lock().await;
+        let fresh = state
+            .cached
+            .as_ref()
+            .filter(|cached| cached.at.elapsed() < ROSTER_TTL)
+            .map(|cached| cached.roster.clone());
+        let (mut roster, just_read) = match fresh {
+            Some(roster) => (roster, false),
+            None => (self.read(&mut state).await?, true),
         };
-        if roster.contains(signer) {
-            return Ok(());
+        let names_signer = |roster: &Option<Arc<Vec<Fingerprint>>>| {
+            roster
+                .as_deref()
+                .is_some_and(|roster| roster.contains(signer))
+        };
+        if !names_signer(&roster) && !just_read && state.miss_refresh_due() {
+            state.miss_refreshed_at = Some(Instant::now());
+            roster = self.read(&mut state).await?;
         }
-        Err(Status::permission_denied(format!(
-            "signer {signer} is not in the ceremony's committed KP roster"
-        )))
+        match roster {
+            Some(roster) if roster.contains(signer) => Ok(()),
+            Some(_) => Err(Status::permission_denied(format!(
+                "signer {signer} is not in the ceremony's committed KP roster"
+            ))),
+            None => Err(Status::failed_precondition(
+                "no KP share log in the guardian bucket; run the key ceremony first",
+            )),
+        }
+    }
+
+    /// One read of the share log, cached whatever it finds.
+    async fn read(&self, state: &mut State) -> Result<Option<Arc<Vec<Fingerprint>>>, Status> {
+        let roster = latest_kp_roster(&self.store)
+            .await
+            .map_err(|e| {
+                warn!(error = %format!("{e:#}"), "KP roster read failed");
+                Status::unavailable("KP roster unavailable; retry")
+            })?
+            .map(Arc::new);
+        state.cached = Some(Cached {
+            at: Instant::now(),
+            roster: roster.clone(),
+        });
+        Ok(roster)
     }
 }
 
@@ -124,9 +145,9 @@ impl<L: LogStore> RosterCache<L> {
 pub(crate) mod test_utils {
     use crate::widlog::test_store::MemStore;
 
-    /// Commit a one-cert-per-share roster at sharing_seq 0, in the layout the
+    /// Commit a one-cert-per-share roster at `sharing_seq`, in the layout the
     /// enclave writes today.
-    pub(crate) fn seed_roster(store: &MemStore, fingerprints: &[&str]) {
+    pub(crate) fn seed_roster(store: &MemStore, sharing_seq: u64, fingerprints: &[&str]) {
         let shares: Vec<serde_json::Value> = fingerprints
             .iter()
             .enumerate()
@@ -140,18 +161,18 @@ pub(crate) mod test_utils {
             "session_id": "test-session",
             "timestamp_ms": 0,
             "message": { "KpShareState": {
-                "sharing_seq": 0,
+                "sharing_seq": sharing_seq,
                 "cert_seq": 0,
                 "encrypted_shares": shares,
             }},
             "signature": null,
         });
         store.insert(
-            "kp-shares/00000000000000000000/00000000000000000000-test-session.json".to_string(),
+            format!("kp-shares/{sharing_seq:020}/00000000000000000000-test-session.json"),
             serde_json::to_vec(&record).unwrap(),
         );
         store.insert(
-            "ceremony/00000000000000000000-test-session.json".to_string(),
+            format!("ceremony/{sharing_seq:020}-test-session.json"),
             b"{}".to_vec(),
         );
     }
@@ -285,6 +306,7 @@ fn parse_recipient_fingerprint(label: &str) -> anyhow::Result<Fingerprint> {
 
 #[cfg(test)]
 mod tests {
+    use super::test_utils::seed_roster;
     use super::*;
     use crate::widlog::test_store::MemStore;
     use std::sync::atomic::Ordering;
@@ -594,50 +616,84 @@ mod tests {
         assert!(latest_kp_roster(&store).await.is_err());
     }
 
-    #[tokio::test]
-    async fn cache_reads_the_committed_roster() {
+    #[tokio::test(start_paused = true)]
+    async fn a_rostered_signer_is_served_from_cache_until_the_ttl() {
         let store = MemStore::default();
-        let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
-        store.insert(key, bytes);
-        complete_ceremony(&store, 0);
-
-        let roster = RosterCache::new(store).get().await.unwrap().unwrap();
-        assert_eq!(*roster, vec![fp(FP_A)]);
-    }
-
-    #[tokio::test]
-    async fn cache_serves_the_cached_roster_within_the_ttl() {
-        let store = MemStore::default();
-        let (key, bytes) = kp_shares_record(0, 0, &[FP_A]);
-        store.insert(key, bytes);
-        complete_ceremony(&store, 0);
+        seed_roster(&store, 0, &[FP_A]);
         let cache = RosterCache::new(store);
+        cache.authorize(&fp(FP_A)).await.unwrap();
 
-        let first = cache.get().await.unwrap();
         // The store now fails hard; a fresh read would error, the cache must not.
         cache.store.fail_lists.store(true, Ordering::SeqCst);
-        assert_eq!(first, cache.get().await.unwrap());
-    }
+        cache.authorize(&fp(FP_A)).await.unwrap();
 
-    #[tokio::test]
-    async fn cache_reports_a_missing_share_log_as_none() {
-        assert!(RosterCache::new(MemStore::default())
-            .get()
-            .await
-            .unwrap()
-            .is_none());
+        tokio::time::advance(ROSTER_TTL).await;
+        let err = cache.authorize(&fp(FP_A)).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unavailable);
     }
 
     #[tokio::test]
     async fn authorize_matches_fingerprints_by_value() {
         let store = MemStore::default();
         // Share-log labels are bare hex, so case must not matter.
-        super::test_utils::seed_roster(&store, &[&FP_A.to_lowercase()]);
+        seed_roster(&store, 0, &[&FP_A.to_lowercase()]);
         let cache = RosterCache::new(store);
 
         cache.authorize(&fp(FP_A)).await.unwrap();
         let err = cache.authorize(&fp(FP_B)).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    /// `SetupNewKey` and `RotateKpSet` commit a new roster over the operator's
+    /// tunnel, never through the proxy, so nothing invalidates the cache: a KP
+    /// the new roster adds must be admitted on its first call, not after the
+    /// TTL (`key-provisioner ceremony` confirms once and does not retry).
+    #[tokio::test]
+    async fn a_kp_added_since_the_last_read_is_admitted_on_its_first_call() {
+        let store = MemStore::default();
+        seed_roster(&store, 0, &[FP_A]);
+        let cache = RosterCache::new(store);
+        cache.authorize(&fp(FP_A)).await.unwrap();
+
+        // A KP-set rotation commits sharing_seq 1 with a new holder.
+        seed_roster(&cache.store, 1, &[FP_A, FP_B]);
+        cache.authorize(&fp(FP_B)).await.unwrap();
+        cache.authorize(&fp(FP_A)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn the_first_ceremony_is_admitted_from_a_cached_none() {
+        let cache = RosterCache::new(MemStore::default());
+        let err = cache.authorize(&fp(FP_A)).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+
+        seed_roster(&cache.store, 0, &[FP_A]);
+        cache.authorize(&fp(FP_A)).await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn miss_refreshes_are_bounded() {
+        let store = MemStore::default();
+        seed_roster(&store, 0, &[FP_A]);
+        let cache = RosterCache::new(store);
+        cache.authorize(&fp(FP_A)).await.unwrap();
+        let reads = || cache.store.list_calls.load(Ordering::SeqCst);
+
+        // The first unrostered signer costs one re-read; the next does not.
+        let before = reads();
+        let err = cache.authorize(&fp(FP_B)).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(reads() > before);
+        let before = reads();
+        let err = cache.authorize(&fp(FP_B)).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert_eq!(reads(), before);
+
+        // The budget renews after the interval.
+        tokio::time::advance(MISS_REFRESH_INTERVAL).await;
+        let err = cache.authorize(&fp(FP_B)).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        assert!(reads() > before);
     }
 
     #[tokio::test]
@@ -671,18 +727,19 @@ mod tests {
         store.insert(key, bytes);
         complete_ceremony(&store, 0);
         let cache = RosterCache::new(store);
-        assert_eq!(*cache.get().await.unwrap().unwrap(), vec![fp(FP_A)]);
+        cache.authorize(&fp(FP_A)).await.unwrap();
 
         // A cert rotation commits a higher cert_seq under the same sharing_seq.
         let (key, bytes) = kp_shares_record(0, 1, &[FP_B]);
         cache.store.insert(key, bytes);
-        assert_eq!(
-            *cache.get().await.unwrap().unwrap(),
-            vec![fp(FP_A)],
-            "still cached until invalidated"
-        );
+        cache
+            .authorize(&fp(FP_A))
+            .await
+            .expect("still cached until invalidated");
 
         cache.invalidate().await;
-        assert_eq!(*cache.get().await.unwrap().unwrap(), vec![fp(FP_B)]);
+        let err = cache.authorize(&fp(FP_A)).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+        cache.authorize(&fp(FP_B)).await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Since #1073 a ceremony completes only once every KP has confirmed its share to the live ceremony guardian, but the proxy answered `ConfirmCeremony` with `PERMISSION_DENIED`, so a KP could only confirm over the operator's SSM tunnel. Forward it behind the gate the relay already applies to share submissions: the KP signature must verify, and the signer must be in the ceremony's committed roster read from the S3 share log. The enclave repeats both checks and binds each confirmation to its session and ceremony digest, so the proxy adds no authority; the roster check keeps a flood of self-signed requests off the enclave's serialized control lock. Exercised live on the `testing` stack: two KPs confirmed through the public endpoint and the ceremony completed.

## Changes

- `forward.rs`: forward `ConfirmCeremony` after the signature and roster checks. `OperatorInit`, `SetupNewKey`, `ProvisionerInit`, `OperatorActivate` and `RotateKpSet` stay denied.
- `RosterCache::authorize` is the one roster gate: the relay's share submissions and both forwarded KP-signed RPCs (`ProvisionerRotateCert` included, closing its TODO) go through it.
- A miss re-reads the share log, at most once per 5 s. `SetupNewKey` and `RotateKpSet` commit a new roster over the operator's tunnel, so nothing invalidates the cache for them; without the re-read a KP the new roster adds would be denied until the 60 s TTL, and `key-provisioner ceremony` confirms once without retrying.
- Tests: a rostered confirmation reaches the backend, an unrostered or malformed one is rejected before it, a tampered one fails `UNAUTHENTICATED`; in `roster.rs`, a KP added since the last read is admitted on its first call, the first ceremony is admitted from a cached miss, the re-read is bounded, and the gate's failure modes.
