### PR TITLE
committee: never authorize the zero address as a member's sender

### DIFF
--- a/packages/hashi/sources/core/committee/committee_set.move
+++ b/packages/hashi/sources/core/committee/committee_set.move
@@ -618,11 +618,15 @@ fun new_committee_from_voting_powers(
     )
 }
 
-/// True if the tx sender is authorized to act for this member — its validator
+/// True if the tx sender is authorized to act for this member: its validator
 /// key or its delegated operator key. The validator key always retains authority.
+///
+/// The zero address is never authorized. Sui system transactions run with `@0x0`
+/// as their sender, so an operator delegation that was "cleared" to `@0x0` must
+/// not hand them authority over the member.
 fun is_authorized(self: &MemberInfo, ctx: &TxContext): bool {
     let sender = ctx.sender();
-    sender == self.validator_address || sender == self.operator_address
+    sender != @0x0 && (sender == self.validator_address || sender == self.operator_address)
 }
 
 /// Whether governance has flagged this member as ignored.

--- a/packages/hashi/tests/operator_delegation_tests.move
+++ b/packages/hashi/tests/operator_delegation_tests.move
@@ -56,6 +56,54 @@ fun test_member_authorized() {
     std::unit_test::destroy(hashi);
 }
 
+#[test]
+/// The zero address is never authorized, even when a validator "clears" its
+/// operator delegation by pointing it at `@0x0`. Sui system transactions run as
+/// `@0x0`, so this delegation must not grant them the member's authority.
+fun test_zero_sender_never_authorized() {
+    let ctx = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+
+    let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    // Undelegated member: the zero sender is a stranger.
+    let cz = &test_utils::new_tx_context(@0x0, 0);
+    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, cz));
+
+    // VALIDATOR1 "clears" its delegation by pointing it at the zero address.
+    let cd = &test_utils::new_tx_context(VALIDATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, @0x0, cd);
+
+    // The zero sender still is not authorized, while the validator key still is.
+    let cz2 = &test_utils::new_tx_context(@0x0, 0);
+    assert!(!hashi.committee_set().member_authorized(VALIDATOR1, cz2));
+    let cv = &test_utils::new_tx_context(VALIDATOR1, 0);
+    assert!(hashi.committee_set().member_authorized(VALIDATOR1, cv));
+
+    std::unit_test::destroy(hashi);
+}
+
+#[test]
+#[expected_failure]
+/// A delegation cleared to `@0x0` does not let a zero-address sender re-point
+/// the operator address.
+fun test_set_operator_address_rejects_zero_sender() {
+    let ctx = &mut test_utils::new_tx_context(VALIDATOR1, 0);
+
+    let voters = vector[VALIDATOR1, VALIDATOR2, VALIDATOR3];
+    let mut hashi = test_utils::create_hashi_with_committee(voters, ctx);
+
+    let cd = &test_utils::new_tx_context(VALIDATOR1, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, @0x0, cd);
+
+    // The zero sender matches the cleared operator slot but is never authorized -> aborts.
+    let cz = &test_utils::new_tx_context(@0x0, 0);
+    hashi.committee_set_mut().set_operator_address(VALIDATOR1, @0xBEEF, cz);
+
+    // Won't reach here.
+    std::unit_test::destroy(hashi);
+}
+
 // ======== Operator Acting On Behalf Of Validator ========
 
 #[test]


### PR DESCRIPTION
## Problem

`committee_set::is_authorized` accepts any sender equal to the member's validator or operator address. A validator that "clears" its operator delegation by pointing it at `@0x0` would hand that member's authority to Sui system transactions, which run with `@0x0` as their sender.

## Fix

Reject `@0x0` before the address comparison. Not reachable today, since sui-core hardcodes the framework package, so this is defence in depth as agreed in the Certora thread (2026-07-31 finding #4, signed off by Zhou).

## Tests

- `test_zero_sender_never_authorized`: an undelegated member rejects the zero sender; after the delegation is cleared to `@0x0` the zero sender is still rejected while the validator key keeps its authority.
- `test_set_operator_address_rejects_zero_sender`: a zero-sender `set_operator_address` against a cleared delegation aborts.

Full Move suite: 273 passed.

Fixes IOP-595
