### PR TITLE
cli: act as --sender without a keypair; refuse doomed config and resignation proposals early

### DIFF
--- a/crates/e2e-tests/src/main.rs
+++ b/crates/e2e-tests/src/main.rs
@@ -979,6 +979,7 @@ fn build_cli_config(
         hashi_object_id: state.hashi_object_id.parse().ok(),
         keypair_path,
         gas_coin: None,
+        acting_sender: None,
         bitcoin: Some(hashi::cli::config::BitcoinConfig {
             rpc_url: Some(state.btc_rpc_url.clone()),
             rpc_user: Some(state.btc_rpc_user.clone()),

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -324,6 +324,7 @@ impl HashiClient {
             std::time::Duration::from_secs(10),
         )
         .await
+        .map_err(crate::cli::explain_tx_error)
     }
 
     // ========================================================================

--- a/crates/hashi/src/cli/client.rs
+++ b/crates/hashi/src/cli/client.rs
@@ -124,6 +124,9 @@ pub struct HashiClient {
     /// build fully-resolved shared inputs (see
     /// [`build_create_proposal_transaction`]).
     hashi_initial_shared_version: u64,
+    /// `--sender`, when given: the identity governance commands act as when
+    /// there is no keypair to derive one from.
+    acting_sender: Option<Address>,
     /// Optional executor for signing and submitting transactions
     executor: Option<SuiTxExecutor>,
     /// The RPC endpoint this client talks to (used for explorer deep-links)
@@ -266,6 +269,7 @@ impl HashiClient {
             onchain_state,
             hashi_ids,
             hashi_initial_shared_version,
+            acting_sender: config.acting_sender,
             executor,
             sui_rpc_url: config.sui_rpc_url.clone(),
         })
@@ -560,15 +564,55 @@ impl HashiClient {
         self.executor.as_ref().map(|e| e.sender())
     }
 
-    /// Resolve the committee member (validator address) the configured
-    /// keypair acts for in governance calls: an exact validator match wins,
-    /// otherwise exactly one operator delegation; more than one is an error
-    /// (see `resolve_governance_identity`).
+    /// The address a transaction is built for: `--sender` when given,
+    /// otherwise the configured keypair's address. This is also the address
+    /// whose committee identity the governance commands act as, so the
+    /// serialize-unsigned and dry-run paths work without a keypair. When both
+    /// are present and differ, the chain rejects the signature anyway, so the
+    /// explicit sender wins here too.
+    pub fn acting_address(&self) -> Option<Address> {
+        self.acting_sender.or_else(|| self.signer_address())
+    }
+
+    /// Resolve the committee member (validator address) the acting address
+    /// acts for in governance calls: an exact validator match wins, otherwise
+    /// exactly one operator delegation; more than one is an error (see
+    /// `resolve_governance_identity`).
     pub fn resolve_validator_address(&self) -> anyhow::Result<Address> {
-        let sender = self
-            .signer_address()
-            .ok_or_else(|| anyhow::anyhow!("Cannot resolve validator: no keypair configured"))?;
+        let sender = self.acting_address().ok_or_else(|| {
+            anyhow::anyhow!("Cannot resolve validator: no keypair configured and no --sender given")
+        })?;
         resolve_governance_identity(&self.fetch_committee_members(), sender)
+    }
+
+    /// The registration record for `validator`, if it is registered.
+    pub fn member_info(&self, validator: &Address) -> Option<MemberInfo> {
+        self.fetch_committee_members()
+            .into_iter()
+            .find(|m| m.validator_address() == validator)
+    }
+
+    /// The current on-chain value of `key` in the instant config store.
+    pub fn instant_config_value(&self, key: &str) -> Option<ConfigValue> {
+        self.onchain_state
+            .state()
+            .hashi()
+            .config
+            .config
+            .get(key)
+            .cloned()
+    }
+
+    /// The current on-chain value of `key` in the epoch config store.
+    pub fn epoch_config_value(&self, key: &str) -> Option<ConfigValue> {
+        self.onchain_state
+            .state()
+            .hashi()
+            .epoch_config
+            .entries()
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.clone())
     }
 
     /// Build a vote transaction for a proposal.

--- a/crates/hashi/src/cli/commands/deposit.rs
+++ b/crates/hashi/src/cli/commands/deposit.rs
@@ -218,7 +218,8 @@ async fn request(
         tx_opts.mode(),
         std::time::Duration::from_secs(10),
     )
-    .await?;
+    .await
+    .map_err(crate::cli::explain_tx_error)?;
 
     if let Some(response) = crate::cli::print_tx_outcome(outcome, &config.sui_rpc_url) {
         let request_id = crate::sui_tx_executor::deposit_request_id_from_response(&response)?;
@@ -369,7 +370,8 @@ async fn request_all(
 
         let request_ids = executor
             .execute_create_deposit_requests_batch(txid_address, chunk, derivation_path)
-            .await?;
+            .await
+            .map_err(crate::cli::explain_tx_error)?;
         all_request_ids.extend(request_ids);
     }
 

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -43,9 +43,9 @@ fn print_metadata(metadata: &[(String, String)]) {
 /// [`HashiClient::resolve_validator_address`] for the rules.
 pub(crate) fn print_acting_validator(client: &HashiClient) -> Result<()> {
     let validator_address = client.resolve_validator_address()?;
-    let via_operator = match client.signer_address() {
-        Some(signer) if signer != validator_address => {
-            format!(" (delegated operator {})", signer.to_hex().dimmed())
+    let via_operator = match client.acting_address() {
+        Some(acting) if acting != validator_address => {
+            format!(" (delegated operator {})", acting.to_hex().dimmed())
         }
         _ => String::new(),
     };
@@ -262,6 +262,107 @@ fn seated_members(
             c.members().iter().map(|m| m.validator_address()).collect(),
         )
     })
+}
+
+/// Which governed store a config proposal targets.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfigStore {
+    Instant,
+    Epoch,
+}
+
+impl ConfigStore {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Instant => "instant",
+            Self::Epoch => "epoch",
+        }
+    }
+    fn other(self) -> Self {
+        match self {
+            Self::Instant => Self::Epoch,
+            Self::Epoch => Self::Instant,
+        }
+    }
+    fn update_command(self) -> &'static str {
+        match self {
+            Self::Instant => "hashi proposal create update-config",
+            Self::Epoch => "hashi proposal create update-epoch-config",
+        }
+    }
+}
+
+fn config_value_type(value: &hashi_types::move_types::ConfigValue) -> &'static str {
+    use hashi_types::move_types::ConfigValue;
+    match value {
+        ConfigValue::U64(_) => "u64",
+        ConfigValue::U128(_) => "u128",
+        ConfigValue::U256(_) => "u256",
+        ConfigValue::Address(_) => "address",
+        ConfigValue::String(_) => "string",
+        ConfigValue::Bool(_) => "bool",
+        ConfigValue::Bytes(_) => "bytes",
+    }
+}
+
+/// Refuse an update the chain would reject with `EInvalidConfigEntry`: the
+/// key must already exist in the targeted store, and its value type cannot
+/// change. When the key lives in the other store, name the right command.
+pub fn refuse_bad_config_update(
+    key: &str,
+    proposed: &hashi_types::move_types::ConfigValue,
+    target: ConfigStore,
+    current: Option<&hashi_types::move_types::ConfigValue>,
+    in_other_store: bool,
+) -> Result<()> {
+    let Some(current) = current else {
+        if in_other_store {
+            anyhow::bail!(
+                "key {key} is not in the {} config; it lives in the {} config. Use `{}` instead.",
+                target.name(),
+                target.other().name(),
+                target.other().update_command()
+            );
+        }
+        anyhow::bail!(
+            "key {key} does not exist in the {} config, and updates can only change existing \
+             keys. Use `hashi proposal create add-config` to introduce a new key, or \
+             `hashi config on-chain` to see the current keys.",
+            target.name()
+        );
+    };
+    anyhow::ensure!(
+        std::mem::discriminant(current) == std::mem::discriminant(proposed),
+        "key {key} holds a {} value on chain but the proposed value is {}; a key's value \
+         type cannot change",
+        config_value_type(current),
+        config_value_type(proposed)
+    );
+    Ok(())
+}
+
+/// Refuse an add the chain would reject with `EKeyAlreadyExists`, and warn
+/// when the same name already exists in the other store.
+pub fn refuse_bad_config_add(
+    key: &str,
+    target: ConfigStore,
+    in_target_store: bool,
+    in_other_store: bool,
+) -> Result<Option<String>> {
+    anyhow::ensure!(
+        !in_target_store,
+        "key {key} already exists in the {} config; use `{}` to change it",
+        target.name(),
+        target.update_command()
+    );
+    Ok(in_other_store.then(|| {
+        format!(
+            "key {key} already exists in the {} config; adding it to the {} config as well \
+             creates two same-named keys that nodes read from different places",
+            target.other().name(),
+            target.name()
+        )
+    }))
 }
 
 fn now_ms() -> u64 {
@@ -630,7 +731,7 @@ pub async fn vote(
     // first, from one live read of the proposal.
     let details = client.fetch_proposal_details(proposal_addr).await?;
     let committee = client.fetch_current_committee();
-    if client.signer_address().is_some() {
+    if client.acting_address().is_some() {
         let validator = client.resolve_validator_address()?;
         let seated = seated_members(committee.as_ref());
         refuse_if_not_seated(validator, seated.as_ref().map(|(e, m)| (*e, m.as_slice())))?;
@@ -735,7 +836,7 @@ pub async fn remove_vote(config: &CliConfig, proposal_id: &str, tx_opts: &TxOpti
         client.sui_rpc_url(),
     )?;
     refuse_if_expired(&proposal, proposal_id, now_ms())?;
-    if client.signer_address().is_some() {
+    if client.acting_address().is_some() {
         let validator = client.resolve_validator_address()?;
         let details = client.fetch_proposal_details(proposal_addr).await?;
         refuse_vote_state(
@@ -818,7 +919,7 @@ pub async fn execute(config: &CliConfig, proposal_id: &str, tx_opts: &TxOptions)
     print_detail(&format!("  ID:   {}", proposal_id));
     print_detail(&format!("  Votes: {}", progress.describe()));
     // Execution is permissionless, so the sender is whoever pays gas.
-    if let Some(sender) = tx_opts.sender.or_else(|| client.signer_address()) {
+    if let Some(sender) = client.acting_address() {
         print_detail(&format!("  Sender: {}", sender.to_hex().cyan()));
     }
 
@@ -1128,6 +1229,13 @@ pub async fn create_update_config_proposal(
     print_metadata(&metadata);
 
     let mut client = HashiClient::new(config).await?;
+    refuse_bad_config_update(
+        key,
+        &value,
+        ConfigStore::Instant,
+        client.instant_config_value(key).as_ref(),
+        client.epoch_config_value(key).is_some(),
+    )?;
     print_acting_validator(&client)?;
 
     if !prompt_continue("create this config update proposal", tx_opts).await? {
@@ -1167,12 +1275,21 @@ pub async fn create_update_epoch_config_proposal(
     print_detail("  Takes effect: next committee formed after execution");
     print_metadata(&metadata);
 
+    let mut client = HashiClient::new(config).await?;
+    refuse_bad_config_update(
+        key,
+        &value,
+        ConfigStore::Epoch,
+        client.epoch_config_value(key).as_ref(),
+        client.instant_config_value(key).is_some(),
+    )?;
+    print_acting_validator(&client)?;
+
     if !prompt_continue("create this epoch config update proposal", tx_opts).await? {
         crate::cli::print_warning("Aborted.");
         return Ok(());
     }
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::UpdateEpochConfig {
         key: key.to_string(),
         value,
@@ -1210,12 +1327,32 @@ pub async fn create_add_config_proposal(
     ));
     print_metadata(&metadata);
 
+    let mut client = HashiClient::new(config).await?;
+    let target = if epoch {
+        ConfigStore::Epoch
+    } else {
+        ConfigStore::Instant
+    };
+    let (in_target, in_other) = match target {
+        ConfigStore::Epoch => (
+            client.epoch_config_value(key).is_some(),
+            client.instant_config_value(key).is_some(),
+        ),
+        ConfigStore::Instant => (
+            client.instant_config_value(key).is_some(),
+            client.epoch_config_value(key).is_some(),
+        ),
+    };
+    if let Some(warning) = refuse_bad_config_add(key, target, in_target, in_other)? {
+        print_warning(&warning);
+    }
+    print_acting_validator(&client)?;
+
     if !prompt_continue("create this add config proposal", tx_opts).await? {
         crate::cli::print_warning("Aborted.");
         return Ok(());
     }
 
-    let mut client = HashiClient::new(config).await?;
     let tx = client.build_create_proposal_transaction(CreateProposalParams::AddConfig {
         epoch,
         key: key.to_string(),

--- a/crates/hashi/src/cli/commands/proposal.rs
+++ b/crates/hashi/src/cli/commands/proposal.rs
@@ -452,7 +452,7 @@ pub fn explain_execution_error(
 /// mode produced it: the executor wraps the execute path's build error in
 /// `TxFailure::NotSubmitted`, while dry-run and serialize-unsigned return the
 /// SDK build error bare, so both shapes are searched.
-fn explain_move_abort(err: &anyhow::Error) -> Option<String> {
+pub(crate) fn explain_move_abort(err: &anyhow::Error) -> Option<String> {
     let from_executor = crate::sui_tx_executor::transaction_execution_error(err);
     let from_builder =
         err.chain().find_map(
@@ -495,14 +495,8 @@ pub(crate) async fn execute_or_simulate(
         TxMode::Execute => print_info("Executing transaction..."),
     }
 
-    let outcome =
-        client
-            .finalize_tx(tx, tx_opts)
-            .await
-            .map_err(|e| match explain_move_abort(&e) {
-                Some(explanation) => e.context(explanation),
-                None => e,
-            })?;
+    // `finalize_tx` decodes Move aborts for every command that goes through it.
+    let outcome = client.finalize_tx(tx, tx_opts).await?;
     Ok(crate::cli::print_tx_outcome(outcome, client.sui_rpc_url()).map(|response| *response))
 }
 

--- a/crates/hashi/src/cli/commands/proposal_tests.rs
+++ b/crates/hashi/src/cli/commands/proposal_tests.rs
@@ -251,6 +251,89 @@ fn quorum_progress_rounds_the_threshold_up_and_describes_both_states() {
     assert!(!empty.met());
 }
 
+// ===== config proposal pre-flights =====
+
+#[test]
+fn updating_an_existing_key_of_the_same_type_passes() {
+    use hashi_types::move_types::ConfigValue;
+    refuse_bad_config_update(
+        "bitcoin_deposit_minimum",
+        &ConfigValue::U64(1),
+        ConfigStore::Instant,
+        Some(&ConfigValue::U64(25_000)),
+        false,
+    )
+    .unwrap();
+}
+
+#[test]
+fn updating_a_key_that_lives_in_the_other_store_names_the_right_command() {
+    use hashi_types::move_types::ConfigValue;
+    let err = refuse_bad_config_update(
+        "mpc_max_faulty_in_basis_points",
+        &ConfigValue::U64(1),
+        ConfigStore::Instant,
+        None,
+        true,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("lives in the epoch config"), "{err}");
+    assert!(err.contains("update-epoch-config"), "{err}");
+}
+
+#[test]
+fn updating_an_unknown_key_points_at_add_config() {
+    use hashi_types::move_types::ConfigValue;
+    let err = refuse_bad_config_update(
+        "nope",
+        &ConfigValue::U64(1),
+        ConfigStore::Epoch,
+        None,
+        false,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("does not exist in the epoch config"), "{err}");
+    assert!(err.contains("add-config"), "{err}");
+}
+
+#[test]
+fn changing_a_keys_value_type_is_refused() {
+    use hashi_types::move_types::ConfigValue;
+    let err = refuse_bad_config_update(
+        "bitcoin_deposit_minimum",
+        &ConfigValue::Bool(true),
+        ConfigStore::Instant,
+        Some(&ConfigValue::U64(25_000)),
+        false,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("holds a u64 value"), "{err}");
+    assert!(err.contains("proposed value is bool"), "{err}");
+}
+
+#[test]
+fn adding_an_existing_key_is_refused_and_a_same_name_elsewhere_only_warns() {
+    let err = refuse_bad_config_add("k", ConfigStore::Epoch, true, false)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("already exists in the epoch config"), "{err}");
+    assert!(err.contains("update-epoch-config"), "{err}");
+    let warning = refuse_bad_config_add("k", ConfigStore::Epoch, false, true).unwrap();
+    assert!(
+        warning
+            .unwrap()
+            .contains("already exists in the instant config")
+    );
+    assert!(
+        refuse_bad_config_add("k", ConfigStore::Instant, false, false)
+            .unwrap()
+            .is_none()
+    );
+}
+
 // ===== decoding Move aborts =====
 
 fn move_abort(module: &str, code: u64, clever: Option<(&str, &str)>) -> ExecutionError {

--- a/crates/hashi/src/cli/commands/validator.rs
+++ b/crates/hashi/src/cli/commands/validator.rs
@@ -15,9 +15,53 @@ use crate::cli::config::CliConfig;
 use crate::cli::print_detail;
 use crate::cli::print_info;
 
+/// What a resign-family command is about to do, for the pre-check text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResignationAction {
+    Resign,
+    Withdraw,
+}
+
+/// Refuse a resign or withdrawal the chain would reject (`EAlreadyResigned`
+/// / `ENotResigned`), from the registration record already in the scrape.
+/// `resigned` is `None` when the validator is not registered at all.
+pub fn refuse_resignation_state(
+    validator: sui_sdk_types::Address,
+    resigned: Option<bool>,
+    action: ResignationAction,
+) -> Result<()> {
+    let Some(resigned) = resigned else {
+        anyhow::bail!(
+            "validator {} is not registered, so there is nothing to resign from or withdraw",
+            validator.to_hex()
+        );
+    };
+    match action {
+        ResignationAction::Resign => anyhow::ensure!(
+            !resigned,
+            "validator {} has already resigned; nothing to do. Use `hashi validator \
+             withdraw-resignation` to cancel it.",
+            validator.to_hex()
+        ),
+        ResignationAction::Withdraw => anyhow::ensure!(
+            resigned,
+            "validator {} has no pending resignation to withdraw",
+            validator.to_hex()
+        ),
+    }
+    Ok(())
+}
+
+fn refuse_from_registration(client: &HashiClient, action: ResignationAction) -> Result<()> {
+    let validator = client.resolve_validator_address()?;
+    let resigned = client.member_info(&validator).map(|m| m.resigned);
+    refuse_resignation_state(validator, resigned, action)
+}
+
 /// Voluntarily resign from the committee.
 pub async fn resign(config: &CliConfig, tx_opts: &TxOptions) -> Result<()> {
     let mut client = HashiClient::new(config).await?;
+    refuse_from_registration(&client, ResignationAction::Resign)?;
 
     print_detail(&format!("\n{}", "Resigning from the committee:".bold()));
     match client.onchain_state().pending_epoch_change() {
@@ -51,6 +95,7 @@ pub async fn resign(config: &CliConfig, tx_opts: &TxOptions) -> Result<()> {
 /// Withdraw a pending resignation.
 pub async fn withdraw_resignation(config: &CliConfig, tx_opts: &TxOptions) -> Result<()> {
     let mut client = HashiClient::new(config).await?;
+    refuse_from_registration(&client, ResignationAction::Withdraw)?;
 
     print_detail(&format!(
         "\n{}",
@@ -105,3 +150,7 @@ pub async fn remove_inactive(
     execute_or_simulate(&mut client, tx, tx_opts).await?;
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "validator_tests.rs"]
+mod tests;

--- a/crates/hashi/src/cli/commands/validator_tests.rs
+++ b/crates/hashi/src/cli/commands/validator_tests.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+fn v() -> sui_sdk_types::Address {
+    sui_sdk_types::Address::new([5; 32])
+}
+
+#[test]
+fn an_unregistered_validator_cannot_resign_or_withdraw() {
+    for action in [ResignationAction::Resign, ResignationAction::Withdraw] {
+        let err = refuse_resignation_state(v(), None, action)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is not registered"), "{err}");
+    }
+}
+
+#[test]
+fn resigning_twice_is_refused_and_points_at_withdrawal() {
+    refuse_resignation_state(v(), Some(false), ResignationAction::Resign).unwrap();
+    let err = refuse_resignation_state(v(), Some(true), ResignationAction::Resign)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("has already resigned"), "{err}");
+    assert!(err.contains("withdraw-resignation"), "{err}");
+}
+
+#[test]
+fn withdrawing_without_a_pending_resignation_is_refused() {
+    refuse_resignation_state(v(), Some(true), ResignationAction::Withdraw).unwrap();
+    let err = refuse_resignation_state(v(), Some(false), ResignationAction::Withdraw)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("no pending resignation"), "{err}");
+}

--- a/crates/hashi/src/cli/commands/withdraw.rs
+++ b/crates/hashi/src/cli/commands/withdraw.rs
@@ -122,7 +122,8 @@ async fn request(
             tx_opts.mode(),
             std::time::Duration::from_secs(10),
         )
-        .await?;
+        .await
+        .map_err(crate::cli::explain_tx_error)?;
 
         if let Some(response) = crate::cli::print_tx_outcome(outcome, &config.sui_rpc_url) {
             let request_id =
@@ -167,7 +168,8 @@ async fn request(
         ));
         let ids = executor
             .execute_create_withdrawal_requests_batch(amount, destination_bytes.clone(), this_batch)
-            .await?;
+            .await
+            .map_err(crate::cli::explain_tx_error)?;
         submitted += ids.len();
         remaining -= this_batch;
     }
@@ -233,7 +235,8 @@ async fn cancel(config: &CliConfig, tx_opts: &TxOptions, request_id: &str) -> Re
         tx_opts.mode(),
         std::time::Duration::from_secs(10),
     )
-    .await?;
+    .await
+    .map_err(crate::cli::explain_tx_error)?;
 
     if crate::cli::print_tx_outcome(outcome, &config.sui_rpc_url).is_some() {
         print_success("Withdrawal cancelled.");

--- a/crates/hashi/src/cli/config.rs
+++ b/crates/hashi/src/cli/config.rs
@@ -56,6 +56,13 @@ pub struct CliConfig {
     /// Optional: Gas coin object ID to use for transactions
     pub gas_coin: Option<Address>,
 
+    /// `--sender` from the command line: the address the transaction is built
+    /// for, and the identity the governance commands act as when no keypair
+    /// is configured (the serialize-unsigned and dry-run paths). Never read
+    /// from or written to the file.
+    #[serde(skip)]
+    pub acting_sender: Option<Address>,
+
     /// Optional Bitcoin configuration for deposit/withdrawal commands
     #[serde(default)]
     pub bitcoin: Option<BitcoinConfig>,
@@ -77,6 +84,7 @@ impl Default for CliConfig {
             hashi_object_id: None,
             keypair_path: None,
             gas_coin: None,
+            acting_sender: None,
             bitcoin: None,
         }
     }

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -1387,6 +1387,18 @@ pub fn print_detail(msg: &str) {
     eprintln!("{msg}");
 }
 
+/// Attach a human explanation to a transaction failure when it is a Move
+/// abort (a clever `#[error]` constant with a hint, or the framework's
+/// dynamic-field miss); other errors pass through unchanged. Every CLI path
+/// that finalizes or executes a transaction maps its error through this, so
+/// the operator never has to read a raw `MoveAbort` line first.
+pub fn explain_tx_error(err: anyhow::Error) -> anyhow::Error {
+    match commands::proposal::explain_move_abort(&err) {
+        Some(explanation) => err.context(explanation),
+        None => err,
+    }
+}
+
 /// Ask the operator to confirm. Requires an explicit `y`; anything else is a
 /// decline. When stdin is not a terminal there is nobody to answer, so the
 /// command refuses to proceed instead of treating an empty read as consent,

--- a/crates/hashi/src/cli/mod.rs
+++ b/crates/hashi/src/cli/mod.rs
@@ -104,7 +104,8 @@ pub struct CliGlobalOpts {
 
     /// Sender address to build the transaction for (e.g. a multisig address).
     /// Defaults to the configured keypair's address; required when serializing
-    /// or dry-running without a keypair.
+    /// or dry-running without a keypair, where it is also the committee
+    /// identity the governance commands act as.
     #[clap(global = true, long)]
     pub sender: Option<String>,
 
@@ -1016,7 +1017,7 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
         private_key: opts.btc_private_key,
     };
 
-    let config = config::CliConfig::load(
+    let mut config = config::CliConfig::load(
         opts.config.as_deref(),
         opts.sui_rpc_url,
         opts.package_id,
@@ -1031,6 +1032,7 @@ pub async fn run(opts: CliGlobalOpts, command: CliCommand) -> anyhow::Result<()>
         .map(str::parse::<sui_sdk_types::Address>)
         .transpose()
         .context("Invalid --sender address")?;
+    config.acting_sender = sender;
     let gas_object = opts
         .gas
         .as_deref()


### PR DESCRIPTION
## Summary

Last of the CLI ergonomics PRs, on top of #1118.

- **`--sender` is an identity, not just a gas payer.** Governance identity was resolved from the configured keypair only, and the acting-validator line ran before the keypair check, so `--serialize-unsigned-transaction --sender <addr>` could not build a vote, remove-vote or resignation at all despite the help text. The CLI config now carries the `--sender` address at runtime (never written to the file) and the client resolves the committee identity from the acting address: `--sender` when given, otherwise the keypair. This does not loosen SEC-546: the exact-match-then-single-delegation rule is unchanged, only its input is. Execute mode still requires a keypair, and when both are present and differ the chain rejects the signature anyway, so the explicit sender wins.
- **Config proposals check the store first.** `create update-config` and `update-epoch-config` used to fail on chain with `EInvalidConfigEntry` after the prompt for a key that was not in the targeted store, or held another value type. Now a key that lives in the other store names the right command, an unknown key points at `add-config`, and a type change is refused naming both types. `add-config` refuses a key already in its target store and warns when the same name exists in the other store. Both commands build the client and show the acting validator before the prompt, as `update-config` already did.
- **Resignation pre-checks.** `resign` and `withdraw-resignation` ignored the `resigned` flag already in the scrape and failed on chain with `EAlreadyResigned` or `ENotResigned`. Both check the registration record first, and an unregistered validator is told so.

- **The abort decoder covers every submit path.** Found in the localnet pass: `withdraw cancel` and a below-minimum `withdraw request` still printed the raw `MoveAbort` line, because the deposit and withdraw commands call the executor's `finalize` directly and #1116 attached the decoder to the proposal helper only. One owned-error wrapper now applies at `HashiClient::finalize_tx` and at the four direct call sites, so those read `ECannotCancelProcessingWithdrawal: Cannot cancel a withdrawal that is already being processed` and `EBelowMinimumWithdrawal: Withdrawal amount is below the minimum`.

## Localnet pass

Every command was run against a four-validator localnet built from this stack (results in the session scratchpad): config show / on-chain / template, committee list / epoch, the full proposal cycle (create, vote, already-voted and no-vote refusals, execute before quorum refused with the tally, vote --execute at quorum, vote / execute / remove-vote on the executed proposal refused before the prompt, view Status line, list --executed / --votes / --json, missing id), the config pre-flights, `--sender` serialize and dry-run without a keypair, the non-TTY prompt refusal, resign / withdraw-resignation pre-checks, `remove-inactive` on a seated member (decoded `EMemberStillActive`), a real regtest deposit through `deposit request` to a confirmed hBTC balance, `withdraw request` through to BTC received at the destination, `withdraw status`, and `launch --status`. `register` is covered by the CLI e2e test on this tree (no node config exists on disk in the auto-mode localnet); `backup` by `--help` only.

## Tests

Config pre-flights in `proposal_tests.rs` (existing key passes, other-store key names the right command, unknown key points at add-config, type change refused, add of an existing key refused with a same-name-elsewhere warning). Resignation pre-checks in the new `validator_tests.rs`. CLI unit tests, clippy on hashi and e2e-tests, and a warnings-denied doc build are clean.
