### PR TITLE
Make guardian kp config order independent

### DIFF
--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -52,9 +52,9 @@ targets that cert (parsed without decrypting) → cross-checks the guardian's
 `ceremony/` audit log and `kp-shares/` recovery log.
 It then waits for every KP to confirm successful share recovery.
 
-`kp_roster.kp_pgp_cert_paths` is an ordered list with one certificate path per
-KP/share id. Each share has one encrypted ciphertext addressed to that
-certificate's fingerprint.
+`kp_roster.kp_pgp_cert_paths` lists one certificate per KP, in any order.
+New ceremonies assign share IDs by fingerprint order; existing assignments
+come from signed `kp-shares/` state.
 
 ```bash
 cargo run -p hashi-guardian-init -- operator ceremony --config guardian-init.sample.yaml
@@ -87,9 +87,7 @@ The selected ciphertext is piped from memory to `gpg` over stdin. No temporary
 ciphertext or plaintext file is written locally; only the verified ceremony
 state containing the encrypted shares is persisted.
 
-The selected `kp_pgp_cert_path` must name the certificate configured for this
-KP/share in `kp_roster`; a local certificate outside the roster cannot confirm
-the ceremony.
+`kp_pgp_cert_path` must name a certificate in `kp_roster`.
 
 ```bash
 cargo run -p hashi-guardian-init -- key-provisioner ceremony --config guardian-init.sample.yaml --encrypted-shares-path /secure/path/kp-shares.json
@@ -206,14 +204,13 @@ It:
 2. Fetches and verifies the active guardian's `GuardianInfo` through
    `relay_endpoint`, then requires its BTC public key to match the latest
    attested `ceremony/` log and uses that log's sharing instance.
-3. Reads and verifies the latest `kp-shares/{sharing_seq}/` state against the
-   current roster, decrypts the old cert's ciphertext, and verifies the share
-   commitment.
+3. Verifies the latest `kp-shares/{sharing_seq}/` state against the configured
+   certificate set, decrypts this KP's share, and checks its commitment.
 4. HPKE-encrypts the same share to the guardian, signs the request with the old
    cert, binds the observed `cert_seq` to reject stale updates, and calls
    `ProvisionerRotateCert` through the relay.
