### PR TITLE
[Guardian] Serve limiter status from a snapshot, not the withdrawal lock

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -945,8 +945,7 @@ mod tests {
             .expect("harness present after 2-of-2 cutover")
             .enclave()
             .state
-            .limiter_state()
-            .await
+            .limiter_snapshot()
             .expect("guardian limiter state present after a successful withdrawal");
         assert_eq!(guardian_state.next_seq, 1);
         let local_state = hashi

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -86,6 +86,9 @@ pub struct EnclaveState {
     /// Rate limiter. Set once during operator_activate.
     /// Uses `Arc<tokio::Mutex>` so the guard can be held across `.await`.
     rate_limiter: OnceLock<Arc<tokio::sync::Mutex<RateLimiter>>>,
+    /// Mirrors the limiter's state so status reads never wait on the limiter
+    /// lock, which a withdrawal holds across its durable log write.
+    limiter_snapshot: RwLock<Option<LimiterState>>,
 }
 
 /// Inputs needed only between operator initialization and activation.
@@ -330,9 +333,12 @@ impl EnclaveState {
     fn set_rate_limiter(&self, limiter: RateLimiter) -> GuardianResult<()> {
         info!("Setting rate limiter.");
 
+        let state = *limiter.state();
         self.rate_limiter
             .set(Arc::new(tokio::sync::Mutex::new(limiter)))
-            .map_err(|_| InvalidInputs("rate_limiter already initialized".into()))
+            .map_err(|_| InvalidInputs("rate_limiter already initialized".into()))?;
+        *self.limiter_snapshot.write().unwrap() = Some(state);
+        Ok(())
     }
 
     /// Timeout for acquiring the limiter lock. If a withdrawal is in progress and
@@ -368,10 +374,16 @@ impl EnclaveState {
         Ok(guard)
     }
 
-    /// Return the limiter state for status reporting, or `None` if the limiter
-    /// is uninitialized or remains locked through the acquisition deadline.
-    pub async fn limiter_state(&self) -> Option<LimiterState> {
-        Some(*self.lock_limiter().await.ok()?.state())
+    /// Record the consumption a withdrawal has just made durable, then release
+    /// the limiter. Consuming the guard orders the record before the release.
+    pub fn set_limiter_snapshot(&self, guard: OwnedMutexGuard<RateLimiter>) {
+        *self.limiter_snapshot.write().unwrap() = Some(*guard.state());
+    }
+
+    /// The limiter state as of the last durably logged withdrawal. `None` means
+    /// no limiter exists; it never reports absence for a limiter that is busy.
+    pub fn limiter_snapshot(&self) -> Option<LimiterState> {
+        *self.limiter_snapshot.read().unwrap()
     }
 }
 
@@ -394,6 +406,7 @@ impl Enclave {
                 }),
                 committee: RwLock::new(None),
                 rate_limiter: OnceLock::new(),
+                limiter_snapshot: RwLock::new(None),
             },
             temporary_init_state: RwLock::new(None),
             pending_ceremony: OnceLock::new(),
@@ -623,7 +636,7 @@ impl Enclave {
                 .and_then(|state| state.genesis_state.as_ref().map(GenesisState::digest)),
             untrusted_git_revision: self.reported_git_revision(),
             enclave_btc_pubkey: self.config.enclave_btc_pubkey().ok(),
-            limiter_state: self.state.limiter_state().await,
+            limiter_state: self.state.limiter_snapshot(),
             limiter_config: self.limiter_config().ok(),
             current_committee_epoch: self.state.get_committee().ok().map(|c| c.epoch()),
             mpc_master_g: self.config.hashi_btc_master_pubkey.get().copied(),

--- a/crates/hashi-guardian/src/log_writer.rs
+++ b/crates/hashi-guardian/src/log_writer.rs
@@ -251,6 +251,30 @@ mod tests {
         assert_eq!(put_flaky.num_calls(), 5);
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn retries_under_a_live_fence() {
+        let put_flaky = mock!(Client::put_object)
+            .sequence()
+            .output(|| PutObjectOutput::builder().build())
+            .http_status(500, None)
+            .times(3)
+            .output(|| PutObjectOutput::builder().build())
+            .build();
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&put_flaky]);
+        let s3 = mock_s3(client);
+        let writer = LogWriter::new();
+        let signing_key = signing_key();
+
+        writer
+            .write(&s3, session_id(&signing_key), heartbeat(1), &signing_key)
+            .await;
+        writer
+            .write(&s3, session_id(&signing_key), signed_init(), &signing_key)
+            .await;
+
+        assert_eq!(put_flaky.num_calls(), 5);
+    }
+
     #[tokio::test]
     async fn write_waits_for_serialization_lock_before_put() {
         let put_ok = mock!(Client::put_object).then_output(|| PutObjectOutput::builder().build());

--- a/crates/hashi-guardian/src/operator_init.rs
+++ b/crates/hashi-guardian/src/operator_init.rs
@@ -213,7 +213,7 @@ async fn commit_operator_init(enclave: &Enclave, install: OIInstall) {
             signing_public_key: signing_pk,
         })
         .await
-        .expect("Unable to log OperatorInitAttestationUnsigned");
+        .expect("S3 logger must be initialized to log the OI attestation");
 
     // 2) Share commitments help KPs confirm that the right private key will be constructed.
     // This pre-transition snapshot reports `Uninitialized`; successfully
