### PR TITLE
cli: global flags in any position, one confirm helper, notes on stderr, network header

### DIFF
--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -183,6 +183,28 @@ pub fn locate_proposal(
     ProposalLocation::Missing
 }
 
+/// A gRPC `NotFound` while loading the Hashi object almost always means the
+/// configured ids and the RPC URL come from different networks; say so instead
+/// of surfacing the bare status.
+pub fn explain_missing_object(
+    err: anyhow::Error,
+    hashi_ids: HashiIds,
+    sui_rpc_url: &str,
+) -> anyhow::Error {
+    let not_found = err.chain().any(|e| {
+        matches!(e.downcast_ref::<tonic::Status>(), Some(s) if s.code() == tonic::Code::NotFound)
+    });
+    if not_found {
+        err.context(format!(
+            "Hashi object {} (package {}) was not found on {sui_rpc_url}: check that package-id, \
+             hashi-object-id and the RPC URL all belong to the same network",
+            hashi_ids.hashi_object_id, hashi_ids.package_id
+        ))
+    } else {
+        err
+    }
+}
+
 impl HashiClient {
     /// Client for governance and config commands. Skips the Bitcoin
     /// collections, which none of them read.
@@ -204,6 +226,11 @@ impl HashiClient {
             hashi_object_id: config.hashi_object_id(),
         };
 
+        // Say which network every command is talking to: the RPC URL defaults
+        // to mainnet when no config is found, and a wrong-network object id is
+        // otherwise indistinguishable from a typo.
+        crate::cli::print_info(&format!("Sui RPC: {}", config.sui_rpc_url));
+
         let onchain_state = OnchainState::new_reader(
             &config.sui_rpc_url,
             hashi_ids,
@@ -211,11 +238,13 @@ impl HashiClient {
             scope,
         )
         .await
+        .map_err(|e| explain_missing_object(e, hashi_ids, &config.sui_rpc_url))
         .context("Failed to initialize on-chain state")?;
 
         let hashi_initial_shared_version =
             fetch_initial_shared_version(&mut onchain_state.client(), hashi_ids.hashi_object_id)
-                .await?;
+                .await
+                .map_err(|e| explain_missing_object(e, hashi_ids, &config.sui_rpc_url))?;
 
         // Try to create executor if keypair is available
         let executor = match config.load_keypair()? {

--- a/crates/hashi/src/cli/commands/config.rs
+++ b/crates/hashi/src/cli/commands/config.rs
@@ -20,12 +20,10 @@ pub fn generate_template(output: &Path) -> Result<()> {
 
     if output.exists() {
         print_warning(&format!(
-            "File {} already exists. Overwrite? (y/N)",
+            "File {} already exists and will be overwritten.",
             output.display()
         ));
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input)?;
-        if !input.trim().eq_ignore_ascii_case("y") {
+        if !crate::cli::confirm()? {
             print_info("Cancelled.");
             return Ok(());
         }

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -432,7 +432,10 @@ pub async fn vote(
     print_detail(&format!("  Type: {}", proposal_type_str.cyan()));
     print_acting_validator(&client)?;
 
-    prompt_continue("vote on this proposal", tx_opts).await?;
+    if !prompt_continue("vote on this proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     print_info("Building vote transaction...");
 
@@ -539,7 +542,10 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
     print_detail(&format!("  Type: {}", proposal_type_str.cyan()));
     print_acting_validator(&client)?;
 
-    prompt_continue("remove your vote from this proposal", tx_opts).await?;
+    if !prompt_continue("remove your vote from this proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     print_info("Building remove_vote transaction...");
 
@@ -586,7 +592,10 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
     print_detail(&format!("  Type: {}", proposal_type_str.cyan()));
     print_detail(&format!("  ID:   {}", proposal_id));
 
-    prompt_continue("execute this proposal", tx_opts).await?;
+    if !prompt_continue("execute this proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_execute_proposal_transaction(proposal_addr, proposal_type)?;
 
@@ -699,11 +708,15 @@ pub async fn execute_upgrade(
          build from the same commit with the same `sui` that produced the proposal.",
     );
 
-    prompt_continue(
+    if !prompt_continue(
         "execute this upgrade (execute + publish + finalize in one transaction)",
         tx_opts,
     )
-    .await?;
+    .await?
+    {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let hashi_ids = *client.hashi_ids();
     let tx =
@@ -850,7 +863,10 @@ pub async fn create_upgrade_proposal(
     print_metadata(&metadata);
     print_acting_validator(&client)?;
 
-    prompt_continue("create this upgrade proposal", tx_opts).await?;
+    if !prompt_continue("create this upgrade proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::Upgrade {
         digest: digest_bytes,
@@ -884,7 +900,10 @@ pub async fn create_update_config_proposal(
     let mut client = HashiClient::new(config).await?;
     print_acting_validator(&client)?;
 
-    prompt_continue("create this config update proposal", tx_opts).await?;
+    if !prompt_continue("create this config update proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateConfig {
         key: key.to_string(),
@@ -918,7 +937,10 @@ pub async fn create_update_epoch_config_proposal(
     print_detail("  Takes effect: next committee formed after execution");
     print_metadata(&metadata);
 
-    prompt_continue("create this epoch config update proposal", tx_opts).await?;
+    if !prompt_continue("create this epoch config update proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateEpochConfig {
@@ -958,7 +980,10 @@ pub async fn create_add_config_proposal(
     ));
     print_metadata(&metadata);
 
-    prompt_continue("create this add config proposal", tx_opts).await?;
+    if !prompt_continue("create this add config proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::AddConfig {
@@ -1028,7 +1053,10 @@ pub async fn create_update_mpc_config_proposal(
     let mut client = HashiClient::new(config).await?;
     print_acting_validator(&client)?;
 
-    prompt_continue("create this MPC config update proposal", tx_opts).await?;
+    if !prompt_continue("create this MPC config update proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateMpcConfig {
         max_faulty_bps,
@@ -1078,7 +1106,10 @@ pub async fn create_enable_version_proposal(
     let mut client = HashiClient::new(config).await?;
     print_acting_validator(&client)?;
 
-    prompt_continue("create this enable version proposal", tx_opts).await?;
+    if !prompt_continue("create this enable version proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::EnableVersion {
         version,
@@ -1108,7 +1139,10 @@ pub async fn create_disable_version_proposal(
     let mut client = HashiClient::new(config).await?;
     print_acting_validator(&client)?;
 
-    prompt_continue("create this disable version proposal", tx_opts).await?;
+    if !prompt_continue("create this disable version proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::DisableVersion {
         version,
@@ -1135,7 +1169,10 @@ pub async fn create_abort_reconfig_proposal(
     let mut client = HashiClient::new(config).await?;
     print_acting_validator(&client)?;
 
-    prompt_continue("create this abort reconfig proposal", tx_opts).await?;
+    if !prompt_continue("create this abort reconfig proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::AbortReconfig {
         epoch,
@@ -1165,7 +1202,10 @@ pub async fn create_update_guardian_proposal(
     let mut client = HashiClient::new(config).await?;
     print_acting_validator(&client)?;
 
-    prompt_continue("create this update guardian proposal", tx_opts).await?;
+    if !prompt_continue("create this update guardian proposal", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateGuardian {
         url: url.to_string(),
@@ -1198,11 +1238,15 @@ pub async fn create_emergency_pause_proposal(
     let mut client = HashiClient::new(config).await?;
     print_acting_validator(&client)?;
 
-    prompt_continue(
+    if !prompt_continue(
         &format!("create this emergency {} proposal", action.to_lowercase()),
         tx_opts,
     )
-    .await?;
+    .await?
+    {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_create_proposal_transaction(CreateProposalParams::EmergencyPause {
         pause: !unpause,
@@ -1265,11 +1309,15 @@ pub async fn create_ignore_member_proposal(
 
     print_acting_validator(&client)?;
 
-    prompt_continue(
+    if !prompt_continue(
         &format!("create this {} member proposal", action.to_lowercase()),
         tx_opts,
     )
-    .await?;
+    .await?
+    {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let mut client = client;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::IgnoreMember {
@@ -1377,27 +1425,19 @@ fn print_proposal_detailed(
     println!("{}", "━".repeat(60).dimmed());
 }
 
-/// Pause for user acknowledgement before an actual execution. No-op when the
-/// user passed `-y/--yes`, or in dry-run / serialize-unsigned mode — those
-/// change no on-chain state, and serialize mode must keep stdout clean.
-pub(crate) async fn prompt_continue(action: &str, tx_opts: &TxOptions) -> Result<()> {
+/// Ask the operator to confirm before a real execution. Returns `true` to
+/// proceed. Always `true` with `-y/--yes`, or in dry-run and
+/// serialize-unsigned mode, which change no on-chain state. Requires an
+/// explicit `y`, and refuses when stdin is not a terminal (see
+/// [`crate::cli::confirm`]).
+pub(crate) async fn prompt_continue(action: &str, tx_opts: &TxOptions) -> Result<bool> {
     use crate::sui_tx_executor::TxMode;
-    use tokio::io::AsyncBufReadExt;
-    use tokio::io::BufReader;
 
     if tx_opts.skip_confirm || tx_opts.mode() != TxMode::Execute {
-        return Ok(());
+        return Ok(true);
     }
-
-    eprintln!(
-        "\n{}",
-        format!("Press enter to {action}, or Ctrl+C to cancel...").yellow()
-    );
-
-    let mut reader = BufReader::new(tokio::io::stdin());
-    let mut input = String::new();
-    reader.read_line(&mut input).await?;
-    Ok(())
+    eprintln!("\n{}", format!("About to {action}.").yellow());
+    crate::cli::confirm()
 }
 
 #[cfg(test)]

--- a/crates/hashi/src/cli/commands/validator.rs
+++ b/crates/hashi/src/cli/commands/validator.rs
@@ -37,7 +37,10 @@ pub async fn resign(config: &CliConfig, tx_opts: &TxOptions) -> Result<()> {
     );
     print_acting_validator(&client)?;
 
-    prompt_continue("resign from the committee", tx_opts).await?;
+    if !prompt_continue("resign from the committee", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_resign_transaction()?;
     print_info("Transaction: validator::resign");
@@ -59,7 +62,10 @@ pub async fn withdraw_resignation(config: &CliConfig, tx_opts: &TxOptions) -> Re
     );
     print_acting_validator(&client)?;
 
-    prompt_continue("withdraw the resignation", tx_opts).await?;
+    if !prompt_continue("withdraw the resignation", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_withdraw_resignation_transaction()?;
     print_info("Transaction: validator::withdraw_resignation");
@@ -89,7 +95,10 @@ pub async fn remove_inactive(
          in Sui's active validator set.",
     );
 
-    prompt_continue("remove this member's registration", tx_opts).await?;
+    if !prompt_continue("remove this member's registration", tx_opts).await? {
+        crate::cli::print_warning("Aborted.");
+        return Ok(());
+    }
 
     let tx = client.build_remove_inactive_member_transaction(validator)?;
     print_info("Transaction: validator::remove_inactive_member");

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -34,61 +34,64 @@ pub enum OutputFormat {
 
 /// CLI-specific global options, flattened into each CLI subcommand.
 #[derive(Args)]
+/// Every flag here is `global`, so it parses in any position:
+/// `hashi proposal vote <id> -y --dry-run` and `hashi -y proposal vote <id>`
+/// both work.
 pub struct CliGlobalOpts {
     /// Path to the CLI configuration file
-    #[clap(long, short, env = "HASHI_CLI_CONFIG")]
+    #[clap(global = true, long, short, env = "HASHI_CLI_CONFIG")]
     pub config: Option<std::path::PathBuf>,
 
     /// Sui RPC URL (overrides config file)
-    #[clap(long, env = "SUI_RPC_URL")]
+    #[clap(global = true, long, env = "SUI_RPC_URL")]
     pub sui_rpc_url: Option<String>,
 
     /// Hashi package ID (overrides config file)
-    #[clap(long, env = "HASHI_PACKAGE_ID")]
+    #[clap(global = true, long, env = "HASHI_PACKAGE_ID")]
     pub package_id: Option<String>,
 
     /// Hashi shared object ID (overrides config file)
-    #[clap(long, env = "HASHI_OBJECT_ID")]
+    #[clap(global = true, long, env = "HASHI_OBJECT_ID")]
     pub hashi_object_id: Option<String>,
 
     /// Path to the keypair file for signing transactions
-    #[clap(long, short = 'k', env = "HASHI_KEYPAIR")]
+    #[clap(global = true, long, short = 'k', env = "HASHI_KEYPAIR")]
     pub keypair: Option<std::path::PathBuf>,
 
     /// Bitcoin RPC URL (overrides config file)
-    #[clap(long, env = "BTC_RPC_URL")]
+    #[clap(global = true, long, env = "BTC_RPC_URL")]
     pub btc_rpc_url: Option<String>,
 
     /// Bitcoin RPC username (overrides config file)
-    #[clap(long, env = "BTC_RPC_USER")]
+    #[clap(global = true, long, env = "BTC_RPC_USER")]
     pub btc_rpc_user: Option<String>,
 
     /// Bitcoin RPC password (overrides config file)
-    #[clap(long, env = "BTC_RPC_PASSWORD")]
+    #[clap(global = true, long, env = "BTC_RPC_PASSWORD")]
     pub btc_rpc_password: Option<String>,
 
     /// Bitcoin network: regtest, testnet4, or mainnet (overrides config file)
-    #[clap(long, env = "BTC_NETWORK")]
+    #[clap(global = true, long, env = "BTC_NETWORK")]
     pub btc_network: Option<String>,
 
     /// Path to Bitcoin private key file in WIF format (overrides config file)
-    #[clap(long, env = "BTC_PRIVATE_KEY")]
+    #[clap(global = true, long, env = "BTC_PRIVATE_KEY")]
     pub btc_private_key: Option<std::path::PathBuf>,
 
     /// Enable verbose output
-    #[clap(long, short)]
+    #[clap(global = true, long, short)]
     pub verbose: bool,
 
     /// Skip all confirmation prompts
-    #[clap(long, short = 'y')]
+    #[clap(global = true, long, short = 'y')]
     pub yes: bool,
 
     /// Gas budget for transactions (in MIST). If not set, estimates via dry-run.
-    #[clap(long, env = "HASHI_GAS_BUDGET")]
+    #[clap(global = true, long, env = "HASHI_GAS_BUDGET")]
     pub gas_budget: Option<u64>,
 
     /// Simulate the transaction without executing (dry-run)
-    #[clap(long)]
+    #[clap(global = true, long)]
     pub dry_run: bool,
 
     /// Build the transaction and print it as base64 (BCS `TransactionData`)
@@ -96,23 +99,23 @@ pub struct CliGlobalOpts {
     /// written to stdout, ready for `sui keytool sign` + `sui client
     /// execute-signed-tx` (e.g. multisig). No keypair required; pair with
     /// --sender to set the signing address.
-    #[clap(long, conflicts_with = "dry_run")]
+    #[clap(global = true, long, conflicts_with = "dry_run")]
     pub serialize_unsigned_transaction: bool,
 
     /// Sender address to build the transaction for (e.g. a multisig address).
     /// Defaults to the configured keypair's address; required when serializing
     /// or dry-running without a keypair.
-    #[clap(long)]
+    #[clap(global = true, long)]
     pub sender: Option<String>,
 
     /// Pin the gas coin (object id) used to pay for the transaction. Only the
     /// id is needed. Defaults to fullnode gas selection, or `gas_coin` from the
     /// config file.
-    #[clap(long)]
+    #[clap(global = true, long)]
     pub gas: Option<String>,
 
     /// Gas price override in MIST per unit. Defaults to the reference gas price.
-    #[clap(long)]
+    #[clap(global = true, long)]
     pub gas_price: Option<u64>,
 }
 
@@ -1033,10 +1036,6 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
         gas_price: opts.gas_price,
     };
 
-    // In serialize-unsigned mode, keep stdout clean (base64 only) by sending
-    // all human-readable notes to stderr.
-    set_notes_to_stderr(tx_opts.serialize_unsigned);
-
     match command {
         CliCommand::Proposal { action } => match action {
             ProposalCommands::List { r#type, detailed } => {
@@ -1356,30 +1355,31 @@ fn init_tracing(verbose: bool) {
         .init();
 }
 
-/// When set, human-readable notes/summaries are written to stderr instead of
-/// stdout. This is enabled in `--serialize-unsigned-transaction` mode so that
-/// stdout carries only the base64 unsigned transaction (safe to pipe into
-/// `sui keytool sign`).
-static NOTES_TO_STDERR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Route human-readable notes/summaries to stderr (keeping stdout clean for
-/// machine-readable output). Call once when entering a serialize-unsigned flow.
-pub fn set_notes_to_stderr(enabled: bool) {
-    NOTES_TO_STDERR.store(enabled, std::sync::atomic::Ordering::Relaxed);
-}
-
-fn notes_to_stderr() -> bool {
-    NOTES_TO_STDERR.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// Print a human-readable note/summary line. Goes to stderr in serialize mode
-/// (so stdout stays clean for the base64 transaction), stdout otherwise.
+/// Print a human-readable note or summary line. Notes always go to stderr:
+/// stdout carries only results (tables, JSON, a proposal id, a transaction
+/// digest, or the base64 unsigned transaction), so piping any command's
+/// stdout into another tool never picks up progress chatter.
 pub fn print_detail(msg: &str) {
-    if notes_to_stderr() {
-        eprintln!("{msg}");
-    } else {
-        println!("{msg}");
+    eprintln!("{msg}");
+}
+
+/// Ask the operator to confirm. Requires an explicit `y`; anything else is a
+/// decline. When stdin is not a terminal there is nobody to answer, so the
+/// command refuses to proceed instead of treating an empty read as consent,
+/// and points at `--yes`.
+pub fn confirm() -> anyhow::Result<bool> {
+    use std::io::IsTerminal;
+
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "this command needs confirmation but stdin is not a terminal; pass --yes / -y \
+             to confirm non-interactively"
+        );
     }
+    eprint!("Continue? [y/N] ");
+    let mut answer = String::new();
+    std::io::stdin().read_line(&mut answer)?;
+    Ok(answer.trim().eq_ignore_ascii_case("y"))
 }
 
 /// Print a success message
@@ -1417,11 +1417,8 @@ pub fn explorer_tx_url(sui_rpc_url: &str, digest: &str) -> Option<String> {
 /// Print a transaction digest with its explorer deep-link (when the network
 /// has one) so the result can be verified in a browser with one click.
 pub fn print_tx_digest(sui_rpc_url: &str, digest: &str) {
-    print_detail(&format!(
-        "\n{} Transaction submitted: {}",
-        "✓".green(),
-        digest.cyan()
-    ));
+    // The digest is the command's result, so it is the one line on stdout.
+    println!("\n{} Transaction submitted: {}", "✓".green(), digest.cyan());
     if let Some(url) = explorer_tx_url(sui_rpc_url, digest) {
         print_detail(&format!("  {} {}", "Explorer:".dimmed(), url.cyan()));
     }
@@ -1542,14 +1539,14 @@ pub fn print_tx_outcome(
 /// Print an in-progress status line (no newline) that can be overwritten.
 pub fn print_step(msg: &str) {
     use std::io::Write;
-    print!("\r\x1b[2K{} {}", "ℹ".blue().bold(), msg);
-    let _ = std::io::stdout().flush();
+    eprint!("\r\x1b[2K{} {}", "ℹ".blue().bold(), msg);
+    let _ = std::io::stderr().flush();
 }
 
 /// Overwrite the current status line with a success message.
 pub fn complete_step(msg: &str) {
-    print!("\r\x1b[2K");
-    println!("{} {}", "✓".green().bold(), msg);
+    eprint!("\r\x1b[2K");
+    eprintln!("{} {}", "✓".green().bold(), msg);
 }
 
 /// Run the `publish` command – build, publish, and initialise the Hashi package.
@@ -1605,10 +1602,7 @@ pub async fn run_publish(opts: PublishOpts) -> anyhow::Result<()> {
     if !opts.yes {
         print_info("This will publish the package (1 transaction).");
         print_info("Use --yes / -y to skip this prompt.");
-        eprint!("Continue? [y/N] ");
-        let mut answer = String::new();
-        std::io::stdin().read_line(&mut answer)?;
-        if !answer.trim().eq_ignore_ascii_case("y") {
+        if !confirm()? {
             print_warning("Aborted.");
             return Ok(());
         }
@@ -1660,10 +1654,6 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
 
     crate::init_crypto_provider();
     init_tracing(opts.verbose);
-
-    // In serialize/status mode keep stdout clean (base64 / the LAUNCH_STATUS
-    // line only); notes go to stderr.
-    set_notes_to_stderr(opts.serialize_unsigned || opts.status);
 
     // Resolve ids: explicit flags win, else the hashi_ids.json from publish.
     let ids: crate::config::HashiIds = match (&opts.package_id, &opts.hashi_object_id) {
@@ -1907,10 +1897,7 @@ pub async fn run_launch(opts: LaunchOpts) -> anyhow::Result<()> {
              registered right now (1 transaction).",
         );
         print_info("Use --yes / -y to skip this prompt.");
-        eprint!("Continue? [y/N] ");
-        let mut answer = String::new();
-        std::io::stdin().read_line(&mut answer)?;
-        if !answer.trim().eq_ignore_ascii_case("y") {
+        if !confirm()? {
             print_warning("Aborted.");
             return Ok(());
         }
@@ -1974,9 +1961,6 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
     use sui_sdk_types::bcs::ToBcs;
 
     init_tracing(opts.verbose);
-
-    // In serialize mode keep stdout clean (base64 only); notes go to stderr.
-    set_notes_to_stderr(opts.serialize_unsigned);
 
     // Load the validator config and refuse a chain pairing the protocol
     // never deploys. The config's Sui chain ID is confirmed against the RPC
@@ -2062,10 +2046,7 @@ pub async fn run_register(opts: RegisterOpts) -> anyhow::Result<()> {
     if !opts.yes {
         print_info("This will register the validator on-chain (1 transaction).");
         print_info("Use --yes / -y to skip this prompt.");
-        eprint!("Continue? [y/N] ");
-        let mut answer = String::new();
-        std::io::stdin().read_line(&mut answer)?;
-        if !answer.trim().eq_ignore_ascii_case("y") {
+        if !confirm()? {
             print_warning("Aborted.");
             return Ok(());
         }

--- a/crates/hashi/tests/cli_global_flags.rs
+++ b/crates/hashi/tests/cli_global_flags.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The global CLI flags parse in any position. `main.rs` flattens
+//! `CliGlobalOpts` beside each top-level subcommand, so this mirrors that
+//! shape and checks that `-y`, `--dry-run` and friends are accepted after the
+//! leaf subcommand as well as before it.
+
+use clap::Parser;
+use hashi::cli::CliGlobalOpts;
+use hashi::cli::ProposalCommands;
+
+#[derive(Parser)]
+struct Shape {
+    #[clap(flatten)]
+    cli_opts: CliGlobalOpts,
+    #[clap(subcommand)]
+    action: ProposalCommands,
+}
+
+#[test]
+fn flags_after_the_leaf_subcommand_are_accepted() {
+    let parsed = Shape::try_parse_from(["hashi", "vote", "0x1", "-y", "--dry-run"]).unwrap();
+    assert!(parsed.cli_opts.yes);
+    assert!(parsed.cli_opts.dry_run);
+    assert!(matches!(parsed.action, ProposalCommands::Vote { .. }));
+}
+
+#[test]
+fn flags_before_the_leaf_subcommand_still_work() {
+    let parsed =
+        Shape::try_parse_from(["hashi", "--keypair", "/tmp/k.key", "-y", "vote", "0x1"]).unwrap();
+    assert!(parsed.cli_opts.yes);
+    assert_eq!(
+        parsed.cli_opts.keypair.as_deref(),
+        Some(std::path::Path::new("/tmp/k.key"))
+    );
+}
+
+#[test]
+fn flags_split_around_the_leaf_subcommand_combine() {
+    let parsed = Shape::try_parse_from([
+        "hashi",
+        "--sui-rpc-url",
+        "http://localhost:9000",
+        "view",
+        "0x1",
+        "--verbose",
+    ])
+    .unwrap();
+    assert!(parsed.cli_opts.verbose);
+    assert_eq!(
+        parsed.cli_opts.sui_rpc_url.as_deref(),
+        Some("http://localhost:9000")
+    );
+}


### PR DESCRIPTION
## Summary

Second of the CLI ergonomics PRs, on top of #1116. Four papercuts every operator hits during governance work.

- **Global flags in any position.** `hashi proposal vote <id> -y` was rejected; the flags only parsed on the first-level subcommand and the runbook had to teach the ordering. Every field of `CliGlobalOpts` is now `global`, so `-y`, `--dry-run`, `--keypair`, `--sui-rpc-url` and the rest parse before or after the leaf.
- **One confirmation helper.** Five prompts were hand-rolled three ways. The proposal and validator commands accepted any input as consent, including an empty read on a closed stdin, so a non-interactive run without `-y` proceeded. `confirm()` asks `[y/N]`, requires an explicit `y`, and when stdin is not a terminal refuses with a pointer to `--yes` instead of treating silence as yes. Declining prints `Aborted.` and exits 0 everywhere.
- **Notes on stderr, results on stdout.** Progress notes went to stdout unless the command was serializing an unsigned transaction. They now always go to stderr, so piping any command's stdout picks up only results: tables, JSON, a proposal id, a transaction digest, the base64 transaction. The serialize-only switch is deleted.
- **Network header and a readable NotFound.** The RPC URL defaults to mainnet when no config is found, and a wrong-network object id surfaced as a bare gRPC NotFound. Every client build prints `Sui RPC: <url>`, and a NotFound while loading the Hashi object says the ids and the URL do not belong to the same network. The default itself is unchanged.

## Behaviour change to know about

Automation that piped `echo y` into a prompt instead of passing `-y` now gets a refusal naming `--yes`. Anything already passing `-y` (including the sui-operations launch flow, which uses `--status` and `--yes`) is unaffected.

## Tests

`crates/hashi/tests/cli_global_flags.rs` mirrors the `main.rs` shape (`CliGlobalOpts` flattened beside a subcommand enum) and checks flags after, before and around the leaf. CLI unit tests, clippy and a warnings-denied doc build are clean.
