### PR TITLE
[Guardian] Publish ceremony logs after confirmation

### DIFF
--- a/crates/hashi-guardian-init/README.md
+++ b/crates/hashi-guardian-init/README.md
@@ -40,17 +40,19 @@ default credential chain.
 The production guardian key ceremony — genesis setup, run once by the operator.
 
 One S3 bucket is involved: the guardian's **log bucket** (object-lock enabled).
-The guardian writes its `init/` attestation, `ceremony/` audit log, and
-`kp-shares/` encrypted-share recovery log here. The operator and key provisioner
-ceremony commands both read it.
+The guardian writes its `init/` attestation and a session-addressed
+`kp-shares/proposed/` record here. The operator and key provisioner ceremony
+commands both verify that proposal. Once every KP confirms, the guardian
+publishes the finalized `kp-shares/` recovery state and `ceremony/` audit log.
 
 Drives a fresh **ceremony-mode** guardian through the one-time genesis BTC key
 setup (`sharing_seq = 0`). It connects over gRPC and: `operator_init` (ceremony mode, S3-only) →
 `setup_new_key` → verifies the response signature and shape → confirms each
 share's recipient matches its expected KP cert and its PGP-encrypted ciphertext
-targets that cert (parsed without decrypting) → cross-checks the guardian's
-`ceremony/` audit log and `kp-shares/` recovery log.
-It then waits for every KP to confirm successful share recovery.
+targets that cert (parsed without decrypting) →
+cross-checks the guardian's `kp-shares/proposed/` record. It then waits for every
+KP to confirm successful share recovery and for the finalized `kp-shares/` and
+`ceremony/` records to be published.
 
 `kp_roster.kp_pgp_cert_paths` lists one certificate per KP, in any order.
 New ceremonies assign share IDs by fingerprint order; existing assignments
@@ -65,23 +67,24 @@ command uses `guardian_endpoint`, `hashi`, and `kp_roster`.
 
 ## key-provisioner ceremony
 
-Confirms a KP can fetch and decrypt their share from the latest setup or
-rotation ceremony. Trust is anchored to the guardian's S3 attestation log: it
-discovers the latest ceremony and KP-share state from S3, verifies each record
-against its writing session's attested signing pubkey and the expected `n`/`t`,
-and confirms each share's recipient and PGP-encrypted ciphertext match the
-expected KP cert. It then uses `kp_pgp_cert_path` to identify and decrypt this
-KP's share and verifies its commitment. After verification it saves the full
-ceremony state, including every KP's encrypted share and the public ceremony
-data, to the requested path, then
+Confirms a KP can fetch and decrypt their share from the live setup or rotation
+ceremony. Trust is anchored to the guardian's S3 attestation log: it verifies
+the live guardian, reads that session's exact `kp-shares/proposed/` record, and
+checks the proposal against the live secret-sharing instance and expected
+`n`/`t`. It then confirms each share's recipient and PGP-encrypted ciphertext
+match the expected KP cert, uses `kp_pgp_cert_path` to identify and decrypt this
+KP's share, and verifies its commitment. After verification it saves the full
+proposed ceremony state, including every KP's encrypted share and the public
+ceremony data, then
 signs and submits a confirmation to the live guardian. The guardian completes
-the ceremony only after all KP/share entries have confirmed.
+the ceremony and publishes the finalized `kp-shares/` and `ceremony/` records
+only after all KP/share entries have confirmed.
 For rotations, the external orchestrator must keep the ceremony guardian
 running after `RotateKpSet` returns until its lifecycle reaches `Completed`.
 
 Both ceremony commands verify live guardian info and Nitro attestation against
-the configured current build. The KP additionally anchors the ceremony and
-share logs to their writing session's S3 `init/` attestation.
+the configured current build. The KP additionally anchors the proposal to its
+writing session's S3 `init/` attestation.
 
 The selected ciphertext is piped from memory to `gpg` over stdin. No temporary
 ciphertext or plaintext file is written locally; only the verified ceremony

--- a/crates/hashi-guardian-init/src/kp_ceremony.rs
+++ b/crates/hashi-guardian-init/src/kp_ceremony.rs
@@ -64,23 +64,42 @@ pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
     // The selected cert identifies this KP's roster entry.
     let kp_pgp_cert_path = cfg.require_kp_pgp_cert_path("key-provisioner ceremony")?;
     let kp_cert = load_kp_cert(kp_pgp_cert_path)?;
+    let kp_fingerprint = kp_cert.fingerprint();
     certs_roster
-        .cert_for_fingerprint(&kp_cert.fingerprint())
+        .cert_for_fingerprint(&kp_fingerprint)
         .with_context(|| {
             format!(
                 "this KP's cert (fingerprint {}) is not among the configured \
                  kp_roster.kp_pgp_cert_paths",
-                kp_cert.fingerprint()
+                kp_fingerprint
             )
         })?;
     info!(
         phase = "setup",
-        fingerprint = %kp_cert.fingerprint(),
+        fingerprint = %kp_fingerprint,
         "identified this KP's configured certificate",
     );
 
