### PR TITLE
withdrawal: remove status enum field

### DIFF
--- a/crates/e2e-tests/src/test_helpers.rs
+++ b/crates/e2e-tests/src/test_helpers.rs
@@ -20,7 +20,6 @@ use hashi_types::move_types::DepositConfirmed;
 use hashi_types::move_types::ProtocolType;
 use hashi_types::move_types::StampedDealerSubmissionV1;
 use hashi_types::move_types::WithdrawalConfirmed;
-use hashi_types::move_types::WithdrawalStatus;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -408,8 +407,8 @@ pub async fn wait_for_spent_utxo_cleanup(networks: &TestNetworks, timeout: Durat
 /// Wait until every node's object mirror shows the deferred withdrawal
 /// archival completed: no withdrawal transaction with
 /// `confirmed_timestamp_ms` set is still sitting in the hot
-/// `withdrawal_txns` bag, and no request in a post-commit status
-/// (Processing/Signed/Confirmed) is lingering in the hot `requests` bag.
+/// `withdrawal_txns` bag, and no committed request (linked to a withdrawal
+/// txn) is lingering in the hot `requests` bag.
 ///
 /// Under the v2 package `confirm_withdrawal` leaves the transaction (and
 /// its requests) in the hot bags; the leader's deferred-archival GC
@@ -440,14 +439,7 @@ pub async fn wait_for_withdrawal_archival(
                     let terminal_requests = state
                         .withdrawal_requests()
                         .iter()
-                        .filter(|request| {
-                            matches!(
-                                request.status,
-                                WithdrawalStatus::Processing
-                                    | WithdrawalStatus::Signed
-                                    | WithdrawalStatus::Confirmed
-                            )
-                        })
+                        .filter(|request| request.is_committed())
                         .count();
                     (confirmed_txns > 0 || terminal_requests > 0).then_some((
                         index,

--- a/crates/hashi-types/src/move_types/mod.rs
+++ b/crates/hashi-types/src/move_types/mod.rs
@@ -591,47 +591,11 @@ pub struct WithdrawalRequestQueue {
     pub confirmed_txns: Bag,
 }
 
-/// Rust version of the Move hashi::withdrawal_queue::WithdrawalStatus enum.
-#[derive(Clone, Debug, PartialEq, serde_derive::Deserialize, serde_derive::Serialize)]
-pub enum WithdrawalStatus {
-    Requested,
-    Approved,
-    Processing,
-    Signed,
-    Confirmed,
-}
-
-impl WithdrawalStatus {
-    /// Returns true if the status is `Approved`.
-    pub fn is_approved(&self) -> bool {
-        matches!(self, Self::Approved)
-    }
-
-    /// Returns true if the status is `Requested`.
-    pub fn is_requested(&self) -> bool {
-        matches!(self, Self::Requested)
-    }
-
-    /// Returns true while the request still awaits action in the queue
-    /// (`Requested` or `Approved`); false once committed into a withdrawal
-    /// txn. Mirrors Move's `WithdrawalStatus::is_active`.
-    pub fn is_active(&self) -> bool {
-        matches!(self, Self::Requested | Self::Approved)
-    }
-
-    /// Lowercase status name, for metric labels and CLI rendering.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Requested => "requested",
-            Self::Approved => "approved",
-            Self::Processing => "processing",
-            Self::Signed => "signed",
-            Self::Confirmed => "confirmed",
-        }
-    }
-}
-
 /// Rust version of the Move hashi::withdrawal_queue::WithdrawalRequest type.
+///
+/// Lifecycle state is derived, not stored: `approval_cert` marks approval
+/// and `withdrawal_txn_id` marks commitment into a withdrawal txn, whose own
+/// signing and confirmation fields carry the rest of the lifecycle.
 #[derive(Clone, Debug, PartialEq, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct WithdrawalRequest {
     pub id: Address,
@@ -639,17 +603,43 @@ pub struct WithdrawalRequest {
     pub btc_amount: u64,
     pub bitcoin_address: Vec<u8>,
     pub created_timestamp_ms: u64,
-    pub status: WithdrawalStatus,
     /// Committee certificate recorded at approval time. `None` until
     /// `approve_request` has been called.
     pub approval_cert: Option<CommitteeSignature>,
     /// Clock timestamp at the moment of approval. `None` until
     /// `approve_request` has been called.
     pub approved_timestamp_ms: Option<u64>,
+    /// The withdrawal txn this request was committed into. `None` until
+    /// commitment; once set, the BTC is drained and the request can no
+    /// longer be approved or cancelled.
     pub withdrawal_txn_id: Option<Address>,
     pub sui_tx_digest: Digest,
     /// BTC balance in satoshis.
     pub btc: u64,
+}
+
+impl WithdrawalRequest {
+    /// The committee has recorded an approval cert. Stays true after
+    /// commitment; see `awaits_commitment` for the actionable set.
+    pub fn is_approved(&self) -> bool {
+        self.approval_cert.is_some()
+    }
+
+    /// Committed into a withdrawal txn: the BTC is drained, and the request
+    /// only lingers in the mirrored map until the archival GC sweeps it.
+    pub fn is_committed(&self) -> bool {
+        self.withdrawal_txn_id.is_some()
+    }
+
+    /// Not yet approved by the committee (and therefore not committed).
+    pub fn awaits_approval(&self) -> bool {
+        !self.is_approved()
+    }
+
+    /// Approved but not yet committed into a withdrawal txn.
+    pub fn awaits_commitment(&self) -> bool {
+        self.is_approved() && !self.is_committed()
+    }
 }
 
 /// Lightweight info extracted from a request at commit time for validation.

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -19,7 +19,6 @@ use crate::cli::print_info;
 use crate::cli::print_success;
 use crate::cli::types::display;
 use crate::onchain::types::WithdrawalRequest;
-use crate::onchain::types::WithdrawalStatus;
 use crate::onchain::types::WithdrawalTransaction;
 
 pub async fn run(action: WithdrawCommands, config: &CliConfig, tx_opts: &TxOptions) -> Result<()> {
@@ -257,9 +256,9 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
     println!("{}", "━".repeat(60).dimmed());
 
     // Check the mirrored request map first. With deferred archival a request
-    // stays here for its whole live lifecycle — Requested/Approved, then
-    // Processing/Signed once committed into a withdrawal txn, then Confirmed
-    // until the archival GC moves it to the processed archive.
+    // stays here for its whole live lifecycle — awaiting approval, then
+    // commitment, then committed into a withdrawal txn until the archival GC
+    // moves it to the processed archive.
     if let Some(wr) = withdrawal_requests.iter().find(|w| w.id == req_addr) {
         println!(
             "  {} {}",
@@ -283,71 +282,49 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
             display::format_timestamp(wr.created_timestamp_ms)
         );
 
-        match wr.status {
-            WithdrawalStatus::Requested | WithdrawalStatus::Approved => {
+        // Committed into a withdrawal txn (BTC drained): render the txn's
+        // signing progress, looked up by the request's withdrawal_txn_id.
+        if let Some(txn_id) = wr.withdrawal_txn_id {
+            if let Some(pw) = withdrawal_txns.iter().find(|p| p.id == txn_id) {
+                print_txn_progress(config, pw);
+            } else {
                 println!();
-                let status_label = if wr.status.is_approved() {
-                    "Approved".green()
-                } else {
-                    "Requested".yellow()
-                };
+                print_info(&format!(
+                    "Request is committed to withdrawal transaction {} but that \
+                     transaction was not found in the pending queues.",
+                    display::format_address_full(&txn_id)
+                ));
+            }
+        } else {
+            println!();
+            let status_label = if wr.is_approved() {
+                "Approved".green()
+            } else {
+                "Requested".yellow()
+            };
 
-                let step = if wr.status.is_approved() { 2 } else { 1 };
-                println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
-                println!(
-                    "    {} Requested",
-                    if step >= 1 {
-                        "[done]".green()
-                    } else {
-                        "[    ]".dimmed()
-                    }
-                );
-                println!(
-                    "    {} Approved",
-                    if step >= 2 {
-                        "[done]".green()
-                    } else {
-                        "[    ]".dimmed()
-                    }
-                );
-                println!("    {} Committed", "[    ]".dimmed());
-                println!("    {} Signed", "[    ]".dimmed());
-                println!("    {} Broadcast", "[    ]".dimmed());
-                println!("    {} Confirmed", "[    ]".dimmed());
-            }
-            // Committed into a withdrawal txn (BTC drained): render the txn's
-            // signing progress, looked up by the request's withdrawal_txn_id.
-            WithdrawalStatus::Processing | WithdrawalStatus::Signed => {
-                let txn = wr
-                    .withdrawal_txn_id
-                    .and_then(|id| withdrawal_txns.iter().find(|p| p.id == id));
-                if let Some(pw) = txn {
-                    print_txn_progress(config, pw);
+            let step = if wr.is_approved() { 2 } else { 1 };
+            println!("  {} {} ({}/6)", "Progress:".bold(), status_label, step);
+            println!(
+                "    {} Requested",
+                if step >= 1 {
+                    "[done]".green()
                 } else {
-                    println!();
-                    print_info(&format!(
-                        "Request status is {} but its withdrawal transaction was not \
-                         found in the pending queues.",
-                        wr.status.as_str()
-                    ));
+                    "[    ]".dimmed()
                 }
-            }
-            // Terminal state: the withdrawal is complete; the request only
-            // lingers on-chain until the archival GC sweeps it.
-            WithdrawalStatus::Confirmed => {
-                println!();
-                println!(
-                    "  {} {} (6/6)",
-                    "Progress:".bold(),
-                    "Confirmed (archival pending)".green()
-                );
-                println!("    {} Requested", "[done]".green());
-                println!("    {} Approved", "[done]".green());
-                println!("    {} Committed", "[done]".green());
-                println!("    {} Signed", "[done]".green());
-                println!("    {} Broadcast", "[done]".green());
-                println!("    {} Confirmed", "[done]".green());
-            }
+            );
+            println!(
+                "    {} Approved",
+                if step >= 2 {
+                    "[done]".green()
+                } else {
+                    "[    ]".dimmed()
+                }
+            );
+            println!("    {} Committed", "[    ]".dimmed());
+            println!("    {} Signed", "[    ]".dimmed());
+            println!("    {} Broadcast", "[    ]".dimmed());
+            println!("    {} Confirmed", "[    ]".dimmed());
         }
     }
     // Check committed/signed withdrawal transactions
@@ -373,8 +350,8 @@ async fn status(config: &CliConfig, request_id: &str) -> Result<()> {
 
 /// Render the committed-phase progress checklist (steps 3-6) and Bitcoin-side
 /// context for a withdrawal transaction. Shared by the request-map lookup
-/// (Processing/Signed requests point at their txn via `withdrawal_txn_id`)
-/// and the txn-map fallback lookup.
+/// (committed requests point at their txn via `withdrawal_txn_id`) and the
+/// txn-map fallback lookup.
 fn print_txn_progress(config: &CliConfig, pw: &WithdrawalTransaction) {
     let txid: bitcoin::Txid = pw.txid.into();
     let is_confirmed = pw.is_confirmed();
@@ -483,7 +460,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                     serde_json::json!({
                         "request_id": wr.id.to_string(),
                         "amount_sats": wr.btc_amount,
-                        "status": wr.status.as_str(),
+                        "status": queued_status(wr),
                         "caller": wr.sender.to_string(),
                         "requested_ms": wr.created_timestamp_ms,
                     })
@@ -527,7 +504,7 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
                             "  {:<20} {:<14} {:<10} {:<20} {}",
                             display::format_address_full(&wr.id),
                             wr.btc_amount,
-                            wr.status.as_str(),
+                            queued_status(wr),
                             display::format_address_full(&wr.sender),
                             display::format_timestamp(wr.created_timestamp_ms)
                         );
@@ -575,15 +552,25 @@ async fn list(config: &CliConfig, output_format: OutputFormat) -> Result<()> {
     Ok(())
 }
 
-/// Split the mirrored request map into the actionable queue
-/// (Requested/Approved) and the requests the v2 flow committed in place
-/// (Processing/Signed, plus the defensively handled Confirmed). The latter
-/// must not report as queued backlog: their BTC is already drained into a
-/// withdrawal txn, which the txn view counts.
+/// Split the mirrored request map into the actionable queue (awaiting
+/// approval or commitment) and the requests the v2 flow committed in place.
+/// The latter must not report as queued backlog: their BTC is already
+/// drained into a withdrawal txn, which the txn view counts.
 fn partition_queued(
     requests: &[WithdrawalRequest],
 ) -> (Vec<&WithdrawalRequest>, Vec<&WithdrawalRequest>) {
-    requests.iter().partition(|wr| wr.status.is_active())
+    requests.iter().partition(|wr| !wr.is_committed())
+}
+
+/// Lowercase state of a request in the actionable queue, for JSON rows and
+/// the table. Only meaningful for uncommitted requests (see
+/// `partition_queued`).
+fn queued_status(wr: &WithdrawalRequest) -> &'static str {
+    if wr.is_approved() {
+        "approved"
+    } else {
+        "requested"
+    }
 }
 
 /// The JSON row for one in-flight withdrawal transaction.
@@ -611,6 +598,7 @@ fn withdrawal_txn_row(pw: &WithdrawalTransaction) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+    use hashi_types::move_types::CommitteeSignature;
     use hashi_types::move_types::MpcSig;
     use hashi_types::move_types::SigningBatch;
 
@@ -675,19 +663,25 @@ mod tests {
         assert_eq!(row["status"], "confirmed");
     }
 
-    fn request_with_status(status: WithdrawalStatus) -> WithdrawalRequest {
+    /// A request at one of the three mirrored lifecycle points: requested,
+    /// approved (cert recorded), or committed (linked to a withdrawal txn,
+    /// BTC drained).
+    fn request(id: u8, approved: bool, committed: bool) -> WithdrawalRequest {
         WithdrawalRequest {
-            id: sui_sdk_types::Address::new([1; 32]),
+            id: sui_sdk_types::Address::new([id; 32]),
             sender: sui_sdk_types::Address::new([2; 32]),
             btc_amount: 1,
             bitcoin_address: vec![0; 20],
             created_timestamp_ms: 0,
-            status,
-            approval_cert: None,
-            approved_timestamp_ms: None,
-            withdrawal_txn_id: None,
+            approval_cert: approved.then(|| CommitteeSignature {
+                epoch: 0,
+                signature: Vec::new(),
+                signers_bitmap: Vec::new(),
+            }),
+            approved_timestamp_ms: approved.then_some(1),
+            withdrawal_txn_id: committed.then(|| sui_sdk_types::Address::new([9; 32])),
             sui_tx_digest: sui_sdk_types::Digest::new([0; 32]),
-            btc: 1,
+            btc: if committed { 0 } else { 1 },
         }
     }
 
@@ -696,28 +690,22 @@ mod tests {
     /// (they are already counted through their withdrawal txn).
     #[test]
     fn queued_view_excludes_committed_in_place_requests() {
-        let requests: Vec<_> = [
-            WithdrawalStatus::Requested,
-            WithdrawalStatus::Approved,
-            WithdrawalStatus::Processing,
-            WithdrawalStatus::Signed,
-            WithdrawalStatus::Confirmed,
-        ]
-        .into_iter()
-        .map(request_with_status)
-        .collect();
+        let requests = vec![
+            request(1, false, false),
+            request(2, true, false),
+            request(3, true, true),
+        ];
 
         let (queued, committed_in_place) = partition_queued(&requests);
-        let statuses = |group: &[&WithdrawalRequest]| {
-            group
-                .iter()
-                .map(|wr| wr.status.as_str())
-                .collect::<Vec<_>>()
-        };
-        assert_eq!(statuses(&queued), ["requested", "approved"]);
+        let ids = |group: &[&WithdrawalRequest]| group.iter().map(|wr| wr.id).collect::<Vec<_>>();
+        assert_eq!(ids(&queued), [requests[0].id, requests[1].id]);
+        assert_eq!(ids(&committed_in_place), [requests[2].id]);
         assert_eq!(
-            statuses(&committed_in_place),
-            ["processing", "signed", "confirmed"]
+            queued
+                .iter()
+                .map(|wr| queued_status(wr))
+                .collect::<Vec<_>>(),
+            ["requested", "approved"]
         );
     }
 }

--- a/crates/hashi/src/leader/withdrawal_request_flow.rs
+++ b/crates/hashi/src/leader/withdrawal_request_flow.rs
@@ -38,7 +38,7 @@ impl LeaderService {
     // Step 1: Approve unapproved withdrawal requests
     // ========================================================================
 
-    /// Approve every actionable Requested withdrawal, one task and one
+    /// Approve every unapproved withdrawal, one task and one
     /// transaction per request (mirroring the deposit approval pool). Each
     /// task holds its request in `inflight_withdrawal_approvals` through the
     /// object-mirror wait, so a later cycle cannot re-approve it while other
@@ -56,7 +56,7 @@ impl LeaderService {
             .onchain_state()
             .withdrawal_requests()
             .into_iter()
-            .filter(|r| r.status.is_requested())
+            .filter(|r| r.awaits_approval())
             .collect();
         unapproved.sort_by_key(|r| r.created_timestamp_ms);
 
@@ -387,7 +387,7 @@ impl LeaderService {
             .onchain_state()
             .withdrawal_requests()
             .into_iter()
-            .filter(|r| r.status.is_approved())
+            .filter(|r| r.awaits_commitment())
             .collect();
         approved.sort_by_key(|r| r.created_timestamp_ms);
 

--- a/crates/hashi/src/metrics.rs
+++ b/crates/hashi/src/metrics.rs
@@ -1526,38 +1526,25 @@ impl Metrics {
         //                               is not yet Bitcoin-confirmed
         //   confirmed_pending_archive = the request's withdrawal txn is
         //                               Bitcoin-confirmed, awaiting the
-        //                               archival GC. The request's own status
-        //                               stays Signed until archival (confirm
-        //                               only stamps the txn), so this is
-        //                               derived from the txn's confirmed
-        //                               timestamp.
+        //                               archival GC. A request carries no
+        //                               state of its own past commitment
+        //                               (confirm only stamps the txn), so
+        //                               this is derived from the txn's
+        //                               confirmed timestamp.
         {
-            use crate::onchain::types::WithdrawalStatus;
             let mut requested = Vec::new();
             let mut approved = Vec::new();
             let mut committed = Vec::new();
             let mut confirmed_pending_archive = Vec::new();
             let txns = hashi.bitcoin().withdrawal_queue.withdrawal_txns();
             for r in hashi.bitcoin().withdrawal_queue.requests().values() {
-                match r.status {
-                    WithdrawalStatus::Requested => requested.push(r),
-                    WithdrawalStatus::Approved => approved.push(r),
-                    WithdrawalStatus::Processing | WithdrawalStatus::Signed => {
-                        if r.withdrawal_txn_id
-                            .as_ref()
-                            .and_then(|id| txns.get(id))
-                            .is_some_and(|t| t.is_confirmed())
-                        {
-                            confirmed_pending_archive.push(r)
-                        } else {
-                            committed.push(r)
-                        }
+                match r.withdrawal_txn_id {
+                    None if r.is_approved() => approved.push(r),
+                    None => requested.push(r),
+                    Some(txn_id) if txns.get(&txn_id).is_some_and(|t| t.is_confirmed()) => {
+                        confirmed_pending_archive.push(r)
                     }
-                    // Defensive: `archive_request` flips a request to
-                    // Confirmed in the same Move call that moves it out of
-                    // the hot bag, so this arm is unreachable from mirrored
-                    // post-transaction state.
-                    WithdrawalStatus::Confirmed => confirmed_pending_archive.push(r),
+                    Some(_) => committed.push(r),
                 }
             }
             for (label, class) in [

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -33,7 +33,6 @@ pub use hashi_types::move_types::Utxo;
 pub use hashi_types::move_types::UtxoId;
 pub use hashi_types::move_types::UtxoRecord;
 pub use hashi_types::move_types::WithdrawalRequest;
-pub use hashi_types::move_types::WithdrawalStatus;
 pub use hashi_types::move_types::WithdrawalTransaction;
 
 const NOT_SCRAPED: &str = "Bitcoin state was not scraped (ScrapeScope::GovernanceOnly)";

--- a/crates/hashi/src/withdrawals.rs
+++ b/crates/hashi/src/withdrawals.rs
@@ -141,22 +141,22 @@ const _: () = assert!(
 );
 
 /// Runtime-object cost model for `confirm_withdrawal`, with conservative
-/// upper-bound coefficients. `update_requests_confirmed` borrows each
-/// request in the `processed` ObjectBag (at most the `Field` wrapper plus
-/// the child object, 2 per request), and `mark_spent` borrows each input's
-/// `utxo_records` entry (1 per input; the record removal itself is deferred
-/// to `cleanup_spent_utxos`). `finalize_withdrawal` has the same
-/// per-request shape via `update_requests_signed` but no per-input loop, so
-/// confirm dominates it and is the only post-commit transaction modeled
-/// here.
+/// upper-bound coefficients. Confirm touches no request objects (the
+/// requests' move to the archive is deferred to the archival GC), and
+/// `mark_spent` borrows each input's `utxo_records` entry (1 per input; the
+/// record removal itself is deferred to `cleanup_spent_utxos`).
+/// `finalize_withdrawal` touches only the txn object, with no per-request
+/// or per-input loop, so confirm dominates it and is the only post-commit
+/// transaction modeled here.
 ///
 /// With these coefficients the commit model above binds at every request
 /// count that matters (3 objects per request versus 2), but confirm is
 /// checked alongside it so a future change to either cost cannot silently
 /// regress the other.
 const WITHDRAWAL_CONFIRM_FIXED_RUNTIME_OBJECTS: usize = 43;
-/// v2 confirm defers every request-status write to the archival GC, so its
-/// object cost no longer scales with the request count.
+/// v2 confirm defers the requests' archive move to the archival GC and
+/// writes nothing on the requests themselves, so its object cost does not
+/// scale with the request count.
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_REQUEST: usize = 0;
 const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
 
@@ -164,7 +164,8 @@ const WITHDRAWAL_CONFIRM_RUNTIME_OBJECTS_PER_INPUT: usize = 1;
 /// GC: ~3 objects per archived txn (hot-bag `Field` + child
 /// borrow, new cold-bag `Field`; the remove reuses the cache) and ~3 per
 /// request (the `requests` removal `Field` + child + the new `processed`
-/// `Field`; the pre-upgrade-leftover fallback path costs the same bound).
+/// `Field`; an already-archived or pre-upgrade-leftover request is skipped
+/// after the `requests` probe alone, under the same bound).
 /// Conservative upper bounds pending sui-replay measurement; the executor's
 /// greedy packer sizes each GC transaction from these.
 pub(crate) const WITHDRAWAL_ARCHIVE_FIXED_RUNTIME_OBJECTS: usize = 12;
@@ -173,9 +174,10 @@ pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECTS_PER_REQUEST: usize = 3;
 pub(crate) const WITHDRAWAL_ARCHIVE_RUNTIME_OBJECT_BUDGET: usize = WITHDRAWAL_RUNTIME_OBJECT_BUDGET;
 
 /// Cost of `finish_archive_withdrawal_txn`'s completeness walk: the walk
-/// probes only the `processed` bag, and its per-request ObjectBag borrow
-/// touches two runtime objects (the `Field` wrapper plus the child
-/// request), on top of the txn borrow.
+/// only probes the `processed` bag for each request (a `contains`, at most
+/// the `Field` wrapper) on top of the txn borrow. Kept at the earlier
+/// borrow-based bound of two objects per request (`Field` wrapper plus
+/// child) as a conservative margin pending sui-replay measurement.
 pub(crate) const WITHDRAWAL_ARCHIVE_FINISH_RUNTIME_OBJECTS_PER_REQUEST: usize = 2;
 
 // A txn whose requests exceed one GC transaction archives through the
@@ -440,7 +442,13 @@ impl Hashi {
                     approval.request_id
                 ))
             })?;
-        if request.status.is_approved() {
+        if request.is_committed() {
+            return Err(WithdrawalApprovalError::NeverRetry(anyhow!(
+                "Withdrawal request {} is already committed to a withdrawal transaction",
+                approval.request_id
+            )));
+        }
+        if request.is_approved() {
             return Err(WithdrawalApprovalError::NeverRetry(anyhow!(
                 "Withdrawal request {} is already approved",
                 approval.request_id
@@ -497,7 +505,8 @@ impl Hashi {
             &approval.outputs,
         )?;
 
-        // 1. Verify each request_id exists and is approved
+        // 1. Verify each request_id exists, is approved, and is not already
+        //    committed into another withdrawal txn.
         let requests: Vec<WithdrawalRequest> = approval
             .request_ids
             .iter()
@@ -507,7 +516,11 @@ impl Hashi {
                     .withdrawal_request(id)
                     .ok_or_else(|| anyhow!("Withdrawal request {id} not found in queue"))?;
                 anyhow::ensure!(
-                    request.status.is_approved(),
+                    !request.is_committed(),
+                    "Withdrawal request {id} is already committed to a withdrawal transaction"
+                );
+                anyhow::ensure!(
+                    request.is_approved(),
                     "Withdrawal request {id} has not been approved"
                 );
                 Ok(request)

--- a/packages/hashi/sources/btc/withdraw.move
+++ b/packages/hashi/sources/btc/withdraw.move
@@ -175,7 +175,7 @@ entry fun commit_withdrawal_tx(
         hashi.bitcoin_mut().utxo_pool_mut().lock(utxo.id(), withdrawal_txn_id);
     });
 
-    // Commit requests: drain BTC, set status + withdrawal_txn_id, move to processed.
+    // Commit requests in place: drain BTC and link each to this transaction.
     let btc_to_burn = hashi.bitcoin_mut().withdrawal_queue_mut().commit_requests(&withdrawal_txn);
 
     // Burn BTC balance
@@ -249,11 +249,12 @@ entry fun finalize_withdrawal(
         guardian_signatures,
     };
     hashi.verify(hashi::intent::withdrawal_signed(), approval, cert);
-    let WithdrawalSignedMessage { request_ids, guardian_signatures, .. } = approval;
+    let WithdrawalSignedMessage { guardian_signatures, .. } = approval;
 
-    let queue = hashi.bitcoin_mut().withdrawal_queue_mut();
-    queue.finalize_withdrawal_txn(withdrawal_id, guardian_signatures, clock);
-    queue.update_requests_signed(&request_ids);
+    hashi
+        .bitcoin_mut()
+        .withdrawal_queue_mut()
+        .finalize_withdrawal_txn(withdrawal_id, guardian_signatures, clock);
 }
 
 entry fun confirm_withdrawal(
@@ -283,10 +284,10 @@ entry fun confirm_withdrawal(
     );
 
     // Copy the input/change data out of a short borrow; the txn itself stays
-    // in the hot bag. Its move to `confirmed_txns` — and the requests' status
-    // flip and move to `processed` — are deferred to
-    // `archive_confirmed_withdrawals`, keeping this transaction's runtime
-    // object count independent of the request count.
+    // in the hot bag. Its move to `confirmed_txns` — and the requests' move
+    // to `processed` — are deferred to `archive_confirmed_withdrawals`,
+    // keeping this transaction's runtime object count independent of the
+    // request count.
     let (inputs, change_ids) = {
         let txn = hashi.bitcoin().withdrawal_queue().borrow_withdrawal_txn(withdrawal_id);
         (*txn.withdrawal_txn_inputs(), txn.change_utxo_ids())
@@ -315,8 +316,7 @@ entry fun confirm_withdrawal(
 
 /// Deferred archival for confirmed withdrawals: move each transaction from
 /// `withdrawal_txns` to `confirmed_txns` and its requests from `requests` to
-/// `processed` (setting status Confirmed). Idempotent per id, so callers may
-/// batch and retry freely.
+/// `processed`. Idempotent per id, so callers may batch and retry freely.
 ///
 /// Carries no committee cert: every write is derivable from already-certified
 /// state (`confirmed_timestamp_ms` is only ever set under a confirmation
@@ -447,10 +447,10 @@ public fun request_withdrawal(
 
 /// Cancel a pending withdrawal request and return the stored BTC to the requester.
 ///
-/// Cancellation is allowed while the request is in the `Requested` or `Approved`
-/// state (i.e. still in the active requests bag). Once the committee commits the
-/// request to a `WithdrawalTransaction` it moves to `Processing` in the processed
-/// bag and its BTC is burned — cancellation is no longer possible.
+/// Cancellation is allowed while the request awaits approval or commitment.
+/// Once the committee commits the request to a `WithdrawalTransaction` its BTC
+/// is burned and the request is linked to that transaction — cancellation is
+/// no longer possible.
 public fun cancel_withdrawal(
     hashi: &mut Hashi,
     request_id: address,

--- a/packages/hashi/sources/btc/withdrawal_queue.move
+++ b/packages/hashi/sources/btc/withdrawal_queue.move
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Storage and state machine for Bitcoin withdrawals. Holds `WithdrawalRequest`
-/// objects as they move from Requested through Approved, Processing, Signed,
-/// and Confirmed, plus the `WithdrawalTransaction` objects that batch them:
+/// objects as they move from requested through approved and committed to
+/// archived, plus the `WithdrawalTransaction` objects that batch them:
 /// each transaction tracks its input UTXOs, withdrawal and change outputs, and
 /// the incrementally collected MPC and guardian signatures. Certificate
 /// verification and funds movement are driven by `hashi::withdraw`.
@@ -25,6 +25,9 @@ use fun btc_config::worst_case_network_fee as Config.worst_case_network_fee;
 
 #[error]
 const ERequestNotApproved: vector<u8> = b"Withdrawal request has not been approved";
+#[error]
+const ERequestAlreadyCommitted: vector<u8> =
+    b"Withdrawal request has already been committed to a withdrawal transaction";
 #[error]
 const EOutputBelowDust: vector<u8> =
     b"Withdrawal output would be below dust threshold after miner fee deduction";
@@ -66,24 +69,18 @@ const ERequestTxnMismatch: vector<u8> =
 
 // ~~~~~~~ Structs ~~~~~~~
 
-public enum WithdrawalStatus has copy, drop, store {
-    Requested,
-    Approved,
-    Processing,
-    Signed,
-    Confirmed,
-}
-
 /// Unified withdrawal request object. Tracks the full lifecycle of a withdrawal,
 /// from initial request through to confirmation or cancellation.
 ///
-/// The `status` field is authoritative for lifecycle state. A request lives in
-/// the `requests` bag for its whole live lifecycle (Requested through
-/// Confirmed-awaiting-archival) and is moved to the `processed` archive only by
-/// the deferred `archive_withdrawal_txn` GC — keeping the per-request cost of
-/// commit/confirm to an in-place borrow instead of a bag move. Requests
-/// committed before the v2 upgrade were moved to `processed` at commit time
-/// and stay there; dual-location helpers cover both homes.
+/// Lifecycle state is derived, not stored: `approval_cert` marks approval and
+/// `withdrawal_txn_id` marks commitment into a `WithdrawalTransaction`, whose
+/// own signing and confirmation fields carry the rest of the lifecycle. A
+/// request lives in the `requests` bag for its whole live lifecycle (requested
+/// through confirmed-awaiting-archival) and is moved to the `processed`
+/// archive only by the deferred `archive_withdrawal_txn` GC — keeping the
+/// per-request cost of commit/confirm to an in-place borrow instead of a bag
+/// move. Requests committed before the v2 upgrade were moved to `processed`
+/// at commit time and stay there; dual-location helpers cover both homes.
 ///
 /// The BTC balance starts full and is drained to zero at commit (burned) or cancel (returned).
 public struct WithdrawalRequest has key, store {
@@ -92,24 +89,28 @@ public struct WithdrawalRequest has key, store {
     btc_amount: u64,
     bitcoin_address: vector<u8>,
     created_timestamp_ms: u64,
-    status: WithdrawalStatus,
     /// Committee certificate recorded at approval time. `None` until
     /// `approve_request` has been called.
     approval_cert: Option<CommitteeSignature>,
     /// Clock timestamp at the moment of approval. `None` until
     /// `approve_request` has been called.
     approved_timestamp_ms: Option<u64>,
+    /// The `WithdrawalTransaction` this request was committed into. `None`
+    /// until `commit_requests`; once set, the BTC is drained and the request
+    /// can no longer be approved or cancelled.
     withdrawal_txn_id: Option<address>,
     sui_tx_digest: vector<u8>,
     btc: Balance<BTC>,
 }
 
 public struct WithdrawalRequestQueue has store {
-    /// Active requests awaiting action (Requested, Approved).
+    /// Live requests: awaiting approval or commitment, plus requests committed
+    /// in place and awaiting the archival GC.
     /// ObjectBag so WithdrawalRequest UIDs are directly accessible via getObject.
     requests: ObjectBag,
-    /// Processed requests — BTC consumed, lifecycle continuing or complete
-    /// (Processing, Signed, Confirmed).
+    /// Archived requests — BTC consumed and their withdrawal transaction
+    /// confirmed (plus requests committed before the deferred-archival
+    /// upgrade, which were moved here at commit time).
     processed: ObjectBag,
     /// In-flight withdrawal transactions (unsigned, signed but unconfirmed).
     /// ObjectBag so WithdrawalTransaction UIDs are directly accessible via getObject.
@@ -278,7 +279,6 @@ public(package) fun create_withdrawal(
         btc_amount,
         bitcoin_address,
         created_timestamp_ms: clock.timestamp_ms(),
-        status: WithdrawalStatus::Requested,
         approval_cert: option::none(),
         approved_timestamp_ms: option::none(),
         withdrawal_txn_id: option::none(),
@@ -298,7 +298,7 @@ public(package) fun insert_withdrawal(
     self.requests.add(request_id, request);
 }
 
-/// Approve a withdrawal request. Updates status in the requests bag.
+/// Approve a withdrawal request: record the cert and approval time in place.
 /// The caller must have verified `cert` against the current committee.
 public(package) fun approve_withdrawal(
     self: &mut WithdrawalRequestQueue,
@@ -308,16 +308,10 @@ public(package) fun approve_withdrawal(
 ) {
     let request: &mut WithdrawalRequest = self.requests.borrow_mut(request_id);
     // A committed request stays in `requests` until archival, so an approval
-    // cert replayed after commit would otherwise reset Processing back to
-    // Approved — re-arming `commit_requests` on a request whose BTC is
-    // already drained. Before deferred archival this protection came from
+    // cert replayed after commit would otherwise re-stamp a request whose BTC
+    // is already drained. Before deferred archival this protection came from
     // the request having left the bag.
-    assert!(request.status.is_active(), ECannotApproveCommittedRequest);
-    // `withdrawal_txn_id` is written together with the Processing status at
-    // commit; assert it separately so approval can never touch a request a
-    // withdrawal transaction already references, even if the status were
-    // ever to fall out of sync with the link.
-    assert!(request.withdrawal_txn_id.is_none(), ECannotApproveCommittedRequest);
+    assert!(!request.is_committed(), ECannotApproveCommittedRequest);
     // Re-approval is only allowed with a cert from a strictly later epoch
     // than the stored one: a new committee refreshing a cert left stale by
     // reconfiguration. A same-epoch cert is a replay that would only reset
@@ -327,7 +321,6 @@ public(package) fun approve_withdrawal(
             request.approval_cert.borrow().signature_epoch() < cert.signature_epoch(),
         EApprovalCertNotNewer,
     );
-    request.status = WithdrawalStatus::Approved;
     request.approval_cert = option::some(cert);
     request.approved_timestamp_ms = option::some(clock.timestamp_ms());
 }
@@ -360,8 +353,9 @@ public(package) fun extract_request_infos(
     })
 }
 
-/// Commit approved requests for a withdrawal transaction: drain BTC and
-/// update status in place. Returns the merged BTC balance for burning.
+/// Commit approved requests for a withdrawal transaction: drain BTC and link
+/// each request to the transaction in place. Returns the merged BTC balance
+/// for burning.
 /// The request stays in `requests` — the move to `processed` is deferred to
 /// `archive_withdrawal_txn` so this transaction pays two runtime objects per
 /// request instead of three.
@@ -374,42 +368,16 @@ public(package) fun commit_requests(
 
     withdrawal_txn.request_ids.do_ref!(|id| {
         let request: &mut WithdrawalRequest = self.requests.borrow_mut(*id);
-        assert!(request.status == WithdrawalStatus::Approved, ERequestNotApproved);
+        assert!(request.is_approved(), ERequestNotApproved);
+        // The link doubles as the drained marker: a second commit would pay
+        // the user's Bitcoin output again without burning any BTC.
+        assert!(!request.is_committed(), ERequestAlreadyCommitted);
 
-        // Drain the BTC balance and merge
         total_btc.join(request.btc.withdraw_all());
-
-        // Update status and link to the withdrawal transaction
-        request.status = WithdrawalStatus::Processing;
         request.withdrawal_txn_id = option::some(withdrawal_txn_id);
     });
 
     total_btc
-}
-
-/// Update request statuses to Signed after MPC signing completes.
-public(package) fun update_requests_signed(
-    self: &mut WithdrawalRequestQueue,
-    request_ids: &vector<address>,
-) {
-    request_ids.do_ref!(|id| {
-        let request = self.borrow_request_mut_any(*id);
-        request.status = WithdrawalStatus::Signed;
-    });
-}
-
-/// Borrow a committed request wherever it lives: `requests` (in-place
-/// lifecycle) first, falling back to `processed` (requests committed before
-/// the deferred-archival upgrade, and archived requests).
-fun borrow_request_mut_any(
-    self: &mut WithdrawalRequestQueue,
-    request_id: address,
-): &mut WithdrawalRequest {
-    if (self.requests.contains(request_id)) {
-        self.requests.borrow_mut(request_id)
-    } else {
-        self.processed.borrow_mut(request_id)
-    }
 }
 
 /// Cancel a withdrawal: drain BTC, clean up user index, destroy the request.
@@ -424,7 +392,7 @@ public(package) fun cancel_withdrawal(
     // WithdrawalTransaction; destroying it would permanently abort that
     // txn's archival. The entry-level `is_request_processing` gate refuses
     // first — this backstops it.
-    assert!(request.status.is_active(), ERequestNotCancellable);
+    assert!(!request.is_committed(), ERequestNotCancellable);
 
     let WithdrawalRequest {
         id,
@@ -432,7 +400,6 @@ public(package) fun cancel_withdrawal(
         btc_amount: _,
         bitcoin_address: _,
         created_timestamp_ms: _,
-        status: _,
         approval_cert: _,
         approved_timestamp_ms: _,
         withdrawal_txn_id: _,
@@ -452,9 +419,9 @@ public(package) fun borrow_request(
 }
 
 /// Check if a request has already been committed to a WithdrawalTransaction.
-/// Status-first: a committed request stays in `requests` (as
-/// Processing/Signed/Confirmed) until archival; the `processed` fallback
-/// covers requests committed before the deferred-archival upgrade and
+/// Link-first: a committed request stays in `requests` until archival, so
+/// its `withdrawal_txn_id` is the authority; the `processed` fallback covers
+/// requests committed before the deferred-archival upgrade and
 /// already-archived requests.
 public(package) fun is_request_processing(
     self: &WithdrawalRequestQueue,
@@ -462,7 +429,7 @@ public(package) fun is_request_processing(
 ): bool {
     if (self.requests.contains(request_id)) {
         let request: &WithdrawalRequest = self.requests.borrow(request_id);
-        !request.status.is_active()
+        request.is_committed()
     } else {
         self.processed.contains(request_id)
     }
@@ -638,12 +605,12 @@ public(package) fun mark_txn_confirmed(
 }
 
 /// Deferred archival for one confirmed withdrawal: move the txn to
-/// `confirmed_txns` and each of its requests to `processed` with status
-/// Confirmed. Idempotent — no-ops if the txn already archived (re-run or
-/// raced GC). Aborts if the txn exists but is not confirmed (caller error).
+/// `confirmed_txns` and each of its requests to `processed`. Idempotent —
+/// no-ops if the txn already archived (re-run or raced GC). Aborts if the txn
+/// exists but is not confirmed (caller error).
 ///
 /// Requests committed before the deferred-archival upgrade already live in
-/// `processed`; for those only the status write applies.
+/// `processed` and need no write.
 public(package) fun archive_withdrawal_txn(
     self: &mut WithdrawalRequestQueue,
     withdrawal_id: address,
@@ -663,25 +630,21 @@ public(package) fun archive_withdrawal_txn(
     self.confirmed_txns.add(withdrawal_id, txn);
 }
 
-/// Archive one request of a confirmed withdrawal wherever it lives. The
-/// `withdrawal_txn_id` cross-check runs in BOTH branches: the chunked entry
-/// takes caller-supplied ids, and without the check in the fallback branch a
-/// caller could flip an unrelated archived request's status.
+/// Archive one request of a confirmed withdrawal: move it from `requests` to
+/// `processed`. A request already in `processed` (archived earlier, or
+/// committed before the deferred-archival upgrade) needs no write, so it is
+/// skipped without being touched. The `withdrawal_txn_id` cross-check matters
+/// because the chunked entry takes caller-supplied ids: without it a caller
+/// could archive a live request of an unrelated withdrawal.
 fun archive_request(
     self: &mut WithdrawalRequestQueue,
     withdrawal_id: address,
     request_id: address,
 ) {
-    if (self.requests.contains(request_id)) {
-        let mut request: WithdrawalRequest = self.requests.remove(request_id);
-        assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
-        request.status = WithdrawalStatus::Confirmed;
-        self.processed.add(request_id, request);
-    } else {
-        let request: &mut WithdrawalRequest = self.processed.borrow_mut(request_id);
-        assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
-        request.status = WithdrawalStatus::Confirmed;
-    }
+    if (!self.requests.contains(request_id)) return;
+    let request: WithdrawalRequest = self.requests.remove(request_id);
+    assert!(request.withdrawal_txn_id == option::some(withdrawal_id), ERequestTxnMismatch);
+    self.processed.add(request_id, request);
 }
 
 /// Chunked archival: archive only the listed requests of a confirmed
@@ -689,7 +652,8 @@ fun archive_request(
 /// count exceeds one Sui transaction's runtime-object budget archive across
 /// several transactions; `finish_archive_withdrawal_txn` moves the txn once
 /// every request is archived. No-ops if the txn is already fully archived
-/// (re-run or raced GC); idempotent per request via the `processed` branch.
+/// (re-run or raced GC); idempotent per request (an already-archived request
+/// is skipped).
 public(package) fun archive_withdrawal_requests(
     self: &mut WithdrawalRequestQueue,
     withdrawal_id: address,
@@ -704,19 +668,15 @@ public(package) fun archive_withdrawal_requests(
 }
 
 /// Finish a chunked archival: move the txn to `confirmed_txns` once every
-/// one of its requests has been archived — absent from the hot `requests`
-/// bag and, when resident in `processed`, flipped to `Confirmed`. Bag
-/// location alone is not completion: `processed` also holds requests
-/// committed before the v2 upgrade, still `Processing`/`Signed` until
-/// `archive_request` confirms them in place, so a location-only probe would
-/// let the permissionless finisher retire the txn immediately after
-/// confirmation and strand those requests with stale statuses. Silently
-/// no-ops while any request is still unarchived (or if the txn is already
-/// archived), so batched GC calls survive races with in-flight chunk
-/// transactions; the caller re-arms and retries from mirror state. The walk
-/// costs two runtime objects per request (the `processed` field wrapper and
-/// the borrowed child), which fits Sui's object budget at the largest batch
-/// size — see the probe comment in the body.
+/// one of its requests is resident in `processed`. Bag location is the whole
+/// of archival, since a request carries no lifecycle state of its own:
+/// requests committed before the v2 upgrade already live in `processed` and
+/// count as archived from the start. Silently no-ops while any request is
+/// still unarchived (or if the txn is already archived), so batched GC calls
+/// survive races with in-flight chunk transactions; the caller re-arms and
+/// retries from mirror state. The walk costs at most one runtime object per
+/// request (the `processed` field wrapper), inside Sui's object budget at
+/// the largest batch size — see the probe comment in the body.
 public(package) fun finish_archive_withdrawal_txn(
     self: &mut WithdrawalRequestQueue,
     withdrawal_id: address,
@@ -727,21 +687,12 @@ public(package) fun finish_archive_withdrawal_txn(
         assert!(txn.confirmed_timestamp_ms.is_some(), EWithdrawalNotConfirmed);
         txn.request_ids
     };
-    let mut i = 0;
-    let n = request_ids.length();
-    while (i < n) {
-        let id = request_ids[i];
-        // A committed request lives in exactly one bag and archival only
-        // ever adds to `processed`, so probing `processed` alone suffices: a
-        // request still in `requests` is simply not there yet. Skipping the
-        // `requests` probe keeps the walk at two runtime objects per request
-        // (field wrapper + child), inside Sui's object budget even at the
-        // largest batch size; a third probe per request would blow it.
-        if (!self.processed.contains(id)) return;
-        let request: &WithdrawalRequest = self.processed.borrow(id);
-        if (request.status != WithdrawalStatus::Confirmed) return;
-        i = i + 1;
-    };
+    // A committed request lives in exactly one bag and archival only ever
+    // adds to `processed`, so probing `processed` alone suffices: a request
+    // still in `requests` is simply not there yet. Skipping the `requests`
+    // probe keeps the walk at one runtime object per request (the field
+    // wrapper), inside Sui's object budget even at the largest batch size.
+    if (request_ids.any!(|id| !self.processed.contains(*id))) return;
     let txn: WithdrawalTransaction = self.withdrawal_txns.remove(withdrawal_id);
     sui::event::emit(WithdrawalArchived {
         withdrawal_txn_id: withdrawal_id,
@@ -881,28 +832,25 @@ public(package) fun request_btc_amount(self: &WithdrawalRequest): u64 {
     self.btc_amount
 }
 
-public(package) fun request_status(self: &WithdrawalRequest): &WithdrawalStatus {
-    &self.status
-}
-
 public(package) fun request_bitcoin_address(self: &WithdrawalRequest): &vector<u8> {
     &self.bitcoin_address
 }
 
-public(package) fun is_approved(self: &WithdrawalStatus): bool {
-    match (self) {
-        WithdrawalStatus::Approved => true,
-        _ => false,
-    }
+/// The withdrawal transaction this request was committed into, if any.
+public(package) fun request_withdrawal_txn_id(self: &WithdrawalRequest): Option<address> {
+    self.withdrawal_txn_id
 }
 
-/// Status is Requested or Approved: the request has not been committed to a
-/// withdrawal transaction, so it can still be approved or cancelled.
-public(package) fun is_active(self: &WithdrawalStatus): bool {
-    match (self) {
-        WithdrawalStatus::Requested | WithdrawalStatus::Approved => true,
-        _ => false,
-    }
+/// The committee has recorded an approval cert. Stays true after commitment;
+/// pair with `is_committed` to find requests still awaiting commitment.
+public(package) fun is_approved(self: &WithdrawalRequest): bool {
+    self.approval_cert.is_some()
+}
+
+/// Committed into a withdrawal transaction: the BTC is drained and the
+/// request can no longer be approved or cancelled.
+public(package) fun is_committed(self: &WithdrawalRequest): bool {
+    self.withdrawal_txn_id.is_some()
 }
 
 // === Event Emitters ===
@@ -996,45 +944,6 @@ public(package) fun has_confirmed_txn(self: &WithdrawalRequestQueue, id: address
     self.confirmed_txns.contains(id)
 }
 
-/// Status of a request wherever it lives (requests first, processed fallback).
-#[test_only]
-public(package) fun request_status_any(
-    self: &WithdrawalRequestQueue,
-    id: address,
-): WithdrawalStatus {
-    if (self.requests.contains(id)) {
-        let request: &WithdrawalRequest = self.requests.borrow(id);
-        request.status
-    } else {
-        let request: &WithdrawalRequest = self.processed.borrow(id);
-        request.status
-    }
-}
-
-#[test_only]
-public(package) fun is_processing(self: &WithdrawalStatus): bool {
-    match (self) {
-        WithdrawalStatus::Processing => true,
-        _ => false,
-    }
-}
-
-#[test_only]
-public(package) fun is_signed(self: &WithdrawalStatus): bool {
-    match (self) {
-        WithdrawalStatus::Signed => true,
-        _ => false,
-    }
-}
-
-#[test_only]
-public(package) fun is_confirmed(self: &WithdrawalStatus): bool {
-    match (self) {
-        WithdrawalStatus::Confirmed => true,
-        _ => false,
-    }
-}
-
 /// Replicates the pre-deferred-archival commit (remove from `requests`, add
 /// to `processed`) so tests can simulate requests committed before the
 /// upgrade.
@@ -1047,9 +956,9 @@ public(package) fun commit_requests_v1_style_for_testing(
     let mut total_btc = sui::balance::zero<BTC>();
     withdrawal_txn.request_ids.do_ref!(|id| {
         let mut request: WithdrawalRequest = self.requests.remove(*id);
-        assert!(request.status == WithdrawalStatus::Approved, ERequestNotApproved);
+        assert!(request.is_approved(), ERequestNotApproved);
+        assert!(!request.is_committed(), ERequestAlreadyCommitted);
         total_btc.join(request.btc.withdraw_all());
-        request.status = WithdrawalStatus::Processing;
         request.withdrawal_txn_id = option::some(withdrawal_txn_id);
         self.processed.add(*id, request);
     });

--- a/packages/hashi/tests/withdraw_tests.move
+++ b/packages/hashi/tests/withdraw_tests.move
@@ -223,8 +223,8 @@ fun test_approve_then_cancel() {
 
 #[test]
 #[expected_failure(abort_code = hashi::withdraw::ECannotCancelProcessingWithdrawal)]
-/// Once a request has been committed to a WithdrawalTransaction it is in the
-/// Processing state and its BTC has been burned — cancellation must be rejected.
+/// Once a request has been committed to a WithdrawalTransaction its BTC has
+/// been burned — cancellation must be rejected.
 fun test_cancel_processing_request() {
     let epoch = 0u64;
     let ctx = &mut test_utils::new_tx_context(REQUESTER, epoch);
@@ -244,7 +244,7 @@ fun test_cancel_processing_request() {
     let cert = test_utils::sign_certificate(epoch, &message_bytes, 3);
     hashi::withdraw::approve_request(&mut hashi, id1, cert, &clock);
 
-    // Commit the request into a WithdrawalTransaction — this moves it to Processing.
+    // Commit the request into a WithdrawalTransaction.
     let test_utxo = utxo::utxo(utxo::utxo_id(@0xBEEF, 0), 1_000_000, option::none());
     let txn = withdrawal_queue::new_withdrawal_txn_for_testing(
         vector[id1],
@@ -308,7 +308,6 @@ fun setup_fully_signed_txn(
     let queue = hashi.bitcoin_mut().withdrawal_queue_mut();
     queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
     queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], clock);
-    queue.update_requests_signed(&vector[id]);
     (id, txn_id)
 }
 
@@ -334,13 +333,12 @@ fun test_confirm_withdrawal_defers_archival() {
     let (id, txn_id) = setup_fully_signed_txn(&mut hashi, &clock, ctx);
     confirm_via_entry(&mut hashi, txn_id, &clock);
 
-    // Confirm recorded in place: txn stays in the hot bag, request keeps its
-    // Signed status in `requests`; both moves are deferred to archival.
+    // Confirm recorded in place: txn stays in the hot bag, request stays in
+    // `requests`; both moves are deferred to archival.
     let queue = hashi.bitcoin().withdrawal_queue();
     assert!(queue.has_withdrawal_txn(txn_id));
     assert!(!queue.has_confirmed_txn(txn_id));
     assert!(queue.request_in_requests(id));
-    assert!(queue.request_status_any(id).is_signed());
 
     // The archival GC completes both moves.
     hashi::withdraw::archive_confirmed_withdrawals(&mut hashi, vector[txn_id]);
@@ -348,7 +346,6 @@ fun test_confirm_withdrawal_defers_archival() {
     assert!(!queue.has_withdrawal_txn(txn_id));
     assert!(queue.has_confirmed_txn(txn_id));
     assert!(queue.request_in_processed(id));
-    assert!(queue.request_status_any(id).is_confirmed());
 
     clock.destroy_for_testing();
     std::unit_test::destroy(hashi);
@@ -404,7 +401,6 @@ fun test_archive_entry_batch_mixed() {
         let queue = hashi.bitcoin_mut().withdrawal_queue_mut();
         queue.record_input_signatures(txn_id2, vector[0], vector[x"DEADBEEF"]);
         queue.finalize_withdrawal_txn(txn_id2, vector[x"AAAAAAAA"], &clock);
-        queue.update_requests_signed(&vector[id2]);
     };
     confirm_via_entry(&mut hashi, txn_id2, &clock);
 
@@ -429,7 +425,7 @@ fun test_cancel_pre_upgrade_processed_request() {
 
     // Simulate a request committed before the deferred-archival upgrade: it
     // sits in `processed`, so the cancellation gate must trip via the
-    // fallback bag check rather than the status-first path.
+    // fallback bag check rather than the in-place txn-link check.
     let id = setup_withdrawal_request(&mut hashi, &clock, 10_000, ctx);
     hashi.bitcoin_mut().withdrawal_queue_mut().approve_withdrawal(id, dummy_queue_cert(), &clock);
     let input = utxo::utxo(utxo::utxo_id(@0xBEEF, 0), 1_000_000, option::none());

--- a/packages/hashi/tests/withdrawal_queue_tests.move
+++ b/packages/hashi/tests/withdrawal_queue_tests.move
@@ -18,6 +18,7 @@ use hashi::{
         EMinerFeeExceedsMax,
         ECannotApproveCommittedRequest,
         EApprovalCertNotNewer,
+        ERequestAlreadyCommitted,
         ERequestNotCancellable,
         EWithdrawalNotConfirmed,
         EWithdrawalAlreadyConfirmed,
@@ -995,16 +996,36 @@ fun test_miner_fee_exceeds_max_aborts() {
 // ======== Deferred archival tests ========
 
 #[test]
-fun test_commit_leaves_request_in_requests_with_processing() {
+fun test_commit_leaves_request_in_requests_linked_to_txn() {
     let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
     let mut queue = setup_queue(ctx);
     let clock = clock::create_for_testing(ctx);
 
-    let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+    let id = setup_request(&mut queue, &clock, 50_000, ctx);
+    queue.approve_withdrawal(id, dummy_cert(), &clock);
+    {
+        let request = queue.borrow_request(id);
+        assert!(request.is_approved());
+        assert!(!request.is_committed());
+        assert!(request.request_withdrawal_txn_id().is_none());
+    };
+    assert!(!queue.is_request_processing(id));
 
+    let txn = make_test_txn(vector[id], @0xBEEF, &clock, ctx);
+    let txn_id = txn.withdrawal_txn_id();
+    let btc = queue.commit_requests(&txn);
+    assert!(btc.value() == 50_000);
+    btc.destroy_for_testing();
+    queue.insert_withdrawal_txn(txn);
+
+    // Committed in place: the request stays in `requests`, and the txn link
+    // is what marks it as committed.
     assert!(queue.request_in_requests(id));
     assert!(!queue.request_in_processed(id));
-    assert!(queue.request_status_any(id).is_processing());
+    let request = queue.borrow_request(id);
+    assert!(request.is_approved());
+    assert!(request.is_committed());
+    assert!(request.request_withdrawal_txn_id() == option::some(txn_id));
     // The bag-membership gate must still recognize the request as committed.
     assert!(queue.is_request_processing(id));
 
@@ -1021,37 +1042,26 @@ fun test_approve_committed_request_aborts() {
 
     let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
     // Replay of an approval cert against the committed request must not
-    // reset Processing back to Approved (it would re-arm commit on a
-    // drained request).
+    // re-stamp a request whose BTC is already drained.
     queue.approve_withdrawal(id, dummy_cert(), &clock);
     abort 0
 }
 
 #[test]
-fun test_update_requests_signed_both_locations() {
+#[expected_failure(abort_code = ERequestAlreadyCommitted)]
+fun test_commit_committed_request_aborts() {
     let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
     let mut queue = setup_queue(ctx);
     let clock = clock::create_for_testing(ctx);
 
-    // v2-committed: request lives in `requests`.
-    let (v2_id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
-    queue.update_requests_signed(&vector[v2_id]);
-    assert!(queue.request_in_requests(v2_id));
-    assert!(queue.request_status_any(v2_id).is_signed());
-
-    // v1-committed (pre-upgrade): request lives in `processed`.
-    let v1_id = setup_request(&mut queue, &clock, 60_000, ctx);
-    queue.approve_withdrawal(v1_id, dummy_cert(), &clock);
-    let txn = make_test_txn(vector[v1_id], @0xF00D, &clock, ctx);
-    let btc = queue.commit_requests_v1_style_for_testing(&txn);
+    let (id, _info) = approve_and_commit(&mut queue, &clock, 50_000, ctx);
+    // The request still carries its approval cert, so the txn link alone
+    // must refuse a second commit (which would pay the user's output again
+    // from an already-drained request).
+    let txn = make_test_txn(vector[id], @0xF00D, &clock, ctx);
+    let btc = queue.commit_requests(&txn);
     btc.destroy_for_testing();
-    queue.insert_withdrawal_txn(txn);
-    queue.update_requests_signed(&vector[v1_id]);
-    assert!(queue.request_in_processed(v1_id));
-    assert!(queue.request_status_any(v1_id).is_signed());
-
-    clock.destroy_for_testing();
-    std::unit_test::destroy(queue);
+    abort 0
 }
 
 #[test]
@@ -1079,7 +1089,7 @@ fun test_archive_moves_request_and_txn() {
 }
 
 #[test]
-fun test_archive_flips_request_to_confirmed_in_processed() {
+fun test_archive_moves_request_to_processed() {
     let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
     let mut queue = setup_queue(ctx);
     let clock = clock::create_for_testing(ctx);
@@ -1093,14 +1103,12 @@ fun test_archive_flips_request_to_confirmed_in_processed() {
     queue.insert_withdrawal_txn(txn);
     queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
     queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
-    queue.update_requests_signed(&vector[id]);
     queue.mark_txn_confirmed(txn_id, &clock);
 
     queue.archive_withdrawal_txn(txn_id);
 
     assert!(!queue.request_in_requests(id));
     assert!(queue.request_in_processed(id));
-    assert!(queue.request_status_any(id).is_confirmed());
     assert!(queue.is_request_processing(id));
 
     clock.destroy_for_testing();
@@ -1148,7 +1156,7 @@ fun test_archive_v1_leftover_stays_in_processed() {
     let clock = clock::create_for_testing(ctx);
 
     // Simulate a request committed before the upgrade: it already lives in
-    // `processed`, status Processing.
+    // `processed`.
     let id = setup_request(&mut queue, &clock, 50_000, ctx);
     queue.approve_withdrawal(id, dummy_cert(), &clock);
     let txn = make_test_txn(vector[id], @0xBEEF, &clock, ctx);
@@ -1158,15 +1166,13 @@ fun test_archive_v1_leftover_stays_in_processed() {
     queue.insert_withdrawal_txn(txn);
     queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
     queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
-    queue.update_requests_signed(&vector[id]);
 
-    // Confirmed under v2, archived by GC: the request gets its terminal
-    // status in place, no second move.
+    // Confirmed under v2, archived by GC: the request needs no write and no
+    // second move; only the txn moves.
     queue.mark_txn_confirmed(txn_id, &clock);
     queue.archive_withdrawal_txn(txn_id);
 
     assert!(queue.request_in_processed(id));
-    assert!(queue.request_status_any(id).is_confirmed());
     assert!(queue.has_confirmed_txn(txn_id));
 
     clock.destroy_for_testing();
@@ -1225,7 +1231,6 @@ fun setup_confirmed_three_request_txn(
     queue.insert_withdrawal_txn(txn);
     queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
     queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], clock);
-    queue.update_requests_signed(&vector[id1, id2, id3]);
     queue.mark_txn_confirmed(txn_id, clock);
     (vector[id1, id2, id3], txn_id)
 }
@@ -1241,10 +1246,8 @@ fun test_chunked_archive_partial_then_finish() {
     // Archive two of three: those move, the third stays, the txn stays hot.
     queue.archive_withdrawal_requests(txn_id, &vector[ids[0], ids[1]]);
     assert!(queue.request_in_processed(ids[0]));
-    assert!(queue.request_status_any(ids[0]).is_confirmed());
     assert!(queue.request_in_processed(ids[1]));
     assert!(queue.request_in_requests(ids[2]));
-    assert!(queue.request_status_any(ids[2]).is_signed());
     assert!(queue.has_withdrawal_txn(txn_id));
 
     // Finish must no-op while a request remains unarchived.
@@ -1271,10 +1274,9 @@ fun test_chunked_archive_rerun_idempotent() {
     let (ids, txn_id) = setup_confirmed_three_request_txn(&mut queue, &clock, ctx);
 
     queue.archive_withdrawal_requests(txn_id, &vector[ids[0]]);
-    // Re-running the same chunk is a no-op status re-write, not an abort.
+    // Re-running the same chunk is a no-op, not an abort.
     queue.archive_withdrawal_requests(txn_id, &vector[ids[0]]);
     assert!(queue.request_in_processed(ids[0]));
-    assert!(queue.request_status_any(ids[0]).is_confirmed());
 
     // After the txn is fully archived, chunk calls no-op entirely.
     queue.archive_withdrawal_requests(txn_id, &vector[ids[1], ids[2]]);
@@ -1294,8 +1296,7 @@ fun test_chunked_archive_foreign_request_aborts() {
     let clock = clock::create_for_testing(ctx);
 
     let (_ids, txn_id) = setup_confirmed_three_request_txn(&mut queue, &clock, ctx);
-    // A request belonging to a different withdrawal must be rejected in the
-    // requests branch (and the processed branch carries the same check).
+    // A live request belonging to a different withdrawal must be rejected.
     let (foreign_id, _info) = approve_and_commit(&mut queue, &clock, 40_000, ctx);
     queue.archive_withdrawal_requests(txn_id, &vector[foreign_id]);
     abort 0
@@ -1314,12 +1315,12 @@ fun test_chunked_archive_unconfirmed_txn_aborts() {
 }
 
 #[test]
-/// Regression: `processed` residency is not archival. A request committed
-/// before the v2 upgrade lives in `processed` while still `Signed`, so an
-/// adversarial early finish right after confirmation must no-op instead of
-/// retiring the txn and stranding the request with a stale status; archiving
-/// the request (Confirmed in place) then lets the finish complete.
-fun test_finish_archive_waits_for_v1_committed_requests() {
+/// A request committed before the v2 upgrade already lives in `processed`
+/// and carries no lifecycle state of its own to flip, so it counts as
+/// archived from the start: the finish completes right after confirmation
+/// without any `archive_request` chunk, and a later chunk naming the request
+/// is a no-op rather than an abort.
+fun test_finish_archive_v1_committed_request_counts_as_archived() {
     let ctx = &mut test_utils::new_tx_context(REQUESTER, 0);
     let mut queue = setup_queue(ctx);
     let clock = clock::create_for_testing(ctx);
@@ -1334,24 +1335,17 @@ fun test_finish_archive_waits_for_v1_committed_requests() {
     queue.insert_withdrawal_txn(txn);
     queue.record_input_signatures(txn_id, vector[0], vector[x"DEADBEEF"]);
     queue.finalize_withdrawal_txn(txn_id, vector[x"AAAAAAAA"], &clock);
-    queue.update_requests_signed(&vector[id]);
     queue.mark_txn_confirmed(txn_id, &clock);
     assert!(queue.request_in_processed(id));
-    assert!(queue.request_status_any(id).is_signed());
 
-    // Adversarial early finish before any archive_request ran: must no-op.
-    queue.finish_archive_withdrawal_txn(txn_id);
-    assert!(queue.has_withdrawal_txn(txn_id));
-    assert!(!queue.has_confirmed_txn(txn_id));
-    assert!(queue.request_status_any(id).is_signed());
-
-    // Archive the request (Confirmed in place), then the finish completes.
-    queue.archive_withdrawal_requests(txn_id, &vector[id]);
     queue.finish_archive_withdrawal_txn(txn_id);
     assert!(!queue.has_withdrawal_txn(txn_id));
     assert!(queue.has_confirmed_txn(txn_id));
     assert!(queue.request_in_processed(id));
-    assert!(queue.request_status_any(id).is_confirmed());
+
+    // A chunk naming the already-archived request no-ops.
+    queue.archive_withdrawal_requests(txn_id, &vector[id]);
+    assert!(queue.request_in_processed(id));
 
     clock.destroy_for_testing();
     std::unit_test::destroy(queue);


### PR DESCRIPTION
Remove the status enum field to reduce work done in move as the status can always be derived from other fields that were set.