@@ -226,7 +226,7 @@ async fn commit_operator_init(enclave: &Enclave, install: OIInstall) {
     enclave
         .log_init(OIGuardianInfo(Box::new(enclave.info().await)))
         .await
-        .expect("Unable to log GuardianInfo");
+        .expect("S3 logger must be initialized to log GuardianInfo");
 
     let initialized = match enclave.mode() {
         EnclaveMode::Ceremony => CeremonyStage::OperatorInitialized.into(),

--- a/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
+++ b/crates/hashi-guardian/src/withdraw_mode/standard_withdrawal.rs
@@ -150,11 +150,11 @@ async fn log_withdrawal_success(
     enclave
         .log_withdraw(msg)
         .await
-        .expect("withdrawal log write failed");
+        .expect("S3 logger must be initialized to log a withdrawal");
     info!("Withdrawal {} logged.", wid);
-    // Rust would drop this guard at function exit; the explicit drop documents
-    // that the next withdrawal may enter only after this one is durably logged.
-    drop(limiter_guard);
+    // Consumes the guard: the now-durable consumption is recorded, and only
+    // then may the next withdrawal enter.
+    enclave.state.set_limiter_snapshot(limiter_guard);
     Ok(())
 }
 
@@ -273,6 +273,79 @@ mod tests {
 
         let result = normal_withdrawal_inner(enclave, signed_request).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn limiter_state_is_readable_while_a_withdrawal_holds_the_guard() {
+        let (signed_request, committee) =
+            StandardWithdrawalRequest::mock_signed_and_committee_with_seq(
+                Network::Regtest,
+                WithdrawalID::new([0xac; 32]),
+                now_timestamp_secs(),
+                0,
+            );
+        let amount_sats = signed_request
+            .message()
+            .utxos()
+            .gross_outflow_amount()
+            .to_sat();
+        let (enclave, _captures) =
+            setup_fully_initialized_enclave(Network::Regtest, committee, amount_sats).await;
+
+        // A withdrawal holds the limiter across its durable log write.
+        let guard = enclave
+            .state
+            .consume_from_limiter(0, now_timestamp_secs(), amount_sats)
+            .await
+            .expect("limiter accepts the first withdrawal");
+
+        // Readable rather than timing out into `None`, and still reporting the
+        // durable state: this consumption is not logged yet.
+        let state = enclave
+            .state
+            .limiter_snapshot()
+            .expect("limiter state stays readable while the guard is held");
+        assert_eq!(state.next_seq, 0);
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn limiter_state_advances_once_the_withdrawal_is_logged() {
+        let (signed_request, committee) =
+            StandardWithdrawalRequest::mock_signed_and_committee_with_seq(
+                Network::Regtest,
+                WithdrawalID::new([0xad; 32]),
+                now_timestamp_secs(),
+                0,
+            );
+        let amount_sats = signed_request
+            .message()
+            .utxos()
+            .gross_outflow_amount()
+            .to_sat();
+        let (enclave, _captures) =
+            setup_fully_initialized_enclave(Network::Regtest, committee, amount_sats).await;
+        assert_eq!(
+            enclave
+                .state
+                .limiter_snapshot()
+                .expect("activated")
+                .next_seq,
+            0
+        );
+
+        standard_withdrawal(enclave.clone(), signed_request)
+            .await
+            .expect("withdrawal succeeds");
+
+        assert_eq!(
+            enclave
+                .state
+                .limiter_snapshot()
+                .expect("activated")
+                .next_seq,
+            1
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION

`limiter_state()` took the limiter mutex, which a withdrawal holds across its durable S3 write. Hence the 10s `LIMITER_LOCK_TIMEOUT` — and `.ok()?` folded that timeout into the same `None` that means "no limiter exists":

```rust
Some(*self.lock_limiter().await.ok()?.state())
```

Callers cannot tell the two apart. Four init preflights (`operator_provision.rs:304`/`:379`, `operator_activate.rs:326`, `kp_provision.rs:238`) read `None` as "not provisioned, proceed"; each is backstopped by a lock-free neighbour so no guard actually opens, but they can silently pass. The node records `NO_LIMITER_YET` (`lib.rs:960`), silently skips the reconcile (`lib.rs:1051`), and `/info` drops the limiter panel.

## Fix

Mirror `LimiterState` in an `RwLock` and read that for status. The mutex keeps serializing withdrawals — it was never there to protect three integers from readers. `limiter_snapshot()` is synchronous, never touches the withdrawal lock, and its `None` means only "no limiter exists", so every caller above becomes correct unchanged and the wire type is untouched.

## Worth checking

- The snapshot is written at **finalize** (after `log_withdraw`), not at consume, so the guardian still advances `next_seq` where the node's reconcile expects it: *"the mirror debits at sign-time, the guardian at finalize-time"* (`lib.rs`).
- `set_limiter_snapshot` consumes the `OwnedMutexGuard`, so the write provably precedes releasing the limiter to the next withdrawal.

## Also

Three `expect` messages that can only fire for an uninitialized S3 logger now that `LogWriter::write` returns `()`; `retries_under_a_live_fence`, since both existing retry tests run unfenced via `first_init`; `e2e_flow.rs` drops an `.await` now that the accessor is synchronous.