-    // 1. Discover and verify the latest ceremony from the immutable log
-    //    (attestation-verified once via the reader's session-key cache).
+    // 1. Verify and pin the live guardian session, then read that session's
+    //    signed ceremony proposal as the source of provisional ceremony state.
+    info!(
+        phase = "confirmation",
+        endpoint = %cfg.guardian_endpoint,
+        "connecting to live ceremony guardian",
+    );
+    let mut client = GuardianServiceClient::connect(cfg.guardian_endpoint.clone())
+        .await
+        .with_context(|| format!("connect to ceremony guardian at {}", cfg.guardian_endpoint))?;
+    let verified =
+        verified_live_guardian_info(&mut client, cfg.kp_roster.pcr_allowlist.current_build())
+            .await?;
+    ensure!(
+        verified.info.lifecycle == CeremonyStage::AwaitingKeyProvisionerConfirmations.into()
+            || verified.info.lifecycle == CeremonyStage::Completed.into(),
+        "guardian is not accepting key provisioner ceremony confirmations"
+    );
+    let session_id = verified.session_id;
+
     info!(
         phase = "s3 connect",
         bucket = guardian_s3.bucket_name(),
@@ -95,11 +114,9 @@ pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
 
     info!(
         phase = "ceremony scrape",
-        "scraping latest ceremony/ + kp-shares/ logs (attestation-anchored)",
+        "scraping this guardian session's ceremony proposal (attestation-anchored)",
     );
-    let state = reader
-        .read_latest_ceremony_state_from_current_build()
-        .await?;
+    let state = reader.read_live_ceremony_proposal(&session_id).await?;
     state.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     info!(
         phase = "ceremony scrape",
@@ -120,7 +137,7 @@ pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
     state.encrypted_shares.verify_recipient_set(&certs_roster)?;
     info!(
         phase = "roster verify",
-        "ceremony/ and kp-shares/ logs verified against expected params and KP certs",
+        "ceremony proposal verified against expected params and KP certs",
     );
 
     // 3. Decrypt and commitment-check this KP's ciphertext.
@@ -162,24 +179,7 @@ pub async fn run(cfg: Config, encrypted_shares_path: &Path) -> Result<()> {
 
     // 5. Submit a signed confirmation only after the verified recovery artifact
     //    is safely stored locally.
-    info!(
-        phase = "confirmation",
-        endpoint = %cfg.guardian_endpoint,
-        "connecting to live ceremony guardian",
-    );
-    let mut client = GuardianServiceClient::connect(cfg.guardian_endpoint.clone())
-        .await
-        .with_context(|| format!("connect to ceremony guardian at {}", cfg.guardian_endpoint))?;
-    let verified =
-        verified_live_guardian_info(&mut client, cfg.kp_roster.pcr_allowlist.current_build())
-            .await?;
-    ensure!(
-        verified.info.lifecycle == CeremonyStage::AwaitingKeyProvisionerConfirmations.into()
-            || verified.info.lifecycle == CeremonyStage::Completed.into(),
-        "guardian is not accepting key provisioner ceremony confirmations"
-    );
-    let kp_fingerprint = kp_cert.fingerprint();
-    let confirmation = CeremonyConfirmationRequest::new(verified.session_id, state.digest());
+    let confirmation = CeremonyConfirmationRequest::new(session_id, state.digest());
     let signed = KpSigned::sign(confirmation, kp_cert, None)
         .map_err(anyhow::Error::msg)
         .context("sign ceremony confirmation with the KP key")?;

--- a/crates/hashi-guardian-init/src/operator_ceremony.rs
+++ b/crates/hashi-guardian-init/src/operator_ceremony.rs
@@ -7,8 +7,8 @@
 //! [`OperatorInit`] (ceremony mode, S3-only) -> [`SetupNewKey`] -> confirm each
 //! share's recipient matches its expected KP cert and its ciphertext targets
 //! that cert (without decrypting) -> cross-check the
-//! guardian's `ceremony/` audit log and `kp-shares/` recovery log -> wait for
-//! every KP to confirm successful recovery.
+//! guardian's session-scoped `kp-shares/proposed/` record -> wait for every KP
+//! to confirm successful recovery and commit the finalized logs.
 //!
 //! [`OperatorInit`]: hashi_types::guardian::OperatorInitRequest
 //! [`SetupNewKey`]: hashi_types::guardian::SetupNewKeyRequest
@@ -213,28 +213,26 @@ pub async fn run(cfg: Config) -> Result<()> {
         "all returned PGP-encrypted share ciphertexts verified against expected KP certificates",
     );
 
-    // 9. Cross-check the latest guardian ceremony/ and kp-shares/ logs.
-    //    KPs will fetch the same KP share state during key-provisioner ceremony.
+    // 9. Cross-check this session's proposed ceremony state. KPs will fetch the
+    //    same proposal during key-provisioner ceremony.
     info!(
         phase = "log cross-check",
-        "cross-checking the latest guardian ceremony/ and kp-shares/ logs",
+        "cross-checking this guardian session's ceremony proposal",
     );
-    let logged = reader
-        .read_latest_ceremony_state_from_current_build()
-        .await?;
+    let logged = reader.read_live_ceremony_proposal(&session_id).await?;
     logged.validate_sharing_params(cfg.kp_roster.num_shares, cfg.kp_roster.threshold)?;
     anyhow::ensure!(
         logged == live,
-        "ceremony/ and kp-shares/ logs differ from the SetupNewKeyResponse"
+        "ceremony proposal differs from the SetupNewKeyResponse"
     );
     info!(
         phase = "log cross-check",
-        "ceremony/ and kp-shares/ logs match the SetupNewKeyResponse",
+        "ceremony proposal matches the SetupNewKeyResponse",
     );
 
     info!(
         phase = "KP confirmations",
-        "ceremony state published; waiting for every key provisioner to run key-provisioner ceremony",
+        "ceremony proposal published; waiting for every key provisioner to run key-provisioner ceremony",
     );
     loop {
         let status = match verified_live_guardian_info(&mut client, allowlist.current_build()).await

--- a/crates/hashi-guardian/README.md
+++ b/crates/hashi-guardian/README.md
@@ -73,6 +73,7 @@ Canonical key layout:
 - `heartbeat/{yyyy}/{mm}/{dd}/{hh}/{session_id}-{counter:020}.json`
 - `withdraw/{yyyy}/{mm}/{dd}/{hh}/success-{seq:020}-{session_id}-wid{wid}.json`
 - `withdraw/{yyyy}/{mm}/{dd}/{hh}/failure-{session_id}-wid{wid}-{rand32}.json`
+- `kp-shares/proposed/{session_id}.json`
 - `ceremony/{sharing_seq:020}-{session_id}.json`
 - `kp-shares/{sharing_seq:020}/{cert_seq:020}-{session_id}.json`
 - `genesis/record.json`
@@ -84,7 +85,7 @@ Where:
 - `session_id` is the first 16 hex chars of the enclave ephemeral signing pubkey (lowercase). Acts as a short per-session tag in keys; full pubkey verification still happens via the signed log payload (`SessionID::HEX_LEN` in `hashi-types`).
 - `counter` is a zero-padded decimal sequence number (used in heartbeats only).
 - `seq` (in `withdraw/`) is the zero-padded limiter sequence number consumed by the withdrawal.
-- `sharing_seq` (in `ceremony/`) is a zero-padded rotation counter — `setup_new_key` writes `0`; each `rotate_kp_set` appends `prev+1`.
+- `sharing_seq` (in `ceremony/`) is a zero-padded rotation counter — completed setup publishes `0`; each completed KP-set rotation appends `prev+1`.
 - `cert_seq` (in `kp-shares/`) is a zero-padded recipient-cert state counter within one `sharing_seq`. Setup/rotation write `0`; future individual KP cert rotations append higher values.
 - `new_epoch` / `proposed_epoch` (in `committee-update/`) are the zero-padded committee epoch numbers — `new_epoch` is the just-applied epoch for successes; `proposed_epoch` is the requested epoch for failures. Hashi reconfig is sparse, so neither is guaranteed to be `from_epoch + 1`.
 - `rand32` is a random 32-hex suffix to avoid key collisions (failures only — successes are uniquely keyed by seq).
@@ -94,8 +95,9 @@ Where:
 - `init` logs are grouped per session and numerically ordered by lifecycle step.
 - `heartbeat` logs are hour-partitioned and strictly ordered per session.
 - `withdraw` logs are hour-partitioned. Successes are seq-sorted within a bucket so the KP rotating in the next enclave can recover limiter state by reading the lexicographically last success key.
-- `ceremony` logs are flat (not date-partitioned). Each entry is a `CeremonyLogMessage` — `NewKey { instance }` written by `setup_new_key` (genesis, `sharing_seq=0`) or `Rotate { old_instance, new_instance }` written by `rotate_kp_set` (each rotation, `sharing_seq=prev+1`). A rotation records the `old_instance` it consumed so the chain is auditable from the log alone (each entry's `old_instance` should match the prior entry's instance). KPs read the lexicographically last entry to learn the current authoritative instance (commitments + N + T). The log does not carry encrypted shares or a separate recipient roster.
-- `kp-shares` logs carry the current encrypted KP share state for a `sharing_seq`. Written by `setup_new_key` (`sharing_seq=0, cert_seq=0`) and each `rotate_kp_set` (`cert_seq=0` for the new instance). Each share id has one recipient fingerprint and one PGP-encrypted ciphertext. An individual certificate rotation can append a higher `cert_seq` entry under the same `sharing_seq`; readers take the lexicographically last entry under `kp-shares/{sharing_seq:020}/`. Integrity is the enclave signature, not S3 immutability, so these get only a short object lock (a fetch-window guarantee) and stay readable until purged.
+- `kp-shares/proposed` contains one session-addressed ceremony proposal with the ceremony metadata and initial encrypted KP shares. Ceremony participants read this record before confirmation. Proposals use the short object-lock policy and are not authoritative serving state.
+- `ceremony` logs are flat (not date-partitioned) and contain only completed ceremonies. After every KP confirms a proposal, the guardian writes its initial finalized `kp-shares` state and then its `CeremonyLogMessage`; the ceremony write is the commit record. `NewKey { instance }` represents genesis (`sharing_seq=0`) and `Rotate { old_instance, new_instance }` advances `sharing_seq` by one. A rotation records the `old_instance` it consumed so the chain is auditable from the log alone. Readers select the lexicographically last ceremony as the current authoritative instance.
+- Finalized `kp-shares` logs carry the current encrypted KP share state for a completed `sharing_seq`. Setup and KP-set rotation publish `cert_seq=0` during ceremony completion; individual KP cert rotations append higher `cert_seq` entries. Each share id has one recipient fingerprint and one PGP-encrypted ciphertext. Readers take the lexicographically last entry under `kp-shares/{sharing_seq:020}/`. Integrity is the enclave signature, not S3 immutability, so these get only a short object lock (a fetch-window guarantee) and stay readable until purged.
 - `genesis` is a fixed singleton record carrying the first-deploy committee, Hashi object id, and MPC master `G` after KP-authorized PI reaches threshold, before any `committee-update/` success exists. Deployed V1 records contain only the committee.
 - `committee-update` logs are flat (not date-partitioned). Successes are epoch-sorted; failures lead with `failure-` so all successes sort first — the lex-last non-`failure-` key is the latest successfully-applied epoch.
 
@@ -103,6 +105,6 @@ Where:
 
 - `init/{session_id}-...` keeps init logs session-addressable.
 - `heartbeat/...` and `withdraw/...` date partitions support efficient hour-based polling.
-- `ceremony/` and `committee-update/` are flat because the consumer always wants "latest"; a lex sort over the whole prefix is cheap and gives that directly. `kp-shares/` is nested by `sharing_seq` because readers want the latest cert state within one current sharing instance. `genesis/record.json` is fixed because there is at most one bootstrap record.
+- `ceremony/` and `committee-update/` are flat because the consumer always wants "latest"; a lex sort over the whole prefix is cheap and gives that directly. `kp-shares/proposed/` is session-addressed because a live ceremony has exactly one proposal. Finalized `kp-shares/` is nested by `sharing_seq` because readers want the latest cert state within one current sharing instance. `genesis/record.json` is fixed because there is at most one bootstrap record.
 - Zero-padding (`{seq:020}` in `withdraw/`, `{sharing_seq:020}` in `ceremony/`, `{cert_seq:020}` in `kp-shares/`, `{new_epoch:020}` in `committee-update/`) makes lexicographic order over the keys equal seq/epoch order. The signed log payload embeds the same value, so a fetched object's filename and content can be cross-checked.
 - Prefixes (`init`, `heartbeat`, `withdraw`, `ceremony`, `kp-shares`, `genesis`, `committee-update`) allow independent S3 deletion policies.

--- a/crates/hashi-guardian/src/ceremony_mode/confirm.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/confirm.rs
@@ -45,6 +45,7 @@ pub async fn confirm_ceremony(
     );
 
     if status.completed && lifecycle == CeremonyStage::AwaitingKeyProvisionerConfirmations.into() {
+        enclave.publish_pending_ceremony(pending).await?;
         enclave
             .advance_lifecycle_into(CeremonyStage::Completed.into())
             .expect("all KP confirmations should complete the ceremony lifecycle");
@@ -60,6 +61,7 @@ mod tests {
     use crate::ceremony_mode::setup::setup_new_key;
     use crate::mock_logger_capturing;
     use crate::test_utils::mock_kp_certs_roster_with_secrets;
+    use crate::test_utils::CapturedPuts;
     use crate::test_utils::MockKpSecretKeys;
     use hashi_types::guardian::CeremonyState;
     use hashi_types::guardian::KpCertRoster;
@@ -77,11 +79,12 @@ mod tests {
         ceremony_digest: [u8; 32],
         roster: KpCertRoster,
         secret_keys: MockKpSecretKeys,
+        captures: CapturedPuts,
     }
 
     async fn setup_context() -> TestContext {
         let (roster, secret_keys) = mock_kp_certs_roster_with_secrets(TEST_N);
-        let (logger, _) = mock_logger_capturing();
+        let (logger, captures) = mock_logger_capturing();
         let enclave = Enclave::create_operator_initialized_ceremony(logger);
         let response = setup_new_key(
             enclave.clone(),
@@ -97,6 +100,7 @@ mod tests {
             ceremony_digest: CeremonyState::from(response).digest(),
             roster,
             secret_keys,
+            captures,
         }
     }
 
@@ -136,6 +140,7 @@ mod tests {
             context.enclave.lifecycle(),
             CeremonyStage::AwaitingKeyProvisionerConfirmations.into()
         );
+        assert_eq!(context.captures.lock().unwrap().len(), 1);
 
         let first = context.signed_confirmation(0);
         let status = confirm_ceremony(context.enclave.clone(), first.clone())
@@ -158,6 +163,15 @@ mod tests {
             assert_eq!(status.completed, index + 1 == TEST_N);
         }
         assert_eq!(context.enclave.lifecycle(), CeremonyStage::Completed.into());
+        {
+            let captured = context.captures.lock().unwrap();
+            assert_eq!(captured.len(), 3);
+            assert!(captured[0].0.starts_with("kp-shares/proposed/"));
+            assert!(captured[1]
+                .0
+                .starts_with("kp-shares/00000000000000000000/00000000000000000000-"));
+            assert!(captured[2].0.starts_with("ceremony/00000000000000000000-"));
+        }
         let repeated = confirm_ceremony(
             context.enclave.clone(),
             context.signed_confirmation(TEST_N - 1),
@@ -165,6 +179,7 @@ mod tests {
         .await
         .unwrap();
         assert!(repeated.completed);
+        assert_eq!(context.captures.lock().unwrap().len(), 3);
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian/src/ceremony_mode/rotate.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/rotate.rs
@@ -218,30 +218,21 @@ async fn finalize_rotation(
 
     let new_sharing_seq = old_instance.sharing_seq() + 1;
     let new_instance = SecretSharingInstance::new(share_commitments, n, t, new_sharing_seq)?;
-    info!(
-        "Persisting rotation sharing_seq={new_sharing_seq} cert_seq=0 to kp-shares/ + ceremony/."
-    );
-    enclave
-        .log_kp_share_state(new_sharing_seq, 0, encrypted_shares.clone())
-        .await?;
-
     let ceremony_log = CeremonyLogMessage::Rotate {
         old_instance: old_instance.clone(),
         new_instance: new_instance.clone(),
         btc_master_pubkey,
     };
-    enclave.log_ceremony(ceremony_log.clone()).await?;
+    let proposal = CeremonyProposalLogMessage::new(ceremony_log, encrypted_shares.clone());
+    info!("Persisting rotation proposal to kp-shares/proposed/.");
+    enclave.log_ceremony_proposal(proposal.clone()).await?;
 
     info!("Rotation complete; awaiting every new key provisioner's confirmation.");
     let response = RotateKpSetResponse {
         encrypted_shares,
         new_instance,
     };
-    let pending_state = CeremonyState::new(
-        ceremony_log,
-        KpShareStateLogMessage::new(new_sharing_seq, 0, response.encrypted_shares.clone()),
-    )?;
-    enclave.install_pending_ceremony(pending_state)?;
+    enclave.install_pending_ceremony(proposal)?;
     Ok(enclave.sign(response))
 }
 
@@ -431,9 +422,8 @@ mod tests {
             .response
     }
 
-    /// Assert the rotation returned `new_n` PGP-armored shares and produced
-    /// exactly one `ceremony/` log at `sharing_seq = 1` carrying the instance
-    /// only (no ciphertexts).
+    /// Assert the rotation returned `new_n` PGP-armored shares and produced one
+    /// session-scoped proposal without publishing finalized ceremony state.
     fn assert_rotation_output(
         captures: &CapturedPuts,
         response: &RotateKpSetResponse,
@@ -453,32 +443,23 @@ mod tests {
         }
 
         let captured = captures.lock().unwrap();
-        let ceremony_logs: Vec<_> = captured
-            .iter()
-            .filter(|(k, _)| k.starts_with("ceremony/"))
-            .collect();
-        assert_eq!(ceremony_logs.len(), 1, "expected one ceremony/ log");
-        let (key, body) = ceremony_logs[0];
+        assert!(!captured.iter().any(|(key, _)| key.starts_with("ceremony/")));
+        assert_eq!(captured.len(), 1, "expected only the ceremony proposal");
+        let (key, body) = &captured[0];
         assert!(
-            key.starts_with("ceremony/00000000000000000001-"),
-            "expected sharing_seq=1, got key {key}"
+            key.starts_with("kp-shares/proposed/"),
+            "expected a proposed KP-share key, got {key}"
         );
-        assert!(
-            !std::str::from_utf8(body)
-                .unwrap()
-                .contains("BEGIN PGP MESSAGE"),
-            "ceremony log must not contain ciphertexts"
-        );
-
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessageV2::Ceremony(ceremony)) = record.message() else {
-            panic!("expected V2 Ceremony variant");
+        let VersionedLogMessage::V2(LogMessageV2::CeremonyProposal(proposal)) = record.message()
+        else {
+            panic!("expected V2 CeremonyProposal variant");
         };
         let CeremonyLogMessage::Rotate {
             old_instance,
             new_instance,
             btc_master_pubkey,
-        } = ceremony.as_ref()
+        } = &proposal.ceremony
         else {
             panic!("expected Rotate variant");
         };
@@ -505,28 +486,8 @@ mod tests {
             "threshold decrypted rotation shares should reconstruct the original key"
         );
 
-        // The new shares are persisted to kp-shares/ keyed by the new sharing_seq
-        // and initial cert_seq=0.
-        let shares_logs: Vec<_> = captured
-            .iter()
-            .filter(|(k, _)| k.starts_with("kp-shares/"))
-            .collect();
-        assert_eq!(shares_logs.len(), 1, "expected one kp-shares/ log");
-        let (shares_key, shares_body) = shares_logs[0];
-        assert!(
-            shares_key.starts_with("kp-shares/00000000000000000001/00000000000000000000-"),
-            "expected sharing_seq=1 cert_seq=0, got key {shares_key}"
-        );
-        let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessageV2::KpShareState(shares)) = shares_record.message()
-        else {
-            panic!("expected V2 KpShareState variant");
-        };
-        let shares = shares.as_ref();
-        assert_eq!(shares.sharing_seq, 1);
-        assert_eq!(shares.cert_seq, 0);
-        assert_eq!(shares.encrypted_shares, *response_shares);
-        assert_eq!(shares.encrypted_shares.share_count(), new_n);
+        assert_eq!(proposal.encrypted_shares, *response_shares);
+        assert_eq!(proposal.encrypted_shares.share_count(), new_n);
     }
 
     #[tokio::test]
@@ -574,11 +535,8 @@ mod tests {
         assert!(matches!(err, LifecycleMismatch { .. }));
 
         let captured = ctx.captures.lock().unwrap();
-        let count = captured
-            .iter()
-            .filter(|(k, _)| k.starts_with("ceremony/"))
-            .count();
-        assert_eq!(count, 1, "rotation must finalize exactly once");
+        assert_eq!(captured.len(), 1, "rotation must create one proposal");
+        assert!(captured[0].0.starts_with("kp-shares/proposed/"));
     }
 
     #[tokio::test]

--- a/crates/hashi-guardian/src/ceremony_mode/setup.rs
+++ b/crates/hashi-guardian/src/ceremony_mode/setup.rs
@@ -12,7 +12,7 @@ use tracing::info;
 /// Set up a new BTC key. Flow:
 ///     1. KPs send their OpenPGP certificates to the operator
 ///     2. Operator calls setup_new_key
-///     3. KPs fetch commitments from `ceremony/` and ciphertexts from `kp-shares/`
+///     3. KPs fetch the proposed ceremony state from `kp-shares/proposed/`
 pub async fn setup_new_key(
     enclave: Arc<Enclave>,
     request: SetupNewKeyRequest,
@@ -59,24 +59,22 @@ pub async fn setup_new_key(
     let ss_instance = SecretSharingInstance::new(share_commitments.clone(), n, t, 0)
         .expect("(n, t) validated by SetupNewKeyRequest; commitments produced with matching count");
 
-    info!("Persisting setup sharing_seq=0 cert_seq=0 to kp-shares/ + ceremony/.");
-    enclave
-        .log_kp_share_state(0, 0, encrypted_shares.clone())
-        .await?;
-
-    enclave
-        .log_ceremony(CeremonyLogMessage::NewKey {
+    let proposal = CeremonyProposalLogMessage::new(
+        CeremonyLogMessage::NewKey {
             instance: ss_instance.clone(),
             btc_master_pubkey,
-        })
-        .await?;
+        },
+        encrypted_shares.clone(),
+    );
+    info!("Persisting setup proposal to kp-shares/proposed/.");
+    enclave.log_ceremony_proposal(proposal.clone()).await?;
 
     let response = SetupNewKeyResponse {
         encrypted_shares,
         secret_sharing_instance: ss_instance,
         btc_master_pubkey,
     };
-    enclave.install_pending_ceremony(CeremonyState::from(response.clone()))?;
+    enclave.install_pending_ceremony(proposal)?;
     let response = enclave.sign(response);
 
     enclave
@@ -145,29 +143,24 @@ mod tests {
             "threshold decrypted setup shares should reconstruct the ceremony key"
         );
 
-        // The ceremony log records the instance only — no ciphertexts.
+        // Only the session-scoped proposal is visible before KP confirmation.
         let captured = captures.lock().unwrap();
-        let ceremony_logs: Vec<_> = captured
-            .iter()
-            .filter(|(k, _)| k.starts_with("ceremony/"))
-            .collect();
-        assert_eq!(ceremony_logs.len(), 1, "expected one ceremony/ log");
-        let (_key, body) = ceremony_logs[0];
-        assert!(
-            !std::str::from_utf8(body)
-                .unwrap()
-                .contains("BEGIN PGP MESSAGE"),
-            "ceremony log must not contain ciphertexts"
+        assert!(!captured.iter().any(|(key, _)| key.starts_with("ceremony/")));
+        assert_eq!(captured.len(), 1, "expected only the ceremony proposal");
+        let (key, body) = &captured[0];
+        assert_eq!(
+            key,
+            &format!("kp-shares/proposed/{}.json", enclave.s3_session_id())
         );
-
         let record: LogRecord = serde_json::from_slice(body).unwrap();
-        let VersionedLogMessage::V2(LogMessageV2::Ceremony(ceremony)) = record.message() else {
-            panic!("expected V2 Ceremony variant");
+        let VersionedLogMessage::V2(LogMessageV2::CeremonyProposal(proposal)) = record.message()
+        else {
+            panic!("expected V2 CeremonyProposal variant");
         };
         let CeremonyLogMessage::NewKey {
             instance,
             btc_master_pubkey,
-        } = ceremony.as_ref()
+        } = &proposal.ceremony
         else {
             panic!("expected NewKey variant");
         };
@@ -175,37 +168,10 @@ mod tests {
         assert_eq!(instance.sharing_seq(), 0);
         assert_eq!(instance.num_shares(), TEST_N);
         assert_eq!(instance.threshold(), TEST_T);
-        // The ceremony log records the same BTC master pubkey as the response.
         assert_eq!(*btc_master_pubkey, validated_resp.btc_master_pubkey);
-
-        // The encrypted shares are persisted to kp-shares/ keyed by sharing_seq
-        // and cert_seq, and carry the ciphertexts the ceremony log omits.
-        let shares_logs: Vec<_> = captured
-            .iter()
-            .filter(|(k, _)| k.starts_with("kp-shares/"))
-            .collect();
-        assert_eq!(shares_logs.len(), 1, "expected one kp-shares/ log");
-        let (shares_key, shares_body) = shares_logs[0];
-        assert_eq!(
-            *shares_key,
-            format!(
-                "kp-shares/{:020}/{:020}-{}.json",
-                0,
-                0,
-                enclave.s3_session_id()
-            )
-        );
-        let shares_record: LogRecord = serde_json::from_slice(shares_body).unwrap();
-        let VersionedLogMessage::V2(LogMessageV2::KpShareState(shares)) = shares_record.message()
-        else {
-            panic!("expected V2 KpShareState variant");
-        };
-        let shares = shares.as_ref();
-        assert_eq!(shares.sharing_seq, 0);
-        assert_eq!(shares.cert_seq, 0);
-        assert_eq!(shares.encrypted_shares, validated_resp.encrypted_shares);
-        assert_eq!(shares.encrypted_shares.share_count(), TEST_N);
-        assert!(std::str::from_utf8(shares_body)
+        assert_eq!(proposal.encrypted_shares, validated_resp.encrypted_shares);
+        assert_eq!(proposal.encrypted_shares.share_count(), TEST_N);
+        assert!(std::str::from_utf8(body)
             .unwrap()
             .contains("BEGIN PGP MESSAGE"));
     }

--- a/crates/hashi-guardian/src/enclave.rs
+++ b/crates/hashi-guardian/src/enclave.rs
@@ -104,18 +104,19 @@ pub struct TemporaryInitState {
 }
 
 pub(crate) struct PendingCeremony {
+    proposal: CeremonyProposalLogMessage,
     digest: [u8; 32],
-    encrypted_shares: KpEncryptedShareRoster,
     confirmed_share_ids: RwLock<BTreeSet<ShareID>>,
 }
 
 impl PendingCeremony {
-    fn new(state: CeremonyState) -> Self {
-        Self {
+    fn new(proposal: CeremonyProposalLogMessage) -> GuardianResult<Self> {
+        let state = CeremonyState::from_proposal(proposal.clone())?;
+        Ok(Self {
+            proposal,
             digest: state.digest(),
-            encrypted_shares: state.encrypted_shares,
             confirmed_share_ids: RwLock::new(BTreeSet::new()),
-        }
+        })
     }
 
     pub(crate) fn validate_confirmation(
@@ -129,6 +130,7 @@ impl PendingCeremony {
             ));
         }
         let share = self
+            .proposal
             .encrypted_shares
             .find_by_fingerprint(signer_fingerprint)
             .ok_or_else(|| {
@@ -153,7 +155,10 @@ impl PendingCeremony {
             .write()
             .expect("pending ceremony lock poisoned");
         confirmed.insert(share_id);
-        CeremonyConfirmationResponse::new(confirmed.len(), self.encrypted_shares.share_count())
+        CeremonyConfirmationResponse::new(
+            confirmed.len(),
+            self.proposal.encrypted_shares.share_count(),
+        )
     }
 
     pub(crate) fn status(&self) -> GuardianResult<CeremonyConfirmationResponse> {
@@ -162,7 +167,7 @@ impl PendingCeremony {
                 .read()
                 .expect("pending ceremony lock poisoned")
                 .len(),
-            self.encrypted_shares.share_count(),
+            self.proposal.encrypted_shares.share_count(),
         )
     }
 
@@ -696,6 +701,32 @@ impl Enclave {
         self.write_log(LogMessage::Ceremony(Box::new(state))).await
     }
 
+    pub async fn log_ceremony_proposal(
+        &self,
+        proposal: CeremonyProposalLogMessage,
+    ) -> GuardianResult<()> {
+        self.write_log(LogMessage::CeremonyProposal(Box::new(proposal)))
+            .await
+    }
+
+    /// Publish the pending ceremony to the established authoritative locations.
+    /// The ceremony record is written last and therefore acts as the commit.
+    pub(crate) async fn publish_pending_ceremony(
+        &self,
+        pending: &PendingCeremony,
+    ) -> GuardianResult<()> {
+        let CeremonyProposalLogMessage {
+            ceremony,
+            encrypted_shares,
+        } = pending.proposal.clone();
+        let kp_share_state =
+            KpShareStateLogMessage::new(ceremony.sharing_seq(), 0, encrypted_shares);
+        self.write_log(LogMessage::KpShareState(Box::new(kp_share_state)))
+            .await?;
+        self.write_log(LogMessage::Ceremony(Box::new(ceremony)))
+            .await
+    }
+
     /// Persist the current encrypted KP share state to `kp-shares/` for recovery.
     /// `sharing_seq` pairs it with the matching `ceremony/` instance, while
     /// `cert_seq` versions recipient-cert rotations within that instance.
@@ -715,9 +746,13 @@ impl Enclave {
     // Pending Ceremony State
     // ========================================================================
 
-    pub(crate) fn install_pending_ceremony(&self, state: CeremonyState) -> GuardianResult<()> {
+    pub(crate) fn install_pending_ceremony(
+        &self,
+        proposal: CeremonyProposalLogMessage,
+    ) -> GuardianResult<()> {
+        let pending = PendingCeremony::new(proposal)?;
         self.pending_ceremony
-            .set(PendingCeremony::new(state))
+            .set(pending)
             .map_err(|_| InvalidInputs("Pending ceremony state already set".into()))
     }
 

--- a/crates/hashi-guardian/src/s3_reader/mod.rs
+++ b/crates/hashi-guardian/src/s3_reader/mod.rs
@@ -11,6 +11,7 @@ use crate::s3_client::GuardianS3Client;
 use crate::s3_client::ImmutabilityCheck;
 use hashi_types::guardian::s3::S3HourScopedDirectory;
 use hashi_types::guardian::CeremonyLogMessage;
+use hashi_types::guardian::CeremonyProposalLogMessage;
 use hashi_types::guardian::CeremonyState;
 use hashi_types::guardian::CommitteeUpdateLogMessage;
 use hashi_types::guardian::GenesisLogMessage;
@@ -219,6 +220,33 @@ impl GuardianReader {
     ) -> GuardianResult<KpShareStateLogMessage> {
         let key = KpShareStateLogMessage::object_key(session_id, sharing_seq, cert_seq);
         self.read_kp_share_state_log_at_key(&key, true).await
+    }
+
+    /// Read and verify the proposal written by one live ceremony session.
+    pub async fn read_live_ceremony_proposal(
+        &mut self,
+        session_id: &SessionID,
+    ) -> GuardianResult<CeremonyState> {
+        let key = CeremonyProposalLogMessage::object_key(session_id);
+        // A live proposal has just been published, so its short-lived Compliance
+        // lock must still be active.
+        let verified_record = self.read_verified_record(&key).await?;
+        self.allowlist
+            .require_current_build(verified_record.build_pcrs())?;
+        let writing_session_id = verified_record.entry().session_id().clone();
+        let proposal = match verified_record.into_entry().into_message() {
+            V2(LogMessageV2::CeremonyProposal(proposal)) => *proposal,
+            V1(_) | V2(_) => {
+                return Err(InvalidS3Log(format!(
+                    "expected a ceremony proposal log at {key}"
+                )));
+            }
+        };
+        let state = CeremonyState::from_proposal(proposal).map_err(|error| {
+            InvalidS3Log(format!("invalid ceremony proposal at {key}: {error}"))
+        })?;
+        log_verified_read(&key, &writing_session_id);
+        Ok(state)
     }
 
     /// Read and verify one KP-share object under the requested build policy.

--- a/crates/hashi-guardian/src/s3_reader/verified.rs
+++ b/crates/hashi-guardian/src/s3_reader/verified.rs
@@ -67,7 +67,10 @@ impl InitCheckpoint {
                 EnclaveMode::Ceremony => Self::OperatorInitialized,
                 EnclaveMode::Withdraw => Self::OperatorActivated,
             },
-            LogType::Heartbeat | LogType::Ceremony | LogType::Genesis => Self::OperatorInitialized,
+            LogType::Heartbeat
+            | LogType::CeremonyCompleted
+            | LogType::CeremonyProposal
+            | LogType::Genesis => Self::OperatorInitialized,
         };
         Ok(required)
     }
@@ -343,7 +346,12 @@ mod tests {
                 InitCheckpoint::required_for(LogType::CommitteeUpdate, mode).unwrap(),
                 OperatorActivated
             );
-            for log_type in [LogType::Heartbeat, LogType::Ceremony, LogType::Genesis] {
+            for log_type in [
+                LogType::Heartbeat,
+                LogType::CeremonyCompleted,
+                LogType::CeremonyProposal,
+                LogType::Genesis,
+            ] {
                 assert_eq!(
                     InitCheckpoint::required_for(log_type, mode).unwrap(),
                     OperatorInitialized

--- a/crates/hashi-types/src/guardian/ceremony_state.rs
+++ b/crates/hashi-types/src/guardian/ceremony_state.rs
@@ -4,6 +4,7 @@
 //! Combined ceremony and KP share state derived from guardian log messages.
 
 use super::s3::log::CeremonyLogMessage;
+use super::s3::log::CeremonyProposalLogMessage;
 use super::s3::log::KpShareStateLogMessage;
 use crate::bitcoin::BitcoinPubkey;
 use crate::guardian::GuardianError;
@@ -51,6 +52,22 @@ impl CeremonyState {
             btc_master_pubkey,
             kp_share_state.cert_seq,
             kp_share_state.encrypted_shares,
+        )
+    }
+
+    /// Validate and combine a live ceremony proposal into the state confirmed
+    /// by ceremony participants.
+    pub fn from_proposal(proposal: CeremonyProposalLogMessage) -> GuardianResult<Self> {
+        let CeremonyProposalLogMessage {
+            ceremony,
+            encrypted_shares,
+        } = proposal;
+        let (secret_sharing_instance, btc_master_pubkey) = ceremony.into_instance_and_pubkey();
+        Self::from_parts(
+            secret_sharing_instance,
+            btc_master_pubkey,
+            0,
+            encrypted_shares,
         )
     }
 

--- a/crates/hashi-types/src/guardian/mod.rs
+++ b/crates/hashi-types/src/guardian/mod.rs
@@ -99,8 +99,6 @@ pub struct GuardianInfo {
     pub secret_sharing_instance: Option<SecretSharingInstance>,
     /// S3 bucket name (if set). Used by KPs to check S3 bucket info.
     pub bucket_info: Option<S3BucketInfo>,
-    // TODO(SEC-525): Include the Bitcoin network in signed GuardianInfo so
-    // readers with a trusted expected network can validate it.
     /// Encryption key. Used by KPs to encrypt their shares.
     #[serde(with = "hex::serde")]
     pub encryption_pubkey: EncPubKeyBytes,
@@ -291,8 +289,10 @@ pub struct CeremonyOperatorInitRequest {
     pub s3_config: ResolvedS3Config,
 }
 
-/// TODO: Replace the operator-authored setup request with a batch of new-KP-signed
-/// approvals binding the session, roster, sharing params, and S3 policy.
+/// New KPs authorize the session, roster, and sharing parameters by confirming
+/// the live proposal digest before completed ceremony state is published.
+/// TODO(SEC-525): Bind the ceremony's Bitcoin network and S3 retention
+/// environment into the proposal digest that every KP confirms.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SetupNewKeyRequest {
     /// One ordered KP certificate per secret share.

--- a/crates/hashi-types/src/guardian/s3/log_messages/ceremony.rs
+++ b/crates/hashi-types/src/guardian/s3/log_messages/ceremony.rs
@@ -3,7 +3,9 @@
 
 use super::super::log_layout::ObjectKeyPattern;
 use super::super::log_layout::S3_DIR_CEREMONY;
+use super::super::log_layout::S3_DIR_KP_SHARES;
 use crate::bitcoin::BitcoinPubkey;
+use crate::guardian::KpEncryptedShareRoster;
 use crate::guardian::SecretSharingInstance;
 use serde::Deserialize;
 use serde::Serialize;
@@ -82,5 +84,34 @@ impl CeremonyLogMessage {
 
     pub fn object_key_pattern(&self, session_id: &str) -> ObjectKeyPattern {
         ObjectKeyPattern::Fixed(self.object_key(session_id))
+    }
+}
+
+/// A ceremony attempt awaiting confirmation from every key provisioner.
+///
+/// The proposal carries the ceremony metadata and encrypted shares that will
+/// become authoritative only after every key provisioner confirms.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct CeremonyProposalLogMessage {
+    pub ceremony: CeremonyLogMessage,
+    pub encrypted_shares: KpEncryptedShareRoster,
+}
+
+impl CeremonyProposalLogMessage {
+    pub fn new(ceremony: CeremonyLogMessage, encrypted_shares: KpEncryptedShareRoster) -> Self {
+        Self {
+            ceremony,
+            encrypted_shares,
+        }
+    }
+
+    /// `kp-shares/proposed/{session_id}.json` — one proposal per ceremony
+    /// enclave session.
+    pub fn object_key(session_id: &str) -> String {
+        format!("{S3_DIR_KP_SHARES}/proposed/{session_id}.json")
+    }
+
+    pub fn object_key_pattern(&self, session_id: &str) -> ObjectKeyPattern {
+        ObjectKeyPattern::Fixed(Self::object_key(session_id))
     }
 }

--- a/crates/hashi-types/src/guardian/s3/log_record.rs
+++ b/crates/hashi-types/src/guardian/s3/log_record.rs
@@ -397,6 +397,7 @@ impl LogRecord {
 mod tests {
     use super::*;
     use crate::guardian::CeremonyLogMessage;
+    use crate::guardian::CeremonyProposalLogMessage;
     use crate::guardian::CommitteeUpdateLogMessage;
     use crate::guardian::GenesisLogMessage;
     use crate::guardian::GuardianError;
@@ -565,10 +566,21 @@ mod tests {
             (
                 "ceremony rotate",
                 LogMessage::Ceremony(Box::new(CeremonyLogMessage::Rotate {
-                    old_instance: instance_0,
-                    new_instance: instance_1,
+                    old_instance: instance_0.clone(),
+                    new_instance: instance_1.clone(),
                     btc_master_pubkey,
                 })),
+            ),
+            (
+                "ceremony proposal",
+                LogMessage::CeremonyProposal(Box::new(CeremonyProposalLogMessage::new(
+                    CeremonyLogMessage::Rotate {
+                        old_instance: instance_0,
+                        new_instance: instance_1,
+                        btc_master_pubkey,
+                    },
+                    encrypted_shares.clone(),
+                ))),
             ),
             (
                 "KP share state",
@@ -743,6 +755,7 @@ mod tests {
             LogMessageV2::Init(message) => init_shape(message),
             LogMessageV2::Withdrawal(message) => withdrawal_shape(message),
             LogMessageV2::Ceremony(message) => ceremony_shape(message),
+            LogMessageV2::CeremonyProposal(..) => "ceremony-proposal",
             LogMessageV2::KpShareState(..) => "kp-share-state",
             LogMessageV2::CommitteeUpdate(message) => committee_update_shape(message),
             LogMessageV2::Genesis(..) => "genesis",
@@ -1377,6 +1390,34 @@ mod tests {
             log.object_key(),
             "kp-shares/00000000000000000007/00000000000000000003-session-d.json"
         );
+        assert_eq!(
+            log.object_lock_duration(TESTNET_S3_OBJECT_LOCK_POLICY),
+            TESTNET_S3_OBJECT_LOCK_POLICY.short_lived
+        );
+    }
+
+    #[test]
+    fn object_key_and_lock_for_ceremony_proposal() {
+        let session_id: SessionID = "session-proposal".into();
+        let signing_key = GuardianSignKeyPair::from([14u8; 32]);
+        let btc_master_pubkey = crate::bitcoin::create_btc_keypair_for_test(&[4u8; 32])
+            .x_only_public_key()
+            .0;
+        let proposal = CeremonyProposalLogMessage::new(
+            CeremonyLogMessage::NewKey {
+                instance: test_sharing_instance(0),
+                btc_master_pubkey,
+            },
+            RotateKpSetResponse::mock_for_testing().encrypted_shares,
+        );
+        let log = LogRecord::new_at_timestamp(
+            session_id,
+            LogMessage::CeremonyProposal(Box::new(proposal)),
+            &signing_key,
+            1_700_000_000_000,
+        );
+
+        assert_eq!(log.object_key(), "kp-shares/proposed/session-proposal.json");
         assert_eq!(
             log.object_lock_duration(TESTNET_S3_OBJECT_LOCK_POLICY),
             TESTNET_S3_OBJECT_LOCK_POLICY.short_lived

--- a/crates/hashi-types/src/guardian/s3/log_schema.rs
+++ b/crates/hashi-types/src/guardian/s3/log_schema.rs
@@ -7,6 +7,7 @@
 use super::config::S3ObjectLockPolicy;
 use super::log_layout::ObjectKeyPattern;
 use super::log_messages::CeremonyLogMessage;
+use super::log_messages::CeremonyProposalLogMessage;
 use super::log_messages::CommitteeUpdateLogMessage;
 use super::log_messages::GenesisLogMessageV1;
 use super::log_messages::GenesisLogMessageV2;
@@ -84,6 +85,7 @@ pub enum LogMessageV2 {
     KpShareState(Box<KpShareStateLogMessage>),
     CommitteeUpdate(Box<CommitteeUpdateLogMessage>),
     Genesis(Box<GenesisLogMessageV2>),
+    CeremonyProposal(Box<CeremonyProposalLogMessage>),
 }
 
 /// Writer-facing alias for the log-message schema emitted by guardians.
@@ -95,7 +97,8 @@ pub enum LogType {
     Heartbeat,
     Init,
     Withdrawal,
-    Ceremony,
+    CeremonyCompleted,
+    CeremonyProposal,
     KpShareState,
     CommitteeUpdate,
     Genesis,
@@ -104,10 +107,10 @@ pub enum LogType {
 impl LogType {
     pub(super) const fn object_lock_duration(self, policy: S3ObjectLockPolicy) -> Duration {
         match self {
-            Self::Heartbeat | Self::KpShareState => policy.short_lived,
+            Self::Heartbeat | Self::CeremonyProposal | Self::KpShareState => policy.short_lived,
             Self::Init
             | Self::Withdrawal
-            | Self::Ceremony
+            | Self::CeremonyCompleted
             | Self::CommitteeUpdate
             | Self::Genesis => policy.long_lived,
         }
@@ -121,17 +124,18 @@ trait LogMessageSchema {
 }
 
 macro_rules! impl_log_message_schema {
-    ($schema:ty) => {
+    ($schema:ty $(, $proposal_variant:ident)?) => {
         impl LogMessageSchema for $schema {
             fn log_type(&self) -> LogType {
                 match self {
                     Self::Heartbeat(..) => LogType::Heartbeat,
                     Self::Init(..) => LogType::Init,
                     Self::Withdrawal(..) => LogType::Withdrawal,
-                    Self::Ceremony(..) => LogType::Ceremony,
+                    Self::Ceremony(..) => LogType::CeremonyCompleted,
                     Self::KpShareState(..) => LogType::KpShareState,
                     Self::CommitteeUpdate(..) => LogType::CommitteeUpdate,
                     Self::Genesis(..) => LogType::Genesis,
+                    $(Self::$proposal_variant(..) => LogType::CeremonyProposal,)?
                 }
             }
 
@@ -152,6 +156,7 @@ macro_rules! impl_log_message_schema {
                     Self::KpShareState(message) => message.object_key_pattern(session_id),
                     Self::CommitteeUpdate(message) => message.object_key_pattern(session_id),
                     Self::Genesis(message) => message.object_key_pattern(),
+                    $(Self::$proposal_variant(message) => message.object_key_pattern(session_id),)?
                 }
             }
         }
@@ -159,7 +164,7 @@ macro_rules! impl_log_message_schema {
 }
 
 impl_log_message_schema!(LogMessageV1);
-impl_log_message_schema!(LogMessageV2);
+impl_log_message_schema!(LogMessageV2, CeremonyProposal);
 
 impl VersionedLogMessage {
     pub const SCHEMA_VERSION_V1: u64 = 1;

--- a/design/docs/guardian.mdx
+++ b/design/docs/guardian.mdx
@@ -98,12 +98,14 @@ sequenceDiagram
     Operator->>Guardian: OperatorInit(S3 config)
     Guardian->>S3: log(init attestation + GuardianInfo)
     Operator->>Guardian: SetupNewKey(ordered KP PGP certs, n, t)
-    Guardian->>S3: log(ceremony/NewKey + kp-shares state)
+    Guardian->>S3: log(kp-shares/proposed/{session})
     Guardian-->>Operator: encrypted KP share state + guardian BTC pubkey
 
-    KPs->>S3: Read init, ceremony, and kp-shares logs
+    KPs->>S3: Read init and the session's proposed ceremony
     S3-->>KPs: One PGP-encrypted share addressed to this KP cert fingerprint
     KPs->>KPs: Decrypt share and verify attestation, recipients, commitment
+    KPs->>Guardian: Confirm proposed ceremony digest
+    Guardian->>S3: Publish kp-shares state, then ceremony commit
 ```
 
 ## Withdraw-mode provisioning flow


### PR DESCRIPTION
## Summary

- stage setup and rotation output in a session-scoped `kp-shares/proposed/` record
- publish finalized KP shares followed by the ceremony commit only after every KP confirms
- have ceremony participants read the exact live-session proposal while existing readers continue consuming finalized state

## Testing

- `cargo check`
- `make fmt` *(Rust and protobuf formatting completed; Move formatting could not run because `prettier-move` is not installed locally)*