### PR TITLE
onchain: stop mirroring the spent_utxos bag

### DIFF
--- a/crates/e2e-tests/src/e2e_flow.rs
+++ b/crates/e2e-tests/src/e2e_flow.rs
@@ -3700,6 +3700,15 @@ mod tests {
         executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
         info!("cleanup_spent_utxos succeeded");
 
+        // The tombstones are not mirrored; the deposit replay checks read
+        // them live, so pin that lookup against what just landed.
+        for utxo_id in &utxo_ids {
+            anyhow::ensure!(
+                hashi.onchain_state().is_utxo_spent(utxo_id).await?,
+                "cleanup landed but {utxo_id:?} does not read back as spent"
+            );
+        }
+
         info!("=== Large Withdrawal Stress Test Passed ===");
         Ok(())
     }
@@ -3994,6 +4003,15 @@ mod tests {
         let utxo_ids: Vec<_> = picked.inputs.iter().map(|u| u.id).collect();
         executor.execute_cleanup_spent_utxos(&utxo_ids).await?;
         info!("cleanup_spent_utxos succeeded");
+
+        // The tombstones are not mirrored; the deposit replay checks read
+        // them live, so pin that lookup against what just landed.
+        for utxo_id in &utxo_ids {
+            anyhow::ensure!(
+                hashi.onchain_state().is_utxo_spent(utxo_id).await?,
+                "cleanup landed but {utxo_id:?} does not read back as spent"
+            );
+        }
 
         info!("=== Drain Mode Max Batch Test Passed ===");
         Ok(())

--- a/crates/e2e-tests/src/test_helpers.rs
+++ b/crates/e2e-tests/src/test_helpers.rs
@@ -19,6 +19,7 @@ use hashi_types::bitcoin::BitcoinAddress;
 use hashi_types::move_types::DepositConfirmed;
 use hashi_types::move_types::ProtocolType;
 use hashi_types::move_types::StampedDealerSubmissionV1;
+use hashi_types::move_types::UtxoId;
 use hashi_types::move_types::WithdrawalConfirmed;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -361,18 +362,29 @@ pub async fn create_withdrawal_and_wait(
     Ok(confirmed)
 }
 
-/// Wait until every node's object mirror shows the spent withdrawal
-/// inputs cleaned up: at least one `spent_utxos` tombstone exists and no
-/// `utxo_records` entry is still marked spent.
+/// Wait until the spent withdrawal inputs are cleaned up: the chain
+/// holds at least one `spent_utxos` tombstone and no node's object
+/// mirror still has a `utxo_records` entry marked spent.
 ///
 /// The cleanup transaction (`cleanup_spent_utxos`) emits no event, so
 /// this passing proves both halves of the eventless-write path: the
 /// leader's GC decided on the cleanup from its mirror, and every node's
 /// mirror applied the resulting Field deletions from the object stream
 /// alone — no rescrape exists to paper over a miss.
+///
+/// The tombstones themselves are not mirrored (the bag only grows), so
+/// they are listed from the chain; every id listed must then read back
+/// as spent through a node's live lookup, which pins the derived-id
+/// read the deposit replay checks depend on against the chain's own
+/// listing.
 pub async fn wait_for_spent_utxo_cleanup(networks: &TestNetworks, timeout: Duration) -> Result<()> {
     info!("Waiting for the spent-UTXO cleanup to reach every node's mirror...");
     let deadline = std::time::Instant::now() + timeout;
+    let state = networks.hashi_network.nodes()[0]
+        .hashi()
+        .onchain_state()
+        .clone();
+    let spent_utxos_id = *state.state().hashi().bitcoin().utxo_pool.spent_utxos_id();
     loop {
         let laggard =
             networks
@@ -381,23 +393,45 @@ pub async fn wait_for_spent_utxo_cleanup(networks: &TestNetworks, timeout: Durat
                 .iter()
                 .enumerate()
                 .find_map(|(index, node)| {
-                    let state = node.hashi().onchain_state();
-                    let pending = state
+                    let pending = node
+                        .hashi()
+                        .onchain_state()
                         .utxo_records()
                         .values()
                         .filter(|record| record.spent_epoch.is_some())
                         .count();
-                    let tombstones = state.spent_utxos_entries().len();
-                    (pending > 0 || tombstones == 0).then_some((index, pending, tombstones))
+                    (pending > 0).then_some((index, pending))
                 });
-        let Some((index, pending, tombstones)) = laggard else {
-            info!("Every node's mirror shows the spent UTXOs cleaned up");
+        let tombstones =
+            list_all_dynamic_fields(&networks.sui_network.client, spent_utxos_id).await?;
+        if laggard.is_none() && !tombstones.is_empty() {
+            info!(
+                tombstones = tombstones.len(),
+                "Every node's mirror shows the spent UTXOs cleaned up"
+            );
+            for field in &tombstones {
+                let utxo_id: UtxoId = field
+                    .name()
+                    .deserialize()
+                    .map_err(|e| anyhow!("failed to deserialize a spent_utxos key: {e}"))?;
+                anyhow::ensure!(
+                    state.is_utxo_spent(&utxo_id).await?,
+                    "the chain lists {utxo_id:?} as spent but the live lookup does not find it"
+                );
+            }
             return Ok(());
-        };
+        }
         if std::time::Instant::now() >= deadline {
+            let mirror = match laggard {
+                Some((index, pending)) => {
+                    format!("node {index}'s mirror still shows {pending} spent record(s)")
+                }
+                None => "every mirror is clean".to_string(),
+            };
             return Err(anyhow!(
-                "Timeout after {timeout:?} waiting for the spent-UTXO cleanup: node {index}'s \
-                 mirror still shows {pending} spent record(s) and {tombstones} tombstone(s)"
+                "Timeout after {timeout:?} waiting for the spent-UTXO cleanup: {mirror} and the \
+                 chain holds {} tombstone(s)",
+                tombstones.len()
             ));
         }
         tokio::time::sleep(Duration::from_millis(500)).await;

--- a/crates/hashi/src/deposits.rs
+++ b/crates/hashi/src/deposits.rs
@@ -37,6 +37,8 @@ impl Hashi {
         deposit_request: &DepositRequest,
     ) -> Result<(), UnapprovedDepositError> {
         self.validate_deposit_request_on_sui(deposit_request)?;
+        self.validate_deposit_utxo_unspent_on_sui(deposit_request)
+            .await?;
         self.validate_deposit_request_on_bitcoin(deposit_request)
             .await?;
         self.screen_deposit(deposit_request).await?;
@@ -129,14 +131,39 @@ impl Hashi {
             }
         }
 
+        // The mirrored half of the on-chain replay guard; the tombstoned
+        // half is `validate_deposit_utxo_unspent_on_sui`.
         let utxo_pool = &state.hashi().bitcoin().utxo_pool;
-        if utxo_pool.is_active_or_spent(&deposit_request.utxo.id) {
+        if utxo_pool.has_record(&deposit_request.utxo.id) {
             return Err(UnapprovedDepositError::DuplicateOrSpentOnSui(anyhow!(
-                "UTXO {:?} is already active or spent",
+                "UTXO {:?} is already in the UTXO pool",
                 deposit_request.utxo.id
             )));
         }
 
+        Ok(())
+    }
+
+    /// Reject a deposit of a UTXO the bridge has already spent. The
+    /// `spent_utxos` tombstones are not mirrored (the bag only grows),
+    /// so this is a live read; a lookup failure is retried rather than
+    /// treated as either answer.
+    #[tracing::instrument(level = "debug", skip_all, fields(deposit_id = %deposit_request.id))]
+    async fn validate_deposit_utxo_unspent_on_sui(
+        &self,
+        deposit_request: &DepositRequest,
+    ) -> Result<(), UnapprovedDepositError> {
+        let spent = self
+            .onchain_state()
+            .is_utxo_spent(&deposit_request.utxo.id)
+            .await
+            .map_err(UnapprovedDepositError::SpentUtxoLookupFailed)?;
+        if spent {
+            return Err(UnapprovedDepositError::DuplicateOrSpentOnSui(anyhow!(
+                "UTXO {:?} is already spent",
+                deposit_request.utxo.id
+            )));
+        }
         Ok(())
     }
 
@@ -416,6 +443,9 @@ pub enum UnapprovedDepositError {
     #[error("UTXO is already active or spent on Sui: {0}")]
     DuplicateOrSpentOnSui(#[source] anyhow::Error),
 
+    #[error("Failed to look up the UTXO in the on-chain spent set: {0}")]
+    SpentUtxoLookupFailed(#[source] anyhow::Error),
+
     #[error("Deposit UTXO has already been spent on Bitcoin: {0}")]
     BitcoinUtxoSpent(#[source] anyhow::Error),
 
@@ -453,6 +483,7 @@ impl UnapprovedDepositError {
             Self::BitcoinConfirmFailed(_)
             | Self::BitcoinNotConfirmed(_)
             | Self::AmlServiceError(_)
+            | Self::SpentUtxoLookupFailed(_)
             | Self::FailedQuorum { .. }
             | Self::CertificateBuildFailed(_)
             | Self::ExecutorInitFailed(_)
@@ -471,6 +502,7 @@ impl UnapprovedDepositError {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum ApprovedDepositErrorKind {
+    SpentUtxoLookupFailed,
     ExecutorInitFailed,
     ConfirmDepositFailed,
     TimedOut,
@@ -478,6 +510,9 @@ pub(crate) enum ApprovedDepositErrorKind {
 
 #[derive(Debug, Error)]
 pub enum ApprovedDepositError {
+    #[error("Failed to look up the UTXO in the on-chain spent set: {0}")]
+    SpentUtxoLookupFailed(#[source] anyhow::Error),
+
     #[error("Failed to create Sui transaction executor: {0}")]
     ExecutorInitFailed(#[source] anyhow::Error),
 
@@ -494,6 +529,7 @@ pub enum ApprovedDepositError {
 impl ApprovedDepositError {
     pub(crate) fn kind(&self) -> ApprovedDepositErrorKind {
         match self {
+            Self::SpentUtxoLookupFailed(_) => ApprovedDepositErrorKind::SpentUtxoLookupFailed,
             Self::ExecutorInitFailed(_) => ApprovedDepositErrorKind::ExecutorInitFailed,
             Self::ConfirmDepositFailed(_) => ApprovedDepositErrorKind::ConfirmDepositFailed,
             Self::TimedOut(_) | Self::CheckpointWaitTimedOut => ApprovedDepositErrorKind::TimedOut,

--- a/crates/hashi/src/leader/deposits.rs
+++ b/crates/hashi/src/leader/deposits.rs
@@ -42,6 +42,16 @@ pub(super) struct UnapprovedDepositTaskResult {
     result: Result<(), UnapprovedDepositError>,
 }
 
+/// How a confirm task ended when nothing went wrong.
+#[derive(Debug)]
+pub(super) enum ApprovedDepositOutcome {
+    Confirmed,
+    /// The chain already holds a `spent_utxos` tombstone for the
+    /// request's UTXO, so `confirm_deposit` can never succeed; the
+    /// request is left for expiry GC instead of being retried.
+    UtxoAlreadySpent,
+}
+
 impl LeaderService {
     pub(super) fn process_actionable_unapproved_deposits(&mut self) {
         self.reload_pending_unapproved_deposit_requests(UnapprovedDepositReloadMode::All);
@@ -195,13 +205,18 @@ impl LeaderService {
             .iter()
             .map(|r| r.id)
             .collect();
-        let spent_or_active_utxo_ids = self.inner.onchain_state().find_spent_or_active_utxo_ids(
-            deposit_confirmation_candidates.iter().map(|r| r.utxo.id),
-        );
+        // A request whose UTXO the pool already holds is doomed:
+        // `confirm_deposit` would abort inserting the duplicate record.
+        // The pool's spent tombstones are the other half of that guard;
+        // they are not mirrored, so each confirm task asks the chain.
+        let used_utxo_ids = self
+            .inner
+            .onchain_state()
+            .find_utxo_ids_with_records(deposit_confirmation_candidates.iter().map(|r| r.utxo.id));
         let (utxo_already_used_count, duplicate_utxo_count) =
             filter_deposit_confirmation_candidates(
                 &mut deposit_confirmation_candidates,
-                &spent_or_active_utxo_ids,
+                &used_utxo_ids,
             );
 
         self.inner
@@ -348,15 +363,37 @@ impl LeaderService {
 
     pub(super) fn handle_completed_approved_deposit_task(
         &mut self,
-        result: Result<(Address, Result<(), ApprovedDepositError>), tokio::task::JoinError>,
+        result: Result<
+            (
+                Address,
+                Result<ApprovedDepositOutcome, ApprovedDepositError>,
+            ),
+            tokio::task::JoinError,
+        >,
     ) {
         match result {
             Ok((deposit_id, result)) => {
                 self.inflight_deposits.remove(&deposit_id);
                 match result {
-                    Ok(()) => {
+                    Ok(ApprovedDepositOutcome::Confirmed) => {
                         self.approved_deposit_retry_tracker.clear(&deposit_id);
                         info!(deposit_id = %deposit_id, "Deposit processed successfully");
+                    }
+                    Ok(ApprovedDepositOutcome::UtxoAlreadySpent) => {
+                        // Tombstones are permanent, so no retry can
+                        // ever succeed; the same set that parks
+                        // rejected approvals parks this until the
+                        // request expires and leaves the queue.
+                        self.approved_deposit_retry_tracker.clear(&deposit_id);
+                        self.never_retry_deposit_ids.insert(deposit_id);
+                        self.inner
+                            .metrics
+                            .never_retry_deposit_ids
+                            .set(self.never_retry_deposit_ids.len() as i64);
+                        warn!(
+                            deposit_id = %deposit_id,
+                            "Marking approved deposit as never retry: its UTXO is already spent on Sui"
+                        );
                     }
                     Err(err) => {
                         if !self.inner.onchain_state().has_deposit_request(&deposit_id) {
@@ -534,8 +571,24 @@ impl LeaderService {
         inner: Arc<Hashi>,
         deposit_request: DepositRequest,
         deadline: Instant,
-    ) -> Result<(), ApprovedDepositError> {
+    ) -> Result<ApprovedDepositOutcome, ApprovedDepositError> {
         info!("Confirming approved deposit request");
+
+        // The caller already dropped requests whose UTXO has a pool
+        // record; the spent tombstones are not mirrored, so ask the
+        // chain before spending gas on a confirm it would reject.
+        let spent = tokio::time::timeout_at(
+            deadline,
+            inner
+                .onchain_state()
+                .is_utxo_spent(&deposit_request.utxo.id),
+        )
+        .await
+        .map_err(|_| ApprovedDepositError::TimedOut(LEADER_TASK_TIMEOUT))?
+        .map_err(ApprovedDepositError::SpentUtxoLookupFailed)?;
+        if spent {
+            return Ok(ApprovedDepositOutcome::UtxoAlreadySpent);
+        }
 
         let mut executor = match SuiTxExecutor::from_hashi(inner.clone()) {
             Ok(executor) => executor,
@@ -571,7 +624,7 @@ impl LeaderService {
         )
         .await
         .map_err(|_| ApprovedDepositError::CheckpointWaitTimedOut)?;
-        Ok(())
+        Ok(ApprovedDepositOutcome::Confirmed)
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(validator = %member.validator_address()))]
@@ -693,11 +746,11 @@ fn deposit_request_to_proto(req: &DepositRequest) -> SignDepositConfirmationRequ
 
 fn filter_deposit_confirmation_candidates(
     candidates: &mut Vec<DepositRequest>,
-    spent_or_active_utxo_ids: &HashSet<UtxoId>,
+    used_utxo_ids: &HashSet<UtxoId>,
 ) -> (usize, usize) {
-    // Remove requests for spent or active UTXOs and count them.
+    // Remove requests for UTXOs the pool already holds and count them.
     let count_before_filter = candidates.len();
-    candidates.retain(|r| !spent_or_active_utxo_ids.contains(&r.utxo.id));
+    candidates.retain(|r| !used_utxo_ids.contains(&r.utxo.id));
     let utxo_already_used_count = count_before_filter - candidates.len();
 
     // Keep the earliest-approved request per UTXO and count later duplicates.
@@ -758,7 +811,7 @@ mod tests {
         let distinct = deposit_request(3, 3);
         let used_duplicate = deposit_request(4, 1);
         let duplicate = deposit_request(5, 2);
-        let spent_or_active_utxo_ids = HashSet::from([used.utxo.id]);
+        let used_utxo_ids = HashSet::from([used.utxo.id]);
         let mut candidates = vec![
             used,
             first.clone(),
@@ -767,8 +820,7 @@ mod tests {
             duplicate,
         ];
 
-        let counts =
-            filter_deposit_confirmation_candidates(&mut candidates, &spent_or_active_utxo_ids);
+        let counts = filter_deposit_confirmation_candidates(&mut candidates, &used_utxo_ids);
 
         assert_eq!(candidates, vec![first, distinct]);
         assert_eq!(counts, (2, 1));

--- a/crates/hashi/src/leader/mod.rs
+++ b/crates/hashi/src/leader/mod.rs
@@ -7,6 +7,7 @@ mod guardian;
 mod retry;
 mod withdrawal_request_flow;
 mod withdrawal_transactions;
+use deposits::ApprovedDepositOutcome;
 use deposits::UnapprovedDepositTaskResult;
 pub(crate) use retry::RetryPolicy;
 
@@ -67,7 +68,10 @@ pub(crate) struct LeaderService {
     // Background tasks currently approving Bitcoin deposits.
     unapproved_deposit_tasks: JoinSet<UnapprovedDepositTaskResult>,
     // Background tasks currently confirming approved Bitcoin deposits.
-    approved_deposit_tasks: JoinSet<(Address, Result<(), ApprovedDepositError>)>,
+    approved_deposit_tasks: JoinSet<(
+        Address,
+        Result<ApprovedDepositOutcome, ApprovedDepositError>,
+    )>,
     // Deposit requests loaded from Bitcoin/on-chain state and waiting for approval processing.
     pending_unapproved_deposit_requests: VecDeque<DepositRequest>,
     // Last hashi epoch processed by the checkpoint-triggered deposit path.

--- a/crates/hashi/src/onchain/apply.rs
+++ b/crates/hashi/src/onchain/apply.rs
@@ -608,14 +608,12 @@ fn apply_write(
             TrackedKind::UtxoRecord(utxo_id)
         }),
         Slot::SpentUtxos => {
-            decode::<move_types::Field<types::UtxoId, u64>>(contents, &id).map(|field| {
-                hashi
-                    .bitcoin_mut()
-                    .utxo_pool
-                    .spent_utxos
-                    .insert(field.name, field.value);
-                TrackedKind::SpentUtxo(field.name)
-            })
+            // A tombstone is created once and never rewritten, moved,
+            // or deleted, so there is no version to guard a replay
+            // with and nothing for a deletion to retire: recording it
+            // would only make the index grow with the bag, the very
+            // growth the mirror stopped tracking the bag to avoid.
+            return;
         }
         Slot::DepositRequests => {
             decode::<move_types::DepositRequest>(contents, &id).map(|request| {
@@ -845,9 +843,6 @@ fn retire(
         TrackedKind::UtxoRecord(utxo_id) => {
             hashi.bitcoin_mut().utxo_pool.utxo_records.remove(utxo_id);
         }
-        TrackedKind::SpentUtxo(utxo_id) => {
-            hashi.bitcoin_mut().utxo_pool.spent_utxos.remove(utxo_id);
-        }
         TrackedKind::DepositRequest(id) => {
             hashi.bitcoin_mut().deposit_queue.requests.remove(id);
             effects.push(Effect::DepositRequestRemoved(*id));
@@ -909,7 +904,6 @@ fn slot_for_kind(kind: &TrackedKind) -> Option<Slot> {
         TrackedKind::Member(_) => Some(Slot::Members),
         TrackedKind::Committee(_) | TrackedKind::CommitteeHandoff(_) => Some(Slot::Committees),
         TrackedKind::UtxoRecord(_) => Some(Slot::UtxoRecords),
-        TrackedKind::SpentUtxo(_) => Some(Slot::SpentUtxos),
         TrackedKind::DepositRequest(_) => Some(Slot::DepositRequests),
         TrackedKind::WithdrawalRequest(_) => Some(Slot::WithdrawalRequests),
         TrackedKind::WithdrawalTxn(_) => Some(Slot::WithdrawalTxns),
@@ -1189,7 +1183,6 @@ mod tests {
                         utxo_records_id: utxo_records_id(),
                         utxo_records: BTreeMap::new(),
                         spent_utxos_id: spent_utxos_id(),
-                        spent_utxos: BTreeMap::new(),
                     },
                 }),
                 proposals: types::Proposals {
@@ -1455,6 +1448,23 @@ mod tests {
         )
     }
 
+    /// A `spent_utxos` bag entry (`Field<UtxoId, u64>`) for the UTXO
+    /// `utxo_field_object` records, as `cleanup_spent_utxos` writes it.
+    fn spent_utxo_tombstone_object(field_id: Address, version: u64) -> Object {
+        let contents = bcs::to_bytes(&FieldEnc {
+            id: field_id,
+            name: utxo(0x77, 0, 1_000).id,
+            value: 7u64,
+        })
+        .unwrap();
+        obj(
+            field_tag(hashi_struct("utxo", "UtxoId", vec![]), TypeTag::U64),
+            version,
+            Owner::Object(spent_utxos_id()),
+            contents,
+        )
+    }
+
     fn deposit_request_object(id: Address, version: u64, approved: bool) -> Object {
         obj(
             tag(addr(PACKAGE), "deposit_queue", "DepositRequest", vec![]),
@@ -1566,11 +1576,28 @@ mod tests {
         assert_eq!(fixture.hashi.bitcoin().utxo_pool.utxo_records.len(), 1);
 
         // The cleanup transaction deletes the Field object with no
-        // event; the mirror must still drop the record.
-        let out = fixture.apply(&tx(vec![TxChange::Deleted { id: field_id }]));
+        // event and writes the UTXO's `spent_utxos` tombstone. The
+        // mirror must still drop the record, and must route the
+        // tombstone as a known write without indexing it: the bag is
+        // not mirrored, and indexing would grow with it.
+        let tombstone_id = addr(0x51);
+        let out = fixture.apply(&tx(vec![
+            written(spent_utxo_tombstone_object(tombstone_id, 1)),
+            TxChange::Deleted { id: field_id },
+        ]));
         assert!(out.unrouted.is_empty());
         assert!(fixture.hashi.bitcoin().utxo_pool.utxo_records.is_empty());
         assert!(fixture.index.get(&field_id).is_none());
+        assert!(fixture.index.get(&tombstone_id).is_none());
+        assert_eq!(fixture.index.len(), 0);
+
+        // A replayed tombstone write is equally inert.
+        let out = fixture.apply(&tx(vec![written(spent_utxo_tombstone_object(
+            tombstone_id,
+            1,
+        ))]));
+        assert!(out.unrouted.is_empty());
+        assert_eq!(fixture.index.len(), 0);
     }
 
     #[test]

--- a/crates/hashi/src/onchain/mod.rs
+++ b/crates/hashi/src/onchain/mod.rs
@@ -73,6 +73,7 @@ pub enum ScrapeScope {
 mod apply;
 mod mirror;
 mod route;
+mod spent_utxos;
 pub mod types;
 pub mod version;
 mod versioned_decode;
@@ -871,17 +872,6 @@ impl OnchainState {
             .any(|t| !t.is_fully_signed())
     }
 
-    pub fn spent_utxos_entries(&self) -> Vec<(types::UtxoId, u64)> {
-        self.state()
-            .hashi()
-            .bitcoin()
-            .utxo_pool
-            .spent_utxos()
-            .iter()
-            .map(|(utxo_id, epoch)| (*utxo_id, *epoch))
-            .collect()
-    }
-
     pub fn active_utxos(&self) -> Vec<types::Utxo> {
         self.state()
             .hashi()
@@ -892,15 +882,34 @@ impl OnchainState {
             .collect()
     }
 
-    pub fn find_spent_or_active_utxo_ids(
+    /// The subset of `utxo_ids` that have a `utxo_records` entry
+    /// (active, locked, or spent but not yet cleaned up), read from the
+    /// mirror. Tombstoned ids are not covered; see [`Self::is_utxo_spent`].
+    pub fn find_utxo_ids_with_records(
         &self,
         utxo_ids: impl IntoIterator<Item = types::UtxoId>,
     ) -> HashSet<types::UtxoId> {
         let mut utxo_ids: HashSet<_> = utxo_ids.into_iter().collect();
         let state = self.state();
         let utxo_pool = &state.hashi().bitcoin().utxo_pool;
-        utxo_ids.retain(|id| utxo_pool.is_active_or_spent(id));
+        utxo_ids.retain(|id| utxo_pool.has_record(id));
         utxo_ids
+    }
+
+    /// Whether the chain holds a `spent_utxos` tombstone for `utxo_id`.
+    ///
+    /// The tombstone bag is not mirrored (it only ever grows), so this
+    /// is a live read against the fullnode; the `spent_utxos` module
+    /// documents the mechanics and the failure semantics.
+    pub async fn is_utxo_spent(&self, utxo_id: &types::UtxoId) -> Result<bool> {
+        let spent_utxos_id = *self.state().hashi().bitcoin().utxo_pool.spent_utxos_id();
+        spent_utxos::lookup_spent_utxo(
+            self.client(),
+            spent_utxos_id,
+            self.package_id_original(),
+            utxo_id,
+        )
+        .await
     }
 
     pub fn withdrawal_txn(&self, id: &Address) -> Option<types::WithdrawalTransaction> {
@@ -2118,11 +2127,11 @@ async fn scrape_utxo_pool(
     utxo_pool: move_types::UtxoPool,
     metrics: Option<&crate::metrics::Metrics>,
 ) -> Result<(route::ContainerSeed, types::UtxoPool)> {
-    let ((mut records_seed, utxo_records), (spent_seed, spent_utxos)) = tokio::try_join!(
-        scrape_utxo_records(client.clone(), utxo_pool.utxo_records.id, metrics),
-        scrape_spent_utxos(client.clone(), utxo_pool.spent_utxos.id, metrics),
-    )?;
-    records_seed.merge(spent_seed);
+    // The `spent_utxos` tombstones are deliberately not scraped: the
+    // bag is unbounded (see `types::UtxoPool`), and the mirror only
+    // needs its id to answer point lookups.
+    let (records_seed, utxo_records) =
+        scrape_utxo_records(client, utxo_pool.utxo_records.id, metrics).await?;
 
     Ok((
         records_seed,
@@ -2130,7 +2139,6 @@ async fn scrape_utxo_pool(
             utxo_records_id: utxo_pool.utxo_records.id,
             utxo_records,
             spent_utxos_id: utxo_pool.spent_utxos.id,
-            spent_utxos,
         },
     ))
 }
@@ -2179,44 +2187,6 @@ async fn scrape_utxo_records(
     )
     .await?;
     Ok((seed, utxo_records))
-}
-
-async fn scrape_spent_utxos(
-    client: Client,
-    spent_utxos_id: Address,
-    metrics: Option<&crate::metrics::Metrics>,
-) -> Result<(route::ContainerSeed, BTreeMap<types::UtxoId, u64>)> {
-    let mut seed = route::ContainerSeed::default();
-    let mut spent_utxos = BTreeMap::new();
-    seed.height = scrape_dynamic_field_pages(
-        &client,
-        spent_utxos_id,
-        plain_field_mask(),
-        "spent_utxos",
-        metrics,
-        |fields| {
-            for field in fields {
-                let utxo_id: types::UtxoId = field
-                    .name()
-                    .deserialize()
-                    .map_err(|e| anyhow!("failed to deserialize UtxoId: {e}"))?;
-                let spent_epoch: u64 = field
-                    .value()
-                    .deserialize()
-                    .map_err(|e| anyhow!("failed to deserialize spent epoch: {e}"))?;
-                let field_id: Address = field.field_id().parse()?;
-                seed.entries.push((
-                    field_id,
-                    field.field_object().version(),
-                    route::TrackedKind::SpentUtxo(utxo_id),
-                ));
-                spent_utxos.insert(utxo_id, spent_epoch);
-            }
-            Ok(())
-        },
-    )
-    .await?;
-    Ok((seed, spent_utxos))
 }
 
 async fn scrape_proposals(

--- a/crates/hashi/src/onchain/route.rs
+++ b/crates/hashi/src/onchain/route.rs
@@ -31,7 +31,6 @@ pub(super) enum Slot {
     Members,
     Committees,
     UtxoRecords,
-    SpentUtxos,
     // ObjectBag containers whose child objects are mirrored.
     DepositRequests,
     WithdrawalRequests,
@@ -50,6 +49,11 @@ pub(super) enum Slot {
     DepositProcessed,
     WithdrawalProcessed,
     ConfirmedTxns,
+    /// The `UtxoPool.spent_utxos` tombstone bag. Append-only and never
+    /// pruned on chain, so mirroring it would grow a node's memory
+    /// without bound; the two replay checks that need membership read
+    /// it live instead (`OnchainState::is_utxo_spent`).
+    SpentUtxos,
     /// The `BitcoinState.user_requests` table of per-user request bags.
     UserRequests,
     /// One per-user `Bag` stored as a `user_requests` value.
@@ -208,7 +212,6 @@ pub(super) enum TrackedKind {
     Committee(u64),
     CommitteeHandoff(u64),
     UtxoRecord(UtxoId),
-    SpentUtxo(UtxoId),
     DepositRequest(Address),
     WithdrawalRequest(Address),
     WithdrawalTxn(Address),

--- a/crates/hashi/src/onchain/spent_utxos.rs
+++ b/crates/hashi/src/onchain/spent_utxos.rs
@@ -1,0 +1,218 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Live membership lookups against the on-chain `spent_utxos` bag.
+//!
+//! The bag holds one `UtxoId -> spent_epoch` tombstone per UTXO the
+//! bridge has ever spent, kept permanently as replay protection. It
+//! only grows, and on a busy network it runs to millions of entries,
+//! so the object mirror deliberately does not track it (see
+//! `route::Slot::SpentUtxos`). The two replay checks that need
+//! membership — approving a deposit and confirming an approved one —
+//! ask the fullnode for the single entry instead.
+
+use anyhow::Result;
+use sui_rpc::Client;
+use sui_rpc::field::FieldMask;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
+use sui_rpc::proto::sui::rpc::v2::Object;
+use sui_sdk_types::Address;
+use sui_sdk_types::Identifier;
+use sui_sdk_types::StructTag;
+use sui_sdk_types::TypeTag;
+use sui_sdk_types::bcs::ToBcs;
+
+use super::types::UtxoId;
+
+/// Whether the `spent_utxos` bag holds an entry for `utxo_id`.
+///
+/// A bag entry is a dynamic field whose object id derives from the bag
+/// id and the BCS-encoded key, so one `GetObject` decides membership:
+/// an object means spent, `NotFound` means not spent, and any other
+/// status is an error for the caller to retry. A wrong "not spent"
+/// costs one rejected transaction, never a double-spend — every entry
+/// function that inserts a UTXO re-checks the bag itself.
+pub(super) async fn lookup_spent_utxo(
+    mut client: Client,
+    spent_utxos_id: Address,
+    package_id: Address,
+    utxo_id: &UtxoId,
+) -> Result<bool> {
+    let field_id = spent_utxo_field_id(spent_utxos_id, package_id, utxo_id);
+    let response = client
+        .ledger_client()
+        .get_object(
+            GetObjectRequest::new(&field_id)
+                .with_read_mask(FieldMask::from_paths([Object::path_builder().object_id()])),
+        )
+        .await;
+    match response {
+        Ok(_) => Ok(true),
+        Err(status) if status.code() == tonic::Code::NotFound => Ok(false),
+        Err(status) => Err(anyhow::Error::new(status).context(format!(
+            "failed to look up the spent_utxos entry for {utxo_id:?}"
+        ))),
+    }
+}
+
+/// The derived object id of the `spent_utxos` bag entry keyed by
+/// `utxo_id`. The key type is `utxo::UtxoId` from the original package:
+/// a struct keeps its defining package's address through upgrades.
+fn spent_utxo_field_id(spent_utxos_id: Address, package_id: Address, utxo_id: &UtxoId) -> Address {
+    let key_type = TypeTag::Struct(Box::new(StructTag::new(
+        package_id,
+        Identifier::from_static("utxo"),
+        Identifier::from_static("UtxoId"),
+        vec![],
+    )));
+    spent_utxos_id.derive_dynamic_child_id(
+        &key_type,
+        &utxo_id
+            .to_bcs()
+            .expect("UtxoId BCS serialization cannot fail"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use hashi_types::bitcoin_txid::BitcoinTxid;
+    use sui_rpc::proto::sui::rpc::v2::GetObjectResponse;
+    use sui_rpc::proto::sui::rpc::v2::ledger_service_server::LedgerService;
+    use sui_rpc::proto::sui::rpc::v2::ledger_service_server::LedgerServiceServer;
+
+    fn addr(byte: u8) -> Address {
+        Address::from_bytes([byte; 32]).unwrap()
+    }
+
+    fn utxo_id(byte: u8, vout: u32) -> UtxoId {
+        UtxoId {
+            txid: BitcoinTxid::from(addr(byte)),
+            vout,
+        }
+    }
+
+    /// A ledger that knows one object id and answers everything else
+    /// with the configured status, recording what it was asked for.
+    #[derive(Clone)]
+    struct OneObjectLedger {
+        known: Address,
+        miss: tonic::Code,
+        asked: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[tonic::async_trait]
+    impl LedgerService for OneObjectLedger {
+        async fn get_object(
+            &self,
+            request: tonic::Request<GetObjectRequest>,
+        ) -> Result<tonic::Response<GetObjectResponse>, tonic::Status> {
+            let object_id = request.into_inner().object_id.unwrap_or_default();
+            self.asked.lock().unwrap().push(object_id.clone());
+            if object_id != self.known.to_string() {
+                return Err(tonic::Status::new(self.miss, "no such object"));
+            }
+            let mut object = Object::default();
+            object.object_id = Some(object_id);
+            Ok(tonic::Response::new(GetObjectResponse::new(object)))
+        }
+    }
+
+    async fn spawn_ledger(ledger: OneObjectLedger) -> Client {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = futures::stream::unfold(listener, |listener| async move {
+            let result = listener.accept().await.map(|(stream, _)| stream);
+            Some((result, listener))
+        });
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(LedgerServiceServer::new(ledger))
+                .serve_with_incoming(incoming),
+        );
+        Client::new(format!("http://{addr}").as_str()).unwrap()
+    }
+
+    #[test]
+    fn field_id_depends_on_bag_key_and_package() {
+        let base = spent_utxo_field_id(addr(0x10), addr(0xAA), &utxo_id(0x77, 0));
+        assert_ne!(
+            base,
+            spent_utxo_field_id(addr(0x11), addr(0xAA), &utxo_id(0x77, 0))
+        );
+        assert_ne!(
+            base,
+            spent_utxo_field_id(addr(0x10), addr(0xAB), &utxo_id(0x77, 0))
+        );
+        assert_ne!(
+            base,
+            spent_utxo_field_id(addr(0x10), addr(0xAA), &utxo_id(0x77, 1))
+        );
+        assert_eq!(
+            base,
+            spent_utxo_field_id(addr(0x10), addr(0xAA), &utxo_id(0x77, 0))
+        );
+    }
+
+    #[tokio::test]
+    async fn present_entry_is_spent_and_missing_entry_is_not() {
+        let spent_utxos_id = addr(0x10);
+        let package_id = addr(0xAA);
+        let spent = utxo_id(0x77, 0);
+        let unspent = utxo_id(0x77, 1);
+        let ledger = OneObjectLedger {
+            known: spent_utxo_field_id(spent_utxos_id, package_id, &spent),
+            miss: tonic::Code::NotFound,
+            asked: Arc::default(),
+        };
+        let client = spawn_ledger(ledger.clone()).await;
+
+        assert!(
+            lookup_spent_utxo(client.clone(), spent_utxos_id, package_id, &spent)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !lookup_spent_utxo(client, spent_utxos_id, package_id, &unspent)
+                .await
+                .unwrap()
+        );
+
+        // Each answer came from exactly the derived entry id, not from
+        // a listing or a guess.
+        let asked = ledger.asked.lock().unwrap();
+        assert_eq!(
+            *asked,
+            vec![
+                spent_utxo_field_id(spent_utxos_id, package_id, &spent).to_string(),
+                spent_utxo_field_id(spent_utxos_id, package_id, &unspent).to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn any_status_but_not_found_is_an_error() {
+        let spent_utxos_id = addr(0x10);
+        let package_id = addr(0xAA);
+        let ledger = OneObjectLedger {
+            known: addr(0xFF),
+            miss: tonic::Code::Unavailable,
+            asked: Arc::default(),
+        };
+        let client = spawn_ledger(ledger).await;
+
+        let err = lookup_spent_utxo(client, spent_utxos_id, package_id, &utxo_id(0x77, 0))
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<tonic::Status>().map(|s| s.code()),
+            Some(tonic::Code::Unavailable),
+            "{err:#}"
+        );
+    }
+}

--- a/crates/hashi/src/onchain/types.rs
+++ b/crates/hashi/src/onchain/types.rs
@@ -908,8 +908,12 @@ impl hashi_types::intent::IntentMessage for DepositConfirmationMessage {
 pub struct UtxoPool {
     pub(super) utxo_records_id: Address,
     pub(super) utxo_records: BTreeMap<UtxoId, UtxoRecord>,
+    /// The on-chain `spent_utxos` bag (`UtxoId -> spent_epoch`), the
+    /// tombstones kept permanently as replay protection. The bag only
+    /// ever grows — millions of entries on a busy network — so it is
+    /// not mirrored; membership is read live through
+    /// [`super::OnchainState::is_utxo_spent`].
     pub(super) spent_utxos_id: Address,
-    pub(super) spent_utxos: BTreeMap<UtxoId, u64>,
 }
 
 impl UtxoPool {
@@ -930,16 +934,16 @@ impl UtxoPool {
             .map(|(id, r)| (id, &r.utxo))
     }
 
-    pub fn is_active_or_spent(&self, id: &UtxoId) -> bool {
-        self.utxo_records.contains_key(id) || self.spent_utxos.contains_key(id)
+    /// True when `id` has a `utxo_records` entry: active, locked by a
+    /// withdrawal, or spent but not yet cleaned up. This is the mirrored
+    /// half of the on-chain `assert_not_spent_or_active` guard; the
+    /// tombstoned half is [`super::OnchainState::is_utxo_spent`].
+    pub fn has_record(&self, id: &UtxoId) -> bool {
+        self.utxo_records.contains_key(id)
     }
 
     pub fn spent_utxos_id(&self) -> &Address {
         &self.spent_utxos_id
-    }
-
-    pub fn spent_utxos(&self) -> &BTreeMap<UtxoId, u64> {
-        &self.spent_utxos
     }
 }
 


### PR DESCRIPTION
Previously, the object mirror scraped the whole `spent_utxos` bag at boot and kept every `UtxoId -> spent_epoch` tombstone in memory for the life of the process. The bag is append-only and never pruned on chain, so a node's resident set grew without bound; on testnet it holds over two million entries and the scrape alone blew the memory budget.

With this commit, the bag is a known-but-unmirrored container. Tombstone writes still route cleanly, so they never trip the mirror-gap tripwire, but they are not applied and not recorded in the object index either: a tombstone is created once and never rewritten, moved, or deleted, so the index has nothing to version for it. The pool keeps only the bag id.

The two replay checks that consulted the mirrored set now read the chain at the moment they run. A bag entry's object id derives from the bag id and the BCS key, so one `GetObject` decides membership: an object means spent, `NotFound` means not spent, and any other status is an error the caller retries.

- Deposit validation keeps the synchronous check against the mirrored `utxo_records`, then makes one lookup for the tombstone. A hit is the existing never-retry rejection; a lookup failure is a new retriable error.
- The leader's confirmation filter only drops candidates whose UTXO has a pool record. The per-deposit confirm task asks the chain for the tombstone before submitting, under the existing task deadline. A spent answer is a new task outcome that parks the request in the never-retry set, so the leader loop stays synchronous and each doomed request costs exactly one lookup.

Also add unit tests for the lookup against a fake `LedgerService`, extend the apply test to cover a cleanup transaction's tombstone write, and rework the e2e cleanup helper to list tombstones from the chain and assert each reads back as spent through a node's live lookup.