### PR TITLE
Expire old database backups

### DIFF
--- a/crates/e2e-tests/src/backup_restore.rs
+++ b/crates/e2e-tests/src/backup_restore.rs
@@ -25,7 +25,6 @@ mod tests {
     use hashi::cli::commands::backup::RestoreDecryptor;
     use hashi::config::Config as HashiConfig;
     use hashi_types::pgp::test_utils::mock_pgp_keypair;
-    use tempfile::TempDir;
 
     use crate::HashiNodeHandle;
     use crate::TestNetworksBuilder;
@@ -168,22 +167,22 @@ mod tests {
             .clone();
 
         // 3. Serialise config, generate OpenPGP keypair, save backup.
-        let backup_dir = tempfile::Builder::new()
+        let config_dir = tempfile::Builder::new()
             .prefix("hashi-backup-e2e-")
             .tempdir()?;
-        let node_config_path = write_node_config_to_disk(&node0_config, backup_dir.path());
-        let (recipient, secret_key_path) = generate_pgp_keypair(backup_dir.path());
+        let node_config_path = write_node_config_to_disk(&node0_config, config_dir.path());
+        let (recipient, secret_key_path) = generate_pgp_keypair(config_dir.path());
 
-        let save_out_dir: TempDir = tempfile::Builder::new()
-            .prefix("hashi-backup-out-")
-            .tempdir()?;
-        commands::backup::save(&node_config_path, Some(recipient), save_out_dir.path())?;
-        let tarball = find_backup_tarball(save_out_dir.path());
+        // Keep this manual archive separate from automatic backups, which use
+        // the node's configured recipient rather than the key generated above.
+        let save_out_dir = node0_config.backup_dir.join("manual");
+        commands::backup::save(&node_config_path, Some(recipient), &save_out_dir)?;
+        let tarball = find_backup_tarball(&save_out_dir);
 
         // 4. Destroy node 0's on-disk state so `restore --copy-to-original-paths`
-        //    actually has to put things back. The node config lives under
-        //    `backup_dir`; the DB lives under the TestNetworks tempdir, which
-        //    stays alive because the handle still owns it.
+        //    actually has to put things back. The config has its own tempdir;
+        //    both the DB and configured backups live under the TestNetworks
+        //    tempdir, which stays alive because the handle still owns it.
         std::fs::remove_dir_all(&original_db_path)?;
         std::fs::remove_file(&node_config_path)?;
 

--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -3,6 +3,7 @@
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Context;
     use anyhow::Result;
     use anyhow::anyhow;
     use bitcoin::Amount;
@@ -1710,6 +1711,17 @@ mod tests {
         };
         info!(?target, "resignation submitted; closing the epoch");
 
+        let backup_dir = networks.hashi_network.nodes()[3]
+            .hashi()
+            .config
+            .backup_dir
+            .clone();
+        std::fs::create_dir_all(&backup_dir)?;
+        let older_backup = backup_dir.join("hashi-backup-19990101T000000Z.tar.asc");
+        let newest_backup = backup_dir.join("hashi-backup-20000101T000000Z.tar.asc");
+        std::fs::write(&older_backup, b"older archive")?;
+        std::fs::write(&newest_backup, b"last recovery archive")?;
+
         networks.sui_network.force_close_epoch().await?;
         let target_epoch = initial_epoch + 1;
         let futs: Vec<_> = networks
@@ -1835,6 +1847,17 @@ mod tests {
         }
         info!("registration removed; closing the second epoch");
 
+        // Finish the dealer-only epoch's worker before seeding the next sweep.
+        // These in-process nodes have no config path, but must still run retention.
+        tokio::time::timeout(Duration::from_secs(60), async {
+            while older_backup.exists() {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .context("departed dealer did not sweep backups without a config path")?;
+        std::fs::write(&older_backup, b"older archive")?;
+
         networks.sui_network.force_close_epoch().await?;
         let second_epoch = target_epoch + 1;
         let futs: Vec<_> = networks
@@ -1869,6 +1892,20 @@ mod tests {
                 .ok_or_else(|| anyhow!("no committee after second epoch change"))?;
             assert!(committee.index_of(&target).is_none());
         }
+        // Node 3 is now in neither committee: NoRole must enqueue housekeeping
+        // through the real backup worker even though it must not write an archive.
+        tokio::time::timeout(Duration::from_secs(60), async {
+            while older_backup.exists() {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .context("no-role validator did not sweep its expired backup")?;
+        assert_eq!(std::fs::read(&newest_backup)?, b"last recovery archive");
+        let remaining_backups = std::fs::read_dir(&backup_dir)?
+            .map(|entry| entry.map(|entry| entry.path()))
+            .collect::<std::io::Result<Vec<_>>>()?;
+        assert_eq!(remaining_backups, vec![newest_backup]);
         networks.hashi_network.nodes_mut()[3].restart().await?;
         {
             let nodes = networks.hashi_network.nodes();

--- a/crates/e2e-tests/src/hashi_network.rs
+++ b/crates/e2e-tests/src/hashi_network.rs
@@ -584,7 +584,9 @@ impl HashiNetworkBuilder {
             config.bitcoin_chain_id = Some(hashi::constants::BITCOIN_REGTEST_CHAIN_ID.to_string());
             config.sui_chain_id = service_info.chain_id.clone();
             config.screener_endpoint = Some(screener_endpoint.clone());
-            config.db = Some(dir.join(validator_address.to_string()));
+            let node_name = validator_address.to_string();
+            config.backup_dir = dir.join("backups").join(&node_name);
+            config.db = Some(dir.join(node_name));
             configs.push(config);
         }
 

--- a/crates/e2e-tests/src/main.rs
+++ b/crates/e2e-tests/src/main.rs
@@ -408,6 +408,8 @@ async fn cmd_start(
             server.operator_private_key = cfg.operator_private_key.clone();
             server.sui_rpc = Some(state.sui_rpc_url.clone());
             server.hashi_ids = Some(ids);
+            let node_dir = validators_dir.join(format!("validator_{i}"));
+            server.backup_dir = node_dir.join("backups");
             server
                 .save(&validators_dir.join(format!("validator_{i}.toml")))
                 .context("Failed to write validator server config")?;

--- a/crates/hashi/src/backup.rs
+++ b/crates/hashi/src/backup.rs
@@ -41,7 +41,9 @@ pub const BACKUP_FILE_NAME_PREFIX: &str = "hashi-backup";
 pub const BACKUP_MANIFEST_FILE_NAME: &str = "hashi-backup-manifest.toml";
 pub const DB_SNAPSHOT_TAR_PREFIX: &str = "hashi-db-snapshot";
 
-const BACKUP_FILE_NAME_FORMAT: &str = "hashi-backup-%Y%m%dT%H%M%SZ.tar.asc";
+const BACKUP_FILE_NAME_SUFFIX_FORMAT: &str = "-%Y%m%dT%H%M%SZ.tar.asc";
+const BACKUP_STAGING_FILE_NAME_PREFIX: &str = ".hashi-backup-";
+pub(crate) const RESTORE_STAGING_DIR_NAME_PREFIX: &str = ".hashi-restore-";
 const BACKUP_RETENTION: jiff::SignedDuration = jiff::SignedDuration::from_hours(14 * 24);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -51,7 +53,7 @@ pub enum BackupArchiveFormat {
 }
 
 enum BackupRequest {
-    EpochChanged(u64),
+    EpochChanged { epoch: u64, write_backup: bool },
 }
 
 #[derive(Clone, Debug)]
@@ -60,10 +62,13 @@ pub struct BackupHandle {
 }
 
 impl BackupHandle {
-    pub fn backup_after_epoch_change(&self, epoch: u64) {
+    pub fn backup_after_epoch_change(&self, epoch: u64, write_backup: bool) {
         if self
             .sender
-            .send(BackupRequest::EpochChanged(epoch))
+            .send(BackupRequest::EpochChanged {
+                epoch,
+                write_backup,
+            })
             .is_err()
         {
             warn!(
@@ -100,10 +105,13 @@ impl BackupService {
     async fn run(mut self) {
         while let Some(request) = self.receiver.recv().await {
             match request {
-                BackupRequest::EpochChanged(epoch) => {
+                BackupRequest::EpochChanged {
+                    epoch,
+                    write_backup,
+                } => {
                     let hashi = self.inner.clone();
                     match tokio::task::spawn_blocking(move || {
-                        hashi.backup_after_epoch_change(epoch)
+                        hashi.backup_after_epoch_change(epoch, write_backup)
                     })
                     .await
                     {
@@ -251,8 +259,21 @@ pub fn encrypt_files_to_pgp_archive(
     recipient: &PgpPublicCert,
     output_path: &Path,
 ) -> Result<()> {
-    let output = create_file_strict(output_path)?;
-    let mut encrypted = armored_encrypt_writer(output, recipient)?;
+    // Stage beside the destination so retention sees only fully finalized archives.
+    let parent = output_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let mut staging = tempfile::Builder::new()
+        .prefix(BACKUP_STAGING_FILE_NAME_PREFIX)
+        .tempfile_in(parent)
+        .with_context(|| {
+            format!(
+                "Failed to create backup staging file in {}",
+                parent.display()
+            )
+        })?;
+    let mut encrypted = armored_encrypt_writer(staging.as_file_mut(), recipient)?;
     {
         let mut archive = tar::Builder::new(&mut encrypted);
         append_backup_manifest(&mut archive, manifest)?;
@@ -272,6 +293,21 @@ pub fn encrypt_files_to_pgp_archive(
         archive.finish()?;
     }
     encrypted.finalize()?;
+    staging
+        .as_file()
+        .sync_all()
+        .context("Failed to sync backup staging file")?;
+    staging
+        .persist_noclobber(output_path)
+        // Drop the temporary file even if the caller retains the error.
+        .map_err(|e| e.error)
+        .with_context(|| format!("Failed to publish backup {}", output_path.display()))?;
+    if let Err(error) = File::open(parent).and_then(|directory| directory.sync_all()) {
+        error!(
+            directory = %parent.display(),
+            "Backup published, but syncing its directory failed: {error}"
+        );
+    }
 
     Ok(())
 }
@@ -367,38 +403,120 @@ pub fn encrypted_backup_file_name() -> PathBuf {
     // ISO 8601 basic format in UTC, e.g. 20260409T230419Z. Compact, sorts
     // lexicographically, and contains no characters that need escaping on any
     // common filesystem.
-    jiff::Timestamp::now()
-        .to_zoned(jiff::tz::TimeZone::UTC)
-        .strftime(BACKUP_FILE_NAME_FORMAT)
-        .to_string()
-        .into()
+    format!(
+        "{BACKUP_FILE_NAME_PREFIX}{}",
+        jiff::Timestamp::now()
+            .to_zoned(jiff::tz::TimeZone::UTC)
+            .strftime(BACKUP_FILE_NAME_SUFFIX_FORMAT)
+    )
+    .into()
 }
 
-/// Remove expired local archives, preserving the backup that just completed.
-pub(crate) fn cleanup_old_backups(
-    output_dir: &Path,
-    current_backup: &Path,
-    now: jiff::Timestamp,
-) -> Result<()> {
+/// Remove expired archives and abandoned staging entries, always keeping the newest archive.
+pub(crate) fn cleanup_old_backups(output_dir: &Path, now: jiff::Timestamp) -> Result<()> {
     let cutoff = now.checked_sub(BACKUP_RETENTION)?;
-    for entry in fs::read_dir(output_dir)
-        .with_context(|| format!("Failed to read backup directory {}", output_dir.display()))?
-    {
-        let entry = entry?;
+    let staging_cutoff: std::time::SystemTime = cutoff.into();
+    let entries = match fs::read_dir(output_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("Failed to read backup directory {}", output_dir.display())
+            });
+        }
+    };
+    let mut newest: Option<(jiff::Timestamp, PathBuf)> = None;
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                warn!(
+                    directory = %output_dir.display(),
+                    "Failed to read backup directory entry: {error}"
+                );
+                continue;
+            }
+        };
         let file_name = entry.file_name();
+        let file_name = file_name.as_encoded_bytes();
+        let restore_staging = file_name.starts_with(RESTORE_STAGING_DIR_NAME_PREFIX.as_bytes());
+        if restore_staging || file_name.starts_with(BACKUP_STAGING_FILE_NAME_PREFIX.as_bytes()) {
+            let path = entry.path();
+            // DirEntry::metadata does not follow symlinks.
+            let modified = entry.metadata().and_then(|metadata| {
+                if (restore_staging && metadata.is_dir())
+                    || (!restore_staging && metadata.is_file())
+                {
+                    metadata.modified().map(Some)
+                } else {
+                    Ok(None)
+                }
+            });
+            match modified {
+                Ok(Some(modified)) if modified < staging_cutoff => {
+                    let removed = if restore_staging {
+                        fs::remove_dir_all(&path)
+                    } else {
+                        fs::remove_file(&path)
+                    };
+                    if let Err(error) = removed {
+                        warn!(
+                            path = %path.display(),
+                            "Failed to remove expired staging entry: {error}"
+                        );
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    warn!(
+                        path = %path.display(),
+                        "Failed to read staging entry metadata: {error}"
+                    );
+                }
+            }
+            continue;
+        }
+        let Some(suffix) = file_name.strip_prefix(BACKUP_FILE_NAME_PREFIX.as_bytes()) else {
+            continue;
+        };
         let Ok(created_at) =
-            jiff::civil::DateTime::strptime(BACKUP_FILE_NAME_FORMAT, file_name.as_encoded_bytes())
+            jiff::civil::DateTime::strptime(BACKUP_FILE_NAME_SUFFIX_FORMAT, suffix)
                 .and_then(|datetime| datetime.to_zoned(jiff::tz::TimeZone::UTC))
         else {
             continue;
         };
-        if created_at.timestamp() >= cutoff || !entry.file_type()?.is_file() {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) => {
+                warn!(
+                    path = %path.display(),
+                    "Failed to read backup file type: {error}"
+                );
+                continue;
+            }
+        };
+        if !file_type.is_file() {
             continue;
         }
-        let path = entry.path();
-        if path != current_backup {
-            fs::remove_file(&path)
-                .with_context(|| format!("Failed to remove expired backup {}", path.display()))?;
+        let candidate = (created_at.timestamp(), path);
+        // Only delete an archive once another valid regular archive is known to be newer.
+        let (created_at, path) = match newest.as_mut() {
+            Some(newest) if candidate.0 > newest.0 => std::mem::replace(newest, candidate),
+            Some(_) => candidate,
+            None => {
+                newest = Some(candidate);
+                continue;
+            }
+        };
+        if created_at >= cutoff {
+            continue;
+        }
+        if let Err(error) = fs::remove_file(&path) {
+            warn!(
+                path = %path.display(),
+                "Failed to remove expired backup: {error}"
+            );
         }
     }
     Ok(())
@@ -1093,15 +1211,185 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_old_backups_accepts_missing_directory() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let missing = tmpdir.path().join("missing");
+
+        cleanup_old_backups(&missing, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+
+        assert!(!missing.exists());
+    }
+
+    #[test]
+    fn cleanup_old_backups_recognizes_generated_archive_name() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let now = jiff::Timestamp::now();
+        let older = tmpdir.path().join(format!(
+            "{BACKUP_FILE_NAME_PREFIX}{}",
+            now.checked_sub(jiff::SignedDuration::from_hours(24))
+                .unwrap()
+                .to_zoned(jiff::tz::TimeZone::UTC)
+                .strftime(BACKUP_FILE_NAME_SUFFIX_FORMAT)
+        ));
+        let generated = tmpdir.path().join(encrypted_backup_file_name());
+        fs::write(&older, b"older archive").unwrap();
+        fs::write(&generated, b"generated recovery archive").unwrap();
+        let sweep_time = now
+            .checked_add(BACKUP_RETENTION)
+            .unwrap()
+            .checked_add(jiff::SignedDuration::from_hours(24))
+            .unwrap();
+
+        cleanup_old_backups(tmpdir.path(), sweep_time).unwrap();
+
+        assert!(!older.exists());
+        assert_eq!(fs::read(generated).unwrap(), b"generated recovery archive");
+    }
+
+    #[test]
+    fn cleanup_old_backups_removes_only_expired_restore_staging_directories() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = tmpdir.path();
+        let now: jiff::Timestamp = "2026-09-08T12:00:00Z".parse().unwrap();
+        let cutoff: std::time::SystemTime = now.checked_sub(BACKUP_RETENTION).unwrap().into();
+        let expired = dir.join(format!("{RESTORE_STAGING_DIR_NAME_PREFIX}expired"));
+        let boundary = dir.join(format!("{RESTORE_STAGING_DIR_NAME_PREFIX}boundary"));
+        let recent = dir.join(format!("{RESTORE_STAGING_DIR_NAME_PREFIX}recent"));
+        let contents = [
+            ("operator.key", b"secret key".as_slice()),
+            ("config.toml", b"node config".as_slice()),
+            (
+                "hashi-db-snapshot/keyspace/segment",
+                b"database data".as_slice(),
+            ),
+        ];
+        for (path, modified) in [
+            (&expired, cutoff - std::time::Duration::from_secs(1)),
+            (&boundary, cutoff),
+            (&recent, now.into()),
+        ] {
+            fs::create_dir_all(path.join("hashi-db-snapshot/keyspace")).unwrap();
+            for (name, data) in contents {
+                fs::write(path.join(name), data).unwrap();
+            }
+            // Set the directory's mtime last; child files deliberately have fresh mtimes.
+            File::open(path)
+                .unwrap()
+                .set_times(fs::FileTimes::new().set_modified(modified))
+                .unwrap();
+        }
+
+        cleanup_old_backups(dir, now).unwrap();
+
+        assert!(!expired.exists());
+        for path in [boundary, recent] {
+            for (name, data) in contents {
+                assert_eq!(fs::read(path.join(name)).unwrap(), data);
+            }
+        }
+    }
+
+    #[test]
+    fn cleanup_old_backups_preserves_restore_symlink_targets_and_unrelated_entries() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = tmpdir.path();
+        let outside = tempfile::tempdir().unwrap();
+        let target = outside.path().join("secret.key");
+        fs::write(&target, b"outside secret").unwrap();
+        let old: jiff::Timestamp = "2026-08-01T00:00:00Z".parse().unwrap();
+        let times = fs::FileTimes::new().set_modified(old.into());
+        File::open(outside.path())
+            .unwrap()
+            .set_times(times)
+            .unwrap();
+        let staging = dir.join(format!("{RESTORE_STAGING_DIR_NAME_PREFIX}abandoned"));
+        fs::create_dir(&staging).unwrap();
+        std::os::unix::fs::symlink(outside.path(), staging.join("linked-db")).unwrap();
+        File::open(&staging).unwrap().set_times(times).unwrap();
+        let link = dir.join(format!("{RESTORE_STAGING_DIR_NAME_PREFIX}symlink"));
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+        let wrong_type = dir.join(format!("{RESTORE_STAGING_DIR_NAME_PREFIX}regular-file"));
+        fs::write(&wrong_type, b"not a staging directory").unwrap();
+        File::open(&wrong_type).unwrap().set_times(times).unwrap();
+        let completed = dir.join(extract_dir_name(&encrypted_backup_file_name()).unwrap());
+        let db_restore = dir.join(".hashi-db-restore-abandoned");
+        for path in [&completed, &db_restore] {
+            fs::create_dir(path).unwrap();
+            fs::write(path.join("config.toml"), b"preserved config").unwrap();
+            File::open(path).unwrap().set_times(times).unwrap();
+        }
+
+        cleanup_old_backups(dir, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+
+        assert!(!staging.exists());
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read(target).unwrap(), b"outside secret");
+        assert_eq!(fs::read(wrong_type).unwrap(), b"not a staging directory");
+        for path in [completed, db_restore] {
+            assert_eq!(
+                fs::read(path.join("config.toml")).unwrap(),
+                b"preserved config"
+            );
+        }
+    }
+
+    #[test]
+    fn cleanup_old_backups_removes_only_expired_staging_files() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = tmpdir.path();
+        let now: jiff::Timestamp = "2026-09-08T12:00:00Z".parse().unwrap();
+        let cutoff: std::time::SystemTime = now.checked_sub(BACKUP_RETENTION).unwrap().into();
+        let expired = dir.join(format!("{BACKUP_STAGING_FILE_NAME_PREFIX}expired"));
+        let boundary = dir.join(format!("{BACKUP_STAGING_FILE_NAME_PREFIX}boundary"));
+        let recent = dir.join(format!("{BACKUP_STAGING_FILE_NAME_PREFIX}recent"));
+        for (path, modified) in [
+            (&expired, cutoff - std::time::Duration::from_secs(1)),
+            (&boundary, cutoff),
+            (&recent, now.into()),
+        ] {
+            let mut file = File::create(path).unwrap();
+            file.write_all(b"staged data").unwrap();
+            file.set_times(fs::FileTimes::new().set_modified(modified))
+                .unwrap();
+        }
+
+        cleanup_old_backups(dir, now).unwrap();
+
+        assert!(!expired.exists());
+        assert_eq!(fs::read(boundary).unwrap(), b"staged data");
+        assert_eq!(fs::read(recent).unwrap(), b"staged data");
+    }
+
+    #[test]
+    fn cleanup_old_backups_ignores_staging_directories_and_symlinks() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = tmpdir.path();
+        let old: jiff::Timestamp = "2026-08-01T00:00:00Z".parse().unwrap();
+        let times = fs::FileTimes::new().set_modified(old.into());
+        let nested = dir.join(format!("{BACKUP_STAGING_FILE_NAME_PREFIX}directory"));
+        fs::create_dir(&nested).unwrap();
+        let nested_file = nested.join(format!("{BACKUP_STAGING_FILE_NAME_PREFIX}nested"));
+        fs::write(&nested_file, b"nested data").unwrap();
+        File::open(&nested_file).unwrap().set_times(times).unwrap();
+        File::open(&nested).unwrap().set_times(times).unwrap();
+        let link = dir.join(format!("{BACKUP_STAGING_FILE_NAME_PREFIX}symlink"));
+        std::os::unix::fs::symlink(&nested_file, &link).unwrap();
+
+        cleanup_old_backups(dir, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+
+        assert_eq!(fs::read(nested_file).unwrap(), b"nested data");
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+    }
+
+    #[test]
     fn cleanup_old_backups_preserves_boundary_and_unrelated_entries() {
         let tmpdir = tempfile::tempdir().unwrap();
         let dir = tmpdir.path();
         let expired = dir.join("hashi-backup-20260825T115959Z.tar.asc");
         fs::write(&expired, b"expired despite fresh mtime").unwrap();
-        let current = dir.join("hashi-backup-20260801T000000Z.tar.asc");
         let preserved = [
             "hashi-backup-20260825T120000Z.tar.asc",
-            "hashi-backup-20260801T000000Z.tar.asc",
+            "hashi-backup-20260908T120000Z.tar.asc",
             "hashi-backup-20260230T000000Z.tar.asc",
             "hashi-backup-20260801T000000Z.tar.asc.partial",
             "other-backup-20260801T000000Z.tar.asc",
@@ -1109,18 +1397,59 @@ mod tests {
         for name in preserved {
             fs::write(dir.join(name), b"keep").unwrap();
         }
-        let nested = dir.join("hashi-backup-20260802T000000Z.tar.asc");
-        fs::create_dir(&nested).unwrap();
-        let nested_archive = nested.join("hashi-backup-20260801T000000Z.tar.asc");
-        fs::write(&nested_archive, b"nested").unwrap();
-        let link = dir.join("hashi-backup-20260803T000000Z.tar.asc");
-        std::os::unix::fs::symlink(&current, &link).unwrap();
 
-        cleanup_old_backups(dir, &current, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+        cleanup_old_backups(dir, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
 
         assert!(!expired.exists());
         for name in preserved {
             assert_eq!(fs::read(dir.join(name)).unwrap(), b"keep", "{name}");
+        }
+    }
+
+    #[test]
+    fn cleanup_old_backups_preserves_newest_expired_regular_archive() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = tmpdir.path();
+        let newest = dir.join("hashi-backup-20260803T000000Z.tar.asc");
+        fs::write(&newest, b"newest recovery archive").unwrap();
+        let staging = dir.join(format!("{BACKUP_STAGING_FILE_NAME_PREFIX}abandoned"));
+        fs::write(&staging, b"not a recovery archive").unwrap();
+        let staging_modified: jiff::Timestamp = "2026-08-24T00:00:00Z".parse().unwrap();
+        File::open(&staging)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(staging_modified.into()))
+            .unwrap();
+        let older = [
+            dir.join("hashi-backup-20260801T000000Z.tar.asc"),
+            dir.join("hashi-backup-20260802T000000Z.tar.asc"),
+        ];
+        for archive in &older {
+            fs::write(archive, b"older archive with newer mtime").unwrap();
+        }
+        let unrelated = [
+            "hashi-backup-20260831T000000Z.tar.asc.partial",
+            "other-backup-20260831T000000Z.tar.asc",
+            "hashi-backup-20260931T000000Z.tar.asc",
+        ];
+        for name in unrelated {
+            fs::write(dir.join(name), b"unrelated").unwrap();
+        }
+        let nested = dir.join("hashi-backup-20260804T000000Z.tar.asc");
+        fs::create_dir(&nested).unwrap();
+        let nested_archive = nested.join("hashi-backup-20260801T000000Z.tar.asc");
+        fs::write(&nested_archive, b"nested").unwrap();
+        let link = dir.join("hashi-backup-20260805T000000Z.tar.asc");
+        std::os::unix::fs::symlink(&newest, &link).unwrap();
+
+        cleanup_old_backups(dir, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+
+        assert_eq!(fs::read(newest).unwrap(), b"newest recovery archive");
+        assert!(!staging.exists());
+        for archive in older {
+            assert!(!archive.exists());
+        }
+        for name in unrelated {
+            assert_eq!(fs::read(dir.join(name)).unwrap(), b"unrelated");
         }
         assert_eq!(fs::read(nested_archive).unwrap(), b"nested");
         assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
@@ -1378,6 +1707,54 @@ mod tests {
         assert!(
             format!("{err:#}").contains("failed to deserialize backup keyspace encryption_keys"),
             "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn failed_encrypted_archive_leaves_no_partial_backup_for_retention() {
+        let src = tempfile::tempdir().unwrap();
+        let db = Database::open(src.path()).unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let recovery = out.path().join("hashi-backup-20260801T000000Z.tar.asc");
+        fs::write(&recovery, b"last recovery archive").unwrap();
+        let output = out.path().join("hashi-backup-20260802T000000Z.tar.asc");
+        let mut manifest = db_only_manifest();
+        manifest.paths.push(BackupManifestEntry {
+            original_path: src.path().join("missing-config.toml"),
+            archive_name: PathBuf::from("config.toml"),
+        });
+
+        let result = encrypt_files_to_pgp_archive(&manifest, &db, &mock_pgp_cert(), &output);
+
+        assert!(result.is_err());
+        assert_eq!(
+            fs::read_dir(out.path())
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .collect::<Vec<_>>(),
+            vec![recovery.clone()],
+        );
+        cleanup_old_backups(out.path(), "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+        assert_eq!(fs::read(recovery).unwrap(), b"last recovery archive");
+    }
+
+    #[test]
+    fn encrypted_archive_collision_preserves_existing_backup() {
+        let src = tempfile::tempdir().unwrap();
+        let db = Database::open(src.path()).unwrap();
+        let out = tempfile::tempdir().unwrap();
+        let output = out.path().join("hashi-backup-20260801T000000Z.tar.asc");
+        fs::write(&output, b"existing recovery archive").unwrap();
+        let recipient = mock_pgp_cert();
+        let collision = encrypt_files_to_pgp_archive(&db_only_manifest(), &db, &recipient, &output);
+        assert!(collision.is_err());
+        assert_eq!(fs::read(&output).unwrap(), b"existing recovery archive");
+        assert_eq!(
+            fs::read_dir(out.path())
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .collect::<Vec<_>>(),
+            vec![output],
         );
     }
 

--- a/crates/hashi/src/backup.rs
+++ b/crates/hashi/src/backup.rs
@@ -52,20 +52,20 @@ pub enum BackupArchiveFormat {
     Unencrypted,
 }
 
-enum BackupRequest {
+enum BackupMaintenanceRequest {
     EpochChanged { epoch: u64, write_backup: bool },
 }
 
 #[derive(Clone, Debug)]
 pub struct BackupHandle {
-    sender: mpsc::UnboundedSender<BackupRequest>,
+    sender: mpsc::UnboundedSender<BackupMaintenanceRequest>,
 }
 
 impl BackupHandle {
-    pub fn backup_after_epoch_change(&self, epoch: u64, write_backup: bool) {
+    pub fn maintain_backups_after_epoch_change(&self, epoch: u64, write_backup: bool) {
         if self
             .sender
-            .send(BackupRequest::EpochChanged {
+            .send(BackupMaintenanceRequest::EpochChanged {
                 epoch,
                 write_backup,
             })
@@ -73,7 +73,7 @@ impl BackupHandle {
         {
             warn!(
                 epoch,
-                "Skipping automatic backup: backup service is stopped"
+                write_backup, "Skipping epoch backup maintenance: backup service is stopped"
             );
         }
     }
@@ -81,7 +81,7 @@ impl BackupHandle {
 
 pub struct BackupService {
     inner: Arc<Hashi>,
-    receiver: mpsc::UnboundedReceiver<BackupRequest>,
+    receiver: mpsc::UnboundedReceiver<BackupMaintenanceRequest>,
 }
 
 impl BackupService {
@@ -105,22 +105,28 @@ impl BackupService {
     async fn run(mut self) {
         while let Some(request) = self.receiver.recv().await {
             match request {
-                BackupRequest::EpochChanged {
+                BackupMaintenanceRequest::EpochChanged {
                     epoch,
                     write_backup,
                 } => {
                     let hashi = self.inner.clone();
                     match tokio::task::spawn_blocking(move || {
-                        hashi.backup_after_epoch_change(epoch, write_backup)
+                        hashi.maintain_backups_after_epoch_change(epoch, write_backup)
                     })
                     .await
                     {
                         Ok(Ok(_)) => {}
                         Ok(Err(e)) => {
-                            error!("Automatic backup after epoch {epoch} failed: {e:#}");
+                            error!(
+                                epoch,
+                                write_backup, "Epoch backup maintenance failed: {e:#}"
+                            );
                         }
                         Err(e) => {
-                            error!("Automatic backup after epoch {epoch} failed to join: {e}");
+                            error!(
+                                epoch,
+                                write_backup, "Epoch backup maintenance failed to join: {e}"
+                            );
                         }
                     }
                 }

--- a/crates/hashi/src/backup.rs
+++ b/crates/hashi/src/backup.rs
@@ -418,13 +418,20 @@ pub fn encrypted_backup_file_name() -> PathBuf {
     .into()
 }
 
+#[derive(Default)]
+pub(crate) struct CleanupStats {
+    pub(crate) removed: usize,
+    pub(crate) failed: usize,
+}
+
 /// Remove expired archives and abandoned staging entries, always keeping the newest archive.
-pub(crate) fn cleanup_old_backups(output_dir: &Path, now: jiff::Timestamp) -> Result<()> {
+pub(crate) fn cleanup_old_backups(output_dir: &Path, now: jiff::Timestamp) -> Result<CleanupStats> {
     let cutoff = now.checked_sub(BACKUP_RETENTION)?;
     let staging_cutoff: std::time::SystemTime = cutoff.into();
+    let mut stats = CleanupStats::default();
     let entries = match fs::read_dir(output_dir) {
         Ok(entries) => entries,
-        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(stats),
         Err(error) => {
             return Err(error).with_context(|| {
                 format!("Failed to read backup directory {}", output_dir.display())
@@ -436,6 +443,7 @@ pub(crate) fn cleanup_old_backups(output_dir: &Path, now: jiff::Timestamp) -> Re
         let entry = match entry {
             Ok(entry) => entry,
             Err(error) => {
+                stats.failed += 1;
                 warn!(
                     directory = %output_dir.display(),
                     "Failed to read backup directory entry: {error}"
@@ -466,14 +474,18 @@ pub(crate) fn cleanup_old_backups(output_dir: &Path, now: jiff::Timestamp) -> Re
                         fs::remove_file(&path)
                     };
                     if let Err(error) = removed {
+                        stats.failed += 1;
                         warn!(
                             path = %path.display(),
                             "Failed to remove expired staging entry: {error}"
                         );
+                    } else {
+                        stats.removed += 1;
                     }
                 }
                 Ok(_) => {}
                 Err(error) => {
+                    stats.failed += 1;
                     warn!(
                         path = %path.display(),
                         "Failed to read staging entry metadata: {error}"
@@ -495,6 +507,7 @@ pub(crate) fn cleanup_old_backups(output_dir: &Path, now: jiff::Timestamp) -> Re
         let file_type = match entry.file_type() {
             Ok(file_type) => file_type,
             Err(error) => {
+                stats.failed += 1;
                 warn!(
                     path = %path.display(),
                     "Failed to read backup file type: {error}"
@@ -519,13 +532,16 @@ pub(crate) fn cleanup_old_backups(output_dir: &Path, now: jiff::Timestamp) -> Re
             continue;
         }
         if let Err(error) = fs::remove_file(&path) {
+            stats.failed += 1;
             warn!(
                 path = %path.display(),
                 "Failed to remove expired backup: {error}"
             );
+        } else {
+            stats.removed += 1;
         }
     }
-    Ok(())
+    Ok(stats)
 }
 
 fn append_backup_manifest<W: std::io::Write>(
@@ -1221,7 +1237,9 @@ mod tests {
         let tmpdir = tempfile::tempdir().unwrap();
         let missing = tmpdir.path().join("missing");
 
-        cleanup_old_backups(&missing, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+        let stats = cleanup_old_backups(&missing, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+        assert_eq!(stats.removed, 0);
+        assert_eq!(stats.failed, 0);
 
         assert!(!missing.exists());
     }
@@ -1285,7 +1303,9 @@ mod tests {
                 .unwrap();
         }
 
-        cleanup_old_backups(dir, now).unwrap();
+        let stats = cleanup_old_backups(dir, now).unwrap();
+        assert_eq!(stats.removed, 1);
+        assert_eq!(stats.failed, 0);
 
         assert!(!expired.exists());
         for path in [boundary, recent] {
@@ -1447,7 +1467,9 @@ mod tests {
         let link = dir.join("hashi-backup-20260805T000000Z.tar.asc");
         std::os::unix::fs::symlink(&newest, &link).unwrap();
 
-        cleanup_old_backups(dir, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+        let stats = cleanup_old_backups(dir, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+        assert_eq!(stats.removed, 3);
+        assert_eq!(stats.failed, 0);
 
         assert_eq!(fs::read(newest).unwrap(), b"newest recovery archive");
         assert!(!staging.exists());

--- a/crates/hashi/src/backup.rs
+++ b/crates/hashi/src/backup.rs
@@ -41,6 +41,9 @@ pub const BACKUP_FILE_NAME_PREFIX: &str = "hashi-backup";
 pub const BACKUP_MANIFEST_FILE_NAME: &str = "hashi-backup-manifest.toml";
 pub const DB_SNAPSHOT_TAR_PREFIX: &str = "hashi-db-snapshot";
 
+const BACKUP_FILE_NAME_FORMAT: &str = "hashi-backup-%Y%m%dT%H%M%SZ.tar.asc";
+const BACKUP_RETENTION: jiff::SignedDuration = jiff::SignedDuration::from_hours(14 * 24);
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BackupArchiveFormat {
     Encrypted,
@@ -364,11 +367,41 @@ pub fn encrypted_backup_file_name() -> PathBuf {
     // ISO 8601 basic format in UTC, e.g. 20260409T230419Z. Compact, sorts
     // lexicographically, and contains no characters that need escaping on any
     // common filesystem.
-    let timestamp = jiff::Timestamp::now()
+    jiff::Timestamp::now()
         .to_zoned(jiff::tz::TimeZone::UTC)
-        .strftime("%Y%m%dT%H%M%SZ")
-        .to_string();
-    PathBuf::from(format!("{BACKUP_FILE_NAME_PREFIX}-{timestamp}.tar.asc"))
+        .strftime(BACKUP_FILE_NAME_FORMAT)
+        .to_string()
+        .into()
+}
+
+/// Remove expired local archives, preserving the backup that just completed.
+pub(crate) fn cleanup_old_backups(
+    output_dir: &Path,
+    current_backup: &Path,
+    now: jiff::Timestamp,
+) -> Result<()> {
+    let cutoff = now.checked_sub(BACKUP_RETENTION)?;
+    for entry in fs::read_dir(output_dir)
+        .with_context(|| format!("Failed to read backup directory {}", output_dir.display()))?
+    {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Ok(created_at) =
+            jiff::civil::DateTime::strptime(BACKUP_FILE_NAME_FORMAT, file_name.as_encoded_bytes())
+                .and_then(|datetime| datetime.to_zoned(jiff::tz::TimeZone::UTC))
+        else {
+            continue;
+        };
+        if created_at.timestamp() >= cutoff || !entry.file_type()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path != current_backup {
+            fs::remove_file(&path)
+                .with_context(|| format!("Failed to remove expired backup {}", path.display()))?;
+        }
+    }
+    Ok(())
 }
 
 fn append_backup_manifest<W: std::io::Write>(
@@ -1057,6 +1090,40 @@ mod tests {
             archive.finish().unwrap();
         }
         tar_bytes
+    }
+
+    #[test]
+    fn cleanup_old_backups_preserves_boundary_and_unrelated_entries() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = tmpdir.path();
+        let expired = dir.join("hashi-backup-20260825T115959Z.tar.asc");
+        fs::write(&expired, b"expired despite fresh mtime").unwrap();
+        let current = dir.join("hashi-backup-20260801T000000Z.tar.asc");
+        let preserved = [
+            "hashi-backup-20260825T120000Z.tar.asc",
+            "hashi-backup-20260801T000000Z.tar.asc",
+            "hashi-backup-20260230T000000Z.tar.asc",
+            "hashi-backup-20260801T000000Z.tar.asc.partial",
+            "other-backup-20260801T000000Z.tar.asc",
+        ];
+        for name in preserved {
+            fs::write(dir.join(name), b"keep").unwrap();
+        }
+        let nested = dir.join("hashi-backup-20260802T000000Z.tar.asc");
+        fs::create_dir(&nested).unwrap();
+        let nested_archive = nested.join("hashi-backup-20260801T000000Z.tar.asc");
+        fs::write(&nested_archive, b"nested").unwrap();
+        let link = dir.join("hashi-backup-20260803T000000Z.tar.asc");
+        std::os::unix::fs::symlink(&current, &link).unwrap();
+
+        cleanup_old_backups(dir, &current, "2026-09-08T12:00:00Z".parse().unwrap()).unwrap();
+
+        assert!(!expired.exists());
+        for name in preserved {
+            assert_eq!(fs::read(dir.join(name)).unwrap(), b"keep", "{name}");
+        }
+        assert_eq!(fs::read(nested_archive).unwrap(), b"nested");
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
     }
 
     #[test]

--- a/crates/hashi/src/cli/commands/backup.rs
+++ b/crates/hashi/src/cli/commands/backup.rs
@@ -131,7 +131,7 @@ pub fn restore(
     // cleaned on `TempDir` drop) so the user can retry without manual cleanup
     // and the final `extract_dir` never appears half-populated.
     let staging = tempfile::Builder::new()
-        .prefix(".hashi-restore-")
+        .prefix(backup::RESTORE_STAGING_DIR_NAME_PREFIX)
         .tempdir_in(output_dir)
         .with_context(|| {
             format!(

--- a/crates/hashi/src/config.rs
+++ b/crates/hashi/src/config.rs
@@ -98,11 +98,7 @@ pub struct Config {
     pub backup_pgp_cert: hashi_types::pgp::PgpPublicCert,
 
     /// Directory to write automatic encrypted backups into.
-    ///
-    /// Defaults to `/tmp` if not specified.
-    // TODO: eventually we should probably make this field mandatory
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub backup_dir: Option<PathBuf>,
+    pub backup_dir: PathBuf,
 
     /// Force validator to run as leader, or never run as leader
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -387,10 +383,6 @@ impl Config {
         self.force_run_as_leader.clone().unwrap_or_default()
     }
 
-    pub fn backup_dir(&self) -> &Path {
-        self.backup_dir.as_deref().unwrap_or(Path::new("/tmp"))
-    }
-
     pub fn test_weight_divisor(&self) -> u16 {
         self.test_weight_divisor.unwrap_or(1)
     }
@@ -473,7 +465,10 @@ impl Config {
             bitcoin_trusted_peers: None,
             db: None,
             backup_pgp_cert: hashi_types::pgp::test_utils::mock_pgp_cert(),
-            backup_dir: None,
+            backup_dir: std::env::temp_dir().join(format!(
+                "hashi-test-backups-{:032x}",
+                rand::random::<u128>()
+            )),
             force_run_as_leader: None,
             test_weight_divisor: None,
             test_batch_size_per_weight: None,
@@ -596,23 +591,14 @@ mod tests {
             "backup-pgp-cert".to_string(),
             toml::Value::String(cert_path.to_string_lossy().into_owned()),
         );
+        config.insert(
+            "backup-dir".to_string(),
+            toml::Value::String(dir.path().join("backups").to_string_lossy().into_owned()),
+        );
         std::fs::write(&config_path, toml::to_string(&config).unwrap()).unwrap();
 
         let config = Config::load(&config_path).unwrap();
         assert_eq!(config.backup_pgp_cert.armored(), public_cert.as_str());
-    }
-
-    #[test]
-    fn backup_pgp_cert_is_required() {
-        let error = toml::from_str::<Config>("").unwrap_err().to_string();
-        assert!(error.contains("missing field `backup-pgp-cert`"), "{error}");
-    }
-
-    #[test]
-    fn backup_dir_uses_configured_path() {
-        let mut config = Config::new_for_testing();
-        config.backup_dir = Some(PathBuf::from("/var/lib/hashi/backups"));
-        assert_eq!(config.backup_dir(), Path::new("/var/lib/hashi/backups"));
     }
 
     #[test]

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -341,18 +341,23 @@ impl Hashi {
             .await
     }
 
-    pub(crate) fn backup_after_epoch_change(
+    pub(crate) fn maintain_backups_after_epoch_change(
         &self,
         epoch: u64,
         write_backup: bool,
     ) -> anyhow::Result<Option<PathBuf>> {
-        if let Err(error) =
-            crate::backup::cleanup_old_backups(&self.config.backup_dir, jiff::Timestamp::now())
-        {
-            tracing::warn!(
+        match crate::backup::cleanup_old_backups(&self.config.backup_dir, jiff::Timestamp::now()) {
+            Ok(()) => tracing::info!(
                 epoch,
+                write_backup,
+                directory = %self.config.backup_dir.display(),
+                "Epoch backup retention sweep completed",
+            ),
+            Err(error) => tracing::warn!(
+                epoch,
+                write_backup,
                 "Cleanup of expired backups failed; continuing epoch maintenance: {error:#}",
-            );
+            ),
         }
         if !write_backup {
             return Ok(None);
@@ -1632,13 +1637,13 @@ mod test {
         std::fs::write(&older, b"older archive").unwrap();
         std::fs::remove_file(&config_path).unwrap();
 
-        assert!(hashi.backup_after_epoch_change(6, true).is_err());
+        assert!(hashi.maintain_backups_after_epoch_change(6, true).is_err());
         assert_eq!(std::fs::read(&expired).unwrap(), b"old archive");
         assert!(!older.exists());
         hashi.config.save(&config_path).unwrap();
 
         let output = hashi
-            .backup_after_epoch_change(7, true)
+            .maintain_backups_after_epoch_change(7, true)
             .unwrap()
             .expect("backup should run");
 
@@ -1647,7 +1652,7 @@ mod test {
         assert_eq!(std::fs::read(&expired).unwrap(), b"old archive");
 
         std::fs::remove_file(config_path).unwrap();
-        assert!(hashi.backup_after_epoch_change(8, true).is_err());
+        assert!(hashi.maintain_backups_after_epoch_change(8, true).is_err());
         assert!(!expired.exists());
         assert!(output.is_file());
     }
@@ -1675,7 +1680,10 @@ mod test {
         std::fs::write(&older, b"older archive").unwrap();
         std::fs::write(&newest, b"last recovery archive").unwrap();
 
-        assert_eq!(hashi.backup_after_epoch_change(7, false).unwrap(), None);
+        assert_eq!(
+            hashi.maintain_backups_after_epoch_change(7, false).unwrap(),
+            None
+        );
 
         assert!(!older.exists());
         assert_eq!(std::fs::read(&newest).unwrap(), b"last recovery archive");
@@ -1704,7 +1712,9 @@ mod test {
         )
         .unwrap();
 
-        let error = hashi.backup_after_epoch_change(7, true).unwrap_err();
+        let error = hashi
+            .maintain_backups_after_epoch_change(7, true)
+            .unwrap_err();
         assert!(
             error.to_string().contains(config_path.to_str().unwrap()),
             "backup should attempt to read its input after cleanup fails: {error:#}",

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -347,10 +347,12 @@ impl Hashi {
         write_backup: bool,
     ) -> anyhow::Result<Option<PathBuf>> {
         match crate::backup::cleanup_old_backups(&self.config.backup_dir, jiff::Timestamp::now()) {
-            Ok(()) => tracing::info!(
+            Ok(stats) => tracing::info!(
                 epoch,
                 write_backup,
                 directory = %self.config.backup_dir.display(),
+                removed = stats.removed,
+                failed = stats.failed,
                 "Epoch backup retention sweep completed",
             ),
             Err(error) => tracing::warn!(

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -341,7 +341,22 @@ impl Hashi {
             .await
     }
 
-    pub(crate) fn backup_after_epoch_change(&self, epoch: u64) -> anyhow::Result<Option<PathBuf>> {
+    pub(crate) fn backup_after_epoch_change(
+        &self,
+        epoch: u64,
+        write_backup: bool,
+    ) -> anyhow::Result<Option<PathBuf>> {
+        if let Err(error) =
+            crate::backup::cleanup_old_backups(&self.config.backup_dir, jiff::Timestamp::now())
+        {
+            tracing::warn!(
+                epoch,
+                "Cleanup of expired backups failed; continuing epoch maintenance: {error:#}",
+            );
+        }
+        if !write_backup {
+            return Ok(None);
+        }
         let Some(config_path) = self.config_path.as_deref() else {
             tracing::warn!(
                 epoch,
@@ -354,23 +369,13 @@ impl Hashi {
             &self.config,
             self.db.as_ref(),
             &self.config.backup_pgp_cert,
-            self.config.backup_dir(),
+            &self.config.backup_dir,
         )?;
         tracing::info!(
             epoch,
             output = %output_path.display(),
             "Automatic backup completed after epoch change",
         );
-        if let Err(error) = crate::backup::cleanup_old_backups(
-            self.config.backup_dir(),
-            &output_path,
-            jiff::Timestamp::now(),
-        ) {
-            tracing::warn!(
-                epoch,
-                "Automatic backup succeeded, but cleanup of expired backups failed: {error:#}",
-            );
-        }
         Ok(Some(output_path))
     }
 
@@ -1600,7 +1605,7 @@ mod test {
     }
 
     #[test]
-    fn automatic_backup_after_epoch_change_uses_configured_backup_dir() {
+    fn automatic_backup_expires_archives_without_losing_recovery_after_failed_save() {
         let tmpdir = tempfile::Builder::new().tempdir().unwrap();
         let db_path = tmpdir.path().join("db");
         let backup_dir = tmpdir.path().join("backups");
@@ -1609,7 +1614,7 @@ mod test {
         let mut config = Config::new_for_testing();
         config.db = Some(db_path);
         config.backup_pgp_cert = mock_pgp_cert();
-        config.backup_dir = Some(backup_dir.clone());
+        config.backup_dir = backup_dir.clone();
         config.save(&config_path).unwrap();
 
         let server_version = ServerVersion::new("unknown", "unknown");
@@ -1623,20 +1628,87 @@ mod test {
         std::fs::create_dir_all(&backup_dir).unwrap();
         let expired = backup_dir.join("hashi-backup-20000101T000000Z.tar.asc");
         std::fs::write(&expired, b"old archive").unwrap();
+        let older = backup_dir.join("hashi-backup-19990101T000000Z.tar.asc");
+        std::fs::write(&older, b"older archive").unwrap();
+        std::fs::remove_file(&config_path).unwrap();
+
+        assert!(hashi.backup_after_epoch_change(6, true).is_err());
+        assert_eq!(std::fs::read(&expired).unwrap(), b"old archive");
+        assert!(!older.exists());
+        hashi.config.save(&config_path).unwrap();
 
         let output = hashi
-            .backup_after_epoch_change(7)
+            .backup_after_epoch_change(7, true)
             .unwrap()
             .expect("backup should run");
 
         assert!(output.is_file());
-        assert_eq!(output.parent(), Some(backup_dir.as_path()));
-        assert!(!expired.exists());
+        // The pre-save sweep keeps the previous recovery archive even after a successful save.
+        assert_eq!(std::fs::read(&expired).unwrap(), b"old archive");
 
-        std::fs::write(&expired, b"old archive").unwrap();
         std::fs::remove_file(config_path).unwrap();
-        assert!(hashi.backup_after_epoch_change(8).is_err());
-        assert_eq!(std::fs::read(expired).unwrap(), b"old archive");
+        assert!(hashi.backup_after_epoch_change(8, true).is_err());
+        assert!(!expired.exists());
+        assert!(output.is_file());
+    }
+
+    #[test]
+    fn automatic_backup_cleanup_only_preserves_recovery_without_writing() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let config_path = tmpdir.path().join("config.toml");
+        let backup_dir = tmpdir.path().join("backups");
+        let mut config = Config::new_for_testing();
+        config.db = Some(tmpdir.path().join("db"));
+        config.backup_pgp_cert = mock_pgp_cert();
+        config.backup_dir = backup_dir.clone();
+        config.save(&config_path).unwrap();
+        let hashi = Hashi::new_with_registry(
+            ServerVersion::new("unknown", "unknown"),
+            Some(config_path),
+            config,
+            &prometheus::Registry::new(),
+        )
+        .unwrap();
+        std::fs::create_dir_all(&backup_dir).unwrap();
+        let older = backup_dir.join("hashi-backup-19990101T000000Z.tar.asc");
+        let newest = backup_dir.join("hashi-backup-20000101T000000Z.tar.asc");
+        std::fs::write(&older, b"older archive").unwrap();
+        std::fs::write(&newest, b"last recovery archive").unwrap();
+
+        assert_eq!(hashi.backup_after_epoch_change(7, false).unwrap(), None);
+
+        assert!(!older.exists());
+        assert_eq!(std::fs::read(&newest).unwrap(), b"last recovery archive");
+        let remaining = std::fs::read_dir(&backup_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect::<Vec<_>>();
+        assert_eq!(remaining, vec![newest]);
+    }
+
+    #[test]
+    fn automatic_backup_attempts_save_after_cleanup_error() {
+        let tmpdir = tempfile::Builder::new().tempdir().unwrap();
+        let config_path = tmpdir.path().join("missing-config.toml");
+        let backup_dir = tmpdir.path().join("not-a-directory");
+        std::fs::write(&backup_dir, b"not a directory").unwrap();
+
+        let mut config = Config::new_for_testing();
+        config.db = Some(tmpdir.path().join("db"));
+        config.backup_dir = backup_dir;
+        let hashi = Hashi::new_with_registry(
+            ServerVersion::new("unknown", "unknown"),
+            Some(config_path.clone()),
+            config,
+            &prometheus::Registry::new(),
+        )
+        .unwrap();
+
+        let error = hashi.backup_after_epoch_change(7, true).unwrap_err();
+        assert!(
+            error.to_string().contains(config_path.to_str().unwrap()),
+            "backup should attempt to read its input after cleanup fails: {error:#}",
+        );
     }
 
     #[test]

--- a/crates/hashi/src/lib.rs
+++ b/crates/hashi/src/lib.rs
@@ -361,6 +361,16 @@ impl Hashi {
             output = %output_path.display(),
             "Automatic backup completed after epoch change",
         );
+        if let Err(error) = crate::backup::cleanup_old_backups(
+            self.config.backup_dir(),
+            &output_path,
+            jiff::Timestamp::now(),
+        ) {
+            tracing::warn!(
+                epoch,
+                "Automatic backup succeeded, but cleanup of expired backups failed: {error:#}",
+            );
+        }
         Ok(Some(output_path))
     }
 
@@ -1603,7 +1613,16 @@ mod test {
         config.save(&config_path).unwrap();
 
         let server_version = ServerVersion::new("unknown", "unknown");
-        let hashi = Hashi::new(server_version, Some(config_path), config).unwrap();
+        let hashi = Hashi::new_with_registry(
+            server_version,
+            Some(config_path.clone()),
+            config,
+            &prometheus::Registry::new(),
+        )
+        .unwrap();
+        std::fs::create_dir_all(&backup_dir).unwrap();
+        let expired = backup_dir.join("hashi-backup-20000101T000000Z.tar.asc");
+        std::fs::write(&expired, b"old archive").unwrap();
 
         let output = hashi
             .backup_after_epoch_change(7)
@@ -1612,6 +1631,12 @@ mod test {
 
         assert!(output.is_file());
         assert_eq!(output.parent(), Some(backup_dir.as_path()));
+        assert!(!expired.exists());
+
+        std::fs::write(&expired, b"old archive").unwrap();
+        std::fs::remove_file(config_path).unwrap();
+        assert!(hashi.backup_after_epoch_change(8).is_err());
+        assert_eq!(std::fs::read(expired).unwrap(), b"old archive");
     }
 
     #[test]

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -290,9 +290,8 @@ impl MpcService {
         if tombstoned {
             self.run_major_compaction(target_epoch).await;
         }
-        if backup == Backup::Write {
-            self.backup_handle.backup_after_epoch_change(target_epoch);
-        }
+        self.backup_handle
+            .backup_after_epoch_change(target_epoch, backup == Backup::Write);
     }
 
     async fn sleep_if_still_pending(&self, epoch: u64) {

--- a/crates/hashi/src/mpc/service.rs
+++ b/crates/hashi/src/mpc/service.rs
@@ -291,7 +291,7 @@ impl MpcService {
             self.run_major_compaction(target_epoch).await;
         }
         self.backup_handle
-            .backup_after_epoch_change(target_epoch, backup == Backup::Write);
+            .maintain_backups_after_epoch_change(target_epoch, backup == Backup::Write);
     }
 
     async fn sleep_if_still_pending(&self, epoch: u64) {

--- a/design/docs/node-backup.mdx
+++ b/design/docs/node-backup.mdx
@@ -247,21 +247,37 @@ files.
 
 ## Configuring hashi
 
-Every node config must provide the PGP public certificate under the field
-`backup-pgp-cert`. The value can be a certificate file path or inline armored
-text:
+Every node config must provide `backup-pgp-cert` (a certificate file path or inline
+armored text) and `backup-dir`:
 
 ```toml
 backup-pgp-cert = "/path/to/hashi-backup-cert.asc"
+backup-dir = "/var/lib/hashi/backups"
 ```
 
-You can also configure the location where Hashi saves backups with the field
-`backup-dir`.
+Use a persistent, node-specific backup directory outside the database directory,
+with write access restricted to the node's user.
 
-After each successful automatic backup, Hashi deletes local backup archives older
-than 14 days, based on their filenames. The new backup and unrelated files are
-preserved. Failed or manual backups do not trigger cleanup, so expired archives
-remain until the next successful automatic backup.
+On epoch housekeeping, cleanup deletes archives older than 14 days by filename
+timestamp, except the newest archive. It also runs for nodes with no role, even
+though those nodes do not write a new backup. Unrelated files are preserved.
+Individual entry errors do not stop the sweep; cleanup failures do not prevent
+backup attempts. Retention runs before saving and still applies if the save fails.
+Manual backups do not trigger cleanup, but archives placed in `backup-dir` follow
+the same policy. Keep longer-term copies elsewhere.
+
+Archives are staged in `backup-dir`, finalized and synced to disk before publication;
+the directory is synced afterward on a best-effort basis. A directory sync failure
+is logged at error level without failing the already-published backup. Failed saves
+remove their temporary files and never overwrite existing archives. Within
+`backup-dir`, cleanup removes abandoned
+`.hashi-backup-*` files and `.hashi-restore-*` directories older than 14 days by
+modification time, without retaining the newest staging entry. Recent staging
+entries and symlinks are left alone. Restore staging and completed restore output
+contain decrypted keys and database data; use a private restore output directory.
+Completed restores, `.hashi-db-restore-*` staging directories beside the destination
+database, and restore output elsewhere are not swept by automatic backup cleanup.
+Operators must remove these plaintext copies when no longer needed.
 
 ## Cloud backup
 

--- a/design/docs/node-backup.mdx
+++ b/design/docs/node-backup.mdx
@@ -258,6 +258,11 @@ backup-pgp-cert = "/path/to/hashi-backup-cert.asc"
 You can also configure the location where Hashi saves backups with the field
 `backup-dir`.
 
+After each successful automatic backup, Hashi deletes local backup archives older
+than 14 days, based on their filenames. The new backup and unrelated files are
+preserved. Failed or manual backups do not trigger cleanup, so expired archives
+remain until the next successful automatic backup.
+
 ## Cloud backup
 
 In the future, we will likely add support for automatically uploading backups

--- a/design/docs/node-backup.mdx
+++ b/design/docs/node-backup.mdx
@@ -261,7 +261,9 @@ with write access restricted to the node's user.
 On epoch housekeeping, cleanup deletes archives older than 14 days by filename
 timestamp, except the newest archive. It also runs for nodes with no role, even
 though those nodes do not write a new backup. Each completed sweep logs its epoch,
-directory, and whether a backup was requested. Unrelated files are preserved.
+directory, whether a backup was requested, and `removed`/`failed` counts. Counts are
+per top-level entry; a removed restore directory counts once. Missing directories
+report zero counts. Unrelated files are preserved.
 Individual entry errors do not stop the sweep; cleanup failures do not prevent
 backup attempts. Retention runs before saving and still applies if the save fails.
 Manual backups do not trigger cleanup, but archives placed in `backup-dir` follow

--- a/design/docs/node-backup.mdx
+++ b/design/docs/node-backup.mdx
@@ -260,7 +260,8 @@ with write access restricted to the node's user.
 
 On epoch housekeeping, cleanup deletes archives older than 14 days by filename
 timestamp, except the newest archive. It also runs for nodes with no role, even
-though those nodes do not write a new backup. Unrelated files are preserved.
+though those nodes do not write a new backup. Each completed sweep logs its epoch,
+directory, and whether a backup was requested. Unrelated files are preserved.
 Individual entry errors do not stop the sweep; cleanup failures do not prevent
 backup attempts. Retention runs before saving and still applies if the save fails.
 Manual backups do not trigger cleanup, but archives placed in `backup-dir` follow

--- a/design/docs/node-operator-runbook.mdx
+++ b/design/docs/node-operator-runbook.mdx
@@ -390,7 +390,7 @@ Hashi creates encrypted backups of critical state (MPC key shares, DB, config) e
 - **Option 1 (recommended): YubiKey.** Generate the key on the device; the private key never leaves it.
 - **Option 2: local OpenPGP key.** Generate with `sq` or `gpg`.
 
-Set the armored public certificate (a file path or inline armored text) in the node config:
+Set the public certificate and a persistent, node-specific backup directory outside the database directory, writable only by the node's user:
 
 ```toml
 backup-pgp-cert = "/path/to/hashi-backup-cert.asc"   # armored OpenPGP public cert, or inline armored text
@@ -474,8 +474,8 @@ db = "/var/lib/hashi/db"
 # Armored OpenPGP public certificate (file path or inline) for encrypted backups (required)
 backup-pgp-cert = "/path/to/hashi-backup-cert.asc"
 
-# Backup output directory (default: /tmp)
-# backup-dir = "/var/lib/hashi/backups"
+# Persistent, node-specific backup output directory (required; restrict write access)
+backup-dir = "/var/lib/hashi/backups"
 
 # ── Optional Integrations ─────────────────────────────────────────────
 
@@ -1096,7 +1096,7 @@ After execution, the previous committee resumes; the system can trigger a new re
 
 The full key-generation and restore procedures (including YubiKey setup with `oct` and decrypting over SSH) are in the [Hashi Node Backups](node-backup.mdx) guide. This section is a quick summary.
 
-The node automatically writes an encrypted backup every epoch using the required `backup-pgp-cert`: it packs the DB (MPC key shares, signing/encryption keys), config, and referenced key files into a tar archive and wraps it as an ASCII-armored OpenPGP (Sequoia) message. Encrypted archives use the suffix `.tar.asc`; unencrypted archives use `.tar`. The node writes backups to `backup-dir` (default `/tmp`, so set a persistent path). Encryption needs only the public certificate, so the private key need not be present during normal operation.
+The node automatically writes an encrypted backup every epoch using the required `backup-pgp-cert`: it packs the DB (MPC key shares, signing/encryption keys), config, and referenced key files into a tar archive and wraps it as an ASCII-armored OpenPGP (Sequoia) message. Encrypted archives use the suffix `.tar.asc`; unencrypted archives use `.tar`. Backups go to the required `backup-dir` and follow the retention policy in the [backup guide](node-backup.mdx#configuring-hashi). Encryption needs only the public certificate, so the private key need not be present during normal operation.
 
 Because backups use OpenPGP, you can restore over SSH: plug the YubiKey into your laptop, forward your `gpg-agent` to the server, and decrypt the backup there. The private key never leaves the YubiKey.
 


### PR DESCRIPTION
- Run retention on epoch housekeeping, including for departed/NoRole validators that must not create new archives. The existing serialized backup worker sweeps before the write-policy and config-path gates.
- Delete archives older than 14 days while always preserving the newest archive. Generation and parsing share the authoritative filename prefix and timestamp/suffix format.
- Continue cleanup after individual entry failures. Within backup-dir, expire abandoned .hashi-backup-* files and .hashi-restore-* directories after 14 days by modification time, preserving recent entries and symlinks. Completed restores, .hashi-db-restore-* directories, and restore output elsewhere remain operator-managed.
- Finalize and sync staged encrypted backups before no-clobber publication. Sync the destination directory afterward on a best-effort basis; failure logs at ERROR without failing the already-published backup.
- Require an explicit backup-dir; generated validator configs use node-specific paths outside database storage.
- Verification: 49 backup-related tests and the resigned-member end-to-end test pass, including retention after NoRole and cleanup without a config path. Workspace Clippy and make fmt completed. Existing archive publication, retention boundary, staging safety, and restore/rejoin coverage retained.
- Fixes [IOP-713](https://linear.app/mysten-labs/issue/IOP-713/add-expiry-on-db-backups).