### PR TITLE
Update hashi runtime image to debian trixie

### DIFF
--- a/docker/hashi/Containerfile
+++ b/docker/hashi/Containerfile
@@ -52,7 +52,7 @@ RUN --network=none cargo build --release --frozen --target "$TARGET" --bin hashi
 #
 # Package stage: runtime image with debug tools
 #
-FROM library/debian@sha256:f18adf4e1d04b1d8ba48025b8e35003f4c748ddd3dd8e875fe4e7d9a9c0dec84
+FROM library/debian:trixie-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates curl \


### PR DESCRIPTION
- Replace the digest-pinned Bullseye runtime image with digest-pinned Debian trixie-slim; leave the package list and Rust build stages unchanged.
- Fix Docker CI failures caused by expired Bullseye security repository metadata. Debian 11 reached end-of-life on August 31, 2026: https://www.debian.org/News/2026/20260831.
- Verified the updated runtime base and existing package-install step with docker build --no-cache (exit code 0). Full Rust build and application runtime were not exercised.