### PR TITLE
[Guardian] Discover withdrawal prefixes from S3 version history

### DIFF
--- a/crates/hashi-guardian/src/s3_client.rs
+++ b/crates/hashi-guardian/src/s3_client.rs
@@ -411,31 +411,32 @@ impl GuardianS3Client {
     // S3 Reads
     // ========================================================================
 
-    /// Lists immediate subdirectories under `prefix` (S3 `CommonPrefixes`,
-    /// returned by `list_objects_v2` with `delimiter='/'`). Used to tree-walk
-    /// the hour-partitioned withdraw layout (`withdraw/YYYY/MM/DD/HH/`)
-    /// without paginating every object key. Returned prefixes are unique and
-    /// sorted lexicographically.
+    /// Lists immediate subdirectories using S3 version history, including prefixes
+    /// whose objects are hidden by delete markers. Uses `delimiter='/'` to walk
+    /// the hour-partitioned withdraw layout without paginating every object key.
+    /// Returned prefixes are unique and sorted lexicographically.
     pub async fn list_common_prefixes(&self, prefix: &str) -> GuardianResult<Vec<String>> {
-        let mut continuation_token: Option<String> = None;
-        let mut out: BTreeSet<String> = BTreeSet::new();
+        let mut key_marker: Option<String> = None;
+        let mut version_id_marker: Option<String> = None;
+        let mut out = BTreeSet::new();
         loop {
-            let mut req = self
+            let response = self
                 .client
-                .list_objects_v2()
+                .list_object_versions()
                 .bucket(self.config.bucket_name())
                 .prefix(prefix)
-                .delimiter("/");
-            if let Some(ref token) = continuation_token {
-                req = req.continuation_token(token);
-            }
-            let response = req.send().await.map_err(|e| {
-                S3Error(format!(
-                    "Failed to list common prefixes under {}: {}",
-                    prefix,
-                    DisplayErrorContext(&e)
-                ))
-            })?;
+                .delimiter("/")
+                .set_key_marker(key_marker)
+                .set_version_id_marker(version_id_marker)
+                .send()
+                .await
+                .map_err(|e| {
+                    S3Error(format!(
+                        "Failed to list common prefixes under {}: {}",
+                        prefix,
+                        DisplayErrorContext(&e)
+                    ))
+                })?;
             for cp in response.common_prefixes() {
                 if let Some(p) = cp.prefix() {
                     out.insert(p.to_string());
@@ -444,13 +445,14 @@ impl GuardianS3Client {
             if response.is_truncated() != Some(true) {
                 break;
             }
-            let Some(token) = response.next_continuation_token() else {
+            let Some(marker) = response.next_key_marker() else {
                 return Err(S3Error(format!(
-                    "Truncated response but no next_continuation_token for prefix {}",
+                    "Truncated response but no next_key_marker for prefix {}",
                     prefix
                 )));
             };
-            continuation_token = Some(token.to_string());
+            key_marker = Some(marker.to_string());
+            version_id_marker = response.next_version_id_marker().map(str::to_owned);
         }
         Ok(out.into_iter().collect())
     }

--- a/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
+++ b/crates/hashi-guardian/src/s3_reader/limiter_recovery.rs
@@ -305,6 +305,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn find_latest_success_bucket_rejects_deleted_latest_hour() {
+        let s3 = crate::test_utils::mock_logger_with_deleted_layout(
+            [withdraw_success_key(2024, 3, 15, 13, 5)],
+            [withdraw_success_key(2024, 3, 15, 14, 7)],
+        );
+        let err = find_latest_success_bucket(&s3).await.unwrap_err();
+        assert!(matches!(
+            err,
+            GuardianError::S3Error(message)
+                if message == "Delete marker found under prefix withdraw/2024/03/15/14/success-"
+        ));
+    }
+
+    #[tokio::test]
     async fn find_latest_success_bucket_skips_latest_hour_with_only_failures() {
         let keys = vec![
             withdraw_failure_key(2024, 3, 15, 14, 0xdead_beef),

--- a/crates/hashi-guardian/src/test_utils.rs
+++ b/crates/hashi-guardian/src/test_utils.rs
@@ -146,8 +146,8 @@ pub fn mock_logger_capturing() -> (GuardianS3Client, CapturedPuts) {
     (logger, captures)
 }
 
-/// Mock S3 logger whose `list_objects_v2(delimiter='/')` and
-/// `list_object_versions` responses are computed from an in-memory key set —
+/// Mock S3 logger whose `list_object_versions` responses, with and without
+/// a delimiter, are computed from an in-memory key set —
 /// useful for testing layered prefix tree-walks. PutObject also succeeds.
 ///
 /// The dynamic responses depend on inspecting the request `prefix`; we capture
@@ -156,10 +156,19 @@ pub fn mock_logger_capturing() -> (GuardianS3Client, CapturedPuts) {
 /// is sound under a single-threaded async runtime — each S3 call's predicate
 /// runs immediately before its output factory.
 pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> GuardianS3Client {
+    mock_logger_with_deleted_layout(keys, std::iter::empty())
+}
+
+/// Like `mock_logger_with_layout`, with additional keys whose current versions
+/// are delete markers. Their retained versions still contribute to prefixes.
+pub fn mock_logger_with_deleted_layout(
+    keys: impl IntoIterator<Item = String>,
+    deleted_keys: impl IntoIterator<Item = String>,
+) -> GuardianS3Client {
     use aws_sdk_s3::operation::list_object_versions::ListObjectVersionsOutput;
-    use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
     use aws_sdk_s3::operation::put_object::PutObjectOutput;
     use aws_sdk_s3::types::CommonPrefix;
+    use aws_sdk_s3::types::DeleteMarkerEntry;
     use aws_sdk_s3::types::ObjectVersion;
     use aws_sdk_s3::Client;
     use aws_smithy_mocks::mock;
@@ -170,24 +179,29 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
     use std::sync::Arc;
     use std::sync::Mutex;
 
-    let keys: Arc<BTreeSet<String>> = Arc::new(keys.into_iter().collect());
+    let deleted_keys: Arc<BTreeSet<String>> = Arc::new(deleted_keys.into_iter().collect());
+    let keys: Arc<BTreeSet<String>> = Arc::new(
+        keys.into_iter()
+            .chain(deleted_keys.iter().cloned())
+            .collect(),
+    );
 
-    let v2_prefix: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-    let v2_prefix_w = v2_prefix.clone();
-    let v2_prefix_r = v2_prefix.clone();
-    let v2_keys = keys.clone();
-    let list_v2 = mock!(Client::list_objects_v2)
+    let dirs_prefix: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let dirs_prefix_w = dirs_prefix.clone();
+    let dirs_prefix_r = dirs_prefix.clone();
+    let dirs_keys = keys.clone();
+    let list_dirs = mock!(Client::list_object_versions)
         .match_requests(move |req| {
             if req.delimiter() != Some("/") {
                 return false;
             }
-            *v2_prefix_w.lock().unwrap() = req.prefix().map(|s| s.to_string());
+            *dirs_prefix_w.lock().unwrap() = req.prefix().map(|s| s.to_string());
             true
         })
         .then_output(move || {
-            let prefix = v2_prefix_r.lock().unwrap().clone().unwrap_or_default();
+            let prefix = dirs_prefix_r.lock().unwrap().clone().unwrap_or_default();
             let mut children: BTreeSet<String> = BTreeSet::new();
-            for key in v2_keys.iter() {
+            for key in dirs_keys.iter() {
                 let Some(rest) = key.strip_prefix(&prefix) else {
                     continue;
                 };
@@ -201,7 +215,7 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
                 .into_iter()
                 .map(|c| CommonPrefix::builder().prefix(c).build())
                 .collect();
-            ListObjectsV2Output::builder()
+            ListObjectVersionsOutput::builder()
                 .set_common_prefixes(Some(common_prefixes))
                 .build()
         });
@@ -210,8 +224,12 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
     let lv_prefix_w = lv_prefix.clone();
     let lv_prefix_r = lv_prefix.clone();
     let lv_keys = keys.clone();
+    let lv_deleted_keys = deleted_keys.clone();
     let list_versions = mock!(Client::list_object_versions)
         .match_requests(move |req| {
+            if req.delimiter().is_some() {
+                return false;
+            }
             *lv_prefix_w.lock().unwrap() = req.prefix().map(|s| s.to_string());
             true
         })
@@ -220,9 +238,21 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
             let versions: Vec<ObjectVersion> = lv_keys
                 .iter()
                 .filter(|k| k.starts_with(&prefix))
-                .map(|k| ObjectVersion::builder().key(k).is_latest(true).build())
+                .map(|k| {
+                    ObjectVersion::builder()
+                        .key(k)
+                        .is_latest(!lv_deleted_keys.contains(k))
+                        .build()
+                })
                 .collect();
             ListObjectVersionsOutput::builder()
+                .set_delete_markers(Some(
+                    lv_deleted_keys
+                        .iter()
+                        .filter(|k| k.starts_with(&prefix))
+                        .map(|k| DeleteMarkerEntry::builder().key(k).is_latest(true).build())
+                        .collect(),
+                ))
                 .set_versions(Some(versions))
                 .build()
         });
@@ -232,7 +262,7 @@ pub fn mock_logger_with_layout(keys: impl IntoIterator<Item = String>) -> Guardi
     let client = mock_client!(
         aws_sdk_s3,
         RuleMode::MatchAny,
-        &[&list_v2, &list_versions, &put_ok]
+        &[&list_dirs, &list_versions, &put_ok]
     );
     GuardianS3Client::from_client_for_tests(ResolvedS3Config::mock_for_testing(), client)
 }


### PR DESCRIPTION
When delete markers hide every current object in the newest withdrawal hour, `ListObjectsV2` omits that hour from prefix discovery. Limiter recovery can then select an older success record without reaching the existing deletion check.

Use `ListObjectVersions` with `/` as the delimiter for prefix discovery, including key/version marker pagination. The walk now discovers retained history and the existing success-record check rejects delete markers. Update the layout mocks and add a regression case covering a deleted newest success with an older success still present.

Addresses the hidden-prefix defect in [SEC-527](https://linear.app/mysten-labs/issue/SEC-527). Genesis fallback and node-side guards are unchanged; this does not detect permanently removed history.

Validation:
- Focused latest-success-bucket tests: 6 passed.
- `cargo check`: passed.
- `make fmt`: Rust and protobuf formatting completed; Move formatting could not run because `prettier-move` is not installed.
