### PR TITLE
Update key provisioner terminal and mac update workflow

### DIFF
--- a/key-provisioner/flake.nix
+++ b/key-provisioner/flake.nix
@@ -25,6 +25,7 @@
                 pkgs.awscli2
                 pkgs.cargo
                 pkgs.gnupg
+                pkgs.ghostty-bin
                 pkgs.neovim
                 pkgs.openpgp-card-tools
                 pkgs.rustc
@@ -44,6 +45,19 @@
               system.primaryUser = "kp";
               system.stateVersion = 7;
 
+              system.activationScripts.postActivation.text = ''
+                /usr/bin/install -d -o kp -m 0755 "/Users/kp/Library/Application Support/com.mitchellh.ghostty"
+                /usr/bin/install -o kp -m 0644 ${
+                  pkgs.writeText "ghostty-config" ''
+                    auto-update = off
+                    theme = Dimidium
+                    font-size = 16
+                    maximize = true
+                    quit-after-last-window-closed = true
+                  ''
+                } "/Users/kp/Library/Application Support/com.mitchellh.ghostty/config.ghostty"
+              '';
+
               system.defaults = {
                 CustomUserPreferences = {
                   NSGlobalDomain.ApplePersistenceIgnoreState = true;
@@ -62,10 +76,10 @@
                 };
 
                 dock = {
-                  autohide = false;
+                  autohide = true;
                   orientation = "right";
                   persistent-apps = [
-                    "/System/Applications/Utilities/Terminal.app"
+                    "/Applications/Nix Apps/Ghostty.app"
                   ];
                   persistent-others = [ ];
                   show-recents = false;

--- a/key-provisioner/provision.md
+++ b/key-provisioner/provision.md
@@ -93,9 +93,20 @@ applies the nix-darwin configuration that installs the required tooling.
    the `kp` account password and check **Remember this password in my keychain**
    before unlocking it.
 
-   Quit Terminal completely with **Command-Q**, then reopen it to load the new
-   shell environment. Do not continue in a Terminal session restored after the
-   restart; the installed tools may not be on its `PATH`.
+   Open **Ghostty** from the Dock and use it instead of macOS Terminal for all
+   remaining commands. Ghostty was installed by the nix-darwin configuration.
+   If Terminal reopened after the restart, quit it with **Command-Q** rather
+   than continuing in the restored session.
+
+   If macOS asks whether to allow Ghostty to modify system settings, access
+   files or folders, or grant other permissions needed for provisioning,
+   select **Allow** or approve the request.
+
+   In Ghostty, return to the repository directory:
+
+   ```sh
+   cd ~/hashi
+   ```
 
 Congratulations, your MacBook Neo setup is complete! Continue below to set up
 your YubiKey.

--- a/key-provisioner/scripts/update-mac.sh
+++ b/key-provisioner/scripts/update-mac.sh
@@ -5,9 +5,17 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
-echo "Updating to latest main..."
-git checkout main
-git pull --ff-only origin main
+branch="$(git symbolic-ref --short HEAD)"
+if [[ "$branch" != "main" ]]; then
+    if read -r -p "WARNING: main must be used for key provisioner operations. You're on '$branch'. Switch to main? [y/N] " answer &&
+        [[ "$answer" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+        branch="main"
+    fi
+fi
+
+echo "Updating to latest $branch..."
+git checkout "$branch"
+git pull --ff-only origin "$branch"
 
 echo "Recent commits:"
 git log --oneline -5
@@ -16,4 +24,7 @@ echo "Applying nix-darwin config"
 sudo darwin-rebuild switch --flake "$repo_root/key-provisioner#hashi-guardian-key-provisioner"
 
 echo "Installing all macOS software updates"
-sudo softwareupdate --install --all --restart
+sudo softwareupdate --install --all
+
+echo "Update complete. Restarting to apply settings..."
+sudo shutdown -r now


### PR DESCRIPTION
- Install and configure Ghostty through Nix, add it to the auto-hiding Dock, and document using it after provisioning.
- Prompt before switching a non-main checkout to main during Mac updates, retaining the current branch when declined.
- Explicitly restart after applying the configuration and installing macOS updates.