-5. Verifies the guardian-signed response and the next `kp-shares/` snapshot,
-   including that only this share's recipient and ciphertext changed.
+5. Verifies the signed response and next `kp-shares/` snapshot: only this share's
+   recipient and ciphertext change, targeting the new cert and retaining its ID.
 
 ```bash
 cargo run -p hashi-guardian-init -- key-provisioner rotate-cert \

--- a/crates/hashi-guardian-init/guardian-init.sample.yaml
+++ b/crates/hashi-guardian-init/guardian-init.sample.yaml
@@ -52,7 +52,8 @@ kp_roster:
   num_shares: 5
   threshold: 3
 
-  # Ordered paths to the armored OpenPGP public cert for each KP/share id.
+  # One armored OpenPGP public cert per KP; path order is irrelevant.
+  # New ceremonies assign IDs by fingerprint order; signed state retains existing IDs.
   kp_pgp_cert_paths:
     - /path/to/kp1.asc
     - /path/to/kp2.asc

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -117,7 +117,7 @@ pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
         share_count = state.encrypted_shares.share_count(),
         "verifying every PGP-encrypted share against the expected KP certs (without decrypting)",
     );
-    state.encrypted_shares.verify_recipients(&certs_roster)?;
+    state.encrypted_shares.verify_recipient_set(&certs_roster)?;
     info!(
         phase = "roster verify",
         "ceremony/ and kp-shares/ logs verified against expected params and KP certs",

--- a/crates/hashi-guardian-init/src/kp_provision.rs
+++ b/crates/hashi-guardian-init/src/kp_provision.rs
@@ -365,7 +365,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
         sharing_seq, "verifying this KP's encrypted share from kp-shares/",
     );
     state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
-    state.encrypted_shares.verify_recipients(&certs_roster)?;
+    state.encrypted_shares.verify_recipient_set(&certs_roster)?;
     info!(
         phase = "share read",
         cert_seq = state.cert_seq,

--- a/crates/hashi-guardian-init/src/kp_roster.rs
+++ b/crates/hashi-guardian-init/src/kp_roster.rs
@@ -46,9 +46,9 @@ pub struct KpRosterConfig {
     pub num_shares: usize,
     /// Reconstruction threshold. Must satisfy `2 <= threshold <= num_shares`.
     pub threshold: usize,
-    /// Ordered paths to each KP's armored OpenPGP public certificate. The path
-    /// at index `i` is assigned share id `i + 1`; read-only commands match
-    /// shares by fingerprint.
+    /// Paths to each KP's armored OpenPGP public certificate, in any order.
+    /// New ceremonies assign IDs by fingerprint order; existing signed state
+    /// owns the share assignments.
     pub kp_pgp_cert_paths: Vec<PathBuf>,
     #[serde(flatten)]
     pub pcr_allowlist: PcrAllowlist,
@@ -284,21 +284,6 @@ mod tests {
              \x20 pcr0: \"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n\
              prev_builds: []\n"
         )
-    }
-
-    #[test]
-    fn flat_kp_cert_paths_deserialize_in_order() {
-        let cfg: KpRosterConfig =
-            serde_yaml::from_str(&roster_yaml("  - /path/kp1.asc\n  - /path/kp2.asc\n")).unwrap();
-
-        assert_eq!(
-            cfg.kp_pgp_cert_paths,
-            vec![
-                PathBuf::from("/path/kp1.asc"),
-                PathBuf::from("/path/kp2.asc")
-            ]
-        );
-        cfg.validate().unwrap();
     }
 
     #[test]

--- a/crates/hashi-guardian-init/src/kp_rotate_cert.rs
+++ b/crates/hashi-guardian-init/src/kp_rotate_cert.rs
@@ -120,7 +120,7 @@ pub async fn run(cfg: Config, new_kp_pgp_cert_path: PathBuf) -> anyhow::Result<(
     );
     let sharing_seq = state.secret_sharing_instance.sharing_seq();
 
-    state.encrypted_shares.verify_recipients(&certs_roster)?;
+    state.encrypted_shares.verify_recipient_set(&certs_roster)?;
     let old_cert_seq = state.cert_seq;
     let old_encrypted_shares = state.encrypted_shares.clone();
     let decrypted = decrypt_kp_share(&state, &signing_cert)?;
@@ -128,7 +128,7 @@ pub async fn run(cfg: Config, new_kp_pgp_cert_path: PathBuf) -> anyhow::Result<(
     let request = ProvisionerRotateCertRequest::new(
         session_id.clone(),
         old_cert_seq,
-        new_cert,
+        new_cert.clone(),
         &decrypted,
         &guardian_pub_key,
         &mut thread_rng(),
@@ -162,11 +162,8 @@ pub async fn run(cfg: Config, new_kp_pgp_cert_path: PathBuf) -> anyhow::Result<(
         decrypted.id.get()
     );
     let rotated_share_id = encrypted_share.id;
-    let expected_cert = expected_certs_roster
-        .cert_for_share(rotated_share_id)
-        .context("rotated share id missing from expected KP certificate roster")?;
     encrypted_share
-        .verify_recipient(expected_cert)
+        .verify_recipient(&new_cert)
         .context("verify the rotated KP share returned by the guardian")?;
 
     let (expected_encrypted_shares, _) = old_encrypted_shares.replace_recipient(
@@ -181,7 +178,7 @@ pub async fn run(cfg: Config, new_kp_pgp_cert_path: PathBuf) -> anyhow::Result<(
         .context("read the certificate-rotation kp-shares snapshot")?;
     updated_state
         .encrypted_shares
-        .verify_recipients(&expected_certs_roster)
+        .verify_recipient_set(&expected_certs_roster)
         .context("verify persisted kp-shares snapshot against the rotated certificate roster")?;
     anyhow::ensure!(
         updated_state.encrypted_shares == expected_encrypted_shares,

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -22,6 +22,7 @@ use hashi_guardian::s3_reader::GuardianReader;
 use hashi_types::guardian::CeremonyStage;
 use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::GuardianSignedResponse;
+use hashi_types::guardian::KpCertRoster;
 use hashi_types::guardian::OperatorInitRequest;
 use hashi_types::guardian::SetupNewKeyRequest;
 use hashi_types::guardian::SetupNewKeyResponse;
@@ -78,7 +79,10 @@ pub async fn run(cfg: Config) -> Result<()> {
         share_count = cfg.kp_roster.kp_pgp_cert_paths.len(),
         "loading + validating full KP certificate roster",
     );
-    let certs_roster = cfg.kp_roster.load_certs_roster()?;
+    let mut certs = cfg.kp_roster.load_certs_roster()?.into_vec();
+    // Only a new ceremony assigns share IDs; existing state retains its mapping.
+    certs.sort_by_cached_key(|cert| cert.fingerprint().to_hex());
+    let certs_roster = KpCertRoster::new(certs)?;
     info!(
         phase = "roster load",
         share_count = certs_roster.num_kps(),

--- a/crates/hashi-guardian-init/src/operator_provision.rs
+++ b/crates/hashi-guardian-init/src/operator_provision.rs
@@ -148,7 +148,7 @@ pub async fn run(cfg: Config, do_genesis: bool) -> anyhow::Result<()> {
     ceremony_state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     ceremony_state
         .encrypted_shares
-        .verify_recipients(&certs_roster)?;
+        .verify_recipient_set(&certs_roster)?;
     let scraped_instance = ceremony_state.secret_sharing_instance.clone();
     let sharing_seq = scraped_instance.sharing_seq();
     info!(

--- a/crates/hashi-types/src/guardian/crypto/encryption.rs
+++ b/crates/hashi-types/src/guardian/crypto/encryption.rs
@@ -284,6 +284,31 @@ impl KpEncryptedShareRoster {
         }
         Ok(())
     }
+
+    /// Verify the exact configured certificate set and ciphertext recipients,
+    /// leaving share assignments to the signed encrypted-share roster.
+    pub fn verify_recipient_set(&self, certs_roster: &KpCertRoster) -> GuardianResult<()> {
+        if self.share_count() != certs_roster.num_kps() {
+            return Err(InvalidInputs(format!(
+                "expected {} KP cert roster entries, got {} encrypted shares",
+                certs_roster.num_kps(),
+                self.share_count()
+            )));
+        }
+
+        // Both rosters enforce uniqueness, so equal counts and membership of
+        // every configured fingerprint prove exact set equality.
+        for cert in certs_roster.iter() {
+            let fingerprint = cert.fingerprint().to_hex();
+            let share = self.find_by_fingerprint(&fingerprint).ok_or_else(|| {
+                InvalidInputs(format!(
+                    "KP fingerprint {fingerprint} is not present in the encrypted-share roster"
+                ))
+            })?;
+            share.verify_recipient(cert)?;
+        }
+        Ok(())
+    }
 }
 
 impl<'de> Deserialize<'de> for KpEncryptedShareRoster {
@@ -597,6 +622,74 @@ mod tests {
     }
 
     #[test]
+    fn recipient_set_preserves_assignments_across_config_permutation_and_rotation() {
+        let first = cert();
+        let second = cert();
+        let replacement = cert();
+        let shares = KpEncryptedShareRoster::new(
+            [&first, &second]
+                .into_iter()
+                .enumerate()
+                .map(|(index, cert)| {
+                    let share = Share {
+                        id: ShareID::new(index as u16 + 1).unwrap(),
+                        value: Scalar::ONE,
+                    };
+                    KpEncryptedShare {
+                        id: share.id,
+                        recipient_fingerprint: cert.fingerprint().to_hex(),
+                        armored_ciphertext: encrypt_share_for_provisioner(&share, cert),
+                    }
+                })
+                .collect(),
+        )
+        .unwrap();
+        let config = KpCertRoster::new(vec![second.clone(), first.clone()]).unwrap();
+        assert!(shares.verify_recipients(&config).is_err());
+        shares.verify_recipient_set(&config).unwrap();
+        assert!(
+            shares
+                .verify_recipient_set(&KpCertRoster::new(vec![first.clone()]).unwrap())
+                .is_err()
+        );
+        assert!(
+            shares
+                .verify_recipient_set(
+                    &KpCertRoster::new(vec![first.clone(), replacement.clone()]).unwrap()
+                )
+                .is_err()
+        );
+
+        // The second config entry owns signed share 1, not share 2.
+        let rotated_config = config
+            .replace_cert(&first.fingerprint(), replacement.clone())
+            .unwrap();
+        let (rotated, changed) = shares
+            .clone()
+            .replace_recipient(
+                &first.fingerprint().to_hex(),
+                replacement.fingerprint().to_hex(),
+                encrypt_share_for_provisioner(
+                    &Share {
+                        id: ShareID::new(1).unwrap(),
+                        value: Scalar::ONE,
+                    },
+                    &replacement,
+                ),
+            )
+            .unwrap();
+        changed.verify_recipient(&replacement).unwrap();
+        assert!(
+            changed
+                .verify_recipient(rotated_config.cert_for_share(changed.id).unwrap())
+                .is_err()
+        );
+        rotated.verify_recipient_set(&rotated_config).unwrap();
+        assert_eq!(changed.id.get(), 1);
+        assert_eq!(rotated.iter().nth(1), shares.iter().nth(1));
+    }
+
+    #[test]
     fn encrypted_share_roster_deserializes_through_validation() {
         let json = serde_json::to_string(&vec![
             test_kp_encrypted_share(2),
@@ -663,6 +756,13 @@ mod tests {
             .verify_recipient(&recipient)
             .expect_err("the recorded recipient fingerprint must identify the supplied cert");
         assert!(format!("{err}").contains("recipient differs"), "{err}");
+        wrong_recorded_fingerprint.recipient_fingerprint = "not a fingerprint".into();
+        assert!(
+            KpEncryptedShareRoster::new(vec![wrong_recorded_fingerprint])
+                .unwrap()
+                .verify_recipient_set(&KpCertRoster::new(vec![recipient]).unwrap())
+                .is_err()
+        );
 
         let wrong_ciphertext_recipient = KpEncryptedShare {
             recipient_fingerprint: other.fingerprint().to_hex(),
@@ -674,6 +774,12 @@ mod tests {
         assert!(
             format!("{err}").contains("which is not in that cert"),
             "{err}"
+        );
+        assert!(
+            KpEncryptedShareRoster::new(vec![wrong_ciphertext_recipient])
+                .unwrap()
+                .verify_recipient_set(&KpCertRoster::new(vec![other]).unwrap())
+                .is_err()
         );
     }
 
@@ -692,6 +798,12 @@ mod tests {
         assert!(
             format!("{err}").contains("failed to parse PGP recipients"),
             "{err}"
+        );
+        assert!(
+            KpEncryptedShareRoster::new(vec![encrypted_share])
+                .unwrap()
+                .verify_recipient_set(&KpCertRoster::new(vec![recipient]).unwrap())
+                .is_err()
         );
     }
 

--- a/key-provisioner/provision.md
+++ b/key-provisioner/provision.md
@@ -143,8 +143,7 @@ in your GnuPG keyring.
 Send only the `.asc` public certificate and its fingerprint to the guardian
 operator. Do not send either PIN.
 
-The operator assigns each KP one ordered roster entry containing exactly one
-certificate path:
+The operator configures exactly one certificate path per KP, in any order:
 
 ```yaml
 kp_roster:
@@ -157,8 +156,10 @@ kp_roster:
 ```
 
 Each entry represents one KP, one guardian share, and one YubiKey-backed OpenPGP
-certificate. The KP's local `kp_pgp_cert_path` points to the same certificate
-for ceremony and provisioning commands.
+certificate. New ceremonies assign share IDs by fingerprint order; existing
+signed guardian state retains those assignments. The KP's local
+`kp_pgp_cert_path` points to the same certificate for ceremony and provisioning
+commands.
 
 Store the YubiKey separately from the public certificate and guardian
 configuration. Losing the YubiKey prevents that KP from decrypting and


### PR DESCRIPTION
- Fixes [IOP-719](https://linear.app/mysten-labs/issue/IOP-719/order-of-kp-pubkeys-in-guardian-kp-config-files-shouldnt-matter): verify configured KP certificates as an unordered set while preserving signed share assignments.
- Sort fingerprints only for new ceremonies; keep existing share IDs during certificate rotation. No config-schema or wire-format changes.
- Add permutation and rotation regression coverage and update operator docs.
- Verified: 263 affected-crate tests, `make clippy`, and `make fmt`. Full guardian/S3/YubiKey end-to-end flow not run.