### PR TITLE
cli: refuse governance actions on executed proposals before the prompt; explain Move aborts

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -2399,6 +2399,87 @@ mod tests {
         );
         info!("Transaction succeeded: {}", response.transaction().digest());
 
+        // The single member's creation vote is the whole committee, so the
+        // proposal is executable at once. Execute it, then try to vote on it
+        // again: executed proposals move to the executed bag rather than being
+        // deleted, and `proposal::vote` borrows the active bag with no
+        // executed-bag check, so the chain answers with the framework's
+        // `dynamic_field` abort (code 1, no clever payload). The CLI's abort
+        // decoder relies on exactly that shape, so it is pinned here against
+        // the real chain, and the decoder is checked to explain it.
+        let proposal_id = hashi::cli::upgrade::extract_proposal_id_from_response(&response)?;
+        let execute_tx = hashi::cli::upgrade::build_execute_proposal_transaction(
+            hashi_ids,
+            hashi_isv,
+            proposal_id,
+            execute_package_id,
+            "update_config",
+        )?;
+        let exec_resp = executor.execute(execute_tx).await?;
+        assert!(
+            exec_resp.transaction().effects().status().success(),
+            "update_config::execute failed: {:?}",
+            exec_resp.transaction().effects().status()
+        );
+
+        let type_arg = sui_sdk_types::TypeTag::Struct(Box::new(sui_sdk_types::StructTag::new(
+            hashi_ids.package_id,
+            sui_sdk_types::Identifier::new("update_config")?,
+            sui_sdk_types::Identifier::new("UpdateConfig")?,
+            vec![],
+        )));
+        let late_vote = hashi::cli::client::build_vote_transaction(
+            hashi_ids,
+            hashi_isv,
+            execute_package_id,
+            validator_address,
+            proposal_id,
+            type_arg,
+        );
+        let err = executor
+            .execute(late_vote)
+            .await
+            .expect_err("a vote on an executed proposal must not build");
+        let execution_error = {
+            use hashi::sui_tx_executor::TxFailure;
+            let builder_error = match err.downcast_ref::<TxFailure>() {
+                Some(TxFailure::NotSubmitted(inner)) => {
+                    inner.downcast_ref::<sui_transaction_builder::Error>()
+                }
+                _ => err
+                    .chain()
+                    .find_map(|e| e.downcast_ref::<sui_transaction_builder::Error>()),
+            };
+            match builder_error {
+                Some(sui_transaction_builder::Error::SimulationFailure(failure)) => {
+                    failure.execution_error()
+                }
+                _ => panic!("expected a simulation failure, got: {err:#}"),
+            }
+        };
+        let abort = execution_error
+            .abort_opt()
+            .expect("the late vote must fail with a Move abort");
+        let clever_constant = abort
+            .clever_error
+            .as_ref()
+            .and_then(|clever| clever.constant_name.as_deref());
+        assert!(
+            (abort.location().module_opt() == Some("dynamic_field")
+                && abort.abort_code == Some(1)
+                && clever_constant.is_none())
+                || clever_constant == Some("EProposalAlreadyExecuted"),
+            "unexpected abort for a vote on an executed proposal: {abort:?}"
+        );
+        let explanation = hashi::cli::commands::proposal::explain_execution_error(execution_error)
+            .expect("the CLI decoder must explain a vote on an executed proposal");
+        assert!(
+            explanation.contains("no longer in the active proposal bag")
+                || explanation.contains("already been executed"),
+            "{explanation}"
+        );
+        info!("late vote refused as expected: {explanation}");
+
         info!("=== UpdateConfig Proposal E2E Test Passed ===");
         Ok(())
     }

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -155,6 +155,34 @@ pub async fn fetch_initial_shared_version(
     Ok(response.object().owner().version())
 }
 
+/// Which on-chain proposal bag holds a proposal. Executed proposals are not
+/// deleted: `proposal::execute` moves them from the active bag to the
+/// executed bag, where they stay for inspection, so a lookup that only asks
+/// "does it exist" cannot tell an open proposal from a finished one.
+#[derive(Clone, Debug)]
+pub enum ProposalLocation {
+    Active(Proposal),
+    Executed(Proposal),
+    /// In neither bag: the id is wrong, or the proposal expired and was
+    /// deleted.
+    Missing,
+}
+
+/// Locate `proposal_id` in the scraped active and executed bags.
+pub fn locate_proposal(
+    active: &[Proposal],
+    executed: &[Proposal],
+    proposal_id: &Address,
+) -> ProposalLocation {
+    if let Some(proposal) = active.iter().find(|p| p.id == *proposal_id) {
+        return ProposalLocation::Active(proposal.clone());
+    }
+    if let Some(proposal) = executed.iter().find(|p| p.id == *proposal_id) {
+        return ProposalLocation::Executed(proposal.clone());
+    }
+    ProposalLocation::Missing
+}
+
 impl HashiClient {
     /// Client for governance and config commands. Skips the Bitcoin
     /// collections, which none of them read.
@@ -302,6 +330,21 @@ impl HashiClient {
     /// Fetch a specific proposal by ID
     pub fn fetch_proposal(&self, proposal_id: &Address) -> Option<Proposal> {
         self.onchain_state.proposal(proposal_id)
+    }
+
+    /// Fetch all executed (archived) proposals
+    pub fn fetch_executed_proposals(&self) -> Vec<Proposal> {
+        self.onchain_state.executed_proposals()
+    }
+
+    /// Where `proposal_id` sits in the two on-chain proposal bags, as of the
+    /// scrape this client was built from.
+    pub fn locate_proposal(&self, proposal_id: &Address) -> ProposalLocation {
+        locate_proposal(
+            &self.fetch_proposals(),
+            &self.fetch_executed_proposals(),
+            proposal_id,
+        )
     }
 
     /// Fetch committee members for the current epoch

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -14,6 +14,7 @@ use tabled::Tabled;
 use crate::cli::TxOptions;
 use crate::cli::client::CreateProposalParams;
 use crate::cli::client::HashiClient;
+use crate::cli::client::ProposalLocation;
 use crate::cli::config::CliConfig;
 use crate::cli::print_detail;
 use crate::cli::print_info;
@@ -55,6 +56,181 @@ pub(crate) fn print_acting_validator(client: &HashiClient) -> Result<()> {
     Ok(())
 }
 
+/// Mirrors `MAX_PROPOSAL_DURATION_MS` in `proposal.move`: a proposal can be
+/// voted on and executed for seven days after creation, then only deleted.
+const PROPOSAL_MAX_AGE_MS: u64 = 1000 * 60 * 60 * 24 * 7;
+
+/// What the operator is trying to do to a proposal, for the refusal text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProposalAction {
+    Vote,
+    RemoveVote,
+    Execute,
+}
+
+/// Return the proposal when it is open, and otherwise refuse with a message
+/// that names the proposal, its type and why the action cannot happen.
+///
+/// Executed proposals stay on chain in a second bag, so without this the
+/// command finds the proposal, prints its details, prompts, and only then
+/// fails in simulation with a framework abort (`dynamic_field` code 1) that
+/// never mentions the word "executed" and shares its code with the
+/// vote-already-counted error.
+pub fn open_proposal(
+    location: ProposalLocation,
+    proposal_id: &str,
+    action: ProposalAction,
+    sui_rpc_url: &str,
+) -> Result<Proposal> {
+    match location {
+        ProposalLocation::Active(proposal) => Ok(proposal),
+        ProposalLocation::Executed(proposal) => {
+            let kind = display::format_proposal_type(&proposal.proposal_type);
+            let consequence = match action {
+                ProposalAction::Vote => {
+                    "voting is closed and there is nothing to submit".to_owned()
+                }
+                ProposalAction::RemoveVote => {
+                    "its votes are final and cannot be removed".to_owned()
+                }
+                ProposalAction::Execute => {
+                    "nothing to execute; its effect is already on chain".to_owned()
+                }
+            };
+            anyhow::bail!(
+                "proposal {proposal_id} ({kind}) has already been executed; {consequence}. \
+                 Run `hashi proposal view {proposal_id}` for the final tally."
+            )
+        }
+        ProposalLocation::Missing => anyhow::bail!(
+            "proposal {proposal_id} was not found in the active or executed proposals on \
+             {sui_rpc_url}: either the id is wrong, or the proposal expired (7 days after \
+             creation) and was deleted. Run `hashi proposal list` to see the open proposals."
+        ),
+    }
+}
+
+/// One-line lifecycle status for `proposal view`, from bag membership and
+/// the seven-day expiry.
+pub fn proposal_status(location: &ProposalLocation, now_ms: u64) -> String {
+    match location {
+        ProposalLocation::Executed(_) => "Executed".to_owned(),
+        ProposalLocation::Active(proposal) => {
+            let expires_ms = proposal.timestamp_ms.saturating_add(PROPOSAL_MAX_AGE_MS);
+            if now_ms > expires_ms {
+                format!(
+                    "Expired on {} (no longer votable; awaiting deletion)",
+                    display::format_timestamp(expires_ms)
+                )
+            } else {
+                format!("Active (expires {})", display::format_timestamp(expires_ms))
+            }
+        }
+        ProposalLocation::Missing => "Not found".to_owned(),
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// A human explanation for a governance transaction that failed in
+/// simulation or on chain, or `None` when the failure is not a Move abort.
+///
+/// Two sources: a clever `#[error]` constant from the hashi package, which is
+/// named and given a one-line hint; and the one framework abort every
+/// governance entry can hit, `dynamic_field` code 1 when the proposal has
+/// left the active bag between the pre-flight and the simulate. Matching is
+/// on module and constant name, never on the bare code: `1` is also
+/// `EVoteAlreadyCounted`, and `0` is both `EVersionDisabled` and
+/// `EUnauthorizedCaller`.
+pub fn explain_execution_error(
+    error: &sui_rpc::proto::sui::rpc::v2::ExecutionError,
+) -> Option<String> {
+    use sui_rpc::proto::sui::rpc::v2::clever_error::Value;
+    use sui_rpc::proto::sui::rpc::v2::execution_error::ExecutionErrorKind;
+
+    if error
+        .kind
+        .and_then(|kind| ExecutionErrorKind::try_from(kind).ok())
+        != Some(ExecutionErrorKind::MoveAbort)
+    {
+        return None;
+    }
+    let abort = error.abort_opt()?;
+    let module = abort.location().module_opt();
+    let clever = abort.clever_error.as_ref();
+    let constant = clever.and_then(|c| c.constant_name.as_deref());
+    let rendered = clever.and_then(|c| match &c.value {
+        Some(Value::Rendered(text)) => Some(text.as_str()),
+        _ => None,
+    });
+
+    match (module, abort.abort_code, constant) {
+        (Some("dynamic_field"), Some(1), None) => Some(
+            "the proposal is no longer in the active proposal bag: it was executed, or \
+             deleted after expiring, while this command was running. Run \
+             `hashi proposal view <proposal-id>` to see its state."
+                .to_owned(),
+        ),
+        (_, _, Some(name)) => {
+            let hint = match name {
+                "EVoteAlreadyCounted" => Some("this validator has already voted on the proposal"),
+                "ENoVoteFound" => Some("this validator has no vote on the proposal to remove"),
+                "EQuorumNotReached" => Some(
+                    "the proposal has not reached quorum yet; `hashi proposal view` shows the tally",
+                ),
+                "EProposalExpired" => {
+                    Some("proposals expire 7 days after creation; this one can only be deleted")
+                }
+                "EProposalAlreadyExecuted" => Some("the proposal has already been executed"),
+                "ENotCommitteeMember" => {
+                    Some("the validator is registered but not seated in the current committee")
+                }
+                "EUnauthorizedCaller" => {
+                    Some("the signer is neither the validator's address nor its delegated operator")
+                }
+                "EVersionDisabled" => Some(
+                    "this binary targets a package version governance has disabled; upgrade hashi",
+                ),
+                _ => None,
+            };
+            let mut text = match rendered {
+                Some(rendered) => format!("{name}: {rendered}"),
+                None => name.to_owned(),
+            };
+            if let Some(hint) = hint {
+                text.push_str(" (");
+                text.push_str(hint);
+                text.push(')');
+            }
+            Some(text)
+        }
+        _ => None,
+    }
+}
+
+/// [`explain_execution_error`] for the error `finalize_tx` returns, whichever
+/// mode produced it: the executor wraps the execute path's build error in
+/// `TxFailure::NotSubmitted`, while dry-run and serialize-unsigned return the
+/// SDK build error bare, so both shapes are searched.
+fn explain_move_abort(err: &anyhow::Error) -> Option<String> {
+    let from_executor = crate::sui_tx_executor::transaction_execution_error(err);
+    let from_builder =
+        err.chain().find_map(
+            |e| match e.downcast_ref::<sui_transaction_builder::Error>() {
+                Some(sui_transaction_builder::Error::SimulationFailure(failure)) => {
+                    Some(failure.execution_error())
+                }
+                _ => None,
+            },
+        );
+    explain_execution_error(from_executor.or(from_builder)?)
+}
+
 /// Finalize a transaction according to `tx_opts`: serialize it unsigned,
 /// dry-run it, or sign and submit it.
 ///
@@ -84,7 +260,14 @@ pub(crate) async fn execute_or_simulate(
         TxMode::Execute => print_info("Executing transaction..."),
     }
 
-    let outcome = client.finalize_tx(tx, tx_opts).await?;
+    let outcome =
+        client
+            .finalize_tx(tx, tx_opts)
+            .await
+            .map_err(|e| match explain_move_abort(&e) {
+                Some(explanation) => e.context(explanation),
+                None => e,
+            })?;
     Ok(crate::cli::print_tx_outcome(outcome, client.sui_rpc_url()).map(|response| *response))
 }
 
@@ -152,7 +335,8 @@ pub async fn list_proposals(
         // List mode skips the per-proposal vote/quorum fetch to avoid N extra
         // network calls; use `proposal view <id>` for full vote progress.
         for proposal in &proposals {
-            print_proposal_detailed(proposal, None, None);
+            let status = proposal_status(&ProposalLocation::Active(proposal.clone()), now_ms());
+            print_proposal_detailed(proposal, &status, None, None);
             println!();
         }
     } else {
@@ -197,15 +381,25 @@ pub async fn view_proposal(config: &CliConfig, proposal_id: &str) -> Result<()> 
 
     print_info(&format!("Fetching proposal {}...", proposal_id));
 
-    let proposal = client
-        .fetch_proposal(&proposal_addr)
-        .ok_or_else(|| anyhow::anyhow!("Proposal not found: {}", proposal_id))?;
+    let location = client.locate_proposal(&proposal_addr);
+    let proposal = match &location {
+        ProposalLocation::Active(proposal) | ProposalLocation::Executed(proposal) => {
+            proposal.clone()
+        }
+        ProposalLocation::Missing => anyhow::bail!(
+            "proposal {proposal_id} was not found in the active or executed proposals on {}: \
+             either the id is wrong, or the proposal expired (7 days after creation) and \
+             was deleted. Run `hashi proposal list` to see the open proposals.",
+            client.sui_rpc_url()
+        ),
+    };
+    let status = proposal_status(&location, now_ms());
 
     let details = client.fetch_proposal_details(proposal_addr).await.ok();
     let committee = client.fetch_current_committee();
 
     println!();
-    print_proposal_detailed(&proposal, details.as_ref(), committee.as_ref());
+    print_proposal_detailed(&proposal, &status, details.as_ref(), committee.as_ref());
 
     Ok(())
 }
@@ -225,9 +419,12 @@ pub async fn vote(
 
     print_info(&format!("Fetching proposal {}...", proposal_id));
 
-    let proposal = client
-        .fetch_proposal(&proposal_addr)
-        .ok_or_else(|| anyhow::anyhow!("Proposal not found: {}", proposal_id))?;
+    let proposal = open_proposal(
+        client.locate_proposal(&proposal_addr),
+        proposal_id,
+        ProposalAction::Vote,
+        client.sui_rpc_url(),
+    )?;
 
     let proposal_type_str = display::format_proposal_type(&proposal.proposal_type);
 
@@ -329,9 +526,12 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
 
     print_info(&format!("Fetching proposal {}...", proposal_id));
 
-    let proposal = client
-        .fetch_proposal(&proposal_addr)
-        .ok_or_else(|| anyhow::anyhow!("Proposal not found: {}", proposal_id))?;
+    let proposal = open_proposal(
+        client.locate_proposal(&proposal_addr),
+        proposal_id,
+        ProposalAction::RemoveVote,
+        client.sui_rpc_url(),
+    )?;
 
     let proposal_type_str = display::format_proposal_type(&proposal.proposal_type);
 
@@ -365,9 +565,12 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
 
     print_info(&format!("Fetching proposal {}...", proposal_id));
 
-    let proposal = client
-        .fetch_proposal(&proposal_addr)
-        .ok_or_else(|| anyhow::anyhow!("Proposal not found: {}", proposal_id))?;
+    let proposal = open_proposal(
+        client.locate_proposal(&proposal_addr),
+        proposal_id,
+        ProposalAction::Execute,
+        client.sui_rpc_url(),
+    )?;
 
     let proposal_type = &proposal.proposal_type;
     let proposal_type_str = display::format_proposal_type(proposal_type);
@@ -1085,6 +1288,7 @@ pub async fn create_ignore_member_proposal(
 
 fn print_proposal_detailed(
     proposal: &Proposal,
+    status: &str,
     details: Option<&crate::cli::client::ProposalDetails>,
     committee: Option<&hashi_types::committee::Committee>,
 ) {
@@ -1099,6 +1303,7 @@ fn print_proposal_detailed(
         "Type:".bold(),
         display::format_proposal_type(&proposal.proposal_type).green()
     );
+    println!("  {} {}", "Status:".bold(), status);
     println!(
         "  {} {}",
         "Created:".bold(),
@@ -1196,28 +1401,5 @@ pub(crate) async fn prompt_continue(action: &str, tx_opts: &TxOptions) -> Result
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn exclusive_digest_is_refused_without_acknowledgement() {
-        let err = check_exclusive_digest_acknowledged(Some("ab"), true, false).unwrap_err();
-        // Pin both remedies the message offers: the verified path and the
-        // explicit acknowledgement.
-        assert!(err.to_string().contains("--package-path"));
-        assert!(err.to_string().contains("--allow-unverified-exclusive"));
-    }
-
-    #[test]
-    fn exclusive_digest_is_allowed_with_acknowledgement() {
-        check_exclusive_digest_acknowledged(Some("ab"), true, true).unwrap();
-    }
-
-    #[test]
-    fn other_flag_combinations_are_unaffected() {
-        // A non-exclusive upgrade digest stays recoverable on-chain.
-        check_exclusive_digest_acknowledged(Some("ab"), false, false).unwrap();
-        // --package-path runs the pre-flight, so nothing needs acknowledging.
-        check_exclusive_digest_acknowledged(None, true, false).unwrap();
-    }
-}
+#[path = "proposal_tests.rs"]
+mod tests;

--- a/crates/hashi/src/cli/commands/proposal_tests.rs
+++ b/crates/hashi/src/cli/commands/proposal_tests.rs
@@ -1,0 +1,258 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::cli::client::locate_proposal;
+use crate::onchain::types::ProposalType;
+use sui_rpc::proto::sui::rpc::v2::CleverError;
+use sui_rpc::proto::sui::rpc::v2::ExecutionError;
+use sui_rpc::proto::sui::rpc::v2::MoveAbort;
+use sui_rpc::proto::sui::rpc::v2::MoveLocation;
+use sui_rpc::proto::sui::rpc::v2::clever_error::Value;
+use sui_rpc::proto::sui::rpc::v2::execution_error::ErrorDetails;
+use sui_rpc::proto::sui::rpc::v2::execution_error::ExecutionErrorKind;
+
+const RPC: &str = "http://fullnode.invalid:443";
+
+fn proposal(id: u8, created_ms: u64) -> Proposal {
+    Proposal {
+        id: Address::new([id; 32]),
+        timestamp_ms: created_ms,
+        proposal_type: ProposalType::UpdateConfig,
+    }
+}
+
+fn hex(id: u8) -> String {
+    Address::new([id; 32]).to_hex()
+}
+
+// ===== locating a proposal in the two bags =====
+
+#[test]
+fn an_open_proposal_is_found_in_the_active_bag() {
+    let active = [proposal(1, 0)];
+    let executed = [proposal(2, 0)];
+    assert!(matches!(
+        locate_proposal(&active, &executed, &Address::new([1; 32])),
+        ProposalLocation::Active(p) if p.id == Address::new([1; 32])
+    ));
+}
+
+#[test]
+fn an_executed_proposal_is_found_in_the_executed_bag() {
+    let active = [proposal(1, 0)];
+    let executed = [proposal(2, 0)];
+    assert!(matches!(
+        locate_proposal(&active, &executed, &Address::new([2; 32])),
+        ProposalLocation::Executed(p) if p.id == Address::new([2; 32])
+    ));
+}
+
+#[test]
+fn an_unknown_id_is_missing() {
+    let active = [proposal(1, 0)];
+    let executed = [proposal(2, 0)];
+    assert!(matches!(
+        locate_proposal(&active, &executed, &Address::new([3; 32])),
+        ProposalLocation::Missing
+    ));
+}
+
+// ===== refusing actions on proposals that are not open =====
+
+#[test]
+fn an_open_proposal_passes_through() {
+    let got = open_proposal(
+        ProposalLocation::Active(proposal(1, 0)),
+        &hex(1),
+        ProposalAction::Vote,
+        RPC,
+    )
+    .unwrap();
+    assert_eq!(got.id, Address::new([1; 32]));
+}
+
+#[test]
+fn voting_on_an_executed_proposal_is_refused_by_name_and_type() {
+    let err = open_proposal(
+        ProposalLocation::Executed(proposal(2, 0)),
+        &hex(2),
+        ProposalAction::Vote,
+        RPC,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains(&hex(2)), "{err}");
+    assert!(err.contains("UpdateConfig"), "{err}");
+    assert!(err.contains("has already been executed"), "{err}");
+    assert!(err.contains("voting is closed"), "{err}");
+    assert!(err.contains("hashi proposal view"), "{err}");
+}
+
+#[test]
+fn removing_a_vote_from_an_executed_proposal_is_refused() {
+    let err = open_proposal(
+        ProposalLocation::Executed(proposal(2, 0)),
+        &hex(2),
+        ProposalAction::RemoveVote,
+        RPC,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("has already been executed"), "{err}");
+    assert!(err.contains("cannot be removed"), "{err}");
+}
+
+#[test]
+fn executing_an_executed_proposal_is_refused() {
+    let err = open_proposal(
+        ProposalLocation::Executed(proposal(2, 0)),
+        &hex(2),
+        ProposalAction::Execute,
+        RPC,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("has already been executed"), "{err}");
+    assert!(err.contains("nothing to execute"), "{err}");
+}
+
+#[test]
+fn a_missing_proposal_names_the_rpc_and_the_expiry_path() {
+    let err = open_proposal(
+        ProposalLocation::Missing,
+        &hex(3),
+        ProposalAction::Vote,
+        RPC,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains(&hex(3)), "{err}");
+    assert!(err.contains(RPC), "{err}");
+    assert!(err.contains("expired"), "{err}");
+    assert!(err.contains("hashi proposal list"), "{err}");
+}
+
+// ===== the status line =====
+
+#[test]
+fn status_reads_active_with_its_expiry_before_seven_days() {
+    let created = 1_700_000_000_000;
+    let status = proposal_status(&ProposalLocation::Active(proposal(1, created)), created + 1);
+    assert!(status.starts_with("Active (expires "), "{status}");
+}
+
+#[test]
+fn status_reads_expired_after_seven_days() {
+    let created = 1_700_000_000_000;
+    let week = 1000 * 60 * 60 * 24 * 7;
+    let status = proposal_status(
+        &ProposalLocation::Active(proposal(1, created)),
+        created + week + 1,
+    );
+    assert!(status.starts_with("Expired on "), "{status}");
+}
+
+#[test]
+fn status_reads_executed_for_the_executed_bag() {
+    assert_eq!(
+        proposal_status(&ProposalLocation::Executed(proposal(2, 0)), u64::MAX),
+        "Executed"
+    );
+}
+
+// ===== decoding Move aborts =====
+
+fn move_abort(module: &str, code: u64, clever: Option<(&str, &str)>) -> ExecutionError {
+    // The SDK protos are non-exhaustive, so they are built by mutation.
+    let mut location = MoveLocation::default();
+    location.module = Some(module.to_owned());
+    location.function_name = Some("borrow_child_object_mut".to_owned());
+    let mut abort = MoveAbort::default();
+    abort.abort_code = Some(code);
+    abort.location = Some(location);
+    abort.clever_error = clever.map(|(name, rendered)| {
+        let mut clever = CleverError::default();
+        clever.constant_name = Some(name.to_owned());
+        clever.value = Some(Value::Rendered(rendered.to_owned()));
+        clever
+    });
+    let mut error = ExecutionError::default();
+    error.kind = Some(ExecutionErrorKind::MoveAbort as i32);
+    error.error_details = Some(ErrorDetails::Abort(abort));
+    error
+}
+
+#[test]
+fn a_bag_miss_is_explained_as_the_proposal_leaving_the_active_bag() {
+    let text = explain_execution_error(&move_abort("dynamic_field", 1, None)).unwrap();
+    assert!(
+        text.contains("no longer in the active proposal bag"),
+        "{text}"
+    );
+    assert!(text.contains("executed"), "{text}");
+}
+
+#[test]
+fn a_clever_constant_is_named_rendered_and_hinted() {
+    let text = explain_execution_error(&move_abort(
+        "proposal",
+        1,
+        Some(("EVoteAlreadyCounted", "Vote already counted")),
+    ))
+    .unwrap();
+    assert!(
+        text.starts_with("EVoteAlreadyCounted: Vote already counted"),
+        "{text}"
+    );
+    assert!(text.contains("already voted"), "{text}");
+}
+
+#[test]
+fn an_unknown_clever_constant_is_still_named() {
+    let text =
+        explain_execution_error(&move_abort("btc_config", 9, Some(("ESomethingNew", "New"))))
+            .unwrap();
+    assert_eq!(text, "ESomethingNew: New");
+}
+
+#[test]
+fn a_hashi_abort_with_code_one_is_not_mistaken_for_the_bag_miss() {
+    // Same numeric code as the framework abort, different module, no clever
+    // payload: nothing certain can be said, so nothing is claimed.
+    assert_eq!(
+        explain_execution_error(&move_abort("proposal", 1, None)),
+        None
+    );
+}
+
+#[test]
+fn a_non_abort_failure_is_left_alone() {
+    let mut error = ExecutionError::default();
+    error.kind = Some(ExecutionErrorKind::InsufficientGas as i32);
+    assert_eq!(explain_execution_error(&error), None);
+}
+
+// ===== exclusive-upgrade acknowledgement (moved from the module) =====
+
+#[test]
+fn exclusive_digest_is_refused_without_acknowledgement() {
+    let err = check_exclusive_digest_acknowledged(Some("ab"), true, false).unwrap_err();
+    // Pin both remedies the message offers: the verified path and the
+    // explicit acknowledgement.
+    assert!(err.to_string().contains("--package-path"));
+    assert!(err.to_string().contains("--allow-unverified-exclusive"));
+}
+
+#[test]
+fn exclusive_digest_is_allowed_with_acknowledgement() {
+    check_exclusive_digest_acknowledged(Some("ab"), true, true).unwrap();
+}
+
+#[test]
+fn other_flag_combinations_are_unaffected() {
+    // A non-exclusive upgrade digest stays recoverable on-chain.
+    check_exclusive_digest_acknowledged(Some("ab"), false, false).unwrap();
+    // --package-path runs the pre-flight, so nothing needs acknowledging.
+    check_exclusive_digest_acknowledged(None, true, false).unwrap();
+}

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -929,6 +929,8 @@ Builds, publishes, and initializes the Hashi Move package (including its onchain
 
 ### 7.3 Lifecycle example: UpdateConfig
 
+Executed proposals stay on chain for inspection. Voting on, removing a vote from, or executing one is refused before anything is signed, with a message that names the proposal and its type; `hashi proposal view <id>` shows `Status: Executed`, `Active (expires <date>)`, or `Expired` for a proposal past its seven-day window.
+
 ```bash
 # 1. Create the proposal
 hashi proposal create update-config bitcoin_deposit_minimum u64:50000 \


### PR DESCRIPTION
## Summary

Voting on a proposal that has already been executed produced this, after the CLI had printed the proposal's details and asked for confirmation:

```
Error: transaction not submitted: transaction simulation failed in command 0 (MOVE_ABORT): MoveAbort(MoveLocation { module: ModuleId { address: 0000...0002, name: Identifier("dynamic_field") }, function: ..., instruction: 0, function_name: Some("borrow_child_object_mut") }, 1) in command 0 at 0x...02::dynamic_field::borrow_child_object_mut
```

Executed proposals are not deleted: `proposal::execute` moves them from the active bag to the executed bag, where they stay for inspection. The CLI's only guard looked in both bags, so it found the proposal, and the Move `vote` entry borrows the active bag with no executed-bag check, so simulation ended in the framework's `dynamic_field` abort. Nothing in that line says "executed", and abort code 1 is also `proposal::EVoteAlreadyCounted`, so an operator who greps the Move source is misled. `remove-vote` and `execute` failed the same way.

## Changes

- **Pre-flight from data the CLI already has.** `HashiClient::locate_proposal` reports active, executed or missing from the scrape taken at startup. `vote`, `remove-vote` and `execute` refuse before printing details or prompting, in every mode including `--dry-run` and `--serialize-unsigned-transaction`:

  ```
  Error: proposal 0x... (UpdateConfig) has already been executed; voting is closed and there is nothing to submit. Run `hashi proposal view 0x...` for the final tally.
  ```

  A missing id names the RPC and the expiry path (proposals expire seven days after creation and can then be deleted) instead of the bare `Proposal not found`.
- **`proposal view` gains a Status line**: `Active (expires <date>)`, `Expired on <date> (...)`, or `Executed`. `list --detailed` shows the same line. `view` still accepts executed proposals.
- **Move aborts are decoded at the shared execute path** (`execute_or_simulate`, which every governance and validator command goes through). A clever `#[error]` constant is named, rendered and given a one-line hint (`EVoteAlreadyCounted: Vote already counted (this validator has already voted on the proposal)`, quorum not reached, not a committee member, version disabled, and so on). The bare `dynamic_field` code 1 is explained as the proposal having left the active bag while the command was running, which covers the race the pre-flight cannot. Matching is on module and constant name, never on the bare code. The raw SDK error stays underneath as `Caused by`.

Not changed: the Move `vote` and `remove_vote` entries still lack the executed-bag assert that `execute` and `delete_expired` have. Adding it (body-only, upgrade compatible) would give raw PTBs and older CLIs a clever `EProposalAlreadyExecuted` instead of the framework abort; that is a separate Move change, and the decoder here already handles both shapes.

## Tests

`crates/hashi/src/cli/commands/proposal_tests.rs` (the module's existing tests move there too): the location lookup, each refusal text pinned by id, type and remedy, the three status strings, and the decoder on hand-built protos, including that a hashi abort with code 1 and no clever payload is not mistaken for the bag miss, and that a non-abort failure is left alone.

`test_create_update_config_proposal` now executes its proposal and votes on it again, asserting the real chain abort (`dynamic_field` code 1 with no clever payload, or `EProposalAlreadyExecuted` once Move gains the assert) and that the decoder explains it. Full hashi unit suite, clippy and a warnings-denied doc build are clean.
